### PR TITLE
Upper case the values for datapipeline status

### DIFF
--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -220,7 +220,7 @@ class QueryArgBuilder(object):
             'fieldName': '@status',
             'operator': {
                 'type': 'EQ',
-                'values': parsed_args.status
+                'values': [status.upper() for status in parsed_args.status]
             }
         })
 
@@ -331,7 +331,7 @@ class ListRunsCommand(BasicCommand):
     ]
     VALID_STATUS = ['waiting', 'pending', 'cancelled', 'running',
                     'finished', 'failed', 'waiting_for_runner',
-                    'waiting_on_dependencies']
+                    'waiting_on_dependencies', 'shutting_down']
 
     def __init__(self, session, formatter=None):
         super(ListRunsCommand, self).__init__(session)

--- a/tests/unit/customizations/datapipeline/test_arg_serialize.py
+++ b/tests/unit/customizations/datapipeline/test_arg_serialize.py
@@ -171,7 +171,7 @@ class TestCLIArgumentSerialize(unittest.TestCase):
                 'fieldName': '@status',
                  'operator': {
                      'type': 'EQ',
-                     'values': ['pending']
+                     'values': ['PENDING']
                  }
             },
             ]
@@ -197,7 +197,7 @@ class TestCLIArgumentSerialize(unittest.TestCase):
                 'fieldName': '@status',
                  'operator': {
                      'type': 'EQ',
-                     'values': ['pending', 'waiting_on_dependencies']
+                     'values': ['PENDING', 'WAITING_ON_DEPENDENCIES']
                  }
             },
             ]
@@ -235,7 +235,7 @@ class TestCLIArgumentSerialize(unittest.TestCase):
                 'fieldName': '@status',
                  'operator': {
                      'type': 'EQ',
-                     'values': ['pending', 'waiting_on_dependencies']
+                     'values': ['PENDING', 'WAITING_ON_DEPENDENCIES']
                  }
             },]
         })


### PR DESCRIPTION
They need to match the status given in the response
output.

Before:

```
$ aws datapipeline list-runs --pipeline-id df-id --status finished
       Name                                                Scheduled Start      Status
       ID                                                  Started              Ended
---------------------------------------------------------------------------------------------------
```

After:
```
$ aws datapipeline list-runs --pipeline-id df-id --status finished
       Name                                                Scheduled Start      Status
       ID                                                  Started              Ended
---------------------------------------------------------------------------------------------------
   1.  CliActivity                                         2015-01-27T20:32:46  FINISHED
       @CliActivity_2015-01-27T20:32:46                    2015-01-27T20:32:49  2015-01-27T20:35:27

   2.  Ec2Instance                                         2015-01-27T20:32:46  FINISHED
       @Ec2Instance_2015-01-27T20:32:46                    2015-01-27T20:32:50  2015-01-27T20:37:29
```

cc @kyleknap @danielgtaylor 