### PR TITLE
Register timestamp parser after profile is set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* bugfix:``aws s3``: Fix issue where datetime's were not being
+  parsed properly when a profile was specified
+  (`issue 1020 <https://github.com/aws/aws-cli/issues/1020>`__)
+
+
 1.6.3
 =====
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -193,6 +193,7 @@ class CLIDriver(object):
             # general exception handling logic as calling into the
             # command table.  This is why it's in the try/except clause.
             self._handle_top_level_args(parsed_args)
+            self._emit_session_event()
             return command_table[parsed_args.command](remaining, parsed_args)
         except UnknownArgumentError as e:
             sys.stderr.write("\n")
@@ -214,6 +215,14 @@ class CLIDriver(object):
             sys.stderr.write("\n")
             sys.stderr.write("%s\n" % e)
             return 255
+
+    def _emit_session_event(self):
+        # This event is guaranteed to run after the session has been
+        # initialized and a profile has been set.  This was previously
+        # problematic because if something in CLIDriver caused the
+        # session components to be reset (such as session.profile = foo)
+        # then all the prior registered components would be removed.
+        self.session.emit('session-initialized', session=self.session)
 
     def _show_error(self, msg):
         LOG.debug(msg, exc_info=True)

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -28,7 +28,7 @@ in the future.
 
 """
 def register_scalar_parser(event_handlers):
-    event_handlers.register('building-command-table.main',
+    event_handlers.register('session-initialized',
                             add_scalar_parsers)
 
 

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1541,5 +1541,26 @@ class TestStreams(BaseS3CLICommand):
         self.assertEqual(p.stdout, data_encoded.decode(get_stdout_encoding()))
 
 
+class TestLSWithProfile(BaseS3CLICommand):
+    def extra_setup(self):
+        self.config_file = os.path.join(self.files.rootdir, 'tmpconfig')
+        with open(self.config_file, 'w') as f:
+            creds = self.session.get_credentials()
+            f.write(
+                "[profile testprofile]\n"
+                "aws_access_key_id=%s\n"
+                "aws_secret_access_key=%s\n" % (
+                    creds.access_key,
+                    creds.secret_key)
+            )
+            if creds.token is not None:
+                f.write("aws_session_token=%s\n" % creds.token)
+
+    def test_can_ls_with_profile(self):
+        p = aws('s3 ls s3:// --profile testprofile',
+                env_vars={'AWS_CONFIG_FILE': self.config_file})
+        self.assert_no_errors(p)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/test_scalarparse.py
+++ b/tests/unit/customizations/test_scalarparse.py
@@ -23,7 +23,7 @@ class TestScalarParse(unittest.TestCase):
         event_handers = mock.Mock()
         scalarparse.register_scalar_parser(event_handers)
         event_handers.register.assert_called_with(
-            'building-command-table.main', scalarparse.add_scalar_parsers)
+            'session-initialized', scalarparse.add_scalar_parsers)
 
     def test_identity(self):
         self.assertEqual(scalarparse.identity('foo'), 'foo')

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -243,6 +243,7 @@ class TestCliDriverHooks(unittest.TestCase):
             'building-command-table.main',
             'building-top-level-params',
             'top-level-args-parsed',
+            'session-initialized',
             'building-command-table.s3',
             'building-argument-table.s3.list-objects',
             'before-building-argument-table-parser.s3.list-objects',


### PR DESCRIPTION
The issue was that setting a profile for a session resets all
the registered components for the session, including the
response parser that alters the timetsamp parsing behavior in the
AWS CLI.

To fix this, I've added a new event that I think will be useful
in general, a `session-initialized` event, sent once the session
has its profile set.  There are actually several handlers that
I think should switch over to this signal, which I'll add in
a separate pull request.

I've also added an integration test to ensure we don't regress
on this issue again.

Fixes #1020.

cc @kyleknap @danielgtaylor 
