### PR TITLE
Change event name of top command table

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -98,7 +98,7 @@ class CLIDriver(object):
 
         """
         command_table = self._build_builtin_commands(self.session)
-        self.session.emit('building-command-table',
+        self.session.emit('building-command-table.main',
                           command_table=command_table,
                           session=self.session)
         return command_table

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -189,7 +189,7 @@ class TestCliDriverHooks(unittest.TestCase):
         driver.main('s3 list-objects --bucket foo'.split())
         self.assert_events_fired_in_order([
             # Events fired while parser is being created.
-            'building-command-table',
+            'building-command-table.main',
             'building-top-level-params',
             'top-level-args-parsed',
             'building-command-table.s3',


### PR DESCRIPTION
Now that the root command table is 'building-command-table'
and service subcommands are 'building-command-table.servicename',
this makes it hard for a handler that wants to add a new top level
command as they have to parse the event name.  In this change,
the handlers can subscribe to 'building-command-table.main' which
makes it easy to subscribe to the event you want.
