### PR TITLE
Unify boolean params

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -118,7 +118,7 @@ class OperationArgParser(CLIArgParser):
     def _build(self, argument_table, name):
         for arg_name in argument_table:
             argument = argument_table[arg_name]
-            argument.add_to_parser(self, '--' + arg_name)
+            argument.add_to_parser(self)
 
     def parse_known_args(self, args):
         if len(args) == 1 and args[0] == 'help':

--- a/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
+++ b/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
@@ -36,6 +36,17 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
                   'ShouldDecrementDesiredCapacity': 'false'}
         self.assert_params_for_cmd(cmdline, params)
 
+    def test_last_arg_wins(self):
+        cmdline = self.PREFIX
+        cmdline += ' --instance-id i-12345678'
+        cmdline += ' --should-decrement-desired-capacity'
+        cmdline += ' --no-should-decrement-desired-capacity'
+        # Since the --no-should-decrement-desired-capacity was
+        # was added last, it wins.
+        params = {'InstanceId': 'i-12345678',
+                  'ShouldDecrementDesiredCapacity': 'false'}
+        self.assert_params_for_cmd(cmdline, params)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -140,3 +140,11 @@ class TestAWSHelpOutput(BaseCLIDriverTest):
     def test_examples_in_operation_help(self):
         self.driver.main(['ec2', 'run-instances', 'help'])
         self.assert_contains('========\nExamples\n========')
+
+    def test_boolean_param_documented(self):
+        self.driver.main(['autoscaling',
+                          'terminate-instance-in-auto-scaling-group', 'help'])
+        self.assert_contains(
+            '``--should-decrement-desired-capacity`` (boolean)')
+        self.assert_contains(
+            '``--no-should-decrement-desired-capacity`` (boolean)')


### PR DESCRIPTION
Required and optional boolean params are treated the same.
For every option 'foo', you get a `--foo` and a `--no-foo`.
I've also removed the mutually exclusive groups for boolean
params.

The new behavior is that the last specified boolean param wins.

There's still an existing issue for docs (we currently generate the same
docs twice for the `--foo` and the `--no-foo`), but this fixes the issue
now where you actually get the same parameter documented twice,
and the negative param is not documented:

```
       --should-decrement-desired-capacity (boolean) Specifies whether (true )
       or  not  (false  )  terminating this instance should also decrement the
       size of the  AutoScalingGroup .

       --should-decrement-desired-capacity (boolean) Specifies whether (true )
       or  not  (false  )  terminating this instance should also decrement the
       size of the  AutoScalingGroup .
```

I plan on some larger refactorings to the parameter code but wanted to
get this commit in first.
