### PR TITLE
Implement seek for read file parts

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -216,6 +216,10 @@ class ReadFileChunk(object):
             self._amount_read += actual_amount
             return data
 
+    def seek(self, where):
+        self._fileobj.seek(self._start_byte + where)
+        self._amount_read = where
+
     def close(self):
         self._fileobj.close()
 

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -108,6 +108,16 @@ class TestReadFileChunk(unittest.TestCase):
         self.assertEqual(chunk.read(1), b'r')
         self.assertEqual(chunk.read(1), b'')
 
+    def test_reset_stream_emulation(self):
+        filename = os.path.join(self.tempdir, 'foo')
+        f = open(filename, 'wb')
+        f.write(b'onetwothreefourfivesixseveneightnineten')
+        f.flush()
+        chunk = ReadFileChunk(filename, start_byte=11, size=4)
+        self.assertEqual(chunk.read(), b'four')
+        chunk.seek(0)
+        self.assertEqual(chunk.read(), b'four')
+
     def test_read_past_end_of_file(self):
         filename = os.path.join(self.tempdir, 'foo')
         f = open(filename, 'wb')


### PR DESCRIPTION
So that an upload part can be rewound and therefore
properly retried.

Fixes #401.

Also needed https://github.com/boto/botocore/pull/158 to
fully fix this issue.  The botocore PR tries to rewind a stream
on retries, this PR implement seek for a read file part object
sp it can be reset.
