### PR TITLE
Missing --recursive option in recursive example for aws s3 ls

### DIFF
--- a/awscli/examples/s3/ls.rst
+++ b/awscli/examples/s3/ls.rst
@@ -48,7 +48,7 @@ prefixes under the specified bucket and prefix.
 
 ::
 
-    aws s3 ls s3://mybucket/
+    aws s3 ls s3://mybucket --recursive
 
 *Output*
 ::


### PR DESCRIPTION
I found that the recursive example was missing the `--recursive` flag.

I was a bit confused with this example because the only difference between the normal and non-recursive examples was a trailing slash:
`aws s3 ls s3://mybucket`
`aws s3 ls s3://mybucket/` (missing `--recursive`)
