### PR TITLE
Fix failing test from recent Botocore changes

### DIFF
--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -13,6 +13,7 @@
 import sys
 import os
 
+import botocore
 import jmespath
 
 from awscli.compat import urlparse
@@ -75,4 +76,4 @@ def no_sign_request(parsed_args, session, **kwargs):
 
 
 def disable_signing(service, **kwargs):
-    service.signature_version = None
+    service.signature_version = botocore.UNSIGNED


### PR DESCRIPTION
This makes the CLI work with the changes in boto/botocore#448 that support
anonymous (unsigned) clients using the new `botocore.UNSIGNED` sentinel.

It requires the upstream Botocore change, so tests are likely to fail in this pull request.

cc @jamesls @kyleknap 