### PR TITLE
Add `ca_bundle` config option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,7 @@ The quickest way to get started is to run the ``aws configure`` command::
     AWS Secret Access Key: bar
     Default region name [us-west-2]: us-west-2
     Default output format [None]: json
+    CA certificate bundle [None]: /path/to/ca-bundle.pem
 
 To use environment variables, do the following::
 
@@ -117,6 +118,8 @@ To use a config file, create a configuration file like this::
     aws_secret_access_key=<default secret key>
     # Optional, to define default region for this profile.
     region=us-west-1
+    # Optional, define the default CA certificate bundle.
+    ca_bundle=/path/to/ca-bundle.pem
 
     [profile testing]
     aws_access_key_id=<testing access key>
@@ -152,23 +155,25 @@ In addition to credentials, a number of other variables can be
 configured either with environment variables, configuration file
 entries or both.  The following table documents these.
 
-=========== ========= ===================== ===================== ============================
-Variable    Option    Config Entry          Environment Variable  Description
-=========== ========= ===================== ===================== ============================
-profile     --profile profile               AWS_DEFAULT_PROFILE   Default profile name
------------ --------- --------------------- --------------------- ----------------------------
-region      --region  region                AWS_DEFAULT_REGION    Default AWS Region
------------ --------- --------------------- --------------------- ----------------------------
-config_file                                 AWS_CONFIG_FILE       Alternate location of config
------------ --------- --------------------- --------------------- ----------------------------
-output      --output  output                AWS_DEFAULT_OUTPUT    Default output style
------------ --------- --------------------- --------------------- ----------------------------
-access_key            aws_access_key_id     AWS_ACCESS_KEY_ID     AWS Access Key
------------ --------- --------------------- --------------------- ----------------------------
-secret_key            aws_secret_access_key AWS_SECRET_ACCESS_KEY AWS Secret Key
------------ --------- --------------------- --------------------- ----------------------------
-token                 aws_session_token     AWS_SESSION_TOKEN     AWS Token (temp credentials)
-=========== ========= ===================== ===================== ============================
+=========== =========== ===================== ===================== ============================
+Variable    Option      Config Entry          Environment Variable  Description
+=========== =========== ===================== ===================== ============================
+profile     --profile   profile               AWS_DEFAULT_PROFILE   Default profile name
+----------- ----------- --------------------- --------------------- ----------------------------
+region      --region    region                AWS_DEFAULT_REGION    Default AWS Region
+----------- ----------- --------------------- --------------------- ----------------------------
+config_file                                   AWS_CONFIG_FILE       Alternate location of config
+----------- ----------- --------------------- --------------------- ----------------------------
+output      --output    output                AWS_DEFAULT_OUTPUT    Default output style
+----------- ----------- --------------------- --------------------- ----------------------------
+ca_bundle   --ca-bundle ca_bundle             AWS_CA_BUNDLE         CA Certificate Bundle
+----------- ----------- --------------------- --------------------- ----------------------------
+access_key              aws_access_key_id     AWS_ACCESS_KEY_ID     AWS Access Key
+----------- ----------- --------------------- --------------------- ----------------------------
+secret_key              aws_secret_access_key AWS_SECRET_ACCESS_KEY AWS Secret Key
+----------- ----------- --------------------- --------------------- ----------------------------
+token                   aws_session_token     AWS_SESSION_TOKEN     AWS Token (temp credentials)
+=========== =========== ===================== ===================== ============================
 
 ^^^^^^^^
 Examples

--- a/awscli/__init__.py
+++ b/awscli/__init__.py
@@ -35,7 +35,7 @@ os.environ['AWS_DATA_PATH'] = os.pathsep.join(_awscli_data_path)
 
 
 EnvironmentVariables = {
-    'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None),
+    'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
     'output': ('output', 'AWS_DEFAULT_OUTPUT', 'json', None),
 }
 

--- a/awscli/__init__.py
+++ b/awscli/__init__.py
@@ -35,6 +35,7 @@ os.environ['AWS_DATA_PATH'] = os.pathsep.join(_awscli_data_path)
 
 
 EnvironmentVariables = {
+    'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None),
     'output': ('output', 'AWS_DEFAULT_OUTPUT', 'json', None),
 }
 

