### PR TITLE
Set mtime of S3 downloaded object when file is closed

### DIFF
--- a/awscli/customizations/s3/executor.py
+++ b/awscli/customizations/s3/executor.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import logging
 import sys
 import threading
@@ -175,6 +176,9 @@ class IOWriterThread(threading.Thread):
                 if fileobj is not None:
                     fileobj.close()
                     del self.fd_descriptor_cache[task.filename]
+                if task.desired_mtime is not None:
+                    os.utime(task.filename, (task.desired_mtime,
+                                             task.desired_mtime))
 
     def _cleanup(self):
         for fileobj in self.fd_descriptor_cache.values():

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -310,12 +310,12 @@ class CompleteDownloadTask(OrderableTask):
         self._context.wait_for_completion()
         last_update_tuple = self._filename.last_update.timetuple()
         mod_timestamp = time.mktime(last_update_tuple)
-        os.utime(self._filename.dest, (int(mod_timestamp), int(mod_timestamp)))
+        desired_mtime = int(mod_timestamp)
         message = print_operation(self._filename, False,
                                   self._parameters['dryrun'])
         print_task = {'message': message, 'error': False}
         self._result_queue.put(PrintTask(**print_task))
-        self._io_queue.put(IOCloseRequest(self._filename.dest))
+        self._io_queue.put(IOCloseRequest(self._filename.dest, desired_mtime))
 
 
 class DownloadPartTask(OrderableTask):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -452,4 +452,7 @@ IORequest = namedtuple('IORequest',
                        ['filename', 'offset', 'data', 'is_stream'])
 # Used to signal that IO for the filename is finished, and that
 # any associated resources may be cleaned up.
-IOCloseRequest = namedtuple('IOCloseRequest', ['filename'])
+_IOCloseRequest = namedtuple('IOCloseRequest', ['filename', 'desired_mtime'])
+class IOCloseRequest(_IOCloseRequest):
+    def __new__(cls, filename, desired_mtime=None):
+        return super(IOCloseRequest, cls).__new__(cls, filename, desired_mtime)


### PR DESCRIPTION
This is the original patch from @kirat-singh, but the forked
repo is no longer available.

I've added a unit test for this that shows that the mtime modification
is tied to the execution of an IOCloseRequest instead of the enqueuing
of the IOCloseRequest.

Fixes #1072
Closes #994

cc @kyleknap @danielgtaylor 