### PR TITLE
Update doc for route53 create-hosted-zone

### DIFF
--- a/awscli/customizations/route53.py
+++ b/awscli/customizations/route53.py
@@ -13,8 +13,9 @@
 
 
 def register_create_hosted_zone_doc_fix(cli):
-    # Docs may actually refer to actual api name (not the CLI command).
-    # In that case we want to remove the translation map.
+    # We can remove this customization once we begin documenting
+    # members of complex parameters because the member's docstring
+    # has the necessary documentation.
     cli.register(
         'doc-option.route53.create-hosted-zone.hosted-zone-config',
         add_private_zone_note)

--- a/awscli/customizations/route53.py
+++ b/awscli/customizations/route53.py
@@ -1,0 +1,29 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+def register_create_hosted_zone_doc_fix(cli):
+    # Docs may actually refer to actual api name (not the CLI command).
+    # In that case we want to remove the translation map.
+    cli.register(
+        'doc-option.route53.create-hosted-zone.hosted-zone-config',
+        add_private_zone_note)
+
+
+def add_private_zone_note(help_command, **kwargs):
+    note = (
+        '<p>Note do <b>not</b> include <code>PrivateZone</code> in this '
+        'input structure. Its value is returned in the output to the command.'
+        '</p>'
+    )
+    help_command.doc.include_doc_string(note)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -62,6 +62,7 @@ from awscli.customizations.scalarparse import register_scalar_parser
 from awscli.customizations.opsworks import initialize as opsworks_init
 from awscli.customizations.awslambda import register_lambda_create_function
 from awscli.customizations.kms import register_fix_kms_create_grant_docs
+from awscli.customizations.route53 import register_create_hosted_zone_doc_fix
 
 
 def awscli_initialize(event_handlers):
@@ -126,3 +127,4 @@ def awscli_initialize(event_handlers):
     opsworks_init(event_handlers)
     register_lambda_create_function(event_handlers)
     register_fix_kms_create_grant_docs(event_handlers)
+    register_create_hosted_zone_doc_fix(event_handlers)

--- a/tests/unit/docs/test_help_output.py
+++ b/tests/unit/docs/test_help_output.py
@@ -351,3 +351,11 @@ class TestKMSCreateGrant(BaseAWSHelpOutputTest):
         # Ensure that the proper casing is used for this command's docs.
         self.assert_not_contains('generate-data-key')
         self.assert_contains('GenerateDataKey')
+
+
+class TestRoute53CreateHostedZone(BaseAWSHelpOutputTest):
+    def test_proper_casing(self):
+        self.driver.main(['route53', 'create-hosted-zone', 'help'])
+        # Ensure that the proper casing is used for this command's docs.
+        self.assert_contains(
+            'do **not** include ``PrivateZone`` in this input structure')


### PR DESCRIPTION
There has been some confusion where user's try to make a private hosted zone using the ``--hosted-zone-config`` parameter for ``create-hosted-zone`` command. If you do specify it in the command, you get the following error:

```
aws route53 create-hosted-zone --name cli123.com --caller-reference foo --hosted-zone-config Comment=bar,PrivateZone=true

A client error (InvalidInput) occurred when calling the CreateHostedZone operation: Invalid XML ; cvc-complex-type.2.4.d: Invalid content was found starting with element 'PrivateZone'. No child element is expected at this point. 
```

The member ``PrivateZone`` has the following doc string: 
```
"<p>A value that indicates whether this is a private hosted zone. The value is returned in the response; do not specify it in the request.</p>"
```
The issue is that we do not document the members of structures in the docs so users are not exposed to this. The long term solution would to be expose these descriptions, but that would be a lot more work. I also considered popping off the shape from the model, but I am really hesitant to be modifying model shapes. So I decided to just add it to the parameter description.

cc @jamesls 