### PR TITLE
Rename doc event

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -79,13 +79,13 @@ class CLIDocumentEventHandler(object):
         if doc.target != 'man':
             cmd_names = help_command.event_class.split('.')
             doc.write('[ ')
-            doc.write(':ref:`aws <aws>`')
+            doc.write(':ref:`aws <cli:aws>`')
             full_cmd_list = ['aws']
             for cmd in cmd_names[:-1]:
                 doc.write(' . ')
                 full_cmd_list.append(cmd)
                 full_cmd_name = ' '.join(full_cmd_list)
-                doc.write(':ref:`%s <%s>`' % (cmd, full_cmd_name))
+                doc.write(':ref:`%s <cli:%s>`' % (cmd, full_cmd_name))
             doc.write(' ]')
 
     def doc_title(self, help_command, **kwargs):
@@ -94,7 +94,7 @@ class CLIDocumentEventHandler(object):
         reference = help_command.event_class.replace('.', ' ')
         if reference != 'aws':
             reference = 'aws ' + reference
-        doc.writeln('.. _%s:' % reference)
+        doc.writeln('.. _cli:%s:' % reference)
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -74,8 +74,27 @@ class CLIDocumentEventHandler(object):
 
     # These are default doc handlers that apply in the general case.
 
+    def doc_breadcrumbs(self, help_command, **kwargs):
+        doc = help_command.doc
+        if doc.target != 'man':
+            cmd_names = help_command.event_class.split('.')
+            doc.write('[ ')
+            doc.write(':ref:`aws <aws>`')
+            full_cmd_list = ['aws']
+            for cmd in cmd_names[:-1]:
+                doc.write(' . ')
+                full_cmd_list.append(cmd)
+                full_cmd_name = ' '.join(full_cmd_list)
+                doc.write(':ref:`%s <%s>`' % (cmd, full_cmd_name))
+            doc.write(' ]')
+
     def doc_title(self, help_command, **kwargs):
         doc = help_command.doc
+        doc.style.new_paragraph()
+        reference = help_command.event_class.replace('.', ' ')
+        if reference != 'aws':
+            reference = 'aws ' + reference
+        doc.writeln('.. _%s:' % reference)
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):
@@ -143,6 +162,9 @@ class CLIDocumentEventHandler(object):
 
 
 class ProviderDocumentEventHandler(CLIDocumentEventHandler):
+
+    def doc_breadcrumbs(self, help_command, event_name, **kwargs):
+        pass
 
     def doc_synopsis_start(self, help_command, **kwargs):
         doc = help_command.doc
@@ -215,10 +237,6 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
     def doc_options_end(self, help_command, **kwargs):
         pass
 
-    def doc_title(self, help_command, **kwargs):
-        doc = help_command.doc
-        doc.style.h1(help_command.name)
-
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc
         service = help_command.obj
@@ -255,22 +273,6 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         for operation in operation.service.operations:
             d[operation.name] = operation.cli_name
         return d
-
-    def doc_breadcrumbs(self, help_command, event_name, **kwargs):
-        doc = help_command.doc
-        if doc.target != 'man':
-            l = event_name.split('.')
-            if len(l) > 1:
-                service_name = l[1]
-                doc.write('[ ')
-                doc.style.ref('aws', '../index')
-                doc.write(' . ')
-                doc.style.ref(service_name, 'index')
-                doc.write(' ]')
-
-    def doc_title(self, help_command, **kwargs):
-        doc = help_command.doc
-        doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -407,7 +407,7 @@ class ServiceCommand(CLICommand):
                                   obj=service_object,
                                   command_table=command_table,
                                   arg_table=None,
-                                  event_class='Operation',
+                                  event_class='.'.join(self.lineage_names),
                                   name=self._name)
 
     def _create_parser(self):
@@ -544,7 +544,7 @@ class ServiceOperation(object):
         return OperationHelpCommand(
             self._service_object.session, self._service_object,
             self._operation_object, arg_table=self.arg_table,
-            name=self._name, event_class=self._parent_name)
+            name=self._name, event_class='.'.join(self.lineage_names))
 
     def _add_help(self, parser):
         # The 'help' output is processed a little differently from

