### PR TITLE
Retry intermittent S3 download failures

### DIFF
--- a/tests/unit/customizations/s3/fake_session.py
+++ b/tests/unit/customizations/s3/fake_session.py
@@ -262,6 +262,7 @@ class FakeOperation(object):
                 else:
                     body = body[int(beginning):(int(end) + 1)]
             mock_response = BytesIO(body)
+            mock_response.set_socket_timeout = Mock()
             response_data['Body'] = mock_response
             etag = self.session.s3[bucket][key]['ETag']
             response_data['ETag'] = etag + '--'


### PR DESCRIPTION
This builds on the recent work in botocore
(https://github.com/boto/botocore/pull/210) to address two things:
- ensure than any .read() call used from the streaming response of
  `GetObject` will never hang.  We do this by applying a timeout
  to the underlying socket.
- Catch and retry IncompleteReadError. There may be times when we
  don't receive all of the contents from a `GetObject` request such
  that amount_read != content-length header.  Botocore now checks
  this and raises an exception, which the CLI now catches and retries.
