### PR TITLE
Correct the predefined section name to be plugins

### DIFF
--- a/awscli/customizations/configure.py
+++ b/awscli/customizations/configure.py
@@ -24,7 +24,7 @@ from awscli.customizations.commands import BasicCommand
 logger = logging.getLogger(__name__)
 NOT_SET = '<not set>'
 
-PREDEFINED_SECTION_NAMES = ('preview', 'plugin')
+PREDEFINED_SECTION_NAMES = ('preview', 'plugins')
 
 def register_configure_cmd(cli):
     cli.register('building-command-table.main',

--- a/tests/unit/customizations/test_configure.py
+++ b/tests/unit/customizations/test_configure.py
@@ -816,6 +816,16 @@ class TestConfigureSetCommand(unittest.TestCase):
             {'__section__': 'default',
              'emr': {'instance_profile': 'my_ip_emr'}}, 'myconfigfile')
 
+    def test_configure_set_handles_predefined_plugins_section(self):
+        self.session.variables['profile'] = 'default'
+        set_command = configure.ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(
+            args=['plugins.foo', 'mypackage'], parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'plugins',
+             'foo': 'mypackage'}, 'myconfigfile')
+
     def test_configure_set_command_dotted_with_profile(self):
         self.session.profile = 'emr-dev'
         set_command = configure.ConfigureSetCommand(


### PR DESCRIPTION
The special cased name is plugins, not plugin.
Added a test for this as well.

Note here: https://github.com/aws/aws-cli/blob/develop/awscli/clidriver.py#L55  the usage of "plugins" not "plugin".

cc @kyleknap @danielgtaylor