### PR TITLE
Update reference in meta-docs

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -4,7 +4,7 @@ Building The Documentation
 
 The process for building the documention is:
 
-* Run ``rstgen`` which does the following:
+* Run ``htmlgen`` which does the following:
 
   * Generates all of the source reference ReST files.
   * Generates the ``aws_man_pages.json`` file which contains the list


### PR DESCRIPTION
rstgen was renamed to htmlgen in commit
22debac04de4daa8dd3f8375a36e9efac1b3767d, updating README accordingly.
