### PR TITLE
Add lineage attribute across commands

### DIFF
--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -122,6 +122,7 @@ class BasicCommand(CLICommand):
         self._session = session
         self._arg_table = None
         self._subcommand_table = None
+        self._lineage = [self]
 
     def __call__(self, args, parsed_globals):
         # args is the remaining unparsed args.
@@ -213,6 +214,7 @@ class BasicCommand(CLICommand):
                            command_table=subcommand_table,
                            session=self._session,
                            command_object=self)
+        self._add_lineage(subcommand_table)        
         return subcommand_table
 
     def _display_help(self, parsed_args, parsed_globals):
@@ -253,6 +255,11 @@ class BasicCommand(CLICommand):
             arg_table[arg_data['name']] = custom_argument
         return arg_table
 
+    def _add_lineage(self, command_table):
+        for command in command_table:
+            command_obj = command_table[command]
+            command_obj.lineage = self.lineage + [command_obj]
+
     @property
     def arg_table(self):
         if self._arg_table is None:
@@ -272,6 +279,14 @@ class BasicCommand(CLICommand):
     @property
     def name(self):
         return self.NAME
+
+    @property
+    def lineage(self):
+        return self._lineage
+
+    @lineage.setter
+    def lineage(self, value):
+        self._lineage = value
 
 
 class BasicHelp(HelpCommand):

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -236,6 +236,7 @@ class BasicCommand(CLICommand):
         commands = {}
         for command in self.SUBCOMMANDS:
             commands[command['name']] = command['command_class'](self._session)
+        self._add_lineage(commands)
         return commands
 
     def _build_arg_table(self):

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -69,6 +69,7 @@ class WaitCommand(BasicCommand):
     def _build_subcommand_table(self):
         subcommand_table = super(WaitCommand, self)._build_subcommand_table()
         self.waiter_cmd_builder.build_all_waiter_state_cmds(subcommand_table)
+        self._add_lineage(subcommand_table)
         return subcommand_table
 
     def create_help_command(self):

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -60,12 +60,13 @@ class TestBasicCommand(unittest.TestCase):
         self.assertEqual(self.command.lineage, [self.command])
 
     def test_pass_lineage_to_child_command(self):
-        subcommands = [{'name': 'bar', 'command_class': BasicCommand}]
-        basic_command_class = 'awscli.customizations.commands.BasicCommand'
-        subcommand_patch = basic_command_class + '.SUBCOMMANDS'
-        with mock.patch(subcommand_patch, subcommands):
-            lineage = self.command.subcommand_table['bar'].lineage
-            self.assertEqual(len(lineage), 2)
-            self.assertEqual(lineage[0], self.command)
-            self.assertIsInstance(lineage[1], BasicCommand)
+        class MockCustomCommand(BasicCommand):
+            NAME = 'mock'
 
+            SUBCOMMANDS = [{'name': 'basic', 'command_class': BasicCommand}]
+
+        self.command = MockCustomCommand(self.session)
+        lineage = self.command.subcommand_table['basic'].lineage
+        self.assertEqual(len(lineage), 2)
+        self.assertEqual(lineage[0], self.command)
+        self.assertIsInstance(lineage[1], BasicCommand)

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -55,3 +55,17 @@ class TestBasicCommand(unittest.TestCase):
         # Ensure the ``subcommand_table`` is not built again if
         # ``subcommand_table`` property is called again.
         self.assertIs(orig_subcommand_table, self.command.subcommand_table)
+
+    def test_load_lineage(self):
+        self.assertEqual(self.command.lineage, [self.command])
+
+    def test_pass_lineage_to_child_command(self):
+        subcommands = [{'name': 'bar', 'command_class': BasicCommand}]
+        basic_command_class = 'awscli.customizations.commands.BasicCommand'
+        subcommand_patch = basic_command_class + '.SUBCOMMANDS'
+        with mock.patch(subcommand_patch, subcommands):
+            lineage = self.command.subcommand_table['bar'].lineage
+            self.assertEqual(len(lineage), 2)
+            self.assertEqual(lineage[0], self.command)
+            self.assertIsInstance(lineage[1], BasicCommand)
+

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -117,6 +117,12 @@ class TestWaitCommand(unittest.TestCase):
         self.service_object = mock.Mock()
         self.cmd = WaitCommand(self.model, self.service_object)
 
+    def test_passes_on_lineage(self):
+        child_cmd = self.cmd.subcommand_table['foo']
+        self.assertEqual(len(child_cmd.lineage), 2)
+        self.assertEqual(child_cmd.lineage[0], self.cmd) 
+        self.assertIsInstance(child_cmd.lineage[1], WaiterStateCommand)
+
     def test_run_main_error(self):
         self.parsed_args = mock.Mock()
         self.parsed_args.subcommand = None


### PR DESCRIPTION
For each of the command classes, a ``lineage`` attribute was added. The purpose of the ``lineage`` attribute is to be able to tell how to get to a specific command came from in the CLI. The ``lineage`` attribute is represented by a list of all of the commands that came before that specific command (in order) including the command itself. So for these commands, here are their lineages:

* ``aws ec2`` --> [``'ec2'``]
* ``aws ec2 run-instances`` --> [``'ec2'``, ``run-instances'``]
* ``aws s3 ls`` --> [``'s3'``, ``'ls'``]
* ``aws s3api wait object-exists`` --> [``'s3api'``, ``'wait'``, ``'object-exists'``]

This attribute helps unify the data-driven and custom commands because you can see how commands are linked together. Before, figuring out how to get to a command tended to be a little difficult and unreliable because the logic in figuring it out differed across command class and sometimes would require parsing event names.

I did my best to plumb this through to all of the custom commands, but if I missed one, let me know.

cc @jamesls @danielgtaylor 