### PR TITLE
Update events to emit model/session objects

### DIFF
--- a/awscli/customizations/cliinputjson.py
+++ b/awscli/customizations/cliinputjson.py
@@ -21,11 +21,11 @@ def register_cli_input_json(cli):
     cli.register('building-argument-table', add_cli_input_json)
 
 
-def add_cli_input_json(operation, argument_table, **kwargs):
+def add_cli_input_json(session, argument_table, **kwargs):
     # This argument cannot support operations with streaming output which
     # is designated by the argument name `outfile`.
     if 'outfile' not in argument_table:
-        cli_input_json_argument = CliInputJSONArgument(operation)
+        cli_input_json_argument = CliInputJSONArgument(session)
         cli_input_json_argument.add_to_arg_table(argument_table)
 
 
@@ -45,13 +45,11 @@ class CliInputJSONArgument(OverrideRequiredArgsArgument):
                      'the JSON-provided values.'
     }
 
-    def __init__(self, operation_object):
-        self._operation_object = operation_object
-        super(CliInputJSONArgument, self).__init__(
-            self._operation_object.session)
+    def __init__(self, session):
+        super(CliInputJSONArgument, self).__init__(session)
 
     def _register_argument_action(self):
-        self._operation_object.session.register(
+        self._session.register(
             'calling-command', self.add_to_call_parameters)
         super(CliInputJSONArgument, self)._register_argument_action()
 

--- a/awscli/customizations/ec2bundleinstance.py
+++ b/awscli/customizations/ec2bundleinstance.py
@@ -41,18 +41,20 @@ PREFIX_DOCS = ('The prefix for the image component names being stored '
 OWNER_AKID_DOCS = 'The access key ID of the owner of the Amazon S3 bucket.'
 
 # --policy
-POLICY_DOCS = ("An Amazon S3 upload policy that gives "
-               "Amazon EC2 permission to upload items into Amazon S3 "
-               "on the user's behalf. If you provide this parameter, "
-               "you must also provide "
-               "your secret access key, so we can create a policy "
-               "signature for you (the secret access key is not passed "
-               "to Amazon EC2). If you do not provide this parameter, "
-               "we generate an upload policy for you automatically. "
-               "For more information about upload policies see the "
-               "sections about policy construction and signatures in the "
-               '<a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/HTTPPOSTForms.html">'
-               'Amazon Simple Storage Service Developer Guide</a>.')
+POLICY_DOCS = (
+    "An Amazon S3 upload policy that gives "
+    "Amazon EC2 permission to upload items into Amazon S3 "
+    "on the user's behalf. If you provide this parameter, "
+    "you must also provide "
+    "your secret access key, so we can create a policy "
+    "signature for you (the secret access key is not passed "
+    "to Amazon EC2). If you do not provide this parameter, "
+    "we generate an upload policy for you automatically. "
+    "For more information about upload policies see the "
+    "sections about policy construction and signatures in the "
+    '<a href="http://docs.aws.amazon.com/AmazonS3/latest/dev'
+    '/HTTPPOSTForms.html">'
+    'Amazon Simple Storage Service Developer Guide</a>.')
 
 # --owner-sak
 OWNER_SAK_DOCS = ('The AWS secret access key for the owner of the '
@@ -61,7 +63,7 @@ OWNER_SAK_DOCS = ('The AWS secret access key for the owner of the '
                   'signature can be computed for the policy.')
 
 
-def _add_params(argument_table, operation, **kwargs):
+def _add_params(argument_table, **kwargs):
     # Add the scalar parameters and also change the complex storage
     # param to not be required so the user doesn't get an error from
     # argparse if they only supply scalar params.
@@ -152,7 +154,7 @@ EVENTS = [
     ('building-argument-table.ec2.bundle-instance', _add_params),
     ('operation-args-parsed.ec2.bundle-instance', _check_args),
     ('before-parameter-build.ec2.BundleInstance', _check_params),
-    ]
+]
 
 
 def register_bundleinstance(event_handler):
@@ -172,7 +174,6 @@ class BundleArgument(CustomArgument):
         if 'storage' not in params:
             params['storage'] = {'S3': {}}
         params['storage']['S3'][self._storage_param] = value
-
 
     def add_to_params(self, parameters, value):
         if value:

--- a/awscli/customizations/ec2runinstances.py
+++ b/awscli/customizations/ec2runinstances.py
@@ -42,7 +42,7 @@ ASSOCIATE_PUBLIC_IP_ADDRESS_DOCS = (
     '[EC2-VPC] If specified a public IP address will be assigned '
     'to the new instance in a VPC.')
 
-def _add_params(argument_table, operation, **kwargs):
+def _add_params(argument_table, **kwargs):
     arg = SecondaryPrivateIpAddressesArgument(
         name='secondary-private-ip-addresses',
         help_text=SECONDARY_PRIVATE_IP_ADDRESSES_DOCS)

--- a/awscli/customizations/ec2secgroupsimplify.py
+++ b/awscli/customizations/ec2secgroupsimplify.py
@@ -25,7 +25,7 @@ authorize operations:
 from awscli.arguments import CustomArgument
 
 
-def _add_params(argument_table, operation, **kwargs):
+def _add_params(argument_table, **kwargs):
     arg = ProtocolArgument('protocol',
                            help_text=PROTOCOL_DOCS)
     argument_table['protocol'] = arg
@@ -41,7 +41,6 @@ def _add_params(argument_table, operation, **kwargs):
     arg = CidrArgument('cidr', help_text=CIDR_DOCS)
     argument_table['cidr'] = arg
     argument_table['cidr-ip']._UNDOCUMENTED = True
-
 
     arg = SourceGroupArgument('source-group',
                               help_text=SOURCEGROUP_DOCS)
@@ -67,6 +66,7 @@ def _check_args(parsed_args, **kwargs):
                        'with the --ip-permissions option ') % key
                 raise ValueError(msg)
 
+
 def _add_docs(help_command, **kwargs):
     doc = help_command.doc
     doc.style.new_paragraph()
@@ -78,11 +78,14 @@ def _add_docs(help_command, **kwargs):
 
 
 EVENTS = [
-    ('building-argument-table.ec2.authorize-security-group-ingress', _add_params),
-    ('building-argument-table.ec2.authorize-security-group-egress', _add_params),
+    ('building-argument-table.ec2.authorize-security-group-ingress',
+     _add_params),
+    ('building-argument-table.ec2.authorize-security-group-egress',
+     _add_params),
     ('building-argument-table.ec2.revoke-security-group-ingress', _add_params),
     ('building-argument-table.ec2.revoke-security-group-egress', _add_params),
-    ('operation-args-parsed.ec2.authorize-security-group-ingress', _check_args),
+    ('operation-args-parsed.ec2.authorize-security-group-ingress',
+     _check_args),
     ('operation-args-parsed.ec2.authorize-security-group-egress', _check_args),
     ('operation-args-parsed.ec2.revoke-security-group-ingress', _check_args),
     ('operation-args-parsed.ec2.revoke-security-group-egress', _check_args),
@@ -90,7 +93,7 @@ EVENTS = [
     ('doc-description.ec2.authorize-security-group-egress', _add_docs),
     ('doc-description.ec2.revoke-security-group-ingress', _add_docs),
     ('doc-description.ec2.revoke-security-groupdoc-ingress', _add_docs),
-    ]
+]
 PROTOCOL_DOCS = ('<p>The IP protocol of this permission.</p>'
                  '<p>Valid protocol values: <code>tcp</code>, '
                  '<code>udp</code>, <code>icmp</code></p>')
@@ -104,6 +107,7 @@ SOURCEGROUP_DOCS = ('<p>The name or ID of the source security group. '
 GROUPOWNER_DOCS = ('<p>The AWS account ID that owns the source security '
                    'group. Cannot be used when specifying a CIDR IP '
                    'address.</p>')
+
 
 def register_secgroup(event_handler):
     for event, handler in EVENTS:

--- a/awscli/customizations/flatten.py
+++ b/awscli/customizations/flatten.py
@@ -166,14 +166,14 @@ class FlattenArguments(object):
                                                                   operation),
                          self.flatten_args)
 
