### PR TITLE
fix table output for multibyte characters

### DIFF
--- a/awscli/table.py
+++ b/awscli/table.py
@@ -15,6 +15,7 @@ import sys
 import struct
 
 import colorama
+import six
 
 
 def determine_terminal_width(default_width=80):
@@ -397,7 +398,7 @@ class Section(object):
         self._update_max_widths(row)
 
     def _format_row(self, row):
-        return [str(r) for r in row]
+        return [six.text_type(r) for r in row]
 
     def _update_max_widths(self, row):
         if not self._max_widths:

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -83,6 +83,14 @@ class TestSection(unittest.TestCase):
         self.assertEqual(
             self.section.total_width(padding=2, outer_padding=3), 17)
 
+    def test_unicode_text_row(self):
+        self.section.add_row([1])
+        self.section.add_row(['check'])
+        self.section.add_row([u'\u2713'])
+        self.assertEqual(
+            self.section.rows,
+            [[u'1'], [u'check'], [u'\u2713']])
+
 
 class TestMultiTable(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Displaying multibyte characters fail for table outputs.

how to reproduce

```
# create a multibyte tags
$ aws ec2 create-tags  --resources ami-xxxxxxxx --tags  Key=Name,Value=✓
{
    "return": "true"
}
# list tag info w/ table output
$ aws ec2 describe-instances --output table
'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```
