### PR TITLE
Switch to clients for S3 filegenerator

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -314,7 +314,6 @@ class FileGenerator(object):
             if e.http_status_code == 404:
                 # The key does not exist so we'll raise a more specific
                 # error message here.
-                copy_fields['error_code'] = 'NoSuchKey'
                 copy_fields['error_message'] = 'Key "%s" does not exist' % key
             else:
                 reason = six.moves.http_client.responses[

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -636,7 +636,7 @@ class CommandArchitecture(object):
         self._source_client = self._client
         if self.parameters['source_region']:
             if self.parameters['paths_type'] == 's3s3':
-                self._source_endpoint = get_client(
+                self._source_client = get_client(
                     self.session,
                     region=self.parameters['source_region'][0],
                     endpoint_url=None,
@@ -734,13 +734,12 @@ class CommandArchitecture(object):
         }
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type][self.cmd]
-        file_generator = FileGenerator(self._service,
-                                       self._source_endpoint,
+        file_generator = FileGenerator(self._source_client,
                                        operation_name,
                                        self.parameters['follow_symlinks'],
                                        self.parameters['page_size'],
                                        result_queue=result_queue)
-        rev_generator = FileGenerator(self._service, self._endpoint, '',
+        rev_generator = FileGenerator(self._client, '',
                                       self.parameters['follow_symlinks'],
                                       self.parameters['page_size'],
                                       result_queue=result_queue)

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -633,7 +633,7 @@ class CommandArchitecture(object):
             endpoint_url=self.parameters['endpoint_url'],
             verify=self.parameters['verify_ssl']
         )
-        self._source_client = self._client
+        self._source_client = self._client.clone_client()
         if self.parameters['source_region']:
             if self.parameters['paths_type'] == 's3s3':
                 self._source_client = get_client(

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -266,12 +266,20 @@ def get_endpoint(service, region, endpoint_url, verify):
                                 verify=verify)
 
 
+def get_client(session, region, endpoint_url, verify):
+    return session.create_client('s3', region_name=region,
+                                 endpoint_url=endpoint_url, verify=verify)
+
+
 class S3Command(BasicCommand):
     def _run_main(self, parsed_args, parsed_globals):
         self.service = self._session.get_service('s3')
         self.endpoint = get_endpoint(self.service, parsed_globals.region,
                                      parsed_globals.endpoint_url,
                                      parsed_globals.verify_ssl)
+        self.client = get_client(self._session, parsed_globals.region,
+                                 parsed_globals.endpoint_url,
+                                 parsed_globals.verify_ssl)
 
 
 class ListCommand(S3Command):
@@ -321,11 +329,11 @@ class ListCommand(S3Command):
             return 0
 
     def _list_all_objects(self, bucket, key, page_size=None):
-        operation = self.service.get_operation('ListObjects')
-        iterator = operation.paginate(self.endpoint, bucket=bucket,
-                                      prefix=key, delimiter='/',
+        paginator = self.client.get_paginator('list_objects')
+        iterator = paginator.paginate(Bucket=bucket,
+                                      Prefix=key, Delimiter='/',
                                       page_size=page_size)
-        for _, response_data in iterator:
+        for response_data in iterator:
             self._display_page(response_data)
 
     def _display_page(self, response_data, use_basename=True):
@@ -356,8 +364,7 @@ class ListCommand(S3Command):
         self._at_first_page = False
 
     def _list_all_buckets(self):
-        operation = self.service.get_operation('ListBuckets')
-        response_data = operation.call(self.endpoint)[1]
+        response_data = self.client.list_buckets()
         buckets = response_data['Buckets']
         for bucket in buckets:
             last_mod_str = self._make_last_mod_str(bucket['CreationDate'])
@@ -365,10 +372,10 @@ class ListCommand(S3Command):
             uni_print(print_str)
 
     def _list_all_objects_recursive(self, bucket, key, page_size=None):
-        operation = self.service.get_operation('ListObjects')
-        iterator = operation.paginate(self.endpoint, bucket=bucket,
-                                      prefix=key, page_size=page_size)
-        for _, response_data in iterator:
+        paginator = self.client.get_paginator('list_objects')
+        iterator = paginator.paginate(Bucket=bucket,
+                                      Prefix=key, page_size=page_size)
+        for response_data in iterator:
             self._display_page(response_data, use_basename=False)
 
     def _check_no_objects(self):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -482,6 +482,7 @@ class S3TransferCommand(S3Command):
                                   cmd_params.parameters,
                                   runtime_config)
         cmd.set_endpoints()
+        cmd.set_clients()
         cmd.create_instructions()
         return cmd.run()
 
@@ -605,6 +606,8 @@ class CommandArchitecture(object):
         self._service = self.session.get_service('s3')
         self._endpoint = None
         self._source_endpoint = None
+        self._client = None
+        self._source_client = None
 
     def set_endpoints(self):
         self._endpoint = get_endpoint(
@@ -618,6 +621,23 @@ class CommandArchitecture(object):
             if self.parameters['paths_type'] == 's3s3':
                 self._source_endpoint = get_endpoint(
                     self._service,
+                    region=self.parameters['source_region'][0],
+                    endpoint_url=None,
+                    verify=self.parameters['verify_ssl']
+                )
+
+    def set_clients(self):
+        self._client = get_client(
+            self.session,
+            region=self.parameters['region'],
+            endpoint_url=self.parameters['endpoint_url'],
+            verify=self.parameters['verify_ssl']
+        )
+        self._source_client = self._client
+        if self.parameters['source_region']:
+            if self.parameters['paths_type'] == 's3s3':
+                self._source_endpoint = get_client(
+                    self.session,
                     region=self.parameters['source_region'][0],
                     endpoint_url=None,
                     verify=self.parameters['verify_ssl']

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -472,8 +472,7 @@ class BucketLister(object):
         with ScopedEventHandler(self._client.meta.events,
                                 'after-call.s3.ListObjects',
                                 self._decode_keys,
-                                'BucketListerDecodeKeys',
-                                True):
+                                'BucketListerDecodeKeys'):
             paginator = self._client.get_paginator('list_objects')
             pages = paginator.paginate(**kwargs)
             for page in pages:
@@ -493,23 +492,19 @@ class BucketLister(object):
 class ScopedEventHandler(object):
     """Register an event callback for the duration of a scope."""
 
-    def __init__(self, event_emitter, event_name, handler, unique_id=None,
-                 unique_id_uses_count=False):
+    def __init__(self, event_emitter, event_name, handler, unique_id=None):
         self._event_emitter = event_emitter
         self._event_name = event_name
         self._handler = handler
         self._unique_id = unique_id
-        self._unique_id_uses_count = unique_id_uses_count
 
     def __enter__(self):
         self._event_emitter.register(self._event_name, self._handler,
-                                     self._unique_id,
-                                     self._unique_id_uses_count)
+                                     self._unique_id)
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._event_emitter.unregister(self._event_name, self._handler,
-                                       self._unique_id,
-                                       self._unique_id_uses_count)
+                                       self._unique_id)
 
 
 class PrintTask(namedtuple('PrintTask',

--- a/tests/integration/customizations/s3/test_filegenerator.py
+++ b/tests/integration/customizations/s3/test_filegenerator.py
@@ -36,8 +36,7 @@ class S3FileGeneratorIntTest(unittest.TestCase):
         factory.set_parser_defaults(
             blob_parser=lambda x: x,
             timestamp_parser=lambda x: x)
-        self.service = self.session.get_service('s3')
-        self.endpoint = self.service.get_endpoint('us-east-1')
+        self.client = self.session.create_client('s3', region_name='us-east-1')
         self.bucket = make_s3_files(self.session)
         self.file1 = self.bucket + '/' + 'text1.txt'
         self.file2 = self.bucket + '/' + 'another_directory/text2.txt'
@@ -55,8 +54,7 @@ class S3FileGeneratorIntTest(unittest.TestCase):
                          'dir_op': False, 'use_src_name': False}
         expected_file_size = 15
         result_list = list(
-            FileGenerator(self.service, self.endpoint, '').call(
-                input_s3_file))
+            FileGenerator(self.client, '').call(input_s3_file))
         file_stat = FileStat(src=self.file1, dest='text1.txt',
                              compare_key='text1.txt',
                              size=expected_file_size,
@@ -78,8 +76,7 @@ class S3FileGeneratorIntTest(unittest.TestCase):
                          'dest': {'path': '', 'type': 'local'},
                          'dir_op': True, 'use_src_name': True}
         result_list = list(
-            FileGenerator(self.service, self.endpoint, '').call(
-                input_s3_file))
+            FileGenerator(self.client, '').call(input_s3_file))
         file_stat = FileStat(src=self.file2,
                              dest='another_directory' + os.sep + 'text2.txt',
                              compare_key='another_directory/text2.txt',
@@ -110,9 +107,7 @@ class S3FileGeneratorIntTest(unittest.TestCase):
                          'dest': {'path': '', 'type': 'local'},
                          'dir_op': True, 'use_src_name': True}
         result_list = list(
-            FileGenerator(self.service, self.endpoint,
-                          'delete').call(
-                input_s3_file))
+            FileGenerator(self.client, 'delete').call(input_s3_file))
 
         file_stat1 = FileStat(
             src=self.bucket + '/another_directory/',
@@ -149,7 +144,7 @@ class S3FileGeneratorIntTest(unittest.TestCase):
         input_s3_file = {'src': {'path': self.bucket+'/', 'type': 's3'},
                          'dest': {'path': '', 'type': 'local'},
                          'dir_op': True, 'use_src_name': True}
-        file_gen = FileGenerator(self.service, self.endpoint, '',
+        file_gen = FileGenerator(self.client, '',
                                  page_size=1).call(input_s3_file)
         limited_file_gen = itertools.islice(file_gen, 1)
         result_list = list(limited_file_gen)

--- a/tests/unit/customizations/s3/fake_session.py
+++ b/tests/unit/customizations/s3/fake_session.py
@@ -79,6 +79,9 @@ class FakeSession(object):
                    unique_id_uses_call=False):
         pass
 
+    def create_client(self, **kwargs):
+        pass
+
 
 class FakeService(object):
     """

--- a/tests/unit/customizations/s3/fake_session.py
+++ b/tests/unit/customizations/s3/fake_session.py
@@ -79,9 +79,6 @@ class FakeSession(object):
                    unique_id_uses_call=False):
         pass
 
-    def create_client(self, **kwargs):
-        pass
-
 
 class FakeService(object):
     """

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -96,7 +96,7 @@ class LocalFileGeneratorTest(unittest.TestCase):
         self.local_dir = six.text_type(os.path.abspath('.') +
                                        os.sep + 'some_directory' +
                                        os.sep)
-        self.client = mock.Mock()
+        self.client = None
         self.files = make_loc_files()
 
     def tearDown(self):
@@ -136,7 +136,7 @@ class LocalFileGeneratorTest(unittest.TestCase):
                                     'type': 's3'},
                            'dir_op': True, 'use_src_name': True}
         params = {'region': 'us-east-1'}
