### PR TITLE
Disable s3 streaming memory test on RHEL systems

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -59,6 +59,12 @@ def aws(command, collect_memory=False, env_vars=None, wait_for_finish=True,
                 input_file=input_file)
 
 
+def _running_on_rhel():
+    return (
+        hasattr(platform, 'linux_distribution') and
+        platform.linux_distribution()[0] == 'Red Hat Enterprise Linux Server')
+
+
 class BaseS3CLICommand(unittest.TestCase):
     """Base class for aws s3 command.
 
@@ -1291,6 +1297,13 @@ class TestMemoryUtilization(BaseS3CLICommand):
         self.assert_max_memory_used(p, self.max_mem_allowed,
                                     download_full_command)
 
+    # Some versions of RHEL allocate memory in a way where free'd memory isn't
+    # given back to the OS.  We haven't seen behavior as bad as RHEL's to the
+    # point where this test fails on other distros, so for now we're disabling
+    # the test on RHEL until we come up with a better way to collect
+    # memory usage.
+    @unittest.skipIf(_running_on_rhel(),
+                     'Streaming memory tests no supported on RHEL.')
     def test_stream_large_file(self):
         """
         This tests to ensure that streaming files for both uploads and


### PR DESCRIPTION
We've seen this fail semi-regularly on RHEL systems only.
I've done some digging and I can confirm that this is _not_
because anything in our code is actually leaking memory.

The biggest problem with our current memory collection
approach is that we're measuring RSS of the entire CLI process,
which is not *really* what we want.  We really just want to ensure
that our python code is not causing memory to continually be allocated.
Ideally we can measure heap growth.

To confirm we're good on RHEL, I used heapy to snapshot the heap each
time we read from stdin for the command
"aws s3 cp - s3://b/k < largefile".

At it's peak, the heap looks like::
```
Partition of a set of 1781 objects. Total size = 67501448 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0    408  23 67140752  99  67140752  99 str
     1    222  12    79824   0  67220576 100 dict (no owner)
     2     61   3    33968   0  67254544 100 types.FrameType
     3    240  13    29760   0  67284304 100 list
     4     22   1    23056   0  67307360 100 dict of botocore.model.Shape
     5      6   0    20112   0  67327472 100 dict of botocore.awsrequest.AWSHTTPSConnection
     6     15   1    15720   0  67343192 100 dict of cookielib.DefaultCookiePolicy
     7    192  11    14080   0  67357272 100 tuple
     8     66   4    10152   0  67367424 100 unicode
     9     25   1     8936   0  67376360 100 collections.OrderedDict
```
The 64MB strs matches what we'd expect.  The max threads in streams is 6 threads,
the task queue is capped to 2, and with a part size of 8mb gives us
(6 + 2) * 8 or ~64mb.

cc @kyleknap @danielgtaylor 