### PR TITLE
Enabled ``--page-size`` as global argument.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
+* feature:Page Size: Add a ``--page-size`` option, that 
+  controls page size when perfoming an operation that
+  uses pagination.
+  (`issue 889 <https://github.com/aws/aws-cli/pull/889>`__)
 * bugfix:``aws s3``: Added support for ignoring and warning
   about files that do not exist, user does not have read
   permissions, or are special files (i.e. sockets, FIFOs,

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -546,6 +546,8 @@ class CLIOperationCaller(object):
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl)
         if operation_object.can_paginate and parsed_globals.paginate:
+            if parsed_globals.page_size:
+                parameters['page_size'] = parsed_globals.page_size
             pages = operation_object.paginate(endpoint, **parameters)
             self._display_response(operation_object, pages,
                                    parsed_globals)

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -115,11 +115,12 @@ class FileGenerator(object):
     ``FileInfo`` objects to send to a ``Comparator`` or ``S3Handler``.
     """
     def __init__(self, service, endpoint, operation_name,
-                 follow_symlinks=True, result_queue=None):
+                 follow_symlinks=True, page_size=None, result_queue=None):
         self._service = service
         self._endpoint = endpoint
         self.operation_name = operation_name
         self.follow_symlinks = follow_symlinks
+        self.page_size = page_size
         self.result_queue = result_queue
         if not result_queue:
             self.result_queue = queue.Queue()
@@ -284,7 +285,8 @@ class FileGenerator(object):
         else:
             operation = self._service.get_operation('ListObjects')
             lister = BucketLister(operation, self._endpoint)
-            for key in lister.list_objects(bucket=bucket, prefix=prefix):
+            for key in lister.list_objects(bucket=bucket, prefix=prefix,
+                                           page_size=self.page_size):
                 source_path, size, last_update = key
                 if size == 0 and source_path.endswith('/'):
                     if self.operation_name == 'delete':

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -338,8 +338,9 @@ class BucketLister(object):
         self._endpoint = endpoint
         self._date_parser = date_parser
 
-    def list_objects(self, bucket, prefix=None):
-        kwargs = {'bucket': bucket, 'encoding_type': 'url'}
+    def list_objects(self, bucket, prefix=None, page_size=None):
+        kwargs = {'bucket': bucket, 'encoding_type': 'url',
+                  'page_size': page_size}
         if prefix is not None:
             kwargs['prefix'] = prefix
         # This event handler is needed because we use encoding_type url and

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -31,6 +31,10 @@
         "query": {
             "help": "<p>A JMESPath query to use in filtering the response data.</p>"
         },
+        "page-size": {
+            "type": "int",
+            "help": "<p>Specifies the page size when paginating.</p>"
+        },
         "profile": {
             "help": "<p>Use a specific profile from your credential file.</p>"
         },

--- a/tests/unit/customizations/s3/test_ls_command.py
+++ b/tests/unit/customizations/s3/test_ls_command.py
@@ -39,3 +39,36 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         stderr = self.run_cmd('s3 ls --extra-argument-foo', expected_rc=255)[1]
         self.assertIn('Unknown options', stderr)
         self.assertIn('--extra-argument-foo', stderr)
+
+    def test_operations_use_page_size(self):
+        time_utc = "2014-01-09T20:45:49.000Z"
+        self.parsed_responses = [{"CommonPrefixes": [], "Contents": [
+            {"Key": "foo/bar.txt", "Size": 100,
+             "LastModified": time_utc}]}]
+        stdout, _, _ = self.run_cmd('s3 ls s3://bucket/ --page-size 8', expected_rc=0)
+        call_args = self.operations_called[0][1]
+        # We should not be calling the args with any delimiter because we
+        # want a recursive listing.
+        self.assertEqual(call_args['prefix'], '')
+        self.assertEqual(call_args['bucket'], 'bucket')
+        # The page size gets translated to ``MaxKeys`` in the s3 model
+        self.assertEqual(call_args['MaxKeys'], 8)
+
+    def test_operations_use_page_size_recursive(self):
+        time_utc = "2014-01-09T20:45:49.000Z"
+        self.parsed_responses = [{"CommonPrefixes": [], "Contents": [
+            {"Key": "foo/bar.txt", "Size": 100,
+             "LastModified": time_utc}]}]
+        stdout, _, _ = self.run_cmd('s3 ls s3://bucket/ --page-size 8 --recursive', expected_rc=0)
+        call_args = self.operations_called[0][1]
+        # We should not be calling the args with any delimiter because we
+        # want a recursive listing.
+        self.assertEqual(call_args['prefix'], '')
+        self.assertEqual(call_args['bucket'], 'bucket')
+        # The page size gets translated to ``MaxKeys`` in the s3 model
+        self.assertEqual(call_args['MaxKeys'], 8)
+        self.assertNotIn('delimiter', call_args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -57,7 +57,9 @@ class TestLSCommand(unittest.TestCase):
     def test_ls_command_for_bucket(self):
         ls_command = ListCommand(self.session)
         parsed_args = FakeArgs(paths='s3://mybucket/', dir_op=False)
-        ls_command._run_main(parsed_args, mock.Mock())
+        parsed_globals = mock.Mock()
+        parsed_globals.page_size = '5'
+        ls_command._run_main(parsed_args, parsed_globals)
         call = self.session.get_service.return_value.get_operation\
                 .return_value.call
         paginate = self.session.get_service.return_value.get_operation\
@@ -69,7 +71,8 @@ class TestLSCommand(unittest.TestCase):
             'ListObjects')
         self.assertEqual(
             paginate.call_args[1], {'bucket': u'mybucket',
-                                    'delimiter': '/', 'prefix': u''})
+                                    'delimiter': '/', 'prefix': u'',
+                                    'page_size': u'5'})
 
     def test_ls_command_with_no_args(self):
         ls_command = ListCommand(self.session)
@@ -194,7 +197,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': local_file, 'dest': s3_file, 'filters': filters,
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'cp', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -210,7 +213,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': local_file, 'dest': s3_file, 'filters': filters,
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'cp', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -233,7 +236,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': s3_file, 'dest': local_file, 'filters': filters,
                   'paths_type': 's3local', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'cp', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -250,7 +253,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': s3_file, 'dest': s3_file, 'filters': filters,
                   'paths_type': 's3s3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'cp', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -267,7 +270,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': s3_file, 'dest': s3_file, 'filters': filters,
                   'paths_type': 's3s3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'mv', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -284,7 +287,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': s3_file, 'dest': s3_file, 'filters': filters,
                   'paths_type': 's3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'rm', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -305,7 +308,7 @@ class CommandArchitectureTest(S3HandlerBaseTest):
                   'src': local_dir, 'dest': s3_prefix, 'filters': filters,
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
-                  'follow_symlinks': True}
+                  'follow_symlinks': True, 'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'sync', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -320,7 +323,8 @@ class CommandArchitectureTest(S3HandlerBaseTest):
         params = {'dir_op': True, 'dryrun': True, 'quiet': False,
                   'src': s3_prefix, 'dest': s3_prefix, 'paths_type': 's3',
                   'region': 'us-east-1', 'endpoint_url': None,
-                  'verify_ssl': None, 'follow_symlinks': True}
+                  'verify_ssl': None, 'follow_symlinks': True,
+                  'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'mb', params)
         cmd_arc.create_instructions()
         cmd_arc.run()
@@ -335,7 +339,8 @@ class CommandArchitectureTest(S3HandlerBaseTest):
         params = {'dir_op': True, 'dryrun': True, 'quiet': False,
                   'src': s3_prefix, 'dest': s3_prefix, 'paths_type': 's3',
                   'region': 'us-east-1', 'endpoint_url': None,
-                  'verify_ssl': None, 'follow_symlinks': True}
+                  'verify_ssl': None, 'follow_symlinks': True,
+                  'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'rb', params)
         cmd_arc.create_instructions()
         rc = cmd_arc.run()
@@ -351,7 +356,8 @@ class CommandArchitectureTest(S3HandlerBaseTest):
         params = {'dir_op': True, 'dryrun': False, 'quiet': False,
                   'src': s3_prefix, 'dest': s3_prefix, 'paths_type': 's3',
                   'region': 'us-east-1', 'endpoint_url': None,
-                  'verify_ssl': None, 'follow_symlinks': True}
+                  'verify_ssl': None, 'follow_symlinks': True,
+                  'page_size': None}
         cmd_arc = CommandArchitecture(self.session, 'rb', params)
         cmd_arc.create_instructions()
         rc = cmd_arc.run()

--- a/tests/unit/ec2/test_describe_instances.py
+++ b/tests/unit/ec2/test_describe_instances.py
@@ -87,6 +87,12 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(cmdlist, result)
 
+    def test_page_size(self):
+        args = ' --page-size 10'
+        cmdline = self.prefix + args
+        result = {'MaxResults': '10'}
+        self.assert_params_for_cmd(cmdline, result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/s3/test_list_objects.py
+++ b/tests/unit/s3/test_list_objects.py
@@ -39,6 +39,16 @@ class TestListObjects(BaseAWSCommandParamsTest):
                   'headers': {},}
         self.assert_params_for_cmd(cmdline, result, ignore_params=['payload'])
 
+    def test_page_size(self):
+        cmdline = self.prefix
+        cmdline += ' --bucket mybucket'
+        # The max-items is a customization and therefore won't
+        # show up in the result params.
+        cmdline += ' --page-size 100'
+        result = {'uri_params': {'Bucket': 'mybucket', 'MaxKeys': 100},
+                  'headers': {},}
+        self.assert_params_for_cmd(cmdline, result, ignore_params=['payload'])
+
     def test_starting_token(self):
         # We don't need to test this in depth because botocore
         # tests this.  We just want to make sure this is hooked up

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -72,6 +72,10 @@ GET_DATA = {
                 "help": "Disable automatic pagination",
                 "dest": "paginate"
             },
+            "page-size": {
+            "type": "int",
+            "help": "<p>Specifies the page size when paginating.</p>"
+            },
         }
     },
     'aws/_services': {'s3':{}},
@@ -655,6 +659,33 @@ class TestCLIOperationCaller(BaseAWSCommandParamsTest):
         caller = CLIOperationCaller(self.session)
         with self.assertRaises(NoCredentialsError):
             caller.invoke(None, None, None)
+
+    def test_invoke_with_page_size(self):
+        operation_object = mock.Mock()
+        paginate = operation_object.paginate
+        operation_object.can_paginate = True
+        parsed_globals = mock.Mock()
+        parsed_globals.paginate = True
+        parsed_globals.page_size = '10'
+        parameters = {}
+        caller = CLIOperationCaller(self.session)
+        with mock.patch('awscli.clidriver.CLIOperationCaller._display_response'):
+            caller.invoke(operation_object, parameters, parsed_globals)
+        self.assertEqual(paginate.call_args[1], {'page_size': u'10'})
+
+    def test_invoke_with_no_page_size(self):
+        operation_object = mock.Mock()
+        paginate = operation_object.paginate
+        operation_object.can_paginate = True
+        parsed_globals = mock.Mock()
+        parsed_globals.paginate = True
+        parsed_globals.page_size = None
+        parameters = {}
+        caller = CLIOperationCaller(self.session)
+        with mock.patch('awscli.clidriver.CLIOperationCaller._display_response'):
+            caller.invoke(operation_object, parameters, parsed_globals)
+        # No parameters were passed to it (i.e. only self and endpoint).
+        self.assertEqual(len(paginate.call_args), 2)
 
 
 class TestVerifyArgument(BaseAWSCommandParamsTest):

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -23,7 +23,7 @@ from awscli.completer import Completer
 LOG = logging.getLogger(__name__)
 
 GLOBALOPTS = ['--debug', '--endpoint-url', '--no-verify-ssl',
-              '--no-paginate', '--output', '--profile',
+              '--no-paginate', '--output', '--page-size', '--profile',
               '--region', '--version', '--color', '--query', '--no-sign-request']
 
 COMPLETIONS = [
@@ -62,7 +62,7 @@ COMPLETIONS = [
      set(['--filters', '--dry-run', '--no-dry-run', '--endpoint-url',
           '--no-verify-ssl', '--no-paginate', '--no-sign-request',
           '--output', '--profile', '--starting-token', '--max-items',
-          '--region', '--version', '--color', '--query'])),
+          '--region', '--version', '--color', '--query', '--page-size'])),
     ('aws s3', -1, set(['cp', 'mv', 'rm', 'mb', 'rb', 'ls', 'sync', 'website'])),
     ('aws s3 m', -1, set(['mv', 'mb'])),
     ('aws s3 cp -', -1, set(['--no-guess-mime-type', '--dryrun',


### PR DESCRIPTION
The page size controls the amount of items returned by
each page while paginating. Smoke tests were added for `ec2`
and `s3api` to ensure the parameter does what is expected to
do for known paginating operations.

cc @jamesls @danielgtaylor
