### PR TITLE
Fix issue with parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Next Release (TBD)
 * feature:``aws cloudtrail``: Add support for regionalized policy templates
   for the ``create-subscription`` and ``update-subscription`` commands.
   (`issue 1167 <https://github.com/aws/aws-cli/pull/1167>`__)
+* bugfix:parsing: Fix issue where if there is a square bracket inside one
+  of the values of a list, the end character would get removed.
+  (`issue 1183 <https://github.com/aws/aws-cli/pull/1183>`__)
+
 
 1.7.12
 ======

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -85,7 +85,7 @@ def _eat_items(value, iter_parts, part, end_char, replace_char=''):
         except StopIteration:
             raise ValueError(value)
         chunks.append(current.replace(replace_char, ''))
-        if end_char in current:
+        if end_char == current[-1]:
             break
     return ','.join(chunks)
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -85,7 +85,7 @@ def _eat_items(value, iter_parts, part, end_char, replace_char=''):
         except StopIteration:
             raise ValueError(value)
         chunks.append(current.replace(replace_char, ''))
-        if end_char == current[-1]:
+        if current.endswith(end_char):
             break
     return ','.join(chunks)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -82,3 +82,7 @@ class TestCSVSplit(unittest.TestCase):
     def test_bracket_in_middle(self):
         self.assertEqual(split_on_commas('foo,bar=a[b][c],baz'),
                          ['foo', 'bar=a[b][c]', 'baz'])
+
+    def test_end_bracket_in_value(self):
+        self.assertEqual(split_on_commas('foo,bar=[foo,*[biz]*,baz]'),
+                         ['foo', 'bar=foo,*[biz]*,baz'])


### PR DESCRIPTION
Issue was if there is a ] inside one of the values of a list, the end character would get removed. So something like ``foo=[bar, *[biz]*, bar]`` would get parsed to ``foo=bar,*[biz],bar``. To get that to work, you would have to use escape characters.

Note that we still run into the issue where the argument is ``foo=[bar,[biz],bar]``, it will be translated to ``foo=bar,[biz,bar`` and the escape character would need to be used to get the correct format. To fix that, that will take a much larger change in how we parse input.

cc @jamesls @danielgtaylor 