### PR TITLE
Notify user when broken symlinks are encountered

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Next Release (TBD)
   is provided (`issue 501 <https://github.com/aws/aws-cli/issues/501>`__)
 * Don't require key names for structures of single scalar values
   (`issue 484 <https://github.com/aws/aws-cli/issues/484>`__)
+* Fix issue with symlinks silently failing during ``s3 sync/cp``
+  (`issue 425 <https://github.com/aws/aws-cli/issues/425>`__
+   and `issue 487 <https://github.com/aws/aws-cli/issues/487>`__)
 
 
 1.2.5

--- a/awscli/customizations/s3/executer.py
+++ b/awscli/customizations/s3/executer.py
@@ -144,6 +144,7 @@ class PrintThread(threading.Thread):
         self._num_parts = 0
         self._file_count = 0
         self._lock = threading.Lock()
+        self._needs_newline = False
 
         self._total_parts = 0
         self._total_files = '...'
@@ -179,6 +180,8 @@ class PrintThread(threading.Thread):
             except Queue.Empty:
                 pass
             if self._done.isSet():
+                if self._needs_newline:
+                    sys.stdout.write('\n')
                 break
 
     def _process_print_task(self, print_task):
@@ -226,4 +229,5 @@ class PrintThread(threading.Thread):
             final_str += prog_str
         if not self._quiet:
             uni_print(final_str)
+            self._needs_newline = not final_str.endswith('\n')
             sys.stdout.flush()

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -80,10 +80,9 @@ class S3Handler(object):
             self.result_queue.join()
 
         except Exception as e:
-            LOGGER.error('Exception caught during task execution: %s',
-                          str(e))
-            # Log the traceback at DEBUG level.
-            LOGGER.debug(str(e), exc_info=True)
+            LOGGER.debug('Exception caught during task execution: %s',
+                         str(e), exc_info=True)
+            self.result_queue.put({'message': str(e), 'error': True})
         except KeyboardInterrupt:
             self.interrupt.set()
             self.result_queue.put({'message': "Cleaning up. Please wait...",


### PR DESCRIPTION
You will now see an error message shown as well as a non zero
RC:

```
  $ aws s3 sync anotherdir/ s3:/bucket-name/
  [Errno 2] No such file or directory: '/private/tmp/symlnk/anotherdir/z-badsylmink'

  $ echo $?
  1
```

There is potential to add something like a `--skip-bad-symlinks`
option, but the default behavior is to let the user know that we've hit
a bad symlink.  Fies #425 and #487.
