### PR TITLE
Parse "--port 8--1" properly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* bugfix:``aws ec2 revoke-security-group-ingress``: Fix parsing
+  of a ``--port`` value of ICMP echo request
+  (`issue 1075 <https://github.com/aws/aws-cli/issues/1075>`__)
+
+
 1.7.6
 =====
 

--- a/awscli/customizations/ec2secgroupsimplify.py
+++ b/awscli/customizations/ec2secgroupsimplify.py
@@ -154,7 +154,11 @@ class PortArgument(CustomArgument):
                     fromstr = '-1'
                     tostr = '-1'
                 elif '-' in value:
-                    fromstr, tostr = value.split('-')
+                    # We can get away with simple logic here because
+                    # argparse will not allow values such as
+                    # "-1-8", and these aren't actually valid
+                    # values any from from/to ports.
+                    fromstr, tostr = value.split('-', 1)
                 else:
                     fromstr, tostr = (value, value)
                 _build_ip_permissions(parameters, 'FromPort', int(fromstr))

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -345,8 +345,9 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         stdout = captured_stdout.getvalue()
         self.assertEqual(
             rc, expected_rc,
-            "Unexpected rc (expected: %s, actual: %s) for command: %s" % (
-                expected_rc, rc, cmd))
+            "Unexpected rc (expected: %s, actual: %s) for command: %s\n"
+            "stdout:\n%sstderr:\n%s" % (
+                expected_rc, rc, cmd, stdout, stderr))
         return stdout, stderr, rc
 
 

--- a/tests/unit/ec2/test_security_group_operations.py
+++ b/tests/unit/ec2/test_security_group_operations.py
@@ -36,6 +36,17 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                                        'ToPort': -1}]}
         self.assert_params_for_cmd2(args, result)
 
+    def test_icmp_echo_request(self):
+        # This corresponds to a from port of 8 and a to port of -1, i.e
+        # --port 8--1.
+        args = self.prefix + (
+            '--group-name foobar --protocol tcp --port 8--1 --cidr 0.0.0.0/0')
+        result = {'GroupName': 'foobar',
+                  'ip_permissions': [{'FromPort': 8, 'IpProtocol': 'tcp',
+                                      'IpRanges': [{'CidrIp': '0.0.0.0/0'}],
+                                      'ToPort': -1}]}
+        self.assert_params_for_cmd2(args, result)
+
     def test_all_protocol(self):
         args = self.prefix + (
             '--group-name foobar --protocol all --port all --cidr 0.0.0.0/0')


### PR DESCRIPTION
Fixes #1075.

Also, the previous test errors were opaque and just gave a "unexpected rc 2" error message.  I've modified that to also print stdout/stderr so we can more quickly troubleshoot test failures.


cc @kyleknap @danielgtaylor