### PR TITLE
Clarify pronouns for --cli-input-json

### DIFF
--- a/awscli/customizations/cliinputjson.py
+++ b/awscli/customizations/cliinputjson.py
@@ -41,8 +41,8 @@ class CliInputJSONArgument(OverrideRequiredArgsArgument):
         'help_text': 'Performs service operation based on the JSON string '
                      'provided. The JSON string follows the format provided '
                      'by ``--generate-cli-skeleton``. If other arguments are '
-                     'provided on the command line, it will not clobber their '
-                     'values.'
+                     'provided on the command line, the CLI values will override '
+                     'the JSON-provided values.'
     }
 
     def __init__(self, operation_object):


### PR DESCRIPTION
It was not clear what the "it" and "their" pronouns here referred, making it unclear whether the JSON values overrode the CLI values or vice-versa. To make it clear, explicit references to the CLI and JSON values were used instead.

Also it's clearer to express what *will* happen ("will override") instead of the old docs which expressed what *didn't* happen ("won't clobber").