### PR TITLE
Raise exception when bad output format is given

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -249,4 +249,4 @@ def get_formatter(format_type, args):
         return TextFormatter(args)
     elif format_type == 'table':
         return TableFormatter(args)
-    return None
+    raise ValueError("Unknown output type: %s" % format_type)

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -13,12 +13,6 @@
 # language governing permissions and limitations under the License.
 from tests.unit import BaseAWSCommandParamsTest
 import json
-import os
-import sys
-import re
-
-from six.moves import cStringIO
-import mock
 
 
 class TestGetPasswordData(BaseAWSCommandParamsTest):
@@ -26,7 +20,6 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
     prefix = 'iam add-user-to-group '
 
     def test_empty_response_prints_nothing(self):
-        captured = cStringIO()
         # This is the default response, but we want to be explicit
         # that we're returning an empty dict.
         self.parsed_response = {}
@@ -76,3 +69,10 @@ class TestListUsers(BaseAWSCommandParamsTest):
                               expected_rc=0)[0]
         parsed_output = json.loads(output)
         self.assertEqual(parsed_output, ['testuser-50', 'testuser-51'])
+
+    def test_unknown_output_type_from_env_var(self):
+        # argparse already handles the case with a bad --output
+        # specified on the CLI, we need to verify that a bad
+        # output format from the env var still gives an error.
+        self.environ['AWS_DEFAULT_OUTPUT'] = 'bad-output-type'
+        self.run_cmd('iam list-users', expected_rc=255)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -24,6 +24,7 @@ from awscli.clidriver import CLIDriver
 from awscli.clidriver import create_clidriver
 from awscli.clidriver import CustomArgument
 from awscli.clidriver import CLIOperationCaller
+from awscli import formatter
 from botocore.hooks import HierarchicalEmitter
 from botocore.provider import Provider
 
@@ -524,6 +525,12 @@ class TestVerifyArgument(BaseAWSCommandParamsTest):
     def test_verify_argument_is_none_by_default(self):
         self.assert_params_for_cmd('s3api list-buckets'.split())
         self.assertIsNone(self.recorded_args.verify_ssl)
+
+
+class TestFormatter(BaseAWSCommandParamsTest):
+    def test_bad_output(self):
+        with self.assertRaises(ValueError):
+            formatter.get_formatter('bad-type', None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While argparse handles the case where it's specified as an arugment, we need
to validate the case when output is specified as an env var and a config var.
