### PR TITLE
Let `aws_completer` command account for LC_CTYPE of UTF-8

### DIFF
--- a/bin/aws_completer
+++ b/bin/aws_completer
@@ -13,6 +13,8 @@
 # language governing permissions and limitations under the License.
 
 import os
+if os.environ.get('LC_CTYPE', '') == 'UTF-8':
+    os.environ['LC_CTYPE'] = 'en_US.UTF-8'
 import awscli.completer
 
 if __name__ == '__main__':


### PR DESCRIPTION
`aws` command had the same problem and was already fixed in #945.

## How to Reproduce

```
$ uname -a
Darwin latok 14.1.0 Darwin Kernel Version 14.1.0: Thu Feb 26 19:26:47 PST 2015; root:xnu-2782.10.73~1/RELEASE_X86_64 x86_64
$ export LC_CTYPE=UTF-8
$ printenv LC_CTYPE
UTF-8
$ complete -C aws_completer aws
$ aws s3 <TAB>Traceback (most recent call last):
  File "/usr/local/bin/aws_completer", line 16, in <module>
    import awscli.completer
...
    raise ValueError, 'unknown locale: %s' % localename
ValueError: unknown locale: UTF-8
```

Writing an integration test was a bit too heavy for me(there's no integration test for `aws_completer` at the moment), so test case is not included in this PR. 