### PR TITLE
Switch over unit tests to assert_params_for_cmd2

### DIFF
--- a/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
+++ b/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
@@ -13,8 +13,6 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
 
-import awscli.clidriver
-
 
 class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
 
@@ -46,7 +44,3 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
         params = {'InstanceId': 'i-12345678',
                   'ShouldDecrementDesiredCapacity': False}
         self.assert_params_for_cmd2(cmdline, params)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
+++ b/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
@@ -25,16 +25,16 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
         cmdline += ' --instance-id i-12345678'
         cmdline += ' --should-decrement-desired-capacity'
         params = {'InstanceId': 'i-12345678',
-                  'ShouldDecrementDesiredCapacity': 'true'}
-        self.assert_params_for_cmd(cmdline, params)
+                  'ShouldDecrementDesiredCapacity': True}
+        self.assert_params_for_cmd2(cmdline, params)
 
     def test_false(self):
         cmdline = self.PREFIX
         cmdline += ' --instance-id i-12345678'
         cmdline += ' --no-should-decrement-desired-capacity'
         params = {'InstanceId': 'i-12345678',
-                  'ShouldDecrementDesiredCapacity': 'false'}
-        self.assert_params_for_cmd(cmdline, params)
+                  'ShouldDecrementDesiredCapacity': False}
+        self.assert_params_for_cmd2(cmdline, params)
 
     def test_last_arg_wins(self):
         cmdline = self.PREFIX
@@ -44,8 +44,8 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
         # Since the --no-should-decrement-desired-capacity was
         # was added last, it wins.
         params = {'InstanceId': 'i-12345678',
-                  'ShouldDecrementDesiredCapacity': 'false'}
-        self.assert_params_for_cmd(cmdline, params)
+                  'ShouldDecrementDesiredCapacity': False}
+        self.assert_params_for_cmd2(cmdline, params)
 
 
 if __name__ == "__main__":

--- a/tests/unit/cloudformation/test_create_stack.py
+++ b/tests/unit/cloudformation/test_create_stack.py
@@ -56,7 +56,3 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                   'Parameters': [{'ParameterKey': 'foo',
                                   'ParameterValue': 'one,two'}]}
         self.assert_params_for_cmd2(cmdline, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/cloudformation/test_create_stack.py
+++ b/tests/unit/cloudformation/test_create_stack.py
@@ -12,7 +12,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
-import awscli.clidriver
 
 
 class TestDescribeInstances(BaseAWSCommandParamsTest):
@@ -23,7 +22,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --stack-name test-stack --template-url http://foo'
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_create_stack_string_params(self):
         cmdline = self.prefix
@@ -31,11 +30,11 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         cmdline += ' --parameters ParameterKey=foo,ParameterValue=bar'
         cmdline += ' ParameterKey=foo2,ParameterValue=bar2'
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
-                  'Parameters.member.1.ParameterKey': 'foo',
-                  'Parameters.member.1.ParameterValue': 'bar',
-                  'Parameters.member.2.ParameterKey': 'foo2',
-                  'Parameters.member.2.ParameterValue': 'bar2'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Parameters': [
+                      {'ParameterKey': 'foo', 'ParameterValue': 'bar'},
+                      {'ParameterKey': 'foo2', 'ParameterValue': 'bar2'},
+                  ]}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_create_stack_for_csv_params_escaping(self):
         # If a template is specified as a comma delimited list,
@@ -44,10 +43,9 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         cmdline += ' --stack-name test-stack --template-url http://foo'
         cmdline += ' --parameters ParameterKey=foo,ParameterValue=one\,two'
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
-                  'Parameters.member.1.ParameterKey': 'foo',
-                  'Parameters.member.1.ParameterValue': 'one,two',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'Parameters': [{'ParameterKey': 'foo',
+                                  'ParameterValue': 'one,two'}]}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_create_stack_for_csv_with_quoting(self):
         cmdline = self.prefix
@@ -55,10 +53,9 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         # Note how we're quoting the value of parameter_value.
         cmdline += ' --parameters ParameterKey=foo,ParameterValue="one,two"'
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
-                  'Parameters.member.1.ParameterKey': 'foo',
-                  'Parameters.member.1.ParameterValue': 'one,two',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'Parameters': [{'ParameterKey': 'foo',
+                                  'ParameterValue': 'one,two'}]}
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/cloudsearch/test_cloudsearch.py
+++ b/tests/unit/cloudsearch/test_cloudsearch.py
@@ -25,10 +25,9 @@ class TestCloudSearchDefineExpression(BaseAWSCommandParamsTest):
         cmdline += ' --expression 10'
         result = {
             'DomainName': 'abc123',
-            'Expression.ExpressionName': 'foo',
-            'Expression.ExpressionValue': '10'
-        }
-        self.assert_params_for_cmd(cmdline, result)
+            'expression': {'ExpressionName': 'foo',
+                           'ExpressionValue': '10'}}
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
@@ -44,12 +43,11 @@ class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
         cmdline += ' --search-enabled false'
         result = {
             'DomainName': 'abc123',
-            'IndexField.IndexFieldName': 'foo',
-            'IndexField.IndexFieldType': 'int',
-            'IndexField.IntOptions.DefaultValue': 10,
-            'IndexField.IntOptions.SearchEnabled': 'false'
-        }
-        self.assert_params_for_cmd(cmdline, result)
+            'index_field': {'IndexFieldName': 'foo',
+                            'IndexFieldType': 'int',
+                            'IntOptions': {'DefaultValue': 10,
+                                           'SearchEnabled': False}}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_latlon(self):
         cmdline = self.prefix
@@ -60,8 +58,10 @@ class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
         cmdline += ' --search-enabled false'
         result = {
             'DomainName': 'abc123',
-            'IndexField.IndexFieldName': 'foo',
-            'IndexField.IndexFieldType': 'int',
-            'IndexField.LatLonOptions.DefaultValue': 10,
-            'IndexField.LatLonOptions.SearchEnabled': 'false'
-        }
+            'index_field': {
+                'IndexFieldName': 'foo',
+                'IndexFieldType': 'latlon',
+                'LatLonOptions': {
+                    'DefaultValue': '10', 'SearchEnabled': False}}}
+        self.assert_params_for_cmd2(cmdline, result)
+

--- a/tests/unit/customizations/datapipeline/test_arg_serialize.py
+++ b/tests/unit/customizations/datapipeline/test_arg_serialize.py
@@ -76,7 +76,7 @@ class TestErrorMessages(BaseAWSCommandParamsTest):
     prefix = 'datapipeline list-runs'
 
     def test_unknown_status(self):
-        self.assert_params_for_cmd(
+        self.assert_params_for_cmd2(
             self.prefix + ' --pipeline-id foo --status foo',
             expected_rc=255,
             stderr_contains=('Invalid status: foo, must be one of: waiting, '

--- a/tests/unit/customizations/s3/test_copy_params.py
+++ b/tests/unit/customizations/s3/test_copy_params.py
@@ -121,8 +121,8 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += self.file_path
         cmdline += ' s3://mybucket/mykey'
         cmdline += ' --grants read:bob'
-        self.assert_params_for_cmd(cmdline, expected_rc=1,
-                                   ignore_params=['payload'])
+        self.assert_params_for_cmd2(cmdline, expected_rc=1,
+                                    ignore_params=['payload'])
 
     def test_content_type(self):
         cmdline = self.prefix

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -158,8 +158,9 @@ class TestWait(BaseAWSCommandParamsTest):
         cmdline = 'ec2 wait instance-running'
         cmdline += ' --instance-ids i-12345678 i-87654321'
         cmdline += """ --filters {"Name":"group-name","Values":["foobar"]}"""
-        result = {'Filter.1.Value.1': 'foobar', 'Filter.1.Name': 'group-name',
-                  'InstanceId.1': 'i-12345678', 'InstanceId.2': 'i-87654321'}
+        result = {'Filters': [{'Name': 'group-name',
+                               'Values': ['foobar']}],
+                  'InstanceIds': ['i-12345678', 'i-87654321']}
         self.parsed_response = {
             'Reservations': [{
                 'Instances': [{
@@ -169,14 +170,14 @@ class TestWait(BaseAWSCommandParamsTest):
                 }]
             }]
         }
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_dynamodb_table_exists(self):
         cmdline = 'dynamodb wait table-exists'
         cmdline += ' --table-name mytable'
-        result = '{"TableName": "mytable"}'
+        result = {"TableName": "mytable"}
         self.parsed_response = {'Table': {'TableStatus': 'ACTIVE'}}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_elastictranscoder_jobs_complete(self):
         cmdline = 'rds wait db-instance-available'
@@ -187,7 +188,7 @@ class TestWait(BaseAWSCommandParamsTest):
                 'DBInstanceStatus': 'available'
             }]
         }
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 class TestWaiterStateCommandBuilder(unittest.TestCase):

--- a/tests/unit/datapipeline/test_query_objects.py
+++ b/tests/unit/datapipeline/test_query_objects.py
@@ -33,4 +33,4 @@ class TestDataPipelineQueryObjects(BaseAWSCommandParamsTest):
                                                   'values': ['RUNNING']}}]},
             'sphere': 'INSTANCE'
         }