-        files = FileGenerator(self.client,'').call(input_local_dir)
+        files = FileGenerator(self.client, '').call(input_local_dir)
         result_list = []
         for filename in files:
             result_list.append(filename)
@@ -168,7 +168,7 @@ class TestIgnoreFilesLocally(unittest.TestCase):
     skipping symlink when desired.
     """
     def setUp(self):
-        self.client = mock.Mock()
+        self.client = None
         self.files = FileCreator()
 
     def tearDown(self):
@@ -216,7 +216,7 @@ class TestThrowsWarning(unittest.TestCase):
     def setUp(self):
         self.files = FileCreator()
         self.root = self.files.rootdir
-        self.client = mock.Mock()
+        self.client = None
 
     def tearDown(self):
         self.files.remove_all()
@@ -279,7 +279,7 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
     broken symlinks fail.
     """
     def setUp(self):
-        self.client = mock.Mock()
+        self.client = None
         self.files = FileCreator()
         # List of local filenames.
         self.filenames = []
@@ -461,7 +461,7 @@ class TestNormalizeSort(unittest.TestCase):
         filegenerator.normalize_sort(names, os.path.sep, '/')
         for i in range(len(ref_names)):
             self.assertEqual(ref_names[i], names[i])
-    
+
     def test_normalize_sort_backslash(self):
         names = ['xyz123456789',
                  'xyz1\\test',

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 import platform
-from awscli.testutils import unittest, FileCreator
+from awscli.testutils import unittest, FileCreator, BaseAWSCommandParamsTest
 import stat
 import tempfile
 import shutil
@@ -24,10 +24,8 @@ import mock
 from awscli.customizations.s3.filegenerator import FileGenerator, \
     FileDecodingError, FileStat, is_special_file, is_readable
 from awscli.customizations.s3.utils import get_file_stat
-import botocore.session
 from tests.unit.customizations.s3 import make_loc_files, clean_loc_files, \
-    make_s3_files, s3_cleanup, compare_files
-from tests.unit.customizations.s3.fake_session import FakeSession
+    compare_files
 
 
 @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
@@ -98,9 +96,7 @@ class LocalFileGeneratorTest(unittest.TestCase):
         self.local_dir = six.text_type(os.path.abspath('.') +
                                        os.sep + 'some_directory' +
                                        os.sep)
-        self.session = FakeSession()
-        self.service = self.session.get_service('s3')
-        self.endpoint = self.service.get_endpoint('us-east-1')
+        self.client = mock.Mock()
         self.files = make_loc_files()
 
     def tearDown(self):
@@ -116,8 +112,7 @@ class LocalFileGeneratorTest(unittest.TestCase):
                                      'type': 's3'},
                             'dir_op': False, 'use_src_name': False}
         params = {'region': 'us-east-1'}
