### PR TITLE
Add new shorthand parser for nested maps

### DIFF
--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -36,12 +36,17 @@ class ShorthandParseError(Exception):
         super(ShorthandParseError, self).__init__(msg)
 
     def _construct_msg(self):
+        if '\n' in self.value:
+            last_newline = self.value[:self.index].rindex('\n')
+            num_spaces = self.index - last_newline - 1
+        else:
+            num_spaces = self.index
         msg = (
             "Expected: '%s', received: '%s' for input:\n"
             "%s\n"
             "%s\n"
         ) % (self.expected, self.actual, self.value,
-             ' ' * self.index + '^')
+             ' ' * num_spaces + '^')
         return msg
 
 

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -102,15 +102,15 @@ class ShorthandParser(object):
     def _values(self):
         # values = csv-list / explicit-list / hash-literal
         if self._at_eof():
-            return None
+            return ''
         elif self._current() == '[':
             return self._explicit_list()
         elif self._current() == '{':
             return self._hash_literal()
         else:
-            return self._csv_list()
+            return self._csv_value()
 
-    def _csv_list(self):
+    def _csv_value(self):
         first_value = self._first_value()
         self._consume_whitespace()
         if self._at_eof() or self._input_value[self._index] != ',':
@@ -143,6 +143,7 @@ class ShorthandParser(object):
         result = self._FIRST_VALUE.match(self._input_value[self._index:])
         if result is not None:
             return self._consume_matched_regex(result)
