### PR TITLE
Support paging help through "more" command on windows

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -96,20 +96,6 @@ class PosixHelpRenderer(HelpRenderer):
         p4.communicate(input=groff_output)
         sys.exit(1)
 
-    def _get_rst2man_name(self):
-        if self._exists_on_path('rst2man.py'):
-            return 'rst2man.py'
-        elif self._exists_on_path('rst2man'):
-            # Some distros like ubuntu will rename rst2man.py to rst2man
-            # if you install their version (i.e. "apt-get install
-            # python-docutils").  Though they could technically rename
-            # this to anything we'll support it renamed to 'rst2man' by
-            # explicitly checking for this case ourself.
-            return 'rst2man'
-        else:
-            # Give them the original name as set from docutils.
-            raise ExecutableNotFoundError('rst2man.py')
-
     def _exists_on_path(self, name):
         # Since we're only dealing with POSIX systems, we can
         # ignore things like PATHEXT.

--- a/tests/unit/customizations/test_cloudsearchdomain.py
+++ b/tests/unit/customizations/test_cloudsearchdomain.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.help import HelpRenderer
+from awscli.help import PagingHelpRenderer
 from awscli.customizations.cloudsearchdomain import validate_endpoint_url
 
 import mock
@@ -46,7 +46,7 @@ class TestSearchCommand(BaseAWSCommandParamsTest):
     def test_endpoint_not_required_for_help(self):
         cmd = self.prefix + 'help'
         with mock.patch('awscli.help.get_renderer') as get_renderer:
-            mock_render = mock.Mock(spec=HelpRenderer)
+            mock_render = mock.Mock(spec=PagingHelpRenderer)
             get_renderer.return_value = mock_render
             stdout, stderr, rc = self.run_cmd(cmd, expected_rc=None)
             # If we get this far we've succeeded, but we can do


### PR DESCRIPTION
This is an alternate to  #1168 except it refactors the existing internals to support paging through "more" on windows rather than using pydoc.  I also confirmed that this works on powershell as well as cmd.

The existing PR had failing travis CI builds and was overwriting the PAGER env var.


Closes #1168.

cc @kyleknap @danielgtaylor 