### PR TITLE
Handle case when create-virtual-mfa-device errors out

### DIFF
--- a/awscli/customizations/iamvirtmfa.py
+++ b/awscli/customizations/iamvirtmfa.py
@@ -81,6 +81,8 @@ class IAMVMFAWrapper(object):
         argument_table['bootstrap-method'] = self._method
 
     def _save_file(self, parsed, **kwargs):
+        if 'Error' in parsed:
+            return
         method = self._method.value
         outfile = self._outfile.value
         if method in parsed['VirtualMFADevice']:


### PR DESCRIPTION
This was previously propogating a KeyError and would just
display the error message 'VirtualMFADevice'.  Now
we let the error propogate and print a full error message.

cc @kyleknap @mtdowling @rayluo 