### PR TITLE
Fix text output for single scalar value

### DIFF
--- a/awscli/text.py
+++ b/awscli/text.py
@@ -44,6 +44,11 @@ def _format_text(item, stream, identifier=None, scalar_keys=None):
             # For a bare list, just print the contents.
             stream.write('\t'.join([six.text_type(el) for el in item]))
             stream.write('\n')
+    else:
+        # If it's not a list or a dict, we just write the scalar
+        # value out directly.
+        stream.write(item)
+        stream.write('\n')
 
 
 def _all_scalar_keys(list_of_dicts):

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -111,6 +111,9 @@ class TestSection(unittest.TestCase):
         self.assert_text_renders_to([['1', '2', u'\u2713']],
                                     u'1\t2\t\u2713\n')
 
+    def test_single_scalar_value(self):
+        self.assert_text_renders_to('foobarbaz', 'foobarbaz\n')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes the case where a `--query` arg produces a single
scalar value.  For example, this now works as expected:

```
  $ aws ec2 create-key-pair --key-name testkey --query KeyMaterial --output text > ~/.ssh/foobar.pem
```

cc @petermoon