--- a/awscli/customizations/addexamples.py
+++ b/awscli/customizations/addexamples.py
@@ -39,9 +39,8 @@ def add_examples(help_command, **kwargs):
             os.path.dirname(
                 os.path.abspath(__file__))), 'examples')
     doc_path = os.path.join(doc_path,
-                            help_command.event_class)
-    file_name = '%s.rst' % (help_command.name)
-    doc_path = os.path.join(doc_path, file_name)
+                            help_command.event_class.replace('.', os.path.sep))
+    doc_path = doc_path + '.rst'
     LOG.debug("Looking for example file at: %s", doc_path)
     if os.path.isfile(doc_path):
         help_command.doc.style.h2('Examples')

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -291,8 +291,6 @@ class BasicCommand(CLICommand):
 
 
 class BasicHelp(HelpCommand):
-    event_class = 'command'
-
     def __init__(self, session, command_object, command_table, arg_table,
                  event_handler_class=None):
         super(BasicHelp, self).__init__(session, command_object,
@@ -324,6 +322,10 @@ class BasicHelp(HelpCommand):
     @property
     def examples(self):
         return self._get_doc_contents('_examples')
+
+    @property
+    def event_class(self):
+        return '.'.join(self.obj.lineage_names)
 
     def _get_doc_contents(self, attr_name):
         value = getattr(self, attr_name)

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -59,7 +59,7 @@ def register_customizations(cli):
     cli.register(
         'building-command-table.datapipeline',
         register_commands)
-    cli.register(
+    cli.register_last(
         'doc-output.datapipeline.get-pipeline-definition',
         document_translation)
 

--- a/awscli/customizations/dryrundocs.py
+++ b/awscli/customizations/dryrundocs.py
@@ -23,7 +23,7 @@ DOCS = ('<p>Checks whether you have the required permissions for the '
 
 
 def register_dryrun_docs(cli):
-    cli.register('doc-option-example.ec2.*.dry-run', add_docs)
+    cli.register('doc-option-example.ec2.*.*.dry-run', add_docs)
 
 
 def add_docs(help_command, **kwargs):

--- a/awscli/customizations/dryrundocs.py
+++ b/awscli/customizations/dryrundocs.py
@@ -23,7 +23,7 @@ DOCS = ('<p>Checks whether you have the required permissions for the '
 
 
 def register_dryrun_docs(cli):
-    cli.register('doc-option-example.ec2.*.*.dry-run', add_docs)
+    cli.register('doc-option-example.ec2.*.dry-run', add_docs)
 
 
 def add_docs(help_command, **kwargs):

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -253,7 +253,7 @@ class ProviderHelpCommand(HelpCommand):
 
     @property
     def event_class(self):
-        return 'Provider'
+        return 'aws'
 
     @property
     def name(self):

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -16,6 +16,12 @@ import mock
 from awscli.customizations.commands import BasicHelp, BasicCommand
 
 
+class MockCustomCommand(BasicCommand):
+        NAME = 'mock'
+
+        SUBCOMMANDS = [{'name': 'basic', 'command_class': BasicCommand}]
+
+
 class TestCommandLoader(unittest.TestCase):
 
     def test_basic_help_with_contents(self):
@@ -61,11 +67,6 @@ class TestBasicCommand(unittest.TestCase):
         self.assertEqual(self.command.lineage_names, [self.command.name])
 
     def test_pass_lineage_to_child_command(self):
-        class MockCustomCommand(BasicCommand):
-            NAME = 'mock'
-
-            SUBCOMMANDS = [{'name': 'basic', 'command_class': BasicCommand}]
-
         self.command = MockCustomCommand(self.session)
         subcommand = self.command.subcommand_table['basic']
         lineage = subcommand.lineage
@@ -76,3 +77,14 @@ class TestBasicCommand(unittest.TestCase):
             subcommand.lineage_names,
             [self.command.name, subcommand.name]
         )
+
+    def test_event_class(self):
+        self.command = MockCustomCommand(self.session)
+        help_command = self.command.create_help_command()
+        self.assertEqual(help_command.event_class, 'mock')
+        subcommand = self.command.subcommand_table['basic']
+        sub_help_command = subcommand.create_help_command()
+        # Note that the name of this Subcommand was never changed even
+        # though it was put into the table as ``basic``. If no name
+        # is overriden it uses the name ``commandname``.
+        self.assertEqual(sub_help_command.event_class, 'mock.commandname')

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -137,12 +137,14 @@ class TestWaitHelpOutput(BaseAWSHelpOutputTest):
 
     def test_wait_help_command(self):
         self.driver.main(['ec2', 'wait', 'help'])
+        self.assert_contains('.. _aws ec2 wait:')
         self.assert_contains('Wait until a particular condition is satisfied.')
         self.assert_contains('* instance-running')
         self.assert_contains('* vpc-available')
 
     def test_wait_state_help_command(self):
         self.driver.main(['ec2', 'wait', 'instance-running', 'help'])
+        self.assert_contains('.. _aws ec2 wait instance-running:')
         self.assert_contains('``describe-instances``')
         self.assert_contains('[--filters <value>]')
         self.assert_contains('``--filters`` (list)')

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -137,14 +137,14 @@ class TestWaitHelpOutput(BaseAWSHelpOutputTest):
 
     def test_wait_help_command(self):
         self.driver.main(['ec2', 'wait', 'help'])
-        self.assert_contains('.. _aws ec2 wait:')
+        self.assert_contains('.. _cli:aws ec2 wait:')
         self.assert_contains('Wait until a particular condition is satisfied.')
         self.assert_contains('* instance-running')
         self.assert_contains('* vpc-available')
 
     def test_wait_state_help_command(self):
         self.driver.main(['ec2', 'wait', 'instance-running', 'help'])
-        self.assert_contains('.. _aws ec2 wait instance-running:')
+        self.assert_contains('.. _cli:aws ec2 wait instance-running:')
         self.assert_contains('``describe-instances``')
         self.assert_contains('[--filters <value>]')
         self.assert_contains('``--filters`` (list)')

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -30,6 +30,8 @@ import mock
 class TestHelpOutput(BaseAWSHelpOutputTest):
     def test_output(self):
         self.driver.main(['help'])
+        # Check for the reference label.
+        self.assert_contains('.. _aws:')
         self.assert_contains('***\naws\n***')
         self.assert_contains(
             'The AWS Command Line Interface is a unified tool '
@@ -51,6 +53,8 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
 
     def test_service_help_output(self):
         self.driver.main(['ec2', 'help'])
+        # Check for the reference label.
+        self.assert_contains('.. _aws ec2:')
         # We should see the section title for the service.
         self.assert_contains('***\nec2\n***')
         # With a description header.
@@ -62,11 +66,25 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
 
     def test_operation_help_output(self):
         self.driver.main(['ec2', 'run-instances', 'help'])
+        # Check for the reference label.
+        self.assert_contains('.. _aws ec2 run-instances:')
         # Should see the title with the operation name
         self.assert_contains('*************\nrun-instances\n*************')
         # Should contain part of the help text from the model.
         self.assert_contains('Launches the specified number of instances')
         self.assert_contains('``--count`` (string)')
+
+    def test_custom_service_help_output(self):
+        self.driver.main(['s3', 'help'])
+        self.assert_contains('.. _aws s3:')
+        self.assert_contains('high-level S3 commands')
+        self.assert_contains('* cp')
+
+    def test_custom_operation_help_output(self):
+        self.driver.main(['s3', 'ls', 'help'])
+        self.assert_contains('.. _aws s3 ls:')
+        self.assert_contains('List S3 objects')
+        self.assert_contains('--summarize')
 
     def test_arguments_with_example_json_syntax(self):
         self.driver.main(['ec2', 'run-instances', 'help'])

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -31,7 +31,7 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
     def test_output(self):
         self.driver.main(['help'])
         # Check for the reference label.
-        self.assert_contains('.. _aws:')
+        self.assert_contains('.. _cli:aws:')
         self.assert_contains('***\naws\n***')
         self.assert_contains(
             'The AWS Command Line Interface is a unified tool '
@@ -54,7 +54,7 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
     def test_service_help_output(self):
         self.driver.main(['ec2', 'help'])
         # Check for the reference label.
-        self.assert_contains('.. _aws ec2:')
+        self.assert_contains('.. _cli:aws ec2:')
         # We should see the section title for the service.
         self.assert_contains('***\nec2\n***')
         # With a description header.
@@ -67,7 +67,7 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
     def test_operation_help_output(self):
         self.driver.main(['ec2', 'run-instances', 'help'])
         # Check for the reference label.
-        self.assert_contains('.. _aws ec2 run-instances:')
+        self.assert_contains('.. _cli:aws ec2 run-instances:')
         # Should see the title with the operation name
         self.assert_contains('*************\nrun-instances\n*************')
         # Should contain part of the help text from the model.
@@ -76,13 +76,13 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
 
     def test_custom_service_help_output(self):
         self.driver.main(['s3', 'help'])
-        self.assert_contains('.. _aws s3:')
+        self.assert_contains('.. _cli:aws s3:')
         self.assert_contains('high-level S3 commands')
         self.assert_contains('* cp')
 
     def test_custom_operation_help_output(self):
         self.driver.main(['s3', 'ls', 'help'])
-        self.assert_contains('.. _aws s3 ls:')
+        self.assert_contains('.. _cli:aws s3 ls:')
         self.assert_contains('List S3 objects')
         self.assert_contains('--summarize')
 

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -108,7 +108,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
             help_cmd.doc.getvalue().decode('utf-8'),
-            '[ :ref:`aws <aws>` ]'
+            '[ :ref:`aws <cli:aws>` ]'
         )
 
     def test_breadcrumbs_service_command_html(self):
@@ -121,7 +121,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
             help_cmd.doc.getvalue().decode('utf-8'),
-            '[ :ref:`aws <aws>` ]'
+            '[ :ref:`aws <cli:aws>` ]'
         )
 
     def test_breadcrumbs_operation_command_html(self):
@@ -134,7 +134,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
             help_cmd.doc.getvalue().decode('utf-8'),
-            '[ :ref:`aws <aws>` . :ref:`ec2 <aws ec2>` ]'
+            '[ :ref:`aws <cli:aws>` . :ref:`ec2 <cli:aws ec2>` ]'
         )
 
     def test_breadcrumbs_wait_command_html(self):
@@ -147,6 +147,6 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
             help_cmd.doc.getvalue().decode('utf-8'),
-            ('[ :ref:`aws <aws>` . :ref:`s3api <aws s3api>`'
-             ' . :ref:`wait <aws s3api wait>` ]')
+            ('[ :ref:`aws <cli:aws>` . :ref:`s3api <cli:aws s3api>`'
+             ' . :ref:`wait <cli:aws s3api wait>` ]')
         )

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -12,7 +12,9 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
 
-from awscli.clidocs import OperationDocumentEventHandler
+from awscli.clidocs import OperationDocumentEventHandler, \
+    CLIDocumentEventHandler
+from awscli.help import ServiceHelpCommand
 from botocore.model import ShapeResolver, StructureShape
 
 import mock
@@ -72,3 +74,79 @@ class TestRecursiveShapes(unittest.TestCase):
         self.help_command.obj = operation
         self.operation_handler.doc_output(self.help_command, 'event-name')
         self.assert_rendered_docs_contain('( ... recursive ... )')
+
+
+class TestCLIDocumentEventHandler(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock()
+        self.obj = None
+        self.command_table = {}
+        self.arg_table = {}
+        self.name = 'my-command'
+        self.event_class = 'aws'
+
+    def test_breadcrumbs_man(self):
+        # Create an arbitrary help command class. This was chosen
+        # because it is fairly easy to instantiate.
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, self.event_class
+        )
+
+        doc_handler = CLIDocumentEventHandler(help_cmd)
+        doc_handler.doc_breadcrumbs(help_cmd)
+        # These should not show up in the man page
+        self.assertEqual(help_cmd.doc.getvalue().decode('utf-8'), '')
+
+    def test_breadcrumbs_html(self):
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, self.event_class
+        )
+        help_cmd.doc.target = 'html'
+        doc_handler = CLIDocumentEventHandler(help_cmd)
+        doc_handler.doc_breadcrumbs(help_cmd)
+        self.assertEqual(
+            help_cmd.doc.getvalue().decode('utf-8'),
+            '[ :ref:`aws <aws>` ]'
+        )
+
+    def test_breadcrumbs_service_command_html(self):
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, 'ec2'
+        )
+        help_cmd.doc.target = 'html'
+        doc_handler = CLIDocumentEventHandler(help_cmd)
+        doc_handler.doc_breadcrumbs(help_cmd)
+        self.assertEqual(
+            help_cmd.doc.getvalue().decode('utf-8'),
+            '[ :ref:`aws <aws>` ]'
+        )
+
+    def test_breadcrumbs_operation_command_html(self):
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, 'ec2.run-instances'
+        )
+        help_cmd.doc.target = 'html'
+        doc_handler = CLIDocumentEventHandler(help_cmd)
+        doc_handler.doc_breadcrumbs(help_cmd)
+        self.assertEqual(
+            help_cmd.doc.getvalue().decode('utf-8'),
+            '[ :ref:`aws <aws>` . :ref:`ec2 <aws ec2>` ]'
+        )
+
+    def test_breadcrumbs_wait_command_html(self):
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, 's3api.wait.object-exists'
+        )
+        help_cmd.doc.target = 'html'
+        doc_handler = CLIDocumentEventHandler(help_cmd)
+        doc_handler.doc_breadcrumbs(help_cmd)
+        self.assertEqual(
+            help_cmd.doc.getvalue().decode('utf-8'),
+            ('[ :ref:`aws <aws>` . :ref:`s3api <aws s3api>`'
+             ' . :ref:`wait <aws s3api wait>` ]')
+        )

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -766,6 +766,15 @@ class TestServiceCommand(unittest.TestCase):
                          [self.cmd, child_cmd])
         self.assertEqual(child_cmd.lineage_names, ['foo', 'list-objects'])
 
