### PR TITLE
Fail loudly and immediately if we can't gen docs

### DIFF
--- a/doc/source/bootstrapdocs.py
+++ b/doc/source/bootstrapdocs.py
@@ -9,5 +9,5 @@ script_path = os.path.join(os.path.dirname(__file__),
 os.environ['PATH'] += ':.'
 rc = subprocess.call("python "+ script_path, shell=True, env=os.environ)
 if rc != 0:
-    sys.stderr.write("Failed to generate documetation!\n")
+    sys.stderr.write("Failed to generate documentation!\n")
     sys.exit(2)


### PR DESCRIPTION
If htmlgen fails, the whole process fails immediately and you get
a non zero RC.  Previously it would just move on to the rendering
step, which makes it harder to notice build errors.

You now get:

```
  ...rds
  ...redshift
  ...route53
  ...s3
  ...s3api
  Traceback (most recent call last):
    File "aws-cli/doc/source/htmlgen", line 108, in <module>
      do_provider(driver)
    File "aws-cli/doc/source/htmlgen", line 66, in do_provider
      do_service(driver, REF_PATH, service_name, service_command)
    File "aws-cli/doc/source/htmlgen", line 48, in do_service
      help_command(None, None)
    File "aws-cli/awscli/help.py", line 232, in __call__
      bcdoc.docevents.generate_events(self.session, self)
    File "bcdoc/docevents.py", line 50, in generate_events
      help_command.name, help_command=help_command)
    File "bcdoc/docevents.py", line 36, in fire_event
      session.emit(event, **kwargs)
    File "botocore/botocore/session.py", line 551, in emit
      return self._events.emit(event_name, **kwargs)
    File "botocore/botocore/hooks.py", line 158, in emit
      response = handler(**kwargs)
    File "aws-cli/awscli/clidocs.py", line 243, in doc_description
      doc.include_doc_string(service.documentation)
  AttributeError: 'Service' object has no attribute 'documentation'
  Failed to generate documetation!
  make: *** [html] Error 2

  $ echo $?
  2
```
