### PR TITLE
Convert cloudtrail customization over to clients.

### DIFF
--- a/awscli/customizations/cloudtrail.py
+++ b/awscli/customizations/cloudtrail.py
@@ -15,8 +15,8 @@ import logging
 import sys
 
 from awscli.customizations.commands import BasicCommand
-from awscli.customizations.service import Service
 from botocore.vendored import requests
+from botocore.exceptions import ClientError
 
 
 LOG = logging.getLogger(__name__)
@@ -82,36 +82,37 @@ class CloudTrailSubscribe(BasicCommand):
         # Run the command and report success
         self._call(args, parsed_globals)
 
-        return 1
+        return 0
 
     def setup_services(self, args, parsed_globals):
-        endpoint_args = {
+        client_args = {
             'region_name': None,
-            'endpoint_url': None,
             'verify': None
         }
-        if 'region' in parsed_globals:
-            endpoint_args['region_name'] = parsed_globals.region
-        if 'verify_ssl' in parsed_globals:
-            endpoint_args['verify'] = parsed_globals.verify_ssl
+        if parsed_globals.region is not None:
+            client_args['region_name'] = parsed_globals.region
+        if parsed_globals.verify_ssl is not None:
+            client_args['verify'] = parsed_globals.verify_ssl
 
         # Initialize services
         LOG.debug('Initializing S3, SNS and CloudTrail...')
-        self.iam = Service('iam', endpoint_args=endpoint_args,
-                           session=self._session)
-        self.s3 = Service('s3', endpoint_args=endpoint_args,
-                          session=self._session)
-        self.sns = Service('sns', endpoint_args=endpoint_args,
-                           session=self._session)
+        self.iam = self._session.create_client('iam', **client_args)
+        self.s3 = self._session.create_client('s3', **client_args)
+        self.sns = self._session.create_client('sns', **client_args)
+        # This unregister call will go away once the client switchover
+        # is done, but for now we're relying on S3 catching a ClientError
+        # when we check if a bucket exists, so we need to ensure the
+        # botocore ClientError is raised instead of the CLI's error handler.
+        self.s3.meta.events.unregister('after-call',
+                                       unique_id='awscli-error-handler')
 
-        self.region_name = self.s3.endpoint.region_name
+        self.region_name = self.s3.meta.region_name
 
         # If the endpoint is specified, it is designated for the cloudtrail
         # service. Not all of the other services will use it.
-        if 'endpoint_url' in parsed_globals:
-            endpoint_args['endpoint_url'] = parsed_globals.endpoint_url
-        self.cloudtrail = Service('cloudtrail', endpoint_args=endpoint_args,
-                                  session=self._session)
+        if parsed_globals.endpoint_url is not None:
+            client_args['endpoint_url'] = parsed_globals.endpoint_url
+        self.cloudtrail = self._session.create_client('cloudtrail', **client_args)
 
     def _call(self, options, parsed_globals):
         """
@@ -136,8 +137,8 @@ class CloudTrailSubscribe(BasicCommand):
             if self.UPDATE and options.s3_prefix is None:
                 # Prefix was not passed and this is updating the S3 bucket,
                 # so let's find the existing prefix and use that if possible
-                res = self.cloudtrail.DescribeTrails(
-                    trail_name_list=[options.name])
+                res = self.cloudtrail.describe_trails(
+                    trailNameList=[options.name])
                 trail_info = res['trailList'][0]
 
                 if 'S3KeyPrefix' in trail_info:
@@ -159,7 +160,7 @@ class CloudTrailSubscribe(BasicCommand):
             except Exception:
                 # Roll back any S3 bucket creation
                 if options.s3_new_bucket:
-                    self.s3.DeleteBucket(bucket=options.s3_new_bucket)
+                    self.s3.delete_bucket(Bucket=options.s3_new_bucket)
                 raise
 
         try:
@@ -173,9 +174,9 @@ class CloudTrailSubscribe(BasicCommand):
         except Exception:
             # Roll back any S3 bucket / SNS topic creations
             if options.s3_new_bucket:
-                self.s3.DeleteBucket(bucket=options.s3_new_bucket)
+                self.s3.delete_bucket(Bucket=options.s3_new_bucket)
             if options.sns_new_topic:
-                self.sns.DeleteTopic(topic_arn=topic_result['TopicArn'])
+                self.sns.delete_topic(TopicArn=topic_result['TopicArn'])
             raise
 
         sys.stdout.write('CloudTrail configuration:\n{config}\n'.format(
@@ -192,9 +193,9 @@ class CloudTrailSubscribe(BasicCommand):
 
     def _get_policy(self, key_name):
         try:
-            data = self.s3.GetObject(
-                bucket='awscloudtrail-policy-' + self.region_name,
-                key=key_name)
+            data = self.s3.get_object(
+                Bucket='awscloudtrail-policy-' + self.region_name,
+                Key=key_name)
             return data['Body'].read().decode('utf-8')
         except Exception as e:
             raise CloudTrailError(
@@ -210,7 +211,7 @@ class CloudTrailSubscribe(BasicCommand):
             'Setting up new S3 bucket {bucket}...\n'.format(bucket=bucket))
 
         # Who am I?
-        response = self.iam.GetUser()
+        response = self.iam.get_user()
         account_id = response['User']['Arn'].split(':')[4]
 
         # Clean up the prefix - it requires a trailing slash if set
@@ -233,33 +234,29 @@ class CloudTrailSubscribe(BasicCommand):
 
         LOG.debug('Bucket policy:\n{0}'.format(policy))
 
-        # Make sure bucket doesn't already exist
-        # Warn but do not fail if ListBucket permissions
-        # are missing from the IAM role
         try:
-            buckets = self.s3.ListBuckets()['Buckets']
-        except Exception:
-            buckets = []
-            LOG.warn('Unable to list buckets, continuing...')
-
-        if [b for b in buckets if b['Name'] == bucket]:
+            self.s3.head_bucket(Bucket=bucket)
+        except ClientError:
+            # The bucket does not exists.  This is what we want.
+            pass
+        else:
             raise Exception('Bucket {bucket} already exists.'.format(
                 bucket=bucket))
 
         # If we are not using the us-east-1 region, then we must set
         # a location constraint on the new bucket.
-        params = {'bucket': bucket}
+        params = {'Bucket': bucket}
         if self.region_name != 'us-east-1':
             bucket_config = {'LocationConstraint': self.region_name}
-            params['create_bucket_configuration'] = bucket_config
+            params['CreateBucketConfiguration'] = bucket_config
 
-        data = self.s3.CreateBucket(**params)
+        data = self.s3.create_bucket(**params)
 
         try:
-            self.s3.PutBucketPolicy(bucket=bucket, policy=policy)
-        except Exception:
-            # Roll back bucket creation
-            self.s3.DeleteBucket(bucket=bucket)
+            self.s3.put_bucket_policy(Bucket=bucket, Policy=policy)
+        except ClientError:
+            # Roll back bucket creation.
+            self.s3.delete_bucket(Bucket=bucket)
             raise
 
         return data
@@ -273,14 +270,14 @@ class CloudTrailSubscribe(BasicCommand):
             'Setting up new SNS topic {topic}...\n'.format(topic=topic))
 
         # Who am I?
-        response = self.iam.GetUser()
+        response = self.iam.get_user()
         account_id = response['User']['Arn'].split(':')[4]
 
         # Make sure topic doesn't already exist
         # Warn but do not fail if ListTopics permissions
         # are missing from the IAM role?
         try:
-            topics = self.sns.ListTopics()['Topics']
+            topics = self.sns.list_topics()['Topics']
         except Exception:
             topics = []
             LOG.warn('Unable to list topics, continuing...')
@@ -289,7 +286,7 @@ class CloudTrailSubscribe(BasicCommand):
             raise Exception('Topic {topic} already exists.'.format(
                 topic=topic))
 
-        region = self.sns.endpoint.region_name
+        region = self.sns.meta.region_name
 
         # Get the SNS topic policy information to allow CloudTrail
         # write-access.
@@ -302,12 +299,12 @@ class CloudTrailSubscribe(BasicCommand):
                        .replace('<SNSTopicOwnerAccountId>', account_id)\
                        .replace('<SNSTopicName>', topic)
 
-        topic_result = self.sns.CreateTopic(name=topic)
+        topic_result = self.sns.create_topic(Name=topic)
 
         try:
             # Merge any existing topic policy with our new policy statements
-            topic_attr = self.sns.GetTopicAttributes(
-                topic_arn=topic_result['TopicArn'])
+            topic_attr = self.sns.get_topic_attributes(
+                TopicArn=topic_result['TopicArn'])
 
             policy = self.merge_sns_policy(topic_attr['Attributes']['Policy'],
                                            policy)
@@ -315,12 +312,12 @@ class CloudTrailSubscribe(BasicCommand):
             LOG.debug('Topic policy:\n{0}'.format(policy))
 
             # Set the topic policy
-            self.sns.SetTopicAttributes(topic_arn=topic_result['TopicArn'],
-                                        attribute_name='Policy',
-                                        attribute_value=policy)
+            self.sns.set_topic_attributes(TopicArn=topic_result['TopicArn'],
+                                          AttributeName='Policy',
+                                          AttributeValue=policy)
         except Exception:
             # Roll back topic creation
-            self.sns.DeleteTopic(topic_arn=topic_result['TopicArn'])
+            self.sns.delete_topic(TopicArn=topic_result['TopicArn'])
             raise
 
         return topic_result
@@ -342,9 +339,7 @@ class CloudTrailSubscribe(BasicCommand):
         """
         left_parsed = json.loads(left)
         right_parsed = json.loads(right)
-
         left_parsed['Statement'] += right_parsed['Statement']
-
         return json.dumps(left_parsed)
 
     def upsert_cloudtrail_config(self, name, bucket, prefix, topic, gse):
@@ -354,34 +349,28 @@ class CloudTrailSubscribe(BasicCommand):
         """
         sys.stdout.write('Creating/updating CloudTrail configuration...\n')
         config = {
-            'name': name
+            'Name': name
         }
-
         if bucket is not None:
-            config['s3_bucket_name'] = bucket
-
+            config['S3BucketName'] = bucket
         if prefix is not None:
-            config['s3_key_prefix'] = prefix
-
+            config['S3KeyPrefix'] = prefix
         if topic is not None:
-            config['sns_topic_name'] = topic
-
+            config['SnsTopicName'] = topic
         if gse is not None:
-            config['include_global_service_events'] = gse
-
+            config['IncludeGlobalServiceEvents'] = gse
         if not self.UPDATE:
-            self.cloudtrail.CreateTrail(**config)
+            self.cloudtrail.create_trail(**config)
         else:
-            self.cloudtrail.UpdateTrail(**config)
-
-        return self.cloudtrail.DescribeTrails()
+            self.cloudtrail.update_trail(**config)
+        return self.cloudtrail.describe_trails()
 
     def start_cloudtrail(self, name):
         """
         Start the CloudTrail service, which begins logging.
         """
         sys.stdout.write('Starting CloudTrail service...\n')
-        return self.cloudtrail.StartLogging(name=name)
+        return self.cloudtrail.start_logging(Name=name)
 
 
 class CloudTrailUpdate(CloudTrailSubscribe):

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -69,7 +69,8 @@ def awscli_initialize(event_handlers):
     # generic error handler.
     register_s3_error_msg(event_handlers)
     error_handler = ErrorHandler()
-    event_handlers.register('after-call', error_handler)
+    event_handlers.register('after-call', error_handler,
+                            unique_id='awscli-error-handler')
 #    # The following will get fired for every option we are
 #    # documenting.  It will attempt to add an example_fn on to
 #    # the parameter object if the parameter supports shorthand

--- a/tests/unit/customizations/test_cloudtrail.py
+++ b/tests/unit/customizations/test_cloudtrail.py
@@ -10,12 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
 import json
-import argparse
 
-from mock import ANY, Mock, patch, call
-import botocore.session
+from mock import ANY, Mock, call
 from botocore.client import ClientError
 
 from tests.unit.test_clidriver import FakeSession
@@ -151,7 +148,6 @@ class TestCloudTrailCommand(unittest.TestCase):
         self.subscribe.region_name = 'us-west-2'
         s3.head_bucket.side_effect = ClientError(
             {'Error': {'Code': '404', 'Message': ''}}, 'HeadBucket')
-
 
         self.subscribe.setup_new_bucket('test', 'logs')
 

--- a/tests/unit/customizations/test_cloudtrail.py
+++ b/tests/unit/customizations/test_cloudtrail.py
@@ -10,133 +10,155 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import argparse
-import botocore.session
-import json
 import os
-from awscli.compat import six
+import json
+import argparse
 
-from awscli.customizations.cloudtrail import CloudTrailError, \
-                                             CloudTrailSubscribe
-from awscli.customizations.service import Service
-from mock import ANY, Mock, patch
-from awscli.testutils import BaseAWSCommandParamsTest
+from mock import ANY, Mock, patch, call
+import botocore.session
+from botocore.client import ClientError
+
 from tests.unit.test_clidriver import FakeSession
+from awscli.compat import six
+from awscli.customizations import cloudtrail
+from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import unittest
 
 
-class TestCloudTrail(unittest.TestCase):
+class TestCloudTrailPlumbing(unittest.TestCase):
+    def test_initialization_registers_injector(self):
+        cli = Mock()
+        cloudtrail.initialize(cli)
+        cli.register.assert_called_with('building-command-table.cloudtrail',
+                                        cloudtrail.inject_commands)
+
+    def test_injection_adds_two_commands_to_cmd_table(self):
+        command_table = {}
+        session = Mock()
+        cloudtrail.inject_commands(command_table, session)
+        self.assertIn('create-subscription', command_table)
+        self.assertIn('update-subscription', command_table)
+
+
+class TestCreateSubscription(BaseAWSCommandParamsTest):
+    def test_create_subscription_has_zero_rc(self):
+        command = (
+            'cloudtrail create-subscription --s3-use-bucket foo --name bar')
+        stdout = self.run_cmd(command, expected_rc=0)[0]
+        # We don't want to overspecify here, but we'll do a quick check to make
+        # sure it says log delivery is happening.
+        self.assertIn('Logs will be delivered to foo', stdout)
+
+
+class TestCloudTrailCommand(unittest.TestCase):
     def setUp(self):
         self.session = FakeSession({'config_file': 'myconfigfile'})
-        self.subscribe = CloudTrailSubscribe(self.session)
+        self.subscribe = cloudtrail.CloudTrailSubscribe(self.session)
         self.subscribe.region_name = 'us-east-1'
 
         self.subscribe.iam = Mock()
-        self.subscribe.iam.GetUser = Mock(
+        self.subscribe.iam.get_user = Mock(
             return_value={'User': {'Arn': '::::123:456'}})
 
         self.subscribe.s3 = Mock()
-        self.subscribe.s3.endpoint = Mock()
-        self.subscribe.s3.endpoint.region_name = 'us-east-1'
+        self.subscribe.s3.meta.region_name = 'us-east-1'
         policy_template = six.BytesIO(six.b(u'{"Statement": []}'))
-        self.subscribe.s3.GetObject = Mock(
+        self.subscribe.s3.get_object = Mock(
             return_value={'Body': policy_template})
-        self.subscribe.s3.ListBuckets = Mock(
-            return_value={'Buckets': [{'Name': 'test2'}]})
+        self.subscribe.s3.head_bucket.return_value = {}
 
         self.subscribe.sns = Mock()
-        self.subscribe.sns.endpoint = Mock()
-        self.subscribe.sns.endpoint.region_name = 'us-east-1'
-        self.subscribe.sns.ListTopics = Mock(
+        self.subscribe.sns.meta.region_name = 'us-east-1'
+        self.subscribe.sns.list_topics = Mock(
             return_value={'Topics': [{'TopicArn': ':test2'}]})
-        self.subscribe.sns.CreateTopic = Mock(
+        self.subscribe.sns.create_topic = Mock(
             return_value={'TopicArn': 'foo'})
-        self.subscribe.sns.GetTopicAttributes = Mock(
+        self.subscribe.sns.get_topic_attributes = Mock(
             return_value={'Attributes': {'Policy': '{"Statement": []}'}})
 
-    def test_setup_services(self):
-        parsed_args = []
-        parsed_globals = argparse.Namespace()
-        parsed_globals.region = 'us-east-1'
-        parsed_globals.verify_ssl = 'foo'
-        parsed_globals.endpoint_url = 'https://cloudtrail.aws.com'
+    def test_clients_all_from_same_session(self):
+        session = Mock()
+        subscribe_command = cloudtrail.CloudTrailSubscribe(session)
+        parsed_globals = Mock(region=None, verify_ssl=None,
+                              endpoint_url=None)
+        subscribe_command.setup_services(None, parsed_globals)
+        create_client_calls = session.create_client.call_args_list
+        self.assertEqual(
+            create_client_calls, [
+                call('iam', verify=None, region_name=None),
+                call('s3', verify=None, region_name=None),
+                call('sns', verify=None, region_name=None),
+                call('cloudtrail', verify=None, region_name=None),
+            ]
+        )
+        # We should also remove the error handler for S3.
+        # This can be removed once the client switchover is done.
+        subscribe_command.s3.meta.events.unregister.assert_called_with(
+            'after-call', unique_id='awscli-error-handler')
 
-        ref_args = {
-            'region_name': parsed_globals.region,
-            'verify': parsed_globals.verify_ssl,
-            'endpoint_url': None
-        }
-
-        # Reset some of the mocks because we need some introspection on the
-        # session.
-        fake_service = Mock()
-        self.session = Mock()
-        self.session.get_service.return_value = fake_service
-        self.subscribe = CloudTrailSubscribe(self.session)
-
-        self.subscribe.setup_services(parsed_args, parsed_globals)
-
-        get_service_call_args = self.session.get_service.call_args_list
-        endpoint_call_args = fake_service.get_endpoint.call_args_list
-
-        # Ensure all of the services got called.
-        self.assertEqual('iam', get_service_call_args[0][0][0])
-        self.assertEqual('s3', get_service_call_args[1][0][0])
-        self.assertEqual('sns', get_service_call_args[2][0][0])
-        self.assertEqual('cloudtrail', get_service_call_args[3][0][0])
-
-        # Make sure the endpoints were called correctly
-        # The order is iam, s3, sns, cloudtrail based on ``get_service`` calls
-        # from above.
-        self.assertEqual(endpoint_call_args[0][1], ref_args)
-        self.assertEqual(endpoint_call_args[1][1], ref_args)
-        self.assertEqual(endpoint_call_args[2][1], ref_args)
-        # CloudTrail should be using the endpoint.
-        ref_args['endpoint_url'] = parsed_globals.endpoint_url
-        self.assertEqual(endpoint_call_args[3][1], ref_args)
-
-        # Ensure a region name was set on the command class
-        self.assertEqual(self.subscribe.region_name,
-                         fake_service.get_endpoint.return_value.region_name)
+    def test_endpoint_url_is_only_used_for_cloudtrail(self):
+        endpoint_url = 'https://mycloudtrail.awsamazon.com/'
+        session = Mock()
+        subscribe_command = cloudtrail.CloudTrailSubscribe(session)
+        parsed_globals = Mock(region=None, verify_ssl=None,
+                              endpoint_url=endpoint_url)
+        subscribe_command.setup_services(None, parsed_globals)
+        create_client_calls = session.create_client.call_args_list
+        self.assertEqual(
+            create_client_calls, [
+                call('iam', verify=None, region_name=None),
+                call('s3', verify=None, region_name=None),
+                call('sns', verify=None, region_name=None),
+                # Here we should inject the endpoint_url only for cloudtrail.
+                call('cloudtrail', verify=None, region_name=None,
+                     endpoint_url=endpoint_url),
+            ]
+        )
 
     def test_s3_create(self):
         iam = self.subscribe.iam
         s3 = self.subscribe.s3
+        s3.head_bucket.side_effect = ClientError(
+            {'Error': {'Code': '404', 'Message': ''}}, 'HeadBucket')
 
         self.subscribe.setup_new_bucket('test', 'logs')
 
-        iam.GetUser.assert_called()
+        iam.get_user.assert_called()
 
-        s3.GetObject.assert_called()
-        s3.ListBuckets.assert_called()
-        s3.CreateBucket.assert_called()
-        s3.PutBucketPolicy.assert_called()
+        s3.get_object.assert_called()
+        s3.create_bucket.assert_called()
+        s3.put_bucket_policy.assert_called()
 
-        s3.DeleteBucket.assert_not_called()
+        s3.delete_bucket.assert_not_called()
 
-        args, kwargs = s3.CreateBucket.call_args
+        args, kwargs = s3.create_bucket.call_args
         self.assertNotIn('create_bucket_configuration', kwargs)
 
     def test_s3_uses_regionalized_policy(self):
         s3 = self.subscribe.s3
+        s3.head_bucket.side_effect = ClientError(
+            {'Error': {'Code': '404', 'Message': ''}}, 'HeadBucket')
 
         self.subscribe.setup_new_bucket('test', 'logs')
 
-        s3.GetObject.assert_called_with(
-            bucket='awscloudtrail-policy-us-east-1', key=ANY)
+        s3.get_object.assert_called_with(
+            Bucket='awscloudtrail-policy-us-east-1', Key=ANY)
 
     def test_s3_create_non_us_east_1(self):
         # Because this is outside of us-east-1, it should create
         # a bucket configuration with a location constraint.
         s3 = self.subscribe.s3
         self.subscribe.region_name = 'us-west-2'
+        s3.head_bucket.side_effect = ClientError(
+            {'Error': {'Code': '404', 'Message': ''}}, 'HeadBucket')
+
 
         self.subscribe.setup_new_bucket('test', 'logs')
 
-        args, kwargs = s3.CreateBucket.call_args
-        self.assertIn('create_bucket_configuration', kwargs)
+        args, kwargs = s3.create_bucket.call_args
+        self.assertIn('CreateBucketConfiguration', kwargs)
 
-        bucket_config = kwargs['create_bucket_configuration']
+        bucket_config = kwargs['CreateBucketConfiguration']
         self.assertEqual(bucket_config['LocationConstraint'],
                          'us-west-2')
 
@@ -146,22 +168,22 @@ class TestCloudTrail(unittest.TestCase):
 
     def test_s3_create_set_policy_fail(self):
         s3 = self.subscribe.s3
-        orig = s3.PutBucketPolicy
-        s3.PutBucketPolicy = Mock(side_effect=Exception('Error!'))
+        orig = s3.put_bucket_policy
+        s3.put_bucket_policy = Mock(side_effect=Exception('Error!'))
 
         with self.assertRaises(Exception):
             self.subscribe.setup_new_bucket('test', 'logs')
 
-        s3.CreateBucket.assert_called()
-        s3.PutBucketPolicy.assert_called()
+        s3.create_bucket.assert_called()
+        s3.put_bucket_policy.assert_called()
         s3.DeleteBucket.assert_called()
 
-        s3.PutBucketPolicy = orig
+        s3.put_bucket_policy = orig
 
     def test_s3_get_policy_fail(self):
-        self.subscribe.s3.GetObject = Mock(side_effect=Exception('Foo!'))
+        self.subscribe.s3.get_object = Mock(side_effect=Exception('Foo!'))
 
-        with self.assertRaises(CloudTrailError) as cm:
+        with self.assertRaises(cloudtrail.CloudTrailError) as cm:
             self.subscribe.setup_new_bucket('test', 'logs')
 
         # Exception should contain its custom message, the region
@@ -174,13 +196,13 @@ class TestCloudTrail(unittest.TestCase):
             'Body': Mock()
         }
         response['Body'].read.side_effect = Exception('Error!')
-        self.subscribe.s3.GetObject.return_value = response
+        self.subscribe.s3.get_object.return_value = response
 
-        with self.assertRaises(CloudTrailError):
+        with self.assertRaises(cloudtrail.CloudTrailError):
             self.subscribe.setup_new_bucket('test', 'logs')
 
     def test_sns_get_policy_fail(self):
-        self.subscribe.s3.GetObject = Mock(side_effect=Exception('Error!'))
+        self.subscribe.s3.get_object = Mock(side_effect=Exception('Error!'))
 
         with self.assertRaises(Exception):
             self.subscribe.setup_new_bucket('test', 'logs')
@@ -191,20 +213,20 @@ class TestCloudTrail(unittest.TestCase):
 
         self.subscribe.setup_new_topic('test')
 
-        s3.GetObject.assert_called()
-        sns.ListTopics.assert_called()
-        sns.CreateTopic.assert_called()
-        sns.SetTopicAttributes.assert_called()
+        s3.get_object.assert_called()
+        sns.list_topics.assert_called()
+        sns.create_topic.assert_called()
+        sns.set_topic_attributes.assert_called()
 
-        sns.DeleteTopic.assert_not_called()
+        sns.delete_topic.assert_not_called()
 
     def test_sns_uses_regionalized_policy(self):
         s3 = self.subscribe.s3
 
         self.subscribe.setup_new_topic('test')
 
-        s3.GetObject.assert_called_with(
-            bucket='awscloudtrail-policy-us-east-1', key=ANY)
+        s3.get_object.assert_called_with(
+            Bucket='awscloudtrail-policy-us-east-1', Key=ANY)
 
     def test_sns_create_already_exists(self):
         with self.assertRaises(Exception):
@@ -212,18 +234,18 @@ class TestCloudTrail(unittest.TestCase):
 
     def test_cloudtrail_new_call_format(self):
         self.subscribe.cloudtrail = Mock()
-        self.subscribe.cloudtrail.CreateTrail = Mock(return_value={})
-        self.subscribe.cloudtrail.DescribeTrail = Mock(return_value={})
+        self.subscribe.cloudtrail.create_trail = Mock(return_value={})
+        self.subscribe.cloudtrail.describe_trail = Mock(return_value={})
 
         self.subscribe.upsert_cloudtrail_config('test', 'bucket', 'prefix',
                                                 'topic', True)
 
-        self.subscribe.cloudtrail.CreateTrail.assert_called_with(
-            name='test',
-            s3_bucket_name='bucket',
-            s3_key_prefix='prefix',
-            sns_topic_name='topic',
-            include_global_service_events=True
+        self.subscribe.cloudtrail.create_trail.assert_called_with(
+            Name='test',
+            S3BucketName='bucket',
+            S3KeyPrefix='prefix',
+            SnsTopicName='topic',
+            IncludeGlobalServiceEvents=True
         )
 
     def test_sns_policy_merge(self):
@@ -348,29 +370,3 @@ class TestCloudTrail(unittest.TestCase):
         merged = self.subscribe.merge_sns_policy(left, right)
 
         self.assertEqual(json.loads(expected), json.loads(merged))
-
-
-class TestCloudTrailSessions(BaseAWSCommandParamsTest):
-    def test_sessions(self):
-        """
-        Make sure that the session passed to our custom command
-        is the same session used when making service calls.
-        """
-        # Get a new session we will use to test
-        driver = self.driver
-
-        def _mock_call(subscribe, *args, **kwargs):
-            # Store the subscribe command for assertions
-            # This works because the first argument to an
-            # instance method is always the instance itself.
-            self.subscribe = subscribe
-
-        with patch.object(CloudTrailSubscribe, '_call', _mock_call):
-            driver.main('cloudtrail create-subscription --name test --s3-use-bucket test'.split())
-
-            # Test the session that is used in dependent services
-            subscribe = self.subscribe
-            self.assertEqual(driver.session, subscribe.iam.session)
-            self.assertEqual(driver.session, subscribe.s3.session)
-            self.assertEqual(driver.session, subscribe.sns.session)
-            self.assertEqual(driver.session, subscribe.cloudtrail.session)


### PR DESCRIPTION
Also added a bit to the test suite as there some components
I was changing that weren't tested.

The only weird thing I had to add was unregistering the error handler
the awscli uses.  Botocore clients raise exceptions now, but with this
customization in place the AWS CLI's client error was being raised
instead of botocores, which is what we want.

Also, I changed the RC to be 0 in the case of success, which is what we want.

cc @kyleknap @danielgtaylor 