### PR TITLE
Read only profile

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -219,7 +219,7 @@ class CLIDriver(object):
         self.session.emit(
             'top-level-args-parsed', parsed_args=args, session=self.session)
         if args.profile:
-            self.session.profile = args.profile
+            self.session.set_config_variable('profile', args.profile)
         if args.debug:
             # TODO:
             # Unfortunately, by setting debug mode here, we miss out

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -182,7 +182,8 @@ class BaseCLIDriverTest(unittest.TestCase):
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
         emitter = HierarchicalEmitter()
-        session = Session(EnvironmentVariables, emitter, loader=_LOADER)
+        session = Session(EnvironmentVariables, emitter)
+        session.register_component('data_loader', _LOADER)
         load_plugins({}, event_hooks=emitter)
         driver = CLIDriver(session=session)
         self.session = session

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -209,6 +209,10 @@ class FakeSession(object):
     def get_credentials(self):
         return self.credentials
 
+    def set_config_variable(self, name, value):
+        if name == 'profile':
+            self.profile = value
+
 
 class FakeCommand(BasicCommand):
     def _run_main(self, args, parsed_globals):


### PR DESCRIPTION
This is a possible way to handle the read only profile var from https://github.com/boto/botocore/pull/580.

This was branched off of the loader arg removal from the previous pull request so you'll see a diff of that as well until that's merged.

cc @kyleknap @mtdowling