### PR TITLE
remove output from commands that now return null

### DIFF
--- a/awscli/examples/ec2/assign-private-ip-addresses.rst
+++ b/awscli/examples/ec2/assign-private-ip-addresses.rst
@@ -1,27 +1,15 @@
 **To assign a specific secondary private IP address a network interface**
 
-This example assigns the specified secondary private IP address to the specified network interface.
+This example assigns the specified secondary private IP address to the specified network interface. If the command succeeds, no output is returned. 
 
 Command::
 
   aws ec2 assign-private-ip-addresses --network-interface-id eni-e5aa89a3 --private-ip-addresses 10.0.0.82
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To assign secondary private IP addresses that Amazon EC2 selects to a network interface**
 
-This example assigns two secondary private IP addresses to the specified network interface. Amazon EC2 automatically assigns these IP addresses from the available IP addresses in the CIDR block range of the subnet the network interface is associated with.
+This example assigns two secondary private IP addresses to the specified network interface. Amazon EC2 automatically assigns these IP addresses from the available IP addresses in the CIDR block range of the subnet the network interface is associated with. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 assign-private-ip-addresses --network-interface-id eni-e5aa89a3 --secondary-private-ip-address-count 2
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/associate-address.rst
+++ b/awscli/examples/ec2/associate-address.rst
@@ -1,16 +1,10 @@
 **To associate an Elastic IP addresses in EC2-Classic**
 
-This example associates an Elastic IP address with an instance in EC2-Classic.
+This example associates an Elastic IP address with an instance in EC2-Classic. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 associate-address --instance-id i-5203422c --public-ip 198.51.100.0
-
-Output::
-
-  {
-      "return": "true"
-  }
 
 **To associate an Elastic IP address in EC2-VPC**
 
@@ -23,8 +17,7 @@ Command::
 Output::
 
   {
-      "AssociationId": "eipassoc-2bebb745",
-      "return": "true"
+      "AssociationId": "eipassoc-2bebb745"
   }
 
 This example associates an Elastic IP address with a network interface.

--- a/awscli/examples/ec2/associate-dhcp-options.rst
+++ b/awscli/examples/ec2/associate-dhcp-options.rst
@@ -1,27 +1,15 @@
 **To associate a DHCP options set with your VPC**
 
-This example associates the specified DHCP options set with the specified VPC.
+This example associates the specified DHCP options set with the specified VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 associate-dhcp-options --dhcp-options-id dopt-d9070ebb --vpc-id vpc-a01106c2
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To associate the default DHCP options set with your VPC**
 
-This example associates the default DHCP options set with the specified VPC.
+This example associates the default DHCP options set with the specified VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 associate-dhcp-options --dhcp-options-id default --vpc-id vpc-a01106c2
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/attach-internet-gateway.rst
+++ b/awscli/examples/ec2/attach-internet-gateway.rst
@@ -1,13 +1,7 @@
 **To attach an Internet gateway to your VPC**
 
-This example attaches the specified Internet gateway to the specified VPC.
+This example attaches the specified Internet gateway to the specified VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 attach-internet-gateway --internet-gateway-id igw-c0a643a9 --vpc-id vpc-a01106c2
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/authorize-security-group-ingress.rst
+++ b/awscli/examples/ec2/authorize-security-group-ingress.rst
@@ -1,32 +1,35 @@
-**[EC2-Classic] To add a rule to a security group that allows inbound SSH traffic**
+**[EC2-Classic] To add a rule that allows inbound SSH traffic**
 
-This example enables inbound traffic on TCP port 22 (SSH).
+This example enables inbound traffic on TCP port 22 (SSH). If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 authorize-security-group-ingress --group-name MySecurityGroup --protocol tcp --port 22 --cidr 203.0.113.0/24
 
-Output::
+**[EC2-Classic] To add a rule that allows inbound HTTP traffic from a security group in another account**
 
-  {
-      "return": "true"
-  }
+This example enables inbound traffic on TCP port 80 from a source security group (otheraccountgroup) in a different AWS account (123456789012). If the command succeeds, no output is returned.
 
