### PR TITLE
fix for aws s3 sync intermittently setting mtime on a large multipart download to now

### DIFF
--- a/awscli/customizations/s3/executor.py
+++ b/awscli/customizations/s3/executor.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import logging
 from six.moves import queue
+import os
 import sys
 import threading
 
@@ -175,6 +176,8 @@ class IOWriterThread(threading.Thread):
                 if fileobj is not None:
                     fileobj.close()
                     del self.fd_descriptor_cache[task.filename]
+                    if task.last_modified is not None:
+                        os.utime(task.filename, (task.last_modified, task.last_modified))
 
     def _cleanup(self):
         for fileobj in self.fd_descriptor_cache.values():

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -310,12 +310,11 @@ class CompleteDownloadTask(OrderableTask):
         self._context.wait_for_completion()
         last_update_tuple = self._filename.last_update.timetuple()
         mod_timestamp = time.mktime(last_update_tuple)
-        os.utime(self._filename.dest, (int(mod_timestamp), int(mod_timestamp)))
         message = print_operation(self._filename, False,
                                   self._parameters['dryrun'])
         print_task = {'message': message, 'error': False}
         self._result_queue.put(PrintTask(**print_task))
-        self._io_queue.put(IOCloseRequest(self._filename.dest))
+        self._io_queue.put(IOCloseRequest(self._filename.dest, int(mod_timestamp)))
 
 
 class DownloadPartTask(OrderableTask):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -449,6 +449,15 @@ class PrintTask(namedtuple('PrintTask',
 
 IORequest = namedtuple('IORequest',
                        ['filename', 'offset', 'data', 'is_stream'])
+
+
 # Used to signal that IO for the filename is finished, and that
 # any associated resources may be cleaned up.
-IOCloseRequest = namedtuple('IOCloseRequest', ['filename'])
+class IOCloseRequest(namedtuple('IOCloseRequest', ['filename', 'last_modified'])):
+    def __new__(cls, filename, last_modified=None):
+        """
+        :param filename: The filename to close
+        :param last_modified: Int timestamp or None.  If not none we will set the file mtime to this after we close the file.
+        """
+        return super(IOCloseRequest, cls).__new__(cls, filename, last_modified)
+


### PR DESCRIPTION
Hi folks,

I've noticed a lot of unnecessary downloads with aws s3 sync but only for large multi-part files.

Looking over the code I see that CompleteDownloadTask in awscli/customizations/s3/tasks.py sets the file mtime before it is closed.

I can't reliably reproduce it, but off-hand this seems wrong.  I suspect the file has unflushed data, and closing it updates the mtime to now.

So I've made a pretty straightforward fix where IOCloseRequest takes an optional last_updated.  If this is not None, then after the file is closed the IOWriterThread sets the mtime.  And I removed the os.utime call in CompleteDownloadTask since it is now redundant.

In my tests I could not reproduce the problem after the fix was applied.

Please let me know if this is a reasonable change and apologies in advance if I haven't followed protocol, this is the first time I've submitted a pull request here.

best,
-Kirat