### PR TITLE
Fix kms docs for create grant

### DIFF
--- a/awscli/customizations/kms.py
+++ b/awscli/customizations/kms.py
@@ -1,0 +1,22 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+def register_fix_kms_create_grant_docs(cli):
+    # Docs may actually refer to actual api name (not the CLI command).
+    # In that case we want to remove the translation map.
+    cli.register('doc-title.kms.create-grant', remove_translation_map)
+
+
+def remove_translation_map(help_command, **kwargs):
+    help_command.doc.translation_map = {}

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -61,6 +61,7 @@ from awscli.customizations.configservice.rename_cmd import \
 from awscli.customizations.scalarparse import register_scalar_parser
 from awscli.customizations.opsworks import initialize as opsworks_init
 from awscli.customizations.awslambda import register_lambda_create_function
+from awscli.customizations.kms import register_fix_kms_create_grant_docs
 
 
 def awscli_initialize(event_handlers):
@@ -124,3 +125,4 @@ def awscli_initialize(event_handlers):
     register_scalar_parser(event_handlers)
     opsworks_init(event_handlers)
     register_lambda_create_function(event_handlers)
+    register_fix_kms_create_grant_docs(event_handlers)

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -343,3 +343,11 @@ class TestEC2AuthorizeSecurityGroupNotRendered(BaseAWSHelpOutputTest):
         self.assert_not_contains('--to-port')
         self.assert_not_contains('--source-security-group-name')
         self.assert_not_contains('--source-security-group-owner-id')
+
+
+class TestKMSCreateGrant(BaseAWSHelpOutputTest):
+    def test_proper_casing(self):
+        self.driver.main(['kms', 'create-grant', 'help'])
+        # Ensure that the proper casing is used for this command's docs.
+        self.assert_not_contains('generate-data-key')
+        self.assert_contains('GenerateDataKey')


### PR DESCRIPTION
The improper casing was being used as the docs were refering to actual api operation names not the CLI names. Here is a link to the docs: http://docs.aws.amazon.com/cli/latest/reference/kms/create-grant.html. It is especially notable at the ``--operations`` parameter.

cc @jamesls @danielgtaylor 