### PR TITLE
Specify the path for the config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,14 +130,18 @@ To use a config file, create a configuration file like this::
     aws_secret_access_key=<testing secret key>
     region=us-west-2
 
+and place it in ``~/.aws/config`` (or in ``%UserProfile%\.aws\config`` on Windows).
+
 As you can see, you can have multiple ``profiles`` defined in this
 configuration file and specify which profile to use by using the ``--profile``
 option.  If no profile is specified the ``default`` profile is used.  Except
 for the default profile, you **must** prefix each config section of a profile
 group with ``profile``.  For example, if you have a profile named "testing" the
-section header would be ``[profile testing]``.  Once you have created the
-config file, you need to tell aws-cli where to find it.  Do this by setting the
-appropriate environment variable::
+section header would be ``[profile testing]``.
+
+If you wish to place the config file in a different directory than the one
+specified above, you need to tell aws-cli where to find it.  Do this by setting
+the appropriate environment variable::
 
     $ export AWS_CONFIG_FILE=/path/to/config_file
 


### PR DESCRIPTION
That information is present in the `aws-cli.pdf` file but not in
the README file.

This commit also adds whitespace in between the paragraph that discusses
the multiple profiles and the paragraph that talks about moving the
config file location.
