### PR TITLE
Fix regression with old version of pip and cond deps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,12 @@ requires = ['botocore==1.0.0b2',
             'rsa>=3.1.2,<=3.1.4']
 
 
+if sys.version_info[:2] == (2, 6):
+    # For python2.6 we have to require argparse since it
+    # was not in stdlib until 2.7.
+    requires.append('argparse>=1.1')
+
+
 setup_options = dict(
     name='awscli',
     version=awscli.__version__,


### PR DESCRIPTION
Verified with:

```
<mkvirtualenv with python2.6>
pip install pip==1.4.1
<create botocore and awscli sdists>
pip install botocore/dist/<sdist>.tar.gz
pip install awscli/dist/<sdist>.tar.gz
aws --version
```

cc @kyleknap @mtdowling