### PR TITLE
Use -r with less for help output

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -71,7 +71,7 @@ class PosixHelpRenderer(HelpRenderer):
     Linux and MacOS X.
     """
 
-    PAGER = 'less'
+    PAGER = 'less -R'
 
     def get_pager_cmdline(self):
         pager = self.PAGER


### PR DESCRIPTION
groff outputs control characters which less will display escaped by
default.  Since it's all safe (non-cursor moving) commands like bold,
underline, etc., by default allow less to process them with -r

![less-non-escaped](https://f.cloud.github.com/assets/108448/1251175/749ff7e6-2b1b-11e3-9e5d-e182158a253a.png)
