### PR TITLE
Move --security-group-ids value to NetworkInterfaces structure if necessary

### DIFF
--- a/tests/unit/ec2/test_run_instances.py
+++ b/tests/unit/ec2/test_run_instances.py
@@ -163,3 +163,31 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(args_list, result)
 
+    def test_associate_public_ip_address_and_group_id(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--security-group-id sg-12345678 '
+        args += '--associate-public-ip-address --subnet-id subnet-12345678'
+        args_list = (self.prefix + args).split()
+        result = {
+            'NetworkInterface.1.DeviceIndex': '0',
+            'NetworkInterface.1.AssociatePublicIpAddress': 'true',
+            'NetworkInterface.1.SubnetId': 'subnet-12345678',
+            'NetworkInterface.1.SecurityGroupId.1': 'sg-12345678',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_group_id_alone(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--security-group-id sg-12345678'
+        args_list = (self.prefix + args).split()
+        result = {
+            'SecurityGroupId.1': 'sg-12345678',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
+


### PR DESCRIPTION
If we are constructing a NetworkInterfaces structure for the user in run-instances, we need to make sure that any security groups specified via --security-group-ids are moved into the NetworkInterfaces structure.  Otherwise we get a client error from EC2.  Fixes #504.
