### PR TITLE
Correct output for authorize-security-group-ingress

### DIFF
--- a/awscli/examples/ec2/authorize-security-group-ingress.rst
+++ b/awscli/examples/ec2/authorize-security-group-ingress.rst
@@ -9,29 +9,9 @@ Command::
 Output::
 
   {
-      "SecurityGroups": [
-          {
-              "IpPermissionsEgress": [],
-              "Description": "My security group"
-              "IpPermissions": [
-                  {
-                      "ToPort": 22,
-                      "IpProtocol": "tcp",
-                      "IpRanges": [
-                          {
-                              "CidrIp": "203.0.113.0/24"
-                          }
-                      ]
-                      "UserIdGroupPairs": [],
-                      "FromPort": 22
-                  }
-              ],
-              "GroupName": "MySecurityGroup",
-              "OwnerId": "123456789012",
-              "GroupId": "sg-903004f8"
-          }
-      ]
+      "return": "true"
   }
+
 
 For more information, see `Using Security Groups`_ in the *AWS Command Line Interface User Guide*.
 


### PR DESCRIPTION
Verified that we just a return value of `{"return": "true"}`.
This also syncs up with the API docs:
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-AuthorizeSecurityGroupIngress.html#ApiReference-query-AuthorizeSecurityGroupIngress-Response
