### PR TITLE
Rename assert_params_for_cmd2 to assert_params_for_cmd

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -272,40 +272,6 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         if stderr_contains is not None:
             self.assertIn(stderr_contains, stderr)
         if params is not None:
-            last_params = self.last_params
-            if isinstance(last_params, dict):
-                last_params = copy.copy(self.last_params)
-                extra_params_to_ignore = ['Action', 'Version']
-                if ignore_params is None:
-                    ignore_params = extra_params_to_ignore
-                else:
-                    ignore_params.extend(extra_params_to_ignore)
-                for key in ignore_params:
-                    try:
-                        del last_params[key]
-                    except KeyError:
-                        pass
-            if params != last_params:
-                self.fail("Actual params did not match expected params.\n"
-                          "Expected:\n\n"
-                          "%s\n"
-                          "Actual:\n\n%s\n" % (
-                              pformat(params), pformat(last_params)))
-        return stdout, stderr, rc
-
-    def assert_params_for_cmd2(self, cmd, params=None, expected_rc=0,
-                               stderr_contains=None, ignore_params=None):
-        # XXX: This has a terrible name because it's intended to be
-        # temporary.  I want to switch everything off of
-        # assert_params_for_cmd and then I'll rename this to
-        # assert_params_for_cmd2.  The difference between this command
-        # and the other one is that we verify the kwargs that are sent
-        # to botocore's Operation.call(), *not* the serialized parameters
-        # onto the HTTP request.  We're one level up from that.
-        stdout, stderr, rc = self.run_cmd(cmd, expected_rc)
-        if stderr_contains is not None:
-            self.assertIn(stderr_contains, stderr)
-        if params is not None:
             # The last kwargs of Operation.call() in botocore.
             last_kwargs = copy.copy(self.last_kwargs)
             if ignore_params is not None:

--- a/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
+++ b/tests/unit/autoscale/test_terminate_instance_in_autoscaling_group.py
@@ -24,7 +24,7 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
         cmdline += ' --should-decrement-desired-capacity'
         params = {'InstanceId': 'i-12345678',
                   'ShouldDecrementDesiredCapacity': True}
-        self.assert_params_for_cmd2(cmdline, params)
+        self.assert_params_for_cmd(cmdline, params)
 
     def test_false(self):
         cmdline = self.PREFIX
@@ -32,7 +32,7 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
         cmdline += ' --no-should-decrement-desired-capacity'
         params = {'InstanceId': 'i-12345678',
                   'ShouldDecrementDesiredCapacity': False}
-        self.assert_params_for_cmd2(cmdline, params)
+        self.assert_params_for_cmd(cmdline, params)
 
     def test_last_arg_wins(self):
         cmdline = self.PREFIX
@@ -43,4 +43,4 @@ class TestTerminateInstanceInAutoscalingGroup(BaseAWSCommandParamsTest):
         # was added last, it wins.
         params = {'InstanceId': 'i-12345678',
                   'ShouldDecrementDesiredCapacity': False}
-        self.assert_params_for_cmd2(cmdline, params)
+        self.assert_params_for_cmd(cmdline, params)

--- a/tests/unit/cloudformation/test_create_stack.py
+++ b/tests/unit/cloudformation/test_create_stack.py
@@ -22,7 +22,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --stack-name test-stack --template-url http://foo'
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_create_stack_string_params(self):
         cmdline = self.prefix
@@ -34,7 +34,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                       {'ParameterKey': 'foo', 'ParameterValue': 'bar'},
                       {'ParameterKey': 'foo2', 'ParameterValue': 'bar2'},
                   ]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_create_stack_for_csv_params_escaping(self):
         # If a template is specified as a comma delimited list,
@@ -45,7 +45,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
                   'Parameters': [{'ParameterKey': 'foo',
                                   'ParameterValue': 'one,two'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_create_stack_for_csv_with_quoting(self):
         cmdline = self.prefix
@@ -55,4 +55,4 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
                   'Parameters': [{'ParameterKey': 'foo',
                                   'ParameterValue': 'one,two'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/cloudsearch/test_cloudsearch.py
+++ b/tests/unit/cloudsearch/test_cloudsearch.py
@@ -27,7 +27,7 @@ class TestCloudSearchDefineExpression(BaseAWSCommandParamsTest):
             'DomainName': 'abc123',
             'expression': {'ExpressionName': 'foo',
                            'ExpressionValue': '10'}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
@@ -47,7 +47,7 @@ class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
                             'IndexFieldType': 'int',
                             'IntOptions': {'DefaultValue': 10,
                                            'SearchEnabled': False}}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_latlon(self):
         cmdline = self.prefix
@@ -63,5 +63,5 @@ class TestCloudSearchDefineIndexField(BaseAWSCommandParamsTest):
                 'IndexFieldType': 'latlon',
                 'LatLonOptions': {
                     'DefaultValue': '10', 'SearchEnabled': False}}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 

--- a/tests/unit/cloudwatch/test_put_metric_data.py
+++ b/tests/unit/cloudwatch/test_put_metric_data.py
@@ -36,7 +36,7 @@ class TestPutMetricData(BaseAWSCommandParamsTest):
                 '"Timestamp":"2013-08-22T10:58:12.283Z",'
                 '"Value":9130160128}]')
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(cmdline, self.expected_output)
+        self.assert_params_for_cmd(cmdline, self.expected_output)
 
     def test_using_promoted_params(self):
         # This is equivalent to the json version in test_using_json
@@ -47,7 +47,7 @@ class TestPutMetricData(BaseAWSCommandParamsTest):
                 '--timestamp 2013-08-22T10:58:12.283Z '
                 '--value 9130160128')
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(cmdline, self.expected_output)
+        self.assert_params_for_cmd(cmdline, self.expected_output)
 
     def test_using_shorthand_syntax(self):
         args = (
@@ -69,4 +69,4 @@ class TestPutMetricData(BaseAWSCommandParamsTest):
             ],
             'Namespace': 'MyService'
         }
-        self.assert_params_for_cmd2(cmdline, expected)
+        self.assert_params_for_cmd(cmdline, expected)

--- a/tests/unit/customizations/datapipeline/test_arg_serialize.py
+++ b/tests/unit/customizations/datapipeline/test_arg_serialize.py
@@ -69,14 +69,14 @@ class TestPutPipelineDefinition(BaseAWSCommandParamsTest):
                        },
                      ]}]
             }
-            self.assert_params_for_cmd2(cmdline, result)
+            self.assert_params_for_cmd(cmdline, result)
 
 
 class TestErrorMessages(BaseAWSCommandParamsTest):
     prefix = 'datapipeline list-runs'
 
     def test_unknown_status(self):
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             self.prefix + ' --pipeline-id foo --status foo',
             expected_rc=255,
             stderr_contains=('Invalid status: foo, must be one of: waiting, '

--- a/tests/unit/customizations/emr/test_add_instance_groups.py
+++ b/tests/unit/customizations/emr/test_add_instance_groups.py
@@ -55,7 +55,7 @@ class TestAddInstanceGroups(BaseAWSCommandParamsTest):
         result = {'JobFlowId': 'J-ABCD',
                   'InstanceGroups': DEFAULT_INSTANCE_GROUPS}
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_instance_groups_missing_instance_group_type_error(self):
         cmd = self.prefix + ' Name=Task,InstanceType=m1.small,' +\
@@ -108,7 +108,7 @@ class TestAddInstanceGroups(BaseAWSCommandParamsTest):
         result = {'JobFlowId': 'J-ABCD',
                   'InstanceGroups': expected_instance_groups}
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     @patch('awscli.customizations.emr.emrutils.call')
     def test_constructed_result(self, call_patch):

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -113,7 +113,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_custom_jar_step_missing_jar(self):
         cmd = self.prefix + 'Name=CustomJarMissingJar'
@@ -147,7 +147,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_streaming_step_with_default_fields(self):
         cmd = self.prefix + 'Type=Streaming,' + self.STREAMING_ARGS
@@ -160,7 +160,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_streaming_step_missing_args(self):
         cmd = self.prefix + 'Type=Streaming'
@@ -184,7 +184,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_hive_step_with_default_fields(self):
         cmd = self.prefix + 'Type=Hive,' + self.HIVE_BASIC_ARGS
@@ -196,7 +196,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  'HadoopJarStep': self.HIVE_DEFAULT_HADOOP_JAR_STEP
                  }]
             }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_hive_step_missing_args(self):
         cmd = self.prefix + 'Type=Hive'
@@ -220,7 +220,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  'HadoopJarStep': self.HIVE_DEFAULT_HADOOP_JAR_STEP
                  }]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_pig_step_with_default_fields(self):
         cmd = self.prefix + 'Type=Pig,' + self.PIG_BASIC_ARGS
@@ -232,7 +232,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  'HadoopJarStep': self.PIG_DEFAULT_HADOOP_JAR_STEP
                  }]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_pig_missing_args(self):
         cmd = self.prefix + 'Type=Pig'
@@ -257,7 +257,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_impala_step_with_default_fields(self):
         test_step_config = 'Type=Impala,' + \
@@ -271,7 +271,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  'HadoopJarStep': self.IMPALA_BASIC_HADOOP_JAR_STEP
                  }]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_impala_missing_args(self):
         cmd = self.prefix + 'Type=Impala'
@@ -296,7 +296,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_empty_step_args(self):
         cmd = self.prefix + 'Type=Streaming,Args='
