### PR TITLE
Fix parsing issue with quoted shorthand values

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -237,7 +237,7 @@ class ParamShorthand(object):
         valid_names = self._create_name_to_params(param)
         for part in parts:
             try:
-                key, value = part.split('=')
+                key, value = part.split('=', 1)
             except ValueError:
                 raise ParamSyntaxError(part)
             key = key.strip()

--- a/tests/unit/elb/test_configure_health_check.py
+++ b/tests/unit/elb/test_configure_health_check.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+from tests.unit import BaseAWSCommandParamsTest
+
+
+class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
+
+    prefix = 'elb configure-health-check'
+
+    def test_shorthand_basic(self):
+        cmdline = self.prefix
+        cmdline += ' --load-balancer-name my-lb'
+        cmdline += (' --health-check Target=HTTP:80/weather/us/wa/seattle,'
+                    'Interval=300,Timeout=60,UnhealthyThreshold=5,'
+                    'HealthyThreshold=9')
+        result = {'HealthCheck.HealthyThreshold': '9',
+                  'HealthCheck.Interval': '300',
+                  'HealthCheck.Target': 'HTTP:80/weather/us/wa/seattle',
+                  'HealthCheck.Timeout': '60',
+                  'HealthCheck.UnhealthyThreshold': '5',
+                  'LoadBalancerName': 'my-lb'}
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_json(self):
+        cmdline = self.prefix
+        cmdline += ' --load-balancer-name my-lb '
+        cmdline += ('--health-check {"Target":"HTTP:80/weather/us/wa/seattle'
+                    '?a=b","Interval":300,"Timeout":60,'
+                    '"UnhealthyThreshold":5,"HealthyThreshold":9}')
+        result = {'HealthCheck.HealthyThreshold': '9',
+                  'HealthCheck.Interval': '300',
+                  'HealthCheck.Target': 'HTTP:80/weather/us/wa/seattle?a=b',
+                  'HealthCheck.Timeout': '60',
+                  'HealthCheck.UnhealthyThreshold': '5',
+                  'LoadBalancerName': 'my-lb'}
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_shorthand_with_multiple_equals_for_value(self):
+        cmdline = self.prefix
+        cmdline += ' --load-balancer-name my-lb'
+        cmdline += (' --health-check Target="HTTP:80/weather/us/wa/seattle?a=b"'
+                    ',Interval=300,Timeout=60,UnhealthyThreshold=5,'
+                    'HealthyThreshold=9')
+        result = {'HealthCheck.HealthyThreshold': '9',
+                  'HealthCheck.Interval': '300',
+                  'HealthCheck.Target': 'HTTP:80/weather/us/wa/seattle?a=b',
+                  'HealthCheck.Timeout': '60',
+                  'HealthCheck.UnhealthyThreshold': '5',
+                  'LoadBalancerName': 'my-lb'}
+        self.assert_params_for_cmd(cmdline, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -199,7 +199,7 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_error_messages_for_structure_scalar(self):
         p = self.get_param_object(
             'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration')
-        value = 'ApplicationName==foo,TemplateName=bar'
+        value = 'ApplicationName:foo,TemplateName=bar'
         error_msg = "Error parsing parameter --source-configuration.*should be"
         with self.assertRaisesRegexp(ParamError, error_msg):
             self.simplify(p, value)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -29,6 +29,26 @@ class TestCSVSplit(unittest.TestCase):
         self.assertEqual(split_on_commas('foo,bar="1,2,3",baz'),
                          ['foo', 'bar=1,2,3', 'baz'])
 
+    def test_single_quote(self):
+        self.assertEqual(split_on_commas("foo,bar='1,2,3',baz"),
+                         ['foo', 'bar=1,2,3', 'baz'])
+
+    def test_mixing_double_single_quotes(self):
+        self.assertEqual(split_on_commas("""foo,bar="1,'2',3",baz"""),
+                         ['foo', "bar=1,'2',3", 'baz'])
+
+    def test_mixing_double_single_quotes_before_first_comma(self):
+        self.assertEqual(split_on_commas("""foo,bar="1','2',3",baz"""),
+                         ['foo', "bar=1','2',3", 'baz'])
+
+    def test_inner_quote_split_with_equals(self):
+        self.assertEqual(split_on_commas('foo,bar="Foo:80/bar?a=b",baz'),
+                         ['foo', 'bar=Foo:80/bar?a=b', 'baz'])
+
+    def test_single_quoted_inner_value_with_no_commas(self):
+        self.assertEqual(split_on_commas("foo,bar='BAR',baz"),
+                         ['foo', 'bar=BAR', 'baz'])
+
     def test_escape_quotes(self):
         self.assertEqual(split_on_commas('foo,bar=1\,2\,3,baz'),
                          ['foo', 'bar=1,2,3', 'baz'])


### PR DESCRIPTION
Fixes #174.  The problem was that if multiple equal
signs are present in a key/val pair (if the value has
an equal sign) then we would hit this error.

See [here](https://github.com/jamesls/aws-cli/compare/fix-174?expand=1#L2R50) for an example of this.

I double checked the other parsing parts of argprocess, they all
properly use '.split("=", 1)'.

This also required updated the csv parsing to handle the
case where you quote a value without commas, e.g. foo="bar=baz".

cc @garnaat @toastdriven