-    def flatten_args(self, operation, argument_table, **kwargs):
+    def flatten_args(self, command, argument_table, **kwargs):
         # For each argument with a bag of parameters
-        for name, argument in self.configs[operation.cli_name].items():
+        for name, argument in self.configs[command.name].items():
             argument_from_table = argument_table[name]
             overwritten = False
 
             LOG.debug('Flattening {0} argument {1} into {2}'.format(
-                operation, name,
+                command.name, name,
                 ', '.join([v['name'] for k, v in argument['flatten'].items()])
             ))
 

--- a/awscli/customizations/generatecliskeleton.py
+++ b/awscli/customizations/generatecliskeleton.py
@@ -22,11 +22,12 @@ def register_generate_cli_skeleton(cli):
     cli.register('building-argument-table', add_generate_skeleton)
 
 
-def add_generate_skeleton(operation, argument_table, **kwargs):
+def add_generate_skeleton(session, operation_model, argument_table, **kwargs):
     # This argument cannot support operations with streaming output which
     # is designated by the argument name `outfile`.
     if 'outfile' not in argument_table:
-        generate_cli_skeleton_argument = GenerateCliSkeletonArgument(operation)
+        generate_cli_skeleton_argument = GenerateCliSkeletonArgument(
+            session, operation_model)
         generate_cli_skeleton_argument.add_to_arg_table(argument_table)
 
 