--- a/awscli/customizations/configure.py
+++ b/awscli/customizations/configure.py
@@ -524,7 +524,6 @@ class ConfigureCommand(BasicCommand):
         '    AWS Secret Access Key [None]: secretkey\n'
         '    Default region name [None]: us-west-2\n'
         '    Default output format [None]:\n'
-        '    CA certificate bundle [None]: /etc/pki/tls/certs/ca-bundle.crt\n'
         '\n'
         'To update just the region name::\n'
         '\n'
@@ -533,7 +532,6 @@ class ConfigureCommand(BasicCommand):
         '    AWS Secret Access Key [****]:\n'
         '    Default region name [us-west-1]: us-west-2\n'
         '    Default output format [None]:\n'
-        '    CA certificate bundle [None]:\n'
     )
     SUBCOMMANDS = [
         {'name': 'list', 'command_class': ConfigureListCommand},
@@ -548,7 +546,6 @@ class ConfigureCommand(BasicCommand):
         ('aws_secret_access_key', "AWS Secret Access Key"),
         ('region', "Default region name"),
         ('output', "Default output format"),
-        ('ca_bundle', "CA certificate bundle"),
     ]
 
     def __init__(self, session, prompter=None, config_writer=None):

--- a/awscli/customizations/configure.py
+++ b/awscli/customizations/configure.py
@@ -275,6 +275,7 @@ class ConfigureListCommand(BasicCommand):
         '  access_key     ****************ABCD      config_file    ~/.aws/config\n'
         '  secret_key     ****************ABCD      config_file    ~/.aws/config\n'
         '      region                us-west-2              env    AWS_DEFAULT_REGION\n'
+        '   ca_bundle                <not set>             None    None\n'
         '\n'
     )
 
@@ -301,6 +302,9 @@ class ConfigureListCommand(BasicCommand):
 
         region = self._lookup_config('region')
         self._display_config_value(region, 'region')
+
+        ca_bundle = self._lookup_config('ca_bundle')
+        self._display_config_value(ca_bundle, 'ca_bundle')
 
     def _display_config_value(self, config_value, config_name):
         self._stream.write('%10s %24s %16s    %s\n' % (
@@ -520,6 +524,7 @@ class ConfigureCommand(BasicCommand):
         '    AWS Secret Access Key [None]: secretkey\n'
         '    Default region name [None]: us-west-2\n'
         '    Default output format [None]:\n'
+        '    CA certificate bundle [None]: /etc/pki/tls/certs/ca-bundle.crt\n'
         '\n'
         'To update just the region name::\n'
         '\n'
@@ -528,6 +533,7 @@ class ConfigureCommand(BasicCommand):
         '    AWS Secret Access Key [****]:\n'
         '    Default region name [us-west-1]: us-west-2\n'
         '    Default output format [None]:\n'
+        '    CA certificate bundle [None]:\n'
     )
     SUBCOMMANDS = [
         {'name': 'list', 'command_class': ConfigureListCommand},
@@ -542,6 +548,7 @@ class ConfigureCommand(BasicCommand):
         ('aws_secret_access_key', "AWS Secret Access Key"),
         ('region', "Default region name"),
         ('output', "Default output format"),
+        ('ca_bundle', "CA certificate bundle"),
     ]
 
     def __init__(self, session, prompter=None, config_writer=None):

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -50,6 +50,10 @@
             "action": "store_false",
             "dest": "sign_request",
             "help": "<p>Do not sign requests.  Credentials will not be loaded if this argument is provided.</p>"
+        },
+        "ca-bundle": {
+                "dest": "ca_bundle",
+                "help": "<p>The CA certificate bundle to use when verifying SSL certificates. Overrides config/env settings.</p>"
         }
     }
 }

--- a/awscli/examples/configure/set/_examples.rst
+++ b/awscli/examples/configure/set/_examples.rst
@@ -3,6 +3,7 @@ Given an empty config file, the following commands::
     $ aws configure set aws_access_key_id default_access_key
     $ aws configure set aws_secret_access_key default_secret_key
     $ aws configure set default.region us-west-2
