### PR TITLE
Support configure get/set with nested attrs

### DIFF
--- a/awscli/examples/configure/get/_description.rst
+++ b/awscli/examples/configure/get/_description.rst
@@ -36,4 +36,11 @@ This name provides a way to specify the config section from which to retrieve
 the config variable.  When a qualified name is provided to ``aws configure
 get``, the currently specified profile is ignored.  Section names that have
 the format ``[profile profile-name]`` can be specified by using the
-``profile.profile-name.config-value`` syntax.
+``profile.profile-name.config-name`` syntax, and the default profile can be
+specified using the ``default.config-name`` syntax.
+
+If you have a nested config value such as the Amazon S3 ``signature_version``
+config value, you can specify this value using either
+``default.s3.signature_version s3v4`` or
+``profile.name.s3.signature_version s3v4``.  You cannot set a nested config
+value using an unqualified name.


### PR DESCRIPTION
This only works with the full qualified name, i.e.
with the profile specified.  For example:

```
# Works:
aws configure set default.s3.signature_version s3v4
aws configure get default.s3.signature_version s3v4
aws configure set profile.prod.s3.signature_version s3v4
aws configure get profile.prod.s3.signature_version s3v4

# Does not work
aws configure set s3.signature_version s3v4
aws configure get s3.signature_version s3v4
```

May need to rethink the approach.  I've left a failing test
to make it easy to pick right up.

cc @danielgtaylor
