### PR TITLE
Add parameter name for bad json values

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -333,7 +333,8 @@ def unpack_complex_cli_arg(parameter, value):
         if value.lstrip()[0] == '{':
             d = json.loads(value)
         else:
-            msg = 'Structure option value must be JSON or path to file.'
+            msg = 'The value for parameter "%s" must be JSON or path to file.' % (
+                parameter.cli_name)
             raise ValueError(msg)
         return d
     elif parameter.type == 'list':

--- a/tests/unit/ec2/test_modify_image_attribute.py
+++ b/tests/unit/ec2/test_modify_image_attribute.py
@@ -39,6 +39,14 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
                   }
         self.assert_params_for_cmd(cmdline, result)
 
+    def test_assert_error_in_bad_json_path(self):
+        cmdline = self.prefix
+        cmdline += ' --image-id ami-d00dbeef'
+        cmdline += ' --launch-permission THISISNOTJSON'
+        # The arg name should be in the error message.
+        self.assert_params_for_cmd(cmdline, {}, expected_rc=255,
+                                   stderr_contains='launch-permission')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #185

Error is now:

```
The value for parameter "--launch-permission" must be JSON or path to file.\
```
