### PR TITLE
Throw error when too few args are passed to s3.

### DIFF
--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -57,3 +57,8 @@ class S3(BasicCommand):
         {'name': 'mb', 'command_class': MbCommand},
         {'name': 'rb', 'command_class': RbCommand}
     ]
+
+    def _run_main(self, parsed_args, parsed_globals):
+        if parsed_args.subcommand is None:
+            raise ValueError("usage: aws [options] <command> <subcommand> "
+                             "[parameters]\naws: error: too few arguments")

--- a/tests/unit/customizations/s3/test_s3.py
+++ b/tests/unit/customizations/s3/test_s3.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from mock import Mock
 
-from awscli.testutils import unittest
+from awscli.testutils import unittest, BaseAWSCommandParamsTest
 from awscli.customizations.s3.s3 import awscli_initialize, add_s3
 
 
@@ -46,6 +46,14 @@ class CreateTablesTest(unittest.TestCase):
         self.assertEqual(orig_service, s3_service)
         for service in self.services.keys():
             self.assertIn(service, ['s3'])
+
+
+class TestS3(BaseAWSCommandParamsTest):
+    def test_too_few_args(self):
+        stderr = self.run_cmd('s3', expected_rc=255)[1]
+        self.assertIn(("usage: aws [options] <command> "
+                       "<subcommand> [parameters]"), stderr)
+        self.assertIn('too few arguments', stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The error message was also made to be consistent with
the rest of the CLI.

cc @jamesls @danielgtaylor