-        files = FileGenerator(self.service,
-                              self.endpoint, '').call(input_local_file)
+        files = FileGenerator(self.client, '').call(input_local_file)
         result_list = []
         for filename in files:
             result_list.append(filename)
@@ -141,8 +136,7 @@ class LocalFileGeneratorTest(unittest.TestCase):
                                     'type': 's3'},
                            'dir_op': True, 'use_src_name': True}
         params = {'region': 'us-east-1'}
-        files = FileGenerator(self.service,
-                              self.endpoint,'').call(input_local_dir)
+        files = FileGenerator(self.client,'').call(input_local_dir)
         result_list = []
         for filename in files:
             result_list.append(filename)
@@ -174,9 +168,7 @@ class TestIgnoreFilesLocally(unittest.TestCase):
     skipping symlink when desired.
     """
     def setUp(self):
-        self.session = FakeSession()
-        self.service = self.session.get_service('s3')
-        self.endpoint = self.service.get_endpoint('us-east-1')
+        self.client = mock.Mock()
         self.files = FileCreator()
 
     def tearDown(self):
@@ -185,8 +177,7 @@ class TestIgnoreFilesLocally(unittest.TestCase):
     def test_warning(self):
         path = os.path.join(self.files.rootdir, 'badsymlink')
         os.symlink('non-existent-file', path)
-        filegenerator = FileGenerator(self.service, self.endpoint,
-                                      '', True)
+        filegenerator = FileGenerator(self.client, '', True)
         self.assertTrue(filegenerator.should_ignore_file(path))
 
     def test_skip_symlink(self):
@@ -196,8 +187,7 @@ class TestIgnoreFilesLocally(unittest.TestCase):
                                contents='foo.txt contents')
         sym_path = os.path.join(self.files.rootdir, 'symlink')
         os.symlink(filename, sym_path)
-        filegenerator = FileGenerator(self.service, self.endpoint,
-                                      '', False)
+        filegenerator = FileGenerator(self.client, '', False)
         self.assertTrue(filegenerator.should_ignore_file(sym_path))
 
     def test_no_skip_symlink(self):
@@ -207,8 +197,7 @@ class TestIgnoreFilesLocally(unittest.TestCase):
                                       contents='foo.txt contents')
         sym_path = os.path.join(self.files.rootdir, 'symlink')
         os.symlink(path, sym_path)
-        filegenerator = FileGenerator(self.service, self.endpoint,
-                                      '', True)
+        filegenerator = FileGenerator(self.client, '', True)
         self.assertFalse(filegenerator.should_ignore_file(sym_path))
         self.assertFalse(filegenerator.should_ignore_file(path))
 
@@ -218,8 +207,7 @@ class TestIgnoreFilesLocally(unittest.TestCase):
         os.mkdir(path)
         sym_path = os.path.join(self.files.rootdir, 'symlink')
         os.symlink(path, sym_path)
-        filegenerator = FileGenerator(self.service, self.endpoint,
-                                      '', True)
+        filegenerator = FileGenerator(self.client, '', True)
         self.assertFalse(filegenerator.should_ignore_file(sym_path))
         self.assertFalse(filegenerator.should_ignore_file(path))
 
@@ -228,15 +216,13 @@ class TestThrowsWarning(unittest.TestCase):
     def setUp(self):
         self.files = FileCreator()
         self.root = self.files.rootdir
-        self.session = FakeSession()
-        self.service = self.session.get_service('s3')
-        self.endpoint = self.service.get_endpoint('us-east-1')
+        self.client = mock.Mock()
 
     def tearDown(self):
         self.files.remove_all()
 
     def test_no_warning(self):
-        file_gen = FileGenerator(self.service, self.endpoint, '', False)
+        file_gen = FileGenerator(self.client, '', False)
         self.files.create_file("foo.txt", contents="foo")
         full_path = os.path.join(self.root, "foo.txt")
         return_val = file_gen.triggers_warning(full_path)
@@ -244,7 +230,7 @@ class TestThrowsWarning(unittest.TestCase):
         self.assertTrue(file_gen.result_queue.empty())
 
     def test_no_exists(self):
-        file_gen = FileGenerator(self.service, self.endpoint, '', False)
+        file_gen = FileGenerator(self.client, '', False)
         filename = os.path.join(self.root, 'file')
         return_val = file_gen.triggers_warning(filename)
         self.assertTrue(return_val)
@@ -254,7 +240,7 @@ class TestThrowsWarning(unittest.TestCase):
                           filename))
 
     def test_no_read_access(self):
-        file_gen = FileGenerator(self.service, self.endpoint, '', False)
+        file_gen = FileGenerator(self.client, '', False)
         self.files.create_file("foo.txt", contents="foo")
         full_path = os.path.join(self.root, "foo.txt")
         open_function = 'awscli.customizations.s3.filegenerator._open'
@@ -270,7 +256,7 @@ class TestThrowsWarning(unittest.TestCase):
     @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
                      'Special files only supported on mac/linux')
     def test_is_special_file_warning(self):
-        file_gen = FileGenerator(self.service, self.endpoint, '', False)
+        file_gen = FileGenerator(self.client, '', False)
         file_path = os.path.join(self.files.rootdir, 'foo')
         # Use socket for special file.
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -293,9 +279,7 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
     broken symlinks fail.
     """
     def setUp(self):
