### PR TITLE
Allow tcp, udp, icmp, all for --protocol param of ec2 create-network-acl-entry

### DIFF
--- a/awscli/customizations/ec2protocolarg.py
+++ b/awscli/customizations/ec2protocolarg.py
@@ -1,0 +1,35 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+This customization allows the user to specify the values "tcp", "udp",
+or "icmp" as values for the --protocol parameter.  The actual Protocol
+parameter of the operation accepts only integer protocol numbers.
+"""
+
+def _fix_args(operation, endpoint, params, **kwargs):
+    if 'protocol' in params:
+        if params['protocol'] == 'tcp':
+            params['protocol'] = '6'
+        elif params['protocol'] == 'udp':
+            params['protocol'] = '17'
+        elif params['protocol'] == 'icmp':
+            params['protocol'] = '1'
+        elif params['protocol'] == 'all':
+            params['protocol'] = '-1'
+
+
+def register_protocol_args(cli):
+    ('before-parameter-build.ec2.RunInstances', _fix_args),
+    cli.register('before-parameter-build.ec2.CreateNetworkAclEntry',
+                 _fix_args)
+    

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -39,6 +39,7 @@ from awscli.customizations.route53resourceid import register_resource_id
 from awscli.customizations.configure import register_configure_cmd
 from awscli.customizations.cloudtrail import initialize as cloudtrail_init
 from awscli.customizations.toplevelbool import register_bool_params
+from awscli.customizations.ec2protocolarg import register_protocol_args
 
 
 def awscli_initialize(event_handlers):
@@ -81,3 +82,4 @@ def awscli_initialize(event_handlers):
     register_configure_cmd(event_handlers)
     cloudtrail_init(event_handlers)
     register_bool_params(event_handlers)
+    register_protocol_args(event_handlers)

--- a/tests/unit/ec2/test_create_network_acl_entry.py
+++ b/tests/unit/ec2/test_create_network_acl_entry.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+# Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.unit import BaseAWSCommandParamsTest
+
+
+class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
+
+    prefix = 'ec2 create-network-acl-entry'
+
+    def test_tcp(self):
+        cmdline = self.prefix
+        cmdline += ' --network-acl-id acl-12345678'
+        cmdline += ' --rule-number 100'
+        cmdline += ' --protocol tcp'
+        cmdline += ' --rule-action allow'
+        cmdline += ' --ingress'
+        cmdline += ' --port-range From=22,To=22'
+        cmdline += ' --cidr-block 0.0.0.0/0'
+        result = {'NetworkAclId': 'acl-12345678',
+                  'RuleNumber': '100',
+                  'Protocol': '6',
+                  'RuleAction': 'allow',
+                  'Egress': 'false',
+                  'CidrBlock': '0.0.0.0/0',
+                  'PortRange.From': '22',
+                  'PortRange.To': '22'
+                  }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_udp(self):
+        cmdline = self.prefix
+        cmdline += ' --network-acl-id acl-12345678'
+        cmdline += ' --rule-number 100'
+        cmdline += ' --protocol udp'
+        cmdline += ' --rule-action allow'
+        cmdline += ' --ingress'
+        cmdline += ' --port-range From=22,To=22'
+        cmdline += ' --cidr-block 0.0.0.0/0'
+        result = {'NetworkAclId': 'acl-12345678',
+                  'RuleNumber': '100',
+                  'Protocol': '17',
+                  'RuleAction': 'allow',
+                  'Egress': 'false',
+                  'CidrBlock': '0.0.0.0/0',
+                  'PortRange.From': '22',
+                  'PortRange.To': '22'
+                  }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_icmp(self):
+        cmdline = self.prefix
+        cmdline += ' --network-acl-id acl-12345678'
+        cmdline += ' --rule-number 100'
+        cmdline += ' --protocol icmp'
+        cmdline += ' --rule-action allow'
+        cmdline += ' --ingress'
+        cmdline += ' --port-range From=22,To=22'
+        cmdline += ' --cidr-block 0.0.0.0/0'
+        result = {'NetworkAclId': 'acl-12345678',
+                  'RuleNumber': '100',
+                  'Protocol': '1',
+                  'RuleAction': 'allow',
+                  'Egress': 'false',
+                  'CidrBlock': '0.0.0.0/0',
+                  'PortRange.From': '22',
+                  'PortRange.To': '22'
+                  }
+        self.assert_params_for_cmd(cmdline, result)
+        
+    def test_all(self):
+        cmdline = self.prefix
+        cmdline += ' --network-acl-id acl-12345678'
+        cmdline += ' --rule-number 100'
+        cmdline += ' --protocol all'
+        cmdline += ' --rule-action allow'
+        cmdline += ' --ingress'
+        cmdline += ' --port-range From=22,To=22'
+        cmdline += ' --cidr-block 0.0.0.0/0'
+        result = {'NetworkAclId': 'acl-12345678',
+                  'RuleNumber': '100',
+                  'Protocol': '-1',
+                  'RuleAction': 'allow',
+                  'Egress': 'false',
+                  'CidrBlock': '0.0.0.0/0',
+                  'PortRange.From': '22',
+                  'PortRange.To': '22'
+                  }
+        self.assert_params_for_cmd(cmdline, result)
+        
+    def test_number(self):
+        cmdline = self.prefix
+        cmdline += ' --network-acl-id acl-12345678'
+        cmdline += ' --rule-number 100'
+        cmdline += ' --protocol 99'
+        cmdline += ' --rule-action allow'
+        cmdline += ' --ingress'
+        cmdline += ' --port-range From=22,To=22'
+        cmdline += ' --cidr-block 0.0.0.0/0'
+        result = {'NetworkAclId': 'acl-12345678',
+                  'RuleNumber': '100',
+                  'Protocol': '99',
+                  'RuleAction': 'allow',
+                  'Egress': 'false',
+                  'CidrBlock': '0.0.0.0/0',
+                  'PortRange.From': '22',
+                  'PortRange.To': '22'
+                  }
+        self.assert_params_for_cmd(cmdline, result)
+        


### PR DESCRIPTION
Allow the --protocol option of ec2 create-network-acl-entry command to accept tcp|udp|icmp|all in addition to the numeric protocol numbers.  The docs for the command already say it does this but the actual EC2 operation supports only integer values.
