### PR TITLE
Fix issue with create-open-id-connect-provider

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ CHANGELOG
 Next Release (TBD)
 ==================
 
+* bugfix:``aws iam create-open-id-connect-provider``: Fix issue where the
+  ``--url`` parameter would try to retrieve the contents from the url instead
+  of use the url as its value.
+  (`issue 1317 <https://github.com/aws/aws-cli/pull/1317>`__)
 * bugfix:``aws workspaces``: Fix issue where throttling errors were not
   being retried
   (`botocore issue 529 <https://github.com/boto/botocore/pull/529>`__)

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -42,6 +42,8 @@ PARAMFILE_DISABLED = set([
     'custom.mv.website-redirect',
     'custom.sync.website-redirect',
 
+    'iam.create-open-id-connect-provider.url',
+
     'machinelearning.predict.predict-endpoint',
 
     'sqs.add-permission.queue-url',

--- a/tests/unit/iam/test_create_open_id_connect_provider.py
+++ b/tests/unit/iam/test_create_open_id_connect_provider.py
@@ -1,0 +1,29 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateOpenIDConnectProvider(BaseAWSCommandParamsTest):
+
+    prefix = 'iam create-open-id-connect-provider'
+
+    def test_create_open_id_connect_provider(self):
+        cmdline = self.prefix
+        cmdline += ' --url https://example.com '
+        cmdline += '--thumbprint-list 990F4193972F2BECF12DDEDA5237F9C952F20D9E'
+
+        result = {
+            'Url': 'https://example.com',
+            'ThumbprintList': ['990F4193972F2BECF12DDEDA5237F9C952F20D9E']
+        }
+        self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
The --url parameter would try to retrieve the contents from the url instead
of use the actual url itself in the botocore call.