### PR TITLE
Add unittest for website redirect location

### DIFF
--- a/tests/unit/s3/test_put_object.py
+++ b/tests/unit/s3/test_put_object.py
@@ -66,6 +66,20 @@ class TestGetObject(BaseAWSCommandParamsTest):
         payload = self.last_params['payload'].getvalue()
         self.assertEqual(payload.name, self.file_path)
 
+    def test_website_redirect(self):
+        cmdline = self.prefix
+        cmdline += ' --bucket mybucket'
+        cmdline += ' --key mykey'
+        cmdline += ' --acl public-read'
+        cmdline += ' --website-redirect-location http://www.example.com/'
+        result = {
+            'uri_params': {'Bucket': 'mybucket', 'Key': 'mykey'},
+            'headers': {
+                'x-amz-acl': 'public-read',
+                'x-amz-website-redirect-location': 'http://www.example.com/',
+            }}
+        self.assert_params_for_cmd(cmdline, result, ignore_params=['payload'])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a test for https://github.com/boto/botocore/pull/187, so it will fail until that PR is merged.
