### PR TITLE
Backout update to requests 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ Sphinx==1.1.3
 nose==1.3.0
 colorama==0.2.5
 mock==1.0.1
-httpretty==0.7.0
+httpretty==0.6.1
 rsa==3.1.2


### PR DESCRIPTION
Requests 2.0.0 requires httpretty 0.7.0 but that seems to be broken on Python 3.3.  Backing out for now until we resolve the httpretty dependency.