+    def test_help_event_class(self):
+        # Ensures it sends the right event name to the help command
+        help_command = self.cmd.create_help_command()
+        self.assertEqual(help_command.event_class, 'foo')
+        child_cmd = help_command.command_table['list-objects']
+        # Check the ``ServiceOperation`` class help command as well
+        child_help_cmd = child_cmd.create_help_command()
+        self.assertEqual(child_help_cmd.event_class, 'foo.list-objects')
+
 
 class TestServiceOperation(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR switches the ``event_class`` for the the various operation objects. A big problem with the current ``event_class`` attributes was that the values varied widely and were not consistent across help commands.

For example, the values varied from ``Provider`` to ``Operation`` to an abreviation to a service and even just a straight ``command`` for the custom commands.

I switched it so that the event classes rely on a command's lineage for ``event_class`` with the names of the commands in the lineage delimited by periods here are some examples:

* ``aws ec2 help`` --> ``ec2``
* ``aws s3 cp`` --> ``s3.cp``
* ``aws s3api wait object-exists`` --> ``s3api.wait.object-exists``

The end event name that bcdoc fires looks a little weird in the end because bcdoc makes assumptions on how the ``event_class`` is formatted. I can make a subsequent pull request to fix that.

However by using this format in event_class it does several things for us:

1) All of the breadcrumbs are fixed. Here are some before and after pictures of some commands:


