### PR TITLE
Update formatter.py

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -73,9 +73,12 @@ class JSONFormatter(FullyBufferedFormatter):
         # the response will be an empty string.  We don't want to print
         # that out to the user but other "falsey" values like an empty
         # dictionary should be printed.
-        if response:
+        if response == '':
             json.dump(response, stream, indent=4)
             stream.write('\n')
+        else:
+            json.dump(response, stream)
+            stream.write('')
 
 
 class TableFormatter(FullyBufferedFormatter):


### PR DESCRIPTION
Should only be applied on empty response, json is mangled in subprocess output:

```
>>> import subprocess, datetime
>>> now = datetime.datetime.now()
>>> start = now - datetime.timedelta(hours=3) 
>>> queue_name = 'tester'
>>> data = subprocess.Popen(['aws', 'cloudwatch', 'get-metric-statistics', '--namespace', 'AWS/SQS', '--metric-name', 'NumberOfMessagesReceived', '--dimensions', 'Name=QueueName,Value='+queue_name, '--start-time', str(start), '--end-time', str(now), '--period', '900', '--statistics', 'Sum'],stdout = subprocess.PIPE).stdout
>>> 
>>> 
>>> data.read()
'{\n    "Datapoints": [\n        {\n            "Timestamp": "2014-03-03T18:39:00Z", \n            "Sum": 171291.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T17:54:00Z", \n            "Sum": 206961.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T16:39:00Z", \n            "Sum": 201210.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T17:24:00Z", \n            "Sum": 197159.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T18:24:00Z", \n            "Sum": 177225.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T16:24:00Z", \n            "Sum": 181346.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T17:09:00Z", \n            "Sum": 201615.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T16:54:00Z", \n            "Sum": 251720.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T18:54:00Z", \n            "Sum": 162135.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T18:09:00Z", \n            "Sum": 185028.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T19:09:00Z", \n            "Sum": 103027.0, \n            "Unit": "Count"\n        }, \n        {\n            "Timestamp": "2014-03-03T17:39:00Z", \n            "Sum": 219606.0, \n            "Unit": "Count"\n        }\n    ], \n    "Label": "NumberOfMessagesReceived"\n}'
```
