### PR TITLE
Fix issue when error response is receieved for streaming output

### DIFF
--- a/awscli/customizations/streamingoutputarg.py
+++ b/awscli/customizations/streamingoutputarg.py
@@ -89,6 +89,12 @@ class StreamingOutputArgument(BaseCLIArgument):
             service_name, operation_name), self.save_file)
 
     def save_file(self, parsed, **kwargs):
+        if self._response_key not in parsed:
+            # If the response key is not in parsed, then
+            # we've received an error message and we'll let the AWS CLI
+            # error handler print out an error message.  We have no
+            # file to save in this situation.
+            return
         body = parsed[self._response_key]
         buffer_size = self._buffer_size
         with open(self._output_file, 'wb') as fp:

--- a/tests/unit/s3/test_get_object.py
+++ b/tests/unit/s3/test_get_object.py
@@ -37,9 +37,6 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --bucket mybucket'
         cmdline += ' --key mykey'
         cmdline += ' outfile'
-        result = {'uri_params': {'Bucket': 'mybucket',
-                                 'Key': 'mykey'},
-                  'headers': {},}
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
                                               'Key': 'mykey'})
@@ -50,9 +47,6 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --key mykey'
         cmdline += ' --range bytes=0-499'
         cmdline += ' outfile'
-        result = {'uri_params': {'Bucket': 'mybucket',
-                                 'Key': 'mykey'},
-                  'headers': {'Range': 'bytes=0-499'},}
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
                                               'Key': 'mykey',
@@ -65,11 +59,6 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --response-cache-control No-cache'
         cmdline += ' --response-content-encoding x-gzip'
         cmdline += ' outfile'
-        result = {'uri_params': {'Bucket': 'mybucket',
-                                 'Key': 'mykey',
-                                 'ResponseCacheControl': 'No-cache',
-                                 'ResponseContentEncoding': 'x-gzip'},
-                  'headers': {},}
         self.addCleanup(self.remove_file_if_exists, 'outfile')
         self.assert_params_for_cmd2(
             cmdline, {
@@ -78,6 +67,24 @@ class TestGetObject(BaseAWSCommandParamsTest):
                 'ResponseContentEncoding': 'x-gzip'
             }
         )
+
+    def test_streaming_output_arg_with_error_response(self):
+        # Checking that the StreamingOutputArg handles the
+        # case where it's passed an error body.  Previously
+        # it would propogate a KeyError so we want to ensure
+        # this case is handled.
+        self.parsed_response = {
+            'Error': {
+                'Code': 'AuthError', 'Message': 'SomeError'
+            }
+        }
+        cmdline = self.prefix
+        cmdline += ' --bucket mybucket'
+        cmdline += ' --key mykey'
+        cmdline += ' outfile'
+        self.addCleanup(self.remove_file_if_exists, 'outfile')
+        self.assert_params_for_cmd2(
+            cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the second half of #1006.  Now you'll get a proper error
message:

```
$ aws s3api get-object --bucket b --key k /tmp/outfile

A client error (InvalidRequest) occurred when calling the GetObject
operation: The object was stored using a form of Server Side Encryption.
The correct parameters must be provided to retrieve the object.

```

Closes #1006.

cc @kyleknap @danielgtaylor 
