### PR TITLE
add warning to cloudwatch put-metric-alarm

### DIFF
--- a/awscli/examples/cloudwatch/put-metric-alarm.rst
+++ b/awscli/examples/cloudwatch/put-metric-alarm.rst
@@ -4,4 +4,4 @@ The following example uses the ``put-metric-alarm`` command to send an Amazon Si
 
   aws cloudwatch put-metric-alarm --alarm-name cpu-mon --alarm-description "Alarm when CPU exceeds 70 percent" --metric-name CPUUtilization --namespace AWS/EC2 --statistic Average --period 300 --threshold 70 --comparison-operator GreaterThanThreshold  --dimensions  Name=InstanceId,Value=i-12345678 --evaluation-periods 2 --alarm-actions arn:aws:sns:us-east-1:111122223333:MyTopic --unit Percent
 
-This command returns to the prompt if successful.
+This command returns to the prompt if successful. If an alarm with the same name already exists, it will be overwritten by the new alarm.


### PR DESCRIPTION
Command overwrites existing alarms.