### PR TITLE
Remove key file format restrictions for SSH

### DIFF
--- a/awscli/customizations/emr/exceptions.py
+++ b/awscli/customizations/emr/exceptions.py
@@ -163,16 +163,6 @@ class WrongPuttyKeyError(EmrError):
           'ElasticMapReduce/latest/DeveloperGuide/EMR_SetUp_SSH.html. '
 
 
-class WrongSSHKeyError(EmrError):
-
-    """
-    A wrong key has been used with a compatible program.
-    """
-    fmt = 'Key file file format is incorrect. SSH expects a cer or pem file. '\
-          'Please refer to documentation at http://docs.aws.amazon.com/'\
-          'ElasticMapReduce/latest/DeveloperGuide/EMR_SetUp_SSH.html '
-
-
 class SSHNotFoundError(EmrError):
 
     """

--- a/awscli/customizations/emr/ssh.py
+++ b/awscli/customizations/emr/ssh.py
@@ -46,8 +46,7 @@ class Socks(Command):
             key_file = parsed_args.key_pair_file
             sshutils.validate_ssh_with_key_file(key_file)
             f = tempfile.NamedTemporaryFile(delete=False)
-            if (sshutils.check_command_key_format(key_file, ['cer', 'pem']) and
-                    (emrutils.which('ssh') or emrutils.which('ssh.exe'))):
+            if (emrutils.which('ssh') or emrutils.which('ssh.exe')):
                 command = ['ssh', '-o', 'StrictHostKeyChecking=no', '-o',
                            'ServerAliveInterval=10', '-ND', '8157', '-i',
                            parsed_args.key_pair_file, constants.SSH_USER +
@@ -86,8 +85,7 @@ class SSH(Command):
         key_file = parsed_args.key_pair_file
         sshutils.validate_ssh_with_key_file(key_file)
         f = tempfile.NamedTemporaryFile(delete=False)
-        if (sshutils.check_command_key_format(key_file, ['cer', 'pem']) and
-                (emrutils.which('ssh') or emrutils.which('ssh.exe'))):
+        if (emrutils.which('ssh') or emrutils.which('ssh.exe')):
             command = ['ssh', '-o', 'StrictHostKeyChecking=no', '-o',
                        'ServerAliveInterval=10', '-i',
                        parsed_args.key_pair_file, constants.SSH_USER +
@@ -132,8 +130,7 @@ class Put(Command):
 
         key_file = parsed_args.key_pair_file
         sshutils.validate_scp_with_key_file(key_file)
-        if (sshutils.check_command_key_format(key_file, ['cer', 'pem']) and
-                (emrutils.which('scp') or emrutils.which('scp.exe'))):
+        if (emrutils.which('scp') or emrutils.which('scp.exe')):
             command = ['scp', '-r', '-o StrictHostKeyChecking=no',
                        '-i', parsed_args.key_pair_file, parsed_args.src,
                        constants.SSH_USER + '@' + master_dns]
@@ -172,8 +169,7 @@ class Get(Command):
 
         key_file = parsed_args.key_pair_file
         sshutils.validate_scp_with_key_file(key_file)
-        if (sshutils.check_command_key_format(key_file, ['cer', 'pem']) and
-                (emrutils.which('scp') or emrutils.which('scp.exe'))):
+        if (emrutils.which('scp') or emrutils.which('scp.exe')):
             command = ['scp', '-r', '-o StrictHostKeyChecking=no', '-i',
                        parsed_args.key_pair_file, constants.SSH_USER + '@' +
                        master_dns + ':' + parsed_args.src]

--- a/awscli/customizations/emr/sshutils.py
+++ b/awscli/customizations/emr/sshutils.py
@@ -74,11 +74,6 @@ def check_scp_key_format(key_file):
             (emrutils.which('scp.exe') or emrutils.which('scp')) is None):
         if check_command_key_format(key_file, ['ppk']) is False:
             raise exceptions.WrongPuttyKeyError
-    # If only scp is present and the file format is incorrect
-    elif (emrutils.which('pscp.exe') is None and
-            (emrutils.which('scp.exe') or emrutils.which('scp')) is not None):
-        if check_command_key_format(key_file, ['cer', 'pem']) is False:
-            raise exceptions.WrongSSHKeyError
     else:
         pass
 
@@ -89,11 +84,6 @@ def check_ssh_key_format(key_file):
             (emrutils.which('ssh.exe') or emrutils.which('ssh')) is None):
         if check_command_key_format(key_file, ['ppk']) is False:
             raise exceptions.WrongPuttyKeyError
-    # If only ssh is present and the file format is incorrect
-    elif (emrutils.which('putty.exe') is None and
-            (emrutils.which('ssh.exe') or emrutils.which('ssh')) is not None):
-        if check_command_key_format(key_file, ['cer', 'pem']) is False:
-            raise exceptions.WrongSSHKeyError
     else:
         pass
 

--- a/tests/unit/customizations/emr/test_sshutils.py
+++ b/tests/unit/customizations/emr/test_sshutils.py
@@ -43,3 +43,18 @@ class TestSSHUtils(unittest.TestCase):
         with self.assertRaises(exceptions.ClusterTerminatedError):
             sshutils.validate_and_find_master_dns(
                 mock.Mock(), None, 'cluster-id')
+
+    @mock.patch('awscli.customizations.emr.sshutils.emrutils')
+    def test_ssh_scp_key_file_format(self, emrutils):
+        def which_side_effect(program):
+            if program == 'ssh' or program == 'scp':
+                return '/some/path'
+        emrutils.which.side_effect = which_side_effect
+
+        key_file1 = 'key.abc'
+        sshutils.validate_ssh_with_key_file(key_file1)
+        sshutils.validate_scp_with_key_file(key_file1)
+
+        key_file2 = 'key'
+        sshutils.validate_ssh_with_key_file(key_file2)
+        sshutils.validate_scp_with_key_file(key_file2)


### PR DESCRIPTION
We restricted key file formats to pem and cer for use with ssh and
scp. This change removes it as customers have varied key file formats.