### PR TITLE
compare s3's last modified time using server's timezone

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ nose==1.3.0
 colorama==0.2.5
 mock==1.0.1
 rsa==3.1.2
+python-dateutil==2.2

--- a/tests/unit/customizations/s3/test_ls_command.py
+++ b/tests/unit/customizations/s3/test_ls_command.py
@@ -12,14 +12,15 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from tests.unit import BaseAWSCommandParamsTest
-
+from dateutil import parser, tz
 
 class TestLSCommand(BaseAWSCommandParamsTest):
 
     def test_operations_used_in_recursive_list(self):
+        time_utc = "2014-01-09T20:45:49.000Z"
         self.parsed_responses = [{"CommonPrefixes": [], "Contents": [
             {"Key": "foo/bar.txt", "Size": 100,
-             "LastModified": "2014-01-09T20:45:49.000Z"}]}]
+             "LastModified": time_utc}]}]
         stdout, _, _ = self.run_cmd('s3 ls s3://bucket/ --recursive', expected_rc=0)
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
@@ -27,7 +28,8 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         self.assertEqual(call_args['prefix'], '')
         self.assertEqual(call_args['bucket'], 'bucket')
         self.assertNotIn('delimiter', call_args)
-        # Using assertRegexpMatches because the actual time displayed
-        # is specific to your tzinfo.
-        self.assertRegexpMatches(
-            stdout, '2014-01-09 \d{2}:\d{2}:\d{2}        100 foo/bar.txt\n')
+        # Time is stored in UTC timezone, but the actual time displayed
+        # is specific to your tzinfo, so shift the timezone to your local's.
+        time_local = parser.parse(time_utc).astimezone(tz.tzlocal())
+        self.assertEqual(
+            stdout, '%s        100 foo/bar.txt\n'%time_local.strftime('%Y-%m-%d %H:%M:%S'))


### PR DESCRIPTION
S3's last modified time is stored in utc timezone,
but displayed in server's timezone.
Prior to this fix, no timezone calculation was made,
so test_ls_command.py kept failing for some timezones.

In my case, I'm living in UTC+9. UTC time "2014-01-09T20:45:49" is "2014-01-10 05:45:49" in my local time.
but regex pattern is "2014-01-09 \d{2}:\d{2}:\d{2}".
As you see date is different, so this test kept failing in my local machine.

This fix tests displayed last modified time using server's timezone.
