### PR TITLE
fix the UnicodeDecodeError when sort the local files

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -86,7 +86,7 @@ class FileGenerator(object):
                     name.decode(sys.getdefaultencoding())
                     return True
                 except UnicodeDecodeError:
-                    print 'Bad filename: %s, Skip to upload' % name
+                    print ('Bad filename: %s, Skip to upload' % name)
                     return False
 
             names = [ x for x in listdir(path) if is_pass_decode_test(x) ]


### PR DESCRIPTION
I figured out the [s3 sync break by character decoding failed](https://github.com/aws/aws-cli/issues/378) is caused by sorted function. It will happen when 

```
sorted(os.list(u"some unicode path name"))
```

in the sorted function, it will call `filename.decode(...)` and go into trouble when special character in the filename.

My case looks like this:

```
(PYENV)[root@jp1 awscli]# aws s3 sync /usr/local/apache/htdocs/IGDmanual/zh_TW s3://muzee.ixd.foo/data_002 --cache-control 3600 
Bad filename: krazykar##.html, Skip to upload
```

I have no idea how to decode it correctly, but to skip the bad filename looks good to me.

ps. other projects also got troubles in it:
1. https://bugs.pypy.org/issue1035
2. https://bugs.launchpad.net/bzr/+bug/715547
