### PR TITLE
Update tests to work with expect-100 bcore branch

### DIFF
--- a/tests/unit/customizations/s3/test_copy_params.py
+++ b/tests/unit/customizations/s3/test_copy_params.py
@@ -43,6 +43,10 @@ class TestGetObject(BaseAWSCommandParamsTest):
         self.parsed_response = {'ETag': '"120ea8a25e5d487bf68b5f7096440019"',}
 
     def assert_params(self, cmdline, result):
+        # Botocore injects the expect 100 continue header so we'll
+        # automatically add this here so each test doesn't need to specify
+        # this header.
+        result['headers']['Expect'] = '100-continue'
         self.assert_params_for_cmd(cmdline, result, expected_rc=0,
                                    ignore_params=['payload'])
         self.assertIsInstance(self.last_params['payload'].getvalue(),

--- a/tests/unit/s3/test_put_object.py
+++ b/tests/unit/s3/test_put_object.py
@@ -32,6 +32,7 @@ except NameError:
 
 class TestGetObject(BaseAWSCommandParamsTest):
 
+    maxDiff = None
     prefix = 's3api put-object'
 
     def setUp(self):
@@ -46,7 +47,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --body %s' % self.file_path
         result = {'uri_params': {'Bucket': 'mybucket',
                                  'Key': 'mykey'},
-                  'headers': {}}
+                  'headers': {'Expect': '100-continue'}}
         self.assert_params_for_cmd(cmdline, result, ignore_params=['payload'])
         self.assertIsInstance(self.last_params['payload'].getvalue(), file_type)
 
@@ -61,7 +62,9 @@ class TestGetObject(BaseAWSCommandParamsTest):
         result = {'uri_params': {'Bucket': 'mybucket', 'Key': 'mykey'},
                   'headers': {'x-amz-acl': 'public-read',
                               'Content-Encoding': 'x-gzip',
-                              'Content-Type': 'text/plain'}}
+                              'Content-Type': 'text/plain',
+                              'Expect': '100-continue',
+                              }}
         self.assert_params_for_cmd(cmdline, result, ignore_params=['payload'])
         payload = self.last_params['payload'].getvalue()
         self.assertEqual(payload.name, self.file_path)


### PR DESCRIPTION
Note that this build will fail travis.  It depends on the expect-100 branch from botocore to be merged into develop.

cc @danielgtaylor
