### PR TITLE
Switch s3 ls to use clients

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -266,12 +266,20 @@ def get_endpoint(service, region, endpoint_url, verify):
                                 verify=verify)
 
 
+def get_client(session, region, endpoint_url, verify):
+    return session.create_client('s3', region_name=region,
+                                 endpoint_url=endpoint_url, verify=verify)
+
+
 class S3Command(BasicCommand):
     def _run_main(self, parsed_args, parsed_globals):
         self.service = self._session.get_service('s3')
         self.endpoint = get_endpoint(self.service, parsed_globals.region,
                                      parsed_globals.endpoint_url,
                                      parsed_globals.verify_ssl)
+        self.client = get_client(self._session, parsed_globals.region,
+                                 parsed_globals.endpoint_url,
+                                 parsed_globals.verify_ssl)
 
 
 class ListCommand(S3Command):
@@ -321,11 +329,11 @@ class ListCommand(S3Command):
             return 0
 
     def _list_all_objects(self, bucket, key, page_size=None):
-        operation = self.service.get_operation('ListObjects')
-        iterator = operation.paginate(self.endpoint, bucket=bucket,
-                                      prefix=key, delimiter='/',
+        paginator = self.client.get_paginator('list_objects')
+        iterator = paginator.paginate(Bucket=bucket,
+                                      Prefix=key, Delimiter='/',
                                       page_size=page_size)
-        for _, response_data in iterator:
+        for response_data in iterator:
             self._display_page(response_data)
 
     def _display_page(self, response_data, use_basename=True):
@@ -356,8 +364,7 @@ class ListCommand(S3Command):
         self._at_first_page = False
 
     def _list_all_buckets(self):
-        operation = self.service.get_operation('ListBuckets')
-        response_data = operation.call(self.endpoint)[1]
+        response_data = self.client.list_buckets()
         buckets = response_data['Buckets']
         for bucket in buckets:
             last_mod_str = self._make_last_mod_str(bucket['CreationDate'])
@@ -365,10 +372,10 @@ class ListCommand(S3Command):
             uni_print(print_str)
 
     def _list_all_objects_recursive(self, bucket, key, page_size=None):
-        operation = self.service.get_operation('ListObjects')
-        iterator = operation.paginate(self.endpoint, bucket=bucket,
-                                      prefix=key, page_size=page_size)
-        for _, response_data in iterator:
+        paginator = self.client.get_paginator('list_objects')
+        iterator = paginator.paginate(Bucket=bucket,
+                                      Prefix=key, page_size=page_size)
+        for response_data in iterator:
             self._display_page(response_data, use_basename=False)
 
     def _check_no_objects(self):

--- a/tests/unit/customizations/s3/test_ls_command.py
+++ b/tests/unit/customizations/s3/test_ls_command.py
@@ -26,8 +26,8 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
         # want a recursive listing.
-        self.assertEqual(call_args['prefix'], '')
-        self.assertEqual(call_args['bucket'], 'bucket')
+        self.assertEqual(call_args['Prefix'], '')
+        self.assertEqual(call_args['Bucket'], 'bucket')
         self.assertNotIn('delimiter', call_args)
         # Time is stored in UTC timezone, but the actual time displayed
         # is specific to your tzinfo, so shift the timezone to your local's.
@@ -49,8 +49,8 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
         # want a recursive listing.
-        self.assertEqual(call_args['prefix'], '')
-        self.assertEqual(call_args['bucket'], 'bucket')
+        self.assertEqual(call_args['Prefix'], '')
+        self.assertEqual(call_args['Bucket'], 'bucket')
         # The page size gets translated to ``MaxKeys`` in the s3 model
         self.assertEqual(call_args['MaxKeys'], 8)
 
@@ -63,11 +63,11 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
         # want a recursive listing.
-        self.assertEqual(call_args['prefix'], '')
-        self.assertEqual(call_args['bucket'], 'bucket')
+        self.assertEqual(call_args['Prefix'], '')
+        self.assertEqual(call_args['Bucket'], 'bucket')
         # The page size gets translated to ``MaxKeys`` in the s3 model
         self.assertEqual(call_args['MaxKeys'], 8)
-        self.assertNotIn('delimiter', call_args)
+        self.assertNotIn('Delimiter', call_args)
 
     def test_success_rc_has_prefixes_and_objects(self):
         time_utc = "2014-01-09T20:45:49.000Z"


### PR DESCRIPTION
This is part of the switch of the ``s3`` commands to clients. I only switched the ``ls`` command to use clients. All other ``s3`` commands use operation objects.

cc @danielgtaylor @jamesls 