### PR TITLE
Fix ls --recursive discrpency with prefixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,9 @@ Next Release (TBD)
 * bugfix:Timestamp Input: Fix regression where timestamps without any timezone
   information were not being handled properly
   (`issue 982 <https://github.com/aws/aws-cli/issues/982>`__)
+* bugfix:``aws s3 ls --recursive``: Fix issue where objects being listed
+  were not relative to S3 prefix provided.
+  (`issue 1009 <https://github.com/aws/aws-cli/pull/1009>`__)
 
 
 1.6.2

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -975,6 +975,22 @@ class TestLs(BaseS3CLICommand):
         p = aws('s3 ls s3://%s/bar --recursive' % bucket_name)
         self.assertEqual(p.rc, 1)
 
+    def test_ls_recursive_at_bucket_root(self):
+        bucket_name = self.create_bucket()
+        self.put_object(bucket_name, 'temp/foo.txt', 'contents')
+        p = aws('s3 ls s3://%s/ --recursive' % bucket_name)
+        self.assertEqual(p.rc, 0)
+        self.assertIn('temp/foo.txt', p.stdout)
+
+    def test_ls_recursive_at_bucket_root(self):
+        bucket_name = self.create_bucket()
+        self.put_object(bucket_name, 'temp/foo.txt', 'contents')
+        p = aws('s3 ls s3://%s/temp/ --recursive' % bucket_name)
+        self.assertEqual(p.rc, 0)
+        self.assertIn('foo.txt', p.stdout)
+        # The temp prefix should be excluded when listing object temp/foo.txt.
+        self.assertNotIn('temp/foo.txt', p.stdout)
+
 
 class TestMbRb(BaseS3CLICommand):
     """

--- a/tests/unit/customizations/s3/test_ls_command.py
+++ b/tests/unit/customizations/s3/test_ls_command.py
@@ -116,6 +116,41 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         self.parsed_responses = [{}]
         self.run_cmd('s3 ls s3://bucket/foo', expected_rc=1)
 
+    def test_recursive_ls_at_prefix(self):
+        time_utc = "2014-01-09T20:45:49.000Z"
+        self.parsed_responses = [
+            {"Contents": [{"Key": "foo/bar/baz.txt", "Size": 100,
+                           "LastModified": time_utc},
+                          {"Key": "foo/test.txt", "Size": 100,
+                           "LastModified": time_utc}]}
+        ]
+        stdout, _, _ = self.run_cmd('s3 ls s3://bucket/foo/ --recursive',
+                                    expected_rc=0)
+        # Should be listed as test.txt but not as foo/test.txt
+        self.assertIn('test.txt', stdout)
+        self.assertNotIn('foo/test.txt', stdout)
+        # Should be listed as bar/baz.txt but not as foo/bar/baz.txt
+        self.assertIn('bar/baz.txt', stdout)
+        self.assertNotIn('foo/bar/baz.txt', stdout)
+
+    def test_recursive_ls_at_top_level_bucket(self):
+        time_utc = "2014-01-09T20:45:49.000Z"
+        self.parsed_responses = [
+            {"Contents": [{"Key": "foo/bar/baz.txt", "Size": 100,
+                           "LastModified": time_utc},
+                          {"Key": "foo/test.txt", "Size": 100,
+                           "LastModified": time_utc}]}
+        ]
+        stdout, _, _ = self.run_cmd('s3 ls s3://bucket --recursive',
+                                    expected_rc=0)
+        # Should be listed as foo/test.txt when listing from top level of
+        # bucket.
+        self.assertIn('foo/test.txt', stdout)
+        # Should be listed as foo/bar/baz.txt when listing from top level of
+        # bucket.
+        self.assertIn('foo/bar/baz.txt', stdout)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/604

As an example of what is changed, start off with a bucket ``mybucket`` with the key ``foo/bar``.

When we used to run ``aws s3 ls s3://mybucket/foo/ --recursive``, it would list the object as ``foo/bar``. This is inconsistent with ``aws s3 ls s3://mybucket/foo/`` since it would list the object as ``bar``.

This change makes the output consistent with the non-recusive ``ls``.

cc @jamesls @danielgtaylor 