### PR TITLE
Show better error message for invalid JSON

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -202,6 +202,7 @@ class CLIDriver(object):
         except Exception as e:
             LOG.debug("Exception caught in main()", exc_info=True)
             LOG.debug("Exiting with rc 255")
+            sys.stderr.write("\n")
             sys.stderr.write("%s\n" % e)
             return 255
 

--- a/tests/unit/ec2/test_get_password_data.py
+++ b/tests/unit/ec2/test_get_password_data.py
@@ -48,9 +48,9 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         result = {}
         error_msg = self.assert_params_for_cmd(
             cmdline, result, expected_rc=255)[1]
-        self.assertEqual(error_msg, ('priv-launch-key should be a path to '
-                                     'the local SSH private key file used '
-                                     'to launch the instance.\n'))
+        self.assertIn('priv-launch-key should be a path to '
+                      'the local SSH private key file used '
+                      'to launch the instance.\n', error_msg)
 
     def test_priv_launch_key(self):
         key_path = os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
Especially for list params, their error messages were not helpful.
Error messages now include the actual value itself, as we have seen
cases where customers specify valid JSON but the shell they're using
will process arguments and strip out characters such as quotes.
By showing the actual JSON contents it will make this more obvious.

Before:

```
  The value for parameter "--" must be JSON or path to file.
```

After:

```
  Error parsing parameter --block-device-mappings: Invalid JSON:
  [{ ...BAD JSON CONTENTS ...}]
```