+    $ aws configure set default.ca_bundle /path/to/ca-bundle.pem
     $ aws configure set region us-west-1 --profile testing
     $ aws configure set profile.testing2.region eu-west-1
     $ aws configure set preview.cloudsearch true
@@ -11,6 +12,7 @@ will produce the following config file::
 
     [default]
     region = us-west-2
+    ca_bundle = /path/to/ca-bundle.pem
 
     [profile testing]
     region = us-west-1

--- a/tests/unit/customizations/test_configure.py
+++ b/tests/unit/customizations/test_configure.py
@@ -129,7 +129,8 @@ class TestConfigureCommand(unittest.TestCase):
         # Non-credentials config is written to the config file.
         self.writer.update_config.assert_called_with(
             {'region': 'new_value',
-             'output': 'new_value'}, 'myconfigfile')
+             'output': 'new_value',
+			 'ca_bundle': 'new_value'}, 'myconfigfile')
 
     def test_same_values_are_not_changed(self):
         # If the user enters the same value as the current value, we don't need
@@ -186,7 +187,8 @@ class TestConfigureCommand(unittest.TestCase):
         self.writer.update_config.assert_called_with(
             {'__section__': 'profile myname',
              'region': 'new_value',
-             'output': 'new_value'}, 'myconfigfile')
+             'output': 'new_value',
+			 'ca_bundle': 'new_value'}, 'myconfigfile')
 
     def test_session_says_profile_does_not_exist(self):
         # Whenever you try to get a config value from botocore,
@@ -207,7 +209,8 @@ class TestConfigureCommand(unittest.TestCase):
         self.writer.update_config.assert_called_with(
             {'__section__': 'profile profile-does-not-exist',
              'region': 'new_value',
-             'output': 'new_value'}, 'myconfigfile')
+             'output': 'new_value',
+			 'ca_bundle': 'new_value'}, 'myconfigfile')
 
 
 class TestInteractivePrompter(unittest.TestCase):

--- a/tests/unit/customizations/test_configure.py
+++ b/tests/unit/customizations/test_configure.py
@@ -129,8 +129,7 @@ class TestConfigureCommand(unittest.TestCase):
         # Non-credentials config is written to the config file.
         self.writer.update_config.assert_called_with(
             {'region': 'new_value',
-             'output': 'new_value',
-             'ca_bundle': 'new_value'}, 'myconfigfile')
+             'output': 'new_value'}, 'myconfigfile')
 
     def test_same_values_are_not_changed(self):
         # If the user enters the same value as the current value, we don't need
@@ -188,8 +187,7 @@ class TestConfigureCommand(unittest.TestCase):
         self.writer.update_config.assert_called_with(
             {'__section__': 'profile myname',
              'region': 'new_value',
-             'output': 'new_value',
-             'ca_bundle': 'new_value'}, 'myconfigfile')
+             'output': 'new_value'}, 'myconfigfile')
 
     def test_session_says_profile_does_not_exist(self):
         # Whenever you try to get a config value from botocore,
@@ -210,8 +208,7 @@ class TestConfigureCommand(unittest.TestCase):
         self.writer.update_config.assert_called_with(
             {'__section__': 'profile profile-does-not-exist',
              'region': 'new_value',
-             'output': 'new_value',
-             'ca_bundle': 'new_value'}, 'myconfigfile')
+             'output': 'new_value'}, 'myconfigfile')
 
 
 class TestInteractivePrompter(unittest.TestCase):

--- a/tests/unit/customizations/test_configure.py
+++ b/tests/unit/customizations/test_configure.py
@@ -130,7 +130,7 @@ class TestConfigureCommand(unittest.TestCase):
         self.writer.update_config.assert_called_with(
             {'region': 'new_value',
              'output': 'new_value',
-			 'ca_bundle': 'new_value'}, 'myconfigfile')
+             'ca_bundle': 'new_value'}, 'myconfigfile')
 
     def test_same_values_are_not_changed(self):
         # If the user enters the same value as the current value, we don't need
