### PR TITLE
Fix issue with list-runs --schedule-interval

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
+* bugfix:``aws datapipeline list-runs``: Fix issue with
+  ``--schedule-interval`` parameter.
+  (`issue 1225 <https://github.com/aws/aws-cli/pull/1225>`__)
 * bugfix:``aws configservice subscribe``: Fix issue where users could not
   subscribe to a s3 bucket that they had no HeadBucket permissions to.
   (`issue 1223 <https://github.com/aws/aws-cli/pull/1223>`__)

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -208,7 +208,7 @@ class QueryArgBuilder(object):
             start_time_str = parsed_args.schedule_interval[0]
             end_time_str = parsed_args.schedule_interval[1]
             selectors.append({
-                'fieldName': '@scheduleStartTime',
+                'fieldName': '@scheduledStartTime',
                 'operator': {
                     'type': 'BETWEEN',
                     'values': [start_time_str, end_time_str]

--- a/tests/unit/customizations/datapipeline/test_arg_serialize.py
+++ b/tests/unit/customizations/datapipeline/test_arg_serialize.py
@@ -142,7 +142,7 @@ class TestCLIArgumentSerialize(unittest.TestCase):
         query = builder.build_query(parsed_args)
         self.assertEqual(query, {
             'selectors': [{
-                'fieldName': '@scheduleStartTime',
+                'fieldName': '@scheduledStartTime',
                  'operator': {
                      'type': 'BETWEEN',
                      'values': ['2014-02-01T00:00:00',
@@ -225,7 +225,7 @@ class TestCLIArgumentSerialize(unittest.TestCase):
                                 '2014-02-04T00:00:00',],
                  }
             }, {
-                'fieldName': '@scheduleStartTime',
+                'fieldName': '@scheduledStartTime',
                  'operator': {
                      'type': 'BETWEEN',
                      'values': ['2014-02-05T00:00:00',


### PR DESCRIPTION
There was a typo for the element used for schedule interval needed to be
``@scheduledStartTime`` not ``@scheduleStartTime`` as shown in the docs:
http://docs.aws.amazon.com/datapipeline/latest/APIReference/API_Operator.html

Fixes https://github.com/aws/aws-cli/issues/1224

cc @jamesls @danielgtaylor 