### PR TITLE
Fix cloudfront commands after refactor

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -530,7 +530,7 @@ class ServiceOperation(object):
             # No override value was supplied.
             return self._operation_caller.invoke(
                 self._operation_model.service_model.service_name,
-                self._operation_model.name,
+                self._operation_model.api_name,
                 call_parameters, parsed_globals)
 
     def create_help_command(self):

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -361,6 +361,18 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         return stdout, stderr, rc
 
 
+class BaseAWSPreviewCommandParamsTest(BaseAWSCommandParamsTest):
+    def setUp(self):
+        self.preview_patch = mock.patch(
+            'awscli.customizations.preview.mark_as_preview')
+        self.preview_patch.start()
+        super(BaseAWSPreviewCommandParamsTest, self).setUp()
+
+    def tearDown(self):
+        self.preview_patch.stop()
+        super(BaseAWSPreviewCommandParamsTest, self).tearDown()
+
+
 class FileCreator(object):
     def __init__(self):
         self.rootdir = tempfile.mkdtemp()

--- a/tests/unit/cloudfront/__init__.py
+++ b/tests/unit/cloudfront/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/cloudfront/test_get_distribution_config.py
+++ b/tests/unit/cloudfront/test_get_distribution_config.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
+    BaseAWSCommandParamsTest
+
+
+class TestListDistributions(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudfront get-distribution-config'
+
+    def test_list_distributions(self):
+        cmdline = self.prefix
+        cmdline += ' --id foo'
+        result = {'Id': 'foo'}
+        self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
Fix cloudfront commands by using newly exposed api_name. Also added a testing framework to test commands in preview.

Note that this PR will not pass till this PR is merged:
https://github.com/boto/botocore/pull/496

cc @jamesls @danielgtaylor 