### PR TITLE
Use choose-signer event for --no-sign-request

### DIFF
--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -13,7 +13,7 @@
 import sys
 import os
 
-import botocore
+from botocore.handlers import disable_signing
 import jmespath
 
 from awscli.compat import urlparse
@@ -72,8 +72,4 @@ def no_sign_request(parsed_args, session, **kwargs):
         # we need to set the signature_version to None for
         # any service created.  This ensures that get_endpoint()
         # will not look for auth.
-        session.register('service-created', disable_signing)
-
-
-def disable_signing(service, **kwargs):
-    service.signature_version = botocore.UNSIGNED
+        session.register('choose-signer', disable_signing)

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from botocore.handlers import disable_signing
+
 from awscli.testutils import unittest
 from awscli.compat import six
 import mock
@@ -68,7 +70,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         session = mock.Mock()
 
         globalargs.no_sign_request(args, session)
-        session.register.assert_called_with('service-created', mock.ANY)
+        session.register.assert_called_with('choose-signer', disable_signing)
 
     def test_request_signed_by_default(self):
         args = FakeParsedArgs(sign_request=True)
@@ -76,12 +78,6 @@ class TestGlobalArgsCustomization(unittest.TestCase):
 
         globalargs.no_sign_request(args, session)
         self.assertFalse(session.register.called)
-
-    def test_disable_signing(self):
-        service = mock.Mock()
-        service.signature_version = 'v4'
-        globalargs.disable_signing(service)
-        service.signature_version = None
 
     def test_invalid_endpoint_url(self):
         # Invalid jmespath expression.


### PR DESCRIPTION
This fixes the s3 integration test failure with no sign requests. I moved the CLI to rely on the same handler and event that botocore uses, ``choose-signer``. I also added an integration test for the data driven commands, and updated that test to use clients.

cc @jamesls @danielgtaylor 