### PR TITLE
A tentative cloudfront sign implementation, subject to refactoring

### DIFF
--- a/awscli/customizations/cfsign.py
+++ b/awscli/customizations/cfsign.py
@@ -1,0 +1,77 @@
+# Should go into botocore/cloudfront.py
+
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+import json
+from base64 import b64encode
+try:
+    maketrans = bytes.maketrans  # For Python 3
+except:
+    from string import maketrans
+
+import rsa
+
+
+LOG = logging.getLogger(__name__)
+
+
+def cloudfront_b64encode(content):
+    return b64encode(content).translate(maketrans(b'+=/', b'-_~'))
+
+
+def sign(url, key_id, private_key, expires, starts=None, ip_address=None):
+    """
+    Creates a signed CloudFront URL.
+
+    :type url: str
+    :param url: The URL of the protected object.
+
+    :type key_id: str
+    :param key_id: The CloudFront Key Pair ID
+
+    :type private_key: str
+    :param private_key: The private key string used for signing.
+
+    :type expires: int
+    :param expires: The expiry time of the URL. Format is a unix epoch.
+
+    :type starts: int
+    :param starts: The expiry time of the URL. Format is a unix epoch.
+
+    :type ip_address: str
+    :param ip_address: Use 'x.x.x.x' for an IP, or 'x.x.x.x/x' for a subnet.
+
+    :rtype: str
+    :return: The signed URL.
+    """
+    # SEE: http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-creating-signed-url-custom-policy.html
+    condition = {"DateLessThan": {"AWS:EpochTime": int(expires)}}
+    if ip_address:
+        ip_address = ip_address if '/' in ip_address else (ip_address + '/32')
+        condition["IpAddress"] = {"AWS:SourceIp": ip_address}
+    if starts:
+        condition["DateGreaterThan"] = {"AWS:EpochTime": int(starts)}
+    custom_policy = {"Statement": [{"Resource": url, "Condition": condition}]}
+    compact_policy = json.dumps(
+        custom_policy,
+        sort_keys=True,  # Otherwise test cases become unstable on Python3
+        separators=(',', ':')).encode('utf8')
+    LOG.debug("Policy = %s", compact_policy)
+    rsa_pk = rsa.PrivateKey.load_pkcs1(private_key.encode('utf8'))
+    signed_policy = rsa.sign(compact_policy, rsa_pk, 'SHA-1')
+    return url + ('&' if '?' in url else '?') + '&'.join([
+        'Policy=%s' % cloudfront_b64encode(compact_policy).decode('utf8'),
+        'Signature=%s' % cloudfront_b64encode(signed_policy).decode('utf8'),
+        'Key-Pair-Id=%s' % key_id,
+        ])

--- a/awscli/customizations/cfutils.py
+++ b/awscli/customizations/cfutils.py
@@ -1,0 +1,19 @@
+# This one should go into botocore/utils.py
+from datetime import datetime
+
+
+def datetime2epoch(dt):
+    """
+    Calculate the POSIX epoch time based on the given datetime instance.
+
+    If the input datetime is naive, it will be treated as UTC time.
+    (Note that this is different than the timestamp() behavior in Python3.3+.
+    We want unambiguous UTC to avoid test cases failing on different locale.)
+    """
+    if dt.tzinfo:
+        d = dt.replace(tzinfo=None) - dt.utcoffset() - datetime(1970, 1, 1)
+    else:
+        d = dt - datetime(1970, 1, 1)
+    if hasattr(d, "total_seconds"):
+        return d.total_seconds()  # Works in Python 2.7+
+    return (d.microseconds + (d.seconds + d.days * 24 * 3600) * 10**6) / 10**6

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -1,0 +1,74 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.utils import parse_to_aware_datetime
+from awscli.customizations.commands import BasicCommand
+from .cfsign import sign
+from .cfutils import datetime2epoch
+
+
+def initialize(cli):
+    """
+    The entry point for high level commands.
+    """
+    cli.register('building-command-table.cloudfront', inject_commands)
+
+
+def inject_commands(command_table, session, **kwargs):
+    """
+    Called when the command table is being built. Used to inject new
+    high level commands into the command list. These high level commands
+    must not collide with existing low-level API call names.
+    """
+    command_table['sign'] = CloudFrontSign(session)
+
+
+class CloudFrontSign(BasicCommand):
+    NAME = 'sign'
+    DESCRIPTION = 'Sign a given url.'
+    DATETIME_HELP_TEXT = """Acceptable formats include:
+        YYYY-MM-DD, YYYY-MM-DDThh:mm:ssZ,
+        YYYY-MM-DDThh:mm:ss+hh:mm (with offset), or EpochTime.
+        Do NOT use YYYYMMDD, because it will be treated as EpochTime."""
+    ARG_TABLE = [
+        {
+            'name': 'url',
+            'no_paramfile': True,  # To disable the default paramfile behavior
+            'required': True,
+            'help_text': 'The URL to be signed',
+        },
+        {
+            'name': 'key-pair-id',
+            'required': True,
+            'help_text': 'The ID of your CloudFront key pairs.',
+        },
+        {
+            'name': 'private-key',
+            'required': True,
+            'help_text': 'file://path/to/your/private-key.pem',
+        },
+        {'name': 'expires', 'required': True, 'help_text': DATETIME_HELP_TEXT},
+        {'name': 'starts', 'help_text': DATETIME_HELP_TEXT},
+        {'name': 'ip-address', 'help_text': 'Format: x.x.x.x/x or x.x.x.x'},
+    ]
+
+    def _run_main(self, args, parsed_globals):
+        print(sign(
+            args.url,
+            args.key_pair_id,
+            args.private_key,
+            datetime2epoch(parse_to_aware_datetime(args.expires)),
+            datetime2epoch(parse_to_aware_datetime(args.starts))
+                if args.starts else None,
+            args.ip_address,
+            ))
+        return 0

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -37,6 +37,7 @@ from awscli.customizations.iamvirtmfa import IAMVMFAWrapper
 from awscli.customizations.argrename import register_arg_renames
 from awscli.customizations.configure import register_configure_cmd
 from awscli.customizations.cloudtrail import initialize as cloudtrail_init
