### PR TITLE
Double quote exclude/include args

### DIFF
--- a/awscli/examples/s3/_concepts.rst
+++ b/awscli/examples/s3/_concepts.rst
@@ -3,6 +3,7 @@ of commands provided.
 
 Path Argument Type
 ++++++++++++++++++
+
 Whenever using a command, at least one path argument must be specified.  There
 are two types of path arguments: ``LocalPath`` and ``S3Path``.
 
@@ -18,8 +19,10 @@ example, if the S3 object ``myobject`` had the prefix ``myprefix``, the
 S3 key would be ``myprefix/myobject``, and if the object was in the bucket
 ``mybucket``, the ``S3Path`` would be ``s3://mybucket/myprefix/myobject``.
 
+
 Order of Path Arguments
 +++++++++++++++++++++++
+
 Every command takes one or two positional path arguments.  The first path
 argument represents the source, which is the local file/directory or S3
 object/prefix/bucket that is being referenced.  If there is a second path
@@ -28,15 +31,17 @@ or S3 object/prefix/bucket that is being operated on.  Commands with only
 one path argument do not have a destination because the operation is being
 performed only on the source.
 
+
 Single Local File and S3 Object Operations
 ++++++++++++++++++++++++++++++++++++++++++
+
 Some commands perform operations only on single files and S3 objects.  The
 following commands are single file/object operations if no ``--recursive``
 flag is provided.
 
     * ``cp``
     * ``mv``
-    * ``rm``  
+    * ``rm``
 
 For this type of operation, the first path argument, the source, must exist
 and be a local file or S3 object.  The second path argument, the destination,
@@ -53,8 +58,10 @@ adopt the name of the source file or object.  Otherwise, if there is no
 slash at the end, the file or object will be saved under the name provided.
 See examples in ``cp`` and ``mv`` to illustrate this description.
 
+
 Directory and S3 Prefix Operations
 ++++++++++++++++++++++++++++++++++
+
 Some commands only perform operations on the contents of a local directory
 or S3 prefix/bucket.  Adding or omitting a forward slash or back slash to
 the end of any path argument, depending on its type, does not affect the
@@ -64,11 +71,13 @@ a directory or S3 prefix/bucket operation.
     * commands: ``sync``, ``mb``, ``rb``, ``ls``
     * parameters: ``--recursive``
 
+
 Use of Exclude and Include Filters
 ++++++++++++++++++++++++++++++++++
+
 Currently, there is no support for the use of UNIX style wildcards in
-a command's path arguments.  However, most commands have ``--exclude <value>``
-and ``--include <value>`` parameters that can achieve the desired result.
+a command's path arguments.  However, most commands have ``--exclude "<value>"``
+and ``--include "<value>"`` parameters that can achieve the desired result.
 These parameters perform pattern matching to either exclude or include
 a particular file or object.  The following pattern symbols are supported.
 
@@ -82,14 +91,16 @@ can be passed to a command.  When there are multiple filters, the rule is
 the filters that appear later in the command take precedence over filters
 that appear earlier in the command.  For example, if the filter parameters
 passed to the command were
+
 ::
 
-    --exclude * --include *.txt
+    --exclude "*" --include "*.txt"
 
-All files will be excluded from the command except for files ending with 
+All files will be excluded from the command except for files ending with
 ``.txt``  However, if the order of the filter parameters was changed to
+
 ::
 
-    --include *.txt --exclude *
+    --include "*.txt" --exclude "*"
 
-All files will be excluded from the command.       
+All files will be excluded from the command.

--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -23,7 +23,7 @@ bucket and key.
 file locally.
 ::
 
-    aws s3 cp s3://mybucket/test.txt test2.txt 
+    aws s3 cp s3://mybucket/test.txt test2.txt
 
 *Output:*
 ::
@@ -51,7 +51,7 @@ the objects ``test1.txt`` and ``test2.txt``.
 
 *Output:*
 ::
-    
+
     download: s3://mybucket/test1.txt to test1.txt
     download: s3://mybucket/test2.txt to test2.txt
 
@@ -62,11 +62,11 @@ parameter.  In this example, the directory ``myDir`` has the files
 ``test1.txt`` and ``test2.jpg``.
 ::
 
-    aws s3 cp myDir s3://mybucket/ --recursive --exclude *.jpg
+    aws s3 cp myDir s3://mybucket/ --recursive --exclude "*.jpg"
 
 *Output:*
 ::