@@ -351,7 +351,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_all_step_types_from_json(self):
         data_path = os.path.join(
@@ -399,7 +399,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
                  }
             ]
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_add_tags.py
+++ b/tests/unit/customizations/emr/test_add_tags.py
@@ -24,7 +24,7 @@ class TestAddTags(BaseAWSCommandParamsTest):
         result = {'ResourceId': 'j-ABC123456',
                   'Tags': [{'Key': 'k1', 'Value': 'v1'},
                            {'Key': 'k2', 'Value': 'v2'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_add_tags_key_with_empty_value(self):
         args = ' --resource-id j-ABC123456 --tags k1=v1 k2 k3=v3'
@@ -33,7 +33,7 @@ class TestAddTags(BaseAWSCommandParamsTest):
                   'Tags': [{'Key': 'k1', 'Value': 'v1'},
                            {'Key': 'k2', 'Value': ''},
                            {'Key': 'k3', 'Value': 'v3'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_add_tags_key_value_space(self):
         cmdline = ['emr', 'add-tags', '--resource-id', 'j-ABC123456', '--tags',
@@ -42,7 +42,7 @@ class TestAddTags(BaseAWSCommandParamsTest):
                   'Tags': [{'Key': 'k1', 'Value': 'v1'},
                            {'Key': 'k2', 'Value': ''},
                            {'Key': 'k3', 'Value': 'v3 v4'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_create_cluster.py
+++ b/tests/unit/customizations/emr/test_create_cluster.py
@@ -347,14 +347,14 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                 'VisibleToAllUsers': True,
                 'Tags': []
             }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def assert_error_message_has_field_name(self, error_msg, field_name):
         self.assertIn('Missing required parameter', error_msg)
         self.assertIn(field_name, error_msg)
 
     def test_default_cmd(self):
-        self.assert_params_for_cmd2(DEFAULT_CMD, DEFAULT_RESULT)
+        self.assert_params_for_cmd(DEFAULT_CMD, DEFAULT_RESULT)
 
     def test_cluster_without_service_role_and_instance_profile(self):
         cmd = ('emr create-cluster --ami-version 3.0.4 '
@@ -362,7 +362,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result = copy.deepcopy(DEFAULT_RESULT)
         del result['JobFlowRole']
         del result['ServiceRole']
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_cluster_with_service_role_and_instance_profile(self):
         cmd = ('emr create-cluster --ami-version 3.0.4'
@@ -372,7 +372,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result = copy.deepcopy(DEFAULT_RESULT)
         result['JobFlowRole'] = 'Ec2_InstanceProfile'
         result['ServiceRole'] = 'ServiceRole'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_mutual_exclusive_use_default_roles_and_service_role(self):
         cmd = (DEFAULT_CMD +
@@ -400,33 +400,33 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--name MyCluster'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Name'] = 'MyCluster'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_cluster_name_with_space(self):
         cmd = DEFAULT_CMD.split() + ['--name', 'My Cluster']
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Name'] = 'My Cluster'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_ami_version(self):
         cmd = DEFAULT_CMD + '--ami-version 3.0.4'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['AmiVersion'] = '3.0.4'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_log_uri(self):
         test_log_uri = 's3://test/logs'
         cmd = DEFAULT_CMD + '--log-uri ' + test_log_uri
         result = copy.deepcopy(DEFAULT_RESULT)
         result['LogUri'] = test_log_uri
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_additional_info(self):
         test_info = '{ami32: "ami-82e305f5"}'
         cmd = DEFAULT_CMD.split() + ['--additional-info', test_info]
         result = copy.deepcopy(DEFAULT_RESULT)
         result['AdditionalInfo'] = test_info
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_auto_terminte(self):
         cmd = ('emr create-cluster --use-default-roles --ami-version 3.0.4 '
@@ -436,7 +436,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         instances = copy.deepcopy(DEFAULT_INSTANCES)
         instances['KeepJobFlowAliveWhenNoSteps'] = False
         result['Instances'] = instances
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_auto_terminate_and_no_auto_terminate(self):
         cmd = (DEFAULT_CMD + '--ami-version 3.0.4 ' +
@@ -453,11 +453,11 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         instances = copy.deepcopy(DEFAULT_INSTANCES)
         instances['TerminationProtected'] = True
         result['Instances'] = instances
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_no_termination_protected(self):
         cmd = DEFAULT_CMD + '--no-termination-protected'
-        self.assert_params_for_cmd2(cmd, DEFAULT_RESULT)
+        self.assert_params_for_cmd(cmd, DEFAULT_RESULT)
 
     def test_termination_protected_and_no_termination_protected(self):
         cmd = DEFAULT_CMD + \
@@ -470,13 +470,13 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
 
     def test_visible_to_all_users(self):
         cmd = DEFAULT_CMD + '--visible-to-all-users'
-        self.assert_params_for_cmd2(cmd, DEFAULT_RESULT)
+        self.assert_params_for_cmd(cmd, DEFAULT_RESULT)
 
     def test_no_visible_to_all_users(self):
         cmd = DEFAULT_CMD + '--no-visible-to-all-users'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['VisibleToAllUsers'] = False
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_visible_to_all_users_and_no_visible_to_all_users(self):
         cmd = DEFAULT_CMD + '--visible-to-all-users --no-visible-to-all-users'
@@ -493,7 +493,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                 {'Key': 'k2', 'Value': ''},
                 {'Key': 'k3', 'Value': 'spaces  v3'}]
         result['Tags'] = tags
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_enable_debugging(self):
         cmd = DEFAULT_CMD + '--log-uri s3://test/logs --enable-debugging'
@@ -512,7 +512,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                  }
               }]
         result['Steps'] = debugging_config
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
         cmd = DEFAULT_CMD + ('--log-uri s3://test/logs --enable-debugging '
                              '--region us-west-2')
@@ -529,7 +529,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                  }
               }]
         result['Steps'] = debugging_config
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_enable_debugging_no_log_uri(self):
         cmd = DEFAULT_CMD + '--enable-debugging'
@@ -555,7 +555,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'InstanceGroupType=MASTER,InstanceCount=1,InstanceType=m1.large '
             'InstanceGroupType=CORE,InstanceCount=1,InstanceType=m1.large '
             'InstanceGroupType=TASK,InstanceCount=1,InstanceType=m1.large ')
-        self.assert_params_for_cmd2(cmd, DEFAULT_RESULT)
+        self.assert_params_for_cmd(cmd, DEFAULT_RESULT)
 
     def test_instance_groups_instance_group_type_mismatch_cases(self):
         cmd = (
@@ -565,7 +565,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'InstanceType=m1.large Name=CORE,InstanceGroupType=cORE,'
             'InstanceCount=1,InstanceType=m1.large Name=TASK,'
             'InstanceGroupType=tAsK,InstanceCount=1,InstanceType=m1.large')
-        self.assert_params_for_cmd2(cmd, DEFAULT_RESULT)
+        self.assert_params_for_cmd(cmd, DEFAULT_RESULT)
 
     def test_instance_groups_instance_type_and_count(self):
         cmd = (
@@ -582,7 +582,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                   'Market': 'ON_DEMAND',
                   'InstanceType': 'm1.large'}]
              }
-        self.assert_params_for_cmd2(cmd, expected_result)
+        self.assert_params_for_cmd(cmd, expected_result)
         cmd = (
             'emr create-cluster --use-default-roles --ami-version 3.0.4 '
             '--instance-type m1.large --instance-count 3')
@@ -604,7 +604,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                   'InstanceType': 'm1.large'
                   }]
              }
