### PR TITLE
Don't print tracebacks if completer is interrupted

### DIFF
--- a/bin/aws_completer
+++ b/bin/aws_completer
@@ -19,4 +19,9 @@ if __name__ == '__main__':
     # bash exports COMP_LINE and COMP_POINT, tcsh COMMAND_LINE only
     cline = os.environ.get('COMP_LINE') or os.environ.get('COMMAND_LINE') or ''
     cpoint = int(os.environ.get('COMP_POINT') or len(cline))
-    awscli.completer.complete(cline, cpoint)
+    try:
+        awscli.completer.complete(cline, cpoint)
+    except KeyboardInterrupt:
+        # If the user hits Ctrl+C, we don't want to print
+        # a traceback to the user.
+        pass


### PR DESCRIPTION
Fixes #628.

Note that this is a fix to a `bin/` script, so there's not really a good hook to test this, though I did manually test this.  It also doesn't seem to make sense to catch keyboard interrupts in the `complete()` method.  If anyone wants some type of test for this, I'm open to suggestions.
