### PR TITLE
Handle a list of strings from a dict in text output

### DIFF
--- a/awscli/text.py
+++ b/awscli/text.py
@@ -41,6 +41,10 @@ def _format_text(item, stream, identifier=None, scalar_keys=None):
                 for list_element in item:
                     _format_text(list_element, stream=stream,
                                  identifier=identifier)
+            elif identifier is not None:
+                for list_element in item:
+                    stream.write('%s\t%s\n' % (identifier.upper(),
+                                               list_element))
             else:
                 # For a bare list, just print the contents.
                 stream.write('\t'.join([six.text_type(el) for el in item]))

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -131,6 +131,13 @@ class TestSection(unittest.TestCase):
         # We should not call .write() at all for an empty list.
         self.assertFalse(fake_stream.write.called)
 
+    def test_list_of_strings_in_dict(self):
+        self.assert_text_renders_to(
+            {"KeyName": ['a', 'b', 'c']},
+            'KEYNAME\ta\n'
+            'KEYNAME\tb\n'
+            'KEYNAME\tc\n')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This situation comes up in commands such as
`aws elb describe-load-balancers`.  The output
now looks as expected (note the "us-west-2b")

Before:

```
AVAILABILITYZONES   us-west-2a
HEALTHCHECK 10  30  HTTP:80/index.html  5   2
LISTENER    80  HTTP    80  HTTP
SOURCESECURITYGROUP amazon-elb-sg   amazon-elb
LOADBALANCERDESCRIPTIONS        a   b   c   d
us-west-2b
```

Now:

```
AVAILABILITYZONES   us-west-2a
HEALTHCHECK 10  30  HTTP:80/index.html  5   2
LISTENER    80  HTTP    80  HTTP
SOURCESECURITYGROUP amazon-elb-sg   amazon-elb
LOADBALANCERDESCRIPTIONS        a   b   c   d
AVAILABILITYZONES   us-west-2b
```

See: https://forums.aws.amazon.com/thread.jspa?threadID=140646
