### PR TITLE
Unregister event handler after docs are rendered

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -223,12 +223,13 @@ class HelpCommand(object):
 
     def __call__(self, args, parsed_globals):
         # Create an event handler for a Provider Document
-        self.EventHandlerClass(self)
+        instance = self.EventHandlerClass(self)
         # Now generate all of the events for a Provider document.
         # We pass ourselves along so that we can, in turn, get passed
         # to all event handlers.
         bcdoc.clidocevents.generate_events(self.session, self)
         self.renderer.render(self.doc.getvalue())
+        instance.unregister()
 
 
 class ProviderHelpCommand(HelpCommand):


### PR DESCRIPTION
This fixes the case where we're generating multiple docs
in a single invocation (such as html generation).  By
unregistering the event handler, a new instance can come
along and register itself as the object to use for new doc
events.

Don't have any tests for this currently, verified that manually building the html has the same output as the manpage version.
