### PR TITLE
Bump rsa version to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ nose==1.3.0
 colorama==0.2.5
 mock==1.0.1
 httpretty==0.6.1
-rsa==3.1.1
+rsa==3.1.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requires = ['botocore>=0.16.0,<0.17.0',
             'six>=1.1.0',
             'colorama==0.2.5',
             'docutils>=0.10',
-            'rsa==3.1.1']
+            'rsa==3.1.2']
 
 if sys.version_info[:2] == (2, 6):
     # For python2.6 we have to require argparse since it


### PR DESCRIPTION
Fixes the issue with new setuptools and python3.

For more info see:
https://bitbucket.org/sybren/python-rsa/issue/17/pip-install-fails-on-python3-with-newer

Fixes #324.
