### PR TITLE
Added option to compare on ETag/MD5

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -105,7 +105,7 @@ class FileGenerator(object):
         error, listdir = os.error, os.listdir
         if not dir_op:
             size, last_update = get_file_stat(path)
-            md5 = '"%s"' % get_file_md5(open(path))
+            md5 = '"%s"' % get_file_md5(open(path,'rb'))
             yield path, size, last_update, md5
         else:
             # We need to list files in byte order based on the full
@@ -135,7 +135,7 @@ class FileGenerator(object):
                         yield x
                 else:
                     size, last_update = get_file_stat(file_path)
-                    md5 = '"%s"' % get_file_md5(open(file_path))
+                    md5 = '"%s"' % get_file_md5(open(file_path,'rb'))
                     yield file_path, size, last_update, md5
 
     def _check_paths_decoded(self, path, names):

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -133,7 +133,7 @@ class FileInfo(TaskInfo):
     def __init__(self, src, dest=None, compare_key=None, size=None,
                  last_update=None, src_type=None, dest_type=None,
                  operation_name=None, service=None, endpoint=None,
-                 parameters=None):
+                 etag=None, parameters=None):
         super(FileInfo, self).__init__(src, src_type=src_type,
                                        operation_name=operation_name,
                                        service=service,
@@ -143,6 +143,8 @@ class FileInfo(TaskInfo):
         self.compare_key = compare_key
         self.size = size
         self.last_update = last_update
+        self.etag = etag
+        
         # Usually inject ``parameters`` from ``BasicTask`` class.
         if parameters is not None:
             self.parameters = parameters

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -808,7 +808,7 @@ CMD_DICT = {'cp': {'options': {'nargs': 2},
                                 'sse', 'storage-class', 'content-type',
                                 'cache-control', 'content-disposition',
                                 'content-encoding', 'content-language',
-                                'expires']},
+                                'expires', 'compare-on-etag']},
             'ls': {'options': {'nargs': '?', 'default': 's3://'},
                    'params': [], 'default': 's3://',
                    'command_class': ListCommand},
@@ -855,6 +855,13 @@ PARAMS_DICT = {'dryrun': {'options': {'action': 'store_true'}},
                'content-encoding': {'options': {'nargs': 1}},
                'content-language': {'options': {'nargs': 1}},
                'expires': {'options': {'nargs': 1}},
+               'compare-on-etag' : {'options': {'action': 'store_true'},
+                 'documents' : (
+                   'Makes the ETag of each key the only criteria used to '
+                   'decide whether to sync from source to destination. When '
+                   'working with local files, the md5 hash of the file is '
+                   'used.'
+                   )},
                'index-document': {'options': {}, 'documents':
                    ('A suffix that is appended to a request that is for a '
                     'directory on the website endpoint (e.g. if the suffix '

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -92,17 +92,24 @@ def get_file_stat(path):
     return stats.st_size, update_time
 
 
-def check_etag(etag, fileobj):
+def get_file_md5(fileobj):
     """
-    This fucntion checks the etag and the md5 checksum to ensure no
-    data was corrupted upon transfer.
+    This function computes the md5 hash of the specified fileobj.
     """
     get_chunk = partial(fileobj.read, 1024 * 1024)
     m = hashlib.md5()
     for chunk in iter(get_chunk, b''):
         m.update(chunk)
+    
+    return m.hexdigest()
+
+def check_etag(etag, fileobj):
+    """
+    This fucntion checks the etag and the md5 checksum to ensure no
+    data was corrupted upon transfer.
+    """
     if '-' not in etag:
-        if etag != m.hexdigest():
+        if etag != get_file_md5(fileobj):
             raise MD5Error
 
 

--- a/tests/unit/customizations/s3/test_comparator.py
+++ b/tests/unit/customizations/s3/test_comparator.py
@@ -298,7 +298,66 @@ class ComparatorTest(unittest.TestCase):
         for filename in files:
             result_list.append(filename)
         self.assertEqual(result_list, ref_list)
-
+    
+        
+class ComparatorEtagTest(unittest.TestCase):
+    def setUp(self):
+        self.comparator = Comparator({'delete': True, 'compare_on_etag' : True})
+    
+    def test_compare_etag_match(self):
+        """
+        Confirm that we determine files are the same when ETag matches.
+        """
+        src_files = []
+        dest_files = []
+        ref_list = []
+        result_list = []
+        time = datetime.datetime.now()
+        src_file = FileInfo(src='', dest='',
+                            compare_key='comparator_test.py', size=10,
+                            last_update=time, src_type='local',
+                            dest_type='s3', operation_name='upload',
+                            service=None, endpoint=None, etag='a4df78cfcbb934300222157a0d565e77')
+        dest_file = FileInfo(src='', dest='',
+                             compare_key='comparator_test.py', size=10,
+                             last_update=time, src_type='s3',
+                             dest_type='local', operation_name='',
+                             service=None, endpoint=None, etag='a4df78cfcbb934300222157a0d565e77')
+        src_files.append(src_file)
+        dest_files.append(dest_file)
+        self.comparator.compare_on_etag = True
+        files = self.comparator.call(iter(src_files), iter(dest_files))
+        for filename in files:
+            result_list.append(filename)
+        self.assertEqual(result_list, ref_list)
+    
+    def test_compare_etag_differs(self):
+        """
+        Confirm that we determine files are different when ETag differs.
+        """
+        src_files = []
+        dest_files = []
+        ref_list = []
+        result_list = []
+        time = datetime.datetime.now()
+        src_file = FileInfo(src='', dest='',
+                            compare_key='comparator_test.py', size=10,
+                            last_update=time, src_type='local',
+                            dest_type='s3', operation_name='upload',
+                            service=None, endpoint=None, etag='a4df78cfcbb934300222157a0d565e77')
+        dest_file = FileInfo(src='', dest='',
+                             compare_key='comparator_test.py', size=10,
+                             last_update=time, src_type='s3',
+                             dest_type='local', operation_name='',
+                             service=None, endpoint=None, etag='d2a791addeec74d620a34305ab6f48c6')
+        src_files.append(src_file)
+        dest_files.append(dest_file)
+        self.comparator.compare_on_etag = True
+        files = self.comparator.call(iter(src_files), iter(dest_files))
+        ref_list.append(src_file)
+        for filename in files:
+            result_list.append(filename)
+        self.assertEqual(result_list, ref_list)    
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_s3.py
+++ b/tests/unit/customizations/s3/test_s3.py
@@ -92,7 +92,7 @@ class CreateTablesTest(unittest.TestCase):
                        'sse', 'storage-class', 'website-redirect',
                        'content-type', 'cache-control', 'content-disposition',
                        'content-language', 'content-encoding', 'expires',
-                       'grants']
+                       'grants','compare-on-etag']
         for cmd in commands_list:
             self.parameters = {}
             add_cmd_params(self.parameters, cmd)


### PR DESCRIPTION
We have a use case for s3 sync in which we update a staging bucket with production data.  However, the current comparator options will fail to update keys in the staging bucket when they have been updated more recently than the production keys but do not differ in size.

This change adds a --compare-on-etag option that uses the ETag of the key or the md5 of the local file to determine whether or not the source and destination differ.
