### PR TITLE
Use a single IO thread when downloading S3 objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ Next Release (TBD)
 
 * feature:``aws configure``: Add support for ``configure get`` and ``configure
   set`` command which allow you to set and get configuration values from the
-  AWS config file (`issue 602 <https://github.com/aws/aws-cli/issues/602`)
+  AWS config file (`issue 602 <https://github.com/aws/aws-cli/issues/602`__)
+* bugfix:``aws s3``: Fix issue with Amazon S3 downloads on certain OSes
+  (`issue 619 <https://github.com/aws/aws-cli/issues/619`__)
 
 
 1.2.11

--- a/awscli/customizations/s3/executor.py
+++ b/awscli/customizations/s3/executor.py
@@ -15,7 +15,8 @@ from six.moves import queue as Queue
 import sys
 import threading
 
-from awscli.customizations.s3.utils import NoBlockQueue, uni_print
+from awscli.customizations.s3.utils import NoBlockQueue, uni_print, \
+        IORequest, IOCloseRequest
 
 
 LOGGER = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ class Executor(object):
     ``Executor``runs is a worker and a print thread.
     """
     def __init__(self, done, num_threads, result_queue,
-                 quiet, interrupt, max_queue_size):
+                 quiet, interrupt, max_queue_size, write_queue):
         self.queue = None
         self.done = done
         self.num_threads = num_threads
@@ -38,7 +39,9 @@ class Executor(object):
         self.interrupt = interrupt
         self.threads_list = []
         self._max_queue_size = max_queue_size
+        self.write_queue = write_queue
         self.print_thread = None
+        self.io_thread = None
 
     @property
     def num_tasks_failed(self):
@@ -51,6 +54,9 @@ class Executor(object):
         self.print_thread = PrintThread(self.result_queue, self.done,
                                         self.quiet, self.interrupt)
         self.print_thread.daemon = True
+        self.io_thread = IOWriterThread(self.write_queue, self.done)
+        self.io_thread.start()
+        self.threads_list.append(self.io_thread)
         self.queue = NoBlockQueue(self.interrupt, maxsize=self._max_queue_size)
         self.threads_list.append(self.print_thread)
         self.print_thread.start()
@@ -78,12 +84,52 @@ class Executor(object):
         """
         This is used to clean up the ``Executor``.
         """
+        self.write_queue.put(QUEUE_END_SENTINEL)
         self.result_queue.put(QUEUE_END_SENTINEL)
         for i in range(self.num_threads):
             self.queue.put(QUEUE_END_SENTINEL)
 
         for thread in self.threads_list:
             thread.join()
+
+
+class IOWriterThread(threading.Thread):
+    def __init__(self, queue, done):
+        threading.Thread.__init__(self)
+        self.queue = queue
+        self.done = done
+        self.fd_descriptor_cache = {}
+
+    def run(self):
+        while True:
+            task = self.queue.get(True)
+            if task is QUEUE_END_SENTINEL:
+                LOGGER.debug("Sentinel received in IO thread, "
+                             "shutting down.")
+                self._cleanup()
+                return
+            elif isinstance(task, IORequest):
+                filename, offset, data = task
+                fileobj = self.fd_descriptor_cache.get(filename)
+                if fileobj is None:
+                    fileobj = open(filename, 'rb+')
+                    self.fd_descriptor_cache[filename] = fileobj
+                fileobj.seek(offset)
+                LOGGER.debug("Writing data to: %s, offset: %s",
+                             filename, offset)
+                fileobj.write(data)
+                fileobj.flush()
+            elif isinstance(task, IOCloseRequest):
+                LOGGER.debug("IOCloseRequest received for %s, closing file.",
+                             task.filename)
+                fileobj = self.fd_descriptor_cache.get(task.filename)
+                if fileobj is not None:
+                    fileobj.close()
+                    del self.fd_descriptor_cache[task.filename]
+
+    def _cleanup(self):
+        for fileobj in self.fd_descriptor_cache.values():
+            fileobj.close()
 
 
 class Worker(threading.Thread):
@@ -107,8 +153,7 @@ class Worker(threading.Thread):
                 try:
                     function()
                 except Exception as e:
-                    LOGGER.debug('Error calling task: %s', e,
-                                    exc_info=True)
+                    LOGGER.debug('Error calling task: %s', e, exc_info=True)
                 self.queue.task_done()
             except Queue.Empty:
                 pass

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -16,6 +16,7 @@ import hashlib
 import math
 import os
 import sys
+from collections import namedtuple
 from functools import partial
 
 from six import PY3
@@ -260,3 +261,9 @@ class ReadFileChunk(object):
         # already exhausted the stream so iterating over the file immediately
         # steps, which is what we're simulating here.
         return iter([])
+
+
+IORequest = namedtuple('IORequest', ['filename', 'offset', 'data'])
+# Used to signal that IO for the filename is finished, and that
+# any associated resources may be cleaned up.
+IOCloseRequest = namedtuple('IOCloseRequest', ['filename'])

--- a/tests/unit/customizations/s3/test_executor.py
+++ b/tests/unit/customizations/s3/test_executor.py
@@ -1,0 +1,69 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+import os
+import tempfile
+import shutil
+import mock
+from six.moves import queue
+
+from awscli.customizations.s3.executor import IOWriterThread
+from awscli.customizations.s3.executor import QUEUE_END_SENTINEL
+from awscli.customizations.s3.utils import IORequest, IOCloseRequest
+
+
+class TestIOWriterThread(unittest.TestCase):
+
+    def setUp(self):
+        self.queue = queue.Queue()
+        self.io_thread = IOWriterThread(self.queue, mock.Mock())
+        self.temp_dir = tempfile.mkdtemp()
+        self.filename = os.path.join(self.temp_dir, 'foo')
+        # Create the file, since IOWriterThread expects
+        # files to exist, we need to first creat the file.
+        open(self.filename, 'w').close()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_handles_io_request(self):
+        self.queue.put(IORequest(self.filename, 0, b'foobar'))
+        self.queue.put(IOCloseRequest(self.filename))
+        self.queue.put(QUEUE_END_SENTINEL)
+        self.io_thread.run()
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), b'foobar')
+
+    def test_out_of_order_io_requests(self):
+        self.queue.put(IORequest(self.filename, 6, b'morestuff'))
+        self.queue.put(IORequest(self.filename, 0, b'foobar'))
+        self.queue.put(IOCloseRequest(self.filename))
+        self.queue.put(QUEUE_END_SENTINEL)
+        self.io_thread.run()
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), b'foobarmorestuff')
+
+    def test_multiple_files_in_queue(self):
+        second_file = os.path.join(self.temp_dir, 'bar')
+        open(second_file, 'w').close()
+        self.queue.put(IORequest(self.filename, 0, b'foobar'))
+        self.queue.put(IORequest(second_file, 0, b'otherstuff'))
+        self.queue.put(IOCloseRequest(second_file))
+        self.queue.put(IOCloseRequest(self.filename))
+        self.queue.put(QUEUE_END_SENTINEL)
+
+        self.io_thread.run()
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(f.read(), b'foobar')
+        with open(second_file, 'rb') as f:
+            self.assertEqual(f.read(), b'otherstuff')


### PR DESCRIPTION
We have seen issues on some OSes that have trouble with
concurrent IO threads to different parts of the same file.
Despite these being non overlapping parts of the file, this
doesn't always work.

The fix is to switch to a single IO thread. All other threads are
now passed an IO queue in which they can submit either `IORequests`
or `IOCompleteRequests` that the IO thread understands.

Fixes #619 
