### PR TITLE
Handle file:// values containing leading/trailing spaces

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -139,7 +139,7 @@ class ParamShorthand(object):
         if isinstance(value, list):
             check_val = value[0]
         else:
-            check_val = value
+            check_val = value.strip()
         if isinstance(check_val, str) and check_val.startswith(('[', '{')):
             LOG.debug("Param %s looks like JSON, not considered for "
                       "param shorthand.", param.py_name)

--- a/tests/unit/elb/test_register_instances_with_load_balancer.py
+++ b/tests/unit/elb/test_register_instances_with_load_balancer.py
@@ -64,6 +64,14 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline += ' --instances file://%s' % data_path
         self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
+    def test_json_file_with_spaces(self):
+        data_path = os.path.join(os.path.dirname(__file__),
+                                 'test_with_spaces.json')
+        cmdline = self.prefix
+        cmdline += ' --load-balancer-name my-lb'
+        cmdline += ' --instances file://%s' % data_path
+        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+
     def test_two_instance_shorthand(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'

--- a/tests/unit/elb/test_with_spaces.json
+++ b/tests/unit/elb/test_with_spaces.json
@@ -1,0 +1,2 @@
+  [{"InstanceId": "i-12345678"},
+ {"InstanceId": "i-87654321"}]


### PR DESCRIPTION
Fixes #631.  The issue was that shorthand processing was triggered
because we were looking at leading spaces instead of the first non
space character.
