### PR TITLE
Error out for remaining args in custom commands

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -194,6 +194,7 @@ class CLIDriver(object):
             self._handle_top_level_args(parsed_args)
             return command_table[parsed_args.command](remaining, parsed_args)
         except UnknownArgumentError as e:
+            sys.stderr.write("\n")
             sys.stderr.write(str(e) + '\n')
             return 255
         except NoRegionError as e:

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -176,6 +176,8 @@ class BasicCommand(CLICommand):
         elif getattr(parsed_args, 'subcommand', None) is None:
             # No subcommand was specified so call the main
             # function for this top level command.
+            if remaining:
+                raise ValueError("Unknown options: %s" % ','.join(remaining))
             return self._run_main(parsed_args, parsed_globals)
         else:
             return subcommand_table[parsed_args.subcommand](remaining,

--- a/tests/unit/customizations/s3/test_ls_command.py
+++ b/tests/unit/customizations/s3/test_ls_command.py
@@ -14,6 +14,7 @@
 from awscli.testutils import BaseAWSCommandParamsTest
 from dateutil import parser, tz
 
+
 class TestLSCommand(BaseAWSCommandParamsTest):
 
     def test_operations_used_in_recursive_list(self):
@@ -34,6 +35,7 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         self.assertEqual(
             stdout, '%s        100 foo/bar.txt\n'%time_local.strftime('%Y-%m-%d %H:%M:%S'))
 
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_errors_out_with_extra_arguments(self):
+        stderr = self.run_cmd('s3 ls --extra-argument-foo', expected_rc=255)[1]
+        self.assertIn('Unknown options', stderr)
+        self.assertIn('--extra-argument-foo', stderr)


### PR DESCRIPTION
If a user provides additional args that a custom command has not declared in the arg table, we should error out with an unknown options error message like we do for built in commands.

There was also a small change in the new line output for the builtin command case so that we have the exact same output in both cases:

```
$ aws s3api list-objects --bucket foo --extra-argument-foo

Unknown options: --extra-argument-foo

$ aws s3 ls --extra-argument-foo

Unknown options: --extra-argument-foo
```

cc @danielgtaylor @kyleknap