@@ -161,9 +161,10 @@ class TestConfigureCommand(unittest.TestCase):
         # Test the case where the user only wants to change a single_value.
         responses = {
             "AWS Access Key ID": None,
-            "AWS Secert Access Key": None,
+            "AWS Secret Access Key": None,
             "Default region name": None,
             "Default output format": "NEW OUTPUT FORMAT",
+            "CA certificate bundle": None,
         }
         prompter = KeyValuePrompter(responses)
         self.configure = configure.ConfigureCommand(self.session, prompter=prompter,
@@ -188,7 +189,7 @@ class TestConfigureCommand(unittest.TestCase):
             {'__section__': 'profile myname',
              'region': 'new_value',
              'output': 'new_value',
-			 'ca_bundle': 'new_value'}, 'myconfigfile')
+             'ca_bundle': 'new_value'}, 'myconfigfile')
 
     def test_session_says_profile_does_not_exist(self):
         # Whenever you try to get a config value from botocore,
@@ -210,7 +211,7 @@ class TestConfigureCommand(unittest.TestCase):
             {'__section__': 'profile profile-does-not-exist',
              'region': 'new_value',
              'output': 'new_value',
-			 'ca_bundle': 'new_value'}, 'myconfigfile')
+             'ca_bundle': 'new_value'}, 'myconfigfile')
 
 
 class TestInteractivePrompter(unittest.TestCase):
@@ -617,6 +618,7 @@ class TestConfigureListCommand(unittest.TestCase):
         self.assertRegexpMatches(rendered, 'access_key\s+<not set>')
         self.assertRegexpMatches(rendered, 'secret_key\s+<not set>')
         self.assertRegexpMatches(rendered, 'region\s+<not set>')
+        self.assertRegexpMatches(rendered, 'ca_bundle\s+<not set>')
 
     def test_configure_from_env(self):
         env_vars = {
@@ -660,7 +662,8 @@ class TestConfigureListCommand(unittest.TestCase):
             'profile': 'myprofilename'
         }
         config_file_vars = {
-            'region': 'us-west-2'
+            'region': 'us-west-2',
+            'ca_bundle': '/path/to/cacert.pem'
         }
         credentials = mock.Mock()
         credentials.access_key = 'access_key'
@@ -673,7 +676,8 @@ class TestConfigureListCommand(unittest.TestCase):
             credentials=credentials)
         session.session_var_map = {
             'region': ('region', 'AWS_REGION'),
-            'profile': ('profile', 'AWS_DEFAULT_PROFILE')}
+            'profile': ('profile', 'AWS_DEFAULT_PROFILE'),
+            'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_REGION'}}}
         stream = StringIO()
@@ -686,6 +690,9 @@ class TestConfigureListCommand(unittest.TestCase):
         # The region came from the config file.
         self.assertRegexpMatches(
             rendered, 'region\s+us-west-2\s+config-file\s+/config/location')
+        # The ca_bundle came from the config file.
+        self.assertRegexpMatches(
+            rendered, 'ca_bundle\s+/path/to/cacert.pem\s+config-file\s+/config/location')
         # The credentials came from an IAM role.  Note how we're
         # also checking that the access_key/secret_key are masked
         # with '*' chars except for the last 4 chars.

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -152,6 +152,22 @@ class TestGlobalArgsCustomization(unittest.TestCase):
             globalargs.resolve_verify_ssl(parsed_args, session)
             self.assertEqual(parsed_args.verify_ssl, '/path/to/cli_bundle.pem')
 
+    def test_no_verify_ssl_overrides_cli_cert_bundle(self):
+        environ = {
+            'AWS_CA_BUNDLE': '/path/to/env_bundle.pem',
+        }
+        with mock.patch('os.environ', environ):
+            parsed_args = FakeParsedArgs(
+                verify_ssl=False, 
+                ca_bundle='/path/to/cli_bundle.pem')
+            config_file_vars = {}
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(
+                session_vars=session_var_map, 
+                config_file_vars=config_file_vars)
+            globalargs.resolve_verify_ssl(parsed_args, session)
+            self.assertFalse(parsed_args.verify_ssl)
+
     def test_no_sign_request_if_option_specified(self):
         args = FakeParsedArgs(sign_request=False)
         session = mock.Mock()

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -43,9 +43,9 @@ class FakeSession(object):
         value = None
         config_name, envvar_name = self.session_var_map[name]
         if methods is not None:
