### PR TITLE
Add unit test for cloudfront command

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -361,6 +361,18 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         return stdout, stderr, rc
 
 
+class BaseAWSPreviewCommandParamsTest(BaseAWSCommandParamsTest):
+    def setUp(self):
+        self.preview_patch = mock.patch(
+            'awscli.customizations.preview.mark_as_preview')
+        self.preview_patch.start()
+        super(BaseAWSPreviewCommandParamsTest, self).setUp()
+
+    def tearDown(self):
+        self.preview_patch.stop()
+        super(BaseAWSPreviewCommandParamsTest, self).tearDown()
+
+
 class FileCreator(object):
     def __init__(self):
         self.rootdir = tempfile.mkdtemp()

--- a/tests/unit/cloudfront/__init__.py
+++ b/tests/unit/cloudfront/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/cloudfront/test_get_distribution_config.py
+++ b/tests/unit/cloudfront/test_get_distribution_config.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
+    BaseAWSCommandParamsTest
+
+
+class TestListDistributions(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudfront get-distribution-config'
+
+    def test_list_distributions(self):
+        cmdline = self.prefix
+        cmdline += ' --id foo'
+        result = {'Id': 'foo'}
+        self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
This will prevent future regressions against basic
cloudfront commands.

cc @kyleknap @danielgtaylor