### PR TITLE
bugfix: convert ints to strings before write

### DIFF
--- a/awscli/text.py
+++ b/awscli/text.py
@@ -25,7 +25,7 @@ def _format_text(item, stream, identifier=None, scalar_keys=None):
     else:
         # If it's not a list or a dict, we just write the scalar
         # value out directly.
-        stream.write(item)
+        stream.write(six.text_type(item))
         stream.write('\n')
 
 


### PR DESCRIPTION
Minor bugfix.

When using "--output text", if the value returned is an integer, this error is returned:

```
# aws ec2 describe-volumes --volume-ids $VOL_ID --query 'Volumes[0].Size' --output json
10
# aws ec2 describe-volumes --volume-ids $VOL_ID --query 'Volumes[0].Size' --output text

argument 1 must be string or read-only character buffer, not int
```

This patch ensures the value is converted to a string before .write.  After patch:

```
# aws ec2 describe-volumes --volume-ids $VOL_ID --query 'Volumes[0].Size' --output text
10
```
