### PR TITLE
Fix S3 streaming download corruption

### DIFF
--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -414,7 +414,7 @@ class DownloadPartTask(OrderableTask):
         # for only the remaining parts.  The other alternative, which is what
         # we do here, is to just request the entire chunk size write.
         self._context.wait_for_turn(self._part_number)
-        chunk = body.read(self._chunk_size)
+        chunk = body.read()
         offset = self._part_number * self._chunk_size
         LOGGER.debug("Submitting IORequest to write queue.")
         self._io_queue.put(

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -401,10 +401,31 @@ class DownloadPartTask(OrderableTask):
                      self._part_number, self._filename.dest)
         iterate_chunk_size = self.ITERATE_CHUNK_SIZE
         body.set_socket_timeout(self.READ_TIMEOUT)
+        if self._filename.is_stream:
+            self._queue_writes_for_stream(body)
+        else:
+            self._queue_writes_in_chunks(body, iterate_chunk_size)
+
+    def _queue_writes_for_stream(self, body):
+        # We have to handle an output stream differently.  The main reason is
+        # that we cannot seek() in the output stream.  This means that we need
+        # to queue the writes in order.  If we queue IO writes in smaller than
+        # part size chunks, on the case of a retry we'll need to do a range GET
+        # for only the remaining parts.  The other alternative, which is what
+        # we do here, is to just request the entire chunk size write.
+        self._context.wait_for_turn(self._part_number)
+        chunk = body.read(self._chunk_size)
+        offset = self._part_number * self._chunk_size
+        LOGGER.debug("Submitting IORequest to write queue.")
+        self._io_queue.put(
+            IORequest(self._filename.dest, offset, chunk,
+                      self._filename.is_stream)
+        )
+        self._context.done_with_turn()
+
+    def _queue_writes_in_chunks(self, body, iterate_chunk_size):
         amount_read = 0
         current = body.read(iterate_chunk_size)
-        if self._filename.is_stream:
-            self._context.wait_for_turn(self._part_number)
         while current:
             offset = self._part_number * self._chunk_size + amount_read
             LOGGER.debug("Submitting IORequest to write queue.")
@@ -418,8 +439,6 @@ class DownloadPartTask(OrderableTask):
         # Change log message.
         LOGGER.debug("Done queueing writes for part number %s to file: %s",
                      self._part_number, self._filename.dest)
-        if self._filename.is_stream:
-            self._context.done_with_turn()
 
 
 class CreateMultipartUploadTask(BasicTask):

--- a/tests/unit/customizations/s3/test_tasks.py
+++ b/tests/unit/customizations/s3/test_tasks.py
@@ -418,7 +418,7 @@ class TestDownloadPartTask(unittest.TestCase):
         self.assertEqual(len(call_args_list), 1)
         self.assertEqual(call_args_list[0],
                          mock.call(('local/file', 0, b'foobar', True)))
-        success_body.read.assert_called_with(constants.CHUNKSIZE)
+        success_body.read.assert_called_with()
 
 
 class TestMultipartDownloadContext(unittest.TestCase):


### PR DESCRIPTION
When a download is being piped to stdout `aws s3 cp s3://foo/ -`, it's possible that data can be written out twice.  The issue is that the response body is read in chunks smaller than the range get size.  When a retry occurs the whole request (for the entire range) is retried.  If this retry occurs at the Nth chunk, the chunks 1-N will be enqueued again.

The fix for now is to just enqueue writes at the same size as the chunk size.  I think longer term, there are definitely some optimizations we can do to improve this, but that shouldn't block getting a fix in now.

cc @kyleknap 