### PR TITLE
Use CloudTrail's regionalized policy templates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* feature:``aws cloudtrail``: Add support for regionalized policy templates
+  for the ``create-subscription`` and ``update-subscription`` commands.
+  (`issue 1167 <https://github.com/aws/aws-cli/pull/1167>`__)
+
 1.7.12
 ======
 

--- a/awscli/customizations/cloudtrail.py
+++ b/awscli/customizations/cloudtrail.py
@@ -24,6 +24,10 @@ S3_POLICY_TEMPLATE = 'policy/S3/AWSCloudTrail-S3BucketPolicy-2014-12-17.json'
 SNS_POLICY_TEMPLATE = 'policy/SNS/AWSCloudTrail-SnsTopicPolicy-2014-12-17.json'
 
 
+class CloudTrailError(Exception):
+    pass
+
+
 def initialize(cli):
     """
     The entry point for CloudTrail high level commands.
@@ -191,13 +195,11 @@ class CloudTrailSubscribe(BasicCommand):
             data = self.s3.GetObject(
                 bucket='awscloudtrail-policy-' + self.region_name,
                 key=key_name)
-            policy = data['Body'].read().decode('utf-8')
-        except Exception:
-            LOG.error('Unable to get regional policy template for'
-                      ' region %s: %s', self.region_name, key_name)
-            raise
-
-        return policy
+            return data['Body'].read().decode('utf-8')
+        except Exception as e:
+            raise CloudTrailError(
+                'Unable to get regional policy template for'
+                ' region %s: %s. Error: %s', self.region_name, key_name, e)
 
     def setup_new_bucket(self, bucket, prefix, policy_url=None):
         """

--- a/awscli/customizations/cloudtrail.py
+++ b/awscli/customizations/cloudtrail.py
@@ -191,12 +191,13 @@ class CloudTrailSubscribe(BasicCommand):
             data = self.s3.GetObject(
                 bucket='awscloudtrail-policy-' + self.region_name,
                 key=key_name)
+            policy = data['Body'].read().decode('utf-8')
         except Exception:
             LOG.error('Unable to get regional policy template for'
                       ' region %s: %s', self.region_name, key_name)
             raise
 
-        return data['Body'].read().decode('utf-8')
+        return policy
 
     def setup_new_bucket(self, bucket, prefix, policy_url=None):
         """


### PR DESCRIPTION
This change switches away from always using an S3 bucket in `us-west-2`
to fetch CloudTrail policy information for S3 and SNS when setting up
new buckets/topics and instead uses the `awscloudtrail-policy-REGION`
regionalized buckets. It also updates the policy version to use the
most recent release.

Tests are updated and a couple new ones make sure the regionalized
buckets are used.

cc @jamesls @kyleknap 

Note: this code still needs to be updated to use clients, but that seems
like it should be a separate task.