-    
+
     upload: myDir/test1.txt to s3://mybucket2/test1.txt
 
 7) When passed with the parameter ``--recursive``, the following ``cp``
@@ -76,11 +76,11 @@ In this example, the bucket ``mybucket`` has the objects ``test1.txt``
 and ``another/test1.txt``.
 ::
 
-    aws s3 cp s3://mybucket/ s3://mybucket2/ --recursive --exclude mybucket/another/*
+    aws s3 cp s3://mybucket/ s3://mybucket2/ --recursive --exclude "mybucket/another/*"
 
 *Output:*
 ::
-    
+
     copy: s3://mybucket/test1.txt to s3://mybucket2/test1.txt
 
 8) The following ``cp`` command copies a single object to a specified

--- a/awscli/examples/s3/mv.rst
+++ b/awscli/examples/s3/mv.rst
@@ -24,7 +24,7 @@ bucket and key.
 file locally.
 ::
 
-    aws s3 mv s3://mybucket/test.txt test2.txt 
+    aws s3 mv s3://mybucket/test.txt test2.txt
 
 *Output:*
 ::
@@ -52,7 +52,7 @@ the objects ``test1.txt`` and ``test2.txt``.
 
 *Output:*
 ::
-    
+
     move: s3://mybucket/test1.txt to test1.txt
     move: s3://mybucket/test2.txt to test2.txt
 
@@ -63,11 +63,11 @@ parameter.  In this example, the directory ``myDir`` has the files
 ``test1.txt`` and ``test2.jpg``.
 ::
 
-    aws s3 mv myDir s3://mybucket/ --recursive --exclude *.jpg
+    aws s3 mv myDir s3://mybucket/ --recursive --exclude "*.jpg"
 
 *Output:*
 ::
-    
+
     move: myDir/test1.txt to s3://mybucket2/test1.txt
 
 7) When passed with the parameter ``--recursive``, the following ``mv``
@@ -77,11 +77,11 @@ In this example, the bucket ``mybucket`` has the objects ``test1.txt``
 and ``another/test1.txt``.
 ::
 
-    aws s3 mv s3://mybucket/ s3://mybucket2/ --recursive --exclude mybucket/another/*
+    aws s3 mv s3://mybucket/ s3://mybucket2/ --recursive --exclude "mybucket/another/*"
 
 *Output:*
 ::
-    
+
     move: s3://mybucket/test1.txt to s3://mybucket2/test1.txt
 
 8) The following ``mv`` command moves a single object to a specified

--- a/awscli/examples/s3/rm.rst
+++ b/awscli/examples/s3/rm.rst
@@ -4,37 +4,55 @@
     aws s3 rm s3://mybucket/test2.txt
 
 *Output:*
+
 ::
 
     delete: s3://mybucket/test2.txt
 
-2) The following ``rm`` command recursively deletes all objects under a specified bucket and prefix when passed with the parameter ``--recursive``.  In this example, the bucket ``mybucket`` contains the objects ``test1.txt`` and ``test2.txt``.
+2) The following ``rm`` command recursively deletes all objects under a
+   specified bucket and prefix when passed with the parameter ``--recursive``.
+   In this example, the bucket ``mybucket`` contains the objects ``test1.txt``
+   and ``test2.txt``.
+
 ::
 
     aws s3 rm s3://mybucket --recursive
 
 *Output:*
+
 ::
-    
+
     delete: s3://mybucket/test1.txt
     delete: s3://mybucket/test2.txt
 
-3) The following ``rm`` command recursively deletes all objects under a specified bucket and prefix when passed with the parameter ``--recursive`` while excluding some objects by using an ``--exclude`` parameter.  In this example, the bucket ``mybucket`` has the objects ``test1.txt`` and ``test2.jpg``.
+3) The following ``rm`` command recursively deletes all objects under a
+   specified bucket and prefix when passed with the parameter ``--recursive``
+   while excluding some objects by using an ``--exclude`` parameter.  In this
+   example, the bucket ``mybucket`` has the objects ``test1.txt`` and
+   ``test2.jpg``.
+
 ::
 
-    aws s3 rm s3://mybucket/ --recursive --exclude *.jpg
+    aws s3 rm s3://mybucket/ --recursive --exclude "*.jpg"
 
 *Output:*