-**[EC2-VPC] To add a rule to a security group that allows inbound SSH traffic**
+Command::
 
-This example enables inbound traffic on TCP port 22 (SSH). Note that you can't reference a security group for EC2-VPC by name.
+  aws ec2 authorize-security-group-ingress --group-name MySecurityGroup --protocol tcp --port 80 --source-group otheraccountgroup --group-owner 123456789012
+
+**[EC2-VPC] To add a rule that allows inbound SSH traffic**
+
+This example enables inbound traffic on TCP port 22 (SSH). Note that you can't reference a security group for EC2-VPC by name. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 authorize-security-group-ingress --group-id sg-903004f8 --protocol tcp --port 22 --cidr 203.0.113.0/24
 
-Output::
+**[EC2-VPC] To add a rule that allows inbound HTTP traffic from another security group**
 
-  {
-      "return": "true"
-  }
+This example enables inbound access on TCP port 80 from the source security group sg-1a2b3c4d. Note that for EC2-VPC, the source group must be in the same VPC. If the command succeeds, no output is returned.
+
+Command::
+
+  aws ec2 authorize-security-group-ingress --group-id sg-111aaa22 --protocol tcp --port 80 --source-group sg-1a2b3c4d
 
 For more information, see `Using Security Groups`_ in the *AWS Command Line Interface User Guide*.
 
 .. _`Using Security Groups`: http://docs.aws.amazon.com/cli/latest/userguide/cli-ec2-sg.html
-

--- a/awscli/examples/ec2/cancel-conversion-task.rst
+++ b/awscli/examples/ec2/cancel-conversion-task.rst
@@ -1,14 +1,7 @@
 **To cancel an active conversion of an instance or a volume**
 
-This example cancels the upload associated with the task ID import-i-fh95npoc.
+This example cancels the upload associated with the task ID import-i-fh95npoc. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 cancel-conversion-task --conversion-task-id import-i-fh95npoc
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/cancel-export-task.rst
+++ b/awscli/examples/ec2/cancel-export-task.rst
@@ -1,14 +1,7 @@
 **To cancel an active export task**
 
-This example cancels an active export task with the task ID export-i-fgelt0i7.
+This example cancels an active export task with the task ID export-i-fgelt0i7. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 cancel-export-task --export-task-id export-i-fgelt0i7
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/confirm-product-instance.rst
+++ b/awscli/examples/ec2/confirm-product-instance.rst
@@ -9,6 +9,5 @@ Command::
 Output::
 
   {
-      "return": "true"
+    "OwnerId": "123456789012"
   }
-

--- a/awscli/examples/ec2/create-network-acl-entry.rst
+++ b/awscli/examples/ec2/create-network-acl-entry.rst
@@ -1,13 +1,7 @@
 **To create a network ACL entry**
 
-This example creates an entry for the specified network ACL. The rule allows ingress traffic from anywhere (0.0.0.0/0) on UDP port 53 (DNS) into any associated subnet.
+This example creates an entry for the specified network ACL. The rule allows ingress traffic from anywhere (0.0.0.0/0) on UDP port 53 (DNS) into any associated subnet. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 create-network-acl-entry --network-acl-id acl-5fb85d36 --ingress --rule-number 100 --protocol udp --port-range From=53,To=53 --cidr-block 0.0.0.0/0 --rule-action allow
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/create-route.rst
+++ b/awscli/examples/ec2/create-route.rst
@@ -1,20 +1,14 @@
 **To create a route**
 
-This example creates a route for the specified route table. The route matches all traffic (``0.0.0.0/0``) and routes it to the specified Internet gateway.
+This example creates a route for the specified route table. The route matches all traffic (``0.0.0.0/0``) and routes it to the specified Internet gateway. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 create-route --route-table-id rtb-22574640 --destination-cidr-block 0.0.0.0/0 --gateway-id igw-c0a643a9
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 This example command creates a route in route table rtb-g8ff4ea2. The route matches traffic for the CIDR block
 10.0.0.0/16 and routes it to VPC peering connection, pcx-111aaa22. This route enables traffic to be directed to the peer
