### PR TITLE
Use shlex.split to properly split cmd args for pager

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -14,6 +14,7 @@ import sys
 import logging
 import os
 import platform
+import shlex
 from subprocess import Popen, PIPE
 
 from docutils.core import publish_string
@@ -79,7 +80,7 @@ class PosixHelpRenderer(HelpRenderer):
             pager = os.environ['MANPAGER']
         elif 'PAGER' in os.environ:
             pager = os.environ['PAGER']
-        return pager.split()
+        return shlex.split(pager)
 
     def render(self, contents):
         man_contents = publish_string(contents, writer=manpage.Writer())

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -86,3 +86,9 @@ class TestHelpPager(unittest.TestCase):
         with self.assertRaisesRegexp(ExecutableNotFoundError,
                                      'Could not find executable named "groff"'):
             renderer.render('foo')
+
+    def test_shlex_split_for_pager_var(self):
+        pager_cmd = '/bin/sh -c "col -bx | vim -c \'set ft=man\' -"'
+        os.environ['PAGER'] = pager_cmd
+        self.assertEqual(self.renderer.get_pager_cmdline(),
+                         ['/bin/sh', '-c', "col -bx | vim -c 'set ft=man' -"])


### PR DESCRIPTION
Fixes #393, verified that:

```
/bin/sh -c "col -bx | vim -c 'set ft=man' -"
```

Works for MANPAGER and aws help.
