### PR TITLE
Update RDS example to use full option names

### DIFF
--- a/awscli/examples/rds/create-option-group.rst
+++ b/awscli/examples/rds/create-option-group.rst
@@ -1,11 +1,11 @@
-**To launch an Amazon EC2 instance**
+**To create an Amazon RDS option group**
 
 The following ``create-option-group`` command creates a new Amazon RDS option group.
 In the example, the option group is created for Oracle Enterprise Edition version 11.2
 and is named MyOptionGroup and includes a description.
 ::
 
-    aws rds create-option-group MyOptionGroup -e oracle-ee -v 11.2 -d "Oracle Database Manager Database Control"
+    aws rds create-option-group --option-group-name MyOptionGroup --engine-name oracle-ee --major-engine-version 11.2 --option-group-description "Oracle Database Manager Database Control"
 
 This command output a JSON block that contains information on the option group.
 


### PR DESCRIPTION
We don't support the short option names.

Fixes #235.

cc @garnaat