-        self.session = FakeSession()
-        self.service = self.session.get_service('s3')
-        self.endpoint = self.service.get_endpoint('us-east-1')
+        self.client = mock.Mock()
         self.files = FileCreator()
         # List of local filenames.
         self.filenames = []
@@ -339,8 +323,7 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
                            'dest': {'path': self.bucket,
                                     'type': 's3'},
                            'dir_op': True, 'use_src_name': True}
-        file_stats = FileGenerator(self.service, self.endpoint,
-                                   '', False).call(input_local_dir)
+        file_stats = FileGenerator(self.client, '', False).call(input_local_dir)
         self.filenames.sort()
         result_list = []
         for file_stat in file_stats:
@@ -361,9 +344,8 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
                            'dest': {'path': self.bucket,
                                     'type': 's3'},
                            'dir_op': True, 'use_src_name': True}
-        file_stats = FileGenerator(self.service, self.endpoint,
-                                   '', True).call(input_local_dir)
-        file_gen = FileGenerator(self.service, self.endpoint, '', True)
+        file_stats = FileGenerator(self.client, '', True).call(input_local_dir)
+        file_gen = FileGenerator(self.client, '', True)
         file_stats = file_gen.call(input_local_dir)
         all_filenames = self.filenames + self.symlink_files
         all_filenames.sort()
