### PR TITLE
Fixed s3 to s3 sync url decoding pagniation bug.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,10 @@ Next Release (TBD)
 * bugfix:Endpoint URL: Provide a better error message when
   an invalid ``--endpoint-url`` is provided
   (`issue 899 <https://github.com/aws/aws-cli/issues/899>`__)
+* bugfix:``aws s3``: Fix issue when keys do not get properly
+  url decoded when syncing from a bucket that requires pagination
+  to a bucket that requires less pagination
+  (`issue 909 <https://github.com/aws/aws-cli/pull/909>`__)
 
 
 1.4.2

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -350,7 +350,8 @@ class BucketLister(object):
         with ScopedEventHandler(self._operation.session,
                                 'after-call.s3.ListObjects',
                                 self._decode_keys,
-                                'BucketListerDecodeKeys'):
+                                'BucketListerDecodeKeys',
+                                True):
             pages = self._operation.paginate(self._endpoint, **kwargs)
             for response, page in pages:
                 contents = page['Contents']
@@ -368,18 +369,22 @@ class BucketLister(object):
 class ScopedEventHandler(object):
     """Register an event callback for the duration of a scope."""
 
-    def __init__(self, session, event_name, handler, unique_id=None):
+    def __init__(self, session, event_name, handler, unique_id=None,
+                 unique_id_uses_count=False):
         self._session = session
         self._event_name = event_name
         self._handler = handler
         self._unique_id = unique_id
+        self._unique_id_uses_count = unique_id_uses_count
 
     def __enter__(self):
-        self._session.register(self._event_name, self._handler, self._unique_id)
+        self._session.register(self._event_name, self._handler, self._unique_id,
+                               self._unique_id_uses_count)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._session.unregister(self._event_name, self._handler,
-                                 self._unique_id)
+                                 self._unique_id,
+                                 self._unique_id_uses_count)
 
 
 class PrintTask(namedtuple('PrintTask',

--- a/tests/unit/customizations/s3/fake_session.py
+++ b/tests/unit/customizations/s3/fake_session.py
@@ -70,10 +70,12 @@ class FakeSession(object):
     def emit_first_non_none_response(self, *args, **kwargs):
         pass
 
-    def register(self, name, handler, unique_id=None):
+    def register(self, name, handler, unique_id=None,
+                 unique_id_uses_call=False):
         pass
 
-    def unregister(self, name, handler, unique_id=None):
+    def unregister(self, name, handler, unique_id=None,
+                   unique_id_uses_call=False):
         pass
 
 

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -297,15 +297,19 @@ class TestScopedEventHandler(unittest.TestCase):
         session = mock.Mock()
         scoped = ScopedEventHandler(session, 'eventname', 'handler')
         with scoped:
-            session.register.assert_called_with('eventname', 'handler', None)
-        session.unregister.assert_called_with('eventname', 'handler', None)
+            session.register.assert_called_with('eventname', 'handler', None,
+                                                False)
+        session.unregister.assert_called_with('eventname', 'handler', None,
+                                              False)
 
     def test_scoped_session_unique(self):
         session = mock.Mock()
         scoped = ScopedEventHandler(session, 'eventname', 'handler', 'unique')
         with scoped:
-            session.register.assert_called_with('eventname', 'handler', 'unique')
-        session.unregister.assert_called_with('eventname', 'handler', 'unique')
+            session.register.assert_called_with('eventname', 'handler',
+                                                'unique', False)
+        session.unregister.assert_called_with('eventname', 'handler', 'unique',
+                                              False)
 
 
 class TestGetFileStat(unittest.TestCase):


### PR DESCRIPTION
Keys were not getting url decoded properly with pagination.
If one bucket exited ListObjects pagination before
the other bucket, it caused the handler that decodes the keys
to prematurely exit as well. This resulted in some keys not
getting url decoded.

cc @jamesls @danielgtaylor 