-VPC in the VPC peering connection.
+VPC in the VPC peering connection. If the command succeeds, no output is returned.
 
 Command::
 

--- a/awscli/examples/ec2/create-security-group.rst
+++ b/awscli/examples/ec2/create-security-group.rst
@@ -9,7 +9,6 @@ Command::
 Output::
 
   {
-      "return": "true"
       "GroupId": "sg-903004f8"
   }
 
@@ -24,7 +23,6 @@ Command::
 Output::
 
   {
-      "return": "true"
       "GroupId": "sg-903004f8"
   }
 

--- a/awscli/examples/ec2/create-tags.rst
+++ b/awscli/examples/ec2/create-tags.rst
@@ -1,20 +1,14 @@
 **To add a tag to a resource**
 
-This example adds the tag ``Stack=production`` to the specified image, or overwrites an existing tag for the AMI where the tag key is ``Stack``.
+This example adds the tag ``Stack=production`` to the specified image, or overwrites an existing tag for the AMI where the tag key is ``Stack``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 create-tags --resources ami-78a54011 --tags Key=Stack,Value=production
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To add tags to multiple resources**
 
-This example adds (or overwrites) two tags for an AMI and an instance. One of the tags contains just a key (``webserver``), with no value (we set the value to an empty string). The other tag consists of a key (``stack``) and value (``Production``).
+This example adds (or overwrites) two tags for an AMI and an instance. One of the tags contains just a key (``webserver``), with no value (we set the value to an empty string). The other tag consists of a key (``stack``) and value (``Production``). If the command succeeds, no output is returned.
 
 Command::
 

--- a/awscli/examples/ec2/create-vpn-connection-route.rst
+++ b/awscli/examples/ec2/create-vpn-connection-route.rst
@@ -1,13 +1,7 @@
 **To create a static route for a VPN connection**
 
-This example creates a static route for the specified VPN connection.
+This example creates a static route for the specified VPN connection. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 create-vpn-connection-route --vpn-connection-id vpn-40f41529 --destination-cidr-block 11.12.0.0/16
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-customer-gateway.rst
+++ b/awscli/examples/ec2/delete-customer-gateway.rst
@@ -1,13 +1,7 @@
 **To delete a customer gateway**
 
-This example deletes the specified customer gateway.
+This example deletes the specified customer gateway. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-customer-gateway --customer-gateway-id cgw-0e11f167
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-dhcp-options.rst
+++ b/awscli/examples/ec2/delete-dhcp-options.rst
@@ -1,13 +1,7 @@
 **To delete a DHCP options set**
 
-This example deletes the specified DHCP options set.
+This example deletes the specified DHCP options set. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-dhcp-options --dhcp-options-id dopt-d9070ebb
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-internet-gateway.rst
+++ b/awscli/examples/ec2/delete-internet-gateway.rst
@@ -1,13 +1,7 @@
 **To delete an Internet gateway**
 
-This example deletes the specified Internet gateway.
+This example deletes the specified Internet gateway. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-internet-gateway --internet-gateway-id igw-c0a643a9
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-key-pair.rst
+++ b/awscli/examples/ec2/delete-key-pair.rst
@@ -1,16 +1,10 @@
 **To delete a key pair**
 
-This example deletes the key pair named ``MyKeyPair``.
+This example deletes the key pair named ``MyKeyPair``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-key-pair --key-name MyKeyPair
-
-Output::
-
-  {
-      "return": "true"
-  }
 
 For more information, see `Using Key Pairs`_ in the *AWS Command Line Interface User Guide*.
 

--- a/awscli/examples/ec2/delete-network-acl-entry.rst
+++ b/awscli/examples/ec2/delete-network-acl-entry.rst
@@ -1,13 +1,7 @@
 **To delete a network ACL entry**
 
-This example deletes ingress rule number 100 from the specified network ACL.
+This example deletes ingress rule number 100 from the specified network ACL. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-network-acl-entry --network-acl-id acl-5fb85d36 --ingress --rule-number 100
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-network-acl.rst
+++ b/awscli/examples/ec2/delete-network-acl.rst
@@ -1,13 +1,7 @@
 **To delete a network ACL**
 
