### PR TITLE
Fix 'ascii' codec can't encode character u'\xe1' in position 80873: ordinal not in range(128) issue

### DIFF
--- a/bin/aws
+++ b/bin/aws
@@ -12,6 +12,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
+reload(sys)
+sys.setdefaultencoding("utf-8")
 import awscli.clidriver
 
 


### PR DESCRIPTION
Hi,

I ran into an encoding issue today, and I'm providing a fix to it.
I don't know if it is the best way to implement it, since I'm not fluent in python. But it did the trick for me.

The issue happened (in my case) when running ec2-describe-instances, as follows:

$ aws ec2 describe-instances --region sa-east-1
'ascii' codec can't encode character u'\xe1' in position 80873: ordinal not in range(128)

Since its an enconding-related issue, it could happen with any call that brings special chars within the response.

Anyway, the fix was setting the default encoding when running bin/aws, as follows:

reload(sys)
sys.setdefaultencoding("utf-8")

The fix was found here: https://pythonadventures.wordpress.com/2012/09/02/print-unicode-text-to-the-terminal/

Hope it helps.
