### PR TITLE
Add py2exe clause in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python
-
-"""
-distutils/setuptools install script.
-"""
-
 import os
-import awscli
+import sys
 
 from setuptools import setup, find_packages
+
+import awscli
 
 
 requires = ['botocore>=0.15.0,<0.16.0',
@@ -19,7 +16,7 @@ requires = ['botocore>=0.15.0,<0.16.0',
             'rsa==3.1.1']
 
 
-setup(
+setup_options = dict(
     name='awscli',
     version=awscli.__version__,
     description='Universal Command Line Environment for AWS.',
@@ -47,3 +44,24 @@ setup(
         'Programming Language :: Python :: 3.3',
     ),
 )
+
+if 'py2exe' in sys.argv:
+    # This will actually give us a py2exe command.
+    import py2exe
+    # And we have some py2exe specific options.
+    setup_options['options'] = {
+        'py2exe': {
+            'optimize': 0,
+            'skip_archive': True,
+            'includes': ['ConfigParser', 'urllib', 'httplib',
+                         'docutils.readers.standalone',
+                         'docutils.parsers.rst',
+                         'docutils.languages.en',
+                         'xml.etree.ElementTree', 'HTMLParser',
+                         'awscli.handlers'],
+        }
+    }
+    setup_options['console'] = ['bin/aws']
+
+
+setup(**setup_options)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -48,7 +48,11 @@ def _escape_quotes(command):
 def aws(command):
     if platform.system() == 'Windows':
         command = _escape_quotes(command)
-    full_command = 'python %s %s' % (AWS_CMD, command)
+    if 'AWS_TEST_COMMAND' in os.environ:
+        aws_command = os.environ['AWS_TEST_COMMAND']
+    else:
+        aws_command = 'python %s' % AWS_CMD
+    full_command = '%s %s' % (aws_command, command)
     LOG.debug("Running command: %s", full_command)
     env = os.environ.copy()
     env['AWS_DEFAULT_REGION'] = "us-east-1"


### PR DESCRIPTION
Also allow aws path to be specified in integration
tests via an env var.  This allows you to point at a specific aws
executable and run the integration tests.

Note that this only requires py2exe if you run `python setup.py py2exe`.
Otherwise all the normal `setup.py develop/sdist` work just as before.

cc @garnaat
