### PR TITLE
Adding 'aws:kms' encryption support to S3 uploads

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -218,7 +218,7 @@ class FileInfo(TaskInfo):
         if self.parameters['sse']:
             sse = self.parameters['sse'][0]
             if sse == 'aws:kms':
-                self.client._client_config.signature_version = 's3v4'
+                self.client._request_signer._signature_version = 's3v4'
             params['ServerSideEncryption'] = sse
         if self.parameters['storage_class']:
             params['StorageClass'] = self.parameters['storage_class'][0]

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -216,7 +216,10 @@ class FileInfo(TaskInfo):
                                      'permission=principal')
                 params[self._permission_to_param(permission)] = grantee
         if self.parameters['sse']:
-            params['ServerSideEncryption'] = 'AES256'
+            sse = self.parameters['sse'][0]
+            if sse == 'aws:kms':
+                self.client._client_config.signature_version = 's3v4'
+            params['ServerSideEncryption'] = sse
         if self.parameters['storage_class']:
             params['StorageClass'] = self.parameters['storage_class'][0]
         if self.parameters['website_redirect']:

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -266,9 +266,10 @@ class FileInfo(TaskInfo):
         }
         self._handle_object_params(params)
         response_data = self.client.put_object(**params)
-        etag = response_data['ETag'][1:-1]
-        body.seek(0)
-        check_etag(etag, body)
+        if response_data['ServerSideEncryption'] != 'aws:kms':
+            etag = response_data['ETag'][1:-1]
+            body.seek(0)
+            check_etag(etag, body)
 
     def _inject_content_type(self, params, filename):
         # Add a content type param if we can guess the type.

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -56,7 +56,7 @@ class S3Handler(object):
         if not self.result_queue:
             self.result_queue = queue.Queue()
         self.params = {'dryrun': False, 'quiet': False, 'acl': None,
-                       'guess_mime_type': True, 'sse': False,
+                       'guess_mime_type': True, 'sse': None,
                        'storage_class': None, 'website_redirect': None,
                        'content_type': None, 'cache_control': None,
                        'content_disposition': None, 'content_encoding': None,

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -152,9 +152,12 @@ GRANTS = {
         'UsingAuthAccess.html">Access Control</a>')}
 
 
-SSE = {'name': 'sse', 'action': 'store_true',
+SSE = {'name': 'sse', 'nargs': 1,
+       'choices': ['AES256', 'aws:kms'],
        'help_text': (
-           "Enable Server Side Encryption of the object in S3")}
+           "Enable Server Side Encryption of the object in S3. "
+           "Valid choices are: AES256 | aws:kms"
+           "Defaults to 'AES256")}
 
 
 STORAGE_CLASS = {'name': 'storage-class', 'nargs': 1,

--- a/tests/unit/customizations/s3/test_copy_params.py
+++ b/tests/unit/customizations/s3/test_copy_params.py
@@ -57,7 +57,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += self.file_path
         cmdline += ' s3://mybucket/mykey'
-        cmdline += ' --sse'
+        cmdline += ' --sse=AES256'
         result = {'Bucket': u'mybucket', 'Key': u'mykey',
                   'ServerSideEncryption': 'AES256'}
         self.assert_params(cmdline, result)


### PR DESCRIPTION
These changes allow for users to specify 'aws:kms' as a server side encryption method for uploading files to S3.

Instead of `--sse` being a boolean flag to enable AES256, I made it a regular parameter switch that accepts either AES256 or aws:kms, the former being the default.

It's a bit messy as I was implementing this to solve a problem of mine. I will mark the code areas where I've done something probably hacky.

Also, I'm missing unit tests (which I can write when I get time to) and updating of the relevant documentation.

Thanks!