@@ -386,8 +368,7 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
                            'dest': {'path': self.bucket,
                                     'type': 's3'},
                            'dir_op': True, 'use_src_name': True}
-        file_stats = FileGenerator(self.service, self.endpoint,
-                                   '', True).call(input_local_dir)
+        file_stats = FileGenerator(self.client, '', True).call(input_local_dir)
         all_filenames = self.filenames + self.symlink_files
         all_filenames.sort()
         result_list = []
@@ -492,17 +473,13 @@ class TestNormalizeSort(unittest.TestCase):
             self.assertEqual(ref_names[i], names[i])
 
 
-class S3FileGeneratorTest(unittest.TestCase):
+class S3FileGeneratorTest(BaseAWSCommandParamsTest):
     def setUp(self):
-        self.session = FakeSession()
-        self.bucket = make_s3_files(self.session)
+        super(S3FileGeneratorTest, self).setUp()
+        self.client = self.driver.session.create_client('s3')
+        self.bucket = 'foo'
         self.file1 = self.bucket + '/' + 'text1.txt'
         self.file2 = self.bucket + '/' + 'another_directory/text2.txt'
-        self.service = self.session.get_service('s3')
-        self.endpoint = self.service.get_endpoint('us-east-1')
-
-    def tearDown(self):
-        s3_cleanup(self.bucket, self.session)
 
     def test_s3_file(self):
         """
@@ -513,7 +490,11 @@ class S3FileGeneratorTest(unittest.TestCase):
                          'dest': {'path': 'text1.txt', 'type': 'local'},
                          'dir_op': False, 'use_src_name': False}
         params = {'region': 'us-east-1'}
-        file_gen = FileGenerator(self.service, self.endpoint, '')
+        self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
+                                  "LastModified": "2014-01-09T20:45:49.000Z"}]
+        self.patch_make_request()
+
+        file_gen = FileGenerator(self.client, '')
         files = file_gen.call(input_s3_file)
         result_list = []
         for filename in files:
@@ -540,8 +521,15 @@ class S3FileGeneratorTest(unittest.TestCase):
                          'dest': {'path': '', 'type': 'local'},
                          'dir_op': True, 'use_src_name': True}
         params = {'region': 'us-east-1'}
-        files = FileGenerator(self.service, self.endpoint,
-                              '').call(input_s3_file)
+        files = FileGenerator(self.client, '').call(input_s3_file)
+
+        self.parsed_responses = [{
+            "CommonPrefixes": [], "Contents": [
+                {"Key": "another_directory/text2.txt", "Size": 100,
+                 "LastModified": "2014-01-09T20:45:49.000Z"},
+                {"Key": "text1.txt", "Size": 10,
+                 "LastModified": "2013-01-09T20:45:49.000Z"}]}]
+        self.patch_make_request()
         result_list = []
         for filename in files:
             result_list.append(filename)
@@ -575,8 +563,16 @@ class S3FileGeneratorTest(unittest.TestCase):
         input_s3_file = {'src': {'path': self.bucket + '/', 'type': 's3'},
                          'dest': {'path': '', 'type': 'local'},
                          'dir_op': True, 'use_src_name': True}
-        files = FileGenerator(self.service, self.endpoint,
-                              'delete').call(input_s3_file)
+        self.parsed_responses = [{
+            "CommonPrefixes": [], "Contents": [
+                {"Key": "another_directory/", "Size": 0,
+                 "LastModified": "2012-01-09T20:45:49.000Z"},
+                {"Key": "another_directory/text2.txt", "Size": 100,
+                 "LastModified": "2014-01-09T20:45:49.000Z"},
+                {"Key": "text1.txt", "Size": 10,
+                 "LastModified": "2013-01-09T20:45:49.000Z"}]}]
+        self.patch_make_request()
+        files = FileGenerator(self.client, 'delete').call(input_s3_file)
         result_list = []
         for filename in files:
             result_list.append(filename)

--- a/tests/unit/customizations/s3/test_ls_command.py
+++ b/tests/unit/customizations/s3/test_ls_command.py
@@ -26,8 +26,8 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
         # want a recursive listing.
-        self.assertEqual(call_args['prefix'], '')
-        self.assertEqual(call_args['bucket'], 'bucket')
+        self.assertEqual(call_args['Prefix'], '')
+        self.assertEqual(call_args['Bucket'], 'bucket')
         self.assertNotIn('delimiter', call_args)
         # Time is stored in UTC timezone, but the actual time displayed
         # is specific to your tzinfo, so shift the timezone to your local's.
@@ -49,8 +49,8 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
         # want a recursive listing.
-        self.assertEqual(call_args['prefix'], '')
-        self.assertEqual(call_args['bucket'], 'bucket')
+        self.assertEqual(call_args['Prefix'], '')
+        self.assertEqual(call_args['Bucket'], 'bucket')
         # The page size gets translated to ``MaxKeys`` in the s3 model
         self.assertEqual(call_args['MaxKeys'], 8)
 
@@ -63,11 +63,11 @@ class TestLSCommand(BaseAWSCommandParamsTest):
         call_args = self.operations_called[0][1]
         # We should not be calling the args with any delimiter because we
         # want a recursive listing.
-        self.assertEqual(call_args['prefix'], '')
-        self.assertEqual(call_args['bucket'], 'bucket')
+        self.assertEqual(call_args['Prefix'], '')
+        self.assertEqual(call_args['Bucket'], 'bucket')
         # The page size gets translated to ``MaxKeys`` in the s3 model
         self.assertEqual(call_args['MaxKeys'], 8)
-        self.assertNotIn('delimiter', call_args)
+        self.assertNotIn('Delimiter', call_args)
 
     def test_success_rc_has_prefixes_and_objects(self):
         time_utc = "2014-01-09T20:45:49.000Z"

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -76,7 +76,7 @@ class TestRbCommand(unittest.TestCase):
         with mock.patch(cmd_name) as rm_command:
             with mock.patch(arch_name):
                 rb_command._run_main(parsed_args,
-                                    parsed_globals=parsed_globals)
+                                     parsed_globals=parsed_globals)
             # Because of --force we should have called the
             # rm_command with the --recursive option.
             rm_command.return_value.assert_called_with(
@@ -89,8 +89,7 @@ class TestLSCommand(unittest.TestCase):
         self.session.create_client.return_value.list_buckets.return_value\
             = {'Buckets': []}
         self.session.create_client.return_value.get_paginator.return_value\
-                .paginate.return_value = [
-                    {'Contents': [], 'CommonPrefixes': []}]
+            .paginate.return_value = [{'Contents': [], 'CommonPrefixes': []}]
 
     def test_ls_command_for_bucket(self):
         ls_command = ListCommand(self.session)
@@ -101,7 +100,7 @@ class TestLSCommand(unittest.TestCase):
         ls_command._run_main(parsed_args, parsed_globals)
         call = self.session.create_client.return_value.list_objects
         paginate = self.session.create_client.return_value.get_paginator\
-                .return_value.paginate
+            .return_value.paginate
         # We should make no operation calls.
         self.assertEqual(call.call_count, 0)
         # And only a single pagination call to ListObjects.
@@ -203,7 +202,6 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         session.create_client.called_once_with(
             's3', region_name='us-west-1', endpoint_url=None, verify=None
         )
-
 
     def test_set_client_with_source(self):
         session = Mock()
@@ -395,9 +393,9 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         self.assertIn(output_str, self.output.getvalue())
 
     def test_run_cp_copy(self):
-        # This ensures that the architecture sets up correctly for a ``cp`` copy
-        # command.  It is just just a dry run, but all of the components need
-        # to be wired correctly for it to work.
+        # This ensures that the architecture sets up correctly for a ``cp``
+        # copy command.  It is just just a dry run, but all of the
+        # components need to be wired correctly for it to work.
         s3_file = 's3://' + self.bucket + '/' + 'text1.txt'
         filters = [['--include', '*']]
         params = {'dir_op': False, 'dryrun': True, 'quiet': False,
@@ -681,7 +679,9 @@ class HelpDocTest(BaseAWSHelpOutputTest):
         parsed_global = parser.parse_args(['--paginate'])
         help_command = s3.create_help_command()
         help_command([], parsed_global)
-        self.assert_contains("This section explains prominent concepts and notations in the set of high-level S3 commands provided.")
+        self.assert_contains(
+            "This section explains prominent concepts "
+            "and notations in the set of high-level S3 commands provided.")
         self.assert_contains("Every command takes one or two positional")
         self.assert_contains("* rb")
 

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -193,6 +193,40 @@ class CommandArchitectureTest(S3HandlerBaseTest):
         self.assertEqual(endpoint.region_name, 'us-west-1')
         self.assertEqual(source_endpoint.region_name, 'us-west-2')
 
+    def test_set_client_no_source(self):
+        session = Mock()
+        cmd_arc = CommandArchitecture(session, 'sync',
+                                      {'region': 'us-west-1',
+                                       'endpoint_url': None,
+                                       'verify_ssl': None,
+                                       'source_region': None})
+        cmd_arc.set_clients()
+        session.create_client.called_once_with(
+            's3', region_name='us-west-1', endpoint_url=None, verify=None
+        )
+
+
+    def test_set_client_with_source(self):
+        session = Mock()
+        cmd_arc = CommandArchitecture(session, 'sync',
+                                      {'region': 'us-west-1',
+                                       'endpoint_url': None,
+                                       'verify_ssl': None,
+                                       'paths_type': 's3s3',
+                                       'source_region': ['us-west-2']})
+        cmd_arc.set_clients()
+        create_client_args = session.create_client.call_args_list
+        # Assert that two clients were created
+        self.assertEqual(len(create_client_args), 2)
+        self.assertEqual(
+            create_client_args[0][1],
+            {'region_name': 'us-west-1', 'verify': None, 'endpoint_url': None}
+        )
+        self.assertEqual(
+            create_client_args[1][1],
+            {'region_name': 'us-west-2', 'verify': None, 'endpoint_url': None}
+        )
+
     def test_create_instructions(self):
         """
         This tests to make sure the instructions for any command is generated

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -202,6 +202,10 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         session.create_client.called_once_with(
             's3', region_name='us-west-1', endpoint_url=None, verify=None
         )
