### PR TITLE
Add ability to specify alternate doc root that awscli

### DIFF
--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -14,13 +14,26 @@ from awscli.help import HelpCommand
 
 
 LOG = logging.getLogger(__name__)
+_open = open
 
 
 class _FromFile(object):
-    def __init__(self, *paths):
+    def __init__(self, *paths, **kwargs):
+        """
+        ``**kwargs`` can contain a ``root_module`` argument
+        that contains the root module where the file contents
+        should be searched.  This is an optional argument, and if
+        no value is provided, will default to ``awscli``.  This means
+        that by default we look for examples in the ``awscli`` module.
+
+        """
         self.filename = None
         if paths:
             self.filename = os.path.join(*paths)
+        if 'root_module' in kwargs:
+            self.root_module = kwargs['root_module']
+        else:
+            self.root_module = awscli
 
 
 class BasicCommand(CLICommand):
@@ -262,10 +275,11 @@ class BasicHelp(HelpCommand):
                 trailing_path = value.filename
             else:
                 trailing_path = os.path.join(self.name, attr_name + '.rst')
+            root_module = value.root_module
             doc_path = os.path.join(
-                os.path.abspath(os.path.dirname(awscli.__file__)), 'examples',
+                os.path.abspath(os.path.dirname(root_module.__file__)), 'examples',
                 trailing_path)
-            with open(doc_path) as f:
+            with _open(doc_path) as f:
                 return f.read()
         else:
             return value

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -1,0 +1,31 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from tests import unittest
+import mock
+
+from awscli.customizations.commands import BasicHelp, BasicCommand
+
+
+class TestCommandLoader(unittest.TestCase):
+
+    def test_basic_help_with_contents(self):
+        cmd_object = mock.Mock()
+        mock_module = mock.Mock()
+        mock_module.__file__ = '/some/root'
+        cmd_object.DESCRIPTION = BasicCommand.FROM_FILE(
+            'foo', 'bar', 'baz.txt', root_module=mock_module)
+        help_command = BasicHelp(mock.Mock(), cmd_object, {}, {})
+        with mock.patch('awscli.customizations.commands._open') as mock_open:
+            mock_open.return_value.__enter__.return_value.read.return_value = \
+                    'fake description'
+            self.assertEqual(help_command.description, 'fake description')


### PR DESCRIPTION
That way if the code lives outside of awscli, it can still include examples.
