### PR TITLE
Add ``lineage_names`` to commands

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -276,6 +276,14 @@ class CLICommand(object):
         # a list.
         return [self]
 
+    @property
+    def lineage_names(self):
+        # Represents the lineage of a command in terms of command ``name``
+        lineage_names = []
+        for cmd in self.lineage:
+            lineage_names.append(cmd.name)
+        return lineage_names
+
     def __call__(self, args, parsed_globals):
         """Invoke CLI operation.
 
@@ -473,6 +481,14 @@ class ServiceOperation(object):
     @lineage.setter
     def lineage(self, value):
         self._lineage = value
+
+    @property
+    def lineage_names(self):
+        # Represents the lineage of a command in terms of command ``name``
+        lineage_names = []
+        for cmd in self.lineage:
+            lineage_names.append(cmd.name)
+        return lineage_names
 
     @property
     def arg_table(self):

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -279,10 +279,7 @@ class CLICommand(object):
     @property
     def lineage_names(self):
         # Represents the lineage of a command in terms of command ``name``
-        lineage_names = []
-        for cmd in self.lineage:
-            lineage_names.append(cmd.name)
-        return lineage_names
+        return [cmd.name for cmd in self.lineage]
 
     def __call__(self, args, parsed_globals):
         """Invoke CLI operation.
@@ -485,10 +482,7 @@ class ServiceOperation(object):
     @property
     def lineage_names(self):
         # Represents the lineage of a command in terms of command ``name``
-        lineage_names = []
-        for cmd in self.lineage:
-            lineage_names.append(cmd.name)
-        return lineage_names
+        return [cmd.name for cmd in self.lineage]
 
     @property
     def arg_table(self):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -306,8 +306,13 @@ class TestCommandLineage(unittest.TestCase):
         actual_lineage_names = []
         for cmd in command.lineage:
             actual_lineage_names.append(cmd.name)
-
+        
+        # Assert the actual names of each command in a lineage is as expected.
         self.assertEqual(actual_lineage_names, ref_lineage_names)
+
+        # Assert that ``lineage_names`` for each command is in sync with what
+        # is actually in the command's ``lineage``.
+        self.assertEqual(command.lineage_names, actual_lineage_names)
 
     def test_service_level_commands(self):
         # Check a normal unchanged service command

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -58,6 +58,7 @@ class TestBasicCommand(unittest.TestCase):
 
     def test_load_lineage(self):
         self.assertEqual(self.command.lineage, [self.command])
+        self.assertEqual(self.command.lineage_names, [self.command.name])
 
     def test_pass_lineage_to_child_command(self):
         class MockCustomCommand(BasicCommand):
@@ -66,7 +67,12 @@ class TestBasicCommand(unittest.TestCase):
             SUBCOMMANDS = [{'name': 'basic', 'command_class': BasicCommand}]
 
         self.command = MockCustomCommand(self.session)
-        lineage = self.command.subcommand_table['basic'].lineage
+        subcommand = self.command.subcommand_table['basic']
+        lineage = subcommand.lineage
         self.assertEqual(len(lineage), 2)
         self.assertEqual(lineage[0], self.command)
         self.assertIsInstance(lineage[1], BasicCommand)
+        self.assertEqual(
+            subcommand.lineage_names,
+            [self.command.name, subcommand.name]
+        )

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -728,6 +728,10 @@ class TestCLICommand(unittest.TestCase):
     def test_lineage(self):
         self.assertEqual(self.cmd.lineage, [self.cmd])
 
+    def test_lineage_names(self):
+        with self.assertRaises(NotImplementedError):
+            self.cmd.lineage_names
+
     def test_arg_table(self):
         self.assertEqual(self.cmd.arg_table, {})
 
@@ -748,6 +752,9 @@ class TestServiceCommand(unittest.TestCase):
         self.cmd.lineage = ['foo']
         self.assertEqual(self.cmd.lineage, ['foo'])
 
+    def test_lineage_names(self):
+        self.assertEqual(self.cmd.lineage_names, ['foo'])
+
     def test_pass_lineage_to_child(self):
         # In order to introspect the service command's subcommands
         # we introspect the subcommand via the help command since
@@ -756,6 +763,7 @@ class TestServiceCommand(unittest.TestCase):
         child_cmd = help_command.command_table['list-objects']
         self.assertEqual(child_cmd.lineage,
                          [self.cmd, child_cmd])
+        self.assertEqual(child_cmd.lineage_names, ['foo', 'list-objects'])
 
 
 class TestServiceOperation(unittest.TestCase):
@@ -772,6 +780,9 @@ class TestServiceOperation(unittest.TestCase):
         self.assertEqual(self.cmd.lineage, [self.cmd])
         self.cmd.lineage = ['foo']
         self.assertEqual(self.cmd.lineage, ['foo'])
+
+    def test_lineage_names(self):
+        self.assertEqual(self.cmd.lineage_names, ['foo'])
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -748,9 +748,10 @@ class TestServiceCommand(unittest.TestCase):
         self.assertEqual(self.cmd.name, 'bar')
 
     def test_lineage(self):
+        cmd = CLICommand()
         self.assertEqual(self.cmd.lineage, [self.cmd])
-        self.cmd.lineage = ['foo']
-        self.assertEqual(self.cmd.lineage, ['foo'])
+        self.cmd.lineage = [cmd]
+        self.assertEqual(self.cmd.lineage, [cmd])
 
     def test_lineage_names(self):
         self.assertEqual(self.cmd.lineage_names, ['foo'])
@@ -777,9 +778,10 @@ class TestServiceOperation(unittest.TestCase):
         self.assertEqual(self.cmd.name, 'bar')
 
     def test_lineage(self):
+        cmd = CLICommand()
         self.assertEqual(self.cmd.lineage, [self.cmd])
-        self.cmd.lineage = ['foo']
-        self.assertEqual(self.cmd.lineage, ['foo'])
+        self.cmd.lineage = [cmd]
+        self.assertEqual(self.cmd.lineage, [cmd])
 
     def test_lineage_names(self):
         self.assertEqual(self.cmd.lineage_names, ['foo'])


### PR DESCRIPTION
It is a convenience attribute to get the names of all of the commands in a lineage without having to iterate through the lineage each time. This saves us from a lot of duplicate code.

So for a ``lineage`` attribute, you get the elements in the list in terms of command objects. For the ``lineage_names`` attribute, you get the elements in the list in terms of the names of command objects. This attribute I could see really useful for at least two scenarios:

1) Generating event names. All you would have to do to get the command's representation in the event name is ``'.'.join(cmd.lineage_names)``

2) Looking for related command tags in the ``TagTopicDB``. All of the ``related command`` tag values follow the format of ``<service> [operation] ...``. To look for these values, all you would have to do is 
``' '.join(cmd.lineage_names)``. 

I also considered making it a utils function, but it would be pretty annoying to have to import it each time you need to use it. Let me know what you think.

cc @jamesls @danielgtaylor 