### PR TITLE
Use correct pathto args for referencing jquery

### DIFF
--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -4,7 +4,7 @@
 {%- block htmltitle %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ pathto('_static/bootstrap.min.css', 1) }}" />
-  <script type="text/javascript" src="{{ pathto('_static/jquery-1.9.1.min.js')}}"></script>
+  <script type="text/javascript" src="{{ pathto('_static/jquery-1.9.1.min.js', 1)}}"></script>
 {%- endblock %}
 
 {# Displays the next and previous links both before and after content #}


### PR DESCRIPTION
http://sphinx-doc.org/templating.html#pathto

pathto(document)
Return the path to a Sphinx document as a URL. Use this to refer to built documents.

pathto(file, 1)
Return the path to a file which is a filename relative to the root of the generated output. Use this to refer to static files.

Previously this was generating an href of `jquery-1.9.1.min.js.html` which is not what we want.

cc @kyleknap @danielgtaylor 