### PR TITLE
Fix regression when parsing number types in shorthand

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -162,8 +162,8 @@ class ParamShorthand(object):
         if isinstance(value, list):
             check_val = value[0]
         else:
-            check_val = value.strip()
-        if isinstance(check_val, six.string_types) and check_val.startswith(
+            check_val = value
+        if isinstance(check_val, six.string_types) and check_val.strip().startswith(
                 ('[', '{')):
             LOG.debug("Param %s looks like JSON, not considered for "
                       "param shorthand.", param.py_name)

--- a/tests/unit/rds/test_describe_db_log_files.py
+++ b/tests/unit/rds/test_describe_db_log_files.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests.unit import BaseAWSCommandParamsTest
+
+
+class TestDescribeDBLogFiles(BaseAWSCommandParamsTest):
+    maxDiff = None
+    prefix = 'rds describe-db-log-files '
+
+    def test_add_option(self):
+        args = ('--file-last-written 10 '
+                '--db-instance-identifier foo')
+        cmdline = self.prefix + args
+        result = {'DBInstanceIdentifier': 'foo',
+                  'FileLastWritten': '10'}
+        self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
We can't call strip() until we know that the object is a string.
This is a regression introduced in the last CLI release.
