### PR TITLE
Properly configure loader sharing in tests

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -182,7 +182,8 @@ class BaseCLIDriverTest(unittest.TestCase):
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
         emitter = HierarchicalEmitter()
-        session = Session(EnvironmentVariables, emitter, loader=_LOADER)
+        session = Session(EnvironmentVariables, emitter)
+        session.register_component('data_loader', _LOADER)
         load_plugins({}, event_hooks=emitter)
         driver = CLIDriver(session=session)
         self.session = session


### PR DESCRIPTION
The loader argument to the session has been a no op
for a while (being removed in
https://github.com/boto/botocore/pull/579).
The way to set a loader is to just use register_component().

This gives shaves about 4 seconds off of the total unit test time
for me.

cc @kyleknap @mtdowling