### PR TITLE
Add count to output options

### DIFF
--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -27,7 +27,7 @@
                 "table",
                 "count"
             ],
-	        "help": "<p>The formatting style for command output. Note that \"count\" requires the use of \"--query\"</p>"
+	        "help": "<p>The formatting style for command output.</p>"
         },
         "query": {
             "help": "<p>A JMESPath query to use in filtering the response data.</p>"

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -24,9 +24,10 @@
             "choices": [
                 "json",
                 "text",
-                "table"
+                "table",
+                "count"
             ],
-	        "help": "<p>The formatting style for command output.</p>"
+	        "help": "<p>The formatting style for command output. Note that \"count\" requires the use of \"--query\"</p>"
         },
         "query": {
             "help": "<p>A JMESPath query to use in filtering the response data.</p>"

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -20,7 +20,7 @@ from botocore.paginate import PageIterator
 from awscli.table import MultiTable, Styler, ColorizedStyler
 from awscli import text
 from awscli import compat
-from awscli.utils import json_encoder
+from awscli.utils import json_encoder, six
 
 
 LOG = logging.getLogger(__name__)
@@ -94,6 +94,24 @@ class JSONFormatter(FullyBufferedFormatter):
         if response:
             json.dump(response, stream, indent=4, default=json_encoder,
                       ensure_ascii=False)
+            stream.write('\n')
+
+
+class CountFormatter(FullyBufferedFormatter):
+
+    def _format_response(self, command_name, response, stream):
+        if response:
+            if type(response) is list:
+                length = len(response)
+                stream.write(str(length))
+                stream.write('\n')
+            elif type(response) is dict:
+                response_keys = six.next(six.iterkeys(response))
+                length = len(response[response_keys])
+                stream.write(str(length))
+                stream.write('\n')
+        else:
+            stream.write('0')
             stream.write('\n')
 
 
@@ -269,4 +287,6 @@ def get_formatter(format_type, args):
         return TextFormatter(args)
     elif format_type == 'table':
         return TableFormatter(args)
+    elif format_type == 'count':
+        return CountFormatter(args)
     raise ValueError("Unknown output type: %s" % format_type)

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -80,6 +80,7 @@ The valid values of the ``output`` configuration variable are:
 * json
 * table
 * text
+* count
 
 When you specify a profile, either using ``--profile profile-name`` or by
 setting a value for the ``AWS_DEFAULT_PROFILE`` environment variable, profile

--- a/tests/unit/output/test_count_output.py
+++ b/tests/unit/output/test_count_output.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+class TestGetPasswordData(BaseAWSCommandParamsTest):
+
+    prefix = 'iam add-user-to-group '
+
+    def test_empty_response_prints_zero(self):
+        self.parsed_response = {}
+        args = ' --group-name foo --user-name bar --output count'
+        cmdline = self.prefix + args
+        result = {'GroupName': 'foo', 'UserName': 'bar'}
+        stdout = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
+        self.assertEqual(stdout, '0\n')
+
+
+class TestListUsers(BaseAWSCommandParamsTest):
+
+    def setUp(self):
+        super(TestListUsers, self).setUp()
+        self.parsed_response = {
+            'Users': [
+                {
+                    "UserName": "testuser-50",
+                    "Path": "/",
+                    "CreateDate": "2013-02-12T19:08:52Z",
+                    "UserId": "EXAMPLEUSERID",
+                    "Arn": "arn:aws:iam::12345:user/testuser1"
+                },
+                {
+                    "UserName": "testuser-51",
+                    "Path": "/",
+                    "CreateDate": "2012-10-14T23:53:39Z",
+                    "UserId": u"EXAMPLEUSERID",
+                    "Arn": "arn:aws:iam::123456:user/testuser2"
+                },
+                ]
+        }
+
+    def test_count_no_query_response(self):
+        output = self.run_cmd('iam list-users --output count',
+                              expected_rc=0)[0]
+        self.assertEquals(output, '2\n')
+
+    def test_jmespath_count_response(self):
+        jmespath_query = 'Users[*].UserName'
+        output = self.run_cmd('iam list-users --query %s --output count' % jmespath_query,
+                              expected_rc=0)[0]
+        self.assertEquals(output, '2\n')
+
+    def test_unknown_output_type_from_env_var(self):
+        self.environ['AWS_DEFAULT_OUTPUT'] = 'bad-output-type'
+        self.run_cmd('iam list-users', expected_rc=255)


### PR DESCRIPTION
This feature allows users to get a count for the number of elements in the output. This eliminates the need to pipe to wc (or other word count tool) by directly counting the number of values in the output.

This was motivated by the need to write a tool for alerting purposes, where I needed to count the number of machines using describe-instances. 