### PR TITLE
Add tox.ini for tox support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py26,py27,py33
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+commands = nosetests tests/unit
+
+[testenv:py26]
+deps =
+	unittest2
+	-r{toxinidir}/requirements.txt


### PR DESCRIPTION
I was helping a coworker fix up a pull request where the Python 3.3 tests failed on Travis, and I suggested that he use tox to make sure that the testsuite passed on all of the supported Python versions. I found it a little odd that tox was included in `requirements.txt`, even though there was no `tox.ini`. Here is a simple one, ported from `.travis.yml` and compatible with the version of tox listed in `requirements.txt`.
