### PR TITLE
Update search path processing to work on windows

### DIFF
--- a/awscli/__init__.py
+++ b/awscli/__init__.py
@@ -22,15 +22,15 @@ __version__ = '0.11.0'
 #
 # Get our data path to be added to botocore's search path
 #
-p = os.path.split(__file__)[0]
-p = os.path.split(p)[0]
-awscli_data_path = [os.path.join(p, 'awscli/data')]
+_awscli_data_path = [
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+]
 if 'AWS_DATA_PATH' in os.environ:
-    for path in os.environ['AWS_DATA_PATH'].split(':'):
+    for path in os.environ['AWS_DATA_PATH'].split(os.pathsep):
         path = os.path.expandvars(path)
         path = os.path.expanduser(path)
-        awscli_data_path.append(path)
-os.environ['AWS_DATA_PATH'] = ':'.join(awscli_data_path)
+        _awscli_data_path.append(path)
+os.environ['AWS_DATA_PATH'] = os.pathsep.join(_awscli_data_path)
 
 
 EnvironmentVariables = {


### PR DESCRIPTION
We have to use os.path.abspath because this will capture the
current drive we're on.  Otherwise if our cwd is on a different
drive, we'll build our search path based on the current drive.

I've also switched the path separator to os.pathsep.

See (aws/aws-cli#101) for more details.

This also depends on boto/botocore#56 in order for the #101 to be completely fixed (verified this works on windows with both of these changes pulled in).

Note on the travis tests.  The tests will fail as we're currently using the develop branch of botocore.  Once boto/botocore#56 is merged into develop this test will pass, so I'll wait until that happens before commiting this change.
