### PR TITLE
Add shorthand syntax support for list-structure(scalars)

### DIFF
--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -57,12 +57,17 @@ class TestArgShapeDetection(BaseArgProcessTest):
     def test_detect_structure_of_scalars(self):
         self.assert_shape_type(
             'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration',
-            'structure(scalar)')
+            'structure(scalars)')
 
     def test_list_structure_scalars(self):
         self.assert_shape_type(
             'elb.RegisterInstancesWithLoadBalancer.Instances',
             'list-structure(scalar)')
+
+    def test_list_structure_scalars(self):
+        self.assert_shape_type(
+            'elb.CreateLoadBalancer.Listeners',
+            'list-structure(scalars)')
 
     def test_list_structure_of_list_and_strings(self):
         self.assert_shape_type(
@@ -90,7 +95,9 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_simplify_map_scalar(self):
         p = self.get_param_object('sqs.SetQueueAttributes.Attributes')
         returned = self.simplify(p, 'VisibilityTimeout=15')
+        json_version = unpack_cli_arg(p, '{"VisibilityTimeout": "15"}')
         self.assertEqual(returned, {'VisibilityTimeout': '15'})
+        self.assertEqual(returned, json_version)
 
     def test_list_structure_scalars(self):
         p = self.get_param_object(
@@ -122,6 +129,41 @@ class TestParamShorthand(BaseArgProcessTest):
             p, ["name = instance-id, values = i-1,i-2",
                 "name = architecture, values = i386"])
         self.assertEqual(returned2, expected)
+
+    def test_list_structure_scalars(self):
+        p = self.get_param_object('elb.CreateLoadBalancer.Listeners')
+        expected = [
+            {"protocol": "protocol1",
+             "load_balancer_port": 1,
+             "instance_protocol": "instance_protocol1",
+             "instance_port": 2,
+             "ssl_certificate_id": "ssl_certificate_id1"},
+            {"protocol": "protocol2",
+             "load_balancer_port": 3,
+             "instance_protocol": "instance_protocol2",
+             "instance_port": 4,
+             "ssl_certificate_id": "ssl_certificate_id2"},
+        ]
+        returned = unpack_cli_arg(
+            p, ['{"protocol": "protocol1", "load_balancer_port": 1, '
+                '"instance_protocol": "instance_protocol1", '
+                '"instance_port": 2, "ssl_certificate_id": '
+                '"ssl_certificate_id1"}',
+                '{"protocol": "protocol2", "load_balancer_port": 3, '
+                '"instance_protocol": "instance_protocol2", '
+                '"instance_port": 4, "ssl_certificate_id": '
+                '"ssl_certificate_id2"}',
+            ])
+        self.assertEqual(returned, expected)
+        simplified = self.simplify(p, [
+            'protocol=protocol1,load_balancer_port=1,'
+            'instance_protocol=instance_protocol1,'
+            'instance_port=2,ssl_certificate_id=ssl_certificate_id1',
+            'protocol=protocol2,load_balancer_port=3,'
+            'instance_protocol=instance_protocol2,'
+            'instance_port=4,ssl_certificate_id=ssl_certificate_id2'
+        ])
+        self.assertEqual(simplified, expected)
 
     def test_error_messages_for_structure_scalar(self):
         p = self.get_param_object(
@@ -199,6 +241,17 @@ class TestDocGen(BaseArgProcessTest):
         self.assertIn('Shorthand Syntax', rendered)
         # sample syntax
         self.assertIn('--instances instance_id1', rendered)
+
+    def test_gen_list_structure_of_scalars_docs(self):
+        p = self.get_param_object('elb.CreateLoadBalancer.Listeners')
+        op_doc = OperationDocument(self.session, p.operation)
+        self.simplify.add_docs(op_doc, p)
+        fp = six.StringIO()
+        op_doc.render(fp=fp)
+        rendered = fp.getvalue()
+        self.assertIn('Shorthand Syntax', rendered)
+        self.assertIn('--listeners', rendered)
+        self.assertIn('protocol=value', rendered)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This includes shorthand for:
- List of struct of scalars `--foo a=1,b=2 a=3,b=4`

This also includes a bug fix where the sub params are converted to their proper type.  This was previously happening via the `json.loads`, so we need to carry that functionality over to the shorthand syntax.
