### PR TITLE
Remove etag verification on uploads, not needed anymore

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -10,7 +10,7 @@ from dateutil.tz import tzlocal
 
 from botocore.compat import quote
 from awscli.customizations.s3.utils import find_bucket_key, \
-    check_etag, uni_print, guess_content_type, MD5Error, bytes_print
+    uni_print, guess_content_type, MD5Error, bytes_print
 
 
 class CreateDirectoryError(Exception):
@@ -48,7 +48,7 @@ def save_file(filename, response_data, last_update, is_stream=False):
     file_chunks = iter(partial(body.read, 1024 * 1024), b'')
     if is_stream:
         # Need to save the data to be able to check the etag for a stream
-        # becuase once the data is written to the stream there is no
+        # because once the data is written to the stream there is no
         # undoing it.
         payload = write_to_file(None, etag, md5, file_chunks, True)
     else:
@@ -263,9 +263,6 @@ class FileInfo(TaskInfo):
         }
         self._handle_object_params(params)
         response_data = self.client.put_object(**params)
-        etag = response_data['ETag'][1:-1]
-        body.seek(0)
-        check_etag(etag, body)
 
     def _inject_content_type(self, params, filename):
         # Add a content type param if we can guess the type.

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -251,20 +251,6 @@ def find_dest_path_comp_key(files, src_path=None):
     return dest_path, compare_key
 
 
-def check_etag(etag, fileobj):
-    """
-    This fucntion checks the etag and the md5 checksum to ensure no
-    data was corrupted upon transfer.
-    """
-    get_chunk = partial(fileobj.read, 1024 * 1024)
-    m = hashlib.md5()
-    for chunk in iter(get_chunk, b''):
-        m.update(chunk)
-    if '-' not in etag:
-        if etag != m.hexdigest():
-            raise MD5Error
-
-
 def create_warning(path, error_message):
     """
     This creates a ``PrintTask`` for whenever a warning is to be thrown.


### PR DESCRIPTION
This has been pushed down to the botocore layer so other
projects such as boto3 can leverage this logic.

cc @kyleknap @mtdowling