### PR TITLE
Fix issue when disabling pagination

### DIFF
--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -166,7 +166,7 @@ class TestShouldEnablePagination(TestPaginateBase):
         self.parsed_args.foo = None
         self.parsed_args.bar = 10
         paginate.check_should_enable_pagination(
-            input_tokens, self.parsed_args, self.parsed_globals)
+            input_tokens, {}, {}, self.parsed_args, self.parsed_globals)
         # We should have turned paginate off because the
         # user specified --bar 10
         self.assertFalse(self.parsed_globals.paginate)
@@ -178,7 +178,7 @@ class TestShouldEnablePagination(TestPaginateBase):
         self.parsed_args.foo = None
         self.parsed_args.bar = None
         paginate.check_should_enable_pagination(
-            input_tokens, self.parsed_args, self.parsed_globals)
+            input_tokens, {}, {}, self.parsed_args, self.parsed_globals)
         # We should have turned paginate off because the
         # user specified --bar 10
         self.assertTrue(self.parsed_globals.paginate)
@@ -195,6 +195,22 @@ class TestShouldEnablePagination(TestPaginateBase):
         self.parsed_args.foo = None
         self.parsed_args.max_items = 10
         paginate.check_should_enable_pagination(
-            input_tokens, self.parsed_args, self.parsed_globals)
+            input_tokens, {}, {}, self.parsed_args, self.parsed_globals)
         self.assertTrue(self.parsed_globals.paginate,
                         "Pagination was not enabled.")
+
+    def test_shadowed_args_are_replaced_when_pagination_off(self):
+        input_tokens = ['foo', 'bar']
+        self.parsed_globals.paginate = True
+        # Corresponds to --bar 10
+        self.parsed_args.foo = None
+        self.parsed_args.bar = 10
+        shadowed_args = {'foo': mock.sentinel.ORIGINAL_ARG}
+        arg_table = {'foo': mock.sentinel.PAGINATION_ARG}
+        paginate.check_should_enable_pagination(
+            input_tokens, shadowed_args, arg_table,
+            self.parsed_args, self.parsed_globals)
+        # We should have turned paginate off because the
+        # user specified --bar 10
+        self.assertFalse(self.parsed_globals.paginate)
+        self.assertEqual(arg_table['foo'], mock.sentinel.ORIGINAL_ARG)

--- a/tests/unit/route53/test_list_resource_record_sets.py
+++ b/tests/unit/route53/test_list_resource_record_sets.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestGetHostedZone(BaseAWSCommandParamsTest):
+
+    prefix = 'route53 list-resource-record-sets'
+
+    def test_no_pagination_args(self):
+        args = ' --hosted-zone-id /hostedzone/ZD3IYMVP1KDDM'
+        cmdline = self.prefix + args
+        self.assert_params_for_cmd(
+            cmdline, {'HostedZoneId': 'ZD3IYMVP1KDDM'}, expected_rc=0)
+
+    def test_with_max_items_pagination(self):
+        args = ' --hosted-zone-id /hostedzone/ZD3IYMVP1KDDM --max-items 1'
+        cmdline = self.prefix + args
+        # We don't map to the service's max-items
+        self.assert_params_for_cmd(
+            cmdline, {'HostedZoneId': 'ZD3IYMVP1KDDM'}, expected_rc=0)
+
+    def test_with_max_override_starting_args(self):
+        args = (
+            ' --hosted-zone-id /hostedzone/ZD3IYMVP1KDDM'
+            ' --max-items 1'
+            ' --start-record-name foo')
+        cmdline = self.prefix + args
+        # We don't map to the service's max-items
+        self.assert_params_for_cmd(
+            cmdline, {'HostedZoneId': 'ZD3IYMVP1KDDM',
+                      'StartRecordName': 'foo',
+                      'MaxItems': '1'},
+            expected_rc=0)


### PR DESCRIPTION
Fixes #1247.

This was a bug introduced in the botocore client switchover.
The CLI has a feature where, for backcompat, it will detect if the
user is specifying manual pagination args and implicitly turn off
pagination.

This functionality was broken when we shadow an operation argument
with one of the pagination args we add.  Before, this was silently
working because, in this scenario, "max_items" is a valid argument
to both ".paginate()" and "operation.call()".

With the client switchover we need to be more explicit.  If we intend
for "max_items" to go to the paginator it *must* be "max_items" (note
the snake_case).  If it's intended for the operation it *must* be
in the casing originally specified by the service (in this case
it was "MaxItems").

There's not really a clean way to fix this, so what I ended up doing
was tracking any shadowed args, and in the case where we need to turn
off pagination, we put back the arg objects we shadowed.

cc @kyleknap @danielgtaylor