### PR TITLE
NUM_THREADS should match max conns in http conn pool

### DIFF
--- a/awscli/customizations/s3/constants.py
+++ b/awscli/customizations/s3/constants.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 MULTI_THRESHOLD = 8 * (1024 ** 2)
 CHUNKSIZE = 7 * (1024 ** 2)
-NUM_THREADS = 12
+NUM_THREADS = 10
 QUEUE_TIMEOUT_GET = 1.0
 QUEUE_TIMEOUT_WAIT = 0.2
 MAX_PARTS = 950


### PR DESCRIPTION
We're using the default value of requests/urllib3 for the
max size of a connection pool, which is 10.  We should match
this value so that we don't cycle through opening/closing connections.

This should have no functional changes.  We're just making less
http connections overall.

https://github.com/boto/botocore/blob/develop/botocore/vendored/requests/adapters.py#L31
