### PR TITLE
support for interpreting XML-formatted response body

### DIFF
--- a/awscli/errorhandler.py
+++ b/awscli/errorhandler.py
@@ -13,6 +13,7 @@
 
 import sys
 import logging
+import xml.etree.cElementTree
 
 LOG = logging.getLogger(__name__)
 
@@ -86,4 +87,17 @@ class ErrorHandler(object):
                     code = error['Type']
                 if 'Message' in error:
                     message = error['Message']
+        elif 'Body' in response and \
+             response.get('ContentType') == 'application/xml':
+            # XML formatted data
+            body = response['Body'].read()
+            parser = xml.etree.cElementTree.XMLParser(
+                         target=xml.etree.cElementTree.TreeBuilder(),
+                         encoding='UTF-8')
+            parser.feed(body)
+            tree = parser.close()
+            if tree.find('Code') is not None:
+                code = tree.findtext('Code')
+            if tree.find('Message') is not None:
+                message = tree.findtext('Message')
         return (code, message)


### PR DESCRIPTION
how to return xml error message

How to reproduce
1. store object in s3
2. archive to glacier
3. $ aws cp s3://bucket/glacier/foo.jpg  foo.jpg

You'll get XML-formatted response body as follows:

```
<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>InvalidObjectState</Code><Message>The operation is not valid for the object\'s storage class</Message><RequestId>C1E9DD0E49204444</RequestId><HostId>dummy</HostId></Error>
```

before fix

```
download failed: s3://bucket/glacier/foo.jpg to ./foo.jpg A client error (Unknown) occurred when calling the GetObject operation: Unknown
```

after fix

```
download failed: s3://bucket/glacier/foo.jpg to ./foo.jpg A client error (InvalidObjectState) occurred when calling the GetObject operation: The operation is not valid for the object's storage class
```
