### PR TITLE
Add simple, scalar options to allow additional private IP addresses to be assigned with run-instances.

### DIFF
--- a/awscli/customizations/ec2runinstances.py
+++ b/awscli/customizations/ec2runinstances.py
@@ -1,0 +1,116 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+This customization adds two new parameters to the ``ec2 run-instance``
+command.  The first, ``--secondary-private-ip-addresses`` allows a list
+of IP addresses within the specified subnet to be associated with the
+new instance.  The second, ``--secondary-ip-address-count`` allows you
+to specify how many additional IP addresses you want but the actual
+address will be assigned for you.
+
+This functionality (and much more) is also available using the
+``--network-interfaces`` complex argument.  This just makes two of
+the most commonly used features available more easily.
+"""
+from awscli.customizations import CustomArgument
+
+
+# --secondary-private-ip-address
+SECONDARY_PRIVATE_IP_ADDRESSES_DOCS = (
+    '[EC2-VPC] A secondary private IP address for the network interface '
+    'or instance. You can specify this multiple times to assign multiple '
+    'secondary IP addresses.  If you want additional private IP addresses '
+    'but do not need a specific address, use the '
+    '--secondary-private-ip-address-count option.')
+
+# --secondary-private-ip-address-count                                  
+SECONDARY_PRIVATE_IP_ADDRESS_COUNT_DOCS = (
+    '[EC2-VPC] The number of secondary IP addresses to assign to '
+    'the network interface or instance.')
+
+
+def _add_params(argument_table, operation, **kwargs):
+    arg = SecondaryPrivateIpAddressesArgument(
+        operation=operation, name='secondary-private-ip-addresses',
+        documentation=SECONDARY_PRIVATE_IP_ADDRESSES_DOCS)
+    argument_table['secondary-private-ip-addresses'] = arg
+    arg = SecondaryPrivateIpAddressCountArgument(
+        operation=operation, name='secondary-private-ip-address-count',
+        documentation=SECONDARY_PRIVATE_IP_ADDRESS_COUNT_DOCS)
+    argument_table['secondary-private-ip-address-count'] = arg
+
+
+def _check_args(parsed_args, **kwargs):
+    # This function checks the parsed args.  If the user specified
+    # the --network-interfaces option with any of the scalar options we
+    # raise an error.
+    arg_dict = vars(parsed_args)
+    if arg_dict['network-interfaces']:
+        for key in ('secondary-private-ip-addresses',
+                    'secondary-private-ip-address-count'):
+            if arg_dict[key]:
+                msg = ('Mixing the --network-interfaces option '
+                       'with the simple, scalar options is '
+                       'not supported.')
+                raise ValueError(msg)
+
+EVENTS = [
+    ('building-argument-table.ec2.RunInstances', _add_params),
+    ('operation-args-parsed.ec2.RunInstances', _check_args),
+    ]
+
+
+def register_runinstances(event_handler):
+    # Register all of the events for customizing BundleInstance
+    for event, handler in EVENTS:
+        event_handler.register(event, handler)
+
+
+def _build_network_interfaces(params, key, value):
+    # Build up the NetworkInterfaces data structure
+    if 'network_interfaces' not in params:
+        params['network_interfaces'] = [{'DeviceIndex': 0}]
+        
+    if key == 'PrivateIpAddresses':
+        if 'PrivateIpAddresses' not in params['network_interfaces'][0]:
+            params['network_interfaces'][0]['PrivateIpAddresses'] = value
+    else:
+        params['network_interfaces'][0][key] = value
+
+
+class SecondaryPrivateIpAddressesArgument(CustomArgument):
+
+    def add_to_parser(self, parser, cli_name=None):
+        parser.add_argument(self.cli_name, dest=self._name,
+                            default=self._default, nargs='*')
+
+    def add_to_params(self, parameters, value):
+        if value:
+            value = [{'PrivateIpAddress': v, 'Primary': False} for
+                     v in value]
+            _build_network_interfaces(parameters,
+                                      'PrivateIpAddresses',
+                                      value)
+
+
+class SecondaryPrivateIpAddressCountArgument(CustomArgument):
+
+    def add_to_parser(self, parser, cli_name=None):
+        parser.add_argument(self.cli_name, dest=self._name,
+                            default=self._default, type=int)
+
+    def add_to_params(self, parameters, value):
+        if value:
+            _build_network_interfaces(parameters,
+                                      'SecondaryPrivateIpAddressCount',
+                                      value)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -27,6 +27,7 @@ from awscli.customizations.ec2secgroupsimplify import register_secgroup
 from awscli.customizations.preview import register_preview_commands
 from awscli.customizations.ec2bundleinstance import register_bundleinstance
 from awscli.customizations.s3.s3 import s3_plugin_initialize
+from awscli.customizations.ec2runinstances import register_runinstances
 
 
 def awscli_initialize(event_handlers):
@@ -54,5 +55,6 @@ def awscli_initialize(event_handlers):
     register_secgroup(event_handlers)
     register_bundleinstance(event_handlers)
     s3_plugin_initialize(event_handlers)
+    register_runinstances(event_handlers)
     register_removals(event_handlers)
     register_preview_commands(event_handlers)

--- a/tests/unit/ec2/test_run_instances.py
+++ b/tests/unit/ec2/test_run_instances.py
@@ -67,6 +67,46 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(args_list, result)
 
+    def test_secondary_ip_address(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--secondary-private-ip-addresses 10.0.2.106'
+        args_list = (self.prefix + args).split()
+        result = {
+            'NetworkInterface.1.DeviceIndex': '0',
+            'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'false',
+            'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.2.106',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
 
-if __name__ == "__main__":
-    unittest.main()
+    def test_secondary_ip_addresses(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--secondary-private-ip-addresses 10.0.2.106 10.0.2.107'
+        args_list = (self.prefix + args).split()
+        result = {
+            'NetworkInterface.1.DeviceIndex': '0',
+            'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'false',
+            'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.2.106',
+            'NetworkInterface.1.PrivateIpAddresses.2.Primary': 'false',
+            'NetworkInterface.1.PrivateIpAddresses.2.PrivateIpAddress': '10.0.2.107',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
+        
+    def test_secondary_ip_address_count(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--secondary-private-ip-address-count 4'
+        args_list = (self.prefix + args).split()
+        result = {
+            'NetworkInterface.1.DeviceIndex': '0',
+            'NetworkInterface.1.SecondaryPrivateIpAddressCount': '4',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
+


### PR DESCRIPTION
This customization adds two new parameters to the `ec2 run-instance`
command.  The first, `--secondary-private-ip-addresses` allows a list
of IP addresses within the specified subnet to be associated with the
new instance.  The second, `--secondary-ip-address-count` allows you
to specify how many additional IP addresses you want but the actual
address will be assigned for you.

This functionality (and much more) is also available using the
`--network-interfaces` complex argument.  This just makes two of
the most commonly used features available more easily.

This PR is dependent on https://github.com/boto/botocore/pull/106
