### PR TITLE
Added support for tcsh auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ This will install the aws-cli package as well as all dependencies.
 
 Command Completion
 ------------------
-The aws-cli package includes a very useful command completion feature
-that for ``bash`` users.  Currently, this feature is not automatically
-installed so you need to configure it manually.  To enable tab completion use
-the bash built-in command ``complete``.
+The aws-cli package includes a very useful command completion feature.  
+This feature is not automatically installed so you need to configure it manually.
+To enable tab completion for bash use the built-in command ``complete``.
 
     $ complete -C aws_completer aws
+
+For tcsh:
+
+    $ complete aws 'p/*/`aws_completer`/'
 
 You should add this to your startup scripts to enable it for future sessions.
 

--- a/bin/aws_completer
+++ b/bin/aws_completer
@@ -16,7 +16,7 @@ import os
 import awscli.completer
 
 if __name__ == '__main__':
-    cline = os.environ['COMP_LINE']
-    cpoint = int(os.environ['COMP_POINT'])
+    # bash exports COMP_LINE and COMP_POINT, tcsh COMMAND_LINE only
+    cline = os.environ.get('COMP_LINE') or os.environ.get('COMMAND_LINE') or ''
+    cpoint = int(os.environ.get('COMP_POINT') or len(cline))
     awscli.completer.complete(cline, cpoint)
-


### PR DESCRIPTION
Small change to aws_completer to use COMMAND_LINE (as set by tcsh) if COMP_LINE environment variable is not set.

I took a quick look to see if zsh could be supported too (see #5) but didn't see any obvious way to access the current command.
