### PR TITLE
Fix AssumeRole functionality on windows

### DIFF
--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -120,7 +120,8 @@ class JSONFileCache(object):
                              "JSON serializable: %s" % value)
         if not os.path.isdir(self._working_dir):
             os.makedirs(self._working_dir)
-        with open(full_key, 'w') as f:
+        with os.fdopen(os.open(full_key,
+                               os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
             f.write(file_content)
 
     def _convert_cache_key(self, cache_key):

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -13,6 +13,7 @@
 import shutil
 import tempfile
 import os
+import platform
 from datetime import datetime, timedelta
 
 import mock
@@ -353,3 +354,10 @@ class TestJSONCache(unittest.TestCase):
     def test_key_error_raised_when_cache_key_does_not_exist(self):
         with self.assertRaises(KeyError):
             self.cache['foo']
+
+    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
+                     'File permissions tests not supported on Windows.')
+    def test_permissions_for_file_restricted(self):
+        self.cache['mykey'] = {'foo': 'bar'}
+        filename = os.path.join(self.tempdir, 'mykey.json')
+        self.assertEqual(os.stat(filename).st_mode & 0xFFF, 0o600)


### PR DESCRIPTION
On windows, the `:` char is not allowed in the filename, so we replace these with an `_` char.
Also, for POSIX systems, the file is created with `0600` permissions to restrict access to the cache files.

cc @kyleknap @danielgtaylor 