-        self.assert_params_for_cmd(cmdline, expected)
+        self.assert_params_for_cmd2(cmdline, expected)

--- a/tests/unit/ec2/test_associate_address.py
+++ b/tests/unit/ec2/test_associate_address.py
@@ -23,7 +23,7 @@ class TestAssociateAddress(BaseAWSCommandParamsTest):
         cmdline += ' --instance-id i-12345678'
         cmdline += ' --public-ip 192.168.0.0'
         result = {'InstanceId': 'i-12345678', 'PublicIp': '192.168.0.0'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_vpc_basic(self):
         cmdline = self.prefix
@@ -33,9 +33,9 @@ class TestAssociateAddress(BaseAWSCommandParamsTest):
         cmdline += ' --allow-reassociation'
         result = {'InstanceId': 'i-12345678',
                   'PublicIp': '192.168.0.0',
-                  'AllowReassociation': 'true',
+                  'AllowReassociation': True,
                   'AllocationId': 'eipalloc-12345678'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_attach_internet_gateway.py
+++ b/tests/unit/ec2/test_attach_internet_gateway.py
@@ -24,7 +24,7 @@ class TestAttachInternetGateway(BaseAWSCommandParamsTest):
         cmdline += ' --internet-gateway-id igw-12345678'
         result = {'VpcId': 'vpc-12345678',
                   'InternetGatewayId': 'igw-12345678'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_bundle_instance.py
+++ b/tests/unit/ec2/test_bundle_instance.py
@@ -25,13 +25,12 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     prefix = 'ec2 bundle-instance'
 
-    Base64Policy = ('eyJleHBpcmF0aW9uIjogIjIwMTMtMDgtMTBUMDA6MDA6MDAuM'
-                    'DAwMDAwWiIsImNvbmRpdGlvbnMiOiBbeyJidWNrZXQiOiAibXl'
-                    'idWNrZXQifSx7ImFjbCI6ICJlYzItYnVuZGxlLXJlYWQifSxbI'
-                    'nN0YXJ0cy13aXRoIiwgIiRrZXkiLCAiZm9vYmFyIl1dfQ==')
+    POLICY = (
+        '{"expiration": "2013-08-10T00:00:00.000000Z",'
+        '"conditions": [{"bucket": "mybucket"},{"acl": '
+        '"ec2-bundle-read"},["starts-with", "$key", "foobar"]]}')
+    POLICY_SIGNATURE = 'ynxybUMv9YuGbPl7HZ8AFJW/2t0='
 
-    PolicySignature = 'ynxybUMv9YuGbPl7HZ8AFJW/2t0='
-    
     def setUp(self):
         super(TestBundleInstance, self).setUp()
         # This mocks out datetime.datetime.utcnow() so that it always
@@ -40,30 +39,33 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         # don't what the policy or its signature to change each time
         # we run the test.
         self.datetime_patcher = mock.patch.object(
-            awscli.customizations.ec2bundleinstance.datetime, 'datetime',  
+            awscli.customizations.ec2bundleinstance.datetime, 'datetime',
             mock.Mock(wraps=datetime.datetime)
         )
         mocked_datetime = self.datetime_patcher.start()
         mocked_datetime.utcnow.return_value = datetime.datetime(2013, 8, 9)
 
-
     def tearDown(self):
         super(TestBundleInstance, self).tearDown()
         self.datetime_patcher.stop
-        
+
     def test_no_policy_provided(self):
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
         args += ' --bucket mybucket --prefix foobar'
         args_list = (self.prefix + args).split()
         result =  {'InstanceId': 'i-12345678',
-                   'Storage.S3.Bucket': 'mybucket',
-                   'Storage.S3.Prefix': 'foobar',
-                   'Storage.S3.AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE',
-                   'Storage.S3.UploadPolicy': self.Base64Policy,
-                   'Storage.S3.UploadPolicySignature': self.PolicySignature}
-        self.assert_params_for_cmd(args_list, result)
-        
+                   'storage': {
+                       'S3': {
+                           'Bucket': 'mybucket',
+                           'Prefix': 'foobar',
+                           'AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE',
+                           'UploadPolicy': self.POLICY,
+                           'UploadPolicySignature': self.POLICY_SIGNATURE}
+                       }
+                   }
+        self.assert_params_for_cmd2(args_list, result)
+
 
     def test_policy_provided(self):
         policy = '{"notarealpolicy":true}'
@@ -74,21 +76,24 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         args += ' --bucket mybucket --prefix foobar --policy %s' % policy
         args_list = (self.prefix + args).split()
         result =  {'InstanceId': 'i-12345678',
-                   'Storage.S3.Bucket': 'mybucket',
-                   'Storage.S3.Prefix': 'foobar',
-                   'Storage.S3.AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE',
-                   'Storage.S3.UploadPolicy': base64policy,
-                   'Storage.S3.UploadPolicySignature': policy_signature}
-        self.assert_params_for_cmd(args_list, result)
+                   'storage': {
+                       'S3': {
+                           'Bucket': 'mybucket',
+                           'Prefix': 'foobar',
+                           'AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE',
+                           'UploadPolicy': '{"notarealpolicy":true}',
+                           'UploadPolicySignature': policy_signature}
+                       }
+                   }
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_both(self):
         captured = cStringIO()
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
         args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()
-        with mock.patch('sys.stderr', captured):
-            self.assert_params_for_cmd(args_list, {}, expected_rc=255)
+        self.assert_params_for_cmd2(args_list, expected_rc=255)
 
-        
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/ec2/test_create_image.py
+++ b/tests/unit/ec2/test_create_image.py
@@ -25,5 +25,5 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         # gets mapped as 'NoReboot': 'false'.
         cmdline += ' --reboot'
         result = {'InstanceId': 'i-12345678', 'Description': 'foo',
-                  'Name': 'bar', 'NoReboot': 'false'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Name': 'bar', 'NoReboot': False}
+        self.assert_params_for_cmd2(cmdline, result)

--- a/tests/unit/ec2/test_create_network_acl_entry.py
+++ b/tests/unit/ec2/test_create_network_acl_entry.py
@@ -31,12 +31,10 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '6',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_udp(self):
         cmdline = self.prefix
@@ -51,12 +49,10 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '17',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_icmp(self):
         cmdline = self.prefix
@@ -71,12 +67,10 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '1',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_all(self):
         cmdline = self.prefix
@@ -91,12 +85,10 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '-1',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_number(self):
         cmdline = self.prefix
@@ -111,10 +103,8 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '99',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 

--- a/tests/unit/ec2/test_create_tags.py
+++ b/tests/unit/ec2/test_create_tags.py
@@ -25,9 +25,10 @@ class TestCreateTags(BaseAWSCommandParamsTest):
     def test_create_tag_normal(self):
         cmdline = self.prefix
         cmdline += ' --resources i-12345678 --tags Key=Name,Value=bar'
-        result = {'ResourceId.1': 'i-12345678', 'Tag.1.Key': 'Name',
-                  'Tag.1.Value': 'bar'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'Resources': ['i-12345678'],
+            'Tags': [{'Key': 'Name', 'Value': 'bar'}]}
+        self.assert_params_for_cmd2(cmdline, result)
 
     @unittest.skipIf(
         six.PY3, 'Unicode cmd line test only is relevant to python2.')
@@ -38,6 +39,7 @@ class TestCreateTags(BaseAWSCommandParamsTest):
         if encoding is None:
             encoding = 'utf-8'
         cmdline = cmdline.encode(encoding)
-        result = {'ResourceId.1': 'i-12345678', 'Tag.1.Key': 'Name',
-                  'Tag.1.Value': u'\u6211'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'Resources': ['i-12345678'],
+            'Tags': [{'Key': 'Name', 'Value': u'\u6211'}]}
+        self.assert_params_for_cmd2(cmdline, result)

--- a/tests/unit/ec2/test_describe_instance_attribute.py
+++ b/tests/unit/ec2/test_describe_instance_attribute.py
@@ -25,7 +25,7 @@ class TestDescribeInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += ' --attribute blockDeviceMapping'
         result = {'InstanceId': 'i-12345678',
                   'Attribute': 'blockDeviceMapping'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_describe_instances.py
+++ b/tests/unit/ec2/test_describe_instances.py
@@ -21,58 +21,73 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
     def test_no_params(self):
         cmdline = self.prefix
         result = {}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_instance_id(self):
         args = ' --instance-ids i-12345678'
         cmdline = self.prefix + args
-        result = {'InstanceId.1': 'i-12345678'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {'InstanceIds': ['i-12345678']}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_instance_ids(self):
         args = ' --instance-ids i-12345678 i-87654321'
         cmdline = self.prefix + args
-        result = {'InstanceId.1': 'i-12345678', 'InstanceId.2': 'i-87654321'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {'InstanceIds': ['i-12345678', 'i-87654321']}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_instance_ids_alternate(self):
         # Not required, but will still work if you use JSON.
         args = ' --instance-ids ["i-12345678","i-87654321"]'
         cmdline = self.prefix + args
-        result = {'InstanceId.1': 'i-12345678', 'InstanceId.2': 'i-87654321'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {'InstanceIds': ['i-12345678', 'i-87654321']}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_filter_json(self):
         args = """ --filters {"Name":"group-name","Values":["foobar"]}"""
         cmdline = self.prefix + args
-        result = {'Filter.1.Value.1': 'foobar', 'Filter.1.Name': 'group-name'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'Filters': [
+                {'Name': 'group-name',
+                 'Values': ['foobar']},
+            ],
+        }
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_filter_simple(self):
         args = """ --filters Name=group-name,Values=foobar"""
         cmdline = self.prefix + args
-        result = {'Filter.1.Value.1': 'foobar', 'Filter.1.Name': 'group-name'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'Filters': [
+                {'Name': 'group-name',
+                 'Values': ['foobar']},
+            ],
+        }
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_filter_values(self):
         args = """ --filters Name=group-name,Values=foobar,fiebaz"""
         cmdline = self.prefix + args
-        result = {'Filter.1.Value.2': 'fiebaz',
-                  'Filter.1.Value.1': 'foobar',
-                  'Filter.1.Name': 'group-name'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'Filters': [
+                {'Name': 'group-name',
+                 'Values': ['foobar', 'fiebaz']},
+            ],
+        }
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_multiple_filters(self):
         args = (' --filters Name=group-name,Values=foobar '
                 'Name=instance-id,Values=i-12345')
         cmdline = self.prefix + args
         result = {
-            'Filter.1.Name': 'group-name',
-            'Filter.1.Value.1': 'foobar',
-            'Filter.2.Name': 'instance-id',
-            'Filter.2.Value.1': 'i-12345',
+            'Filters': [
+                {'Name': 'group-name',
+                 'Values': ['foobar']},
+                {'Name': 'instance-id',
+                 'Values': ['i-12345']},
+            ],
         }
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_multiple_filters_alternate(self):
         cmdlist = 'ec2 describe-instances'.split()
@@ -80,18 +95,20 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                         'Name = group-name, Values= foobar',
                         'Name=instance-id,Values=i-12345'])
         result = {
-            'Filter.1.Name': 'group-name',
-            'Filter.1.Value.1': 'foobar',
-            'Filter.2.Name': 'instance-id',
-            'Filter.2.Value.1': 'i-12345',
+            'Filters': [
+                {'Name': 'group-name',
+                 'Values': ['foobar']},
+                {'Name': 'instance-id',
+                 'Values': ['i-12345']},
+            ],
         }
-        self.assert_params_for_cmd(cmdlist, result)
+        self.assert_params_for_cmd2(cmdlist, result)
 
     def test_page_size(self):
         args = ' --page-size 10'
         cmdline = self.prefix + args
         result = {'MaxResults': 10}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_get_password_data.py
+++ b/tests/unit/ec2/test_get_password_data.py
@@ -37,7 +37,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         args = ' --instance-id i-12345678'
         cmdline = self.prefix + args
         result = {'InstanceId': 'i-12345678'}
-        output = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
+        output = self.assert_params_for_cmd2(cmdline, result, expected_rc=0)[0]
         self.assertIn('"InstanceId": "i-12345678"', output)
         self.assertIn('"Timestamp": "2013-07-27T18:29:23.000Z"', output)
         self.assertIn('"PasswordData": "%s"' % PASSWORD_DATA, output)
@@ -45,9 +45,8 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
     def test_nonexistent_priv_launch_key(self):
         args = ' --instance-id i-12345678 --priv-launch-key foo.pem'
         cmdline = self.prefix + args
-        result = {}
-        error_msg = self.assert_params_for_cmd(
-            cmdline, result, expected_rc=255)[1]
+        error_msg = self.assert_params_for_cmd2(
+            cmdline, expected_rc=255)[1]
         self.assertIn('priv-launch-key should be a path to '
                       'the local SSH private key file used '
                       'to launch the instance.\n', error_msg)
@@ -58,7 +57,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         args = ' --instance-id i-12345678 --priv-launch-key %s' % key_path
         cmdline = self.prefix + args
         result = {'InstanceId': 'i-12345678'}
-        output = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
+        output = self.assert_params_for_cmd2(cmdline, result, expected_rc=0)[0]
         self.assertIn('"InstanceId": "i-12345678"', output)
         self.assertIn('"Timestamp": "2013-07-27T18:29:23.000Z"', output)
         self.assertIn('"PasswordData": "=mG8.r$o-s"', output)

--- a/tests/unit/ec2/test_modify_image_attribute.py
+++ b/tests/unit/ec2/test_modify_image_attribute.py
@@ -25,26 +25,29 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += ' --user-ids 0123456789012'
         result = {'ImageId': 'ami-d00dbeef',
                   'OperationType': 'add',
-                  'UserId.1': '0123456789012'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'UserIds': ['0123456789012']}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_two(self):
         cmdline = self.prefix
         cmdline += ' --image-id ami-d00dbeef'
         cmdline += (' --launch-permission {"Add":[{"UserId":"123456789012"}],'
                     '"Remove":[{"Group":"all"}]}')
-        result = {'ImageId': 'ami-d00dbeef',
-                  'LaunchPermission.Add.1.UserId': '123456789012',
-                  'LaunchPermission.Remove.1.Group': 'all',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'ImageId': 'ami-d00dbeef',
+            'LaunchPermission': {
+                'Add': [{'UserId': '123456789012'}],
+                'Remove': [{'Group': 'all'}],
+            }
+        }
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_assert_error_in_bad_json_path(self):
         cmdline = self.prefix
         cmdline += ' --image-id ami-d00dbeef'
         cmdline += ' --launch-permission THISISNOTJSON'
         # The arg name should be in the error message.
-        self.assert_params_for_cmd(cmdline, {}, expected_rc=255,
+        self.assert_params_for_cmd2(cmdline, expected_rc=255,
                                    stderr_contains='launch-permission')
 
 

--- a/tests/unit/ec2/test_modify_instance_attribute.py
+++ b/tests/unit/ec2/test_modify_instance_attribute.py
@@ -22,20 +22,20 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         super(TestModifyInstanceAttribute, self).setUp()
         self.expected_result = {
             'InstanceId': 'i-1234',
-            'InstanceInitiatedShutdownBehavior.Value': 'terminate',
+            'InstanceInitiatedShutdownBehavior': {'Value': 'terminate'}
         }
 
     def test_json_version(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--instance-initiated-shutdown-behavior {"Value":"terminate"}'
-        self.assert_params_for_cmd(cmdline, self.expected_result)
+        self.assert_params_for_cmd2(cmdline, self.expected_result)
 
     def test_shorthand_version(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--instance-initiated-shutdown-behavior Value=terminate'
-        self.assert_params_for_cmd(cmdline, self.expected_result)
+        self.assert_params_for_cmd2(cmdline, self.expected_result)
 
     def test_value_not_needed(self):
         # For structs of a single param value, you can skip the keep name,
@@ -43,7 +43,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--instance-initiated-shutdown-behavior terminate'
-        self.assert_params_for_cmd(cmdline, self.expected_result)
+        self.assert_params_for_cmd2(cmdline, self.expected_result)
 
     def test_boolean_value_in_top_level_true(self):
         # Just like everything else in argparse, the last value provided
@@ -52,18 +52,16 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--instance-id i-1234 '
         cmdline += '--ebs-optimized Value=true'
         result = {'InstanceId': 'i-1234',
-                  'EbsOptimized.Value': 'true',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'ebs_optimized': {'Value': True}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_boolean_value_is_top_level_false(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--ebs-optimized Value=false'
         result = {'InstanceId': 'i-1234',
-                  'EbsOptimized.Value': 'false',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'ebs_optimized': {'Value': False}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_boolean_value_in_top_level_true_json(self):
         # Just like everything else in argparse, the last value provided
@@ -72,36 +70,32 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--instance-id i-1234 '
         cmdline += '--ebs-optimized {"Value":true}'
         result = {'InstanceId': 'i-1234',
-                  'EbsOptimized.Value': 'true',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'ebs_optimized': {'Value': True}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_boolean_value_is_top_level_false_json(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--ebs-optimized {"Value":false}'
         result = {'InstanceId': 'i-1234',
-                  'EbsOptimized.Value': 'false',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'ebs_optimized': {'Value': False}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_boolean_param_top_level_true_no_value(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--ebs-optimized'
         result = {'InstanceId': 'i-1234',
-                  'EbsOptimized.Value': 'true',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'ebs_optimized': {'Value': True}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_boolean_param_top_level_false_no_value(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--no-ebs-optimized'
         result = {'InstanceId': 'i-1234',
-                  'EbsOptimized.Value': 'false',
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'ebs_optimized': {'Value': False}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_mix_value_non_value_boolean_param(self):
         cmdline = self.prefix
@@ -109,8 +103,8 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         # Can't mix non-value + value version of the arg.
         cmdline += '--no-ebs-optimized '
         cmdline += '--ebs-optimized Value=true'
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
-                                   stderr_contains='Cannot specify both')
+        self.assert_params_for_cmd2(cmdline, expected_rc=255,
+                                    stderr_contains='Cannot specify both')
 
     def test_mix_non_value_bools_not_allowed(self):
         cmdline = self.prefix
@@ -118,8 +112,8 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         # Can't mix non-value + value version of the arg.
         cmdline += '--no-ebs-optimized '
         cmdline += '--ebs-optimized '
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
-                                   stderr_contains='Cannot specify both')
+        self.assert_params_for_cmd2(cmdline, expected_rc=255,
+                                    stderr_contains='Cannot specify both')
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_replace_network_acl_entry.py
+++ b/tests/unit/ec2/test_replace_network_acl_entry.py
@@ -31,12 +31,10 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '6',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_udp(self):
         cmdline = self.prefix
@@ -51,12 +49,10 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '17',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_icmp(self):
         cmdline = self.prefix
@@ -71,12 +67,10 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '1',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_all(self):
         cmdline = self.prefix
@@ -91,12 +85,10 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '-1',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_number(self):
         cmdline = self.prefix
@@ -111,10 +103,8 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'RuleNumber': 100,
                   'Protocol': '99',
                   'RuleAction': 'allow',
-                  'Egress': 'false',
+                  'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
-                  'PortRange.From': 22,
-                  'PortRange.To': 22
-                  }
-        self.assert_params_for_cmd(cmdline, result)
+                  'PortRange': {'From': 22, 'To': 22}}
+        self.assert_params_for_cmd2(cmdline, result)
 

--- a/tests/unit/ec2/test_run_instances.py
+++ b/tests/unit/ec2/test_run_instances.py
@@ -26,20 +26,20 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         args_list = (self.prefix + args).split()
         result = {
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_count_scalar(self):
         args = ' --image-id ami-foobar --count 2'
         args_list = (self.prefix + args).split()
         result = {
             'ImageId': 'ami-foobar',
-            'MaxCount': 2,
-            'MinCount': 2
+            'max_count': 2,
+            'min_count': 2
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_user_data(self):
         return
@@ -52,21 +52,21 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                     self.prefix +
                     ' --image-id foo --user-data file://%s' % f.name)
                 result = {'ImageId': 'foo',
-                          'MaxCount': 1,
-                          'MinCount': 1,
+                          'max_count': 1,
+                          'min_count': 1,
                           # base64 encoded content of utf-8 encoding of data.
                           'UserData': 'OQ=='}
-            self.assert_params_for_cmd(args, result)
+            self.assert_params_for_cmd2(args, result)
 
     def test_count_range(self):
         args = ' --image-id ami-foobar --count 5:10'
         args_list = (self.prefix + args).split()
         result = {
             'ImageId': 'ami-foobar',
-            'MaxCount': 10,
-            'MinCount': 5
+            'max_count': 10,
+            'min_count': 5
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_block_device_mapping(self):
         args = ' --image-id ami-foobar --count 1'
@@ -79,13 +79,15 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         args_list.append(
             ' [{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":20}}]')
         result = {
-            'BlockDeviceMapping.1.DeviceName': '/dev/sda1',
-            'BlockDeviceMapping.1.Ebs.VolumeSize': 20,
+            'BlockDeviceMappings': [
+                {'DeviceName': '/dev/sda1',
+                 'Ebs': {'VolumeSize': 20}},
+            ],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_secondary_ip_address(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -96,81 +98,91 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'false',
             'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.2.106',
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        result = {
+            'ImageId': 'ami-foobar',
+            'NetworkInterfaces': [
+                {'DeviceIndex': 0,
+                 'PrivateIpAddresses': [
+                     {'Primary': False, 'PrivateIpAddress': '10.0.2.106'}]}],
+            'max_count': 1,
+            'min_count': 1}
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_secondary_ip_addresses(self):
         args = ' --image-id ami-foobar --count 1 '
         args += '--secondary-private-ip-addresses 10.0.2.106 10.0.2.107'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'false',
-            'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.2.106',
-            'NetworkInterface.1.PrivateIpAddresses.2.Primary': 'false',
-            'NetworkInterface.1.PrivateIpAddresses.2.PrivateIpAddress': '10.0.2.107',
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
-        }
-        self.assert_params_for_cmd(args_list, result)
+            'NetworkInterfaces': [
+                {'DeviceIndex': 0,
+                 'PrivateIpAddresses': [
+                     {'Primary': False, 'PrivateIpAddress': u'10.0.2.106'},
+                     {'Primary': False, 'PrivateIpAddress': u'10.0.2.107'}]}],
+            'max_count': 1,
+            'min_count': 1}
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_secondary_ip_address_count(self):
         args = ' --image-id ami-foobar --count 1 '
         args += '--secondary-private-ip-address-count 4'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.SecondaryPrivateIpAddressCount': 4,
+            'NetworkInterfaces': [{'DeviceIndex': 0,
+                                   'SecondaryPrivateIpAddressCount': 4}],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_associate_public_ip_address(self):
         args = ' --image-id ami-foobar --count 1 --subnet-id subnet-12345678 '
         args += '--associate-public-ip-address'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.AssociatePublicIpAddress': 'true',
-            'NetworkInterface.1.SubnetId': 'subnet-12345678',
+            'NetworkInterfaces': [
+                {'DeviceIndex': 0,
+                 'AssociatePublicIpAddress': True,
+                 'SubnetId': 'subnet-12345678'},
+            ],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_associate_public_ip_address_switch_order(self):
         args = ' --image-id ami-foobar --count 1 '
         args += '--associate-public-ip-address --subnet-id subnet-12345678'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.AssociatePublicIpAddress': 'true',
-            'NetworkInterface.1.SubnetId': 'subnet-12345678',
+            'NetworkInterfaces': [
+                {'DeviceIndex': 0,
+                 'AssociatePublicIpAddress': True,
+                 'SubnetId': 'subnet-12345678'}
+            ],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_no_associate_public_ip_address(self):
         args = ' --image-id ami-foobar --count 1  --subnet-id subnet-12345678 '
         args += '--no-associate-public-ip-address'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.AssociatePublicIpAddress': 'false',
-            'NetworkInterface.1.SubnetId': 'subnet-12345678',
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
-        }
-        self.assert_params_for_cmd(args_list, result)
+            'NetworkInterfaces': [{'AssociatePublicIpAddress': False,
+                                   'DeviceIndex': 0,
+                                   'SubnetId': 'subnet-12345678'}],
+            'max_count': 1,
+            'min_count': 1}
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_subnet_alone(self):
         args = ' --image-id ami-foobar --count 1 --subnet-id subnet-12345678'
@@ -178,10 +190,10 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         result = {
             'SubnetId': 'subnet-12345678',
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_associate_public_ip_address_and_group_id(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -189,27 +201,29 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         args += '--associate-public-ip-address --subnet-id subnet-12345678'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.AssociatePublicIpAddress': 'true',
-            'NetworkInterface.1.SubnetId': 'subnet-12345678',
-            'NetworkInterface.1.SecurityGroupId.1': 'sg-12345678',
+            'NetworkInterfaces': [
+                {'DeviceIndex': 0,
+                 'AssociatePublicIpAddress': True,
+                 'SubnetId': 'subnet-12345678',
+                 'Groups': ['sg-12345678']}
+            ],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_group_id_alone(self):
         args = ' --image-id ami-foobar --count 1 '
         args += '--security-group-id sg-12345678'
         args_list = (self.prefix + args).split()
         result = {
-            'SecurityGroupId.1': 'sg-12345678',
+            'SecurityGroupIds': ['sg-12345678'],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_associate_public_ip_address_and_private_ip_address(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -217,16 +231,19 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         args += '--associate-public-ip-address --subnet-id subnet-12345678'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.AssociatePublicIpAddress': 'true',
-            'NetworkInterface.1.SubnetId': 'subnet-12345678',
-            'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.0.200',
-            'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'true',
+            'NetworkInterfaces': [{
+                'DeviceIndex': 0,
+                'AssociatePublicIpAddress': True,
+                'SubnetId': 'subnet-12345678',
+                'PrivateIpAddresses': [
+                    {'PrivateIpAddress': '10.0.0.200',
+                     'Primary': True}],
+            }],
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_private_ip_address_alone(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -235,8 +252,8 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         result = {
             'PrivateIpAddress': '10.0.0.200',
             'ImageId': 'ami-foobar',
-            'MaxCount': 1,
-            'MinCount': 1
+            'max_count': 1,
+            'min_count': 1
         }
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 

--- a/tests/unit/elasticache/test_create_cache_cluster.py
+++ b/tests/unit/elasticache/test_create_cache_cluster.py
@@ -30,17 +30,16 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
                 '--auto-minor-version-upgrade '
                 '--preferred-maintenance-window fri:08:00-fri:09:00')
         cmdline = self.prefix + args
-        result = {'AutoMinorVersionUpgrade': 'true',
+        result = {'AutoMinorVersionUpgrade': True,
                   'CacheClusterId': 'cachecluster-us-east-1c',
                   'CacheNodeType': 'cache.m1.small',
-                  'CacheSecurityGroupNames.member.1': 'group1',
-                  'CacheSecurityGroupNames.member.2': 'group2',
+                  'CacheSecurityGroupNames': ['group1', 'group2'],
                   'Engine': 'memcached',
                   'EngineVersion': '1.4.5',
                   'NumCacheNodes': 1,
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_create_cache_cluster_no_auto_minor_upgrade(self):
         args = ('--cache-cluster-id cachecluster-us-east-1c '
@@ -53,17 +52,16 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
                 '--no-auto-minor-version-upgrade '
                 '--preferred-maintenance-window fri:08:00-fri:09:00')
         cmdline = self.prefix + args
-        result = {'AutoMinorVersionUpgrade': 'false',
+        result = {'AutoMinorVersionUpgrade': False,
                   'CacheClusterId': 'cachecluster-us-east-1c',
                   'CacheNodeType': 'cache.m1.small',
-                  'CacheSecurityGroupNames.member.1': 'group1',
-                  'CacheSecurityGroupNames.member.2': 'group2',
+                  'CacheSecurityGroupNames': ['group1', 'group2'],
                   'Engine': 'memcached',
                   'EngineVersion': '1.4.5',
                   'NumCacheNodes': 1,
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_minor_upgrade_arg_not_specified(self):
         args = ('--cache-cluster-id cachecluster-us-east-1c '
@@ -80,14 +78,13 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
         # AutoMinorVersionUpgrade is not in the result dict.
         result = {'CacheClusterId': 'cachecluster-us-east-1c',
                   'CacheNodeType': 'cache.m1.small',
-                  'CacheSecurityGroupNames.member.1': 'group1',
-                  'CacheSecurityGroupNames.member.2': 'group2',
+                  'CacheSecurityGroupNames': ['group1', 'group2'],
                   'Engine': 'memcached',
                   'EngineVersion': '1.4.5',
                   'NumCacheNodes': 1,
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/elasticache/test_create_cache_cluster.py
+++ b/tests/unit/elasticache/test_create_cache_cluster.py
@@ -85,7 +85,3 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
         self.assert_params_for_cmd2(cmdline, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/elasticbeanstalk/test_create_application.py
+++ b/tests/unit/elasticbeanstalk/test_create_application.py
@@ -24,7 +24,7 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --application-name FooBar'
         result = {'ApplicationName': 'FooBar',}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     @unittest.skipIf(
         six.PY3, 'Unicode cmd line test only is relevant to python2.')
@@ -42,4 +42,4 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
             encoding = 'utf-8'
         cmdline = cmdline.encode(encoding)
         result = {'ApplicationName': u'\u2713',}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)

--- a/tests/unit/elasticbeanstalk/test_update_configuration_template.py
+++ b/tests/unit/elasticbeanstalk/test_update_configuration_template.py
@@ -27,16 +27,18 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
         cmdline += ' --template-name x86_64_m1_medium_config'
         cmdline += ' --option-settings file://%s' % data_path
         cmdline += ' --description This_is_a_test'
-        result = {'ApplicationName': 'FooBar',
-                  'TemplateName': 'x86_64_m1_medium_config',
-                  'Description': 'This_is_a_test',
-                  'OptionSettings.member.1.Namespace': 'aws:autoscaling:launchconfiguration',
-                  'OptionSettings.member.1.OptionName': 'EC2KeyName',
-                  'OptionSettings.member.1.Value': 'webapps',
-                  'OptionSettings.member.2.Namespace': 'aws:elasticbeanstalk:container:tomcat:jvmoptions',
-                  'OptionSettings.member.2.OptionName': 'Xms',
-                  'OptionSettings.member.2.Value': '1256m'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'ApplicationName': 'FooBar',
+            'TemplateName': 'x86_64_m1_medium_config',
+            'Description': 'This_is_a_test',
+            'OptionSettings': [
+                {'Namespace': 'aws:autoscaling:launchconfiguration',
+                 'OptionName': 'EC2KeyName',
+                 'Value': 'webapps'},
+                {'Namespace': 'aws:elasticbeanstalk:container:tomcat:jvmoptions',
+                 'OptionName': 'Xms',
+                 'Value': '1256m'}]}
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/elasticbeanstalk/test_update_configuration_template.py
+++ b/tests/unit/elasticbeanstalk/test_update_configuration_template.py
@@ -39,7 +39,3 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
                  'OptionName': 'Xms',
                  'Value': '1256m'}]}
         self.assert_params_for_cmd2(cmdline, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/elb/test_configure_health_check.py
+++ b/tests/unit/elb/test_configure_health_check.py
@@ -25,13 +25,15 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
         cmdline += (' --health-check Target=HTTP:80/weather/us/wa/seattle,'
                     'Interval=300,Timeout=60,UnhealthyThreshold=5,'
                     'HealthyThreshold=9')
-        result = {'HealthCheck.HealthyThreshold': 9,
-                  'HealthCheck.Interval': 300,
-                  'HealthCheck.Target': 'HTTP:80/weather/us/wa/seattle',
-                  'HealthCheck.Timeout': 60,
-                  'HealthCheck.UnhealthyThreshold': 5,
-                  'LoadBalancerName': 'my-lb'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'HealthCheck': {
+                'HealthyThreshold': 9,
+                'Interval': 300,
+                'Target': 'HTTP:80/weather/us/wa/seattle',
+                'Timeout': 60,
+                'UnhealthyThreshold': 5},
+            'LoadBalancerName': 'my-lb'}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_json(self):
         cmdline = self.prefix
@@ -39,13 +41,15 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
         cmdline += ('--health-check {"Target":"HTTP:80/weather/us/wa/seattle'
                     '?a=b","Interval":300,"Timeout":60,'
                     '"UnhealthyThreshold":5,"HealthyThreshold":9}')
-        result = {'HealthCheck.HealthyThreshold': 9,
-                  'HealthCheck.Interval': 300,
-                  'HealthCheck.Target': 'HTTP:80/weather/us/wa/seattle?a=b',
-                  'HealthCheck.Timeout': 60,
-                  'HealthCheck.UnhealthyThreshold': 5,
-                  'LoadBalancerName': 'my-lb'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'HealthCheck': {
+                'HealthyThreshold': 9,
+                'Interval': 300,
+                'Target': 'HTTP:80/weather/us/wa/seattle?a=b',
+                'Timeout': 60,
+                'UnhealthyThreshold': 5},
+            'LoadBalancerName': 'my-lb'}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_shorthand_with_multiple_equals_for_value(self):
         cmdline = self.prefix
@@ -53,13 +57,15 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
         cmdline += (' --health-check Target="HTTP:80/weather/us/wa/seattle?a=b"'
                     ',Interval=300,Timeout=60,UnhealthyThreshold=5,'
                     'HealthyThreshold=9')
-        result = {'HealthCheck.HealthyThreshold': 9,
-                  'HealthCheck.Interval': 300,
-                  'HealthCheck.Target': 'HTTP:80/weather/us/wa/seattle?a=b',
-                  'HealthCheck.Timeout': 60,
-                  'HealthCheck.UnhealthyThreshold': 5,
-                  'LoadBalancerName': 'my-lb'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'HealthCheck': {
+                'HealthyThreshold': 9,
+                'Interval': 300,
+                'Target': 'HTTP:80/weather/us/wa/seattle?a=b',
+                'Timeout': 60,
+                'UnhealthyThreshold': 5},
+            'LoadBalancerName': 'my-lb'}
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/elb/test_configure_health_check.py
+++ b/tests/unit/elb/test_configure_health_check.py
@@ -11,7 +11,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
 from awscli.testutils import BaseAWSCommandParamsTest
 
 
@@ -54,9 +53,11 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
     def test_shorthand_with_multiple_equals_for_value(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
-        cmdline += (' --health-check Target="HTTP:80/weather/us/wa/seattle?a=b"'
-                    ',Interval=300,Timeout=60,UnhealthyThreshold=5,'
-                    'HealthyThreshold=9')
+        cmdline += (
+            ' --health-check Target="HTTP:80/weather/us/wa/seattle?a=b"'
+            ',Interval=300,Timeout=60,UnhealthyThreshold=5,'
+            'HealthyThreshold=9'
+        )
         result = {
             'HealthCheck': {
                 'HealthyThreshold': 9,
@@ -66,7 +67,3 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
                 'UnhealthyThreshold': 5},
             'LoadBalancerName': 'my-lb'}
         self.assert_params_for_cmd2(cmdline, result)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/elb/test_register_instances_with_load_balancer.py
+++ b/tests/unit/elb/test_register_instances_with_load_balancer.py
@@ -77,7 +77,3 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances i-12345678 i-87654321'
         self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/elb/test_register_instances_with_load_balancer.py
+++ b/tests/unit/elb/test_register_instances_with_load_balancer.py
@@ -17,8 +17,8 @@ import os
 
 TWO_INSTANCE_EXPECTED = {
     'LoadBalancerName': 'my-lb',
-    'Instances.member.1.InstanceId': 'i-12345678',
-    'Instances.member.2.InstanceId': 'i-87654321'
+    'Instances': [{'InstanceId': 'i-12345678'},
+                  {'InstanceId': 'i-87654321'}]
 }
 
 
@@ -31,30 +31,30 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances {"InstanceId":"i-12345678"}'
         result = {'LoadBalancerName': 'my-lb',
-                  'Instances.member.1.InstanceId': 'i-12345678'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Instances': [{'InstanceId': 'i-12345678'}]}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_shorthand(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances i-12345678'
         result = {'LoadBalancerName': 'my-lb',
-                  'Instances.member.1.InstanceId': 'i-12345678'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Instances': [{'InstanceId': 'i-12345678'}]}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_two_instance(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances {"InstanceId":"i-12345678"}'
         cmdline += ' {"InstanceId":"i-87654321"}'
-        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_as_json(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances [{"InstanceId":"i-12345678"},'
         cmdline += '{"InstanceId":"i-87654321"}]'
-        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_from_file(self):
         data_path = os.path.join(os.path.dirname(__file__),
@@ -62,7 +62,7 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances file://%s' % data_path
-        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_json_file_with_spaces(self):
         data_path = os.path.join(os.path.dirname(__file__),
@@ -70,13 +70,13 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances file://%s' % data_path
-        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_shorthand(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances i-12345678 i-87654321'
-        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
 
 
 if __name__ == "__main__":

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -32,7 +32,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         args = ' --group-name foo --user-name bar'
         cmdline = self.prefix + args
         result = {'GroupName': 'foo', 'UserName': 'bar'}
-        stdout = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
+        stdout = self.assert_params_for_cmd2(cmdline, result, expected_rc=0)[0]
         # We should have printed nothing because the parsed response
         # is an empty dict: {}.
         self.assertEqual(stdout, '')

--- a/tests/unit/rds/test_describe_db_log_files.py
+++ b/tests/unit/rds/test_describe_db_log_files.py
@@ -24,4 +24,4 @@ class TestDescribeDBLogFiles(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'DBInstanceIdentifier': 'foo',
                   'FileLastWritten': 10}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)

--- a/tests/unit/rds/test_modify_option_group.py
+++ b/tests/unit/rds/test_modify_option_group.py
@@ -26,16 +26,16 @@ class TestAddOptionGroup(BaseAWSCommandParamsTest):
         args = ('--option-group-name myoptiongroup2 '
                 '--options {"OptionName":"TDE"}')
         cmdline = self.prefix + args
-        result = {'OptionsToInclude.member.1.OptionName': 'TDE',
+        result = {'OptionsToInclude': [{'OptionName': 'TDE'}],
                   'OptionGroupName': 'myoptiongroup2'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_option_to_remove_is_not_allowed(self):
         args = ('--option-group-name myoptiongroup2 '
                 '--options-to-remove foo')
         cmdline = self.prefix + args
-        self.assert_params_for_cmd(
-            cmdline, {}, 255,
+        self.assert_params_for_cmd2(
+            cmdline, expected_rc=255,
             stderr_contains='Unknown options: --options-to-remove')
 
 
@@ -47,20 +47,14 @@ class TestRemoveOptionGroup(BaseAWSCommandParamsTest):
         args = ('--option-group-name myoptiongroup2 '
                 '--options TDE')
         cmdline = self.prefix + args
-        result = {'OptionsToRemove.member.1': 'TDE',
+        result = {'OptionsToRemove': ['TDE'],
                   'OptionGroupName': 'myoptiongroup2'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_option_to_add_is_not_allowed(self):
         args = ('--option-group-name myoptiongroup2 '
                 '--options-to-include {"OptionName":"TDE"}')
         cmdline = self.prefix + args
-        result = {'OptionsToInclude.member.1.OptionName': 'TDE',
-                  'OptionGroupName': 'myoptiongroup2'}
-        self.assert_params_for_cmd(
-            cmdline, {}, 255,
+        self.assert_params_for_cmd2(
+            cmdline, expected_rc=255,
             stderr_contains='Unknown options: --options-to-include')
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/route53/test_resource_id.py
+++ b/tests/unit/route53/test_resource_id.py
@@ -20,7 +20,7 @@ CHANGEBATCH_JSON = ('{"Comment":"string","Changes":['
                     '"Type":"CNAME",'
                     '"TTL":300,'
                     '"ResourceRecords":['
-                    '{"Value":"foo-bar-com.us-west-1.elb.amazonaws.com"}'
+                    '{"Value":"foo-bar-com"}'
                     ']}}]}')
 
 
@@ -34,16 +34,15 @@ class TestGetHostedZone(BaseAWSCommandParamsTest):
     def test_full_resource_id(self):
         args = ' --id /hostedzone/ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
-        expected_id = 'ZD3IYMVP1KDDM'
-        self.assert_params_for_cmd(cmdline, expected_rc=0)
-        self.assertEqual(self.last_kwargs['Id'], expected_id)
+        self.assert_params_for_cmd2(
+            cmdline, {'Id': 'ZD3IYMVP1KDDM'}, expected_rc=0)
 
     def test_short_resource_id(self):
         args = ' --id ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
-        expected_id = 'ZD3IYMVP1KDDM'
-        self.assert_params_for_cmd(cmdline, expected_rc=0)
-        self.assertEqual(self.last_kwargs['Id'], expected_id)
+        self.assert_params_for_cmd2(
+            cmdline, {'Id': 'ZD3IYMVP1KDDM'},
+            expected_rc=0)
 
 
 class TestChangeResourceRecord(BaseAWSCommandParamsTest):
@@ -57,11 +56,28 @@ class TestChangeResourceRecord(BaseAWSCommandParamsTest):
         args = ' --hosted-zone-id /change/ZD3IYMVP1KDDM'
         args += ' --change-batch %s' % CHANGEBATCH_JSON
         cmdline = self.prefix + args
-        expected_hosted_zone = 'ZD3IYMVP1KDDM'
-        self.assert_params_for_cmd2(cmdline, expected_rc=0)
-        # Verify that we used the correct value for HostedZoneId.
-        self.assertEqual(self.last_kwargs['HostedZoneId'],
-                         expected_hosted_zone)
+        expected = {
+            "HostedZoneId": "ZD3IYMVP1KDDM",
+            "ChangeBatch": {
+                "Comment": "string",
+                "Changes": [
+                    {
+                        "Action": "CREATE",
+                        "ResourceRecordSet": {
+                            "Name": "test-foo.bar.com",
+                            "Type": "CNAME",
+                            "TTL": 300,
+                            "ResourceRecords": [
+                                {
+                                    "Value": "foo-bar-com"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
 
 
 class TestGetChange(BaseAWSCommandParamsTest):
@@ -74,16 +90,14 @@ class TestGetChange(BaseAWSCommandParamsTest):
     def test_full_resource_id(self):
         args = ' --id /change/ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
-        expected_id = 'ZD3IYMVP1KDDM'
-        self.assert_params_for_cmd(cmdline, expected_rc=0)
-        self.assertEqual(self.last_kwargs['Id'], expected_id)
+        expected = {'Id': 'ZD3IYMVP1KDDM'}
+        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
 
     def test_short_resource_id(self):
         args = ' --id ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
-        expected_id = 'ZD3IYMVP1KDDM'
-        self.assert_params_for_cmd(cmdline, expected_rc=0)
-        self.assertEqual(self.last_kwargs['Id'], expected_id)
+        expected = {'Id': 'ZD3IYMVP1KDDM'}
+        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
 
 
 class TestReusableDelegationSet(BaseAWSCommandParamsTest):
@@ -96,14 +110,12 @@ class TestReusableDelegationSet(BaseAWSCommandParamsTest):
     def test_full_resource_id(self):
         args = ' --id /delegationset/N9INWVYQ6Q0FN'
         cmdline = self.prefix + args
-        expected_id = 'N9INWVYQ6Q0FN'
         self.assert_params_for_cmd2(cmdline, {'Id': 'N9INWVYQ6Q0FN'},
                                     expected_rc=0)
 
     def test_short_resource_id(self):
         args = ' --id N9INWVYQ6Q0FN'
         cmdline = self.prefix + args
-        expected_id = 'N9INWVYQ6Q0FN'
         self.assert_params_for_cmd2(cmdline, {'Id': 'N9INWVYQ6Q0FN'},
                                     expected_rc=0)
 
@@ -115,8 +127,5 @@ class TestMaxItems(BaseAWSCommandParamsTest):
     def test_full_resource_id(self):
         args = ' --hosted-zone-id /hostedzone/ABCD --max-items 1'
         cmdline = self.prefix + args
-        expected_hosted_zone = 'ABCD'
-        self.assert_params_for_cmd2(cmdline, expected_rc=0)
-        # Verify that we used the correct value for HostedZoneId.
-        self.assertEqual(self.last_kwargs['HostedZoneId'],
-                         expected_hosted_zone)
+        expected = {'HostedZoneId': 'ABCD'}
+        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)

--- a/tests/unit/ses/test_send_email.py
+++ b/tests/unit/ses/test_send_email.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2013-2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -26,24 +26,25 @@ class TestSendEmail(BaseAWSCommandParamsTest):
         args = (' --subject This_is_a_test --from foo@bar.com'
                 ' --to fie@baz.com --text This_is_the_message')
         args_list = (self.prefix + args).split()
-        result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Text.Data': 'This_is_the_message'}
-
-        self.assert_params_for_cmd(args_list, result)
+        result = {
+            'Source': 'foo@bar.com',
+            'destination': {'ToAddresses': ['fie@baz.com']},
+            'message': {'Body': {'Text': {'Data': 'This_is_the_message'}},
+                        'Subject': {'Data': 'This_is_a_test'}}}
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_plain_text_multiple_to(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
                 ' --to fie1@baz.com fie2@baz.com --text This_is_the_message')
         args_list = (self.prefix + args).split()
         result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie1@baz.com',
-                  'Destination.ToAddresses.member.2': 'fie2@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Text.Data': 'This_is_the_message'}
+                  'destination': {
+                      'ToAddresses': ['fie1@baz.com', 'fie2@baz.com']},
+                  'message': {
+                      'Body': {'Text': {'Data': 'This_is_the_message'}},
+                      'Subject': {'Data': 'This_is_a_test'}}}
 
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_plain_text_multiple_cc(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -51,14 +52,14 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                 ' --cc fie3@baz.com fie4@baz.com')
         args_list = (self.prefix + args).split()
         result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie1@baz.com',
-                  'Destination.ToAddresses.member.2': 'fie2@baz.com',
-                  'Destination.CcAddresses.member.1': 'fie3@baz.com',
-                  'Destination.CcAddresses.member.2': 'fie4@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Text.Data': 'This_is_the_message'}
+                  'destination': {
+                      'CcAddresses': ['fie3@baz.com', 'fie4@baz.com'],
+                      'ToAddresses': ['fie1@baz.com', 'fie2@baz.com']},
+                  'message': {
+                      'Body': {'Text': {'Data': 'This_is_the_message'}},
+                      'Subject': {'Data': 'This_is_a_test'}}}
 
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_plain_text_multiple_bcc(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -66,68 +67,76 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                 ' --cc fie3@baz.com fie4@baz.com'
                 ' --bcc fie5@baz.com fie6@baz.com')
         args_list = (self.prefix + args).split()
-        result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie1@baz.com',
-                  'Destination.ToAddresses.member.2': 'fie2@baz.com',
-                  'Destination.CcAddresses.member.1': 'fie3@baz.com',
-                  'Destination.CcAddresses.member.2': 'fie4@baz.com',
-                  'Destination.BccAddresses.member.1': 'fie5@baz.com',
-                  'Destination.BccAddresses.member.2': 'fie6@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Text.Data': 'This_is_the_message'}
 
-        self.assert_params_for_cmd(args_list, result)
+        result = {
+            'Source': 'foo@bar.com',
+            'destination': {'BccAddresses': ['fie5@baz.com', 'fie6@baz.com'],
+                            'CcAddresses': ['fie3@baz.com', 'fie4@baz.com'],
+                            'ToAddresses': ['fie1@baz.com', 'fie2@baz.com']},
+            'message': {
+                'Body': {'Text': {'Data': 'This_is_the_message'}},
+                'Subject': {'Data': 'This_is_a_test'}}}
+
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_html_text(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
                 ' --to fie@baz.com --html This_is_the_html_message')
         args_list = (self.prefix + args).split()
-        result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Html.Data': 'This_is_the_html_message'}
+        result = {
+            'Source': 'foo@bar.com',
+            'destination': {'ToAddresses': ['fie@baz.com']},
+            'message': {'Subject': {'Data': 'This_is_a_test'},
+                        'Body': {
+                            'Html': {'Data': 'This_is_the_html_message'}}}}
 
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_html_both(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
                 ' --to fie@baz.com --html This_is_the_html_message'
                 ' --text This_is_the_text_message')
         args_list = (self.prefix + args).split()
-        result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Text.Data': 'This_is_the_text_message',
-                  'Message.Body.Html.Data': 'This_is_the_html_message'}
-
-        self.assert_params_for_cmd(args_list, result)
+        result = {
+            'Source': 'foo@bar.com',
+            'destination': {'ToAddresses': ['fie@baz.com']},
+            'message': {
+                'Subject': {'Data': 'This_is_a_test'},
+                'Body': {
+                    'Text': {'Data': 'This_is_the_text_message'},
+                    'Html': {'Data': 'This_is_the_html_message'}}}}
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_using_json(self):
-        args = (' --message {"Subject":{"Data":"This_is_a_test"},"Body":{"Text":{"Data":"This_is_the_message"}}}'
+        args = (' --message {"Subject":{"Data":"This_is_a_test"},'
+                '"Body":{"Text":{"Data":"This_is_the_message"}}}'
                 ' --from foo@bar.com'
                 ' --destination {"ToAddresses":["fie@baz.com"]}')
         args_list = (self.prefix + args).split()
-        result = {'Source': 'foo@bar.com',
-                  'Destination.ToAddresses.member.1': 'fie@baz.com',
-                  'Message.Subject.Data': 'This_is_a_test',
-                  'Message.Body.Text.Data': 'This_is_the_message'}
+        result = {'Destination': {'ToAddresses': ['fie@baz.com']},
+                  'Message': {
+                      'Subject': {
+                          'Data': 'This_is_a_test'},
+                      'Body': {
+                          'Text': {'Data': 'This_is_the_message'}}},
+                  'Source': 'foo@bar.com'}
 
-        self.assert_params_for_cmd(args_list, result)
+        self.assert_params_for_cmd2(args_list, result)
 
     def test_both_destination_and_to(self):
-        captured = cStringIO()
-        args = (' --message {"Subject":{"Data":"This_is_a_test"},"Body":{"Text":{"Data":"This_is_the_message"}}}'
+        args = (' --message {"Subject":{"Data":"This_is_a_test"},'
+                '"Body":{"Text":{"Data":"This_is_the_message"}}}'
                 ' --from foo@bar.com'
                 ' --destination {"ToAddresses":["fie@baz.com"]}'
                 ' --to fie2@baz.com')
         args_list = (self.prefix + args).split()
-        self.assert_params_for_cmd(args_list, {}, expected_rc=255)
+        self.run_cmd(args_list, expected_rc=255)
 
     def test_both_message_and_text(self):
-        captured = cStringIO()
-        args = (' --message {"Subject":{"Data":"This_is_a_test"},"Body":{"Text":{"Data":"This_is_the_message"}}}'
+        args = (' --message {"Subject":{"Data":"This_is_a_test"},'
+                '"Body":{"Text":{"Data":"This_is_the_message"}}}'
                 ' --from foo@bar.com'
                 ' --destination {"ToAddresses":["fie@baz.com"]}'
                 ' --text This_is_another_body')
         args_list = (self.prefix + args).split()
-        self.assert_params_for_cmd(args_list, {}, expected_rc=255)
+        self.run_cmd(args_list, expected_rc=255)

--- a/tests/unit/sns/test_create_platform_application.py
+++ b/tests/unit/sns/test_create_platform_application.py
@@ -27,11 +27,9 @@ class TestCreatePlatformApplication(BaseAWSCommandParamsTest):
         cmdline += 'PlatformPrincipal=bar'
         result = {'Name': 'gcmpushapp',
                   'Platform': 'GCM',
-                  'Attributes.entry.1.key': 'PlatformCredential',
-                  'Attributes.entry.1.value': 'foo',
-                  'Attributes.entry.2.key': 'PlatformPrincipal',
-                  'Attributes.entry.2.value': 'bar'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Attributes': {'PlatformCredential': 'foo',
+                                 'PlatformPrincipal': 'bar'}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_gcm_json(self):
         cmdline = self.prefix
@@ -40,13 +38,14 @@ class TestCreatePlatformApplication(BaseAWSCommandParamsTest):
         cmdline += ' --attributes '
         cmdline += ('{"PlatformCredential":"AIzaSyClE2lcV2zEKTLYYo645zfk2jhQPFeyxDo",'
                     '"PlatformPrincipal":"There+is+no+principal+for+GCM"}')
-        result = {'Name': 'gcmpushapp',
-                  'Platform': 'GCM',
-                  'Attributes.entry.1.key': 'PlatformCredential',
-                  'Attributes.entry.1.value': 'AIzaSyClE2lcV2zEKTLYYo645zfk2jhQPFeyxDo',
-                  'Attributes.entry.2.key': 'PlatformPrincipal',
-                  'Attributes.entry.2.value': 'There+is+no+principal+for+GCM'}
-        self.assert_params_for_cmd(cmdline, result)
+        result = {
+            'Name': 'gcmpushapp',
+            'Platform': 'GCM',
+            'Attributes': {
+              'PlatformCredential': 'AIzaSyClE2lcV2zEKTLYYo645zfk2jhQPFeyxDo',
+              'PlatformPrincipal': 'There+is+no+principal+for+GCM'}
+        }
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_add_permission.py
+++ b/tests/unit/sqs/test_add_permission.py
@@ -27,10 +27,10 @@ class TestAddPermission(BaseAWSCommandParamsTest):
         cmdline += ' --actions SendMessage'
         cmdline += ' --label FooBarLabel'
         result = {'QueueUrl': self.queue_url,
-                  'ActionName.1': 'SendMessage',
-                  'AWSAccountId.1': '888888888888',
+                  'Actions': ['SendMessage'],
+                  'AWSAccountIds': ['888888888888'],
                   'Label': 'FooBarLabel'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_multiple_accounts(self):
         cmdline = self.prefix
@@ -39,11 +39,10 @@ class TestAddPermission(BaseAWSCommandParamsTest):
         cmdline += ' --actions SendMessage'
         cmdline += ' --label FooBarLabel'
         result = {'QueueUrl': self.queue_url,
-                  'ActionName.1': 'SendMessage',
-                  'AWSAccountId.1': '888888888888',
-                  'AWSAccountId.2': '999999999999',
+                  'Actions': ['SendMessage'],
+                  'AWSAccountIds': ['888888888888', '999999999999'],
                   'Label': 'FooBarLabel'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_multiple_actions(self):
         cmdline = self.prefix
@@ -52,11 +51,10 @@ class TestAddPermission(BaseAWSCommandParamsTest):
         cmdline += ' --actions SendMessage ReceiveMessage'
         cmdline += ' --label FooBarLabel'
         result = {'QueueUrl': self.queue_url,
-                  'ActionName.1': 'SendMessage',
-                  'ActionName.2': 'ReceiveMessage',
-                  'AWSAccountId.1': '888888888888',
+                  'Actions': ['SendMessage', 'ReceiveMessage'],
+                  'AWSAccountIds': ['888888888888'],
                   'Label': 'FooBarLabel'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_change_message_visibility.py
+++ b/tests/unit/sqs/test_change_message_visibility.py
@@ -29,7 +29,7 @@ class TestChangeMessageVisibility(BaseAWSCommandParamsTest):
         result = {'QueueUrl': self.queue_url,
                   'ReceiptHandle': self.receipt_handle,
                   'VisibilityTimeout': 30}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_create_queue.py
+++ b/tests/unit/sqs/test_create_queue.py
@@ -24,7 +24,7 @@ class TestCreateQueue(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --queue-name %s' % self.queue_name
         result = {'QueueName': self.queue_name}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_get_queue_attributes.py
+++ b/tests/unit/sqs/test_get_queue_attributes.py
@@ -23,29 +23,28 @@ class TestGetQueueAttributes(BaseAWSCommandParamsTest):
     def test_no_attr(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         result = {'QueueUrl': self.queue_url}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_all(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attribute-names All'
         result = {'QueueUrl': self.queue_url,
-                  'AttributeName.1': 'All'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'AttributeNames': ['All']}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_one(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attribute-names VisibilityTimeout'
         result = {'QueueUrl': self.queue_url,
-                  'AttributeName.1': 'VisibilityTimeout'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'AttributeNames': ['VisibilityTimeout']}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_two(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attribute-names VisibilityTimeout QueueArn'
         result = {'QueueUrl': self.queue_url,
-                  'AttributeName.1': 'VisibilityTimeout',
-                  'AttributeName.2': 'QueueArn'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'AttributeNames': ['VisibilityTimeout', 'QueueArn']}
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_list_queues.py
+++ b/tests/unit/sqs/test_list_queues.py
@@ -22,12 +22,12 @@ class TestListQueues(BaseAWSCommandParamsTest):
     def test_no_param(self):
         cmdline = self.prefix
         result = {}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_prefix(self):
         cmdline = self.prefix + ' --queue-name-prefix test'
         result = {'QueueNamePrefix': 'test'}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_purge_queue.py
+++ b/tests/unit/sqs/test_purge_queue.py
@@ -24,7 +24,7 @@ class TestPurgeQueue(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --queue-url %s' % url
         result = {'QueueUrl': url}
-        self.assert_params_for_cmd(cmdline, result)
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_set_queue_attributes.py
+++ b/tests/unit/sqs/test_set_queue_attributes.py
@@ -24,17 +24,16 @@ class TestSetQueueAttributes(BaseAWSCommandParamsTest):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attributes {"VisibilityTimeout":"15"}'
         result = {'QueueUrl': self.queue_url,
-                  'Attribute.1.Name': 'VisibilityTimeout',
-                  'Attribute.1.Value': '15'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Attributes': {
+                      'VisibilityTimeout': '15'}}
+        self.assert_params_for_cmd2(cmdline, result)
 
     def test_shorthand(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attributes VisibilityTimeout=15'
         result = {'QueueUrl': self.queue_url,
-                  'Attribute.1.Name': 'VisibilityTimeout',
-                  'Attribute.1.Value': '15'}
-        self.assert_params_for_cmd(cmdline, result)
+                  'Attributes': {'VisibilityTimeout': '15'}}
+        self.assert_params_for_cmd2(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -389,7 +389,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 'ec2 describe-instances --endpoint-url https://foobar.com/',
                 expected_rc=0)
         endpoint.assert_called_with(region_name=None,
@@ -402,7 +402,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         endpoint.assert_called_with(region_name='us-east-1',
@@ -415,7 +415,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 'ec2 describe-instances --region us-east-1 --no-verify-ssl',
                 expected_rc=0)
         # Because we used --no-verify-ssl, get_endpoint should be
@@ -432,7 +432,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
             self.environ['AWS_CA_BUNDLE'] = '/path/cacert.pem'
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         call_args = endpoint.call_args
@@ -445,7 +445,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             endpoint.return_value.host = ''
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         call_args = endpoint.call_args
@@ -457,7 +457,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {'CommonPrefixes': [], 'Contents': []})
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 's3 ls s3://test --region us-east-1 --endpoint-url https://foobar.com/',
                 expected_rc=0)
         endpoint.assert_called_with(region_name='us-east-1',
@@ -470,7 +470,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {'CommonPrefixes': [], 'Contents': []})
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 's3 ls s3://test --no-verify-ssl',
                 expected_rc=0)
         endpoint.assert_called_with(region_name=None,
@@ -599,7 +599,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         # Simulates the equivalent in bash: --identifies ""
         cmd = 'ses get-identity-dkim-attributes --identities'.split()
         cmd.append('')
-        self.assert_params_for_cmd(cmd,expected_rc=0)
+        self.assert_params_for_cmd2(cmd,expected_rc=0)
 
     def test_file_param_does_not_exist(self):
         driver = create_clidriver()
@@ -672,7 +672,7 @@ class TestHTTPParamFileDoesNotExist(BaseAWSCommandParamsTest):
                      "received non 200 status code of 404")
         with mock.patch('botocore.vendored.requests.get') as get:
             get.return_value.status_code = 404
-            self.assert_params_for_cmd(
+            self.assert_params_for_cmd2(
                 'ec2 describe-instances --filters http://does/not/exist.json',
                 expected_rc=255, stderr_contains=error_msg)
 
@@ -701,11 +701,11 @@ class TestVerifyArgument(BaseAWSCommandParamsTest):
         self.recorded_args = parsed_args
 
     def test_no_verify_argument(self):
-        self.assert_params_for_cmd('s3api list-buckets --no-verify-ssl'.split())
+        self.assert_params_for_cmd2('s3api list-buckets --no-verify-ssl'.split())
         self.assertFalse(self.recorded_args.verify_ssl)
 
     def test_verify_argument_is_none_by_default(self):
-        self.assert_params_for_cmd('s3api list-buckets'.split())
+        self.assert_params_for_cmd2('s3api list-buckets'.split())
         self.assertIsNone(self.recorded_args.verify_ssl)
 
 


### PR DESCRIPTION
This is a branch I've been working on every now and then which updates all tests such that nothing uses assert_params_for_cmd.  Instead anything that needs that type of assertion functionality instead uses assert_params_for_cmd2.  As a reminder:

* assert_params_for_cmd - This verified the serialized params sent to botocore's make_request.  This meant that we were also testing the serialization format of the particular protocol.
* assert_params_for_cmd2 - This tests at the `Operation.call` layer, i.e before it's serialized into the wire format.

### Why Switch?

This came about with the switch over to the normalized models, but the main reasons assert_params_for_cmd is going away is because:

* It shouldn't be the AWS CLI's concern to verify the wire protocol from a command.  We just need to ensure we're calling into botocore correctly and let botocore's test handle the verification of the wire protocol serialization.
* The assert_params_for_cmd could really only verify query services because anything that was rest-xml or json would need to be the request body as a string.  So some of the tests for s3 were verifying the built XML body.  These tests typically over-asserted their expectations such that changing the XML serialization slightly, despite being valid, would cause unnecessary unit test failures.


### Migration Plan

* Get this PR merged.
* Now that nothing depends on assert_params_for_cmd, we can remove the method entirely and rename assert_params_for_cmd2 back to assert_params_for_cmd
* Change to CamelCasing in the customizations where necessary.

As to that third point, some of the customizations (notably EC2) were written when `Operation.call` only accepted `snake_case` names.  Now that `CamelCasing` is supported, and in fact, is the only casing supported in botocore's clients, we need to update these customizations to be CamelCase.  This can wait until the switchover to clients, but I'd rather tackle this now to minimize the amount of work needed for the botocore client switchover.


cc @kyleknap @danielgtaylor 