+        return ''
 
     def _explicit_list(self):
         # explicit-list = "[" [value *(",' value)] "]"

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -50,11 +50,11 @@ class ShorthandParser(object):
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
     _FIRST_VALUE = _NamedRegex('first',
-                               ur'[\!\#-&\(-\+\--\<\>-Z\\-z\u007c-\uffff]'
-                               ur'[\!\#-&\(-\+\--\\\^-\|~-\uffff]*')
+                               u'[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff]'
+                               u'[\!\#-&\(-\+\--\\\\\^-\|~-\uffff]*')
     _SECOND_VALUE = _NamedRegex('second',
-                                ur'[\!\#-&\(-\+\--\<\>-Z\\-z\u007c-\uffff]'
-                                ur'[\!\#-&\(-\+\--\<\>-\uffff]*')
+                                u'[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff]'
+                                u'[\!\#-&\(-\+\--\<\>-\uffff]*')
 
     def __init__(self):
         self._tokens = []

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -1,0 +1,231 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import re
+import string
+
+
+_EOF = object()
+
+
+class _NamedRegex(object):
+    def __init__(self, name, regex_str):
+        self.name = name
+        self.regex = re.compile(regex_str, re.UNICODE)
+
+    def match(self, value):
+        return self.regex.match(value)
+
+
+class ShorthandParseError(Exception):
+    def __init__(self, value, expected, actual, index):
+        self.value = value
+        self.expected = expected
+        self.actual = actual
+        self.index = index
+        msg = self._construct_msg()
+        super(ShorthandParseError, self).__init__(msg)
+
+    def _construct_msg(self):
+        msg = (
+            "Expected: '%s', received: '%s' for input:\n"
+            "%s\n"
+            "%s\n"
+        ) % (self.expected, self.actual, self.value,
+             ' ' * self.index + '^')
+        return msg
+
+
+class ShorthandParser(object):
+
+    _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
+    _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
+    _FIRST_VALUE = _NamedRegex('first',
+                               ur'[\!\#-&\(-\+\--\<\>-Z\\-z\u007c-\uffff]'
+                               ur'[\!\#-&\(-\+\--\\\^-\uffff]*')
+    _SECOND_VALUE = _NamedRegex('second',
+                                ur'[\!\#-&\(-\+\--\<\>-Z\\-z\u007c-\uffff]'
+                                ur'[\!\#-&\(-\+\--\<\>-\uffff]*')
+
+    def __init__(self):
+        self._tokens = []
+
+    def parse(self, value):
+        self._input_value = value
+        self._index = 0
+        return self._parameter()
+
+    def _parameter(self):
+        # parameter = keyval *("," keyval)
+        params = {}
+        params.update(self._keyval())
+        while self._index < len(self._input_value):
+            self._consume_whitespace()
+            self._expect(',')
+            self._consume_whitespace()
+            params.update(self._keyval())
+        return params
+
+    def _keyval(self):
+        # keyval = key "=" [values]
+        key = self._key()
+        self._consume_whitespace()
+        self._expect('=')
+        self._consume_whitespace()
+        values = self._values()
+        return {key: values}
+
+    def _key(self):
+        # key = 1*(alpha / %x30-39)  ; [a-zA-Z0-9]
+        valid_chars = string.ascii_letters + string.digits
+        start = self._index
+        while not self._at_eof():
+            if self._current() not in valid_chars:
+                break
+            self._index += 1
+        return self._input_value[start:self._index]
+
+    def _values(self):
+        # values = csv-list / explicit-list / hash-literal
+        if self._at_eof():
+            return None
+        elif self._current() == '[':
+            return self._explicit_list()
+        elif self._current() == '{':
+            return self._hash_literal()
+        else:
+            return self._csv_list()
+
+    def _csv_list(self):
+        first_value = self._first_value()
+        self._consume_whitespace()
+        if self._at_eof() or self._input_value[self._index] != ',':
+            return first_value
+        self._consume_whitespace()
+        self._expect(',')
+        self._consume_whitespace()
+        csv_list = [first_value]
+        while True:
+            try:
+                current = self._second_value()
+                if current is None:
+                    break
+                self._consume_whitespace()
+                if self._at_eof():
+                    csv_list.append(current)
+                    break
+                self._expect(',')
+                self._consume_whitespace()
+                csv_list.append(current)
+            except ShorthandParseError:
+                # Backtrack to the previous comma.
+                self._backtrack_to(',')
+                break
+        if len(csv_list) == 1:
+            return first_value
+        return csv_list
+
+    def _value(self):
+        result = self._FIRST_VALUE.match(self._input_value[self._index:])
+        if result is not None:
+            return self._consume_matched_regex(result)
+
+    def _explicit_list(self):
+        # explicit-list = "[" [value *(",' value)] "]"
+        self._expect('[')
+        self._consume_whitespace()
+        values = []
+        while self._current() != ']':
+            val = self._value()
+            values.append(val)
+            self._consume_whitespace()
+            if self._current() != ']':
+                self._expect(',')
+                self._consume_whitespace()
+        self._expect(']')
+        return values
+
+    def _hash_literal(self):
+        raise NotImplementedError("_hash_literal")
+
+    def _first_value(self):
+        # first-value = value / single-quoted-val / double-quoted-val
+        if self._current() == "'":
+            return self._single_quoted_value()
+        elif self._current() == '"':
+            return self._double_quoted_value()
+        return self._value()
+
+    def _single_quoted_value(self):
+        # single-quoted-value = %x27 *(val-escaped-single) %x27
+        # val-escaped-single  = %x20-26 / %x28-7F / escaped-escape /
+        #                       (escape single-quote)
+        return self._consume_quoted(self._SINGLE_QUOTED, escaped_char="'")
+
+    def _consume_quoted(self, regex, escaped_char=None):
+        value = self._must_consume_regex(regex)[1:-1]
+        if escaped_char is not None:
+            value = value.replace("\\%s" % escaped_char, escaped_char)
+            value = value.replace("\\\\", "\\")
+        return value
+
+    def _double_quoted_value(self):
+        return self._consume_quoted(self._DOUBLE_QUOTED, escaped_char='"')
+
+    def _second_value(self):
+        if self._current() == "'":
+            return self._single_quoted_value()
+        elif self._current() == '"':
+            return self._double_quoted_value()
+        else:
+            return self._must_consume_regex(self._SECOND_VALUE)
+
+    def _expect(self, char):
+        if self._index >= len(self._input_value):
+            raise ShorthandParseError(self._input_value, char,
+                                      'EOF', self._index)
+        actual = self._input_value[self._index]
+        if actual  != char:
+            raise ShorthandParseError(self._input_value, char,
+                                      actual, self._index)
+        self._index += 1
+
+    def _must_consume_regex(self, regex):
+        result = regex.match(self._input_value[self._index:])
+        if result is not None:
+            return self._consume_matched_regex(result)
+        raise ShorthandParseError(self._input_value, '<%s>' % regex.name,
+                                  '<none>', self._index)
+
+    def _consume_matched_regex(self, result):
+        start, end = result.span()
+        v = self._input_value[self._index+start:self._index+end]
+        self._index += (end - start)
+        return v
+
+    def _current(self):
+        # If the index is at the end of the input value,
+        # then _EOF will be returned.
+        if self._index < len(self._input_value):
+            return self._input_value[self._index]
+        return _EOF
+
+    def _at_eof(self):
+        return self._index >= len(self._input_value)
+
+    def _backtrack_to(self, char):
+        while self._index >= 0 and self._input_value[self._index] != char:
+            self._index -= 1
+
+    def _consume_whitespace(self):
+        while self._current() != _EOF and self._current() in string.whitespace:
+            self._index += 1

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -245,7 +245,7 @@ class ShorthandParser(object):
             raise ShorthandParseError(self._input_value, char,
                                       'EOF', self._index)
         actual = self._input_value[self._index]
