### PR TITLE
Updated for the underlying multiple version support.

### DIFF
--- a/awscli/__init__.py
+++ b/awscli/__init__.py
@@ -22,14 +22,15 @@ __version__ = '1.3.1'
 #
 # Get our data path to be added to botocore's search path
 #
-_awscli_data_path = [
-    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
-]
+_awscli_data_path = []
 if 'AWS_DATA_PATH' in os.environ:
     for path in os.environ['AWS_DATA_PATH'].split(os.pathsep):
         path = os.path.expandvars(path)
         path = os.path.expanduser(path)
         _awscli_data_path.append(path)
+_awscli_data_path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+)
 os.environ['AWS_DATA_PATH'] = os.pathsep.join(_awscli_data_path)
 
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -25,7 +25,6 @@ from awscli.clidriver import create_clidriver
 from awscli.clidriver import CustomArgument
 from awscli.clidriver import CLIOperationCaller
 from botocore.hooks import HierarchicalEmitter
-from botocore.base import get_search_path
 from botocore.provider import Provider
 
 
@@ -293,7 +292,7 @@ class TestSearchPath(unittest.TestCase):
         # we have to force a reimport of the module to test our changes.
         six.moves.reload_module(awscli)
         # Our two overrides should be the last two elements in the search path.
-        search_path = get_search_path(driver.session)[-2:]
+        search_path = driver.session.loader.get_search_paths()[:-2]
         self.assertEqual(search_path, ['c:\\foo', 'c:\\bar'])
 
 


### PR DESCRIPTION
Updated the CLI to work with https://github.com/boto/botocore/pull/120. Most other uses of the older "cherry-pick-out-of-the-JSON" uses of `get_data` seem to no longer be there, so this is a pretty trivial patch. All tests passing.
