### PR TITLE
Remove group-id from the list of incompatible fields in validation.

### DIFF
--- a/awscli/customizations/ec2secgroupsimplify.py
+++ b/awscli/customizations/ec2secgroupsimplify.py
@@ -48,12 +48,11 @@ def _check_args(parsed_args, **kwargs):
     # raise an error.
     arg_dict = vars(parsed_args)
     if arg_dict['ip_permissions']:
-        for key in ('protocol', 'group_id', 'port', 'cidr',
+        for key in ('protocol', 'port', 'cidr',
                     'source_group', 'group_owner'):
             if arg_dict[key]:
-                msg = ('Mixing the --ip-permissions option '
-                       'with the simple, scalar options is '
-                       'not recommended.')
+                msg = ('The --%s option is not compatible '
+                       'with the --ip-permissions option ') % key
                 raise ValueError(msg)
 
 def _add_docs(help_command, **kwargs):

--- a/tests/unit/ec2/test_security_group_operations.py
+++ b/tests/unit/ec2/test_security_group_operations.py
@@ -68,6 +68,17 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                   'IpPermissions.1.IpRanges.1.CidrIp': '192.168.100.0/24'}
         self.assert_params_for_cmd(args_list, result)
 
+    def test_ip_permissions_with_group_id(self):
+        json = """[{"FromPort":8000,"ToPort":9000,"IpProtocol":"tcp","IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]"""
+        args = ' --group-id sg-12345678 --ip-permissions %s' % json
+        args_list = (self.prefix + args).split()
+        result = {'GroupId': 'sg-12345678',
+                  'IpPermissions.1.FromPort': '8000',
+                  'IpPermissions.1.ToPort': '9000',
+                  'IpPermissions.1.IpProtocol': 'tcp',
+                  'IpPermissions.1.IpRanges.1.CidrIp': '192.168.100.0/24'}
+        self.assert_params_for_cmd(args_list, result)
+
     def test_both(self):
         captured = cStringIO()
         json = """[{"FromPort":8000,"ToPort":9000,"IpProtocol":"tcp","IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]"""


### PR DESCRIPTION
  Fixes #435.
