### PR TITLE
Remove session from paramfile interface

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -47,7 +47,7 @@ class ParamUnknownKeyError(Exception):
         super(ParamUnknownKeyError, self).__init__(full_message)
 
 
-def uri_param(param, value, operation, **kwargs):
+def uri_param(param, value, **kwargs):
     """Handler that supports param values from URIs.
     """
     # Some params have a 'no_paramfile' attribute in their JSON
@@ -56,13 +56,13 @@ def uri_param(param, value, operation, **kwargs):
     if hasattr(param, 'no_paramfile'):
         return
     else:
-        return _check_for_uri_param(param, value, operation)
+        return _check_for_uri_param(param, value)
 
-def _check_for_uri_param(param, value, operation):
+def _check_for_uri_param(param, value):
     if isinstance(value, list) and len(value) == 1:
         value = value[0]
     try:
-        return get_paramfile(operation.service.session, value)
+        return get_paramfile(value)
     except ResourceLoadingError as e:
         raise ParamError(param, str(e))
 

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -26,7 +26,7 @@ class ResourceLoadingError(Exception):
     pass
 
 
-def get_paramfile(session, path):
+def get_paramfile(path):
     """
     It is possible to pass parameters to operations by referring
     to files or URI's.  If such a reference is detected, this
@@ -39,11 +39,11 @@ def get_paramfile(session, path):
     if isinstance(path, six.string_types):
         for prefix in PrefixMap:
             if path.startswith(prefix):
-                data = PrefixMap[prefix](session, prefix, path)
+                data = PrefixMap[prefix](prefix, path)
     return data
 
 
-def get_file(session, prefix, path):
+def get_file(prefix, path):
     file_path = path[len(prefix):]
     file_path = os.path.expanduser(file_path)
     file_path = os.path.expandvars(file_path)
@@ -57,7 +57,7 @@ def get_file(session, prefix, path):
             path, e))
 
 
-def get_uri(session, prefix, uri):
+def get_uri(prefix, uri):
     try:
         r = requests.get(uri)
         if r.status_code == 200:

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -50,13 +50,11 @@ class BaseArgProcessTest(BaseCLIDriverTest):
 class TestURIParams(BaseArgProcessTest):
     def test_uri_param(self):
         p = self.get_param_object('ec2.DescribeInstances.Filters')
-        operation = self.session.get_service('ec2')\
-                .get_operation('DescribeInstances')
         with temporary_file('r+') as f:
             json_argument = json.dumps([{"Name": "instance-id", "Values": ["i-1234"]}])
             f.write(json_argument)
             f.flush()
-            result = uri_param(p, 'file://%s' % f.name, operation)
+            result = uri_param(p, 'file://%s' % f.name)
         self.assertEqual(result, json_argument)
 
 


### PR DESCRIPTION
The session variable isn't being used and makes it an unnecessary
requirement for code that wants to use this functionality.

The session variable would be useful for code that needs to make
AWS requests.  For example, if we support `s3://` prefix in the future
(there's an existing issue for this) then _that_ code would need to have
a reference to a session.  However, I think each handler should be
responsible for getting its necessary dependencies.