-        self.assert_params_for_cmd2(cmd, expected_result)
+        self.assert_params_for_cmd(cmd, expected_result)
 
     def test_instance_groups_missing_required_parameter_error(self):
         cmd = (
@@ -709,7 +709,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                  'InstanceType': 'm1.xlarge'
                  }
             ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_ec2_attributes_no_az(self):
         cmd = ('emr create-cluster --ami-version 3.0.4 '
@@ -721,13 +721,13 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result['Instances']['Ec2KeyName'] = 'testkey'
         result['Instances']['Ec2SubnetId'] = 'subnet-123456'
         result['JobFlowRole'] = 'EMR_EC2_DefaultRole'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_ec2_attributes_az(self):
         cmd = DEFAULT_CMD + '--ec2-attributes AvailabilityZone=us-east-1a'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Instances']['Placement'] = {'AvailabilityZone': 'us-east-1a'}
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_ec2_attributes_subnet_az_error(self):
         cmd = DEFAULT_CMD + '--ec2-attributes ' + \
@@ -749,7 +749,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result['Instances']['Ec2KeyName'] = 'testkey'
         result['Instances']['Ec2SubnetId'] = 'subnet-123456'
         result['JobFlowRole'] = 'EMR_EC2_DefaultRole'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_ec2_attributes_with_az_from_json_file(self):
         data_path = os.path.join(
@@ -762,7 +762,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result['Instances']['Ec2KeyName'] = 'testkey'
         result['Instances']['Placement'] = {'AvailabilityZone': 'us-east-1a'}
         result['JobFlowRole'] = 'EMR_EC2_DefaultRole'
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     # Bootstrap Actions test cases
     def test_bootstrap_actions_missing_path_error(self):
@@ -778,7 +778,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result = copy.deepcopy(DEFAULT_RESULT)
         result['BootstrapActions'] = TEST_BA
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_bootstrap_actions_exceed_maximum_error(self):
         cmd = DEFAULT_CMD + ' --bootstrap-actions'
@@ -818,7 +818,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                     {'Path': 's3://test/ba2'}
                  }
             ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_bootstrap_actions_from_json_file(self):
         data_path = os.path.join(
@@ -838,14 +838,14 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                      "Args": ["arg1", "arg2"]}
                  }
             ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     # Applications test cases
     def test_install_hive_with_defaults(self):
         cmd = DEFAULT_CMD + '--applications Name=Hive'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [INSTALL_HIVE_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_hive_with_profile_region(self):
         self.driver.session.set_config_variable('region', 'cn-north-1')
@@ -854,35 +854,35 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             replace('us-east-1', 'cn-north-1')
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [json.loads(HIVE_STEP)]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_hive_site(self):
         cmdline = (DEFAULT_CMD + '--applications Name=Hive,'
                    'Args=[--hive-site=s3://test/hive-conf/hive-site.xml]')
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [INSTALL_HIVE_STEP, INSTALL_HIVE_SITE_STEP]
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
         cmdline = (DEFAULT_CMD + '--applications Name=Hive,'
                    'Args=[--hive-site=s3://test/hive-conf/hive-site.xml,k1]')
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_install_pig_with_defaults(self):
         cmd = DEFAULT_CMD + '--applications Name=Pig'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [INSTALL_PIG_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_ganglia(self):
         cmd = DEFAULT_CMD + '--applications Name=Ganglia'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['BootstrapActions'] = [INSTALL_GANGLIA_BA]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_impala_with_defaults(self):
         cmd = DEFAULT_CMD + '--applications Name=Impala'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['BootstrapActions'] = [INSTALL_IMPALA_BA]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_impala_with_all_fields(self):
         cmd = DEFAULT_CMD + \
@@ -892,21 +892,21 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         ba['ScriptBootstrapAction']['Args'] += \
             ['--impala-conf', 'arg1', 'arg2']
         result['BootstrapActions'] = [ba]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_hbase(self):
         cmd = DEFAULT_CMD + '--applications Name=hbase'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['BootstrapActions'] = [INSTALL_HBASE_BA]
         result['Steps'] = [INSTALL_HBASE_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_mapr_with_args(self):
         cmd = DEFAULT_CMD + \
             '--applications Name=mapr,Args=--edition,m5,--version,3.0.2'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['NewSupportedProducts'] = [INSTALL_MAPR_PRODUCT]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_install_mapr_without_args(self):
         cmd = DEFAULT_CMD + \
@@ -917,7 +917,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                 {'Name': 'mapr',
                  'Args': []}
             ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_supported_products(self):
         cmd = DEFAULT_CMD + (
@@ -927,7 +927,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'Name=unknown,Args=[arg1,k1=v1]')
         result = copy.deepcopy(DEFAULT_RESULT)
         result['NewSupportedProducts'] = INSTALL_SUPPORTED_PRODUCTS
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_applications_all_types(self):
         cmd = DEFAULT_CMD + (
@@ -941,7 +941,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result['Steps'] = step_list
         result['BootstrapActions'] = ba_list
         result['NewSupportedProducts'] = [INSTALL_MAPR_PRODUCT]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_applications_all_types_from_json_file(self):
         data_path = os.path.join(
@@ -958,7 +958,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result['Steps'] = step_list
         result['BootstrapActions'] = ba_list
         result['NewSupportedProducts'] = [INSTALL_MAPR_PRODUCT]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     # Steps test cases
     def test_wrong_step_type_error(self):
@@ -972,7 +972,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Jar=s3://mybucket/mytest.jar'
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [CUSTOM_JAR_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_custom_jar_step_missing_jar(self):
         cmd = DEFAULT_CMD + '--steps Name=CustomJarMissingJar'
@@ -998,7 +998,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         ]
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = expected_steps
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_streaming_step_with_default_fields(self):
         cmd = DEFAULT_CMD + '--steps Type=Streaming,' + STREAMING_ARGS
@@ -1008,7 +1008,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
              'ActionOnFailure': 'CONTINUE',
              'HadoopJarStep': STREAMING_HADOOP_JAR_STEP}
         ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_streaming_step_missing_args(self):
         cmd = DEFAULT_CMD + '--steps Type=Streaming'
@@ -1028,14 +1028,14 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
              'ActionOnFailure': 'CANCEL_AND_WAIT',
              'HadoopJarStep': STREAMING_HADOOP_JAR_STEP}
         ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_hive_step_with_default_fields(self):
         cmd = DEFAULT_CMD + (
             '--applications Name=Hive --steps Type=Hive,' + HIVE_BASIC_ARGS)
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [INSTALL_HIVE_STEP, HIVE_DEFAULT_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_hive_step_missing_args(self):
         cmd = DEFAULT_CMD + '--applications Name=Hive --steps Type=Hive'
@@ -1053,14 +1053,14 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result = copy.deepcopy(DEFAULT_RESULT)
         install_step = copy.deepcopy(INSTALL_HIVE_STEP)
         result['Steps'] = [install_step, HIVE_BASIC_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_pig_step_with_default_fields(self):
         cmd = DEFAULT_CMD + (
             '--applications Name=Pig --steps Type=Pig,' + PIG_BASIC_ARGS)
         result = copy.deepcopy(DEFAULT_RESULT)
         result['Steps'] = [INSTALL_PIG_STEP, PIG_DEFAULT_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_pig_missing_args(self):
         cmd = DEFAULT_CMD + '--applications Name=Pig --steps Type=Pig'
@@ -1078,7 +1078,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result = copy.deepcopy(DEFAULT_RESULT)
         install_step = copy.deepcopy(INSTALL_PIG_STEP)
         result['Steps'] = [install_step, PIG_BASIC_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_impala_step_with_default_fields(self):
         cmd = DEFAULT_CMD + (
@@ -1087,7 +1087,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result = copy.deepcopy(DEFAULT_RESULT)
         result['BootstrapActions'] = [INSTALL_IMPALA_BA]
         result['Steps'] = [IMPALA_DEFAULT_STEP]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_impala_missing_args(self):
         cmd = DEFAULT_CMD + '--applications Name=Impala --steps Type=Impala'
@@ -1108,7 +1108,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         step['Name'] = 'ImpalaBasicStep'
         step['ActionOnFailure'] = 'CANCEL_AND_WAIT'
         result['Steps'] = [step]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_restore_from_hbase(self):
         cmd = DEFAULT_CMD + (
@@ -1132,13 +1132,13 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                     'Jar': '/home/hadoop/lib/hbase.jar'}
             }
         ]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
         data_path = os.path.join(
             os.path.dirname(__file__), 'input_hbase_restore_from_backup.json')
         cmd = DEFAULT_CMD + (
             '--applications Name=hbase --restore-from-hbase-backup '
             'file://' + data_path)
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_empty_step_args(self):
         cmd = DEFAULT_CMD + '--steps Type=Streaming,Args= '
@@ -1253,12 +1253,12 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
              }
         result = copy.deepcopy(DEFAULT_RESULT)
         result['BootstrapActions'] = [emf_fs_ba_config]
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
         data_path = os.path.join(
             os.path.dirname(__file__), 'input_emr_fs.json')
         cmd = DEFAULT_CMD + '--emrfs file://' + data_path
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_all_security_groups(self):
         cmd = DEFAULT_CMD + (
@@ -1279,7 +1279,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         instances['AdditionalSlaveSecurityGroups'] = \
             ADDITIONAL_SLAVE_SECURITY_GROUPS
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_emr_managed_security_groups(self):
         cmd = DEFAULT_CMD + (
@@ -1293,7 +1293,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         instances['EmrManagedSlaveSecurityGroup'] = \
             EMR_MANAGED_SLAVE_SECURITY_GROUP
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_additional_security_groups(self):
         cmd = DEFAULT_CMD + (
@@ -1308,7 +1308,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         instances['AdditionalSlaveSecurityGroups'] = \
             ADDITIONAL_SLAVE_SECURITY_GROUPS
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_security_groups_from_json_file(self):
         data_path = os.path.join(
@@ -1327,7 +1327,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         instances['AdditionalSlaveSecurityGroups'] = \
             ADDITIONAL_SLAVE_SECURITY_GROUPS
 
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_create_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_create_hbase_backup.py
@@ -37,7 +37,7 @@ class TestCreateHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'JobFlowId': 'j-ABCD', 'Steps': self.steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_create_hbase_backup_consitent(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/ --consistent'
@@ -47,7 +47,7 @@ class TestCreateHBaseBackup(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'].append('--consistent')
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_disable_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_disable_hbase_backup.py
@@ -41,7 +41,7 @@ class TestDisableHBaseBackups(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'].append(self.DISABLE_FULL_BACKUP)
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_disable_hbase_backups_incremental(self):
         args = ' --cluster-id j-ABCD --incremental'
@@ -51,7 +51,7 @@ class TestDisableHBaseBackups(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'].append(self.DISABLE_INCR_BACKUP)
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_disable_hbase_backups_both(self):
         args = ' --cluster-id j-ABCD --full --incremental'
@@ -62,7 +62,7 @@ class TestDisableHBaseBackups(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'].append(self.DISABLE_INCR_BACKUP)
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_disable_hbase_backups_none(self):
         args = ' --cluster-id j-ABCD'

--- a/tests/unit/customizations/emr/test_install_applications.py
+++ b/tests/unit/customizations/emr/test_install_applications.py
@@ -72,16 +72,16 @@ class TestInstallApplications(BaseAWSCommandParamsTest):
         result = {'JobFlowId': 'j-ABC123456',
                   'Steps': [INSTALL_HIVE_STEP, INSTALL_HIVE_SITE_STEP]
                   }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
         cmdline = (self.prefix + 'Name=Hive,'
                    'Args=[--hive-site=s3://test/hive-conf/hive-site.xml,k1]')
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_install_hive_and_pig(self):
         cmdline = self.prefix + 'Name=Hive Name=Pig'
         result = {'JobFlowId': 'j-ABC123456', 'Steps': [INSTALL_HIVE_STEP,
                                                         INSTALL_PIG_STEP]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_install_pig_with_profile_region(self):
         self.driver.session.set_config_variable('region', 'cn-north-1')
@@ -90,7 +90,7 @@ class TestInstallApplications(BaseAWSCommandParamsTest):
             replace('us-east-1', 'cn-north-1')
         result = {'JobFlowId': 'j-ABC123456',
                   'Steps': [json.loads(PIG_STEP)]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_install_impala_error(self):
         cmdline = self.prefix + ' Name=Impala'

--- a/tests/unit/customizations/emr/test_list_clusters.py
+++ b/tests/unit/customizations/emr/test_list_clusters.py
@@ -30,25 +30,25 @@ class TestListClusters(BaseAWSCommandParamsTest):
                                     'TERMINATING'
                                     ]
                   }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_list_terminated_clusters(self):
         args = '--terminated'
         cmdline = self.prefix + args
         result = {'ClusterStates': ['TERMINATED']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_list_failed_clusters(self):
         args = '--failed'
         cmdline = self.prefix + args
         result = {'ClusterStates': ['TERMINATED_WITH_ERRORS']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_list_multiple_states(self):
         args = '--cluster-states RUNNING WAITING TERMINATED'
         cmdline = self.prefix + args
         result = {'ClusterStates': ['RUNNING', 'WAITING', 'TERMINATED']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_exclusive_states_filters(self):
         args = '--active --failed'

--- a/tests/unit/customizations/emr/test_modify_cluster_attributes.py
+++ b/tests/unit/customizations/emr/test_modify_cluster_attributes.py
@@ -23,25 +23,25 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
         args = ' --cluster-id j-ABC123456 --visible-to-all-users'
         cmdline = self.prefix + args
         result = {'JobFlowIds': ['j-ABC123456'], 'VisibleToAllUsers': True}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_no_visible_to_all(self):
         args = ' --cluster-id j-ABC123456 --no-visible-to-all-users'
         cmdline = self.prefix + args
         result = {'JobFlowIds': ['j-ABC123456'], 'VisibleToAllUsers': False}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_termination_protected(self):
         args = ' --cluster-id j-ABC123456 --termination-protected'
         cmdline = self.prefix + args
         result = {'JobFlowIds': ['j-ABC123456'], 'TerminationProtected': True}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_no_termination_protected(self):
         args = ' --cluster-id j-ABC123456 --no-termination-protected'
         cmdline = self.prefix + args
         result = {'JobFlowIds': ['j-ABC123456'], 'TerminationProtected': False}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_visible_to_all_and_no_visible_to_all(self):
         args = ' --cluster-id j-ABC123456 --no-visible-to-all-users'\

--- a/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
@@ -37,7 +37,7 @@ class TestRestoreFromHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'JobFlowId': 'j-ABCD', 'Steps': self.steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_restore_from_hbase_backup_version(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/ --backup-version DEF'
@@ -48,7 +48,7 @@ class TestRestoreFromHBaseBackup(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'].append('DEF')
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_schedule_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_schedule_hbase_backup.py
@@ -46,7 +46,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'JobFlowId': 'j-ABCD', 'Steps': self.default_steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_schedule_hbase_backup_full_upper_case(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/ --type FULL' +\
@@ -54,7 +54,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'JobFlowId': 'j-ABCD', 'Steps': self.default_steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_schedule_hbase_backup_incremental_upper_case(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/  --type INCREMENTAL' +\
@@ -83,7 +83,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
 
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_schedule_hbase_backup_wrong_type(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/  --type wrong_type' +\
@@ -115,7 +115,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'].insert(5, '--consistent')
 
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_schedule_hbase_backup_start_time(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/ --type full --interval' +\
@@ -126,7 +126,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         steps[0]['HadoopJarStep']['Args'][10] = '2014-04-18T10:43:24-07:00'
 
         result = {'JobFlowId': 'j-ABCD', 'Steps': steps}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_terminate_clusters.py
+++ b/tests/unit/customizations/emr/test_terminate_clusters.py
@@ -22,13 +22,13 @@ class TestTerminateClusters(BaseAWSCommandParamsTest):
         args = ' --cluster-ids j-ABC123456'
         cmdline = self.prefix + args
         result = {'JobFlowIds': ['j-ABC123456']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_cluster_ids(self):
         args = ' --cluster-ids j-ABC123456 j-AAAAAAA'
         cmdline = self.prefix + args
         result = {'JobFlowIds': ['j-ABC123456', 'j-AAAAAAA']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_copy_params.py
+++ b/tests/unit/customizations/s3/test_copy_params.py
@@ -43,7 +43,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         self.parsed_response = {'ETag': '"120ea8a25e5d487bf68b5f7096440019"',}
 
     def assert_params(self, cmdline, result):
-        foo = self.assert_params_for_cmd2(cmdline, result, expected_rc=0,
+        foo = self.assert_params_for_cmd(cmdline, result, expected_rc=0,
                                           ignore_params=['body'])
 
     def test_simple(self):
@@ -121,7 +121,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += self.file_path
         cmdline += ' s3://mybucket/mykey'
         cmdline += ' --grants read:bob'
-        self.assert_params_for_cmd2(cmdline, expected_rc=1,
+        self.assert_params_for_cmd(cmdline, expected_rc=1,
                                     ignore_params=['payload'])
 
     def test_content_type(self):

--- a/tests/unit/customizations/s3/test_website_command.py
+++ b/tests/unit/customizations/s3/test_website_command.py
@@ -25,14 +25,14 @@ class TestWebsiteCommand(BaseAWSCommandParamsTest):
             'website_configuration':
                 {'IndexDocument': {'Suffix': 'index.html'}}, 'bucket': u'mybucket'}
 
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_error_document(self):
         cmdline = self.prefix + 's3://mybucket --error-document mykey'
         result = {
             'website_configuration': {
                 'ErrorDocument': {'Key': 'mykey'}}, 'bucket': u'mybucket'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/test_cloudsearchdomain.py
+++ b/tests/unit/customizations/test_cloudsearchdomain.py
@@ -35,7 +35,7 @@ class TestSearchCommand(BaseAWSCommandParamsTest):
             'query': u'George Lucas',
             'queryOptions': u'{"defaultOperator":"and","fields":["directors^10"]}'
         }
-        self.assert_params_for_cmd2(cmd, expected)
+        self.assert_params_for_cmd(cmd, expected)
 
     def test_endpoint_is_required(self):
         cmd = self.prefix.split()

--- a/tests/unit/customizations/test_codedeploy.py
+++ b/tests/unit/customizations/test_codedeploy.py
@@ -44,7 +44,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_etag(self):
         cmd = self.prefix + (
@@ -62,7 +62,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_version(self):
         cmd = self.prefix + (
@@ -80,7 +80,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_etag_and_version(self):
         cmd = self.prefix + (
@@ -99,7 +99,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_json(self):
         cmd = self.prefix + (
@@ -118,7 +118,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_missing_bucket(self):
         cmd = self.prefix + (
@@ -146,7 +146,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_github_location_json(self):
         cmd = self.prefix + (
@@ -162,7 +162,7 @@ class GetApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_github_location_missing_repository(self):
         cmd = self.prefix + (
@@ -193,7 +193,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_etag(self):
         cmd = self.prefix + (
@@ -211,7 +211,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_version(self):
         cmd = self.prefix + (
@@ -229,7 +229,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_etag_and_version(self):
         cmd = self.prefix + (
@@ -248,7 +248,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_json(self):
         cmd = self.prefix + (
@@ -267,7 +267,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_missing_bucket(self):
         cmd = self.prefix + (
@@ -295,7 +295,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_github_location_json(self):
         cmd = self.prefix + (
@@ -311,7 +311,7 @@ class RegisterApplicationRevisionLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_github_location_missing_repository(self):
         cmd = self.prefix + (
@@ -345,7 +345,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_etag(self):
         cmd = self.prefix + (
@@ -364,7 +364,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_version(self):
         cmd = self.prefix + (
@@ -383,7 +383,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_with_etag_and_version(self):
         cmd = self.prefix + (
@@ -403,7 +403,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_json(self):
         cmd = self.prefix + (
@@ -423,7 +423,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_s3_location_missing_bucket(self):
         cmd = self.prefix + (
@@ -452,7 +452,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_github_location_json(self):
         cmd = self.prefix + (
@@ -469,7 +469,7 @@ class CreateDpeloymentLocationArgumentsTestCase(
                 }
             }
         }
-        self.assert_params_for_cmd2(cmd, result)
+        self.assert_params_for_cmd(cmd, result)
 
     def test_github_location_missing_repository(self):
         cmd = self.prefix + (

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -172,14 +172,14 @@ class TestWait(BaseAWSCommandParamsTest):
                 }]
             }]
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_dynamodb_table_exists(self):
         cmdline = 'dynamodb wait table-exists'
         cmdline += ' --table-name mytable'
         result = {"TableName": "mytable"}
         self.parsed_response = {'Table': {'TableStatus': 'ACTIVE'}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_elastictranscoder_jobs_complete(self):
         cmdline = 'rds wait db-instance-available'
@@ -190,7 +190,7 @@ class TestWait(BaseAWSCommandParamsTest):
                 'DBInstanceStatus': 'available'
             }]
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 class TestWaiterStateCommandBuilder(unittest.TestCase):

--- a/tests/unit/datapipeline/test_get_pipeline_definition.py
+++ b/tests/unit/datapipeline/test_get_pipeline_definition.py
@@ -24,4 +24,4 @@ class TestGetPipelineDefinition(BaseAWSCommandParamsTest):
         expected = {
             'pipelineId': 'foo', 'version': 'latest'
         }
-        self.assert_params_for_cmd2(cmdline, expected)
+        self.assert_params_for_cmd(cmdline, expected)

--- a/tests/unit/datapipeline/test_query_objects.py
+++ b/tests/unit/datapipeline/test_query_objects.py
@@ -33,4 +33,4 @@ class TestDataPipelineQueryObjects(BaseAWSCommandParamsTest):
                                                   'values': ['RUNNING']}}]},
             'sphere': 'INSTANCE'
         }
-        self.assert_params_for_cmd2(cmdline, expected)
+        self.assert_params_for_cmd(cmdline, expected)

--- a/tests/unit/ec2/test_associate_address.py
+++ b/tests/unit/ec2/test_associate_address.py
@@ -23,7 +23,7 @@ class TestAssociateAddress(BaseAWSCommandParamsTest):
         cmdline += ' --instance-id i-12345678'
         cmdline += ' --public-ip 192.168.0.0'
         result = {'InstanceId': 'i-12345678', 'PublicIp': '192.168.0.0'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_vpc_basic(self):
         cmdline = self.prefix
@@ -35,7 +35,7 @@ class TestAssociateAddress(BaseAWSCommandParamsTest):
                   'PublicIp': '192.168.0.0',
                   'AllowReassociation': True,
                   'AllocationId': 'eipalloc-12345678'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_attach_internet_gateway.py
+++ b/tests/unit/ec2/test_attach_internet_gateway.py
@@ -24,7 +24,7 @@ class TestAttachInternetGateway(BaseAWSCommandParamsTest):
         cmdline += ' --internet-gateway-id igw-12345678'
         result = {'VpcId': 'vpc-12345678',
                   'InternetGatewayId': 'igw-12345678'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_bundle_instance.py
+++ b/tests/unit/ec2/test_bundle_instance.py
@@ -64,7 +64,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
                            'UploadPolicySignature': self.POLICY_SIGNATURE}
                        }
                    }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
 
     def test_policy_provided(self):
@@ -85,14 +85,14 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
                            'UploadPolicySignature': policy_signature}
                        }
                    }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_both(self):
         captured = cStringIO()
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
         args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()
-        self.assert_params_for_cmd2(args_list, expected_rc=255)
+        self.assert_params_for_cmd(args_list, expected_rc=255)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_create_image.py
+++ b/tests/unit/ec2/test_create_image.py
@@ -26,4 +26,4 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         cmdline += ' --reboot'
         result = {'InstanceId': 'i-12345678', 'Description': 'foo',
                   'Name': 'bar', 'NoReboot': False}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/ec2/test_create_network_acl_entry.py
+++ b/tests/unit/ec2/test_create_network_acl_entry.py
@@ -34,7 +34,7 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_udp(self):
         cmdline = self.prefix
@@ -52,7 +52,7 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_icmp(self):
         cmdline = self.prefix
@@ -70,7 +70,7 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_all(self):
         cmdline = self.prefix
@@ -88,7 +88,7 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_number(self):
         cmdline = self.prefix
@@ -106,5 +106,5 @@ class TestCreateNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 

--- a/tests/unit/ec2/test_create_tags.py
+++ b/tests/unit/ec2/test_create_tags.py
@@ -28,7 +28,7 @@ class TestCreateTags(BaseAWSCommandParamsTest):
         result = {
             'Resources': ['i-12345678'],
             'Tags': [{'Key': 'Name', 'Value': 'bar'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     @unittest.skipIf(
         six.PY3, 'Unicode cmd line test only is relevant to python2.')
@@ -42,4 +42,4 @@ class TestCreateTags(BaseAWSCommandParamsTest):
         result = {
             'Resources': ['i-12345678'],
             'Tags': [{'Key': 'Name', 'Value': u'\u6211'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/ec2/test_describe_instance_attribute.py
+++ b/tests/unit/ec2/test_describe_instance_attribute.py
@@ -25,7 +25,7 @@ class TestDescribeInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += ' --attribute blockDeviceMapping'
         result = {'InstanceId': 'i-12345678',
                   'Attribute': 'blockDeviceMapping'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_describe_instances.py
+++ b/tests/unit/ec2/test_describe_instances.py
@@ -21,26 +21,26 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
     def test_no_params(self):
         cmdline = self.prefix
         result = {}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_instance_id(self):
         args = ' --instance-ids i-12345678'
         cmdline = self.prefix + args
         result = {'InstanceIds': ['i-12345678']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_instance_ids(self):
         args = ' --instance-ids i-12345678 i-87654321'
         cmdline = self.prefix + args
         result = {'InstanceIds': ['i-12345678', 'i-87654321']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_instance_ids_alternate(self):
         # Not required, but will still work if you use JSON.
         args = ' --instance-ids ["i-12345678","i-87654321"]'
         cmdline = self.prefix + args
         result = {'InstanceIds': ['i-12345678', 'i-87654321']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_filter_json(self):
         args = """ --filters {"Name":"group-name","Values":["foobar"]}"""
@@ -51,7 +51,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                  'Values': ['foobar']},
             ],
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_filter_simple(self):
         args = """ --filters Name=group-name,Values=foobar"""
@@ -62,7 +62,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                  'Values': ['foobar']},
             ],
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_filter_values(self):
         args = """ --filters Name=group-name,Values=foobar,fiebaz"""
@@ -73,7 +73,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                  'Values': ['foobar', 'fiebaz']},
             ],
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_multiple_filters(self):
         args = (' --filters Name=group-name,Values=foobar '
@@ -87,7 +87,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                  'Values': ['i-12345']},
             ],
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_multiple_filters_alternate(self):
         cmdlist = 'ec2 describe-instances'.split()
@@ -102,13 +102,13 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                  'Values': ['i-12345']},
             ],
         }
-        self.assert_params_for_cmd2(cmdlist, result)
+        self.assert_params_for_cmd(cmdlist, result)
 
     def test_page_size(self):
         args = ' --page-size 10'
         cmdline = self.prefix + args
         result = {'MaxResults': 10}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ec2/test_get_password_data.py
+++ b/tests/unit/ec2/test_get_password_data.py
@@ -37,7 +37,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         args = ' --instance-id i-12345678'
         cmdline = self.prefix + args
         result = {'InstanceId': 'i-12345678'}
-        output = self.assert_params_for_cmd2(cmdline, result, expected_rc=0)[0]
+        output = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
         self.assertIn('"InstanceId": "i-12345678"', output)
         self.assertIn('"Timestamp": "2013-07-27T18:29:23.000Z"', output)
         self.assertIn('"PasswordData": "%s"' % PASSWORD_DATA, output)
@@ -45,7 +45,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
     def test_nonexistent_priv_launch_key(self):
         args = ' --instance-id i-12345678 --priv-launch-key foo.pem'
         cmdline = self.prefix + args
-        error_msg = self.assert_params_for_cmd2(
+        error_msg = self.assert_params_for_cmd(
             cmdline, expected_rc=255)[1]
         self.assertIn('priv-launch-key should be a path to '
                       'the local SSH private key file used '
@@ -57,7 +57,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         args = ' --instance-id i-12345678 --priv-launch-key %s' % key_path
         cmdline = self.prefix + args
         result = {'InstanceId': 'i-12345678'}
-        output = self.assert_params_for_cmd2(cmdline, result, expected_rc=0)[0]
+        output = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
         self.assertIn('"InstanceId": "i-12345678"', output)
         self.assertIn('"Timestamp": "2013-07-27T18:29:23.000Z"', output)
         self.assertIn('"PasswordData": "=mG8.r$o-s"', output)

--- a/tests/unit/ec2/test_modify_image_attribute.py
+++ b/tests/unit/ec2/test_modify_image_attribute.py
@@ -26,7 +26,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         result = {'ImageId': 'ami-d00dbeef',
                   'OperationType': 'add',
                   'UserIds': ['0123456789012']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_two(self):
         cmdline = self.prefix
@@ -40,14 +40,14 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
                 'Remove': [{'Group': 'all'}],
             }
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_assert_error_in_bad_json_path(self):
         cmdline = self.prefix
         cmdline += ' --image-id ami-d00dbeef'
         cmdline += ' --launch-permission THISISNOTJSON'
         # The arg name should be in the error message.
-        self.assert_params_for_cmd2(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=255,
                                    stderr_contains='launch-permission')
 
 

--- a/tests/unit/ec2/test_modify_instance_attribute.py
+++ b/tests/unit/ec2/test_modify_instance_attribute.py
@@ -29,13 +29,13 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--instance-initiated-shutdown-behavior {"Value":"terminate"}'
-        self.assert_params_for_cmd2(cmdline, self.expected_result)
+        self.assert_params_for_cmd(cmdline, self.expected_result)
 
     def test_shorthand_version(self):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--instance-initiated-shutdown-behavior Value=terminate'
-        self.assert_params_for_cmd2(cmdline, self.expected_result)
+        self.assert_params_for_cmd(cmdline, self.expected_result)
 
     def test_value_not_needed(self):
         # For structs of a single param value, you can skip the keep name,
@@ -43,7 +43,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += '--instance-id i-1234 '
         cmdline += '--instance-initiated-shutdown-behavior terminate'
-        self.assert_params_for_cmd2(cmdline, self.expected_result)
+        self.assert_params_for_cmd(cmdline, self.expected_result)
 
     def test_boolean_value_in_top_level_true(self):
         # Just like everything else in argparse, the last value provided
@@ -53,7 +53,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--ebs-optimized Value=true'
         result = {'InstanceId': 'i-1234',
                   'ebs_optimized': {'Value': True}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_boolean_value_is_top_level_false(self):
         cmdline = self.prefix
@@ -61,7 +61,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--ebs-optimized Value=false'
         result = {'InstanceId': 'i-1234',
                   'ebs_optimized': {'Value': False}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_boolean_value_in_top_level_true_json(self):
         # Just like everything else in argparse, the last value provided
@@ -71,7 +71,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--ebs-optimized {"Value":true}'
         result = {'InstanceId': 'i-1234',
                   'ebs_optimized': {'Value': True}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_boolean_value_is_top_level_false_json(self):
         cmdline = self.prefix
@@ -79,7 +79,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--ebs-optimized {"Value":false}'
         result = {'InstanceId': 'i-1234',
                   'ebs_optimized': {'Value': False}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_boolean_param_top_level_true_no_value(self):
         cmdline = self.prefix
@@ -87,7 +87,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--ebs-optimized'
         result = {'InstanceId': 'i-1234',
                   'ebs_optimized': {'Value': True}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_boolean_param_top_level_false_no_value(self):
         cmdline = self.prefix
@@ -95,7 +95,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += '--no-ebs-optimized'
         result = {'InstanceId': 'i-1234',
                   'ebs_optimized': {'Value': False}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_mix_value_non_value_boolean_param(self):
         cmdline = self.prefix
@@ -103,7 +103,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         # Can't mix non-value + value version of the arg.
         cmdline += '--no-ebs-optimized '
         cmdline += '--ebs-optimized Value=true'
-        self.assert_params_for_cmd2(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=255,
                                     stderr_contains='Cannot specify both')
 
     def test_mix_non_value_bools_not_allowed(self):
@@ -112,7 +112,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         # Can't mix non-value + value version of the arg.
         cmdline += '--no-ebs-optimized '
         cmdline += '--ebs-optimized '
-        self.assert_params_for_cmd2(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=255,
                                     stderr_contains='Cannot specify both')
 
 

--- a/tests/unit/ec2/test_replace_network_acl_entry.py
+++ b/tests/unit/ec2/test_replace_network_acl_entry.py
@@ -34,7 +34,7 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_udp(self):
         cmdline = self.prefix
@@ -52,7 +52,7 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_icmp(self):
         cmdline = self.prefix
@@ -70,7 +70,7 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_all(self):
         cmdline = self.prefix
@@ -88,7 +88,7 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_number(self):
         cmdline = self.prefix
@@ -106,5 +106,5 @@ class TestReplaceNetworkACLEntry(BaseAWSCommandParamsTest):
                   'Egress': False,
                   'CidrBlock': '0.0.0.0/0',
                   'PortRange': {'From': 22, 'To': 22}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 

--- a/tests/unit/ec2/test_run_instances.py
+++ b/tests/unit/ec2/test_run_instances.py
@@ -29,7 +29,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_count_scalar(self):
         args = ' --image-id ami-foobar --count 2'
@@ -39,7 +39,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 2,
             'min_count': 2
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_user_data(self):
         return
@@ -56,7 +56,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                           'min_count': 1,
                           # base64 encoded content of utf-8 encoding of data.
                           'UserData': 'OQ=='}
-            self.assert_params_for_cmd2(args, result)
+            self.assert_params_for_cmd(args, result)
 
     def test_count_range(self):
         args = ' --image-id ami-foobar --count 5:10'
@@ -66,7 +66,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 10,
             'min_count': 5
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_block_device_mapping(self):
         args = ' --image-id ami-foobar --count 1'
@@ -87,7 +87,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_secondary_ip_address(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -109,7 +109,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                      {'Primary': False, 'PrivateIpAddress': '10.0.2.106'}]}],
             'max_count': 1,
             'min_count': 1}
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_secondary_ip_addresses(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -124,7 +124,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                      {'Primary': False, 'PrivateIpAddress': u'10.0.2.107'}]}],
             'max_count': 1,
             'min_count': 1}
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_secondary_ip_address_count(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -137,7 +137,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_associate_public_ip_address(self):
         args = ' --image-id ami-foobar --count 1 --subnet-id subnet-12345678 '
@@ -153,7 +153,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_associate_public_ip_address_switch_order(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -169,7 +169,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_no_associate_public_ip_address(self):
         args = ' --image-id ami-foobar --count 1  --subnet-id subnet-12345678 '
@@ -182,7 +182,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
                                    'SubnetId': 'subnet-12345678'}],
             'max_count': 1,
             'min_count': 1}
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_subnet_alone(self):
         args = ' --image-id ami-foobar --count 1 --subnet-id subnet-12345678'
@@ -193,7 +193,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_associate_public_ip_address_and_group_id(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -211,7 +211,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_group_id_alone(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -223,7 +223,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_associate_public_ip_address_and_private_ip_address(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -243,7 +243,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_private_ip_address_alone(self):
         args = ' --image-id ami-foobar --count 1 '
@@ -255,5 +255,5 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
             'max_count': 1,
             'min_count': 1
         }
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 

--- a/tests/unit/ec2/test_security_group_operations.py
+++ b/tests/unit/ec2/test_security_group_operations.py
@@ -25,7 +25,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                   'ip_permissions': [{'FromPort': 22, 'IpProtocol': 'tcp',
                                       'IpRanges': [{'CidrIp': '0.0.0.0/0'}],
                                       'ToPort': 25}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_all_port(self):
         args = self.prefix + (
@@ -34,7 +34,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                    'ip_permissions': [{'FromPort': -1, 'IpProtocol': 'tcp',
                                        'IpRanges': [{'CidrIp': '0.0.0.0/0'}],
                                        'ToPort': -1}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_icmp_echo_request(self):
         # This corresponds to a from port of 8 and a to port of -1, i.e
@@ -45,7 +45,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                   'ip_permissions': [{'FromPort': 8, 'IpProtocol': 'tcp',
                                       'IpRanges': [{'CidrIp': '0.0.0.0/0'}],
                                       'ToPort': -1}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_all_protocol(self):
         args = self.prefix + (
@@ -58,7 +58,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                                        'IpRanges': [{'CidrIp': '0.0.0.0/0'}],
                                        'ToPort': -1}]}
 
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_numeric_protocol(self):
         args = self.prefix + (
@@ -66,7 +66,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
         result = {'GroupName': 'foobar',
                    'ip_permissions': [{'IpProtocol': '200', 'IpRanges':
                                        [{'CidrIp': '0.0.0.0/0'}]}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_negative_one_protocol(self):
         args = self.prefix + (
@@ -74,7 +74,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
         result = {'GroupName': 'foobar',
                    'ip_permissions': [{'IpProtocol': '-1', 'IpRanges':
                                        [{'CidrIp': '0.0.0.0/0'}]}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_classic_group(self):
         args = self.prefix + (
@@ -84,7 +84,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                    'ip_permissions': [{'IpProtocol': 'udp', 'UserIdGroupPairs':
                                        [{'GroupName': 'fiebaz', 'UserId':
                                          '11111111'}]}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_vpc_group(self):
         args = self.prefix + (
@@ -92,7 +92,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
         result = {'GroupName': 'foobar',
                   'ip_permissions': [{'IpProtocol': 'icmp', 'UserIdGroupPairs':
                                       [{'GroupId': 'sg-12345678'}]}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_ip_permissions(self):
         json = (
@@ -103,7 +103,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                    'IpPermissions': [{'FromPort': 8000, 'ToPort': 9000,
                                       'IpProtocol': 'tcp', 'IpRanges':
                                       [{'CidrIp': '192.168.100.0/24'}]}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_ip_permissions_with_group_id(self):
         json = (
@@ -114,14 +114,14 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                   'IpPermissions': [{'FromPort': 8000, 'ToPort': 9000,
                                      'IpProtocol': 'tcp', 'IpRanges':
                                      [{'CidrIp': '192.168.100.0/24'}]}]}
-        self.assert_params_for_cmd2(args, result)
+        self.assert_params_for_cmd(args, result)
 
     def test_both(self):
         json = (
             '[{"FromPort":8000,"ToPort":9000,"IpProtocol":"tcp",'
             '"IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]')
         args = self.prefix + '--group-name foobar --port 100 --ip-permissions %s' % json
-        self.assert_params_for_cmd2(args, expected_rc=255)
+        self.assert_params_for_cmd(args, expected_rc=255)
 
 
 

--- a/tests/unit/elasticache/test_create_cache_cluster.py
+++ b/tests/unit/elasticache/test_create_cache_cluster.py
@@ -39,7 +39,7 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
                   'NumCacheNodes': 1,
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_create_cache_cluster_no_auto_minor_upgrade(self):
         args = ('--cache-cluster-id cachecluster-us-east-1c '
@@ -61,7 +61,7 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
                   'NumCacheNodes': 1,
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_minor_upgrade_arg_not_specified(self):
         args = ('--cache-cluster-id cachecluster-us-east-1c '
@@ -84,4 +84,4 @@ class TestCreateCacheCluster(BaseAWSCommandParamsTest):
                   'NumCacheNodes': 1,
                   'PreferredAvailabilityZone': 'us-east-1c',
                   'PreferredMaintenanceWindow': 'fri:08:00-fri:09:00'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/elasticbeanstalk/test_create_application.py
+++ b/tests/unit/elasticbeanstalk/test_create_application.py
@@ -24,7 +24,7 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --application-name FooBar'
         result = {'ApplicationName': 'FooBar',}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     @unittest.skipIf(
         six.PY3, 'Unicode cmd line test only is relevant to python2.')
@@ -42,4 +42,4 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
             encoding = 'utf-8'
         cmdline = cmdline.encode(encoding)
         result = {'ApplicationName': u'\u2713',}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/elasticbeanstalk/test_update_configuration_template.py
+++ b/tests/unit/elasticbeanstalk/test_update_configuration_template.py
@@ -38,4 +38,4 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
                 {'Namespace': 'aws:elasticbeanstalk:container:tomcat:jvmoptions',
                  'OptionName': 'Xms',
                  'Value': '1256m'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/elb/test_configure_health_check.py
+++ b/tests/unit/elb/test_configure_health_check.py
@@ -32,7 +32,7 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
                 'Timeout': 60,
                 'UnhealthyThreshold': 5},
             'LoadBalancerName': 'my-lb'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_json(self):
         cmdline = self.prefix
@@ -48,7 +48,7 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
                 'Timeout': 60,
                 'UnhealthyThreshold': 5},
             'LoadBalancerName': 'my-lb'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_shorthand_with_multiple_equals_for_value(self):
         cmdline = self.prefix
@@ -66,4 +66,4 @@ class TestConfigureHealthCheck(BaseAWSCommandParamsTest):
                 'Timeout': 60,
                 'UnhealthyThreshold': 5},
             'LoadBalancerName': 'my-lb'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/elb/test_register_instances_with_load_balancer.py
+++ b/tests/unit/elb/test_register_instances_with_load_balancer.py
@@ -32,7 +32,7 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline += ' --instances {"InstanceId":"i-12345678"}'
         result = {'LoadBalancerName': 'my-lb',
                   'Instances': [{'InstanceId': 'i-12345678'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_shorthand(self):
         cmdline = self.prefix
@@ -40,21 +40,21 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline += ' --instances i-12345678'
         result = {'LoadBalancerName': 'my-lb',
                   'Instances': [{'InstanceId': 'i-12345678'}]}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_two_instance(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances {"InstanceId":"i-12345678"}'
         cmdline += ' {"InstanceId":"i-87654321"}'
-        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_as_json(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances [{"InstanceId":"i-12345678"},'
         cmdline += '{"InstanceId":"i-87654321"}]'
-        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_from_file(self):
         data_path = os.path.join(os.path.dirname(__file__),
@@ -62,7 +62,7 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances file://%s' % data_path
-        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_json_file_with_spaces(self):
         data_path = os.path.join(os.path.dirname(__file__),
@@ -70,10 +70,10 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances file://%s' % data_path
-        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_shorthand(self):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances i-12345678 i-87654321'
-        self.assert_params_for_cmd2(cmdline, TWO_INSTANCE_EXPECTED)
+        self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)

--- a/tests/unit/iam/test_create_virtual_mfa_device.py
+++ b/tests/unit/iam/test_create_virtual_mfa_device.py
@@ -89,7 +89,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline += (
             ' --outfile %s --bootstrap-method Base32StringSeed' % outfile)
         result = {"VirtualMFADeviceName": 'fiebaz'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
         self.assertTrue(os.path.exists(outfile))
 
     def test_qrcode(self):
@@ -99,7 +99,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline += ' --virtual-mfa-device-name fiebaz'
         cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
         result = {"VirtualMFADeviceName": 'fiebaz'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
         self.assertTrue(os.path.exists(outfile))
 
     def test_bad_filename(self):
@@ -108,7 +108,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
         cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
-        self.assert_params_for_cmd2(cmdline, expected_rc=255)
+        self.assert_params_for_cmd(cmdline, expected_rc=255)
 
     def test_relative_filename(self):
         outfile = 'filename.png'
@@ -117,7 +117,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline += ' --virtual-mfa-device-name fiebaz'
         cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
         result = {"VirtualMFADeviceName": 'fiebaz'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
         self.assertTrue(os.path.exists(outfile))
 
     def test_bad_relative_filename(self):
@@ -126,4 +126,4 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
         cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
-        self.assert_params_for_cmd2(cmdline, expected_rc=255)
+        self.assert_params_for_cmd(cmdline, expected_rc=255)

--- a/tests/unit/opsworks/test_create_instance.py
+++ b/tests/unit/opsworks/test_create_instance.py
@@ -29,7 +29,7 @@ class TestCreateInstance(BaseAWSCommandParamsTest):
                   'Hostname': 'aws-client-instance',
                   'LayerIds': ['cb27894d-35f3-4435-b422-6641a785fa4a'],
                   'InstanceType': 'c1.medium'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/opsworks/test_create_layer.py
+++ b/tests/unit/opsworks/test_create_layer.py
@@ -44,7 +44,7 @@ class TestCreateLayer(BaseAWSCommandParamsTest):
                                  "ManageBundler": "true",
                                  }
                   }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/opsworks/test_create_stack.py
+++ b/tests/unit/opsworks/test_create_stack.py
@@ -31,7 +31,7 @@ class TestCreateStack(BaseAWSCommandParamsTest):
                   'Region': 'us-west-2',
                   'DefaultInstanceProfileArn': 'arn-foofoofoo'
                   }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/opsworks/test_describe_layers.py
+++ b/tests/unit/opsworks/test_describe_layers.py
@@ -23,7 +23,7 @@ class TestDescribeLayers(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --stack-id 35959772-cd1e-4082-8346-79096d4179f2'
         result = {'StackId': '35959772-cd1e-4082-8346-79096d4179f2'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -32,7 +32,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         args = ' --group-name foo --user-name bar'
         cmdline = self.prefix + args
         result = {'GroupName': 'foo', 'UserName': 'bar'}
-        stdout = self.assert_params_for_cmd2(cmdline, result, expected_rc=0)[0]
+        stdout = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
         # We should have printed nothing because the parsed response
         # is an empty dict: {}.
         self.assertEqual(stdout, '')

--- a/tests/unit/rds/test_describe_db_log_files.py
+++ b/tests/unit/rds/test_describe_db_log_files.py
@@ -24,4 +24,4 @@ class TestDescribeDBLogFiles(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'DBInstanceIdentifier': 'foo',
                   'FileLastWritten': 10}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/rds/test_modify_option_group.py
+++ b/tests/unit/rds/test_modify_option_group.py
@@ -28,13 +28,13 @@ class TestAddOptionGroup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'OptionsToInclude': [{'OptionName': 'TDE'}],
                   'OptionGroupName': 'myoptiongroup2'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_option_to_remove_is_not_allowed(self):
         args = ('--option-group-name myoptiongroup2 '
                 '--options-to-remove foo')
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             cmdline, expected_rc=255,
             stderr_contains='Unknown options: --options-to-remove')
 
@@ -49,12 +49,12 @@ class TestRemoveOptionGroup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = {'OptionsToRemove': ['TDE'],
                   'OptionGroupName': 'myoptiongroup2'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_option_to_add_is_not_allowed(self):
         args = ('--option-group-name myoptiongroup2 '
                 '--options-to-include {"OptionName":"TDE"}')
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             cmdline, expected_rc=255,
             stderr_contains='Unknown options: --options-to-include')

--- a/tests/unit/route53/test_resource_id.py
+++ b/tests/unit/route53/test_resource_id.py
@@ -34,13 +34,13 @@ class TestGetHostedZone(BaseAWSCommandParamsTest):
     def test_full_resource_id(self):
         args = ' --id /hostedzone/ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             cmdline, {'Id': 'ZD3IYMVP1KDDM'}, expected_rc=0)
 
     def test_short_resource_id(self):
         args = ' --id ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             cmdline, {'Id': 'ZD3IYMVP1KDDM'},
             expected_rc=0)
 
@@ -77,7 +77,7 @@ class TestChangeResourceRecord(BaseAWSCommandParamsTest):
                 ]
             }
         }
-        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
+        self.assert_params_for_cmd(cmdline, expected, expected_rc=0)
 
 
 class TestGetChange(BaseAWSCommandParamsTest):
@@ -91,13 +91,13 @@ class TestGetChange(BaseAWSCommandParamsTest):
         args = ' --id /change/ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
         expected = {'Id': 'ZD3IYMVP1KDDM'}
-        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
+        self.assert_params_for_cmd(cmdline, expected, expected_rc=0)
 
     def test_short_resource_id(self):
         args = ' --id ZD3IYMVP1KDDM'
         cmdline = self.prefix + args
         expected = {'Id': 'ZD3IYMVP1KDDM'}
-        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
+        self.assert_params_for_cmd(cmdline, expected, expected_rc=0)
 
 
 class TestReusableDelegationSet(BaseAWSCommandParamsTest):
@@ -110,13 +110,13 @@ class TestReusableDelegationSet(BaseAWSCommandParamsTest):
     def test_full_resource_id(self):
         args = ' --id /delegationset/N9INWVYQ6Q0FN'
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(cmdline, {'Id': 'N9INWVYQ6Q0FN'},
+        self.assert_params_for_cmd(cmdline, {'Id': 'N9INWVYQ6Q0FN'},
                                     expected_rc=0)
 
     def test_short_resource_id(self):
         args = ' --id N9INWVYQ6Q0FN'
         cmdline = self.prefix + args
-        self.assert_params_for_cmd2(cmdline, {'Id': 'N9INWVYQ6Q0FN'},
+        self.assert_params_for_cmd(cmdline, {'Id': 'N9INWVYQ6Q0FN'},
                                     expected_rc=0)
 
 
@@ -128,4 +128,4 @@ class TestMaxItems(BaseAWSCommandParamsTest):
         args = ' --hosted-zone-id /hostedzone/ABCD --max-items 1'
         cmdline = self.prefix + args
         expected = {'HostedZoneId': 'ABCD'}
-        self.assert_params_for_cmd2(cmdline, expected, expected_rc=0)
+        self.assert_params_for_cmd(cmdline, expected, expected_rc=0)

--- a/tests/unit/s3/test_get_object.py
+++ b/tests/unit/s3/test_get_object.py
@@ -38,7 +38,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --key mykey'
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
                                               'Key': 'mykey'})
 
     def test_range(self):
@@ -48,7 +48,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --range bytes=0-499'
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
                                               'Key': 'mykey',
                                               'Range': 'bytes=0-499'})
 
@@ -60,7 +60,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --response-content-encoding x-gzip'
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             cmdline, {
                 'Bucket': 'mybucket', 'Key': 'mykey',
                 'ResponseCacheControl': 'No-cache',
@@ -83,7 +83,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline += ' --key mykey'
         cmdline += ' outfile'
         self.addCleanup(self.remove_file_if_exists, 'outfile')
-        self.assert_params_for_cmd2(
+        self.assert_params_for_cmd(
             cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
 
 

--- a/tests/unit/s3/test_list_objects.py
+++ b/tests/unit/s3/test_list_objects.py
@@ -25,7 +25,7 @@ class TestListObjects(BaseAWSCommandParamsTest):
     def test_simple(self):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket'})
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket'})
 
     def test_max_items(self):
         cmdline = self.prefix
@@ -33,7 +33,7 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # The max-items is a customization and therefore won't
         # show up in the result params.
         cmdline += ' --max-items 100'
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket'})
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket'})
 
     def test_page_size(self):
         cmdline = self.prefix
@@ -41,7 +41,7 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # The max-items is a customization and therefore won't
         # show up in the result params.
         cmdline += ' --page-size 100'
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
                                               'MaxKeys': 100})
 
     def test_starting_token(self):
@@ -51,13 +51,13 @@ class TestListObjects(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
         cmdline += ' --starting-token foo___2'
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
                                               'Marker': 'foo'})
 
     def test_no_paginate(self):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket --no-paginate'
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket'})
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket'})
 
     def test_max_keys_can_be_specified(self):
         cmdline = self.prefix
@@ -65,7 +65,7 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # but for back-compat reasons if a user specifies this,
         # we will automatically see this and turn auto-pagination off.
         cmdline += ' --bucket mybucket --max-keys 1'
-        self.assert_params_for_cmd2(cmdline, {'Bucket': 'mybucket',
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
                                               'MaxKeys': 1})
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(len(self.operations_called), 1)

--- a/tests/unit/s3/test_put_bucket_tagging.py
+++ b/tests/unit/s3/test_put_bucket_tagging.py
@@ -52,7 +52,7 @@ class TestPutBucketTagging(BaseAWSCommandParamsTest):
                 ]
             }
         }
-        self.assert_params_for_cmd2(cmdline, expected)
+        self.assert_params_for_cmd(cmdline, expected)
 
 
 if __name__ == "__main__":

--- a/tests/unit/s3/test_put_object.py
+++ b/tests/unit/s3/test_put_object.py
@@ -57,7 +57,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
             'Bucket': 'mybucket',
             'Key': 'mykey'
         }
-        self.assert_params_for_cmd2(cmdline, expected, ignore_params=['Body'])
+        self.assert_params_for_cmd(cmdline, expected, ignore_params=['Body'])
         self.assertEqual(self.last_kwargs['Body'].name, self.file_path)
 
     def test_headers(self):
@@ -75,7 +75,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
             'ContentType': 'text/plain',
             'Key': 'mykey'
         }
-        self.assert_params_for_cmd2(cmdline, expected, ignore_params=['Body'])
+        self.assert_params_for_cmd(cmdline, expected, ignore_params=['Body'])
         self.assertEqual(self.last_kwargs['Body'].name, self.file_path)
 
     def test_website_redirect(self):
@@ -90,7 +90,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
             'Key': 'mykey',
             'WebsiteRedirectLocation': 'http://www.example.com/'
         }
-        self.assert_params_for_cmd2(cmdline, expected)
+        self.assert_params_for_cmd(cmdline, expected)
 
     def test_sse_key_with_binary_file(self):
         # Create contents that do not get mapped to ascii
@@ -108,7 +108,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
             'SSECustomerKey': 'wg==',  # Note the key gets base64 encoded.
             'SSECustomerKeyMD5': 'ZGXa0dMXUr4/MoPo9w/u9w=='
         }
-        self.assert_params_for_cmd2(cmdline, expected)
+        self.assert_params_for_cmd(cmdline, expected)
 
 
 if __name__ == "__main__":

--- a/tests/unit/ses/test_send_email.py
+++ b/tests/unit/ses/test_send_email.py
@@ -31,7 +31,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
             'destination': {'ToAddresses': ['fie@baz.com']},
             'message': {'Body': {'Text': {'Data': 'This_is_the_message'}},
                         'Subject': {'Data': 'This_is_a_test'}}}
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_plain_text_multiple_to(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -44,7 +44,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                       'Body': {'Text': {'Data': 'This_is_the_message'}},
                       'Subject': {'Data': 'This_is_a_test'}}}
 
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_plain_text_multiple_cc(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -59,7 +59,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                       'Body': {'Text': {'Data': 'This_is_the_message'}},
                       'Subject': {'Data': 'This_is_a_test'}}}
 
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_plain_text_multiple_bcc(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -77,7 +77,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                 'Body': {'Text': {'Data': 'This_is_the_message'}},
                 'Subject': {'Data': 'This_is_a_test'}}}
 
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_html_text(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -90,7 +90,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                         'Body': {
                             'Html': {'Data': 'This_is_the_html_message'}}}}
 
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_html_both(self):
         args = (' --subject This_is_a_test --from foo@bar.com'
@@ -105,7 +105,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                 'Body': {
                     'Text': {'Data': 'This_is_the_text_message'},
                     'Html': {'Data': 'This_is_the_html_message'}}}}
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_using_json(self):
         args = (' --message {"Subject":{"Data":"This_is_a_test"},'
@@ -121,7 +121,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                           'Text': {'Data': 'This_is_the_message'}}},
                   'Source': 'foo@bar.com'}
 
-        self.assert_params_for_cmd2(args_list, result)
+        self.assert_params_for_cmd(args_list, result)
 
     def test_both_destination_and_to(self):
         args = (' --message {"Subject":{"Data":"This_is_a_test"},'

--- a/tests/unit/sns/test_create_platform_application.py
+++ b/tests/unit/sns/test_create_platform_application.py
@@ -29,7 +29,7 @@ class TestCreatePlatformApplication(BaseAWSCommandParamsTest):
                   'Platform': 'GCM',
                   'Attributes': {'PlatformCredential': 'foo',
                                  'PlatformPrincipal': 'bar'}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_gcm_json(self):
         cmdline = self.prefix
@@ -45,7 +45,7 @@ class TestCreatePlatformApplication(BaseAWSCommandParamsTest):
               'PlatformCredential': 'AIzaSyClE2lcV2zEKTLYYo645zfk2jhQPFeyxDo',
               'PlatformPrincipal': 'There+is+no+principal+for+GCM'}
         }
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_add_permission.py
+++ b/tests/unit/sqs/test_add_permission.py
@@ -30,7 +30,7 @@ class TestAddPermission(BaseAWSCommandParamsTest):
                   'Actions': ['SendMessage'],
                   'AWSAccountIds': ['888888888888'],
                   'Label': 'FooBarLabel'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_multiple_accounts(self):
         cmdline = self.prefix
@@ -42,7 +42,7 @@ class TestAddPermission(BaseAWSCommandParamsTest):
                   'Actions': ['SendMessage'],
                   'AWSAccountIds': ['888888888888', '999999999999'],
                   'Label': 'FooBarLabel'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_multiple_actions(self):
         cmdline = self.prefix
@@ -54,7 +54,7 @@ class TestAddPermission(BaseAWSCommandParamsTest):
                   'Actions': ['SendMessage', 'ReceiveMessage'],
                   'AWSAccountIds': ['888888888888'],
                   'Label': 'FooBarLabel'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_change_message_visibility.py
+++ b/tests/unit/sqs/test_change_message_visibility.py
@@ -29,7 +29,7 @@ class TestChangeMessageVisibility(BaseAWSCommandParamsTest):
         result = {'QueueUrl': self.queue_url,
                   'ReceiptHandle': self.receipt_handle,
                   'VisibilityTimeout': 30}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_create_queue.py
+++ b/tests/unit/sqs/test_create_queue.py
@@ -24,7 +24,7 @@ class TestCreateQueue(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --queue-name %s' % self.queue_name
         result = {'QueueName': self.queue_name}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_get_queue_attributes.py
+++ b/tests/unit/sqs/test_get_queue_attributes.py
@@ -23,28 +23,28 @@ class TestGetQueueAttributes(BaseAWSCommandParamsTest):
     def test_no_attr(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         result = {'QueueUrl': self.queue_url}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_all(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attribute-names All'
         result = {'QueueUrl': self.queue_url,
                   'AttributeNames': ['All']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_one(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attribute-names VisibilityTimeout'
         result = {'QueueUrl': self.queue_url,
                   'AttributeNames': ['VisibilityTimeout']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_two(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attribute-names VisibilityTimeout QueueArn'
         result = {'QueueUrl': self.queue_url,
                   'AttributeNames': ['VisibilityTimeout', 'QueueArn']}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_list_queues.py
+++ b/tests/unit/sqs/test_list_queues.py
@@ -22,12 +22,12 @@ class TestListQueues(BaseAWSCommandParamsTest):
     def test_no_param(self):
         cmdline = self.prefix
         result = {}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_prefix(self):
         cmdline = self.prefix + ' --queue-name-prefix test'
         result = {'QueueNamePrefix': 'test'}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_purge_queue.py
+++ b/tests/unit/sqs/test_purge_queue.py
@@ -24,7 +24,7 @@ class TestPurgeQueue(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --queue-url %s' % url
         result = {'QueueUrl': url}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/sqs/test_set_queue_attributes.py
+++ b/tests/unit/sqs/test_set_queue_attributes.py
@@ -26,14 +26,14 @@ class TestSetQueueAttributes(BaseAWSCommandParamsTest):
         result = {'QueueUrl': self.queue_url,
                   'Attributes': {
                       'VisibilityTimeout': '15'}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
     def test_shorthand(self):
         cmdline = self.prefix + ' --queue-url %s' % self.queue_url
         cmdline += ' --attributes VisibilityTimeout=15'
         result = {'QueueUrl': self.queue_url,
                   'Attributes': {'VisibilityTimeout': '15'}}
-        self.assert_params_for_cmd2(cmdline, result)
+        self.assert_params_for_cmd(cmdline, result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -389,7 +389,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 'ec2 describe-instances --endpoint-url https://foobar.com/',
                 expected_rc=0)
         endpoint.assert_called_with(region_name=None,
@@ -402,7 +402,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         endpoint.assert_called_with(region_name='us-east-1',
@@ -415,7 +415,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 'ec2 describe-instances --region us-east-1 --no-verify-ssl',
                 expected_rc=0)
         # Because we used --no-verify-ssl, get_endpoint should be
@@ -432,7 +432,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
             self.environ['AWS_CA_BUNDLE'] = '/path/cacert.pem'
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         call_args = endpoint.call_args
@@ -445,7 +445,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             endpoint.return_value.host = ''
             endpoint.return_value.make_request.return_value = (
                 http_response, {})
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 'ec2 describe-instances --region us-east-1',
                 expected_rc=0)
         call_args = endpoint.call_args
@@ -457,7 +457,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {'CommonPrefixes': [], 'Contents': []})
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 's3 ls s3://test --region us-east-1 --endpoint-url https://foobar.com/',
                 expected_rc=0)
         endpoint.assert_called_with(region_name='us-east-1',
@@ -470,7 +470,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             http_response.status_code = 200
             endpoint.return_value.make_request.return_value = (
                 http_response, {'CommonPrefixes': [], 'Contents': []})
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 's3 ls s3://test --no-verify-ssl',
                 expected_rc=0)
         endpoint.assert_called_with(region_name=None,
@@ -599,7 +599,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         # Simulates the equivalent in bash: --identifies ""
         cmd = 'ses get-identity-dkim-attributes --identities'.split()
         cmd.append('')
-        self.assert_params_for_cmd2(cmd,expected_rc=0)
+        self.assert_params_for_cmd(cmd,expected_rc=0)
 
     def test_file_param_does_not_exist(self):
         driver = create_clidriver()
@@ -672,7 +672,7 @@ class TestHTTPParamFileDoesNotExist(BaseAWSCommandParamsTest):
                      "received non 200 status code of 404")
         with mock.patch('botocore.vendored.requests.get') as get:
             get.return_value.status_code = 404
-            self.assert_params_for_cmd2(
+            self.assert_params_for_cmd(
                 'ec2 describe-instances --filters http://does/not/exist.json',
                 expected_rc=255, stderr_contains=error_msg)
 
@@ -701,11 +701,11 @@ class TestVerifyArgument(BaseAWSCommandParamsTest):
         self.recorded_args = parsed_args
 
     def test_no_verify_argument(self):
-        self.assert_params_for_cmd2('s3api list-buckets --no-verify-ssl'.split())
+        self.assert_params_for_cmd('s3api list-buckets --no-verify-ssl'.split())
         self.assertFalse(self.recorded_args.verify_ssl)
 
     def test_verify_argument_is_none_by_default(self):
-        self.assert_params_for_cmd2('s3api list-buckets'.split())
+        self.assert_params_for_cmd('s3api list-buckets'.split())
         self.assertIsNone(self.recorded_args.verify_ssl)
 
 


### PR DESCRIPTION
assert_params_for_cmd, the only version, is now removed.
When we do these functional tests, we only check down to the
top most botocore layer, not at the wire protocol level.

cc @danielgtaylor @kyleknap