### PR TITLE
Honor --endpoint-url in s3/s3api commands

### DIFF
--- a/awscli/customizations/s3endpoint.py
+++ b/awscli/customizations/s3endpoint.py
@@ -42,4 +42,4 @@ def on_top_level_args_parsed(parsed_args, event_handler, **kwargs):
     # is disabled.
     if parsed_args.command in ['s3', 's3api'] and \
             parsed_args.endpoint_url is not None:
-        event_handler.unregister('before-auth.s3', fix_s3_host)
+        event_handler.unregister('before-sign.s3', fix_s3_host)

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1636,5 +1636,25 @@ class TestNoSignRequests(BaseS3CLICommand):
         self.assert_no_errors(p)
 
 
+class TestHonorsEndpointUrl(BaseS3CLICommand):
+    def test_verify_endpoint_url_is_used(self):
+        # We're going to verify this indirectly by looking at the
+        # debug logs.  The endpoint url we specify should be in the
+        # debug logs, and the endpoint url that botocore would have
+        # used if we didn't provide the endpoint-url should not
+        # be in the debug logs.  The other alternative is to actually
+        # watch what connetions are made in the process, which is not
+        # easy.
+        p = aws('s3 ls s3://dnscompat/ '
+                '--endpoint-url http://localhost:51515 '
+                '--debug')
+        debug_logs = p.stderr
+        original_hostname = 'dnscompat.s3.amazonaws.com'
+        expected = 'localhost'
+        self.assertNotIn(original_hostname, debug_logs,
+                         '--endpoint-url is being ignored in s3 commands.')
+        self.assertIn(expected, debug_logs)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/test_s3endpoint.py
+++ b/tests/unit/customizations/test_s3endpoint.py
@@ -25,7 +25,7 @@ class TestS3EndpointURL(unittest.TestCase):
         args.command = 's3'
         event_handler = mock.Mock()
         on_top_level_args_parsed(args, event_handler)
-        event_handler.unregister.assert_called_with('before-auth.s3', fix_s3_host)
+        event_handler.unregister.assert_called_with('before-sign.s3', fix_s3_host)
 
     def test_unregister_not_called_for_no_endpoint(self):
         args = mock.Mock()


### PR DESCRIPTION
Fixes #1142.

The issue was that the before-auth event was removed in the
internal botocore auth refactor (between 1.7.4-1.7.5), but
this handler was not updated.  I've added an integration
test that should catch this issue in the future.

cc @kyleknap @danielgtaylor 