### PR TITLE
Disable paramfile for sqs purge-queue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Next Release (TBD)
 * bugfix:Locale Settings: Fix issue when Mac OS X has an ``LC_CTYPE`` value
   of ``UTF-8``
   (`issue 945 <https://github.com/aws/aws-cli/issues/945>`__)
+* bugfix:``aws sqs purge-queue``: Fix issue with the processing
+  of the ``--queue-url`` parameter
+  (`issue 1126 <https://github.com/aws/aws-cli/issues/1126>`__)
 
 
 1.7.4

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -50,6 +50,7 @@ PARAMFILE_DISABLED = set([
     'sqs.send-message.queue-url',
     'sqs.send-message-batch.queue-url',
     'sqs.set-queue-attributes.queue-url',
+    'sqs.purge-queue.queue-url',
 
     's3.copy-object.website-redirect-location',
     's3.create-multipart-upload.website-redirect-location',

--- a/tests/unit/sqs/test_purge_queue.py
+++ b/tests/unit/sqs/test_purge_queue.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+import awscli.clidriver
+
+
+class TestCreateQueue(BaseAWSCommandParamsTest):
+
+    prefix = 'sqs purge-queue'
+
+    def test_simple(self):
+        url = 'https://foo.bar/queue'
+        cmdline = self.prefix
+        cmdline += ' --queue-url %s' % url
+        result = {'QueueUrl': url}
+        self.assert_params_for_cmd(cmdline, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/sqs/test_purge_queue.py
+++ b/tests/unit/sqs/test_purge_queue.py
@@ -15,7 +15,7 @@ from awscli.testutils import BaseAWSCommandParamsTest
 import awscli.clidriver
 
 
-class TestCreateQueue(BaseAWSCommandParamsTest):
+class TestPurgeQueue(BaseAWSCommandParamsTest):
 
     prefix = 'sqs purge-queue'
 


### PR DESCRIPTION
Valid values for this param will be https so we need to disable paramfile processing.

cc @kyleknap @danielgtaylor 