### PR TITLE
Fix Python 3.x issue with CloudTrail

### DIFF
--- a/awscli/customizations/cloudtrail.py
+++ b/awscli/customizations/cloudtrail.py
@@ -197,7 +197,7 @@ class CloudTrailSubscribe(BasicCommand):
         else:
             data = self.s3.GetObject(bucket='awscloudtrail',
                                      key=S3_POLICY_TEMPLATE)
-            policy = data['Body'].read()
+            policy = data['Body'].read().decode('utf-8')
 
         policy = policy.replace('<BucketName>', bucket)\
                        .replace('<CustomerAccountID>', account_id)
@@ -267,7 +267,7 @@ class CloudTrailSubscribe(BasicCommand):
         else:
             data = self.s3.GetObject(bucket='awscloudtrail',
                                      key=SNS_POLICY_TEMPLATE)
-            policy = data['Body'].read()
+            policy = data['Body'].read().decode('utf-8')
 
         policy = policy.replace('<Region>', region)\
                        .replace('<SNSTopicOwnerAccountId>', account_id)\

--- a/tests/unit/customizations/test_cloudtrail.py
+++ b/tests/unit/customizations/test_cloudtrail.py
@@ -13,8 +13,8 @@
 
 import botocore.session
 import json
-import io
 import os
+import six
 
 from awscli.customizations.cloudtrail import CloudTrailSubscribe
 from awscli.customizations.service import Service
@@ -36,7 +36,7 @@ class TestCloudTrail(unittest.TestCase):
         self.subscribe.s3 = Mock()
         self.subscribe.s3.endpoint = Mock()
         self.subscribe.s3.endpoint.region_name = 'us-east-1'
-        policy_template = io.StringIO(initial_value=u'{"Statement": []}')
+        policy_template = six.BytesIO(six.b(u'{"Statement": []}'))
         self.subscribe.s3.GetObject = Mock(
             return_value={'Body': policy_template})
         self.subscribe.s3.ListBuckets = Mock(


### PR DESCRIPTION
This adds a test and fixes a bug with Python3 and the custom CloudTrail commands where a buffer was read but not decoded into a string before trying to replace values.

@jamesls please review.
