### PR TITLE
Add retry logic for read timeouts for s3 commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
+* bugfix:``aws s3``: Fix issue where read timeouts were not retried.
+  (`issue 1191 <https://github.com/aws/aws-cli/pull/1191>`__)
 * feature:``aws cloudtrail``: Add support for regionalized policy templates
   for the ``create-subscription`` and ``update-subscription`` commands.
   (`issue 1167 <https://github.com/aws/aws-cli/pull/1167>`__)

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -7,6 +7,8 @@ import threading
 
 from botocore.vendored import requests
 from botocore.exceptions import IncompleteReadError
+from botocore.vendored.requests.packages.urllib3.exceptions import \
+    ReadTimeoutError
 
 from awscli.customizations.s3.utils import find_bucket_key, MD5Error, \
     operate, ReadFileChunk, relative_path, IORequest, IOCloseRequest, \
@@ -383,8 +385,8 @@ class DownloadPartTask(OrderableTask):
                 self._result_queue.put(PrintTask(**result))
                 LOGGER.debug("Task complete: %s", self)
                 return
-            except (socket.timeout, socket.error) as e:
-                LOGGER.debug("Socket timeout caught, retrying request, "
+            except (socket.timeout, socket.error, ReadTimeoutError) as e:
+                LOGGER.debug("Timeout error caught, retrying request, "
                              "(attempt %s / %s)", i, self.TOTAL_ATTEMPTS,
                              exc_info=True)
                 continue


### PR DESCRIPTION
It looks like when we upgraded requests, it upgraded urllib3 which better handles read timeouts. This allows us to retry their read timeouts.

cc @jamesls @danielgtaylor 