### PR TITLE
Document supported config file variables

### DIFF
--- a/awscli/customizations/configure.py
+++ b/awscli/customizations/configure.py
@@ -273,21 +273,7 @@ class ConfigureListCommand(BasicCommand):
 
 class ConfigureCommand(BasicCommand):
     NAME = 'configure'
-    DESCRIPTION = (
-        'Configure AWS CLI configuration data.  If this command '
-        'is run with no arguments, you will be prompted for configuration '
-        'values such as your AWS Access Key Id and you AWS Secret Access '
-        'Key.  You can configure a specific profile using the ``--profile`` '
-        'argument.  If your config file does not exist (the default location '
-        'is ``~/.aws/config``), it will be automatically created for you. '
-        'To keep an existing value, hit enter when prompted for the value.\n\n'
-        'When you are prompted for information, the current value will be '
-        'displayed in ``[brackets]``.  If the config item has no value, it '
-        'be displayed as ``[None]``.\n\n'
-        'Note that the ``configure`` command only work with values from the '
-        'config file.  It does not use any configuration values from '
-        'environment variables or the IAM role.\n'
-    )
+    DESCRIPTION = BasicCommand.FROM_FILE
     SYNOPSIS = ('aws configure [--profile profile-name]')
     EXAMPLES = (
         'To create a new configuration::\n'

--- a/awscli/examples/configure/_description.rst
+++ b/awscli/examples/configure/_description.rst
@@ -1,0 +1,28 @@
+Configure AWS CLI configuration data.  If this command is run with no
+arguments, you will be prompted for configuration values such as your AWS
+Access Key Id and you AWS Secret Access Key.  You can configure a specific
+profile using the ``--profile`` argument.  If your config file does not exist
+(the default location is ``~/.aws/config``), it will be automatically created
+for you.  To keep an existing value, hit enter when prompted for the value.
+When you are prompted for information, the current value will be displayed in
+``[brackets]``.  If the config item has no value, it be displayed as
+``[None]``.  Note that the ``configure`` command only work with values from the
+config file.  It does not use any configuration values from environment
+variables or the IAM role.
+
+=======================
+Configuration Variables
+=======================
+
+The following configuration variables are supported in the config file:
+
+* **aws_access_key_id** - The AWS access key part of your credentials
+* **aws_secret_access_key** - The AWS secret access key part of your credentials
+* **aws_security_token** - The security token part of your credentials (session tokens only)
+* **metadata_service_timeout** - The number of seconds to wait until the metadata service
+  request times out.  This is used if you are using an IAM role to provide
+  your credentials.
+* **metadata_service_num_attempts** - The number of attempts to try to retrieve
+  credentials.  If you know for certain you will be using an IAM role on an
+  Amazon EC2 instance, you can set this value to ensure any intermittent
+  failures are retried.  By default this value is 1.

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -262,3 +262,14 @@ class TestParamRename(BaseAWSHelpOutputTest):
         self.driver.main(['ec2', 'create-image', 'help'])
         self.assert_not_contains('no-no-reboot')
         self.assert_contains('--reboot')
+
+class TestCustomCommandDocsFromFile(BaseAWSHelpOutputTest):
+    def test_description_from_rst_file(self):
+        # The description for the configure command
+        # is in _description.rst.  We're verifying that we
+        # can read those contents properly.
+        self.driver.main(['configure', 'help'])
+        # These are a few options that are documented in the help output.
+        self.assert_contains('metadata_service_timeout')
+        self.assert_contains('metadata_service_num_attempts')
+        self.assert_contains('aws_access_key_id')


### PR DESCRIPTION
This includes the newly added metadata_service_timeout and
metadata_service_num_attempts.  As part of this change,
I've added the ability for custom commands to provide their
description/synopsis/examples in rst files.  That way
the classes for commands do not have to include
the documentation text as part of the class definition.
