### PR TITLE
Call super() in ConfigureCommand

### DIFF
--- a/awscli/customizations/configure.py
+++ b/awscli/customizations/configure.py
@@ -526,7 +526,7 @@ class ConfigureCommand(BasicCommand):
     ]
 
     def __init__(self, session, prompter=None, config_writer=None):
-        self._session = session
+        super(ConfigureCommand, self).__init__(session)
         if prompter is None:
             prompter = InteractivePrompter()
         self._prompter = prompter

--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -14,7 +14,10 @@ import os
 import tempfile
 import random
 
+import mock
+
 from awscli.testutils import unittest, aws
+from awscli.customizations import configure
 
 
 class TestConfigureCommand(unittest.TestCase):
@@ -260,6 +263,13 @@ class TestConfigureCommand(unittest.TestCase):
                 env_vars=self.env_vars)
         self.assertEqual(p.rc, 1)
         self.assertEqual(p.stdout, '')
+
+
+class TestConfigureHasArgTable(unittest.TestCase):
+    def test_configure_command_has_arg_table(self):
+        m = mock.Mock()
+        command = configure.ConfigureCommand(m)
+        self.assertEqual(command.arg_table, {})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes an issue when you try to access the arg_table property,
which was breaking our html doc builds.

cc @kyleknap @danielgtaylor 
