### PR TITLE
Adds `--size-only` param to `aws s3 sync` to allow syncing by filesize only.

### DIFF
--- a/awscli/customizations/s3/comparator.py
+++ b/awscli/customizations/s3/comparator.py
@@ -34,6 +34,10 @@ class Comparator(object):
         if 'delete' in params:
             self.delete = params['delete']
 
+        self.compare_on_size_only = False
+        if 'size_only' in params:
+            self.compare_on_size_only = params['size_only']
+
     def call(self, src_files, dest_files):
         """
         This function preforms the actual comparisons.  The parameters it takes
@@ -102,7 +106,12 @@ class Comparator(object):
                     same_size = self.compare_size(src_file, dest_file)
                     same_last_modified_time = self.compare_time(src_file, dest_file)
 
-                    if (not same_size) or (not same_last_modified_time):
+                    if self.compare_on_size_only:
+                        should_sync = not same_size
+                    else:
+                        should_sync = (not same_size) or (not same_last_modified_time)
+
+                    if should_sync:
                         LOG.debug("syncing: %s -> %s, size_changed: %s, "
                                   "last_modified_time_changed: %s",
                                   src_file.src, src_file.dest,

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -796,7 +796,7 @@ CMD_DICT = {'cp': {'options': {'nargs': 2},
                                 'sse', 'storage-class', 'content-type',
                                 'cache-control', 'content-disposition',
                                 'content-encoding', 'content-language',
-                                'expires']},
+                                'expires', 'size-only']},
             'ls': {'options': {'nargs': '?', 'default': 's3://'},
                    'params': ['recursive'], 'default': 's3://',
                    'command_class': ListCommand},
@@ -830,7 +830,7 @@ PARAMS_DICT = {'dryrun': {'options': {'action': 'store_true'}},
                            'dest': 'filters'}},
                'acl': {'options': {'nargs': 1,
                                    'choices': ['private', 'public-read',
-                                               'public-read-write', 
+                                               'public-read-write',
                                                'authenticated-read',
                                                'bucket-owner-read',
                                                'bucket-owner-full-control',
@@ -847,6 +847,9 @@ PARAMS_DICT = {'dryrun': {'options': {'action': 'store_true'}},
                'content-encoding': {'options': {'nargs': 1}},
                'content-language': {'options': {'nargs': 1}},
                'expires': {'options': {'nargs': 1}},
+               'size-only': {'options': {'action': 'store_true'}, 'documents':
+                   ('Makes the size of each key the only criteria used to '
+                    'decide whether to sync from source to destination.')},
                'index-document': {'options': {}, 'documents':
                    ('A suffix that is appended to a request that is for a '
                     'directory on the website endpoint (e.g. if the suffix '

--- a/tests/unit/customizations/s3/test_comparator.py
+++ b/tests/unit/customizations/s3/test_comparator.py
@@ -300,5 +300,56 @@ class ComparatorTest(unittest.TestCase):
         self.assertEqual(result_list, ref_list)
 
 
+class ComparatorSizeOnlyTest(unittest.TestCase):
+    def setUp(self):
+        self.comparator = Comparator({'delete': True, 'size_only': True})
+
+    def test_compare_size_only_dest_older_than_src(self):
+        """
+        Confirm that files with the same size but different update times are not
+        synced when `size_only` is set.
+        """
+        time_src = datetime.datetime.now()
+        time_dst = time_src + datetime.timedelta(days=1)
+
+        src_file = FileInfo(src='', dest='',
+                            compare_key='test.py', size=10,
+                            last_update=time_src, src_type='local',
+                            dest_type='s3', operation_name='upload',
+                            service=None, endpoint=None)
+
+        dst_file = FileInfo(src='', dest='',
+                            compare_key='test.py', size=10,
+                            last_update=time_dst, src_type='s3',
+                            dest_type='local', operation_name='',
+                            service=None, endpoint=None)
+
+        files = self.comparator.call(iter([src_file]), iter([dst_file]))
+        self.assertEqual(sum(1 for _ in files), 0)
+
+    def test_compare_size_only_src_older_than_dest(self):
+        """
+        Confirm that files with the same size but different update times are not
+        synced when `size_only` is set.
+        """
+        time_dst = datetime.datetime.now()
+        time_src = time_dst + datetime.timedelta(days=1)
+
+        src_file = FileInfo(src='', dest='',
+                            compare_key='test.py', size=10,
+                            last_update=time_src, src_type='local',
+                            dest_type='s3', operation_name='upload',
+                            service=None, endpoint=None)
+
+        dst_file = FileInfo(src='', dest='',
+                            compare_key='test.py', size=10,
+                            last_update=time_dst, src_type='s3',
+                            dest_type='local', operation_name='',
+                            service=None, endpoint=None)
+
+        files = self.comparator.call(iter([src_file]), iter([dst_file]))
+        self.assertEqual(sum(1 for _ in files), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Based heavily off https://github.com/aws/aws-cli/pull/575, implements the `--size-only` param as discussed in #473 and #599.
