### PR TITLE
Add debug log that records initial CLI input

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -232,6 +232,8 @@ class CLIDriver(object):
             LOG.debug("CLI version: %s, botocore version: %s",
                       self.session.user_agent(),
                       botocore_version)
+            LOG.debug("Arguments entered to CLI: %s", sys.argv[1:])
+
         else:
             self.session.set_stream_logger(logger_name='awscli',
                                            log_level=logging.ERROR)


### PR DESCRIPTION
This will help us tell what the user entered using the debug logs, which makes debugging easier.

This is how the debug logs will look now to start:
```
$ aws s3 ls --debug

2015-03-19 11:33:13,851 - MainThread - awscli.clidriver - DEBUG - Arguments entered to CLI: ['s3', 'ls', '--debug']
2015-03-19 11:33:13,851 - MainThread - awscli.clidriver - DEBUG - CLI version: aws-cli/1.7.14 Python/2.7.5 Darwin/13.4.0, botocore version: 0.95.0
```

cc @jamesls @danielgtaylor 