### PR TITLE
Plumb in new shorthand parser into the CLI

### DIFF
--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -86,6 +86,11 @@ class CodeArgument(CLIArgument):
         if value is None:
             return
         unpacked = self._unpack_argument(value)
+        if 'ZipFile' in unpacked:
+            raise ValueError("ZipFile cannot be provided "
+                             "as part of the --code argument.  "
+                             "Please use the '--zip-file' "
+                             "option instead to specify a zip file.")
         if parameters.get('Code'):
             parameters['Code'].update(unpacked)
         else:

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -57,6 +57,12 @@ class ShorthandParseError(Exception):
 
 
 class ShorthandParser(object):
+    """Parses shorthand syntax in the CLI.
+
+    Note that this parser does not rely on any JSON models to control
+    how to parse the shorthand syntax.
+
+    """
 
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
@@ -71,6 +77,19 @@ class ShorthandParser(object):
         self._tokens = []
 
     def parse(self, value):
+        """Parse shorthand syntax.
+
+        For example::
+
+            parser = ShorthandParser()
+            parser.parse('a=b')  # {'a': 'b'}
+            parser.parse('a=b,c')  # {'a': ['b', 'c']}
+
+        :tpye value: str
+        :param value: Any value that needs to be parsed.
+
+        :return: Parsed value, which will be a dictionary.
+        """
         self._input_value = value
         self._index = 0
         return self._parameter()

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -39,7 +39,6 @@ necessary to maintain backwards compatibility.  This is done in the
 
 """
 import re
-import decimal
 import string
 
 
@@ -385,7 +384,7 @@ class BackCompatVisitor(ModelVisitor):
         if type_name in ['integer', 'long']:
             parent[name] = int(value)
         elif type_name in ['double', 'float']:
-            parent[name] = decimal.Decimal(value)
+            parent[name] = float(value)
         elif type_name == 'boolean':
             # We want to make sure we only set a value
             # only if "true"/"false" is specified.

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -374,13 +374,6 @@ class BackCompatVisitor(ModelVisitor):
             # "foo=bar", but "bar" should really be ["bar"].
             if value is not None:
                 parent[name] = [value]
-        elif shape.member.type_name == 'structure' and \
-                len(shape.member.members) == 1:
-            element_name = list(shape.member.members.keys())[0]
-            new_values = []
-            for v in value:
-                new_values.append({element_name: v})
-            parent[name] = new_values
         else:
             return super(BackCompatVisitor, self)._visit_list(
                 parent, shape, name, value)

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -68,11 +68,11 @@ class ShorthandParser(object):
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
     _FIRST_VALUE = _NamedRegex('first',
-                               u'[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff]'
-                               u'[\!\#-&\(-\+\--\\\\\^-\|~-\uffff]*')
+                               u'((\\\\,)|[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff])'
+                               u'((\\\\,)|[\!\#-&\(-\+\--\\\\\^-\|~-\uffff])*')
     _SECOND_VALUE = _NamedRegex('second',
-                                u'[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff]'
-                                u'[\!\#-&\(-\+\--\<\>-\uffff]*')
+                                u'((\\\\,)|[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff])'
+                                u'((\\\\,)|[\!\#-&\(-\+\--\<\>-\uffff])*')
 
     def __init__(self):
         self._tokens = []
@@ -183,7 +183,8 @@ class ShorthandParser(object):
     def _value(self):
         result = self._FIRST_VALUE.match(self._input_value[self._index:])
         if result is not None:
-            return self._consume_matched_regex(result)
+            consumed = self._consume_matched_regex(result)
+            return consumed.replace('\\,', ',')
         return ''
 
     def _explicit_list(self):
@@ -256,7 +257,8 @@ class ShorthandParser(object):
         elif self._current() == '"':
             return self._double_quoted_value()
         else:
-            return self._must_consume_regex(self._SECOND_VALUE)
+            consumed = self._must_consume_regex(self._SECOND_VALUE)
+            return consumed.replace('\\,', ',')
 
     def _expect(self, char, consume_whitespace=False):
         if consume_whitespace:

--- a/tests/functional/awslambda/test_function.py
+++ b/tests/functional/awslambda/test_function.py
@@ -96,7 +96,8 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline += ' --code S3Bucket=mybucket,S3Key=mykey,S3ObjectVersion=vs,'
         cmdline += 'ZipFile=foo'
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
-        self.assertIn('Unknown key \'ZipFile\'', stderr)
+        self.assertIn('ZipFile cannot be provided as part of the --code',
+                      stderr)
 
     def test_create_function_with_invalid_file_contents(self):
         cmdline = self.prefix

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -324,24 +324,9 @@ class TestParamShorthand(BaseArgProcessTest):
         p = self.get_param_model(
             'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration')
         value = 'ApplicationName:foo,TemplateName=bar'
-        error_msg = "Error parsing parameter '--source-configuration'.*should be"
+        error_msg = "Error parsing parameter '--source-configuration'.*Expected"
         with self.assertRaisesRegexp(ParamError, error_msg):
             self.simplify(p, value)
-
-    def test_mispelled_param_name(self):
-        p = self.get_param_model(
-            'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration')
-        # We're checking three things.
-        # 1) The CLI parameter is in the error message
-        # 2) The parameter name that failed validation is in the error message
-        # 3) The correct parameter name is in the error message.
-        error_msg = (
-            '--source-configuration.*'
-            'ApplicationNames.*valid choices.*'
-            'ApplicationName')
-        with self.assertRaisesRegexp(ParamError, error_msg):
-            # Typo in 'ApplicationName'
-            self.simplify(p, 'ApplicationNames=foo, TemplateName=bar')
 
     def test_improper_separator(self):
         # If the user uses ':' instead of '=', we should give a good
@@ -349,21 +334,15 @@ class TestParamShorthand(BaseArgProcessTest):
         p = self.get_param_model(
             'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration')
         value = 'ApplicationName:foo,TemplateName:bar'
-        error_msg = "Error parsing parameter '--source-configuration'.*should be"
+        error_msg = "Error parsing parameter '--source-configuration'.*Expected"
         with self.assertRaisesRegexp(ParamError, error_msg):
             self.simplify(p, value)
 
     def test_improper_separator_for_filters_param(self):
         p = self.get_param_model('ec2.DescribeInstances.Filters')
-        error_msg = "Error parsing parameter '--filters'.*should be"
+        error_msg = "Error parsing parameter '--filters'.*Expected"
         with self.assertRaisesRegexp(ParamError, error_msg):
             self.simplify(p, ["Name:tag:Name,Values:foo"])
-
-    def test_unknown_key_for_filters_param(self):
-        p = self.get_param_model('ec2.DescribeInstances.Filters')
-        with self.assertRaisesRegexp(ParamError,
-                                     '--filters.*Names.*valid choices.*Name'):
-            self.simplify(p, ["Names=instance-id,Values=foo,bar"])
 
     def test_csv_syntax_escaped(self):
         p = self.get_param_model('cloudformation.CreateStack.Parameters')
@@ -391,7 +370,7 @@ class TestParamShorthand(BaseArgProcessTest):
 
     def test_csv_syntax_errors(self):
         p = self.get_param_model('cloudformation.CreateStack.Parameters')
-        error_msg = "Error parsing parameter '--parameters'.*should be"
+        error_msg = "Error parsing parameter '--parameters'.*Expected"
         with self.assertRaisesRegexp(ParamError, error_msg):
             self.simplify(p, ['ParameterKey=key,ParameterValue="foo,bar'])
         with self.assertRaisesRegexp(ParamError, error_msg):

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -181,26 +181,6 @@ class TestModelVisitor(unittest.TestCase):
         b.visit(params, m)
         self.assertEqual(params, {'A': ['foo']})
 
-    def test_promote_list_of_scalars_to_single_struct(self):
-        m = model.DenormalizedStructureBuilder().with_members({
-            'A': {
-                'type': 'list',
-                'member': {
-                    'type': 'structure',
-                    'members': {
-                        'Single': {'type': 'string'}
-                    },
-                },
-            },
-        }).build_model()
-        b = shorthand.BackCompatVisitor()
-
-        params = {'A': ['a', 'b', 'c']}
-        b.visit(params, m)
-        self.assertEqual(params, {'A': [{'Single': 'a'},
-                                        {'Single': 'b'},
-                                        {'Single': 'c'},]})
-
     def test_dont_promote_list_if_none_value(self):
         m = model.DenormalizedStructureBuilder().with_members({
             'A': {

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -58,6 +58,7 @@ def test_parse():
            {'foo': ['a', 'b', 'c']})
     yield (_can_parse, 'foo  =  [ a , b  , c  ]',
            {'foo': ['a', 'b', 'c']})
+    yield (_can_parse, 'foo=[,,]', {'foo': ['', '']})
 
     # Single quoted strings.
     yield (_can_parse, "foo='bar'", {"foo": "bar"})
@@ -145,6 +146,7 @@ def test_error_parsing():
     yield (_is_error, "foo={bar")
     yield (_is_error, "foo={bar}")
     yield (_is_error, "foo={bar=bar")
+    yield (_is_error, "foo=bar,")
 
 
 def _is_error(expr):
@@ -152,6 +154,10 @@ def _is_error(expr):
         shorthand.ShorthandParser().parse(expr)
     except shorthand.ShorthandParseError:
         pass
+    except Exception as e:
+        raise AssertionError(
+            "Expected ShorthandParseError, but received unexpected "
+            "exception instead (%s): %s" % (e.__class__, e))
     else:
         raise AssertionError("Expected ShorthandParseError, but no "
                             "exception was raised for expression: %s" % expr)

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -84,6 +84,15 @@ def test_parse():
     yield (_can_parse, 'foo="bar\\"baz"', {'foo': 'bar"baz'})
     yield (_can_parse, 'foo="bar\\\\baz"', {'foo': 'bar\\baz'})
 
+    # Can escape comma in CSV list.
+    yield (_can_parse, 'foo=a\\,b', {"foo": "a,b"})
+    yield (_can_parse, 'foo=a\\,b', {"foo": "a,b"})
+    yield (_can_parse, 'foo=a\\,', {"foo": "a,"})
+    yield (_can_parse, 'foo=\\,', {"foo": ","})
+    yield (_can_parse, 'foo=a,b\\,c', {"foo": ['a', 'b,c']})
+    yield (_can_parse, 'foo=a,b\\,', {"foo": ['a', 'b,']})
+    yield (_can_parse, 'foo=a,\\,bc', {"foo": ['a', ',bc']})
+
     # Ignores whitespace around '=' and ','
     yield (_can_parse, 'foo= bar', {'foo': 'bar'})
     yield (_can_parse, 'foo =bar', {'foo': 'bar'})

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -213,7 +213,7 @@ class TestModelVisitor(unittest.TestCase):
         b.visit(params, m)
         self.assertEqual(
             params,
-            {'A': 24, 'B': '24', 'C': decimal.Decimal('24.12345'),
+            {'A': 24, 'B': '24', 'C': float('24.12345'),
              'D': True, 'E': False})
 
     def test_empty_values_not_added(self):

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -186,16 +186,47 @@ class TestModelVisitor(unittest.TestCase):
                                         {'Single': 'b'},
                                         {'Single': 'c'},]})
 
+    def test_dont_promote_list_if_none_value(self):
+        m = model.DenormalizedStructureBuilder().with_members({
+            'A': {
+                'type': 'list',
+                'member': {
+                    'type': 'structure',
+                    'members': {
+                        'Single': {'type': 'string'}
+                    },
+                },
+            },
+        }).build_model()
+        b = shorthand.BackCompatVisitor()
+        params = {}
+        b.visit(params, m)
+        self.assertEqual(params, {})
+
     def test_can_convert_scalar_types_from_string(self):
         m = model.DenormalizedStructureBuilder().with_members({
             'A': {'type': 'integer'},
             'B': {'type': 'string'},
             'C': {'type': 'float'},
+            'D': {'type': 'boolean'},
+            'E': {'type': 'boolean'},
         }).build_model()
         b = shorthand.BackCompatVisitor()
 
-        params = {'A': '24', 'B': '24', 'C': '24.12345'}
+        params = {'A': '24', 'B': '24', 'C': '24.12345',
+                  'D': 'true', 'E': 'false'}
         b.visit(params, m)
         self.assertEqual(
             params,
-            {'A': 24, 'B': '24', 'C': decimal.Decimal('24.12345')})
+            {'A': 24, 'B': '24', 'C': decimal.Decimal('24.12345'),
+             'D': True, 'E': False})
+
+    def test_empty_values_not_added(self):
+        m = model.DenormalizedStructureBuilder().with_members({
+            'A': {'type': 'boolean'},
+        }).build_model()
+        b = shorthand.BackCompatVisitor()
+
+        params = {}
+        b.visit(params, m)
+        self.assertEqual(params, {})


### PR DESCRIPTION
This PR builds on https://github.com/aws/aws-cli/pull/1444 and plumbs the parser into the argprocess module.

This PR also includes a backwards compatibility layer that walks the parsed values from the new parser and makes modifications so that the parser produces the same output as the old parser.

All the tests are passing.  The one test customization I had to change was the lambda customization because it assumed that the shorthand parser would throw an error if you gave it a key that wasn't in the model.  Now the customization has to handle that logic itself.

And finally, I had to update the new shorthand parser to handle escaped commas in a CSV list, which the old parser supported, so you'll see some small modifications to the parser.

The only thing remaining is the documentation.  For now I've left the existing doc class as is, so it will generate the same docs as before, but it won't generate docs for the nested map syntax.  That will have to be a future addition.

cc @kyleknap @mtdowling @rayluo 