### PR TITLE
Update s3 integ tests to be less fragile

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -305,19 +305,26 @@ class FileCreator(object):
     def remove_all(self):
         shutil.rmtree(self.rootdir)
 
-    def create_file(self, filename, contents):
+    def create_file(self, filename, contents, mtime=None):
         """Creates a file in a tmpdir
 
         ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
         It will be translated into a full path in a tmp dir.
 
+        If the ``mtime`` argument is provided, then the file's
+        mtime will be set to the provided value (must be an epoch time).
+        Otherwise the mtime is left untouched.
+
         Returns the full path to the file.
+
         """
         full_path = os.path.join(self.rootdir, filename)
         if not os.path.isdir(os.path.dirname(full_path)):
             os.makedirs(os.path.dirname(full_path))
         with open(full_path, 'w') as f:
             f.write(contents)
+        if mtime is not None:
+            os.utime(full_path, (mtime, mtime))
         return full_path
 
     def append_file(self, filename, contents):


### PR DESCRIPTION
The two tests here will sometimes will due to mtime checks
triggering a sync.  We're really just interested in testing the
sync based on filename comparisons for these two tests so we're
now setting the mtime to 5 minutes in the past to avoid this issue.

cc @danielgtaylor
