### PR TITLE
Update ec2 modify-instance-attribute example

### DIFF
--- a/awscli/examples/ec2/modify-instance-attribute.rst
+++ b/awscli/examples/ec2/modify-instance-attribute.rst
@@ -4,7 +4,7 @@ This example modifies the instance type of the specified instance. The instance 
 
 Command::
 
-  aws ec2 modify-instance-attribute --instance-id i-5203422c --instance-type "{\"Value\": \"m1.small\"}"
+  aws ec2 modify-instance-attribute --instance-id i-5203422c --instance-type m1.small
 
 Output::
 
@@ -18,7 +18,7 @@ This example sets the ``sourceDestCheck`` attribute of the specified instance to
 
 Command::
 
-  aws ec2 modify-instance-attribute --instance-id i-5203422c --source-dest-check "{\"Value\": true}"
+  aws ec2 modify-instance-attribute --instance-id i-5203422c --source-dest-check
 
 Output::
 


### PR DESCRIPTION
This reflects the latest shorthand changes where you no longer have to provide
the JSON for a single scalar value, as well as top level boolean params.