+from awscli.customizations.cloudfront import initialize as cloudfront_init
 from awscli.customizations.toplevelbool import register_bool_params
 from awscli.customizations.ec2protocolarg import register_protocol_args
 from awscli.customizations import datapipeline
@@ -110,6 +111,7 @@ def awscli_initialize(event_handlers):
     register_arg_renames(event_handlers)
     register_configure_cmd(event_handlers)
     cloudtrail_init(event_handlers)
+    cloudfront_init(event_handlers)
     register_bool_params(event_handlers)
     register_protocol_args(event_handlers)
     datapipeline.register_customizations(event_handlers)

--- a/tests/unit/test_cfsign.py
+++ b/tests/unit/test_cfsign.py
@@ -1,0 +1,68 @@
+# Should go into botocore/tests/unit
+import unittest
+
+from awscli.customizations.cfsign import cloudfront_b64encode, sign
+
+
+def test_cloudfront_b64encode():
+    assert b'aGVsbG8gd29ybGQ_'==cloudfront_b64encode(b'hello world')
+
+
+class CloudFrontSignTest(unittest.TestCase):
+
+    # The private key, its id, and the domain name used in this class,
+    # are all based on a real CloudFront distribution as test environment.
+    # That distribution and the key will probably not last for long,
+    # but the test case(s) will remain valid.
+
+    key_id = "APKAJW2UAWQ7F2BI3OHA"
+    private_key = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKCAQEAu6o2+Jc8UINw2P/w2l7A1xXu3emQEZQ9diA3bmog8r9Dg+65
+        fZgAqmuNWPqBivv7j3DGnLUdt8uCIr7PYUbK7wDa6n7U3ryOWtO2ZTc3StiJVcqT
+        sokZ0qxGFtDRafjBuydXtcxh52vVTcHqH33nubyyZIzuhTwfmrIOnUXnLwbMrBBP
+        bg/8mlgQooyo1XbrN1eO4XMs+UgQ9Mqc7KRJRinUJ+KYuCnM8f/nN4RjYdjTcghk
+        xCPEHCeSt2luywWyYmfguWCBS2Mu1q0250wKyNazlgiiTJtAuuSeweb4NKPOJL9X
+        hR6Ce6UuU4WYlli8gvQh3FAV3N3C1Rxo20k28QIDAQABAoIBAQCUEkP5dWrzpCJg
+        NeHWizjg/L9SfT1dgXfVQqo6BqckoeElsjDNdifgT6hhcpbQEO52SWeMsiNWp85w
+        l9mNSYxJdIVGzPgtHt27sJyT1DNebOg/tu0+y4qCfcd3rR/u24YQo4RDP5ZoQN82
+        0TBn1LIIDWk8iS6SFdRh/OgnE8bLhNbK9IfZQFEEJrFkArrn/le/ro2mfJkC/imo
+        QvqKmM0dGBXt5SCDSbUQAzKtEcR/4gf/qSjFe2YAwAvSA05WXMH6szdtx6/H/VbK
+        Uck/WwTHvGObQDFEWmICxPK9AWT0qaFNjlUsi3bjQRdIlYYrXe+6nVMB/Jp1awq7
+        tGBqIcWBAoGBAPtXCNuoQhKXqkjJgteQpB+wFav12XRZgpOciYdeviJrgWydpOOu
+        O9wkiRUctUijRJbUuWCJF7SgYGoT2xTTp/COiOReqs7qXLMuuXCZcPKkMRJj5wmo
+        Uc2AwUV/o3+PNz1NFK+2RgciXplac7qugIyuxIvBKuVFTBlCg0+if/0pAoGBAL8k
+        845wKqOeiawwle/o9lKLGPy1T11GrE6l1A5jRuE1WTVM77jRrb0Hmo0mdfHaf5A0
+        EjXGIX/fjcmQzBrEd78eCUsvI2Bgn6xXwhd4TTyWHGZfoQjFqAGkixuLN1oo2h1g
+        bRreFKfAubFP8MC93z23vnH6tdY2VIA4h5ehUFyJAoGAJqxJrKLDJ+E2TmTTQR/8
+        YPPTIdZ+UyzCrrvTXYTydJFeJLxM9suEYmcswJbePgMBNsQckgIGJ8DVlPzhJN88
+        ZANKhPkcByKAiQGTfwPdITiqZE4C6rV/gMNi+bKeEa6TrVcC69Z8B/T94VLNo9fd
+        58esbmSWmRiEkQ5u7f3u+6ECgYA8+6ANCLJB43nPCu07TpsP+LrvHTWF799XdEa0
+        lG3vuiKNA8/TqmoAziU79VJZ6Dkcm9BXga/8aSmGboD/5UDDI+UZLJ/fxtQKmzEc
+        ZdBWjRnge5AYCV+xrnqHPiJZzIDSMIp+sO3sG2vjKzsHc0x/F1lWagOLpWfORLrV
+        4KyP6QKBgAafeSrfK3LM7idiCBuxckLCgFoHa7uXLUNJRS5iIU+bbZLPj2ozu/tk
+        U0jp7sNk1CyMWI36lR3sujkSyH3lPIXVgrXMuGY3PJRGntN8WlWEsw4VUMGRj3h4
+        5rB+y/UOS+nlEwQ6eOS09GByJDEXOXpcwjFcTr/f7V8mi0jH+gY/
+        -----END RSA PRIVATE KEY-----
+        """
+
+    def test_sign_expire_start_ip(self):
+        expected_url = "http://d2ragvjhlngfb6.cloudfront.net/index.html?foo=bar&Policy=eyJTdGF0ZW1lbnQiOlt7IkNvbmRpdGlvbiI6eyJEYXRlR3JlYXRlclRoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTQyMDA3MDQwMH0sIkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzY3MTM5MjAwfSwiSXBBZGRyZXNzIjp7IkFXUzpTb3VyY2VJcCI6IjU0LjI0MC4xOTYuMTY5LzMyIn19LCJSZXNvdXJjZSI6Imh0dHA6Ly9kMnJhZ3ZqaGxuZ2ZiNi5jbG91ZGZyb250Lm5ldC9pbmRleC5odG1sP2Zvbz1iYXIifV19&Signature=ggae69gtUM1c8Av6wWyqlkZWk1sSmUgzPSNn0tUwKwmuEeaDZEy8HqLu~iHYXjHw7uyQomB8O8kg4UozKn~RjIgg4rPo3SjFlcDHB4E-CK8F69w2-bFifLBYb92lhW~qIPtP1HLdc8jXnY3-vp3pj8Lpxl3m7z5UTDZPSAX~u9ZTFZvDo2HEdXWj86EKwXXLqdZlsFBoxC1kVo9hRJPG~zovp0xxz8MdgeidFrHJm-iyiW07A7AJ52mbSZ0KgLOa0TPNgcu-v1jZqUJKDIOtSGU10jh0DM3jpKqcT7gTZW3sQwmApw9Yklf6t0a0pnAE7TDYlLZ6ulnJeQMMKXN8FQ__&Key-Pair-Id=APKAJW2UAWQ7F2BI3OHA"
+        self.assertEqual(expected_url, sign(
+            "http://d2ragvjhlngfb6.cloudfront.net/index.html?foo=bar",
+            self.key_id, self.private_key, expires=1767139200,
+            starts=1420070400, ip_address="54.240.196.169"))
+
+    def test_sign_expire_start(self):
+        expected_url = "http://d2ragvjhlngfb6.cloudfront.net/index.html?Policy=eyJTdGF0ZW1lbnQiOlt7IkNvbmRpdGlvbiI6eyJEYXRlR3JlYXRlclRoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTQyMDA3MDQwMH0sIkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzY3MTM5MjAwfX0sIlJlc291cmNlIjoiaHR0cDovL2QycmFndmpobG5nZmI2LmNsb3VkZnJvbnQubmV0L2luZGV4Lmh0bWwifV19&Signature=DRQ8dBO5SNfoPtFHwmbMFp5MOve8WU5-IkUBm1EMX2xi1tHY1aAiQMlbMtWFel8vHCeYcgcd-aVHRYlwAsG3Fq28HivqGNKBGvhVXUzkM9Jd-BUIWifmpuvH6hw3g7Q6C~3txZ709jxqMBONNSLgBVjL4QXNEycHIgCq43uA9n9Vc3gVOcHf-SVTXpmRl0nt2ZdgjZaN2Dg06sLmE1xEWBbXPrKi455ykZtpsbUXALPHxbnfIOiCi~uF8qrxNvS~nxwQ1zf-kz3avVjd4ruf4Q4QTB8nuGtERBlMCTske8X5-7gzrDejrZW7FMhNiaGdG~QErX0FGMC80XxN-qe0Jw__&Key-Pair-Id=APKAJW2UAWQ7F2BI3OHA"
+        self.assertEqual(expected_url, sign(
+            "http://d2ragvjhlngfb6.cloudfront.net/index.html",
+            self.key_id, self.private_key, expires=1767139200,
+            starts=1420070400))
+
+    def test_sign_expire_ip(self):
+        expected_url = "http://d2ragvjhlngfb6.cloudfront.net/index.html?Policy=eyJTdGF0ZW1lbnQiOlt7IkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc2NzEzOTIwMH0sIklwQWRkcmVzcyI6eyJBV1M6U291cmNlSXAiOiI1NC4yNDAuMTk2LjAvMSJ9fSwiUmVzb3VyY2UiOiJodHRwOi8vZDJyYWd2amhsbmdmYjYuY2xvdWRmcm9udC5uZXQvaW5kZXguaHRtbCJ9XX0_&Signature=JQy1XUUal8fM50FYfVWtu4po0AfzXqN0YwImv0yLbZkYg7~J~ZeESznOdIG8lLyzRLIDXYmrP0Lz4PW-L7UYPkpCiqDI9mHHMBJUF7rMlleR4vSfdyeSqPAPq-R0SarelXNUYN9yaXkVWbgtalcaoC3jNBUwZun7Fhb6PI1~1oKIYIKRIGo~1mfqwOjzBS5B1oHlXO5SmW9yXE9MjkfYYcVlJrGizpwIgj0L6qe8eBCbSQNTq7BpyNc5~4YaiFS-tBv~GpQoJdUey1CSZJrYGfkqySAOZIeWphrNVInfxCy8Hai06UYs7QPszhTuK~hlPEJab2~sZJQ6Ce6hufXx9A__&Key-Pair-Id=APKAJW2UAWQ7F2BI3OHA"
+        self.assertEqual(expected_url, sign(
+            "http://d2ragvjhlngfb6.cloudfront.net/index.html",
+            self.key_id, self.private_key, expires=1767139200,
+            ip_address="54.240.196.0/1"))  # Note: VPN can not fool CloudFront

--- a/tests/unit/test_cfutil.py
+++ b/tests/unit/test_cfutil.py
@@ -1,0 +1,12 @@
+# This one should go into botocore/tests/unit/test_utils.py
+from datetime import datetime
+from dateutil.tz import tzutc
+
+from awscli.customizations.cfutils import datetime2epoch
+
+
+def test_datetime2epoch_naive():
+    assert datetime2epoch(datetime(1970, 1, 2))==86400
+
+def test_datetime2epoch_aware():
+    assert datetime2epoch(datetime(1970, 1, 2, tzinfo=tzutc()))==86400


### PR DESCRIPTION
The sign feature is there. Two helper files and their test cases would better be moved into botocore, and then this PR will be changed accordingly.

And, the code structure is still subject to change when more CloudFront commands are coming.