### PR TITLE
Remove duplicate example data input

### DIFF
--- a/awscli/customizations/emr/addsteps.py
+++ b/awscli/customizations/emr/addsteps.py
@@ -33,7 +33,6 @@ class AddSteps(Command):
          'help_text': helptext.STEPS
          }
     ]
-    EXAMPLES = BasicCommand.FROM_FILE('emr', 'add-steps.rst')
 
     def _run_main_command(self, parsed_args, parsed_globals):
         parsed_steps = parsed_args.steps

--- a/awscli/customizations/emr/createdefaultroles.py
+++ b/awscli/customizations/emr/createdefaultroles.py
@@ -158,7 +158,6 @@ class CreateDefaultRoles(Command):
                       ' custom endpoint should be called for IAM operations'
                       '.</p>'}
     ]
-    EXAMPLES = BasicCommand.FROM_FILE('emr', 'create-default-roles.rst')
 
     def _run_main_command(self, parsed_args, parsed_globals):
         ec2_result = None

--- a/awscli/customizations/emr/describecluster.py
+++ b/awscli/customizations/emr/describecluster.py
@@ -29,7 +29,6 @@ class DescribeCluster(Command):
         {'name': 'cluster-id', 'required': True,
          'help_text': helptext.CLUSTER_ID}
     ]
-    EXAMPLES = BasicCommand.FROM_FILE('emr', 'describe-cluster.rst')
 
     def _run_main_command(self, parsed_args, parsed_globals):
         parameters = {'ClusterId': parsed_args.cluster_id}

--- a/awscli/customizations/emr/hbase.py
+++ b/awscli/customizations/emr/hbase.py
@@ -76,8 +76,6 @@ class ScheduleHBaseBackup(Command):
                       ' during the backup process.</p>'}
     ]
 
-    EXAMPLES = BasicCommand.FROM_FILE('emr', 'schedule-hbase-backup.rst')
-
     def _run_main_command(self, parsed_args, parsed_globals):
         steps = []
         self._check_type(parsed_args.type)

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -72,7 +72,6 @@ class OpsWorksRegister(BasicCommand):
         agent on the target machine and register it with an existing OpsWorks
         stack.
     """).strip()
-    EXAMPLES = BasicCommand.FROM_FILE('opsworks/register.rst')
 
     ARG_TABLE = [
         {'name': 'stack-id', 'required': True,

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -307,7 +307,6 @@ class ListCommand(S3Command):
     ARG_TABLE = [{'name': 'paths', 'nargs': '?', 'default': 's3://',
                   'positional_arg': True, 'synopsis': USAGE}, RECURSIVE,
                  PAGE_SIZE, HUMAN_READABLE, SUMMARIZE]
-    EXAMPLES = BasicCommand.FROM_FILE('s3/ls.rst')
 
     def _run_main(self, parsed_args, parsed_globals):
         super(ListCommand, self)._run_main(parsed_args, parsed_globals)
@@ -550,7 +549,6 @@ class CpCommand(S3TransferCommand):
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
                 [METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
-    EXAMPLES = BasicCommand.FROM_FILE('s3/cp.rst')
 
 
 class MvCommand(S3TransferCommand):
@@ -562,8 +560,6 @@ class MvCommand(S3TransferCommand):
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + [METADATA_DIRECTIVE,
                                                          RECURSIVE]
-    EXAMPLES = BasicCommand.FROM_FILE('s3/mv.rst')
-
 
 class RmCommand(S3TransferCommand):
     NAME = 'rm'
@@ -572,7 +568,6 @@ class RmCommand(S3TransferCommand):
     ARG_TABLE = [{'name': 'paths', 'nargs': 1, 'positional_arg': True,
                   'synopsis': USAGE}, DRYRUN, QUIET, RECURSIVE, INCLUDE,
                  EXCLUDE, ONLY_SHOW_ERRORS, PAGE_SIZE]
-    EXAMPLES = BasicCommand.FROM_FILE('s3/rm.rst')
 
 
 class SyncCommand(S3TransferCommand):
@@ -582,7 +577,6 @@ class SyncCommand(S3TransferCommand):
             "<LocalPath> or <S3Path> <S3Path>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS
-    EXAMPLES = BasicCommand.FROM_FILE('s3/sync.rst')
 
 
 class MbCommand(S3TransferCommand):
@@ -591,7 +585,6 @@ class MbCommand(S3TransferCommand):
     USAGE = "<S3Path>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 1, 'positional_arg': True,
                   'synopsis': USAGE}]
-    EXAMPLES = BasicCommand.FROM_FILE('s3/mb.rst')
 
 
 class RbCommand(S3TransferCommand):
@@ -600,7 +593,6 @@ class RbCommand(S3TransferCommand):
     USAGE = "<S3Path>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 1, 'positional_arg': True,
                   'synopsis': USAGE}, FORCE]
-    EXAMPLES = BasicCommand.FROM_FILE('s3/rb.rst')
 
 
 class CommandArchitecture(object):

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -210,6 +210,14 @@ class BaseAWSHelpOutputTest(BaseCLIDriverTest):
                       "actual rendered contents:\n%s" % (
                           contains, self.renderer.rendered_contents))
 
+    def assert_contains_with_count(self, contains, count):
+        r_count = self.renderer.rendered_contents.count(contains)
+        if r_count != count:
+            self.fail("The expected contents:\n%s\n, with the "
+                      "count:\n%d\nwere not in the actual rendered "
+                      " contents:\n%s\nwith count:\n%d" % (
+                          contains, count, self.renderer.rendered_contents, r_count))
+
     def assert_not_contains(self, contents):
         if contents in self.renderer.rendered_contents:
             self.fail("The contents:\n%s\nwere not suppose to be in the "

--- a/tests/unit/docs/test_examples.py
+++ b/tests/unit/docs/test_examples.py
@@ -53,6 +53,6 @@ def verify_has_examples(command, subcommand):
     t.setUp()
     try:
         t.driver.main([command, subcommand, 'help'])
-        t.assert_contains('========\nExamples\n========')
+        t.assert_contains_with_count('========\nExamples\n========', 1)
     finally:
         t.tearDown()

--- a/tests/unit/docs/test_examples.py
+++ b/tests/unit/docs/test_examples.py
@@ -34,6 +34,8 @@ COMMAND_EXAMPLES = {
     'ec2': ['run-instances', 'start-instances', 'stop-instances'],
     'swf': ['deprecate-domain', 'describe-domain'],
     'sqs': ['create-queue', 'get-queue-attributes'],
+    'emr': ['add-steps', 'create-default-roles', 'describe-cluster', 'schedule-hbase-backup'],
+    'opsworks': ['register'],
 }
 
 


### PR DESCRIPTION
I believe this will clear up issue #1241. The removed lines are the instances where the sub-commands are reading in the example docs after they have already been read in via this event hook in handlers.py:

```
event_handlers.register('doc-examples.*.*', add_examples)
```