-This example deletes the specified network ACL.
+This example deletes the specified network ACL. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-network-acl --network-acl-id acl-5fb85d36
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-network-interface.rst
+++ b/awscli/examples/ec2/delete-network-interface.rst
@@ -1,13 +1,7 @@
 **To delete a network interface**
 
-This example deletes the specified network interface.
+This example deletes the specified network interface. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-network-interface --network-interface-id eni-e5aa89a3
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-route-table.rst
+++ b/awscli/examples/ec2/delete-route-table.rst
@@ -1,13 +1,7 @@
 **To delete a route table**
 
-This example deletes the specified route table.
+This example deletes the specified route table. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-route-table --route-table-id rtb-22574640
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-route.rst
+++ b/awscli/examples/ec2/delete-route.rst
@@ -1,13 +1,7 @@
 **To delete a route**
 
-This example deletes the specified route from the specified route table.
+This example deletes the specified route from the specified route table. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-route --route-table-id rtb-22574640 --destination-cidr-block 0.0.0.0/0
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-security-group.rst
+++ b/awscli/examples/ec2/delete-security-group.rst
@@ -1,30 +1,18 @@
 **[EC2-Classic] To delete a security group**
 
-This example deletes the security group named ``MySecurityGroup``.
+This example deletes the security group named ``MySecurityGroup``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-security-group --group-name MySecurityGroup
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **[EC2-VPC] To delete a security group**
 
-This example deletes the security group with the ID ``sg-903004f8``. Note that you can't reference a security group for EC2-VPC by name.
+This example deletes the security group with the ID ``sg-903004f8``. Note that you can't reference a security group for EC2-VPC by name. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-security-group --group-id sg-903004f8
-
-Output::
-
-  {
-      "return": "true"
-  }
 
 For more information, see `Using Security Groups`_ in the *AWS Command Line Interface User Guide*.
 

--- a/awscli/examples/ec2/delete-snapshot.rst
+++ b/awscli/examples/ec2/delete-snapshot.rst
@@ -1,13 +1,7 @@
 **To delete a snapshot**
 
-This example command deletes a snapshot with the snapshot ID of ``snap-1234abcd``.
+This example command deletes a snapshot with the snapshot ID of ``snap-1234abcd``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-snapshot --snapshot-id snap-1234abcd
-
-Output::
-
-   {
-       "return": "true"
-   }

--- a/awscli/examples/ec2/delete-spot-datafeed-subscription.rst
+++ b/awscli/examples/ec2/delete-spot-datafeed-subscription.rst
@@ -1,14 +1,7 @@
 **To cancel a Spot Instance data feed subscription**
 
-This example command deletes a Spot data feed subscription for the account.
+This example command deletes a Spot data feed subscription for the account. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-spot-datafeed-subscription
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/delete-subnet.rst
+++ b/awscli/examples/ec2/delete-subnet.rst
@@ -1,13 +1,7 @@
 **To delete a subnet**
 
-This example deletes the specified subnet.
+This example deletes the specified subnet. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-subnet --subnet-id subnet-9d4a7b6c
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-tags.rst
+++ b/awscli/examples/ec2/delete-tags.rst
@@ -1,16 +1,11 @@
 **To delete a tag from a resource**
 
-This example deletes the tag ``Stack=Test`` from the specified image.
+This example deletes the tag ``Stack=Test`` from the specified image. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-tags --resources ami-78a54011 --tags Key=Stack,Value=Test
 
-Output::
-
-  {
-      "return": "true"
-  }
 
 It's optional to specify the value for any tag with a value. If you specify a value for the key, the tag is deleted only if the tag's value matches the one you specified. If you specify the empty string as the value, the tag is deleted only if the tag's value is the empty string. The following example specifies the empty string as the value for the tag to delete.
 
@@ -26,7 +21,7 @@ Command::
   
 **To delete a tag from multiple resources**
   
