### PR TITLE
Fix issue with configservice subscribe command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* bugfix:``aws configservice subscribe``: Fix issue where users could not
+  subscribe to a s3 bucket that they had no HeadBucket permissions to.
+  (`issue 1223 <https://github.com/aws/aws-cli/pull/1223>`__)
+* bugfix:``aws cloudtrail create-subscription``: Fix issue where command would
+  try to fetch the contents at a url using the contents of the custom policy
+  as the url.
+  (`issue 1216 <https://github.com/aws/aws-cli/pull/1216/files>`__)
+
+
 1.7.14
 ======
 

--- a/awscli/customizations/cloudtrail.py
+++ b/awscli/customizations/cloudtrail.py
@@ -15,6 +15,7 @@ import logging
 import sys
 
 from awscli.customizations.commands import BasicCommand
+from awscli.customizations.utils import s3_bucket_exists
 from botocore.exceptions import ClientError
 
 
@@ -232,13 +233,8 @@ class CloudTrailSubscribe(BasicCommand):
             policy = policy.replace('<Prefix>', prefix or '')
 
         LOG.debug('Bucket policy:\n{0}'.format(policy))
-
-        try:
-            self.s3.head_bucket(Bucket=bucket)
-        except ClientError:
-            # The bucket does not exists.  This is what we want.
-            pass
-        else:
+        bucket_exists = s3_bucket_exists(self.s3, bucket)
+        if bucket_exists:
             raise Exception('Bucket {bucket} already exists.'.format(
                 bucket=bucket))
 

--- a/awscli/customizations/configservice/subscribe.py
+++ b/awscli/customizations/configservice/subscribe.py
@@ -13,6 +13,8 @@
 import json
 import sys
 
+from botocore.exceptions import ClientError
+
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.s3.utils import find_bucket_key
 
@@ -138,16 +140,25 @@ class S3BucketHelper(object):
         bucket_exists = self._check_bucket_exists(bucket)
         if not bucket_exists:
             self._create_bucket(bucket)
+            sys.stdout.write('Using new S3 bucket: %s\n' % bucket)
+        else:
+            sys.stdout.write('Using existing S3 bucket: %s\n' % bucket)
         return bucket, key
 
     def _check_bucket_exists(self, bucket):
         bucket_exists = True
+        self._s3_client.meta.events.unregister(
+            'after-call',
+            unique_id='awscli-error-handler')
         try:
             # See if the bucket exists by running a head bucket
             self._s3_client.head_bucket(Bucket=bucket)
-        except Exception:
-            # If a client error is thrown than the bucket does not exist.
-            bucket_exists = False
+        except ClientError as e:
+            # If a client error is thrown. Check that it was a 404 error.
+            # If it was a 404 error, than the bucket does not exist.
+            error_code = int(e.response['Error']['Code'])
+            if error_code == 404:
+                bucket_exists = False
         return bucket_exists
 
     def _create_bucket(self, bucket):
@@ -171,6 +182,9 @@ class SNSTopicHelper(object):
         if not self._check_is_arn(sns_topic):
             response = self._sns_client.create_topic(Name=sns_topic)
             sns_topic_arn = response['TopicArn']
+            sys.stdout.write('Using new SNS topic: %s\n' % sns_topic_arn)
+        else:
+            sys.stdout.write('Using existing SNS topic: %s\n' % sns_topic_arn)
         return sns_topic_arn
 
     def _check_is_arn(self, sns_topic):

--- a/awscli/customizations/configservice/subscribe.py
+++ b/awscli/customizations/configservice/subscribe.py
@@ -13,9 +13,8 @@
 import json
 import sys
 
-from botocore.exceptions import ClientError
-
 from awscli.customizations.commands import BasicCommand
+from awscli.customizations.utils import s3_bucket_exists
 from awscli.customizations.s3.utils import find_bucket_key
 
 
@@ -146,20 +145,10 @@ class S3BucketHelper(object):
         return bucket, key
 
     def _check_bucket_exists(self, bucket):
-        bucket_exists = True
         self._s3_client.meta.events.unregister(
             'after-call',
             unique_id='awscli-error-handler')
-        try:
-            # See if the bucket exists by running a head bucket
-            self._s3_client.head_bucket(Bucket=bucket)
-        except ClientError as e:
-            # If a client error is thrown. Check that it was a 404 error.
-            # If it was a 404 error, than the bucket does not exist.
-            error_code = int(e.response['Error']['Code'])
-            if error_code == 404:
-                bucket_exists = False
-        return bucket_exists
+        return s3_bucket_exists(self._s3_client, bucket)
 
     def _create_bucket(self, bucket):
         region_name = self._s3_client._endpoint.region_name

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -14,6 +14,10 @@
 Utility functions to make it easier to work with customizations.
 
 """
+
+from botocore.exceptions import ClientError
+
+
 def rename_argument(argument_table, existing_name, new_name):
     current = argument_table[existing_name]
     argument_table[new_name] = current
@@ -60,3 +64,17 @@ def _get_group_for_key(key, groups):
     for group in groups:
         if key in group:
             return group
+
+
+def s3_bucket_exists(s3_client, bucket_name):
+    bucket_exists = True
+    try:
+        # See if the bucket exists by running a head bucket
+        s3_client.head_bucket(Bucket=bucket_name)
+    except ClientError as e:
+        # If a client error is thrown. Check that it was a 404 error.
+        # If it was a 404 error, than the bucket does not exist.
+        error_code = int(e.response['Error']['Code'])
+        if error_code == 404:
+            bucket_exists = False
+    return bucket_exists


### PR DESCRIPTION
When checking to see if a bucket exists, we assumed that an exception meant that the bucket did not exist when using HeadBucket. In reality, the error could be a 403, and the user wanted to use that bucket but did not have the proper permissions to run a HEAD object on it. Also expanded the output to inform users if a new bucket/topic is being used or an existing one. This helps notify users of what resources they created and/or are using when subscribing to AWS Config.

cc @jamesls @danielgtaylor 