### PR TITLE
Fixes for previous docs update

### DIFF
--- a/awscli/examples/elasticloadbalancing/apply-security-groups-to-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/apply-security-groups-to-load-balancer.rst
@@ -5,12 +5,13 @@ This example associates a security group with a load balancer in Amazon VPC.
 
 Command::
 
-aws elb apply-security-groups-to-load-balancer  --load-balancer-name MyVPCLoadBalancer --security-groups sg-fc448899
+   aws elb apply-security-groups-to-load-balancer  --load-balancer-name MyVPCLoadBalancer --security-groups sg-fc448899
 
 Output::
 
-{
-    "SecurityGroups": [
+   {
+     "SecurityGroups": [
         "sg-fc448899"
-    ]
-}
+     ]
+   }
+

--- a/awscli/examples/elasticloadbalancing/attach-load-balancer-to-subnets.rst
+++ b/awscli/examples/elasticloadbalancing/attach-load-balancer-to-subnets.rst
@@ -5,14 +5,14 @@ This example adds a subnet to the configured subnets in the Amazon VPC for the l
 
 Command::
 
-aws elb attach-load-balancer-to-subnets --load-balancer MyVPCLoadBalancer --subnets subnet-0ecac448
+  aws elb attach-load-balancer-to-subnets --load-balancer MyVPCLoadBalancer --subnets subnet-0ecac448
 
 Output::
 
-{
-    "Subnets": [
+   {
+      "Subnets": [
         "subnet-15aaab61",
         "subnet-0ecac448"
-    ]
-}
+      ]
+   }
 

--- a/awscli/examples/elasticloadbalancing/configure-health-check.rst
+++ b/awscli/examples/elasticloadbalancing/configure-health-check.rst
@@ -5,16 +5,16 @@ This example specifies health check settings to use for evaluating the health of
 
 Command::
 
-aws elb configure-health-check --load-balancer-name MyLoadBalancer --health-check Target=HTTP:80/png,Interval=30,UnhealthyThreshold=2,HealthyThreshold=2,Timeout=3
+    aws elb configure-health-check --load-balancer-name MyLoadBalancer --health-check Target=HTTP:80/png,Interval=30,UnhealthyThreshold=2,HealthyThreshold=2,Timeout=3
 
 Output::
 