-This example deletes the ``Purpose=Test`` tag from a specified instance and AMI. The tag's value can be omitted from the command.
+This example deletes the ``Purpose=Test`` tag from a specified instance and AMI. The tag's value can be omitted from the command. If the command succeeds, no output is returned.
 
 Command::
 

--- a/awscli/examples/ec2/delete-volume.rst
+++ b/awscli/examples/ec2/delete-volume.rst
@@ -1,13 +1,7 @@
 **To delete a volume**
 
-This example command deletes an available volume with the volume ID of ``vol-1234abcd``.
+This example command deletes an available volume with the volume ID of ``vol-1234abcd``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-volume --volume-id vol-1234abcd
-
-Output::
-
-   {
-       "return": "true"
-   }

--- a/awscli/examples/ec2/delete-vpc-peering-connection.rst
+++ b/awscli/examples/ec2/delete-vpc-peering-connection.rst
@@ -9,5 +9,5 @@ Command::
 Output::
 
   {
-      "return": "true"
+      "Return": true
   }

--- a/awscli/examples/ec2/delete-vpc.rst
+++ b/awscli/examples/ec2/delete-vpc.rst
@@ -1,13 +1,7 @@
 **To delete a VPC**
 
-This example deletes the specified VPC.
+This example deletes the specified VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-vpc --vpc-id vpc-a01106c2
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-vpn-connection-route.rst
+++ b/awscli/examples/ec2/delete-vpn-connection-route.rst
@@ -1,13 +1,7 @@
 **To delete a static route from a VPN connection**
 
-This example deletes the specified static route from the specified VPN connection.
+This example deletes the specified static route from the specified VPN connection. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-vpn-connection-route --vpn-connection-id vpn-40f41529 --destination-cidr-block 11.12.0.0/16
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-vpn-connection.rst
+++ b/awscli/examples/ec2/delete-vpn-connection.rst
@@ -1,13 +1,7 @@
 **To delete a VPN connection**
 
-This example deletes the specified VPN connection.
+This example deletes the specified VPN connection. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-vpn-connection --vpn-connection-id vpn-40f41529
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/delete-vpn-gateway.rst
+++ b/awscli/examples/ec2/delete-vpn-gateway.rst
@@ -1,13 +1,7 @@
 **To delete a virtual private gateway**
 
-This example deletes the specified virtual private gateway.
+This example deletes the specified virtual private gateway. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 delete-vpn-gateway --vpn-gateway-id vgw-9a4cacf3
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/deregister-image.rst
+++ b/awscli/examples/ec2/deregister-image.rst
@@ -1,13 +1,7 @@
 **To deregister an AMI**
 
-This example deregisters the specified AMI.
+This example deregisters the specified AMI. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 deregister-image --image-id ami-4fa54026
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/detach-internet-gateway.rst
+++ b/awscli/examples/ec2/detach-internet-gateway.rst
@@ -1,13 +1,7 @@
 **To detach an Internet gateway from your VPC**
 
-This example detaches the specified Internet gateway from the specified VPC.
+This example detaches the specified Internet gateway from the specified VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 detach-internet-gateway --internet-gateway-id igw-c0a643a9 --vpc-id vpc-a01106c2
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/detach-network-interface.rst
+++ b/awscli/examples/ec2/detach-network-interface.rst
@@ -1,13 +1,7 @@
 **To detach a network interface from your instance**
 
-This example detaches the specified network interface from the specified instance.
+This example detaches the specified network interface from the specified instance. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 detach-network-interface --attachment-id eni-attach-66c4350a
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/detach-vpn-gateway.rst
+++ b/awscli/examples/ec2/detach-vpn-gateway.rst
@@ -1,13 +1,7 @@
 **To detach a virtual private gateway from your VPC**
 
-This example detaches the specified virtual private gateway from the specified VPC.
+This example detaches the specified virtual private gateway from the specified VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 detach-internet-gateway --vpn-gateway-id vgw-9a4cacf3 --vpc-id vpc-a01106c2
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/disable-vgw-route-propagation.rst
+++ b/awscli/examples/ec2/disable-vgw-route-propagation.rst
@@ -1,13 +1,7 @@
 **To disable route propagation**
 