before (no breadcrumb):
![screen shot 2015-02-13 at 3 45 56 pm](https://cloud.githubusercontent.com/assets/4605355/6197263/75939936-b397-11e4-9561-ce31bf4d8154.png)
after (breadcrumb is there):
![screen shot 2015-02-13 at 3 47 14 pm](https://cloud.githubusercontent.com/assets/4605355/6197274/9e2bad5c-b397-11e4-8ff3-6834e3dc9867.png)

before (custom commands had weird names):
![screen shot 2015-02-13 at 3 48 02 pm](https://cloud.githubusercontent.com/assets/4605355/6197280/b9a857ce-b397-11e4-9090-6093dbc027d1.png)
after (name is corrected):
![screen shot 2015-02-13 at 3 48 39 pm](https://cloud.githubusercontent.com/assets/4605355/6197283/ce5218f4-b397-11e4-883f-766074e4420e.png)

before (waiters missed some of the commands):
![screen shot 2015-02-13 at 3 49 27 pm](https://cloud.githubusercontent.com/assets/4605355/6197290/ebe35cfc-b397-11e4-8bf5-595290d977fa.png)
after (all commands are included):
![screen shot 2015-02-13 at 3 50 15 pm](https://cloud.githubusercontent.com/assets/4605355/6197295/08401480-b398-11e4-8303-bcba2aeb0bbb.png)


2) Allow us to use ``:ref:`` syntax throughout the cli documentation. I added a reference label to the top of
each reference documentation title. The labels take the form of ``.. _aws [command] ...:``. This allows you to reference the command using the sphynx ``:ref:`` syntax which I switched the breadcrumbs to use.

Note that there are 4 commits in this PR. The first two are directly from this PR: https://github.com/aws/aws-cli/pull/1148. So you do not need to look at those changes for this PR, just for the other PR.

cc @jamesls @danielgtaylor 
