### PR TITLE
Clarifying Sphinx requirement for building docs.

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -4,6 +4,8 @@ Building The Documentation
 
 The process for building the documention is:
 
+* Ensure Sphinx is installed, ``pip install sphinx``.
+
 * Run ``make html`` which will build all of the HTML documentation
   into the ``build/html`` directory.
 


### PR DESCRIPTION
Without Sphinx being installed, building docs yielded

```
$ make html 
sphinx-build -b html -d build/doctrees   source build/html
make: sphinx-build: No such file or directory
make: *** [html] Error 1
```
