### PR TITLE
Fix bug when filtering s3 locations

### DIFF
--- a/awscli/customizations/s3/filters.py
+++ b/awscli/customizations/s3/filters.py
@@ -10,8 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import logging
 import fnmatch
 import os
+
+
+LOG = logging.getLogger(__name__)
 
 
 class Filter(object):
@@ -55,13 +59,21 @@ class Filter(object):
 
                 else:
                     path_pattern = pattern[1].replace(os.sep, '/')
-                    full_path_pattern = path_pattern
-
+                    full_path_pattern = os.path.join(file_path.split('/')[0],
+                                                     path_pattern)
                 is_match = fnmatch.fnmatch(file_path, full_path_pattern)
                 if is_match and pattern_type == '--include':
                     file_status = (file_info, True)
+                    LOG.debug("%s matched include filter: %s",
+                              file_path, full_path_pattern)
                 elif is_match and pattern_type == '--exclude':
                     file_status = (file_info, False)
-
+                    LOG.debug("%s matched exclude filter: %s",
+                              file_path, full_path_pattern)
+                else:
+                    LOG.debug("%s did not match %s filter: %s",
+                              file_path, pattern_type[2:], full_path_pattern)
+            LOG.debug("=%s final filtered status, should_include: %s",
+                      file_path, file_status[1])
             if file_status[1]:
                 yield file_info


### PR DESCRIPTION
The pattern is evaluated against the entire bucket.  This doesn't
mattern for suffix searches, but for a prefix search, you'd have to
include the bucket name.  This is inconsistent with filtering local
files.  Now they're both consistent.  Given:

```
  --exclude 'foo*'
```

This will filter any full path that startsw with foo.  So locally:

```
  rootdir/
    foo.txt      # yes
    foo1.txt     # yes
    foo/bar.txt  # yes
    bar.txt      # no
```

And on s3, we now have the same results:

```
  bucket/
    foo.txt      # yes
    foo1.txt     # yes
    foo/bar.txt  # yes
    bar.txt      # no
```

I also added debug logs to help customers troubleshoot why their
filters aren't working the way they expect.  For example:

```
s3.filters - DEBUG - /private/tmp/syncme/level-1/file-7 matched exclude filter: /private/tmp/syncme/*
s3.filters - DEBUG - /private/tmp/syncme/level-1/file-7 did not match include filter: /private/tmp/syncme/f*
s3.filters - DEBUG - /private/tmp/syncme/level-1/file-7 matched include filter: /private/tmp/syncme/level*
s3.filters - DEBUG - =/private/tmp/syncme/level-1/file-7 final filtered status, should_include: True
```