-{
-    "HealthCheck": {
+   {
+      "HealthCheck": {
         "HealthyThreshold": 2,
         "Interval": 30,
         "Target": "HTTP:80/png",
         "Timeout": 3,
         "UnhealthyThreshold": 2
     }
-	
+

--- a/awscli/examples/elasticloadbalancing/create-app-cookie-stickiness-policy.rst
+++ b/awscli/examples/elasticloadbalancing/create-app-cookie-stickiness-policy.rst
@@ -5,10 +5,9 @@ This example generates a stickiness-policy that follows the sticky session lifet
 
 Command::
 
-aws elb create-app-cookie-stickiness-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name MyAppStickyPolicy --cookie-name MyAppCookie
+    aws elb create-app-cookie-stickiness-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name MyAppStickyPolicy --cookie-name MyAppCookie
 
 Output::
 
-{}
+    {}
 
-	

--- a/awscli/examples/elasticloadbalancing/create-lb-cookie-stickiness-policy.rst
+++ b/awscli/examples/elasticloadbalancing/create-lb-cookie-stickiness-policy.rst
@@ -5,10 +5,9 @@ This example generates a stickiness-policy with sticky session lifetimes control
 
 Command::
 
-aws elb create-lb-cookie-stickiness-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name MyDurationStickyPolicy --cookie-expiration-period 60
+    aws elb create-lb-cookie-stickiness-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name MyDurationStickyPolicy --cookie-expiration-period 60
 
 Output::
 
-{}
+    {}
 
-	

--- a/awscli/examples/elasticloadbalancing/create-load-balancer-listeners.rst
+++ b/awscli/examples/elasticloadbalancing/create-load-balancer-listeners.rst
@@ -5,8 +5,9 @@ This example creates listeners on your load balancer at the specified ports usin
 
 Command::
 
-aws elb create-load-balancer-listeners --load-balancer-name MyHTTPSLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80
+     aws elb create-load-balancer-listeners --load-balancer-name MyHTTPSLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80
 
 Output::
 
-{}
+      {}
+

--- a/awscli/examples/elasticloadbalancing/create-load-balancer-policy.rst
+++ b/awscli/examples/elasticloadbalancing/create-load-balancer-policy.rst
@@ -4,12 +4,12 @@ This example creates a policy that enables Proxy Protocol on your TCP load balan
 
 Command::
 
-aws elb create-load-balancer-policy --load-balancer-name MyLoadBalancer --policy-name EnableProxyProtocol  --policy-type-name ProxyProtocolPolicyType --policy-attributes AttributeName=ProxyProtocol,AttributeValue=True
- 
-  
+     aws elb create-load-balancer-policy --load-balancer-name MyLoadBalancer --policy-name EnableProxyProtocol  --policy-type-name ProxyProtocolPolicyType --policy-attributes AttributeName=ProxyProtocol,AttributeValue=True
+
+
 Output::
 
-{}
+     {}
 
 **To create an SSL negotiation policy using the recommended security policy**
 
@@ -17,13 +17,13 @@ This example creates an SSL negotiation policy for your HTTPS load balancer usin
 
 Command::
 
-aws elb create-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer  --policy-name MySSLNegotiationPolicy  --policy-type-name SSLNegotiationPolicyType --policy-attributes AttributeName=Reference-Security-Policy,AttributeValue=
-ELBSecurityPolicy-2014-01
- 
-  
+      aws elb create-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer  --policy-name MySSLNegotiationPolicy  --policy-type-name SSLNegotiationPolicyType --policy-attributes AttributeName=Reference-Security-Policy,AttributeValue=
+      ELBSecurityPolicy-2014-01
+
+
 Output::
 
-{}
+     {}
 
 **To create an SSL negotiation policy using a custom security policy**
 
@@ -31,13 +31,13 @@ This example creates an SSL negotiation policy for your HTTPS load balancer usin
 
 Command::
 
-aws elb create-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name MySSLNegotiationPolicy --policy-type-name SSLNegotiationPolicyType  --policy-attributes AttributeName=Protocol-SSLv3,AttributeValue=true 
- AttributeName=Protocol-TLSv1.1,AttributeValue=true AttributeName=DHE-RSA-AES256-SHA256,AttributeValue=true AttributeName=Server-Defined-Cipher-Order,AttributeValue=true
- 
-  
+       aws elb create-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name MySSLNegotiationPolicy --policy-type-name SSLNegotiationPolicyType  --policy-attributes AttributeName=Protocol-SSLv3,AttributeValue=true
+       AttributeName=Protocol-TLSv1.1,AttributeValue=true AttributeName=DHE-RSA-AES256-SHA256,AttributeValue=true AttributeName=Server-Defined-Cipher-Order,AttributeValue=true
+
+
 Output::
 
-{}
+       {}
 
 **To create a back-end server authentication policy**
 
@@ -45,10 +45,11 @@ This example creates a back-end server authentication policy that enables authen
 
 Command::
 
-aws elb create-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer  --policy-name MyBackendServerAuthenticationPolicy  --policy-type-name BackendServerAuthenticationPolicyType --policy-attributes AttributeName=PublicKeyPolicy
-Name,AttributeValue=MyPublicKeyPolicy
- 
-  
+        aws elb create-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer  --policy-name MyBackendServerAuthenticationPolicy  --policy-type-name BackendServerAuthenticationPolicyType --policy-attributes AttributeName=PublicKeyPolicy
+        Name,AttributeValue=MyPublicKeyPolicy
+
+
 Output::
 
-{}
+        {}
+

--- a/awscli/examples/elasticloadbalancing/create-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/create-load-balancer.rst
@@ -1,22 +1,20 @@
 **To create HTTP load balancer in EC2-Classic**
 
-This example creates an HTTP load balancer in EC2-Classic. 
+This example creates an HTTP load balancer in EC2-Classic.
 
 Command::
 
-  aws elb create-load-balancer  --load-balancer-name MyLoadBalancer 
-  --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80  --availability-zones us-east-1a us-east-1b
-  
+    aws elb create-load-balancer  --load-balancer-name MyLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80  --availability-zones us-east-1a us-east-1b
+
 Output::
 
-{
-    "DNSName": "MyLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
-}
-
+    {
+       "DNSName": "MyLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
+    }
 
 **To create HTTPS load balancer in EC2-Classic**
 
-This example creates an HTTPS load balancer in EC2-Classic. 
+This example creates an HTTPS load balancer in EC2-Classic.
 
 Command::
 
@@ -25,37 +23,37 @@ lity-zones us-east-1a us-east-1b
 
 Output::
 
-{
-    "DNSName": "MyHTTPSLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
-}
+   {
+        "DNSName": "MyHTTPSLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
+   }
 
 **To create HTTP load balancer in Amazon VPC**
 
-This example creates an HTTP load balancer in Amazon Virtual Private Cloud (Amazon VPC). 
+This example creates an HTTP load balancer in Amazon Virtual Private Cloud (Amazon VPC).
 
 Command::
 
-aws elb create-load-balancer --load-balancer-name MyVPCLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80 
+    aws elb create-load-balancer --load-balancer-name MyVPCLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80
 --subnets subnet-15aaab61 --security-groups sg-a61988c3
 
 Output::
 
-{
-    "DNSName": "MyVPCLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
-}
+    {
+        "DNSName": "MyVPCLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
+    }
 
 **To create an Internal load balancer in Amazon VPC**
 
-This example creates an Internal HTTP load balancer in Amazon VPC. 
+This example creates an Internal HTTP load balancer in Amazon VPC.
 
 Command::
 
-aws elb create-load-balancer --load-balancer-name MyInternalLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80
+    aws elb create-load-balancer --load-balancer-name MyInternalLoadBalancer --listeners Protocol=HTTP,LoadBalancerPort=80,InstanceProtocol=HTTP,InstancePort=80
  --subnets subnet-a85db0df --scheme internal --security-groups sg-a61988c3
- 
+
  Output::
- 
-{
-    "DNSName": "internal-MyInternalLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
-}
+
+    {
+        "DNSName": "internal-MyInternalLoadBalancer-012345678.us-east-1.elb.amazonaws.com"
+    }
 

--- a/awscli/examples/elasticloadbalancing/delete-load-balancer-listeners.rst
+++ b/awscli/examples/elasticloadbalancing/delete-load-balancer-listeners.rst
@@ -4,9 +4,10 @@ This example deletes a listener from your load balancer on the specified port.
 
 Command::
 
-aws elb delete-load-balancer-listeners --load-balancer-name MyHTTPSLoadBalancer --load-balancer-ports 80
- 
-  
+      aws elb delete-load-balancer-listeners --load-balancer-name MyHTTPSLoadBalancer --load-balancer-ports 80
+
+
 Output::
 
-{}
+      {}
+

--- a/awscli/examples/elasticloadbalancing/delete-load-balancer-policy.rst
+++ b/awscli/examples/elasticloadbalancing/delete-load-balancer-policy.rst
@@ -4,9 +4,10 @@ This example deletes a policy.  The policy must not be enabled on any listener.
 
 Command::
 
-aws elb delete-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name EnableDurationStickinessPolicy
- 
-  
+      aws elb delete-load-balancer-policy --load-balancer-name MyHTTPSLoadBalancer --policy-name EnableDurationStickinessPolicy
+
+
 Output::
 
-{}
+      {}
+

--- a/awscli/examples/elasticloadbalancing/delete-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/delete-load-balancer.rst
@@ -4,9 +4,10 @@ This example deletes a specified load balancer.
 
 Command::
 
-aws elb delete-load-balancer --load-balancer-name MyLoadBalancer
- 
-  
+      aws elb delete-load-balancer --load-balancer-name MyLoadBalancer
+
+
 Output::
 
-{}
+         {}
+

--- a/awscli/examples/elasticloadbalancing/deregister-instances-from-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/deregister-instances-from-load-balancer.rst
@@ -1,21 +1,21 @@
 **To deregister instance from your load balancer**
 
-This example deregisters an instance from your load balancer. 
+This example deregisters an instance from your load balancer.
 
 Command::
 
-aws elb deregister-instances-from-load-balancer --load-balancer-name MyHTTPSLoadBalancer --instances i-d6f6fae3 
- 
-  
+      aws elb deregister-instances-from-load-balancer --load-balancer-name MyHTTPSLoadBalancer --instances i-d6f6fae3
+
+
 Output::
 
-{
-    "Instances": [
+      {
+             "Instances": [
         {
             "InstanceId": "i-207d9717"
         },
         {
             "InstanceId": "i-afefb49b"
         }
-    ]
-}
+        ]
+      }

--- a/awscli/examples/elasticloadbalancing/describe-instance-health.rst
+++ b/awscli/examples/elasticloadbalancing/describe-instance-health.rst
@@ -1,41 +1,41 @@
 **To describe the health of a running back-end instance**
 
-This example describes health of a specified instance that is InService. 
+This example describes health of a specified instance that is InService.
 
 Command::
-aws elb describe-instance-health --load-balancer-name MyHTTPSLoadBalancer  --instances i-cb439ec2 
-   
+      aws elb describe-instance-health --load-balancer-name MyHTTPSLoadBalancer  --instances i-cb439ec2
+
 Output::
-{
-    "InstanceStates": [
-        {
+     {
+         "InstanceStates": [
+         {
             "InstanceId": "i-cb439ec2",
             "ReasonCode": "N/A",
             "State": "InService",
             "Description": "N/A"
-        }
-    ]
-}
+          }
+         ]
+     }
 
 **To describe the health of an unhealthy back-end instance**
 
-This example describes health of a specified instance that is OutOfService. 
+This example describes health of a specified instance that is OutOfService.
 
 Command::
 
-aws elb describe-instance-health --load-balancer-name MyHTTPSLoadBalancer  --instances i-42fd1d74 
-   
+     aws elb describe-instance-health --load-balancer-name MyHTTPSLoadBalancer  --instances i-42fd1d74
+
 Output::
-{
-    "InstanceStates": [
-        {
+     {
+         "InstanceStates": [
+         {
             "InstanceId": "i-42fd1d74",
             "ReasonCode": "Instance",
             "State": "OutOfService",
             "Description": "Instance is in the EC2 Availability Zone for which LoadBalancer is not configured to route traffic to."
-        }
-    ]
-}
+         }
+        ]
+      }
 
 **To describe the health of an unhealthy back-end instance**
 
@@ -43,17 +43,18 @@ This example describes health of a specified instance that is registering.
 
 Command::
 
-aws elb describe-instance-health --load-balancer-name MyHTTPSLoadBalancer  --instances i-7299c809 
-   
+       aws elb describe-instance-health --load-balancer-name MyHTTPSLoadBalancer  --instances i-7299c809
+
 Output::
 
-{
-    "InstanceStates": [
-        {
+      {
+          "InstanceStates": [
+          {
             "InstanceId": "i-7299c809",
             "ReasonCode": "ELB",
             "State": "OutOfService",
             "Description": "Instance registration is still in progress"
-        }
-    ]
-}
+           }
+          ]
+      }
+

--- a/awscli/examples/elasticloadbalancing/describe-load-balancer-attributes.rst
+++ b/awscli/examples/elasticloadbalancing/describe-load-balancer-attributes.rst
@@ -1,23 +1,24 @@
 **To describe the attributes of a load balancer**
 
-This example describes the attributes of a specified load balancer. 
+This example describes the attributes of a specified load balancer.
 
 Command::
-aws elb describe-load-balancer-attributes --load-balancer-name MyHTTPSLoadBalancer
+      aws elb describe-load-balancer-attributes --load-balancer-name MyHTTPSLoadBalancer
 
 
 Output::
-{
-    "LoadBalancerAttributes": {
-        "ConnectionDraining": {
-            "Enabled": false,
-            "Timeout": 300
-        },
-        "CrossZoneLoadBalancing": {
+     {
+          "LoadBalancerAttributes": {
+          "ConnectionDraining": {
+             "Enabled": false,
+             "Timeout": 300
+           },
+         "CrossZoneLoadBalancing": {
             "Enabled": true
-        },
-        "AccessLog": {
+          },
+          "AccessLog": {
             "Enabled": false
+          }
         }
-    }
-}
+     }
+

--- a/awscli/examples/elasticloadbalancing/describe-load-balancer-policies.rst
+++ b/awscli/examples/elasticloadbalancing/describe-load-balancer-policies.rst
@@ -1,15 +1,15 @@
 **To describe all the policies associated with a load balancer**
 
-This example describes all the policies associated with a specified load balancer. 
+This example describes all the policies associated with a specified load balancer.
 
 Command::
-aws elb describe-load-balancer-policies --load-balancer-name MyLoadBalancer
+     aws elb describe-load-balancer-policies --load-balancer-name MyLoadBalancer
 
 
 Output::
-{
-    "PolicyDescriptions": [
-        {
+     {
+          "PolicyDescriptions": [
+          {
             "PolicyAttributeDescriptions": [
                 {
                     "AttributeName": "CookieExpirationPeriod",
@@ -18,8 +18,8 @@ Output::
             ],
             "PolicyName": "MyDurationStickyPolicy",
             "PolicyTypeName": "LBCookieStickinessPolicyType"
-        },
-        {
+          },
+          {
             "PolicyAttributeDescriptions": [
                 {
                     "AttributeName": "ProxyProtocol",
@@ -28,8 +28,8 @@ Output::
             ],
             "PolicyName": "EnableProxyProtocol",
             "PolicyTypeName": "ProxyProtocolPolicyType"
-        },
-        {
+          },
+          {
             "PolicyAttributeDescriptions": [
                 {
                     "AttributeName": "CookieName",
@@ -38,22 +38,22 @@ Output::
             ],
             "PolicyName": "MyAppStickyPolicy",
             "PolicyTypeName": "AppCookieStickinessPolicyType"
-        }
-    ]
-}
+          }
+         ]
+      }
 
 **To describe a specified policy associated with a load balancer**
 
 This example describes a specified policy associated with a specified load balancer.
 
 Command::
-aws elb describe-load-balancer-policies --load-balancer-name MyLoadBalancer  --policy-name MyDurationStickyPolicy
+       aws elb describe-load-balancer-policies --load-balancer-name MyLoadBalancer  --policy-name MyDurationStickyPolicy
 
 
 Output::
 
-{
-    "PolicyDescriptions": [
+     {
+        "PolicyDescriptions": [
         {
             "PolicyAttributeDescriptions": [
                 {
@@ -64,6 +64,6 @@ Output::
             "PolicyName": "MyDurationStickyPolicy",
             "PolicyTypeName": "LBCookieStickinessPolicyType"
         }
-    ]
-}
+       ]
+      }
 

--- a/awscli/examples/elasticloadbalancing/describe-load-balancer-policy-types.rst
+++ b/awscli/examples/elasticloadbalancing/describe-load-balancer-policy-types.rst
@@ -1,15 +1,15 @@
 **To describe the load balancer policy types defined by Elastic Load Balancing**
 
-This example describes the load balancer policy types you can use to instantiate policy configurations for your load balancer. 
+This example describes the load balancer policy types you can use to instantiate policy configurations for your load balancer.
 
 Command::
 
-aws elb describe-load-balancer-policy-types
+     aws elb describe-load-balancer-policy-types
 
 Output::
 
-{
-    "PolicyTypeDescriptions": [
+     {
+         "PolicyTypeDescriptions": [
         {
             "PolicyAttributeTypeDescriptions": [
                 {
@@ -80,5 +80,6 @@ Output::
             "PolicyTypeName": "SSLNegotiationPolicyType",
             "Description": "Listener policy that defines the ciphers and protocols that will be accepted by the load balancer. This policy can be associated only with HTTPS/SSL listeners."
         }
-    ]
-}
+       ]
+      }
+

--- a/awscli/examples/elasticloadbalancing/describe-load-balancers.rst
+++ b/awscli/examples/elasticloadbalancing/describe-load-balancers.rst
@@ -3,12 +3,12 @@
 This example describes a specified load balancer.
 
 Command::
- 
-aws elb describe-load-balancers --load-balancer-name MyHTTPSLoadBalancer
+
+    aws elb describe-load-balancers --load-balancer-name MyHTTPSLoadBalancer
 
 Output::
-{
-    "LoadBalancerDescriptions": [
+    {
+        "LoadBalancerDescriptions": [
         {
             "Subnets": [],
             "CanonicalHostedZoneNameID": "Z3DZXE0Q79N41H",
@@ -61,7 +61,7 @@ Output::
                     "AWSConsole-SSLNegotiationPolicy-MyHTTPSLoadBalancer-1395199443332",
                     "ELBSecurityPolicy-2014-01",
                     "AWSConsole-SSLNegotiationPolicy-MyHTTPSLoadBalancer-1401221052287",
-                    "EnableProxyProtocol",                   
+                    "EnableProxyProtocol",
                     "MySSLNegotiationPolicy"
                 ]
             },
@@ -76,6 +76,6 @@ Output::
                 "GroupName": "amazon-elb-sg"
             }
         }
-    ]
-}
+       ]
+    }
 

--- a/awscli/examples/elasticloadbalancing/detach-load-balancer-from-subnets.rst
+++ b/awscli/examples/elasticloadbalancing/detach-load-balancer-from-subnets.rst
@@ -4,13 +4,14 @@ This example detaches your load balancer from the specified subnets in your Amaz
 
 Command::
 
-aws elb detach-load-balancer-from-subnets --load-balancer-name MyVPCLoadBalancer --subnets subnet-0ecac448 
+     aws elb detach-load-balancer-from-subnets --load-balancer-name MyVPCLoadBalancer --subnets subnet-0ecac448
 
 
 Output::
 
-{
-    "Subnets": [
+   {
+      "Subnets": [
         "subnet-15aaab61"
-    ]
-}
+      ]
+   }
+

--- a/awscli/examples/elasticloadbalancing/disable-availaibility-zones-for-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/disable-availaibility-zones-for-load-balancer.rst
@@ -4,14 +4,12 @@ This example removes specified availability zone from  your load balancer. You m
 
 Command::
 
-aws elb disable-availability-zones-for-load-balancer --load-balancer-name MyLoadBalancer  --availability-zones us-east-1a
+    aws elb disable-availability-zones-for-load-balancer --load-balancer-name MyLoadBalancer  --availability-zones us-east-1a
 
 Output::
-{
-    "AvailabilityZones": [
+    {
+      "AvailabilityZones": [
         "us-east-1b"
-    ]
-}
-
-
+      ]
+    }
 

--- a/awscli/examples/elasticloadbalancing/enable-availability-zones-for-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/enable-availability-zones-for-load-balancer.rst
@@ -1,15 +1,16 @@
 **To enable availability zone for your load balancer**
 
-This example adds specified availability zone to your load balancer. 
+This example adds specified availability zone to your load balancer.
 
 Command::
 
-aws elb enable-availability-zones-for-load-balancer --load-balancer-name MyLoadBalancer  --availability-zones us-east-1a
+    aws elb enable-availability-zones-for-load-balancer --load-balancer-name MyLoadBalancer  --availability-zones us-east-1a
 
 Output::
-{
-    "AvailabilityZones": [
-	    "us-east-1a",
+    {
+      "AvailabilityZones": [
+        "us-east-1a",
         "us-east-1b"
-    ]
-}
+      ]
+    }
+

--- a/awscli/examples/elasticloadbalancing/modify-load-balancer-attributes.rst
+++ b/awscli/examples/elasticloadbalancing/modify-load-balancer-attributes.rst
@@ -1,24 +1,23 @@
 **To modify attributes of your load balancer**
 
-This example modifies attributes of a specified load balancer. The following example uses JSON syntax 
-on a Windows operating system to specify the attributes.  For information on specifying JSON syntax on 
-your operating system, see 
+This example modifies attributes of a specified load balancer. The following example uses JSON syntax
+on a Windows operating system to specify the attributes.  For information on specifying JSON syntax on
+your operating system, see
 
 .._'Quoting Strings':http://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#quoting-strings
 
 Command::
 
-aws elb modify-load-balancer-attributes --load-balancer-name MyHTTPSLoadBalancer --load-balancer-attributes "{\"CrossZoneLoadBalancing\":{\"Enabled\":true}}
+    aws elb modify-load-balancer-attributes --load-balancer-name MyHTTPSLoadBalancer --load-balancer-attributes "{\"CrossZoneLoadBalancing\":{\"Enabled\":true}}
 
 
 Output::
-{
-    "LoadBalancerAttributes": {
+   {
+      "LoadBalancerAttributes": {
         "CrossZoneLoadBalancing": {
             "Enabled": true
-        }
-    },
-    "LoadBalancerName": "MyHTTPSLoadBalancer"
-}
-
+          }
+      },
+      "LoadBalancerName": "MyHTTPSLoadBalancer"
+    }
 

--- a/awscli/examples/elasticloadbalancing/register-instances-with-load-balancer.rst
+++ b/awscli/examples/elasticloadbalancing/register-instances-with-load-balancer.rst
@@ -1,14 +1,14 @@
 **To register instance with your load balancer**
 
-This example registers an instance with your load balancer. 
+This example registers an instance with your load balancer.
 
 Command::
-aws elb register-instances-with-load-balancer --load-balancer-name MyHTTPSLoadBalancer --instances i-d6f6fae3 
+      aws elb register-instances-with-load-balancer --load-balancer-name MyHTTPSLoadBalancer --instances i-d6f6fae3
 
-   
+
 Output::
-{
-    "Instances": [
+   {
+      "Instances": [
         {
             "InstanceId": "i-d6f6fae3"
         },
@@ -18,5 +18,6 @@ Output::
         {
             "InstanceId": "i-afefb49b"
         }
-    ]
-}
+      ]
+    }
+

--- a/awscli/examples/elasticloadbalancing/set-load-balancer-listener-ssl-certificate.rst
+++ b/awscli/examples/elasticloadbalancing/set-load-balancer-listener-ssl-certificate.rst
@@ -1,13 +1,13 @@
 **To update SSL certificate for your HTTPS load balancer**
 
-This example replaces the existing SSL certificate for your HTTPS load balancer. 
+This example replaces the existing SSL certificate for your HTTPS load balancer.
 
 Command::
 
-aws elb set-load-balancer-listener-ssl-certificate --load-balancer-name MyHTTPSLoadBalancer --load-balancer-port 443 --ssl-certificate-id arn:aws:iam::012345678901:server-certificate/scert
+      aws elb set-load-balancer-listener-ssl-certificate --load-balancer-name MyHTTPSLoadBalancer --load-balancer-port 443 --ssl-certificate-id arn:aws:iam::012345678901:server-certificate/scert
 
 
 Output::
 
-{}
+    {}
 

--- a/awscli/examples/elasticloadbalancing/set-load-balancer-policies-for-backend-server.rst
+++ b/awscli/examples/elasticloadbalancing/set-load-balancer-policies-for-backend-server.rst
@@ -1,23 +1,23 @@
 **To replace the current policies associated with a specified port on your back-end instance**
 
-This example replaces the existing policies associated with a port on your back-end instance. 
+This example replaces the existing policies associated with a port on your back-end instance.
 
 Command::
 
-aws elb set-load-balancer-policies-for-backend-server --load-balancer-name MyLoadBalancer --instance-port 80 --policy-names EnableProxyProtocol
+      aws elb set-load-balancer-policies-for-backend-server --load-balancer-name MyLoadBalancer --instance-port 80 --policy-names EnableProxyProtocol
 
 
 Output::
 
-{}
+      {}
 
 **To remove all policies associated with a specified port on your back-end instance**
 
-This example removes all policies associated with a specified port on your back-end instance. 
+This example removes all policies associated with a specified port on your back-end instance.
 
 Command::
 
-aws elb set-load-balancer-policies-for-backend-server --load-balancer-name MyLoadBalancer --instance-port 80 --policy-names []
+     aws elb set-load-balancer-policies-for-backend-server --load-balancer-name MyLoadBalancer --instance-port 80 --policy-names []
 
 
 Output::

--- a/awscli/examples/elasticloadbalancing/set-load-balancer-policies-of-listener.rst
+++ b/awscli/examples/elasticloadbalancing/set-load-balancer-policies-of-listener.rst
@@ -1,28 +1,27 @@
 **To replace the current policies associated with your load balancer**
 
-This example replaces the existing policies associated with your load balancer. 
+This example replaces the existing policies associated with your load balancer.
 
 Command::
 
-aws elb set-load-balancer-policies-of-listener --load-balancer-name MyHTTPSLoadBalancer --load-balancer-port 443 --policy-names MySSLNegotiationPolicy
+     aws elb set-load-balancer-policies-of-listener --load-balancer-name MyHTTPSLoadBalancer --load-balancer-port 443 --policy-names MySSLNegotiationPolicy
 
 
 Output::
 
-{}
+      {}
 
 **To remove all policies associated with your load balancer**
 
-This example removes all associated policies from the specified load balancer. 
+This example removes all associated policies from the specified load balancer.
 
 Command::
 
-aws elb set-load-balancer-policies-of-listener --load-balancer-name MyHTTPSLoadBalancer --load-balancer-port 443 --policy-names []
+      aws elb set-load-balancer-policies-of-listener --load-balancer-name MyHTTPSLoadBalancer --load-balancer-port 443 --policy-names []
 
 
 Output::
 
 
 To confirm that all the associated policies are removed from the load balancer, use ''describe-load-balancer-policies'' command and specify the name of your load balancer.
-
 

--- a/awscli/examples/s3api/put-object.rst
+++ b/awscli/examples/s3api/put-object.rst
@@ -5,11 +5,12 @@ The following example uses the ``put-object`` command to upload an object to Ama
 
     aws s3api put-object --bucket text-content --key dir-1/my_images.tar.bz2 --body my_images.tar.bz2
 
-The following example shows an upload of a video file (The video file is
-specified using Windows file system syntax.)::
+The put-object command automatically uses multipart upload for large files.  The following example shows an upload of a
+video file (The video file is specified using Windows file system syntax.)::
 
     aws s3api put-object --bucket text-content --key dir-1/big-video-file.mp4 --body e:\media\videos\f-sharp-3-data-services.mp4
 
 For more information about uploading objects, see `Uploading Objects`_ in the *Amazon S3 Developer Guide*.
 
 .. _`Uploading Objects`: http://docs.aws.amazon.com/AmazonS3/latest/dev/UploadingObjects.html
+


### PR DESCRIPTION
 This fixes some bad formatting of code blocks in some AutoScaling examples.  They should now appear properly as code blocks instead of regular text.