@@ -49,13 +50,12 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
         'group_name': 'generate_cli_skeleton'
     }
 
-    def __init__(self, operation_object):
-        self._operation_object = operation_object
-        super(GenerateCliSkeletonArgument, self).__init__(
-            self._operation_object.session)
+    def __init__(self, session, operation_model):
+        super(GenerateCliSkeletonArgument, self).__init__(session)
+        self._operation_model = operation_model
 
     def _register_argument_action(self):
-        self._operation_object.session.register(
+        self._session.register(
             'calling-command.*', self.generate_json_skeleton)
         super(GenerateCliSkeletonArgument, self)._register_argument_action()
 
@@ -67,7 +67,7 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
         if getattr(parsed_args, 'generate_cli_skeleton', False):
 
             # Obtain the model of the operation
-            operation_model = self._operation_object.model
+            operation_model = self._operation_model
 
             # Generate the skeleton based on the ``input_shape``.
             argument_generator = ArgumentGenerator()

--- a/awscli/customizations/iamvirtmfa.py
+++ b/awscli/customizations/iamvirtmfa.py
@@ -65,7 +65,6 @@ class IAMVMFAWrapper(object):
 
     def __init__(self, event_handler):
         self._event_handler = event_handler
-        self._operation = None
         self._outfile = FileArgument(
             'outfile', help_text=OUTPUT_HELP, required=True)
         self._method = StatefulArgument(
@@ -77,8 +76,7 @@ class IAMVMFAWrapper(object):
         self._event_handler.register(
             'after-call.iam.CreateVirtualMFADevice', self._save_file)
 
-    def _add_options(self, argument_table, operation, **kwargs):
-        self._operation = operation
+    def _add_options(self, argument_table, **kwargs):
         argument_table['outfile'] = self._outfile
         argument_table['bootstrap-method'] = self._method
 

--- a/awscli/customizations/putmetricdata.py
+++ b/awscli/customizations/putmetricdata.py
@@ -39,7 +39,7 @@ def register_put_metric_data(event_handler):
                               'dimensions', 'statistic_values']))
 
 
-def _promote_args(argument_table, operation, **kwargs):
+def _promote_args(argument_table, **kwargs):
     # We're providing top level params for metric-data.  This means
     # that metric-data is now longer a required arg.  We do need
     # to check that either metric-data or the complex args we've added

