### PR TITLE
Ignore paramfile for s3 --website-redirect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
+* bugfix:``aws s3``: Fix issue where literal value for ``--website-redirect``
+  was not being used.
+  (`issue 1137 <https://github.com/aws/aws-cli/pull/1137>`__)
 * bugfix:``aws sqs purge-queue``: Fix issue with the processing
   of the ``--queue-url`` parameter
   (`issue 1126 <https://github.com/aws/aws-cli/issues/1126>`__)

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -37,6 +37,10 @@ PARAMFILE_DISABLED = set([
     'cloudformation.update-stack.stack-policy-url',
     'cloudformation.set-stack-policy.stack-policy-url',
 
+    'custom.cp.website-redirect',
+    'custom.mv.website-redirect',
+    'custom.sync.website-redirect',
+
     'sqs.add-permission.queue-url',
     'sqs.change-message-visibility.queue-url',
     'sqs.change-message-visibility-batch.queue-url',

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -37,6 +37,8 @@ PARAMFILE_DISABLED = set([
     'cloudformation.update-stack.stack-policy-url',
     'cloudformation.set-stack-policy.stack-policy-url',
 
+    # We will want to change the event name to ``s3`` as opposed to
+    # custom in the near future along with ``s3`` to ``s3api``.
     'custom.cp.website-redirect',
     'custom.mv.website-redirect',
     'custom.sync.website-redirect',

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -162,12 +162,16 @@ class BaseS3CLICommand(unittest.TestCase):
         return parsed['Buckets']
 
     def content_type_for_key(self, bucket_name, key_name):
+        parsed = self.head_object(bucket_name, key_name)
+        return parsed['ContentType']
+
+    def head_object(self, bucket_name, key_name):
         operation = self.service.get_operation('HeadObject')
         endpoint = self.service.get_endpoint(self.regions[bucket_name])
         http, parsed = operation.call(
             endpoint, bucket=bucket_name, key=key_name)
         self.assertEqual(http.status_code, 200)
-        return parsed['ContentType']
+        return parsed
 
     def assert_no_errors(self, p):
         self.assertEqual(
@@ -496,6 +500,19 @@ class TestCp(BaseS3CLICommand):
         # Assert that the file was downloaded properly.
         with open(local_filename, 'r') as f:
             self.assertEqual(f.read(), contents)
+
+    def test_website_redirect_ignore_paramfile(self):
+        bucket_name = self.create_bucket()
+        foo_txt = self.files.create_file('foo.txt', 'bar')
+        website_redirect = 'http://someserver'
+        p = aws('s3 cp %s s3://%s/foo.txt --website-redirect %s' %
+                (foo_txt, bucket_name, website_redirect))
+        self.assert_no_errors(p)
+
+        # Ensure that the web address is used as opposed to the contents
+        # of the web address. We can check via a head object.
+        response = self.head_object(bucket_name, 'foo.txt')
+        self.assertEqual(response['WebsiteRedirectLocation'], website_redirect)
 
 
 class TestSync(BaseS3CLICommand):

--- a/tests/unit/customizations/s3/test_cp_command.py
+++ b/tests/unit/customizations/s3/test_cp_command.py
@@ -88,6 +88,19 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(len(self.operations_called), 1, self.operations_called)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
 
+    def test_website_redirect_ignore_paramfile(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt --website-redirect %s' % \
+            (self.prefix, full_path, 'http://someserver')
+        self.parsed_responses = [{'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Make sure that the specified web address is used as opposed to the
+        # contents of the web address.
+        self.assertEqual(
+            self.operations_called[0][1]['website_redirect_location'],
+            'http://someserver'
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_mv_command.py
+++ b/tests/unit/customizations/s3/test_mv_command.py
@@ -41,6 +41,20 @@ class TestMvCommand(BaseAWSCommandParamsTest):
         stderr = self.run_cmd(cmdline, expected_rc=255)[1]
         self.assertIn('Cannot mv a file onto itself', stderr)
 
+    def test_website_redirect_ignore_paramfile(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt --website-redirect %s' % \
+            (self.prefix, full_path, 'http://someserver')
+        self.parsed_responses = [{'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        # Make sure that the specified web address is used as opposed to the
+        # contents of the web address.
+        self.assertEqual(
+            self.operations_called[0][1]['website_redirect_location'],
+            'http://someserver'
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_sync_command.py
+++ b/tests/unit/customizations/s3/test_sync_command.py
@@ -1,0 +1,51 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+import re
+
+import mock
+from awscli.compat import six
+
+
+class TestSyncCommand(BaseAWSCommandParamsTest):
+
+    prefix = 's3 sync '
+
+    def setUp(self):
+        super(TestSyncCommand, self).setUp()
+        self.files = FileCreator()
+
+    def tearDown(self):
+        super(TestSyncCommand, self).tearDown()
+        self.files.remove_all()
+
+    def test_website_redirect_ignore_paramfile(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt --website-redirect %s' % \
+            (self.prefix, self.files.rootdir, 'http://someserver')
+        self.parsed_responses = [
+            {"CommonPrefixes": [], "Contents": []},
+            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+
+        # The only operations we should have called are ListObjects/PutObject.
+        self.assertEqual(len(self.operations_called), 2, self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+        self.assertEqual(self.operations_called[1][0].name, 'PutObject')
+        # Make sure that the specified web address is used as opposed to the
+        # contents of the web address when uploading the object
+        self.assertEqual(
+            self.operations_called[1][1]['website_redirect_location'],
+            'http://someserver'
+        )


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/1130

Since we switched the s3 commands to the ``BasicCommand`` we picked up the paramfile feature (i.e. ``file://``, ``http://``, etc). Thus we need to blacklist ``--website-redirect`` for a couple of the s3 commands.

cc @jamesls @danielgtaylor 