### PR TITLE
Add thread id to debug logs

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -39,6 +39,9 @@ from awscli.argprocess import unpack_argument
 
 
 LOG = logging.getLogger('awscli.clidriver')
+LOG_FORMAT = (
+    '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
+
 
 
 def main():
@@ -221,8 +224,10 @@ class CLIDriver(object):
             # Unfortunately, by setting debug mode here, we miss out
             # on all of the debug events prior to this such as the
             # loading of plugins, etc.
-            self.session.set_debug_logger(logger_name='botocore')
-            self.session.set_debug_logger(logger_name='awscli')
+            self.session.set_stream_logger('botocore', logging.DEBUG,
+                                           format_string=LOG_FORMAT)
+            self.session.set_stream_logger('awscli', logging.DEBUG,
+                                           format_string=LOG_FORMAT)
             LOG.debug("CLI version: %s, botocore version: %s",
                       self.session.user_agent(),
                       botocore_version)


### PR DESCRIPTION
Makes it easier to troubleshoot S3 debug logs.

Logs look like:

```
2014-06-06 11:26:45,583 - MainThread - awscli.customizations.s3.executor - DEBUG - Queueing end sentinel for worker thread (priority: 1)
2014-06-06 11:26:45,583 - Thread-4 - awscli.customizations.s3.executor - DEBUG - Shutdown request received in worker thread, shutting down worker thread.
2014-06-06 11:26:45,583 - MainThread - awscli.customizations.s3.executor - DEBUG - Queueing end sentinel for worker thread (priority: 1)
2014-06-06 11:26:45,584 - MainThread - awscli.customizations.s3.executor - DEBUG - Queueing end sentinel for worker thread (priority: 1)
```

cc @danielgtaylor
