### PR TITLE
Fix bug in special case shorthand docs

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -303,7 +303,7 @@ class ParamShorthand(object):
             # should be skipped for this arg.
             return None
         else:
-            self._docs_key_value_parse(param)
+            return self._docs_key_value_parse(param)
 
     def _docs_key_value_parse(self, param):
         s = '%s ' % param.cli_name

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -230,6 +230,15 @@ class TestStructureScalarHasNoExamples(BaseAWSHelpOutputTest):
         self.assert_not_contains('"Value": "string"')
         self.assert_not_contains('Value=string')
 
+    def test_example_for_single_structure_not_named_value(self):
+        # Verify that if a structure does match our special case
+        # (single element named "Value"), then we still document
+        # the example syntax.
+        self.driver.main(['s3api', 'restore-object', 'help'])
+        self.assert_contains('Days=value')
+        # Also should see the JSON syntax in the help output.
+        self.assert_contains('"Days": integer')
+
 
 class TestJSONListScalarDocs(BaseAWSHelpOutputTest):
     def test_space_separated_list_docs(self):


### PR DESCRIPTION
For structures of a single element that weren't named
`Value`, we weren't returning the value from
`_docs_key_value_parse`.

Fixes #566.
