### PR TITLE
Update session to use single loader instance

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,7 @@ import awscli.clidriver
 from awscli.plugin import load_plugins
 from awscli.clidriver import CLIDriver
 from awscli import EnvironmentVariables
+import botocore.loaders
 
 
 # The unittest module got a significant overhaul
@@ -35,6 +36,15 @@ if sys.version_info[:2] == (2, 6):
     import unittest2 as unittest
 else:
     import unittest
+
+
+_LOADER = botocore.loaders.Loader()
+
+
+def create_clidriver():
+    driver = awscli.clidriver.create_clidriver()
+    driver.session._loader = _LOADER
+    return driver
 
 
 class BaseCLIDriverTest(unittest.TestCase):
@@ -54,7 +64,7 @@ class BaseCLIDriverTest(unittest.TestCase):
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
         emitter = HierarchicalEmitter()
-        session = Session(EnvironmentVariables, emitter)
+        session = Session(EnvironmentVariables, emitter, loader=_LOADER)
         load_plugins({}, event_hooks=emitter)
         driver = CLIDriver(session=session)
         self.session = session

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
+from tests import unittest, create_clidriver
 import os
 import copy
 import logging
@@ -20,8 +20,6 @@ import shutil
 import mock
 import six
 from botocore.vendored import requests
-
-from awscli.clidriver import create_clidriver
 
 
 class BaseAWSCommandParamsTest(unittest.TestCase):

--- a/tests/unit/customizations/test_cloudtrail.py
+++ b/tests/unit/customizations/test_cloudtrail.py
@@ -16,7 +16,6 @@ import json
 import io
 import os
 
-from awscli.clidriver import create_clidriver
 from awscli.customizations.cloudtrail import CloudTrailSubscribe
 from awscli.customizations.service import Service
 from mock import Mock, patch
@@ -259,7 +258,7 @@ class TestCloudTrailSessions(BaseAWSCommandParamsTest):
         is the same session used when making service calls.
         """
         # Get a new session we will use to test
-        driver = create_clidriver()
+        driver = self.driver
 
         def _mock_call(subscribe, *args, **kwargs):
             # Store the subscribe command for assertions

--- a/tests/unit/customizations/test_preview.py
+++ b/tests/unit/customizations/test_preview.py
@@ -16,7 +16,6 @@ import mock
 import six
 
 from awscli.customizations import preview
-from awscli.clidriver import create_clidriver
 from tests import BaseCLIDriverTest
 from tests.unit import BaseAWSCommandParamsTest
 
@@ -28,7 +27,6 @@ class TestPreviewMode(BaseAWSCommandParamsTest):
         self.stderr = six.StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
-        self.driver = create_clidriver()
         self.full_config = {}
         # Implementation detail, but we want to patch out the
         # session config, as that's the only way to control

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from tests import create_clidriver
 import os
 import pprint
 import logging
@@ -112,6 +113,7 @@ def test_completions():
     }
     with mock.patch('os.environ', environ):
         completer = Completer()
+        completer.clidriver = create_clidriver()
         for cmdline, point, expected_results in COMPLETIONS:
             if point == -1:
                 point = len(cmdline)


### PR DESCRIPTION
Reduces memory bloat when running tests, which is causing
issues on some test systems.

cc @danielgtaylor
