### PR TITLE
Rename "--filter" to "--filters"

### DIFF
--- a/awscli/examples/ec2/describe-instances.rst
+++ b/awscli/examples/ec2/describe-instances.rst
@@ -26,7 +26,7 @@ The following JSON input performs the same filtering.
 
 Command::
 
-  aws ec2 describe-instances --filter file://filters.json
+  aws ec2 describe-instances --filters file://filters.json
 
 filters.json::
 

--- a/awscli/examples/ec2/describe-internet-gateways.rst
+++ b/awscli/examples/ec2/describe-internet-gateways.rst
@@ -34,7 +34,7 @@ This example describes the Internet gateway for the specified VPC.
 
 Command::
 
-  aws ec2 describe-subnets --filter "Name=attachment.vpc-id,Values=vpc-a01106c2"
+  aws ec2 describe-subnets --filters "Name=attachment.vpc-id,Values=vpc-a01106c2"
 
 Output::
 

--- a/awscli/examples/ec2/describe-subnets.rst
+++ b/awscli/examples/ec2/describe-subnets.rst
@@ -39,7 +39,7 @@ This example describes the subnets for the specified VPC.
 
 Command::
 
-  aws ec2 describe-subnets --filter "Name=vpc-id,Values=vpc-a01106c2"
+  aws ec2 describe-subnets --filters "Name=vpc-id,Values=vpc-a01106c2"
 
 Output::
 

--- a/awscli/examples/ec2/describe-volume-status.rst
+++ b/awscli/examples/ec2/describe-volume-status.rst
@@ -38,7 +38,7 @@ This example command describes the status for all volumes that are impaired. In 
 
 Command::
 
-  aws ec2 describe-volume-status --filter Name=volume-status.status,Values=impaired
+  aws ec2 describe-volume-status --filters Name=volume-status.status,Values=impaired
 
 Output::
 

--- a/awscli/examples/ec2/describe-volumes.rst
+++ b/awscli/examples/ec2/describe-volumes.rst
@@ -49,7 +49,7 @@ This example command describes all volumes that are both attached to the instanc
 
 Command::
 
-  aws ec2 describe-volumes --region us-east-1 --filter Name=attachment.instance-id,Values=i-abe041d4 Name=attachment.delete-on-termination,Values=true
+  aws ec2 describe-volumes --region us-east-1 --filters Name=attachment.instance-id,Values=i-abe041d4 Name=attachment.delete-on-termination,Values=true
 
 Output::
 


### PR DESCRIPTION
Technically accepted by python's argparse, but our examples
should use the documented argument name.

cc  @danielgtaylor @kyleknap
