### PR TITLE
Remove some references in iam examples

### DIFF
--- a/awscli/examples/iam/change-password.rst
+++ b/awscli/examples/iam/change-password.rst
@@ -11,5 +11,3 @@ If this command is called using account (root) credentials, the command returns 
 
 For more information, see `Managing Passwords`_ in the *Using IAM* guide.
 
-.. _`Managing Passwords`: http://docs.aws.amazon.com/IAM/latest/UserGuide/Credentials-ManagingPasswords.html
-

--- a/awscli/examples/iam/create-login-profile.rst
+++ b/awscli/examples/iam/create-login-profile.rst
@@ -24,4 +24,3 @@ the login profile (``delete-login-profile``) and then create a new login profile
 
 For more information, see `Managing Passwords`_ in the *Using IAM* guide.
 
-.. _`Managing Passwords`: http://docs.aws.amazon.com/IAM/latest/UserGuide/Credentials-ManagingPasswords.html


### PR DESCRIPTION
These references caused the links to break in the command's reference page because the references are declared twice in the same document. Removed the reference in the examples to fix the broken links.

cc @jamesls @danielgtaylor 