### PR TITLE
Use the latest version of virtualenv/pip for bundled installer

### DIFF
--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -24,7 +24,7 @@ from contextlib import contextmanager
 # the installation process.  It is *not* the deps required
 # by awscli/botocore.
 PACKAGE_VERSION = {
-    'virtualenv': '1.10.1',
+    'virtualenv': '13.0.3',
     # These packages are included because they are required for
     # python2.6, but our normal dependency downloading via pip
     # only works if you use python2.6.  To fix this issue, we're


### PR DESCRIPTION
We need a version of pip that supports the extras_require
conditional dependencies we now use for whl files.

This fixes a regression to the bundled installer for python2.6.


cc @kyleknap @mtdowling