-This example disables the specified virtual private gateway from propagating static routes to the specified route table.
+This example disables the specified virtual private gateway from propagating static routes to the specified route table. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 disable-vgw-route-propagation --route-table-id rtb-22574640 --gateway-id vgw-9a4cacf3
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/disassociate-address.rst
+++ b/awscli/examples/ec2/disassociate-address.rst
@@ -1,28 +1,15 @@
 **To disassociate an Elastic IP addresses in EC2-Classic**
 
-This example disassociates an Elastic IP address from an instance in EC2-Classic.
+This example disassociates an Elastic IP address from an instance in EC2-Classic. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 disassociate-address --public-ip 198.51.100.0
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To disassociate an Elastic IP address in EC2-VPC**
 
-This example disassociates an Elastic IP address from an instance in a VPC.
+This example disassociates an Elastic IP address from an instance in a VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 disassociate-address --association-id eipassoc-2bebb745
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/disassociate-route-table.rst
+++ b/awscli/examples/ec2/disassociate-route-table.rst
@@ -1,13 +1,7 @@
 **To disassociate a route table**
 
-This example disassociates the specified route table from the specified subnet.
+This example disassociates the specified route table from the specified subnet. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 disassociate-route-table --association-id rtbassoc-781d0d1a
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/enable-vgw-route-propagation.rst
+++ b/awscli/examples/ec2/enable-vgw-route-propagation.rst
@@ -1,13 +1,7 @@
 **To enable route propagation**
 
-This example enables the specified virtual private gateway to propagate static routes to the specified route table.
+This example enables the specified virtual private gateway to propagate static routes to the specified route table. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 enable-vgw-route-propagation --route-table-id rtb-22574640 --gateway-id vgw-9a4cacf3
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/modify-image-attribute.rst
+++ b/awscli/examples/ec2/modify-image-attribute.rst
@@ -1,55 +1,31 @@
 **To make an AMI public**
 
-This example makes the specified AMI public.
+This example makes the specified AMI public. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-image-attribute --image-id ami-5731123e --launch-permission "{\"Add\": [{\"Group\":\"all\"}]}"
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To make an AMI private**
 
-This example makes the specified AMI private.
+This example makes the specified AMI private. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-image-attribute --image-id ami-5731123e --launch-permission "{\"Remove\": [{\"Group\":\"all\"}]}"
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To grant launch permission to an AWS account**
 
-This example grants launch permissions to the specified AWS account.
+This example grants launch permissions to the specified AWS account. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-image-attribute --image-id ami-5731123e --launch-permission "{\"Add\": [{\"UserId\":\"123456789012\"}]}"
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To removes launch permission from an AWS account**
 
-This example removes launch permissions from the specified AWS account.
+This example removes launch permissions from the specified AWS account. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-image-attribute --image-id ami-5731123e --launch-permission "{\"Remove\": [{\"UserId\":\"123456789012\"}]}"
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/modify-instance-attribute.rst
+++ b/awscli/examples/ec2/modify-instance-attribute.rst
@@ -1,41 +1,31 @@
 **To modify the instance type**
 
-This example modifies the instance type of the specified instance. The instance must be in the ``stopped`` state.
+This example modifies the instance type of the specified instance. The instance must be in the ``stopped`` state. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-instance-attribute --instance-id i-5203422c --instance-type "{\"Value\": \"m1.small\"}"
 
-Output::
+**To enable enhanced networking on an instance**
 
-  {
-      "return": "true"
-  }
+This example enables enhanced networking for the specified instance. The instance must be in the ``stopped`` state. If the command succeeds, no output is returned.
+
+Command::
+
+  aws ec2 modify-instance-attribute --instance-id i-1a2b3c4d --sriov-net-support simple
 
 **To modify the sourceDestCheck attribute**
 