-        if actual  != char:
+        if actual != char:
             raise ShorthandParseError(self._input_value, char,
                                       actual, self._index)
         self._index += 1

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -238,6 +238,16 @@ class TestParamShorthand(BaseArgProcessTest):
                 "Name = architecture, Values = i386"])
         self.assertEqual(returned3, expected)
 
+    def test_parse_empty_values(self):
+        # A value can be omitted and will default to an empty string.
+        p = self.get_param_model('ec2.DescribeInstances.Filters')
+        expected = [{"Name": "", "Values": ["i-1", "i-2"]},
+                    {"Name": "architecture", "Values": ['']}]
+        returned = self.simplify(
+            p, ["Name=,Values=i-1,i-2",
+                "Name=architecture,Values="])
+        self.assertEqual(returned, expected)
+
     def test_list_structure_list_scalar_2(self):
         p = self.get_param_model('emr.ModifyInstanceGroups.InstanceGroups')
         expected = [

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -92,6 +92,12 @@ def test_parse():
     yield (_can_parse, 'Name=foo,Values= a,  b  ,  c',
            {'Name': 'foo', 'Values': ['a', 'b', 'c']})
 
+    # Can handle newlines between values.
+    yield (_can_parse, 'Name=foo,\nValues=a,b,c',
+           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
+    yield (_can_parse, 'A=b,\nC=d,\nE=f\n',
+           {'A': 'b', 'C': 'd', 'E': 'f'})
+
     # Hashes
     yield (_can_parse, 'Name={foo=bar,baz=qux}',
            {'Name': {'foo': 'bar', 'baz': 'qux'}})

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -1,0 +1,124 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli import shorthand
+from nose.tools import assert_equal
+
+
+def test_parse():
+    # Key val pairs with scalar value.
+    yield (_can_parse, 'foo=bar', {'foo': 'bar'})
+    yield (_can_parse, 'foo=bar', {'foo': 'bar'})
+    yield (_can_parse, 'foo=bar,baz=qux', {'foo': 'bar', 'baz': 'qux'})
+    yield (_can_parse, 'a=b,c=d,e=f', {'a': 'b', 'c': 'd', 'e': 'f'})
+    # Empty values are allowed.
+    yield (_can_parse, 'foo=', {'foo': None})
+    yield (_can_parse, 'foo=,bar=', {'foo': None, 'bar': None})
+    # Unicode is allowed.
+    yield (_can_parse, u'foo=\u2713', {'foo': u'\u2713'})
+    yield (_can_parse, u'foo=\u2713,\u2713', {'foo': [u'\u2713', u'\u2713']})
+    # Key val pairs with csv values.
+    yield (_can_parse, 'foo=a,b', {'foo': ['a', 'b']})
+    yield (_can_parse, 'foo=a,b,c', {'foo': ['a', 'b', 'c']})
+    yield (_can_parse, 'foo=a,b,bar=c,d', {'foo': ['a', 'b'],
+                                           'bar': ['c', 'd']})
+    yield (_can_parse, 'foo=a,b,c,bar=d,e,f',
+           {'foo': ['a', 'b', 'c'], 'bar': ['d', 'e', 'f']})
+
+    # Explicit lists.
+    yield (_can_parse, 'foo=[]', {'foo': []})
+    yield (_can_parse, 'foo=[a]', {'foo': ['a']})
+    yield (_can_parse, 'foo=[a,b]', {'foo': ['a', 'b']})
+    yield (_can_parse, 'foo=[a,b,c]', {'foo': ['a', 'b', 'c']})
+    yield (_can_parse, 'foo=[a,b],bar=c,d',
+           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
+    yield (_can_parse, 'foo=[a,b],bar=[c,d]',
+           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
+    yield (_can_parse, 'foo=a,b,bar=[c,d]',
+           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
+    yield (_can_parse, 'foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']})
+    yield (_can_parse, 'foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']})
+    # Lists with whitespace.
+    yield (_can_parse, 'foo=[ a , b  , c  ]',
+           {'foo': ['a', 'b', 'c']})
+    yield (_can_parse, 'foo  =  [ a , b  , c  ]',
+           {'foo': ['a', 'b', 'c']})
+
+    # Single quoted strings.
+    yield (_can_parse, "foo='bar'", {"foo": "bar"})
+    yield (_can_parse, "foo='bar,baz'", {"foo": "bar,baz"})
+    # Single quoted strings for each value in a CSV list.
+    yield (_can_parse, "foo='bar','baz'", {"foo": ['bar', 'baz']})
+    # Can mix single quoted and non quoted values.
+    yield (_can_parse, "foo=bar,'baz'", {"foo": ['bar', 'baz']})
+    # Quoted strings can include chars not allowed in unquoted strings.
+    yield (_can_parse, "foo=bar,'baz=qux'", {"foo": ['bar', 'baz=qux']})
+    yield (_can_parse, "foo=bar,'--option=bar space'",
+           {"foo": ['bar', '--option=bar space']})
+    # Can escape the single quote.
+    yield (_can_parse, "foo='bar\\'baz'", {"foo": "bar'baz"})
+    yield (_can_parse, "foo='bar\\\\baz'", {"foo": "bar\\baz"})
+
+    # Double quoted strings.
+    yield (_can_parse, 'foo="bar"', {'foo': 'bar'})
+    yield (_can_parse, 'foo="bar,baz"', {'foo': 'bar,baz'})
+    yield (_can_parse, 'foo="bar","baz"', {'foo': ['bar', 'baz']})
+    yield (_can_parse, 'foo=bar,"baz=qux"', {'foo': ['bar', 'baz=qux']})
+    yield (_can_parse, 'foo=bar,"--option=bar space"',
+           {'foo': ['bar', '--option=bar space']})
+    yield (_can_parse, 'foo="bar\\"baz"', {'foo': 'bar"baz'})
+    yield (_can_parse, 'foo="bar\\\\baz"', {'foo': 'bar\\baz'})
+
+    # Ignores whitespace around '=' and ','
+    yield (_can_parse, 'foo= bar', {'foo': 'bar'})
+    yield (_can_parse, 'foo =bar', {'foo': 'bar'})
+    yield (_can_parse, 'foo = bar', {'foo': 'bar'})
+    yield (_can_parse, 'foo  =   bar', {'foo': 'bar'})
+    yield (_can_parse, 'foo = bar,baz = qux', {'foo': 'bar', 'baz': 'qux'})
+    yield (_can_parse, 'a = b,  c = d , e = f', {'a': 'b', 'c': 'd', 'e': 'f'})
+    yield (_can_parse, 'foo = ', {'foo': None})
+    yield (_can_parse, 'a=b,c=  d,  e,  f', {'a': 'b', 'c': ['d', 'e', 'f']})
+    yield (_can_parse, 'Name=foo,Values=  a  ,  b  ,  c  ',
+           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
+    yield (_can_parse, 'Name=foo,Values= a,  b  ,  c',
+           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
+
+
+def test_error_parsing():
+    yield (_is_error, 'foo')
+    # Missing closing quotes
+    yield (_is_error, 'foo="bar')
+    yield (_is_error, "foo='bar")
+    yield (_is_error, "foo=[bar")
+
+
+def test_regressions():
+    return
+    with open('/tmp/shorthand') as f:
+        for expr in f:
+            yield _can_parse, expr.strip().decode('utf-8'), {}
+
+
+def _is_error(expr):
+    try:
+        shorthand.ShorthandParser().parse(expr)
+    except shorthand.ShorthandParseError:
+        #except TypeError:
+        # Expected result, test passes.
+        pass
+    else:
+        raise AssertionError("Expected ShorthandParseError, but no "
+                            "exception was raised for expression: %s" % expr)
+
+def _can_parse(data, expected):
+    actual = shorthand.ShorthandParser().parse(data)
+    assert_equal(actual, expected)

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -92,6 +92,24 @@ def test_parse():
     yield (_can_parse, 'Name=foo,Values= a,  b  ,  c',
            {'Name': 'foo', 'Values': ['a', 'b', 'c']})
 
+    # Hashes
+    yield (_can_parse, 'Name={foo=bar,baz=qux}',
+           {'Name': {'foo': 'bar', 'baz': 'qux'}})
+    yield (_can_parse, 'Name={foo=[a,b,c],bar=baz}',
+           {'Name': {'foo': ['a', 'b', 'c'], 'bar': 'baz'}})
+    yield (_can_parse, 'Name={foo=bar},Bar=baz',
+           {'Name': {'foo': 'bar'}, 'Bar': 'baz'})
+    yield (_can_parse, 'Bar=baz,Name={foo=bar}',
+           {'Bar': 'baz', 'Name': {'foo': 'bar'}})
+    yield (_can_parse, 'a={b={c=d}}',
+           {'a': {'b': {'c': 'd'}}})
+    yield (_can_parse, 'a={b={c=d,e=f},g=h}',
+           {'a': {'b': {'c': 'd', 'e': 'f'}, 'g': 'h'}})
+
+    # Combining lists and hashes.
+    #yield (_can_parse, 'Name=[{foo=bar}, {baz=qux}]',
+    #       {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]})
+
 
 def test_error_parsing():
     yield (_is_error, 'foo')
@@ -99,21 +117,15 @@ def test_error_parsing():
     yield (_is_error, 'foo="bar')
     yield (_is_error, "foo='bar")
     yield (_is_error, "foo=[bar")
-
-
-def test_regressions():
-    return
-    with open('/tmp/shorthand') as f:
-        for expr in f:
-            yield _can_parse, expr.strip().decode('utf-8'), {}
+    yield (_is_error, "foo={bar")
+    yield (_is_error, "foo={bar}")
+    yield (_is_error, "foo={bar=bar")
 
 
 def _is_error(expr):
     try:
         shorthand.ShorthandParser().parse(expr)
     except shorthand.ShorthandParseError:
-        #except TypeError:
-        # Expected result, test passes.
         pass
     else:
         raise AssertionError("Expected ShorthandParseError, but no "

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -113,8 +113,12 @@ def test_parse():
            {'a': {'b': {'c': 'd', 'e': 'f'}, 'g': 'h'}})
 
     # Combining lists and hashes.
-    #yield (_can_parse, 'Name=[{foo=bar}, {baz=qux}]',
-    #       {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]})
+    yield (_can_parse, 'Name=[{foo=bar}, {baz=qux}]',
+           {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]})
+
+    # Combining hashes and lists.
+    yield (_can_parse, 'Name=[{foo=[a,b]}, {bar=[c,d]}]',
+           {'Name': [{'foo': ['a', 'b']}, {'bar': ['c', 'd']}]})
 
 
 def test_error_parsing():

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -21,8 +21,8 @@ def test_parse():
     yield (_can_parse, 'foo=bar,baz=qux', {'foo': 'bar', 'baz': 'qux'})
     yield (_can_parse, 'a=b,c=d,e=f', {'a': 'b', 'c': 'd', 'e': 'f'})
     # Empty values are allowed.
-    yield (_can_parse, 'foo=', {'foo': None})
-    yield (_can_parse, 'foo=,bar=', {'foo': None, 'bar': None})
+    yield (_can_parse, 'foo=', {'foo': ''})
+    yield (_can_parse, 'foo=,bar=', {'foo': '', 'bar': ''})
     # Unicode is allowed.
     yield (_can_parse, u'foo=\u2713', {'foo': u'\u2713'})
     yield (_can_parse, u'foo=\u2713,\u2713', {'foo': [u'\u2713', u'\u2713']})
@@ -85,7 +85,7 @@ def test_parse():
     yield (_can_parse, 'foo  =   bar', {'foo': 'bar'})
     yield (_can_parse, 'foo = bar,baz = qux', {'foo': 'bar', 'baz': 'qux'})
     yield (_can_parse, 'a = b,  c = d , e = f', {'a': 'b', 'c': 'd', 'e': 'f'})
-    yield (_can_parse, 'foo = ', {'foo': None})
+    yield (_can_parse, 'foo = ', {'foo': ''})
     yield (_can_parse, 'a=b,c=  d,  e,  f', {'a': 'b', 'c': ['d', 'e', 'f']})
     yield (_can_parse, 'Name=foo,Values=  a  ,  b  ,  c  ',
            {'Name': 'foo', 'Values': ['a', 'b', 'c']})


### PR DESCRIPTION
This adds a new shorthand parser that can handle nested maps via a ``{foo=bar}`` syntax.  Note this is not plumbed into the argprocess module yet, it's entirely standalone in this PR.

The plan for this is:

1. Get this parser reviewed
2. Integrate this with the existing shorthand parser and add in back-compat code (separate PR).

There's one point in this PR not implemented that we need to decide.  Right now, the explicit list parser `[foo, bar baz]` assumes that all the values are strings.  If we want to support nested lists or lists of hashes, we will need to require string values that start with `[` and `{` to be quoted.  There's  a comment on line 148 that explains this.

cc @kyleknap @mtdowling @rayluo 