### PR TITLE
Switch py2exe includes to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,8 @@ if 'py2exe' in sys.argv:
         'py2exe': {
             'optimize': 0,
             'skip_archive': True,
-            'includes': ['ConfigParser', 'urllib', 'httplib',
-                         'docutils.readers.standalone',
-                         'docutils.parsers.rst',
-                         'docutils.languages.en',
-                         'xml.etree.ElementTree', 'HTMLParser',
-                         'awscli.handlers'],
+            'packages': ['docutils', 'urllib', 'httplib', 'HTMLParser',
+                         'awscli', 'ConfigParser', 'xml.etree'],
         }
     }
     setup_options['console'] = ['bin/aws']


### PR DESCRIPTION
That way we don't have to deal with issues where only parts
of a package are imported, and we don't have to worry about keeping
this up to date if we suddenly use a different part of a package
dynamically (e.g. docutils).