+
 ::
-    
+
     delete: myDir/test1.txt to s3://mybucket/test1.txt
 
-4) The following ``rm`` command recursively deletes all objects under a specified bucket and prefix when passed with the parameter ``--recursive`` while excluding all objects under a particular prefix by using an ``--exclude`` parameter.  In this example, the bucket ``mybucket`` has the objects ``test1.txt`` and ``another/test.txt``.
+4) The following ``rm`` command recursively deletes all objects under a
+   specified bucket and prefix when passed with the parameter ``--recursive``
+   while excluding all objects under a particular prefix by using an
+   ``--exclude`` parameter.  In this example, the bucket ``mybucket`` has the
+   objects ``test1.txt`` and ``another/test.txt``.
+
 ::
 
-    aws s3 rm s3://mybucket/ --recursive --exclude mybucket/another/*
+    aws s3 rm s3://mybucket/ --recursive --exclude "mybucket/another/*"
 
 *Output:*
+
 ::
-    
+
     delete: myDir/test1.txt to s3://mybucket/test1.txt

--- a/awscli/examples/s3/sync.rst
+++ b/awscli/examples/s3/sync.rst
@@ -6,12 +6,13 @@ the local file is newer than the last modified time of the s3 object,
 or the local file does not exist under the specified bucket and prefix.
 In this example, the user syncs the bucket ``mybucket`` to the local
 current directory.  The local current directory contains the files
-``test.txt`` and ``test2.txt``.  The bucket ``mybucket`` contains no objects. 
+``test.txt`` and ``test2.txt``.  The bucket ``mybucket`` contains no objects.
 ::
-       
+
     aws s3 sync . s3://mybucket
 
 *Output:*
+
 ::
 
     upload: test.txt to s3://mybucket/test.txt
@@ -25,12 +26,14 @@ modified time of the destination, or the s3 object does not exist under the
 specified bucket and prefix destination.  In this example, the user syncs
 the bucket ``mybucket2`` to the bucket ``mybucket``.  The bucket
 ``mybucket`` contains the objects ``test.txt`` and ``test2.txt``.  The
-bucket ``mybucket2`` contains no objects. 
+bucket ``mybucket2`` contains no objects.
+
 ::
-       
+
     aws s3 sync s3://mybucket s3://mybucket2
 
 *Output:*
+
 ::
 
     copy: s3://mybucket/test.txt to s3://mybucket2/test.txt
@@ -46,9 +49,9 @@ last modified time of the local file is changed to the last modified time
 of the s3 object.  In this example, the user syncs the current local
 directory to the bucket ``mybucket``.  The bucket ``mybucket`` contains the
 objects ``test.txt`` and ``test2.txt``.  The current local directory has
-no files. 
+no files.
 ::
-       
+
     aws s3 sync s3://mybucket .
 
 *Output:*
@@ -64,9 +67,9 @@ under the specified prefix and bucket but not existing in the local
 directory will be deleted.  In this example, the user syncs the bucket
 ``mybucket`` to the local current directory.  The local current directory
 contains the files ``test.txt`` and ``test2.txt``.  The bucket
-``mybucket`` contains the object ``test3.txt``. 
+``mybucket`` contains the object ``test3.txt``.
 ::
-       
+
     aws s3 sync . s3://mybucket --delete
 
 *Output:*
@@ -84,9 +87,10 @@ sync.  In this example, the user syncs the bucket ``mybucket`` to the
 local current directory.  The local current directory contains the files
 ``test.jpg`` and ``test2.txt``.  The bucket ``mybucket`` contains the
 object ``test.jpg`` of a different size than the local ``test.jpg``.
+
 ::
-       
-    aws s3 sync . s3://mybucket --exclude *.jpg
+
+    aws s3 sync . s3://mybucket --exclude "*.jpg"
 
 *Output:*
 ::
@@ -103,9 +107,10 @@ and ``another/test2.txt``.  The bucket ``mybucket`` contains the object
 ``another/test5.txt``.
 ::
 
-    aws s3 sync s3://mybucket/ . --exclude *another/*
+    aws s3 sync s3://mybucket/ . --exclude "*another/*"
 
 *Output:*
+
 ::
-    
+
     download: s3://mybucket/test1.txt to test1.txt


### PR DESCRIPTION
This makes the examples work on Windows, Linux, and Mac.