-            if 'env' in methods:
+            if 'env' in methods and value is None:
                 value = os.environ.get(envvar_name)
-            elif 'config' in methods:
+            if 'config' in methods and value is None:
                 value = self.config_file_vars.get(config_name)
         else:
             value = default
@@ -95,6 +95,62 @@ class TestGlobalArgsCustomization(unittest.TestCase):
             session = FakeSession(session_vars=session_var_map)
             globalargs.resolve_verify_ssl(parsed_args, session)
             self.assertEqual(parsed_args.verify_ssl, '/path/to/bundle.pem')
+
+    def test_config_overrides_cert_bundle(self):
+        environ = {}
+        with mock.patch('os.environ', environ):
+            parsed_args = FakeParsedArgs(verify_ssl=True, ca_bundle=None)
+            config_file_vars = {'ca_bundle': '/path/to/bundle.pem'}
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(
+                session_vars=session_var_map, 
+                config_file_vars=config_file_vars)
+            globalargs.resolve_verify_ssl(parsed_args, session)
+            self.assertEqual(parsed_args.verify_ssl, '/path/to/bundle.pem')
+
+    def test_os_environ_overrides_config_cert_bundle(self):
+        environ = {
+            'AWS_CA_BUNDLE': '/path/to/env_bundle.pem',
+        }
+        with mock.patch('os.environ', environ):
+            parsed_args = FakeParsedArgs(verify_ssl=True, ca_bundle=None)
+            config_file_vars = {'ca_bundle': '/path/to/confg_bundle.pem'}
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(
+                session_vars=session_var_map, 
+                config_file_vars=config_file_vars)
+            globalargs.resolve_verify_ssl(parsed_args, session)
+            self.assertEqual(parsed_args.verify_ssl, '/path/to/env_bundle.pem')
+
+    def test_cli_overrides_cert_bundle(self):
+        environ = {}
+        with mock.patch('os.environ', environ):
+            parsed_args = FakeParsedArgs(
+                verify_ssl=True, 
+                ca_bundle='/path/to/cli_bundle.pem')
+            config_file_vars = {}
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(
+                session_vars=session_var_map, 
+                config_file_vars=config_file_vars)
+            globalargs.resolve_verify_ssl(parsed_args, session)
+            self.assertEqual(parsed_args.verify_ssl, '/path/to/cli_bundle.pem')
+
+    def test_cli_overrides_env_cert_bundle(self):
+        environ = {
+            'AWS_CA_BUNDLE': '/path/to/env_bundle.pem',
+        }
+        with mock.patch('os.environ', environ):
+            parsed_args = FakeParsedArgs(
+                verify_ssl=True, 
+                ca_bundle='/path/to/cli_bundle.pem')
+            config_file_vars = {}
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(
+                session_vars=session_var_map, 
+                config_file_vars=config_file_vars)
+            globalargs.resolve_verify_ssl(parsed_args, session)
+            self.assertEqual(parsed_args.verify_ssl, '/path/to/cli_bundle.pem')
 
     def test_no_sign_request_if_option_specified(self):
         args = FakeParsedArgs(sign_request=False)

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore.handlers import disable_signing
+import os
 
 from awscli.testutils import unittest
 from awscli.compat import six
@@ -25,6 +26,30 @@ class FakeParsedArgs(object):
 
     def __getattr__(self, arg):
         return None
+
+
+class FakeSession(object):
+
+    def __init__(self, session_vars=None, config_file_vars=None):
+        if session_vars is None:
+            session_vars = {}
+        self.session_var_map = session_vars
+        if config_file_vars is None:
+            config_file_vars = {}
+        self.config_file_vars = config_file_vars
+
+    def get_config_variable(self, name, methods=('env', 'config'),
+                            default=None):
+        value = None
+        config_name, envvar_name = self.session_var_map[name]
+        if methods is not None:
+            if 'env' in methods:
+                value = os.environ.get(envvar_name)
+            elif 'config' in methods:
+                value = self.config_file_vars.get(config_name)
+        else:
+            value = default
+        return value
 
 
 class TestGlobalArgsCustomization(unittest.TestCase):
