### PR TITLE
Fix table output with differing keys

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -140,7 +140,7 @@ class TableFormatter(FullyBufferedFormatter):
                               indent_level=indent_level + 1)
 
     def _build_sub_table_from_list(self, current, indent_level, title):
-        headers, more = self._group_scalar_keys(current[0])
+        headers, more = self._group_scalar_keys_from_list(current)
         self.table.add_row_header(headers)
         first = True
         for element in current:
@@ -162,6 +162,20 @@ class TableFormatter(FullyBufferedFormatter):
 
     def _scalar_type(self, element):
         return not isinstance(element, (list, dict))
+
+    def _group_scalar_keys_from_list(self, list_of_dicts):
+        # We want to make sure we catch all the keys in the list of dicts.
+        # Most of the time each list element has the same keys, but sometimes
+        # a list element will have keys not defined in other elements.
+        headers = set()
+        more = set()
+        for item in list_of_dicts:
+            current_headers, current_more = self._group_scalar_keys(item)
+            headers.update(current_headers)
+            more.update(current_more)
+        headers = list(sorted(headers))
+        more = list(sorted(more))
+        return headers, more
 
     def _group_scalar_keys(self, current):
         # Given a dict, separate the keys into those whose values are

--- a/tests/unit/output/test_table_formatter.py
+++ b/tests/unit/output/test_table_formatter.py
@@ -256,6 +256,45 @@ LIST_WITH_MISSING_KEYS_TABLE = """\
 |+-------------+----------+-----------+---------------+---------------------------+------------+-------+----------------+--------------+|
 """
 
+KEYS_NOT_FROM_FIRST_ROW = {
+    "Snapshots": [
+        {
+            "Description": "TestVolume1",
+            "Tags": "foo",
+            "VolumeId": "vol-12345",
+            "State": "completed",
+            "VolumeSize": 8,
+            "Progress": "100%",
+            "StartTime": "start_time",
+            # Missing EndTime.
+            "SnapshotId": "snap-1234567",
+            "OwnerId": "12345"
+        },
+        {
+            "Description": "description",
+            "State": "completed",
+            "VolumeSize": 8,
+            "Progress": "100%",
+            # Missing StartTime
+            "EndTime": "end_time",
+            "SnapshotId": "snap-23456",
+            "OwnerId": "12345"
+        }
+    ]
+}
+
+KEYS_NOT_FROM_FIRST_ROW_TABLE = """\
+------------------------------------------------------------------------------------------------------------------------------------
+|                                                           OperationName                                                          |
++----------------------------------------------------------------------------------------------------------------------------------+
+||                                                            Snapshots                                                           ||
+|+-------------+-----------+----------+-----------+---------------+-------------+------------+-------+-------------+--------------+|
+|| Description |  EndTime  | OwnerId  | Progress  |  SnapshotId   |  StartTime  |   State    | Tags  |  VolumeId   | VolumeSize   ||
+|+-------------+-----------+----------+-----------+---------------+-------------+------------+-------+-------------+--------------+|
+||  TestVolume1|           |  12345   |  100%     |  snap-1234567 |  start_time |  completed |  foo  |  vol-12345  |  8           ||
+||  description|  end_time |  12345   |  100%     |  snap-23456   |             |  completed |       |             |  8           ||
+|+-------------+-----------+----------+-----------+---------------+-------------+------------+-------+-------------+--------------+|
+"""
 
 class Object(object):
     def __init__(self, **kwargs):
@@ -278,6 +317,7 @@ class TestTableFormatter(unittest.TestCase):
         self.formatter(Object(name='OperationName', can_paginate=False),
                               data, self.stream)
         rendered = self.stream.getvalue()
+        print(rendered)
         self.assertEqual(rendered, table)
 
     def test_list_table(self):
@@ -301,3 +341,7 @@ class TestTableFormatter(unittest.TestCase):
     def test_missing_keys(self):
         self.assert_data_renders_to(data=LIST_WITH_MISSING_KEYS,
                                     table=LIST_WITH_MISSING_KEYS_TABLE)
+
+    def test_new_keys_after_first_row(self):
+        self.assert_data_renders_to(data=KEYS_NOT_FROM_FIRST_ROW,
+                                    table=KEYS_NOT_FROM_FIRST_ROW_TABLE)


### PR DESCRIPTION
Fixes two issues:
### First Issue

Find all possible column names in list of dicts

Rather than relying on the first element to tell us all the column names,
we iterate through all the list of dicts collecting the column names.  This
accounts for when new keys are defined in rows other than the first.

Fixes #199
### Second Issue

Account for some keys not being in rows

Fixes #198.
