### PR TITLE
Bump version of six to match botocore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six>=1.8.0,<2.0.0
 tox==1.4
 docutils>=0.10
 Sphinx==1.1.3

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import awscli
 
 requires = ['botocore>=0.78.0,<0.79.0',
             'bcdoc>=0.12.0,<0.13.0',
-            'six>=1.1.0',
+            'six>=1.8.0,<2.0.0',
             'colorama==0.2.5',
             'docutils>=0.10',
             'rsa==3.1.2']


### PR DESCRIPTION
For some reason pip and other types of installers do not actually look at botocore's dependancies of six so we are making it explicit and have it match botocore's dependancy of six.

cc @jamesls @danielgtaylor 
