### PR TITLE
make license a short string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_options = dict(
     package_dir={'awscli': 'awscli'},
     package_data={'awscli': ['data/*.json', 'examples/*/*']},
     install_requires=requires,
-    license="Apache Software License 2.0",
+    license="Apache License 2.0",
     classifiers=(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
the license in setup.py is spec'd as a "short string", it should not have newlines:
http://docs.python.org/2/distutils/setupscript.html#additional-meta-data

otherwise you cannot build rpms:

$ python setup.py bdist --formats=rpm >/dev/null
warning: sdist: standard file not found: should have one of README, README.txt

error: line 14: Unknown tag: Licensed under the Apache License, Version 2.0 (the "License"). You
error: Package has no %description: awscli-1.0.0-1.x86_64
error: query of specfile build/bdist.macosx-10.8-intel/rpm/SPECS/awscli.spec failed, can't parse
error: Failed to execute: "rpm -q --qf '%{name}-%{version}-%{release}.src.rpm %{arch}/%{name}-%{version}-%{release}.%{arch}.rpm\n' --specfile 'build/bdist.macosx-10.8-intel/rpm/SPECS/awscli.spec'"
