### PR TITLE
Don't print empty responses

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -68,9 +68,9 @@ class JSONFormatter(FullyBufferedFormatter):
         # the response will be an empty string.  We don't want to print
         # that out to the user but other "falsey" values like an empty
         # dictionary should be printed.
-        if response != '':
+        if response:
             json.dump(response, stream, indent=4)
-        stream.write('\n')
+            stream.write('\n')
 
 
 class TableFormatter(FullyBufferedFormatter):

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.unit import BaseAWSCommandParamsTest
+import os
+import sys
+import re
+
+from six.moves import cStringIO
+import httpretty
+import mock
+
+ADD_USER_RESPONSE = """\
+<AddUserToGroupResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ResponseMetadata>
+      <RequestId>b8ff9277-0c3a-11e3-941e-8d1b33bbf528</RequestId>
+  </ResponseMetadata>
+</AddUserToGroupResponse>
+"""
+
+
+class TestGetPasswordData(BaseAWSCommandParamsTest):
+
+    prefix = 'iam add-user-to-group '
+
+    def register_uri(self):
+        httpretty.register_uri(httpretty.POST, re.compile('.*'),
+                               body=ADD_USER_RESPONSE)
+
+    def test_empty_response_prints_nothing(self):
+        captured = cStringIO()
+        args = ' --group-name foo --user-name bar'
+        cmdline = self.prefix + args
+        result = {'GroupName': 'foo', 'UserName': 'bar'}
+        with mock.patch('sys.stdout', captured):
+            self.assert_params_for_cmd(cmdline, result, expected_rc=0)
+        output = captured.getvalue()
+        # We should have printed nothing because the parsed response
+        # is an empty dict: {}.
+        self.assertEqual(output, '')


### PR DESCRIPTION
This includes dicts/lists/strings and anything
that evaluates to False.

cc @garnaat @toastdriven
