### PR TITLE
Set a stream logger with level=ERROR by default

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -203,6 +203,8 @@ class CLIDriver(object):
             # loading of plugins, etc.
             self.session.set_debug_logger(logger_name='botocore')
             self.session.set_debug_logger(logger_name='awscli')
+        else:
+            self.session.set_stream_logger(logger_name='awscli', log_level='ERROR')
 
 
 class CLICommand(object):

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -84,6 +84,7 @@ class FakeSession(object):
         self.emitter = emitter
         self.provider = Provider(self, 'aws')
         self.profile = None
+        self.stream_logger_args = None
 
     def register(self, event_name, handler):
         self.emitter.register(event_name, handler)
@@ -138,9 +139,11 @@ class FakeSession(object):
                 ['Bucket', 'Delimiter', 'Marker', 'MaxKeys', 'Prefix']),
         }}}}
 
-
     def user_agent(self):
         return 'user_agent'
+
+    def set_stream_logger(self, *args, **kwargs):
+        self.stream_logger_args = (args, kwargs)
 
 
 class TestCliDriver(unittest.TestCase):
@@ -165,6 +168,12 @@ class TestCliDriver(unittest.TestCase):
         driver = CLIDriver(session=self.session)
         driver.main('s3 list-objects --bucket foo --profile foo'.split())
         self.assertEqual(driver.session.profile, 'foo')
+
+    def test_error_logger(self):
+        driver = CLIDriver(session=self.session)
+        driver.main('s3 list-objects --bucket foo --profile foo'.split())
+        expected = {'log_level': 'ERROR', 'logger_name': 'awscli'}
+        self.assertEqual(driver.session.stream_logger_args[1], expected)
 
 
 class TestCliDriverHooks(unittest.TestCase):


### PR DESCRIPTION
If --debug is not set we create a stream logger that's
set to only show error logs.

This fixes the issue about no handlers conneted to a logger
if something info/warn/error logged something.

Fixes #251.

Depends on https://github.com/boto/botocore/pull/118

cc @garnaat
