### PR TITLE
Support alternate providers

### DIFF
--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -15,7 +15,7 @@
         },
 	"--region": {
 	    "metavar": "region_name",
-	    "choices": "aws/_regions"
+	    "choices": "%(provider)s/_regions"
 	},
 	"--output": {
 	    "choices": ["json", "text"],
@@ -27,7 +27,7 @@
 	    "help": "Display the version of this tool"
 	},
 	"service_name": {
-	    "choices": "aws/_services",
+	    "choices": "%(provider)s/_services",
 	    "metavar": "service_name"
 	}
     }


### PR DESCRIPTION
This is a small patch to remove some hard-coding of the "aws" provider name at the top level.  aws remains the default, but an alternate provider can be specified in the default profile of a config fie.

This code is still not ideal; it would be better to allow a provider to be specified in any profile, or even on the command line.  This would require an extra pass over the argument list to parse out profile and provider before other options.  I thought I'd suggest the less invasive patch first.