--- a/awscli/customizations/rds.py
+++ b/awscli/customizations/rds.py
@@ -61,9 +61,13 @@ def _building_command_table(command_table, session, **kwargs):
         parent_name='rds', name='add-option-to-option-group',
         operation_object=modify_operation,
         operation_caller=CLIOperationCaller(session),
+        session=session,
+        operation_model=modify_operation.model,
         service_object=rds_service)
     command_table['remove-option-from-option-group'] = ServiceOperation(
         parent_name='rds', name='remove-option-from-option-group',
         operation_object=modify_operation,
+        session=session,
+        operation_model=modify_operation.model,
         operation_caller=CLIOperationCaller(session),
         service_object=rds_service)

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -111,10 +111,15 @@ class WaiterStateCommandBuilder(object):
         # operation object is used to generate the arguments for the waiter
         # state command.
         operation_object = self._service_object.get_operation(operation_name)
+        session = operation_object.session
+        operation_model = session.get_service_model(
+            self._service_object.service_name).operation_model(operation_name)
         waiter_state_command = WaiterStateCommand(
             name=waiter_cli_name, parent_name='wait',
             operation_object=operation_object,
             operation_caller=WaiterCaller(waiter_name),
+            session=operation_object.session,
+            operation_model=operation_model,
             service_object=self._service_object
         )
         # Build the top level description for the waiter state command.

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -201,6 +201,9 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         p = aws('s3api list-objects --bucket %s --no-paginate' % bucket_name)
         self.assertEqual(p.rc, 0, p.stdout + p.stderr)
 
+        p = aws('s3api list-objects --bucket %s' % bucket_name)
+        self.assertEqual(p.rc, 0, p.stdout + p.stderr)
+
     def test_top_level_options_debug(self):
         p = aws('ec2 describe-instances --debug')
         self.assertEqual(p.rc, 0)

--- a/tests/unit/customizations/test_cliinputjson.py
+++ b/tests/unit/customizations/test_cliinputjson.py
@@ -22,8 +22,8 @@ from awscli.customizations.cliinputjson import CliInputJSONArgument
 
 class TestCliInputJSONArgument(unittest.TestCase):
     def setUp(self):
-        self.operation_object = mock.Mock()
-        self.argument = CliInputJSONArgument(self.operation_object)
+        self.session = mock.Mock()
+        self.argument = CliInputJSONArgument(self.session)
 
         # Create the various forms the data could come in. The two main forms
         # are as a string and or as a path to a file.
@@ -39,7 +39,7 @@ class TestCliInputJSONArgument(unittest.TestCase):
         shutil.rmtree(self.temp_dir)
 
     def test_register_argument_action(self):
-        register_args = self.operation_object.session.register.call_args_list
+        register_args = self.session.register.call_args_list
         self.assertEqual(register_args[0][0][0], 'calling-command')
         self.assertEqual(register_args[0][0][1],
                          self.argument.add_to_call_parameters)

--- a/tests/unit/customizations/test_flatten.py
+++ b/tests/unit/customizations/test_flatten.py
@@ -132,8 +132,8 @@ class TestFlattenCommands(unittest.TestCase):
 
     def test_flatten_modify_args(self):
         # Mock operation, arguments, and members for a service
-        operation = mock.Mock(spec=Operation)
-        operation.cli_name = 'command-name'
+        command = mock.Mock()
+        command.name = 'command-name'
 
         argument_model1 = mock.Mock()
         argument_model1.required_members = []
@@ -188,7 +188,7 @@ class TestFlattenCommands(unittest.TestCase):
         # Create the flattened argument table
         cli = mock.Mock()
         flatten = FlattenArguments('my-service', FLATTEN_CONFIG)
-        flatten.flatten_args(operation, argument_table)
+        flatten.flatten_args(command, argument_table)
 
         # Make sure new arguments and any with keep=True are there
         self.assertIn('foo', argument_table)

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -22,9 +22,7 @@ from awscli.customizations.generatecliskeleton import \
 
 class TestGenerateCliSkeleton(unittest.TestCase):
     def setUp(self):
