### PR TITLE
Update description of aws s3 sync command.

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -572,7 +572,10 @@ class RmCommand(S3TransferCommand):
 
 class SyncCommand(S3TransferCommand):
     NAME = 'sync'
-    DESCRIPTION = "Syncs directories and S3 prefixes."
+    DESCRIPTION = "Syncs directories and S3 prefixes. Recursively copies " \
+                  "new and updated files from the source directory to " \
+		  "the destination. Only creates folders in the destination" \
+		  "if they contain one or more files."
     USAGE = "<LocalPath> <S3Path> or <S3Path> " \
             "<LocalPath> or <S3Path> <S3Path>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -574,8 +574,8 @@ class SyncCommand(S3TransferCommand):
     NAME = 'sync'
     DESCRIPTION = "Syncs directories and S3 prefixes. Recursively copies " \
                   "new and updated files from the source directory to " \
-		  "the destination. Only creates folders in the destination" \
-		  "if they contain one or more files."
+                  "the destination. Only creates folders in the destination" \
+                  "if they contain one or more files."
     USAGE = "<LocalPath> <S3Path> or <S3Path> " \
             "<LocalPath> or <S3Path> <S3Path>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,


### PR DESCRIPTION
Clarify that empty folders/prefixes are not recreated in the destination directory.