-This example sets the ``sourceDestCheck`` attribute of the specified instance to ``true``. The instance must be in a VPC.
+This example sets the ``sourceDestCheck`` attribute of the specified instance to ``true``. The instance must be in a VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-instance-attribute --instance-id i-5203422c --source-dest-check "{\"Value\": true}"
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To modify the deleteOnTermination attribute of the root volume**
 
-This example sets the ``deleteOnTermination`` attribute for the root volume of the specified Amazon EBS-backed instance to ``false``. By default, this attribute is ``true`` for the root volume.
+This example sets the ``deleteOnTermination`` attribute for the root volume of the specified Amazon EBS-backed instance to ``false``. By default, this attribute is ``true`` for the root volume. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-instance-attribute --instance-id i-5203422c --block-device-mappings "[{\"DeviceName\": \"/dev/sda1\",\"Ebs\":{\"DeleteOnTermination\":false}}]"
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/modify-volume-attribute.rst
+++ b/awscli/examples/ec2/modify-volume-attribute.rst
@@ -1,13 +1,7 @@
 **To modify a volume attribute**
 
-This example sets the ``autoEnableIo`` attribute of the volume with the ID ``vol-1a2b3c4d`` to ``true``.
+This example sets the ``autoEnableIo`` attribute of the volume with the ID ``vol-1a2b3c4d`` to ``true``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-volume-attribute --volume-id vol-1a2b3c4d --auto-enable-io
-
-Output::
-
-   {
-       "return": "true"
-   }

--- a/awscli/examples/ec2/modify-vpc-attribute.rst
+++ b/awscli/examples/ec2/modify-vpc-attribute.rst
@@ -1,27 +1,15 @@
 **To modify the enableDnsSupport attribute**
 
-This example modifies the ``enableDnsSupport`` attribute. This attribute indicates whether DNS resolution is enabled for the VPC. If this attribute is ``true``, the Amazon DNS server resolves DNS hostnames for your instances to their corresponding IP addresses; otherwise, it does not.
+This example modifies the ``enableDnsSupport`` attribute. This attribute indicates whether DNS resolution is enabled for the VPC. If this attribute is ``true``, the Amazon DNS server resolves DNS hostnames for your instances to their corresponding IP addresses; otherwise, it does not. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-vpc-attribute --vpc-id vpc-a01106c2 --enable-dns-support "{\"Value\":false}"
-
-Output::
-
-  {
-      "return": "true"
-  }
   
 **To modify the enableDnsHostnames attribute**
 
-This example modifies the ``enableDnsHostnames`` attribute. This attribute indicates whether instances launched in the VPC get DNS hostnames. If this attribute is ``true``, instances in the VPC get DNS hostnames; otherwise, they do not.
+This example modifies the ``enableDnsHostnames`` attribute. This attribute indicates whether instances launched in the VPC get DNS hostnames. If this attribute is ``true``, instances in the VPC get DNS hostnames; otherwise, they do not. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 modify-vpc-attribute --vpc-id vpc-a01106c2 --enable-dns-hostnames "{\"Value\":false}"
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/reboot-instances.rst
+++ b/awscli/examples/ec2/reboot-instances.rst
@@ -1,16 +1,10 @@
 **To reboot an Amazon EC2 instance**
 
-This example reboots the specified instance.
+This example reboots the specified instance. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 reboot-instances --instance-ids i-1a2b3c4d
-
-Output::
-
-    {
-        "return": "true"
-    }
 
 For more information, see `Reboot Your Instance`_ in the *Amazon Elastic Compute Cloud User Guide*.
 

--- a/awscli/examples/ec2/reject-vpc-peering-connection.rst
+++ b/awscli/examples/ec2/reject-vpc-peering-connection.rst
@@ -9,5 +9,5 @@ Command::
 Output::
 
   {
-      "return": "true"
+      "Return": true
   }

--- a/awscli/examples/ec2/release-address.rst
+++ b/awscli/examples/ec2/release-address.rst
@@ -1,28 +1,15 @@
 **To release an Elastic IP addresses for EC2-Classic**
 
-This example releases an Elastic IP address for use with instances in EC2-Classic.
+This example releases an Elastic IP address for use with instances in EC2-Classic. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 release-address --public-ip 198.51.100.0
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To release an Elastic IP address for EC2-VPC**
 
