### PR TITLE
Remove use of clone client for s3 commands

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -636,7 +636,12 @@ class CommandArchitecture(object):
             endpoint_url=self.parameters['endpoint_url'],
             verify=self.parameters['verify_ssl']
         )
-        self._source_client = self._client.clone_client()
+        self._source_client = get_client(
+            self.session,
+            region=self.parameters['region'],
+            endpoint_url=self.parameters['endpoint_url'],
+            verify=self.parameters['verify_ssl']
+        )
         if self.parameters['source_region']:
             if self.parameters['paths_type'] == 's3s3':
                 self._source_client = get_client(


### PR DESCRIPTION
Removing use of ``clone_client`` due to its removal in botocore.

cc @jamesls @danielgtaylor 