### PR TITLE
Add a doc string to all --dry-run options.

### DIFF
--- a/awscli/customizations/dryrundocs.py
+++ b/awscli/customizations/dryrundocs.py
@@ -1,0 +1,30 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+Add a docstring to all --dryrun parameters.
+"""
+
+DOCS = ('<p>Checks whether you have the required permissions for the '
+        'action, without actually making the request.  '
+        'Using this option will result in one of two possible error'
+        'responses.  If you have the required permissions, the error '
+        'response will be <code>DryRunOperation</code>.  Otherwise '
+        'it will be <code>UnauthorizedOperation</code>.</p>')
+
+
+def register_dryrun_docs(cli):
+    cli.register('doc-option-example.ec2.*.dry-run', add_docs)
+
+
+def add_docs(help_command, **kwargs):
+    help_command.doc.include_doc_string(DOCS)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -34,6 +34,7 @@ from awscli.customizations.putmetricdata import register_put_metric_data
 from awscli.customizations.sessendemail import register_ses_send_email
 from awscli.customizations.iamvirtmfa import IAMVMFAWrapper
 from awscli.customizations.argrename import register_arg_renames
+from awscli.customizations.dryrundocs import register_dryrun_docs
 
 
 def awscli_initialize(event_handlers):
@@ -71,3 +72,4 @@ def awscli_initialize(event_handlers):
     register_ses_send_email(event_handlers)
     IAMVMFAWrapper(event_handlers)
     register_arg_renames(event_handlers)
+    register_dryrun_docs(event_handlers)

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -109,6 +109,11 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
         self.driver.main(['ec2', 'run-instances', 'help'])
         self.assert_contains('========\nExamples\n========')
 
+    def test_add_help_for_dryrun(self):
+        self.driver.main(['ec2', 'run-instances', 'help'])
+        self.assert_contains('DryRunOperation')
+        self.assert_contains('UnauthorizedOperation')
+        
 
 class TestRemoveDeprecatedCommands(BaseAWSHelpOutputTest):
     def assert_command_does_not_exist(self, service, command):


### PR DESCRIPTION
The `--dry-run` option to the EC2 commands has no doc string.  This adds one.