-This example releases an Elastic IP address for use with instances in a VPC.
+This example releases an Elastic IP address for use with instances in a VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 release-address --allocation-id eipalloc-64d5890a
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/replace-route.rst
+++ b/awscli/examples/ec2/replace-route.rst
@@ -1,13 +1,7 @@
 **To replace a route**
 
-This example replaces the specified route in the specified table table. The new route matches the specified CIDR and sends the traffic to the specified virtual private gateway.
+This example replaces the specified route in the specified table table. The new route matches the specified CIDR and sends the traffic to the specified virtual private gateway. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 replace-route --route-table-id rtb-22574640 --destination-cidr-block 10.0.0.0/16 --gateway-id vgw-9a4cacf3
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/reset-image-attribute.rst
+++ b/awscli/examples/ec2/reset-image-attribute.rst
@@ -1,13 +1,7 @@
 **To reset the launchPermission attribute**
 
-This example resets the ``launchPermission`` attribute for the specified AMI to its default value. By default, AMIs are private.
+This example resets the ``launchPermission`` attribute for the specified AMI to its default value. By default, AMIs are private. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 reset-image-attribute --image-id ami-5731123e --attribute launchPermission
-
-Output::
-
-  {
-      "return": "true"
-  }

--- a/awscli/examples/ec2/reset-instance-attribute.rst
+++ b/awscli/examples/ec2/reset-instance-attribute.rst
@@ -1,42 +1,23 @@
 **To reset the sourceDestCheck attribute**
 
-This example resets the ``sourceDestCheck`` attribute of the specified instance. The instance must be in a VPC.
+This example resets the ``sourceDestCheck`` attribute of the specified instance. The instance must be in a VPC. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 reset-instance-attribute --instance-id i-5203422c --attribute sourceDestCheck
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To reset the kernel attribute**
 
-This example resets the ``kernel`` attribute of the specified instance. The instance must be in the ``stopped`` state.
+This example resets the ``kernel`` attribute of the specified instance. The instance must be in the ``stopped`` state. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 reset-instance-attribute --instance-id i-5203422c --attribute kernel
 
-Output::
-
-  {
-      "return": "true"
-  }
-
 **To reset the ramdisk attribute**
 
-This example resets the ``ramdisk`` attribute of the specified instance. The instance must be in the ``stopped`` state.
+This example resets the ``ramdisk`` attribute of the specified instance. The instance must be in the ``stopped`` state. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 reset-instance-attribute --instance-id i-5203422c --attribute ramdisk
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/revoke-security-group-ingress.rst
+++ b/awscli/examples/ec2/revoke-security-group-ingress.rst
@@ -1,14 +1,7 @@
 **To remove a rule from a security group**
 
-This example removes TCP port 22 access for the ``203.0.113.0/24`` address range from the security group named ``MySecurityGroup``.
+This example removes TCP port 22 access for the ``203.0.113.0/24`` address range from the security group named ``MySecurityGroup``. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 revoke-security-group-ingress --group-name MySecurityGroup --protocol tcp --port 22 --cidr 203.0.113.0/24
-
-Output::
-
-  {
-      "return": "true"
-  }
-

--- a/awscli/examples/ec2/unassign-private-ip-addresses.rst
+++ b/awscli/examples/ec2/unassign-private-ip-addresses.rst
@@ -1,13 +1,7 @@
 **To unassign a secondary private IP address from a network interface**
 
-This example unassigns the specified private IP address from the specified network interface.
+This example unassigns the specified private IP address from the specified network interface. If the command succeeds, no output is returned.
 
 Command::
 
   aws ec2 unassign-private-ip-addresses --network-interface-id eni-e5aa89a3 --private-ip-addresses 10.0.0.82
-
-Output::
-
-  {
-      "return": "true"
-  }


### PR DESCRIPTION
updated examples for commands that used to output "return": "true". authorize-security-group-ingress includes further updates from a few weeks ago that had not been merged in yet.
