### PR TITLE
add require for six version. Fixes #1051

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ nose==1.3.0
 colorama==0.2.5
 mock==1.0.1
 rsa==3.1.2
+six>=1.8.0


### PR DESCRIPTION
six needs to be at least 1.8.0 to have shlex_quote
