### PR TITLE
Don't duplicate enum params

### DIFF
--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -272,3 +272,26 @@ class TestCustomCommandDocsFromFile(BaseAWSHelpOutputTest):
         self.assert_contains('metadata_service_timeout')
         self.assert_contains('metadata_service_num_attempts')
         self.assert_contains('aws_access_key_id')
+
+class TestEnumDocsArentDuplicated(BaseAWSHelpOutputTest):
+    def test_enum_docs_arent_duplicated(self):
+        # Test for: https://github.com/aws/aws-cli/issues/609
+        # What's happening is if you have a list param that has
+        # an enum, we document it as:
+        # a|b|c|d   a|b|c|d
+        # Except we show all of the possible enum params twice.
+        # Each enum param should only occur once.  The ideal documentation
+        # should be:
+        #
+        # string1 string2
+        #
+        # Where each value is one of:
+        #     value1
+        #     value2
+        self.driver.main(['cloudformation', 'list-stacks', 'help'])
+        # "CREATE_IN_PROGRESS" is a enum value, and should only
+        # appear once in the help output.
+        contents = self.renderer.rendered_contents
+        self.assertTrue(contents.count("CREATE_IN_PROGRESS") == 1,
+                        ("Enum param was only suppose to be appear once in "
+                         "rendered doc output."))


### PR DESCRIPTION
The new docs look like:

```
  OPTIONS
         --stack-status-filter (list)
            Stack status to use as a filter. Specify one or  more  stack  status
            codes  to  list  only  stacks with the specified status codes. For a
            complete list of stack status codes, see the  StackStatus  parameter
            of the  Stack data type.

         Syntax:

            "string" "string" ...

            Where valid values are:
              CREATE_IN_PROGRESS
              CREATE_FAILED
              CREATE_COMPLETE
              ROLLBACK_IN_PROGRESS
              ROLLBACK_FAILED
              ROLLBACK_COMPLETE
              DELETE_IN_PROGRESS
              DELETE_FAILED
              DELETE_COMPLETE
              UPDATE_IN_PROGRESS
              UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
              UPDATE_COMPLETE
              UPDATE_ROLLBACK_IN_PROGRESS
              UPDATE_ROLLBACK_FAILED
              UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
              UPDATE_ROLLBACK_COMPLETE

```

Fixes #609.
