### PR TITLE
If --private-ip-address is specified with any other options that require...

### DIFF
--- a/awscli/customizations/ec2runinstances.py
+++ b/awscli/customizations/ec2runinstances.py
@@ -100,6 +100,11 @@ def _fix_args(operation, endpoint, params, **kwargs):
             if 'security_group_ids' in params:
                 ni[0]['Groups'] = params['security_group_ids']
                 del params['security_group_ids']
+            if 'private_ip_address' in params:
+                ip_addr = {'PrivateIpAddress': params['private_ip_address'],
+                           'Primary': True}
+                ni[0]['PrivateIpAddresses'] = [ip_addr]
+                del params['private_ip_address']
 
 
 EVENTS = [

--- a/tests/unit/ec2/test_run_instances.py
+++ b/tests/unit/ec2/test_run_instances.py
@@ -191,3 +191,32 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(args_list, result)
 
+    def test_associate_public_ip_address_and_private_ip_address(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--private-ip-address 10.0.0.200 '
+        args += '--associate-public-ip-address --subnet-id subnet-12345678'
+        args_list = (self.prefix + args).split()
+        result = {
+            'NetworkInterface.1.DeviceIndex': '0',
+            'NetworkInterface.1.AssociatePublicIpAddress': 'true',
+            'NetworkInterface.1.SubnetId': 'subnet-12345678',
+            'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.0.200',
+            'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'true',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_private_ip_address_alone(self):
+        args = ' --image-id ami-foobar --count 1 '
+        args += '--private-ip-address 10.0.0.200'
+        args_list = (self.prefix + args).split()
+        result = {
+            'PrivateIpAddress': '10.0.0.200',
+            'ImageId': 'ami-foobar',
+            'MaxCount': '1',
+            'MinCount': '1'
+        }
+        self.assert_params_for_cmd(args_list, result)
+


### PR DESCRIPTION
... the creation of a NetworkInterfaces structure, move the value of --private-ip-address into the NetworkInterfaces structure.  Fixes #520.
