### PR TITLE
Allow a value of all or -1 to be passed to the --protocol option

### DIFF
--- a/awscli/customizations/ec2secgroupsimplify.py
+++ b/awscli/customizations/ec2secgroupsimplify.py
@@ -118,14 +118,17 @@ class ProtocolArgument(CustomArgument):
         if value:
             try:
                 int_value = int(value)
-                if int_value < 0 or int_value > 255:
-                    msg = ('protocol numbers must be in the range 0-255')
+                if (int_value < 0 or int_value > 255) and int_value != -1:
+                    msg = ('protocol numbers must be in the range 0-255 '
+                           'or -1 to specify all protocols')
                     raise ValueError(msg)
             except ValueError:
-                if value not in ('tcp', 'udp', 'icmp'):
+                if value not in ('tcp', 'udp', 'icmp', 'all'):
                     msg = ('protocol parameter should be one of: '
-                           'tcp|udp|icmp or any valid protocol number.')
+                           'tcp|udp|icmp|all or any valid protocol number.')
                     raise ValueError(msg)
+                if value == 'all':
+                    value = '-1'
             _build_ip_permissions(parameters, 'IpProtocol', value)
 
 

--- a/tests/unit/ec2/test_security_group_operations.py
+++ b/tests/unit/ec2/test_security_group_operations.py
@@ -14,7 +14,6 @@
 from tests.unit import BaseAWSCommandParamsTest
 
 from six.moves import cStringIO
-import mock
 
 class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
 
@@ -37,6 +36,32 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                    'IpPermissions.1.FromPort': '-1',
                    'IpPermissions.1.ToPort': '-1',
                    'IpPermissions.1.IpProtocol': 'tcp',
+                   'IpPermissions.1.IpRanges.1.CidrIp': '0.0.0.0/0'}
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_all_protocol(self):
+        args = ' --group-name foobar --protocol all --port all --cidr 0.0.0.0/0'
+        args_list = (self.prefix + args).split()
+        result =  {'GroupName': 'foobar',
+                   'IpPermissions.1.FromPort': '-1',
+                   'IpPermissions.1.ToPort': '-1',
+                   'IpPermissions.1.IpProtocol': '-1',
+                   'IpPermissions.1.IpRanges.1.CidrIp': '0.0.0.0/0'}
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_numeric_protocol(self):
+        args = ' --group-name foobar --protocol 200 --cidr 0.0.0.0/0'
+        args_list = (self.prefix + args).split()
+        result =  {'GroupName': 'foobar',
+                   'IpPermissions.1.IpProtocol': '200',
+                   'IpPermissions.1.IpRanges.1.CidrIp': '0.0.0.0/0'}
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_negative_one_protocol(self):
+        args = ' --group-name foobar --protocol -1 --cidr 0.0.0.0/0'
+        args_list = (self.prefix + args).split()
+        result =  {'GroupName': 'foobar',
+                   'IpPermissions.1.IpProtocol': '-1',
                    'IpPermissions.1.IpRanges.1.CidrIp': '0.0.0.0/0'}
         self.assert_params_for_cmd(args_list, result)
 


### PR DESCRIPTION
 for authorize/revoke commands.  Fixes #460.
