### PR TITLE
Don't shell out to rst2man

### DIFF
--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -77,33 +77,10 @@ class TestHelpPager(unittest.TestCase):
                          pager_cmd.split())
 
     @mock.patch('sys.exit', mock.Mock())
-    def test_with_rst2man_py_exists(self):
-        renderer = FakePosixHelpRenderer()
-        renderer.exists_on_path['rst2man.py'] = True
-        renderer.exists_on_path['rst2man'] = False
-        renderer.exists_on_path['groff'] = True
-        renderer.render('foo')
-        # First call should be to rst2man.py not rst2man
-        # List of tuples, so the first popen call's first position args
-        # first element is the cmdlist ['rst2man.py']
-        self.assertEqual(renderer.popen_calls[0][0][0], ['rst2man.py'])
-
-    @mock.patch('sys.exit', mock.Mock())
-    def test_with_rst2man_py_does_not_exist(self):
-        renderer = FakePosixHelpRenderer()
-        renderer.exists_on_path['rst2man.py'] = False
-        renderer.exists_on_path['rst2man'] = True
-        renderer.exists_on_path['groff'] = True
-        renderer.render('foo')
-        # First call should be to rst2man not rst2man.py
-        self.assertEqual(renderer.popen_calls[0][0][0], ['rst2man'])
-
-    @mock.patch('sys.exit', mock.Mock())
-    def test_no_rst2man_exists(self):
+    def test_no_groff_exists(self):
         renderer = FakePosixHelpRenderer()
         # Simulate neither rst2man.py nor rst2man existing on the path.
-        renderer.exists_on_path['rst2man.py'] = False
-        renderer.exists_on_path['rst2man'] = False
+        renderer.exists_on_path['groff'] = False
         with self.assertRaisesRegexp(ExecutableNotFoundError,
-                                     'Could not find executable named "rst2man.py"'):
+                                     'Could not find executable named "groff"'):
             renderer.render('foo')


### PR DESCRIPTION
This has proven to be problematic.  Instead use
the `manpage.Writer` object directly.

unit/integration tests passing.

Fixes #322.
