### PR TITLE
Add detailed error message on local file encoding errors

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -203,7 +203,8 @@ class CLIDriver(object):
             self.session.set_debug_logger(logger_name='botocore')
             self.session.set_debug_logger(logger_name='awscli')
         else:
-            self.session.set_stream_logger(logger_name='awscli', log_level='ERROR')
+            self.session.set_stream_logger(logger_name='awscli',
+                                           log_level=logging.ERROR)
 
 
 class CLICommand(object):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -80,8 +80,10 @@ class S3Handler(object):
             self.result_queue.join()
 
         except Exception as e:
-            LOGGER.debug('Exception caught during task execution: %s',
-                         str(e), exc_info=True)
+            LOGGER.error('Exception caught during task execution: %s',
+                          str(e))
+            # Log the traceback at DEBUG level.
+            LOGGER.debug(str(e), exc_info=True)
         except KeyboardInterrupt:
             self.interrupt.set()
             self.result_queue.put({'message': "Cleaning up. Please wait...",

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -14,6 +14,7 @@ import os
 import random
 from tests import unittest
 
+import six
 from mock import patch
 
 
@@ -42,21 +43,22 @@ def make_loc_files():
     has the file text1.txt and the directory another_directory inside.  Inside
     of another_directory it creates the file text2.txt.
     """
-    directory1 = os.path.abspath('.') + os.sep + 'some_directory' + os.sep
+    directory1 = six.text_type(
+        os.path.abspath('.') + os.sep + 'some_directory' + os.sep)
     if not os.path.exists(directory1):
         os.mkdir(directory1)
 
     string1 = b"This is a test."
-    filename1 = directory1 + "text1.txt"
+    filename1 = directory1 + u"text1.txt"
     with open(filename1, 'wb') as file1:
         file1.write(string1)
 
-    directory2 = directory1 + 'another_directory' + os.sep
+    directory2 = directory1 + u'another_directory' + os.sep
     if not os.path.exists(directory2):
         os.mkdir(directory2)
 
     string2 = b"This is another test."
-    filename2 = directory2 + "text2.txt"
+    filename2 = directory2 + u"text2.txt"
     with open(filename2, 'wb') as file2:
         file2.write(string2)
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest
 from tests.unit import BaseAWSCommandParamsTest
+import logging
 
 import mock
 import six
@@ -171,7 +172,7 @@ class TestCliDriver(unittest.TestCase):
     def test_error_logger(self):
         driver = CLIDriver(session=self.session)
         driver.main('s3 list-objects --bucket foo --profile foo'.split())
-        expected = {'log_level': 'ERROR', 'logger_name': 'awscli'}
+        expected = {'log_level': logging.ERROR, 'logger_name': 'awscli'}
         self.assertEqual(driver.session.stream_logger_args[1], expected)
 
 


### PR DESCRIPTION
The general error was that `list_files` was raising an exception
that would propogate up to the main clidriver handler and stop
execution.  While `list_files` is doing the right thing, there were
a few issues:
- There were no error message logged to the console (bug in log configuration).
- There were debug logs that indicated an error but the error message
  was vague and complained about a UnicodeDecodeError.  It also wasn't
  clear why it happened or how to fix it.

As to why `list_files` is raising an exception:

The issue is with the call `os.listdir(<unicode>)`.  What is _suppose_
to happen in this case is that python should return unicode objects
if called with a unicode object, and should return bytestrings if called
with a bytestring.  So in python2:

```
os.listdir(u'.') -> [u'unicode']
os.listdir('.') -> ['not unicode']
```

In order to decode the bytes to unicode it uses
`sys.getfilesystemencoding()`.  On Mac/Windows, these values are
hardcoded, but on unix, this is loaded via `nl_langinfo(CODESET)`,
which maps to the `LC_CTYPE` env var.

This is documented here http://docs.python.org/2/library/sys.html#sys.getfilesystemencoding

However, `os.listdir` will return the original bytestring
_if it fails to decode the bytestring_ using `getfilesystemencoding()`.
The full picture is therefore:

```
os.listdir(u'.') -> [u'unicode']
os.listdir(u'.') -> ['possibly byte string if decoding fails']
os.listdir('.') -> ['byte string']
```

Once this happens we're calling `os.path.join(<unicode>, <byestring>)`,
which means we'll need to decode the bytestring to unicode.  In this
situation we use `sys.getdefaultencoding()`, which is likely going to be
ascii, hence the error message about the ascii codec not being able
to decode a byte.

One alternative considered was to just skip the file if we can't decode
the object to unicode.  However, if someone uses the `--delete` flag,
skipping the file will result in the file being deleted on the other
end, which not not desired behavior.

The error message when this happens looks like this:

```
2013-11-05 18:28:50,195 - awscli.customizations.s3.s3handler - ERROR - Exception caught during task execution:
There was an error trying to decode the the file "\xce\x24" in directory "/home/mydir/sync/bar/": 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)

Please check your locale settings.  The filename was decoded as: ANSI_X3.4-1968
On posix platforms, check the LC_CTYPE environment variable.

```

Closes #383.