+        # The client also should have been cloned for the source client
+        # since no source region was provided.
+        self.assertEqual(
+            session.create_client.return_value.clone_client.call_count, 1)
 
     def test_set_client_with_source(self):
         session = Mock()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -343,9 +343,9 @@ class TestScopedEventHandler(unittest.TestCase):
         scoped = ScopedEventHandler(event_emitter, 'eventname', 'handler')
         with scoped:
             event_emitter.register.assert_called_with(
-                'eventname', 'handler', None, False)
+                'eventname', 'handler', None)
         event_emitter.unregister.assert_called_with(
-            'eventname', 'handler', None, False)
+            'eventname', 'handler', None)
 
     def test_scoped_event_unique(self):
         event_emitter = mock.Mock()
@@ -353,9 +353,9 @@ class TestScopedEventHandler(unittest.TestCase):
             event_emitter, 'eventname', 'handler', 'unique')
         with scoped:
             event_emitter.register.assert_called_with(
-                'eventname', 'handler', 'unique', False)
+                'eventname', 'handler', 'unique')
         event_emitter.unregister.assert_called_with(
-            'eventname', 'handler', 'unique', False)
+            'eventname', 'handler', 'unique')
 
 
 class TestGetFileStat(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -296,11 +296,10 @@ class TestBucketList(unittest.TestCase):
                 {'LastModified': '2014-02-27T04:20:38.000Z',
                  'Key': 'a', 'Size': 1},
                 {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': 'b', 'Size': 2},]},
+                 'Key': 'b', 'Size': 2}]},
             {'Contents': [
                 {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': 'c', 'Size': 3},
-             ]},
+                 'Key': 'c', 'Size': 3}]}
         ]
         lister = BucketLister(self.client, self.date_parser)
         objects = list(lister.list_objects(bucket='foo'))
@@ -379,8 +378,7 @@ class TestGetFileStat(unittest.TestCase):
                 f.fromtimestamp.side_effect = ValueError(
                     "timestamp out of range for platform "
                     "localtime()/gmtime() function")
-                with self.assertRaisesRegexp(
-                    ValueError, 'myfilename\.txt'):
+                with self.assertRaisesRegexp(ValueError, 'myfilename\.txt'):
                     get_file_stat('myfilename.txt')
 
 


### PR DESCRIPTION
This pull request switches the ``FileGenerator`` class for the s3 commands to rely on clients as opposed to operation objects. Ignore the first commit about the ``ls`` commands as that is just a commit from another pull request that I needed for this one: https://github.com/aws/aws-cli/pull/1156

I next plan to make the change to clients in the ``S3Handler`` and ``FileInfo`` classes. And then completely remove all functions that are related to operation objects in the s3 command code.

cc @jamesls @danielgtaylor 