### PR TITLE
Fix cloudsearch define-index-field for type latlon

### DIFF
--- a/awscli/customizations/cloudsearch.py
+++ b/awscli/customizations/cloudsearch.py
@@ -49,6 +49,12 @@ def index_hydrate(params, container, cli_type, key, value):
     _type = params['index_field']['IndexFieldType']
     _type = ''.join([i.capitalize() for i in _type.split('-')])
 
+    # ``index_field`` of type ``latlon`` is mapped to ``Latlon``.
+    # However, it is defined as ``LatLon`` in the model so it needs to
+    # be changed.
+    if _type == 'Latlon':
+        _type = 'LatLon'
+
     # Transform string value to the correct type?
     if key.split(SEP)[-1] == 'DefaultValue':
         value = DEFAULT_VALUE_TYPE_MAP.get(_type, lambda x: x)(value)

--- a/tests/unit/cloudsearch/test_cloudsearch.py
+++ b/tests/unit/cloudsearch/test_cloudsearch.py
@@ -50,3 +50,18 @@ class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
             'IndexField.IntOptions.SearchEnabled': 'false'
         }
         self.assert_params_for_cmd(cmdline, result)
+
+    def test_latlon(self):
+        cmdline = self.prefix
+        cmdline += ' --domain-name abc123'
+        cmdline += ' --name foo'
+        cmdline += ' --type latlon'
+        cmdline += ' --default-value 10'
+        cmdline += ' --search-enabled false'
+        result = {
+            'DomainName': 'abc123',
+            'IndexField.IndexFieldName': 'foo',
+            'IndexField.IndexFieldType': 'int',
+            'IndexField.LatLonOptions.DefaultValue': 10,
+            'IndexField.LatLonOptions.SearchEnabled': 'false'
+        }


### PR DESCRIPTION
Was making an incorrect assumption on how the `--type` for  `aws cloudsearch define-index-field` was being mapped to the service model.  Specifically,`latlon` was being mapped to `Latlon`, but in the serivce model, it is `LatLon`.  The assumption in the mapping we make is that all capitalization should happen whenever there is a hyphen in the value of `--type`.  For example, `date-array` is mapped to `DateArray`.  But this does not hold for `latlon`

Fixes https://github.com/aws/aws-cli/issues/929

cc @jamesls @danielgtaylor 
