### PR TITLE
Don't require s3:// prefix on ls commands

### DIFF
--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -342,7 +342,10 @@ class S3SubCommand(object):
 
 class ListCommand(S3SubCommand):
     def _do_command(self, parsed_args, parsed_globals):
-        bucket, key = find_bucket_key(parsed_args.paths[0][5:])
+        path = parsed_args.paths[0]
+        if path.startswith('s3://'):
+            path = path[5:]
+        bucket, key = find_bucket_key(path)
         self.service = self._session.get_service('s3')
         self.endpoint = self._get_endpoint(self.service, parsed_globals)
         if not bucket:

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -534,6 +534,15 @@ class TestLs(BaseS3CLICommand):
         self.assertIn('8 bar.txt', p.stdout)
         self.assertIn('8 subdir/foo.txt', p.stdout)
 
+    def test_ls_without_prefix(self):
+        # The ls command does not require an s3:// prefix,
+        # we're always listing s3 contents.
+        bucket_name = self.create_bucket()
+        self.put_object(bucket_name, 'foo.txt', 'contents')
+        p = aws('s3 ls %s' % bucket_name)
+        self.assertEqual(p.rc, 0)
+        self.assertIn('foo.txt', p.stdout)
+
 
 class TestMbRb(BaseS3CLICommand):
     """


### PR DESCRIPTION
The path will always refer to an s3 object,
so it's not necessary to specify s3://.  Now
we support both versions:
- aws s3 ls s3://bucket-name
- aws s3 ls bucket-name
