### PR TITLE
Add pipes to list of py2exe packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if 'py2exe' in sys.argv:
             'optimize': 0,
             'skip_archive': True,
             'packages': ['docutils', 'urllib', 'httplib', 'HTMLParser',
-                         'awscli', 'ConfigParser', 'xml.etree'],
+                         'awscli', 'ConfigParser', 'xml.etree', 'pipes'],
         }
     }
     setup_options['console'] = ['bin/aws']


### PR DESCRIPTION
This is imported via six dynamically so we don't pick
up on the module as a required import.

cc @kyleknap @danielgtaylor 
