### PR TITLE
Set region by AWS_DEFAULT_REGION correctly

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -285,6 +285,8 @@ class CLIDriver(object):
                 self.region = self.args.region
             elif self.session.get_config():
                 self.region = self.session.get_config().get('region', None)
+            elif os.environ.get(self.session.env_vars['region'], None) is not None:
+                self.region = os.environ.get(self.session.env_vars['region'])
             if self.region is None:
                 msg = self.session.get_data('messages/NoRegionError')
                 raise ValueError(msg)


### PR DESCRIPTION
Set self.region by getting env var.

or `self.session.get_envvar('region')` with botocore of HEAD in develop branch.
- https://github.com/boto/botocore/blob/develop/botocore/session.py
