### PR TITLE
Support strings as bool values in shorthand syntax

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ NEXT RELEASE (TBD)
 * Log the reason why a file is synced when using the ``s3 sync`` command
 * Fix an issue when uploading large files on low bandwidth networks
   (issue 454)
+* Fix an issue with parsing shorthand boolean argument values (issue 477)
 
 
 1.2.3

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -362,6 +362,8 @@ def unpack_scalar_cli_arg(parameter, value):
             raise ValueError(msg)
         return open(file_path, 'rb')
     elif parameter.type == 'boolean':
+        if isinstance(value, str) and value.lower() == 'false':
+            return False
         return bool(value)
     else:
         return str(value)

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -13,6 +13,7 @@
 from tests import unittest
 
 import botocore.session
+import mock
 
 from awscli.clidriver import CLIArgument
 from awscli.help import OperationHelpCommand
@@ -106,6 +107,17 @@ class TestParamShorthand(BaseArgProcessTest):
         returned = self.simplify(p, value)
         json_version = unpack_cli_arg(p, json_value)
         self.assertEqual(returned, json_version)
+
+    def test_parse_boolean_shorthand(self):
+        bool_param = mock.Mock()
+        bool_param.type = 'boolean'
+        self.assertTrue(unpack_cli_arg(bool_param, True))
+        self.assertTrue(unpack_cli_arg(bool_param, 'True'))
+        self.assertTrue(unpack_cli_arg(bool_param, 'true'))
+
+        self.assertFalse(unpack_cli_arg(bool_param, False))
+        self.assertFalse(unpack_cli_arg(bool_param, 'False'))
+        self.assertFalse(unpack_cli_arg(bool_param, 'false'))
 
     def test_simplify_map_scalar(self):
         p = self.get_param_object('sqs.SetQueueAttributes.Attributes')


### PR DESCRIPTION
When using shorthand syntax, bool types are passed as
a string value, so we need to support "true" and "false".

This is fairly conservative in that, it's either exactly
"[Ff]alse", otherwise it's True.  We could require more
strict checking though if we want.

cc @danielgtaylor