@@ -45,15 +70,19 @@ class TestGlobalArgsCustomization(unittest.TestCase):
 
     def test_parse_verify_ssl_default_value(self):
         with mock.patch('os.environ', {}):
-            parsed_args = FakeParsedArgs(verify_ssl=True)
-            globalargs.resolve_types(parsed_args)
+            parsed_args = FakeParsedArgs(verify_ssl=True, ca_bundle=None)
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(session_vars=session_var_map)
+            globalargs.resolve_verify_ssl(parsed_args, session)
             # None, so that botocore can apply it's default logic.
             self.assertIsNone(parsed_args.verify_ssl)
 
     def test_parse_verify_ssl_verify_turned_off(self):
         with mock.patch('os.environ', {}):
-            parsed_args = FakeParsedArgs(verify_ssl=False)
-            globalargs.resolve_types(parsed_args)
+            parsed_args = FakeParsedArgs(verify_ssl=False, ca_bundle=None)
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(session_vars=session_var_map)
+            globalargs.resolve_verify_ssl(parsed_args, session)
             self.assertFalse(parsed_args.verify_ssl)
 
     def test_os_environ_overrides_cert_bundle(self):
@@ -61,8 +90,10 @@ class TestGlobalArgsCustomization(unittest.TestCase):
             'AWS_CA_BUNDLE': '/path/to/bundle.pem',
         }
         with mock.patch('os.environ', environ):
-            parsed_args = FakeParsedArgs(verify_ssl=True)
-            globalargs.resolve_types(parsed_args)
+            parsed_args = FakeParsedArgs(verify_ssl=True, ca_bundle=None)
+            session_var_map = {'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE')}
+            session = FakeSession(session_vars=session_var_map)
+            globalargs.resolve_verify_ssl(parsed_args, session)
             self.assertEqual(parsed_args.verify_ssl, '/path/to/bundle.pem')
 
     def test_no_sign_request_if_option_specified(self):

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -131,6 +131,7 @@ def test_completions():
         'AWS_DEFAULT_REGION': 'us-east-1',
         'AWS_ACCESS_KEY_ID': 'access_key',
         'AWS_SECRET_ACCESS_KEY': 'secret_key',
+        'AWS_CA_BUNDLE': 'ca_bundle',
         'AWS_CONFIG_FILE': '',
     }
     with mock.patch('os.environ', environ):

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(__name__)
 
 GLOBALOPTS = ['--debug', '--endpoint-url', '--no-verify-ssl', '--no-paginate',
               '--output', '--profile', '--region', '--version', '--color',
-              '--query', '--no-sign-request']
+              '--query', '--no-sign-request', '--ca-bundle']
 
 COMPLETIONS = [
     ('aws ', -1, set(['autoscaling', 'cloudformation', 'cloudfront',
@@ -71,7 +71,7 @@ COMPLETIONS = [
      set(['--filters', '--dry-run', '--no-dry-run', '--endpoint-url',
           '--no-verify-ssl', '--no-paginate', '--no-sign-request', '--output',
           '--profile', '--starting-token', '--max-items', '--page-size',
-          '--region', '--version', '--color', '--query',
+          '--region', '--version', '--color', '--query', '--ca-bundle',
           '--generate-cli-skeleton', '--cli-input-json'])),
     ('aws s3', -1, set(['cp', 'mv', 'rm', 'mb', 'rb', 'ls', 'sync', 'website'])),
     ('aws s3 m', -1, set(['mv', 'mb'])),


### PR DESCRIPTION
Previously, a ca_bundle could only be specified as an environment variable, 'AWS_CA_BUNDLE'. This extends support so `ca_bundle` can be defined in the config file or passed on the command line (`--ca-bundle`).

There's also an alias, 'System', to use the the system ca cert bundle. Logic is *very* simplistic right now. Would be nicer if the logic were implemented upstream in requests. The idea was based on the boto config option, but boto uses the ssl module, which natively implements support for reading the system ca cert bundle (or claims to).