### PR TITLE
Honor REQUESTS_CA_BUNDLE env var

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
-* Add support for the ``REQUESTS_CA_BUNDLE`` environment variable so that users
+* Add support for the ``AWS_CA_BUNDLE`` environment variable so that users
   can specify an alternate path to a cert bundle
   (`issue 586 <https://github.com/aws/aws-cli/pull/586>`__)
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
+import os
 import logging
 
 import botocore.session
@@ -515,9 +516,7 @@ class CLIOperationCaller(object):
         # for credentials so we can give a good error message.
         if not self._session.get_credentials():
             raise NoCredentialsError()
-        verify = None
-        if parsed_globals.no_verify_ssl:
-            verify = False
+        verify = self._resolve_verify_var(parsed_globals.no_verify_ssl)
         endpoint = operation_object.service.get_endpoint(
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
@@ -532,6 +531,14 @@ class CLIOperationCaller(object):
             self._display_response(operation_object, response_data,
                                    parsed_globals)
         return 0
+
+    def _resolve_verify_var(self, no_verify_ssl):
+        verify = None
+        if no_verify_ssl:
+            verify = False
+        else:
+            verify = os.environ.get('AWS_CA_BUNDLE')
+        return verify
 
     def _display_response(self, operation, response, args):
         output = args.output

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -356,12 +356,26 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             endpoint.return_value = None
             endpoint.make_request.return_value = (
                 http_response, {})
-            self.environ['REQUESTS_CA_BUNDLE'] = '/path/cacert.pem'
+            self.environ['AWS_CA_BUNDLE'] = '/path/cacert.pem'
             self.assert_params_for_cmd(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         call_args = endpoint.call_args
         self.assertEqual(call_args[1]['verify'], '/path/cacert.pem')
+
+    def test_default_to_verifying_ssl(self):
+        with mock.patch('botocore.endpoint.QueryEndpoint.__init__') as endpoint:
+            environ = {}
+            http_response = models.Response()
+            http_response.status_code = 200
+            endpoint.return_value = None
+            endpoint.make_request.return_value = (
+                http_response, {})
+            self.assert_params_for_cmd(
+                'ec2 describe-instances --region us-east-1',
+                expected_rc=0)
+        call_args = endpoint.call_args
+        self.assertEqual(call_args[1]['verify'], True)
 
     def test_s3_with_region_and_endpoint_url(self):
         with mock.patch('botocore.service.Service.get_endpoint') as endpoint:


### PR DESCRIPTION
This allows a user to specify a different cert bundle via an
env var.  This uses the new verify arg added to get_endpoint
in botocore.

Previously it was creating an Endpoint object and then setting the
verify attribute, but the REQUESTS_CA_BUNDLE lookup happens before
an Endpoint object is created, so we would override the value
from the env var.  By using the verify arg in get_endpoint we
can avoid this.

Note that this depends on https://github.com/boto/botocore/pull/203 and will
fail the tests until this is merged in.
