### PR TITLE
Fix htmlgen

### DIFF
--- a/doc/source/htmlgen
+++ b/doc/source/htmlgen
@@ -4,13 +4,13 @@ import sys
 import json
 import argparse
 import awscli.clidriver
-from awscli.help import HelpRenderer
+from awscli.help import PagingHelpRenderer
 
 REF_PATH = 'reference'
 TUT_PATH = 'tutorial'
 
 
-class FileRenderer(HelpRenderer):
+class FileRenderer(PagingHelpRenderer):
 
     def __init__(self, file_path):
         self._file_path = file_path


### PR DESCRIPTION
HelpRenderer was removed with the paging changes on windows.
We now have to subclass from PagingHelpRenderer.

Verified I could build the html docs locally.

cc @kyleknap @danielgtaylor 