### PR TITLE
Add test for list of scalar complex param

### DIFF
--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -204,3 +204,18 @@ class TestMergeBooleanGroupArgs(BaseAWSHelpOutputTest):
         # --foo | --no-foo foo docs
         self.driver.main(['ec2', 'run-instances', 'help'])
         self.assert_contains('``--dry-run`` | ``--no-dry-run``')
+
+
+class TestJSONListScalarDocs(BaseAWSHelpOutputTest):
+    def test_space_separated_list_docs(self):
+        # A list of scalar type can be specified as JSON:
+        #      JSON Syntax:
+        #
+        #       ["string", ...]
+        # But at the same time you can always replace that with
+        # a space separated list.  Therefore we want to document
+        # the space separated list version and not the JSON list
+        # version.
+        self.driver.main(['ec2', 'terminate-instances', 'help'])
+        self.assert_not_contains('["string", ...]')
+        self.assert_contains('"string" "string"')


### PR DESCRIPTION
Depends on https://github.com/boto/bcdoc/pull/18

So this test will fail until https://github.com/boto/bcdoc/pull/18 is merged in.
