### PR TITLE
Use abspath if relpath fails (windows bug fix)

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -19,7 +19,7 @@ from awscli.customizations.s3.constants import MULTI_THRESHOLD, CHUNKSIZE, \
     NUM_THREADS, QUEUE_TIMEOUT_GET, MAX_UPLOAD_SIZE, \
     MAX_QUEUE_SIZE
 from awscli.customizations.s3.utils import NoBlockQueue, find_chunksize, \
-    operate, find_bucket_key
+    operate, find_bucket_key, relative_path
 from awscli.customizations.s3.executer import Executer
 from awscli.customizations.s3 import tasks
 
@@ -155,7 +155,7 @@ class S3Handler(object):
                 too_large = filename.size > MAX_UPLOAD_SIZE
             if too_large and filename.operation_name == 'upload':
                 warning = "Warning %s exceeds 5 TB and upload is " \
-                            "being skipped" % os.path.relpath(filename.src)
+                            "being skipped" % relative_path(filename.src)
                 self.result_queue.put({'message': warning, 'error': True})
             elif is_multipart_task and not self.params['dryrun']:
                 # If we're in dryrun mode, then we don't need the

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -6,7 +6,7 @@ import time
 import threading
 
 from awscli.customizations.s3.utils import find_bucket_key, MD5Error, \
-    operate, retrieve_http_etag, ReadFileChunk
+    operate, retrieve_http_etag, ReadFileChunk, relative_path
 
 
 LOGGER = logging.getLogger(__name__)
@@ -34,12 +34,12 @@ def print_operation(filename, failed, dryrun=False):
     if filename.src_type == "s3":
         print_str = print_str + "s3://" + filename.src
     else:
-        print_str += os.path.relpath(filename.src)
+        print_str += relative_path(filename.src)
     if filename.operation_name not in ["delete", "make_bucket", "remove_bucket"]:
         if filename.dest_type == "s3":
             print_str += " to s3://" + filename.dest
         else:
-            print_str += " to " + os.path.relpath(filename.dest)
+            print_str += " to " + relative_path(filename.dest)
     return print_str
 
 

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -180,6 +180,22 @@ def guess_content_type(filename):
     return mimetypes.guess_type(filename)[0]
 
 
+def relative_path(filename, start=os.path.curdir):
+    """Cross platform relative path of a filename.
+
+    If no relative path can be calculated (i.e different
+    drives on Windows), then instead of raising a ValueError,
+    the absolulate path is returned.
+
+    """
+    try:
+        dirname, basename = os.path.split(filename)
+        relative_dir = os.path.relpath(dirname, start)
+        return os.path.join(relative_dir, basename)
+    except ValueError:
+        return os.path.abspath(filename)
+
+
 class ReadFileChunk(object):
     def __init__(self, filename, start_byte, size):
         self._filename = filename

--- a/tests/unit/customizations/s3/test_tasks.py
+++ b/tests/unit/customizations/s3/test_tasks.py
@@ -13,9 +13,11 @@
 from tests import unittest
 import random
 import threading
+import mock
 
 from awscli.customizations.s3.tasks import MultipartUploadContext
 from awscli.customizations.s3.tasks import UploadCancelledError
+from awscli.customizations.s3.tasks import print_operation
 
 
 class TestMultipartUploadContext(unittest.TestCase):
@@ -227,3 +229,15 @@ class TestMultipartUploadContext(unittest.TestCase):
 
         # And we should have seen an exception being raised.
         self.assertIsInstance(self.caught_exception, UploadCancelledError)
+
+
+class TestPrintOperation(unittest.TestCase):
+    def test_print_operation(self):
+        filename = mock.Mock()
+        filename.operation_name = 'upload'
+        filename.src = r'e:\foo'
+        filename.src_type = 'local'
+        filename.dest = r's3://foo'
+        filename.dest_type = 's3'
+        message = print_operation(filename, failed=False)
+        self.assertIn(r'e:\foo', message)


### PR DESCRIPTION
If I'm syncing a directory of d:\something and my cwd is c:\something
then os.path.relpath complains that it can't work out a relative path.
When this happens, we just use the abspath instead.
