### PR TITLE
Fix --no-paginate to check for None values

### DIFF
--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -115,4 +115,5 @@ class PageArgument(BaseCLIArgument):
                             type=self.type_map[self._parse_type])
 
     def add_to_params(self, parameters, value):
-        parameters[self.py_name] = value
+        if value is not None:
+            parameters[self.py_name] = value

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -133,6 +133,17 @@ class TestBasicCommandFunctionality(unittest.TestCase):
             contents = f.read()
         self.assertEqual(contents, 'foobar contents')
 
+    def test_no_paginate_arg(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, d)
+        bucket_name = 'nopaginate' + str(
+            int(time.time())) + str(random.randint(1, 100))
+
+        self.put_object(bucket=bucket_name, key='foobar',
+                        content='foobar contents')
+        p = aws('s3api list-objects --bucket %s --no-paginate' % bucket_name)
+        self.assertEqual(p.rc, 0, p.stdout + p.stderr)
+
     def test_top_level_options_debug(self):
         p = aws('ec2 describe-instances --debug')
         self.assertEqual(p.rc, 0)

--- a/tests/unit/s3/test_list_objects.py
+++ b/tests/unit/s3/test_list_objects.py
@@ -51,10 +51,16 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # properly.
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
-        # The max-items is a customization and therefore won't
-        # show up in the result params.
         cmdline += ' --starting-token foo___2'
         result = {'uri_params': {'Bucket': 'mybucket', 'Marker': 'foo'},
+                  'headers': {},
+                  'payload': None}
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_no_paginate(self):
+        cmdline = self.prefix
+        cmdline += ' --bucket mybucket --no-paginate'
+        result = {'uri_params': {'Bucket': 'mybucket'},
                   'headers': {},
                   'payload': None}
         self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
Basically --no-paginate didn't work.  If you don't check for None
values, the arg object will insert args that don't actually exist in the
op model which botocore will (correctly) complain about.

Added an integration test as well as a unit test to catch this
in the future.

cc @garnaat
