### PR TITLE
Aggregate dupe keys into a list in datapipeline translation

### DIFF
--- a/awscli/customizations/datapipeline/translator.py
+++ b/awscli/customizations/datapipeline/translator.py
@@ -80,6 +80,14 @@ def api_to_definition(api_response):
                 value = field['stringValue']
             else:
                 value = {'ref': field['refValue']}
-            current[key] = value
+            if key not in current:
+                current[key] = value
+            elif isinstance(current[key], list):
+                # Dupe keys result in values aggregating
+                # into a list.
+                current[key].append(value)
+            else:
+                converted_list = [current[key], value]
+                current[key] = converted_list
         pipeline_objs.append(current)
     return {'objects': pipeline_objs}

--- a/tests/unit/customizations/datapipeline/test_translator.py
+++ b/tests/unit/customizations/datapipeline/test_translator.py
@@ -169,3 +169,22 @@ class TestTranslatePipelineDefinitions(unittest.TestCase):
                 'output': {'ref': 'OutputData'}
             }]
         })
+
+    def test_api_to_df_with_dupe_keys(self):
+        # Duplicate keys should be aggregated into a list.
+        api = [{"name": "S3ToS3Copy", "id": "S3ToS3Copy",
+                "fields": [{"key": "type", "stringValue": "CopyActivity" },
+                           {"key": "schedule", "refValue": "CopyPeriod" },
+                           {"key": "script", "stringValue": "value1"},
+                           {"key": "script", "stringValue": "value2"}]}]
+        definition = translator.api_to_definition(api)
+        self.assertEqual(definition, {
+            'objects': [{
+                'id': 'S3ToS3Copy',
+                'name': 'S3ToS3Copy',
+                'type': 'CopyActivity',
+                'schedule': {'ref': 'CopyPeriod'},
+                'script': ['value1', 'value2'],
+            }]
+        })
+


### PR DESCRIPTION
When going from API -> definition translation dupe keys should aggregate
their values into a list.