-        self.operation_object = mock.Mock()
-        self.argument = GenerateCliSkeletonArgument(self.operation_object)
-
+        self.session = mock.Mock()
         # Create a mock service operation object
         self.service_operation = mock.Mock()
 
@@ -39,7 +37,8 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         }
         shape = DenormalizedStructureBuilder().with_members(
             self.input_shape).build_model()
-        self.operation_object.model.input_shape = shape
+        self.operation_model = mock.Mock(input_shape=shape)
+        self.argument = GenerateCliSkeletonArgument(self.session, self.operation_model)
 
         # This is what the json should should look like after being
         # generated to standard output.
@@ -47,7 +46,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
             '{\n    "A": {\n        "B": ""\n    }\n}\n'
 
     def test_register_argument_action(self):
-        register_args = self.operation_object.session.register.call_args_list
+        register_args = self.session.register.call_args_list
         self.assertEqual(register_args[0][0][0], 'calling-command.*')
         self.assertEqual(register_args[0][0][1],
                          self.argument.generate_json_skeleton)
@@ -83,7 +82,8 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         parsed_args = mock.Mock()
         parsed_args.generate_cli_skeleton = True
         # Set the input shape to ``None``.
-        self.operation_object.model.input_shape = None
+        self.argument = GenerateCliSkeletonArgument(
+            self.session, mock.Mock(input_shape=None))
         with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -367,7 +367,9 @@ class TestWaiterStateCommand(unittest.TestCase):
             name='wait-state', parent_name='wait',
             operation_object=operation_object,
             operation_caller=mock.Mock(),
-            service_object=mock.Mock()
+            service_object=mock.Mock(),
+            session=None,
+            operation_model=None
         )
         cmd.DESCRIPTION = 'mydescription'
         cmd.create_help_command()

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -151,6 +151,9 @@ class FakeSession(object):
         operation.service.session = self
         return service
 
+    def get_service_model(self, name):
+        return mock.Mock()
+
     def user_agent(self):
         return 'user_agent'
 
@@ -779,7 +782,7 @@ class TestServiceCommand(unittest.TestCase):
 class TestServiceOperation(unittest.TestCase):
     def setUp(self):
         self.name = 'foo'
-        self.cmd = ServiceOperation(self.name, None, None, None, None)
+        self.cmd = ServiceOperation(self.name, None, None, None, None, None, None)
 
     def test_name(self):
         self.assertEqual(self.cmd.name, self.name)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -52,10 +52,10 @@ GET_DATA = {
                 "metavar": "output_format"
             },
             "query": {
-                "help": "<p>A JMESPath query to use in filtering the response data.</p>"
+                "help": ""
             },
             "profile": {
-                "help": "Use a specific profile from your credential file",
+                "help": "",
                 "metavar": "profile_name"
             },
             "region": {
@@ -63,22 +63,22 @@ GET_DATA = {
                 "metavar": "region_name"
             },
             "endpoint-url": {
-                "help": "Override service's default URL with the given URL",
+                "help": "",
                 "metavar": "endpoint_url"
             },
             "no-verify-ssl": {
                 "action": "store_false",
                 "dest": "verify_ssl",
-                "help": "Override default behavior of verifying SSL certificates"
+                "help": "",
             },
             "no-paginate": {
                 "action": "store_false",
-                "help": "Disable automatic pagination",
+                "help": "",
                 "dest": "paginate"
             },
             "page-size": {
-            "type": "int",
-            "help": "<p>Specifies the page size when paginating.</p>"
+                "type": "int",
+                "help": "",
             },
         }
     },


### PR DESCRIPTION
This commit updates the events emitted in cli driver
to emit service/operation object alternatives.  This change
allows handlers to be updated to not require service/operation
objects.

In many cases, some handlers took an `operation` object, but
did not actually use this, so these changes were minimal.

Note that this puts the CLI in an interim state.  The plan is
to not merge this into the develop branch until clidriver is
switched over, but this will allow a common base for all
customization switchovers to be based on.  This is why
this is a pull against the clidriver-no-clients branch for its
base, not develop.


cc @kyleknap @danielgtaylor