### PR TITLE
Rename --version to --pipeline-version

### DIFF
--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -31,6 +31,7 @@ ARGUMENT_RENAMES = {
     'swf.register-activity-type.version': 'activity-version',
     'swf.register-workflow-type.version': 'workflow-version',
     'datapipeline.*.query': 'objects-query',
+    'datapipeline.get-pipeline-definition.version': 'pipeline-version',
     'emr.*.job-flow-ids': 'cluster-ids',
     'emr.*.job-flow-id': 'cluster-id',
     'cloudsearchdomain.search.query': 'search-query',

--- a/tests/unit/datapipeline/test_get_pipeline_definition.py
+++ b/tests/unit/datapipeline/test_get_pipeline_definition.py
@@ -1,0 +1,27 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestGetPipelineDefinition(BaseAWSCommandParamsTest):
+
+    prefix = 'datapipeline get-pipeline-definition '
+
+    def test_renamed_object_query_arg(self):
+        # --version is renamed to --pipeline-version so we don't
+        # conflict with the global --version argument.
+        cmdline = self.prefix + '--pipeline-id foo --pipeline-version latest'
+        expected = {
+            'pipelineId': 'foo', 'version': 'latest'
+        }
+        self.assert_params_for_cmd2(cmdline, expected)


### PR DESCRIPTION
Fixes an issue where `aws datapipeline get-pipeline-definition`
exposed a `--version` argument which was shadowed by the top level
`--version` argument.  This is similar to what was done for
the `--query/--objects-query` argument.

cc @kyleknap @danielgtaylor 
