### PR TITLE
fix minor typo, ACl -> ACL

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -96,7 +96,7 @@ ACL = {'name': 'acl', 'nargs': 1,
                    'authenticated-read', 'bucket-owner-read',
                    'bucket-owner-full-control', 'log-delivery-write'],
        'help_text': (
-           "Sets the ACl for the object when the command is "
+           "Sets the ACL for the object when the command is "
            "performed.  Only accepts values of ``private``, ``public-read``, "
            "``public-read-write``, ``authenticated-read``, "
            "``bucket-owner-read``, ``bucket-owner-full-control`` and "


### PR DESCRIPTION
Simple tyop, I even double-checked that I'm not wrong- AWS documentation is consistent about it being ACL, and the L actually stands for something: http://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html