### PR TITLE
Improved docs for ICMP port ranges

### DIFF
--- a/awscli/customizations/ec2secgroupsimplify.py
+++ b/awscli/customizations/ec2secgroupsimplify.py
@@ -98,9 +98,13 @@ PROTOCOL_DOCS = ('<p>The IP protocol of this permission.</p>'
                  '<p>Valid protocol values: <code>tcp</code>, '
                  '<code>udp</code>, <code>icmp</code></p>')
 PORT_DOCS = ('<p>For TCP or UDP: The range of ports to allow.'
-             '  A single integer or a range (min-max). A value of '
-             '<code>-1</code> indicates all ICMP codes for the '
-             'specified ICMP type.</p>')
+             '  A single integer or a range (<code>min-max</code>).</p>'
+             '<p>For ICMP: A single integer or a range (<code>type-code</code>)'
+             ' representing the ICMP type'
+             ' number and the ICMP code number respectively.'
+             ' A value of -1 indicates all ICMP codes for'
+             ' all ICMP types. A value of -1 just for <code>type</code>'
+             ' indicates all ICMP codes for the specified ICMP type.</p>')
 CIDR_DOCS = '<p>The CIDR IP range.</p>'
 SOURCEGROUP_DOCS = ('<p>The name or ID of the source security group. '
                     'Cannot be used when specifying a CIDR IP address.')


### PR DESCRIPTION
Here is the api doc link to confirm: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AuthorizeSecurityGroupIngress.html

The reason I updated the docs was because it was not clear how to specify both ICMP code and type using ``--port``. Even the ``-1`` comment involving ICMP was a little ambiguous so I tried to clear that up as well.

cc @jamesls @danielgtaylor 