### PR TITLE
Add compat layer for text based stream writers

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -1,0 +1,23 @@
+# Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+
+#     http://aws.amazon.com/apache2.0/
+
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+import six
+
+if six.PY3:
+    def get_stdout_text_writer():
+        return sys.stdout
+else:
+    import codecs
+    import locale
+    def get_stdout_text_writer():
+        return codecs.getwriter(locale.getpreferredencoding())(sys.stdout)


### PR DESCRIPTION
In python2, if a stream has no encoding, unicode is encoded
using the default encoding.  In python3, sys.stdout is already
text based (it expects str() types).

In python2, we introduce a compat layer that will give you a
stream writer that accepts unicode and encodes the contents into
the local.preferredencoding().

Simple repro: tag an ec2 instance with a unicode char and run:

```
aws ec2 describe-instances | grep TAGS
```

You'll get a ascii encode error.  With this change you won't.

Fixes #742.

cc @danielgtaylor
