### PR TITLE
Add a "configure" top level command

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -90,40 +90,28 @@ class ServiceArgParser(CLIArgParser):
         self.add_argument('operation', choices=list(operations_table.keys()))
 
 
-class OperationArgParser(CLIArgParser):
-    Formatter = argparse.RawTextHelpFormatter
+class ArgTableArgParser(CLIArgParser):
+    """CLI arg parser based on an argument table."""
     Usage = ("aws [options] <command> <subcommand> [parameters]")
 
-    type_map = {
-        'structure': str,
-        'map': str,
-        'timestamp': str,
-        'list': str,
-        'string': str,
-        'float': float,
-        'integer': str,
-        'long': int,
-        'boolean': bool,
-        'double': float,
-        'blob': str}
-
-    def __init__(self, argument_table, name):
-        super(OperationArgParser, self).__init__(
+    def __init__(self, argument_table):
+        super(ArgTableArgParser, self).__init__(
             formatter_class=self.Formatter,
             add_help=False,
             usage=self.Usage,
             conflict_handler='resolve')
-        self._build(argument_table, name)
+        self._build(argument_table)
 
-    def _build(self, argument_table, name):
+    def _build(self, argument_table):
         for arg_name in argument_table:
             argument = argument_table[arg_name]
             argument.add_to_parser(self)
 
-    def parse_known_args(self, args):
+    def parse_known_args(self, args, namespace=None):
         if len(args) == 1 and args[0] == 'help':
             namespace = argparse.Namespace()
             namespace.help = 'help'
             return namespace, []
         else:
-            return super(OperationArgParser, self).parse_known_args(args)
+            return super(ArgTableArgParser, self).parse_known_args(
+                args, namespace)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -23,7 +23,7 @@ from awscli.formatter import get_formatter
 from awscli.plugin import load_plugins
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
-from awscli.argparser import OperationArgParser
+from awscli.argparser import ArgTableArgParser
 from awscli.help import ProviderHelpCommand
 from awscli.help import ServiceHelpCommand
 from awscli.help import OperationHelpCommand
@@ -247,6 +247,10 @@ class CLICommand(object):
         # help docs.
         return None
 
+    @property
+    def arg_table(self):
+        return {}
+
 
 class ServiceCommand(CLICommand):
     """A service command for the CLI.
@@ -467,7 +471,7 @@ class ServiceOperation(object):
         return session.emit(name, **kwargs)
 
     def _create_operation_parser(self, arg_table):
-        parser = OperationArgParser(arg_table, self._name)
+        parser = ArgTableArgParser(arg_table)
         return parser
 
 

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -1,0 +1,171 @@
+from bcdoc.clidocs import CLIDocumentEventHandler
+import bcdoc.clidocevents
+
+from awscli.argparser import ArgTableArgParser
+from awscli.clidriver import CLICommand
+from awscli.arguments import CustomArgument
+from awscli.help import HelpCommand
+
+
+class BasicCommand(CLICommand):
+    """Basic top level command with no subcommands.
+
+    If you want to create a new command, subclass this and
+    provide the values documented below.
+
+    """
+
+    # This is the name of your command, so if you want to
+    # create an 'aws mycommand ...' command, the NAME would be
+    # 'mycommand'
+    NAME = 'commandname'
+    # This is the description that will be used for the 'help'
+    # command.
+    DESCRIPTION = 'describe the command'
+    # This is optional, if you are fine with the default synopsis
+    # (the way all the built in operations are documented) then you
+    # can leave this empty.
+    SYNOPSIS = ''
+    # If you want to provide some hand written examples, you can do
+    # so here.  This is written in RST format.  This is optional,
+    # you don't have to provide any examples, though highly encouraged!
+    EXAMPLES = ''
+    # If your command has arguments, you can specify them here.  This is
+    # somewhat of an implementation detail, but this is a list of dicts
+    # where the dicts match the kwargs of the CustomArgument's __init__.
+    # For example, if I want to add a '--argument-one' and an
+    # '--argument-two' command, I'd say:
+    #
+    # ARG_TABLE = [
+    #     {'name': 'argument-one', 'help_text': 'This argument does foo bar.',
+    #      'action': 'store', 'required': False, 'cli_type_name': 'string',},
+    #     {'name': 'argument-two', 'help_text': 'This argument does some other thing.',
+    #      'action': 'store', 'choices': ['a', 'b', 'c']},
+    # ]
+    ARG_TABLE = []
+
+    # At this point, the only other thing you have to implement is a _run_main
+    # method (see the method for more information).
+
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self, args, parsed_globals):
+        # args is the remaining unparsed args.
+        # We might be able to parse these args so we need to create
+        # an arg parser and parse them.
+        parser = ArgTableArgParser(self.arg_table)
+        parsed_args = parser.parse_args(args)
+        if hasattr(parsed_args, 'help'):
+            self._display_help(parsed_args, parsed_globals)
+        else:
+            self._run_main(parsed_args, parsed_globals)
+
+    def _run_main(self, parsed_args, parsed_globals):
+        # Subclasses should implement this method.
+        # parsed_globals are the parsed global args (things like region,
+        # profile, output, etc.)
+        # parsed_args are any arguments you've defined in your ARG_TABLE
+        # that are parsed.  These will come through as whatever you've
+        # provided as the 'dest' key.  Otherwise they default to the
+        # 'name' key.  For example: ARG_TABLE[0] = {"name": "foo-arg", ...}
+        # can be accessed by ``parsed_args.foo_arg``.
+        raise NotImlementedError("_run_main")
+
+    def _display_help(self, parsed_args, parsed_globals):
+        help_command = self.create_help_command()
+        help_command(parsed_args, parsed_globals)
+
+    def create_help_command(self):
+        return BasicHelp(self._session, self, command_table={},
+                         arg_table=self.arg_table)
+
+    @property
+    def arg_table(self):
+        arg_table = {}
+        for arg_data in self.ARG_TABLE:
+            custom_argument = CustomArgument(**arg_data)
+            arg_table[arg_data['name']] = custom_argument
+        return arg_table
+
+    @classmethod
+    def add_command(cls, command_table, session, **kwargs):
+        command_table[cls.NAME] = cls(session)
+
+
+class BasicHelp(HelpCommand):
+    event_class = 'command'
+
+    def __init__(self, session, command_object, command_table, arg_table,
+                 event_handler_class=None):
+        super(BasicHelp, self).__init__(session, command_object,
+                                        command_table, arg_table)
+        # This is defined in HelpCommand so we're matching the
+        # casing here.
+        if event_handler_class is None:
+            event_handler_class=BasicDocHandler
+        self.EventHandlerClass = event_handler_class
+
+        # These are public attributes that are mapped from the command
+        # object.  These are used by the BasicDocHandler below.
+        self.description = command_object.DESCRIPTION
+        self.synopsis = command_object.SYNOPSIS
+        self.examples = command_object.EXAMPLES
+
+    @property
+    def name(self):
+        return self.obj.NAME
+
+    def __call__(self, args, parsed_globals):
+        # Create an event handler for a Provider Document
+        instance = self.EventHandlerClass(self)
+        # Now generate all of the events for a Provider document.
+        # We pass ourselves along so that we can, in turn, get passed
+        # to all event handlers.
+        bcdoc.clidocevents.generate_events(self.session, self)
+        self.renderer.render(self.doc.getvalue())
+        instance.unregister()
+
+
+class BasicDocHandler(CLIDocumentEventHandler):
+    def __init__(self, help_command):
+        super(BasicDocHandler, self).__init__(help_command)
+        self.doc = help_command.doc
+
+    def doc_description(self, help_command, **kwargs):
+        self.doc.style.h2('Description')
+        self.doc.write(help_command.description)
+        self.doc.style.new_paragraph()
+
+    def doc_synopsis_start(self, help_command, **kwargs):
+        if not help_command.synopsis:
+            super(BasicDocHandler, self).doc_synopsis_start(
+                help_command=help_command, **kwargs)
+        else:
+            self.doc.style.h2('Synopsis')
+            self.doc.style.start_codeblock()
+            self.doc.writeln(help_command.synopsis)
+
+    def doc_synopsis_end(self, help_command, **kwargs):
+        if not help_command.synopsis:
+            super(BasicDocHandler, self).doc_synopsis_end(
+                help_command=help_command, **kwargs)
+        else:
+            self.doc.style.end_codeblock()
+
+    def doc_option_example(self, arg_name, help_command, **kwargs):
+        pass
+
+    def doc_examples(self, help_command, **kwargs):
+        if help_command.examples:
+            self.doc.style.h2('Examples')
+            self.doc.write(help_command.examples)
+
+    def doc_subitems_start(self, help_command, **kwargs):
+        pass
+
+    def doc_subitem(self, command_name, help_command, **kwargs):
+        pass
+
+    def doc_subitems_end(self, help_command, **kwargs):
+        pass

--- a/awscli/customizations/configure.py
+++ b/awscli/customizations/configure.py
@@ -1,0 +1,237 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import re
+import logging
+
+import six
+from botocore.exceptions import ProfileNotFound
+
+from awscli.customizations.commands import BasicCommand
+
+
+try:
+    raw_input = raw_input
+except NameError:
+    raw_input = input
+
+
+logger = logging.getLogger(__name__)
+
+
+def register_configure_cmd(cli):
+    cli.register('building-command-table.main',
+                 ConfigureCommand.add_command)
+
+def add_configure_cmd(command_table, session, **kwargs):
+    command_table['configure'] = ConfigureCommand(session)
+
+
+class SectionNotFoundError(Exception):
+    pass
+
+
+class InteractivePrompter(object):
+    def get_value(self, current_value, config_name, prompt_text=''):
+        if config_name in ('aws_access_key_id', 'aws_secret_access_key'):
+            current_value = self._mask_value(current_value)
+        response = raw_input("%s [%s]: " % (prompt_text, current_value))
+        if not response:
+            # If the user hits enter, we return a value of None
+            # instead of an empty string.  That way we can determine
+            # whether or not a value has changed.
+            response = None
+        return response
+
+    def _mask_value(self, current_value):
+        if current_value is None:
+            return 'None'
+        else:
+            return ('*' * 16) +  current_value[-4:]
+
+
+class ConfigFileWriter(object):
+    SECTION_REGEX = re.compile(r'\[(?P<header>[^]]+)\]')
+    OPTION_REGEX = re.compile(
+        r'(?P<option>[^:=\s][^:=]*)'
+        r'\s*(?P<vi>[:=])\s*'
+        r'(?P<value>.*)$'
+    )
+
+    def update_config(self, new_values, config_filename):
+        section_name = new_values.pop('__section__', 'default')
+        if not os.path.isfile(config_filename):
+            self._create_file(config_filename)
+            self._write_new_section(section_name, new_values, config_filename)
+            return
+        with open(config_filename, 'r') as f:
+            contents = f.readlines()
+        # We can only update a single section at a time so we first need
+        # to find the section in question
+        try:
+            self._update_section_contents(contents, section_name, new_values)
+            with open(config_filename, 'w') as f:
+                f.write(''.join(contents))
+        except SectionNotFoundError:
+            self._write_new_section(section_name, new_values, config_filename)
+
+    def _create_file(self, config_filename):
+        # Create the file as well as the parent dir if needed.
+        dirname, basename = os.path.split(config_filename)
+        if not os.path.isdir(dirname):
+            os.makedirs(dirname)
+        with open(config_filename, 'w') as f:
+            pass
+
+    def _write_new_section(self, section_name, new_values, config_filename):
+        with open(config_filename, 'a') as f:
+            f.write('[%s]\n' % section_name)
+            for key, value in new_values.items():
+                f.write('%s = %s\n' % (key, value))
+
+    def _update_section_contents(self, contents, section_name, new_values):
+        new_values = new_values.copy()
+        # contents is a list of file line contents.
+        start_index = 0
+        for i in range(len(contents)):
+            line = contents[i]
+            match = self.SECTION_REGEX.search(line)
+            if match is not None and self._matches_section(match,
+                                                           section_name):
+                break
+        else:
+            raise SectionNotFoundError(section_name)
+        # If we get here, then we've found the section.  We now need
+        # to figure out if we're updating a value or adding a new value.
+        i += 1
+        last_matching_line = i
+        for j in range(i, len(contents)):
+            line = contents[j]
+            match = self.OPTION_REGEX.search(line)
+            if match is not None:
+                last_matching_line = j
+                key_name = match.group(1).strip()
+                if key_name in new_values:
+                    new_line = '%s = %s\n' % (key_name, new_values[key_name])
+                    contents[j] = new_line
+                    del new_values[key_name]
+            elif self.SECTION_REGEX.search(line) is not None:
+                # We've hit a new section which means the config key is
+                # not in the section.  We need to add it here.
+                self._insert_new_values(line_number=last_matching_line,
+                                        contents=contents,
+                                        new_values=new_values)
+                return
+
+        if new_values:
+            if not contents[-1].endswith('\n'):
+                contents.append('\n')
+            self._insert_new_values(line_number=last_matching_line + 1,
+                                    contents=contents,
+                                    new_values=new_values)
+
+    def _insert_new_values(self, line_number, contents, new_values):
+        new_contents = []
+        for key, value in new_values.items():
+            new_contents.append('%s = %s\n' % (key, value))
+        contents.insert(line_number + 1, ''.join(new_contents))
+
+    def _matches_section(self, match, section_name):
+        parts = section_name.split(' ')
+        unquoted_match = match.group(0) == '[%s]' % section_name
+        if len(parts) > 1:
+            quoted_match = match.group(0) == '[%s "%s"]' % (
+                parts[0], ' '.join(parts[1:]))
+            return unquoted_match or quoted_match
+        return unquoted_match
+
+
+class ConfigureCommand(BasicCommand):
+    NAME = 'configure'
+    DESCRIPTION = (
+        'Configure AWS CLI configuration data.  If this command '
+        'is run with no arguments, you will be prompted for configuration '
+        'values such as your AWS Access Key Id and you AWS Secret Access '
+        'Key.  You can configure a specific profile using the ``--profile`` '
+        'argument.  If your config file does not exist (the default location '
+        'is ``~/.aws/config``), it will be automatically created for you. '
+        'To keep an existing value, hit enter when prompted for the value.\n\n'
+        'When you are prompted for information, the current value will be '
+        'displayed in ``[brackets]``.  If the config item has no value, it '
+        'be displayed as ``[None]``.\n\n'
+        'Note that the ``configure`` command only work with values from the '
+        'config file.  It does not use any configuration values from '
+        'environment variables or the IAM role.\n'
+    )
+    SYNOPSIS = ('aws configure [--profile profile-name]')
+    EXAMPLES = (
+        'To create a new configuration::\n'
+        '\n'
+        '    $ aws configure\n'
+        '    AWS Access Key ID [None]: accesskey\n'
+        '    AWS Secret Access Key [None]: secretkey\n'
+        '    Default region name [None]: us-west-2\n'
+        '    Default output format [None]:\n'
+        '\n'
+        'To update just the region name::\n'
+        '\n'
+        '    $ aws configure\n'
+        '    AWS Access Key ID [****]:\n'
+        '    AWS Secret Access Key [****]:\n'
+        '    Default region name [us-west-1]: us-west-2\n'
+        '    Default output format [None]:\n'
+    )
+
+    # If you want to add new values to prompt, update this list here.
+    VALUES_TO_PROMPT = [
+        # (logical_name, config_name, prompt_text)
+        ('aws_access_key_id', "AWS Access Key ID"),
+        ('aws_secret_access_key', "AWS Secret Access Key"),
+        ('region', "Default region name"),
+        ('output', "Default output format"),
+    ]
+
+    def __init__(self, session, prompter=None, config_writer=None):
+        self._session = session
+        if prompter is None:
+            prompter = InteractivePrompter()
+        self._prompter = prompter
+        if config_writer is None:
+            config_writer = ConfigFileWriter()
+        self._config_writer = config_writer
+
+    def _run_main(self, parsed_args, parsed_globals):
+        # Called when invoked with no args "aws configure"
+        new_values = {}
+        if parsed_globals.profile is not None:
+            profile = parsed_globals.profile
+            self._session.profile = parsed_globals.profile
+        # This is the config from the config file scoped to a specific
+        # profile.
+        try:
+            config = self._session.get_config()
+        except ProfileNotFound:
+            config = {}
+        for config_name, prompt_text in self.VALUES_TO_PROMPT:
+            current_value = config.get(config_name)
+            new_value = self._prompter.get_value(current_value, config_name,
+                                                 prompt_text)
+            if new_value is not None and new_value != current_value:
+                new_values[config_name] = new_value
+        config_filename = os.path.expanduser(
+            self._session.get_variable('config_file'))
+        if new_values:
+            if parsed_globals.profile is not None:
+                new_values['__section__'] = (
+                    'profile %s' % parsed_globals.profile)
+            self._config_writer.update_config(new_values, config_filename)

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -16,7 +16,8 @@ import six
 import sys
 
 import awscli
-from awscli.argparser import ServiceArgParser, OperationArgParser
+from awscli.arguments import BaseCLIArgument
+from awscli.argparser import ServiceArgParser, ArgTableArgParser
 from awscli.help import HelpCommand
 from awscli.customizations import utils
 from awscli.customizations.s3.comparator import Comparator
@@ -374,16 +375,16 @@ class S3SubCommand(object):
 
     def _create_operation_parser(self, parameter_table):
         """
-        This creates the OperationArgParser for the command.  It adds
+        This creates the ArgTableArgParser for the command.  It adds
         an extra argument to the parser, paths, which represents a required
         the number of positional argument that must follow the command's name.
         """
-        parser = OperationArgParser(parameter_table, self._name)
+        parser = ArgTableArgParser(parameter_table)
         parser.add_argument("paths", **self.options)
         return parser
 
 
-class S3Parameter(object):
+class S3Parameter(BaseCLIArgument):
     """
     This is a class that is used to add a parameter to the the parser along
     with its respective actions, dest, etc.
@@ -391,7 +392,11 @@ class S3Parameter(object):
     def __init__(self, name, options, documentation=''):
         self._name = name
         self.options = options
-        self.documentation = documentation
+        self._documentation = documentation
+
+    @property
+    def documentation(self):
+        return self._documentation
 
     def add_to_parser(self, parser):
         parser.add_argument('--'+self._name, **self.options)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -36,6 +36,7 @@ from awscli.customizations.iamvirtmfa import IAMVMFAWrapper
 from awscli.customizations.argrename import register_arg_renames
 from awscli.customizations.dryrundocs import register_dryrun_docs
 from awscli.customizations.route53resourceid import register_resource_id
+from awscli.customizations.configure import register_configure_cmd
 
 
 def awscli_initialize(event_handlers):
@@ -75,3 +76,4 @@ def awscli_initialize(event_handlers):
     register_arg_renames(event_handlers)
     register_dryrun_docs(event_handlers)
     register_resource_id(event_handlers)
+    register_configure_cmd(event_handlers)

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -189,7 +189,11 @@ class HelpCommand(object):
     def __init__(self, session, obj, command_table, arg_table):
         self.session = session
         self.obj = obj
+        if command_table is None:
+            command_table = {}
         self.command_table = command_table
+        if arg_table is None:
+            arg_table = {}
         self.arg_table = arg_table
         self.renderer = get_renderer()
         self.doc = ReSTDocument(target='man')

--- a/tests/unit/customizations/test_configure.py
+++ b/tests/unit/customizations/test_configure.py
@@ -1,0 +1,415 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+from tests import BaseAWSHelpOutputTest
+import os
+import tempfile
+import shutil
+
+import mock
+from botocore.exceptions import ProfileNotFound
+
+from awscli.customizations import configure
+
+
+
+class PrecannedPrompter(object):
+    def __init__(self, value):
+        self._value = value
+
+    def get_value(self, current_value, logical_name, prompt_text=''):
+        return self._value
+
+
+class EchoPrompter(object):
+    def get_value(self, current_value, logical_name, prompt_text=''):
+        return current_value
+
+
+class KeyValuePrompter(object):
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get_value(self, current_value, config_name, prompt_text=''):
+        return self.mapping.get(prompt_text)
+
+
+class FakeSession(object):
+    def __init__(self, variables, profile_does_not_exist=False):
+        self.variables = variables
+        self.profile_does_not_exist = profile_does_not_exist
+        self.config = {}
+
+    def get_config(self):
+        if self.profile_does_not_exist:
+            raise ProfileNotFound(profile='foo')
+        return self.config
+
+    def get_variable(self, name, methods=None):
+        if self.profile_does_not_exist and not name == 'config_file':
+            raise ProfileNotFound(profile='foo')
+        return self.variables.get(name)
+
+
+class TestConfigureCommand(unittest.TestCase):
+    def setUp(self):
+        self.writer = mock.Mock()
+        self.global_args = mock.Mock()
+        self.global_args.profile = None
+        self.precanned = PrecannedPrompter(value='new_value')
+        self.session = FakeSession({'config_file': 'myconfigfile'})
+        self.configure = configure.ConfigureCommand(self.session,
+                                                    prompter=self.precanned,
+                                                    config_writer=self.writer)
+
+    def test_configure_command_sends_values_to_writer(self):
+        self.configure(args=[], parsed_globals=self.global_args)
+        self.writer.update_config.assert_called_with(
+            {'aws_access_key_id': 'new_value',
+             'aws_secret_access_key': 'new_value',
+             'region': 'new_value',
+             'output': 'new_value'}, 'myconfigfile')
+
+    def test_same_values_are_not_changed(self):
+        # If the user enters the same value as the current value, we don't need
+        # to write anything to the config.
+        self.configure = configure.ConfigureCommand(self.session,
+                                                    prompter=EchoPrompter(),
+                                                    config_writer=self.writer)
+        self.configure(args=[], parsed_globals=self.global_args)
+        self.assertFalse(self.writer.update_config.called)
+
+    def test_none_values_are_not_changed(self):
+        # If a user hits enter, this will result in a None value which means
+        # don't change the existing values.  In this case, we don't need
+        # to write anything out to the config.
+        user_presses_enter = None
+        precanned = PrecannedPrompter(value=user_presses_enter)
+        self.configure = configure.ConfigureCommand(self.session,
+                                                    prompter=precanned,
+                                                    config_writer=self.writer)
+        self.configure(args=[], parsed_globals=self.global_args)
+        self.assertFalse(self.writer.update_config.called)
+
+    def test_create_configure_cmd_session_only(self):
+        self.configure = configure.ConfigureCommand(self.session)
+        self.assertIsInstance(self.configure, configure.ConfigureCommand)
+
+    def test_some_values_changed(self):
+        # Test the case where the user only wants to change a single_value.
+        user_presses_enter = None
+        responses = {
+            "AWS Access Key ID": None,
+            "AWS Secert Access Key": None,
+            "Default region name": None,
+            "Default output format": "NEW OUTPUT FORMAT",
+        }
+        prompter = KeyValuePrompter(responses)
+        self.configure = configure.ConfigureCommand(self.session, prompter=prompter,
+                                                    config_writer=self.writer)
+        self.configure(args=[], parsed_globals=self.global_args)
+
+        # We only need to write out the default output format.
+        self.writer.update_config.assert_called_with(
+            {'output': 'NEW OUTPUT FORMAT'}, 'myconfigfile')
+
+    def test_section_name_can_be_changed_for_profiles(self):
+        # If the user specifies "--profile myname" we need to write
+        # this out to the [profile myname] section.
+        self.global_args.profile = 'myname'
+        self.configure(args=[], parsed_globals=self.global_args)
+        # Note the __section__ key name.
+        self.writer.update_config.assert_called_with(
+            {'__section__': 'profile myname',
+             'aws_access_key_id': 'new_value',
+             'aws_secret_access_key': 'new_value',
+             'region': 'new_value',
+             'output': 'new_value'}, 'myconfigfile')
+
+    def test_session_says_profile_does_not_exist(self):
+        # Whenever you try to get a config value from botocore,
+        # it will raise an exception complaining about ProfileNotFound.
+        # We should handle this case, and write out a new profile section
+        # in the config file.
+        session = FakeSession({'config_file': 'myconfigfile'},
+                              profile_does_not_exist=True)
+        self.configure = configure.ConfigureCommand(session,
+                                                    prompter=self.precanned,
+                                                    config_writer=self.writer)
+        self.global_args.profile = 'profile-does-not-exist'
+        self.configure(args=[], parsed_globals=self.global_args)
+        self.writer.update_config.assert_called_with(
+            {'__section__': 'profile profile-does-not-exist',
+             'aws_access_key_id': 'new_value',
+             'aws_secret_access_key': 'new_value',
+             'region': 'new_value',
+             'output': 'new_value'}, 'myconfigfile')
+
+
+class TestInteractivePrompter(unittest.TestCase):
+    @mock.patch('awscli.customizations.configure.raw_input')
+    def test_access_key_is_masked(self, mock_raw_input):
+        mock_raw_input.return_value = 'foo'
+        prompter = configure.InteractivePrompter()
+        response = prompter.get_value(
+            current_value='myaccesskey', config_name='aws_access_key_id',
+            prompt_text='Access key')
+        # First we should return the value from raw_input.
+        self.assertEqual(response, 'foo')
+        # We should also not display the entire access key.
+        prompt_text = mock_raw_input.call_args[0][0]
+        self.assertNotIn('myaccesskey', prompt_text)
+        self.assertRegexpMatches(prompt_text, r'\[\*\*\*\*.*\]')
+
+    @mock.patch('awscli.customizations.configure.raw_input')
+    def test_access_key_not_masked_when_none(self, mock_raw_input):
+        mock_raw_input.return_value = 'foo'
+        prompter = configure.InteractivePrompter()
+        response = prompter.get_value(
+            current_value=None, config_name='aws_access_key_id',
+            prompt_text='Access key')
+        # First we should return the value from raw_input.
+        self.assertEqual(response, 'foo')
+        prompt_text = mock_raw_input.call_args[0][0]
+        self.assertIn('[None]', prompt_text)
+
+    @mock.patch('awscli.customizations.configure.raw_input')
+    def test_secret_key_is_masked(self, mock_raw_input):
+        prompter = configure.InteractivePrompter()
+        response = prompter.get_value(
+            current_value='mysupersecretkey',
+            config_name='aws_secret_access_key',
+            prompt_text='Secret Key')
+        # We should also not display the entire secret key.
+        prompt_text = mock_raw_input.call_args[0][0]
+        self.assertNotIn('mysupersecretkey', prompt_text)
+        self.assertRegexpMatches(prompt_text, r'\[\*\*\*\*.*\]')
+
+    @mock.patch('awscli.customizations.configure.raw_input')
+    def test_non_secret_keys_are_not_masked(self, mock_raw_input):
+        prompter = configure.InteractivePrompter()
+        response = prompter.get_value(
+            current_value='mycurrentvalue', config_name='not_a_secret_key',
+            prompt_text='Enter value')
+        # We should also not display the entire secret key.
+        prompt_text = mock_raw_input.call_args[0][0]
+        self.assertIn('mycurrentvalue', prompt_text)
+        self.assertRegexpMatches(prompt_text, r'\[mycurrentvalue\]')
+
+
+class TestConfigFileWriter(unittest.TestCase):
+    def setUp(self):
+        self.dirname = tempfile.mkdtemp()
+        self.config_filename = os.path.join(self.dirname, 'config')
+        self.writer = configure.ConfigFileWriter()
+
+    def tearDown(self):
+        shutil.rmtree(self.dirname)
+
+    def assert_update_config(self, original_config_contents, updated_data,
+                             updated_config_contents):
+        # Given the original_config, when it's updated with update_data,
+        # it should produce updated_config_contents.
+        with open(self.config_filename, 'w') as f:
+            f.write(original_config_contents)
+        self.writer.update_config(updated_data, self.config_filename)
+        with open(self.config_filename, 'r') as f:
+            new_contents = f.read()
+        if new_contents != updated_config_contents:
+            self.fail("Config file contents do not match.\n"
+                      "Expected contents:\n"
+                      "%s\n\n"
+                      "Actual Contents:\n"
+                      "%s\n" % (updated_config_contents, new_contents))
+
+    def test_update_single_existing_value(self):
+        original = '[default]\nfoo = 1\nbar = 1'
+        updated = '[default]\nfoo = newvalue\nbar = 1'
+        self.assert_update_config(
+            original, {'foo': 'newvalue'}, updated)
+
+    def test_update_single_existing_value_no_spaces(self):
+        original = '[default]\nfoo=1\nbar=1'
+        updated = '[default]\nfoo = newvalue\nbar=1'
+        self.assert_update_config(
+            original, {'foo': 'newvalue'}, updated)
+
+    def test_update_single_new_values(self):
+        expected = '[default]\nfoo = 1\nbar = 2\nbaz = newvalue\n'
+        self.assert_update_config(
+            '[default]\nfoo = 1\nbar = 2',
+            {'baz': 'newvalue'}, expected)
+
+    def test_handles_no_spaces(self):
+        expected = '[default]\nfoo=1\nbar=2\nbaz = newvalue\n'
+        self.assert_update_config(
+            '[default]\nfoo=1\nbar=2',
+            {'baz': 'newvalue'}, expected)
+
+    def test_insert_values_in_middle_section(self):
+        original_contents = (
+            '[a]\n'
+            'foo = bar\n'
+            'baz = bar\n'
+            '\n'
+            '[b]\n'
+            '\n'
+            'foo = bar\n'
+            '[c]\n'
+            'foo = bar\n'
+            'baz = bar\n'
+        )
+        expected_contents = (
+            '[a]\n'
+            'foo = bar\n'
+            'baz = bar\n'
+            '\n'
+            '[b]\n'
+            '\n'
+            'foo = newvalue\n'
+            '[c]\n'
+            'foo = bar\n'
+            'baz = bar\n'
+        )
+        self.assert_update_config(
+            original_contents,
+            {'foo': 'newvalue', '__section__': 'b'},
+            expected_contents)
+
+    def test_insert_new_value_in_middle_section(self):
+        original_contents = (
+            '[a]\n'
+            'foo = bar\n'
+            '\n'
+            '[b]\n'
+            '\n'
+            'foo = bar\n'
+            '\n'
+            '[c]\n'
+            'foo = bar\n'
+        )
+        expected_contents = (
+            '[a]\n'
+            'foo = bar\n'
+            '\n'
+            '[b]\n'
+            '\n'
+            'foo = bar\n'
+            'newvalue = newvalue\n'
+            '\n'
+            '[c]\n'
+            'foo = bar\n'
+        )
+        self.assert_update_config(
+            original_contents,
+            {'newvalue': 'newvalue', '__section__': 'b'},
+            expected_contents)
+
+    def test_new_config_file(self):
+        self.assert_update_config(
+            '\n',
+            {'foo': 'value'},
+            '\n[default]\nfoo = value\n')
+
+    def test_section_does_not_exist(self):
+        original_contents = (
+            '[notdefault]\n'
+            'foo = bar\n'
+            'baz = bar\n'
+            '\n'
+            '\n'
+            '\n'
+            '[other "section"]\n'
+            '\n'
+            'foo = bar\n'
+        )
+        appended_contents = (
+            '[default]\n'
+            'foo = value\n'
+        )
+        self.assert_update_config(
+            original_contents,
+            {'foo': 'value'},
+            original_contents + appended_contents)
+
+    def test_config_file_does_not_exist(self):
+        self.writer.update_config({'foo': 'value'}, self.config_filename)
+        with open(self.config_filename, 'r') as f:
+            new_contents = f.read()
+        self.assertEqual(new_contents, '[default]\nfoo = value\n')
+
+    def test_update_config_with_comments(self):
+        original = (
+            '[default]\n'
+            '#foo = 1\n'
+            'bar = 1\n'
+        )
+        self.assert_update_config(
+            original, {'foo': 'newvalue'},
+            '[default]\n'
+            '#foo = 1\n'
+            'bar = 1\n'
+            'foo = newvalue\n'
+        )
+
+    def test_spaces_around_key_names(self):
+        original = (
+            '[default]\n'
+            'foo = 1\n'
+            'bar = 1\n'
+        )
+        self.assert_update_config(
+            original, {'foo': 'newvalue'},
+            '[default]\n'
+            'foo = newvalue\n'
+            'bar = 1\n'
+        )
+
+    def test_unquoted_profile_name(self):
+        original = (
+            '[profile foobar]\n'
+            'foo = 1\n'
+            'bar = 1\n'
+        )
+        self.assert_update_config(
+            original, {'foo': 'newvalue', '__section__': 'profile foobar'},
+            '[profile foobar]\n'
+            'foo = newvalue\n'
+            'bar = 1\n'
+        )
+
+    def test_double_quoted_profile_name(self):
+        original = (
+            '[profile "foobar"]\n'
+            'foo = 1\n'
+            'bar = 1\n'
+        )
+        self.assert_update_config(
+            original, {'foo': 'newvalue', '__section__': 'profile foobar'},
+            '[profile "foobar"]\n'
+            'foo = newvalue\n'
+            'bar = 1\n'
+        )
+
+    def test_profile_with_multiple_spaces(self):
+        original = (
+            '[profile "two  spaces"]\n'
+            'foo = 1\n'
+            'bar = 1\n'
+        )
+        self.assert_update_config(
+            original, {'foo': 'newvalue', '__section__': 'profile two  spaces'},
+            '[profile "two  spaces"]\n'
+            'foo = newvalue\n'
+            'bar = 1\n'
+        )

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -24,7 +24,7 @@ GLOBALOPTS = ['--debug', '--endpoint-url', '--no-verify-ssl',
 
 COMPLETIONS = [
     ('aws ', -1, set(['autoscaling', 'cloudformation', 'cloudfront',
-                      'cloudsearch', 'cloudwatch', 'datapipeline',
+                      'cloudsearch', 'cloudwatch', 'configure', 'datapipeline',
                       'directconnect', 'dynamodb', 'ec2', 'elasticache',
                       'elasticbeanstalk', 'elastictranscoder', 'elb', 'emr',
                       'iam', 'importexport', 'opsworks', 'rds', 'redshift',


### PR DESCRIPTION
This command will allow a user to be interactively prompted for values:

```
  $ aws configure
  AWS Access Key ID [****************]: accesskey
  AWS Secret Access Key [****************]: secretkey
  Default region name [us-west-2]: us-west-2
  Default output format [None]: json
```

This will automatically create an `~/.aws/config` file and write out the
values to this file.  This can also be used to update existing values.
If you run the `configure` command with existing values then the current
value will be provided in `[brackets]`, you can hit enter to accept the
current value or provide a new value.

You can also provide a `--profile` arg to update/create a profile.

Care was taken to _not_ touch any unchanged data on updates.  This means
we don't just simply load the parsed config data, manipulate it, the use
ConfigParser to write out the new data.  This would lose the existing
formatting of the file as well as any comments in the config file.
If I have a config file like this:

```
  aws_access_key_id = myaccesskey
  aws_secret_access_key = secretkey
  ; Here's a comment.

  # Here's a nother comment.
  ; And another comment
  output = text  ; Use text output instead of json
  region = us-west-1
```

And I run `aws configure` and only enter a value for _just_ the region, then
only the region line will be changed.  All the existing comments will be
preserved.
# Internal Changes

Part of this change is the introduction of a `BasicCommand` class that
makes it much easier to create top level commands.  It supports:
- Defining documentation on the command object
- Defining an argument table on the command object
- Automatically managing the argparse creation
- Automatically providing a "help" command

It doesn't support subcommands (mostly because the "configure" command
doesn't have any right now), but I do plan on adding support for
subcommands.

When this means for plugin writers is that you only have to define a
single class to create a new to level command.

This required some small changes to `bcdoc` related to pulling up the
synopsis/option handlers into the base handler class so that we can have
the same look and feel as built the arguments for built in operations.
