### PR TITLE
Introduced related_item attribute for help command

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -195,6 +195,7 @@ class HelpCommand(object):
         if arg_table is None:
             arg_table = {}
         self.arg_table = arg_table
+        self.related_items = []
         self.renderer = get_renderer()
         self.doc = ReSTDocument(target='man')
 


### PR DESCRIPTION
This is needed for the merged bcdoc PR: https://github.com/boto/bcdoc/pull/32

This will make sure unit tests pass.

cc @jamesls @danielgtaylor 