### PR TITLE
Switch shorthand doc gen over to new approach.

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -368,18 +368,8 @@ class ParamShorthand(object):
 class ParamShorthandDocGen(object):
     """Documentation generator for param shorthand syntax."""
 
-    SHORTHAND_SHAPES = {
-        'structure(scalars)': '_key_value_parse',
-        'structure(scalar)': '_special_key_value_parse',
-        'structure(list-scalar, scalar)': '_struct_scalar_list_parse',
-        'map-scalar': '_key_value_parse',
-        'list-structure(scalar)': '_list_scalar_parse',
-        'list-structure(scalars)': '_list_key_value_parse',
-        'list-structure(list-scalar, scalar)': '_list_scalar_list_parse',
-    }
     _DONT_DOC = object()
     _MAX_STACK = 3
-
 
     def supports_shorthand(self, argument_model):
         """Checks if a CLI argument supports shorthand syntax."""

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -454,7 +454,7 @@ class ParamShorthandDocGen(object):
             stack.pop()
         if not stack:
             # Top of the stack means we're a top level shorthand param.
-            return '%s ...' % (element_docs,)# element_docs)
+            return '%s ...' % element_docs
         elif list_member.type_name in COMPLEX_TYPES or len(stack) > 1:
             return '[%s,%s]' % (element_docs, element_docs)
         else:

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -442,10 +442,7 @@ class ParamShorthandDocGen(object):
             element_docs = self._shorthand_docs(argument_model.member, stack)
         finally:
             stack.pop()
-        if not stack:
-            # Top of the stack means we're a top level shorthand param.
-            return '%s ...' % element_docs
-        elif list_member.type_name in COMPLEX_TYPES or len(stack) > 1:
+        if list_member.type_name in COMPLEX_TYPES or len(stack) > 1:
             return '[%s,%s]' % (element_docs, element_docs)
         else:
             return '%s,%s' % (element_docs, element_docs)

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -412,24 +412,22 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
                 return
         argument_model = cli_argument.argument_model
         docgen = ParamShorthandDocGen()
-        if docgen.supports_shorthand(cli_argument):
-            # TODO: bcdoc should not know about shorthand syntax. This
-            # should be pulled out into a separate handler in the
-            # awscli.customizations package.
+        if docgen.supports_shorthand(cli_argument.argument_model):
             example_shorthand_syntax = docgen.generate_shorthand_example(
-                cli_argument)
+                cli_argument.cli_name, cli_argument.argument_model)
             if example_shorthand_syntax is None:
                 # If the shorthand syntax returns a value of None,
                 # this indicates to us that there is no example
                 # needed for this param so we can immediately
                 # return.
                 return
-            doc.style.new_paragraph()
-            doc.write('Shorthand Syntax')
-            doc.style.start_codeblock()
-            for example_line in example_shorthand_syntax.splitlines():
-                doc.writeln(example_line)
-            doc.style.end_codeblock()
+            if example_shorthand_syntax:
+                doc.style.new_paragraph()
+                doc.write('Shorthand Syntax')
+                doc.style.start_codeblock()
+                for example_line in example_shorthand_syntax.splitlines():
+                    doc.writeln(example_line)
+                doc.style.end_codeblock()
         if argument_model is not None and argument_model.type_name == 'list' and \
                 argument_model.member.type_name in SCALAR_TYPES:
             # A list of scalars is special.  While you *can* use

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -137,7 +137,7 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
         self.driver.main(['ec2', 'run-instances', 'help'])
         self.assert_contains('``--iam-instance-profile``')
         self.assert_contains('Shorthand Syntax')
-        self.assert_contains('--iam-instance-profile Arn=value,Name=value')
+        self.assert_contains('Arn=string,Name=string')
 
     def test_required_args_come_before_optional_args(self):
         self.driver.main(['ec2', 'run-instances', 'help'])
@@ -298,7 +298,7 @@ class TestStructureScalarHasNoExamples(BaseAWSHelpOutputTest):
         # (single element named "Value"), then we still document
         # the example syntax.
         self.driver.main(['s3api', 'restore-object', 'help'])
-        self.assert_contains('Days=value')
+        self.assert_contains('Days=integer')
         # Also should see the JSON syntax in the help output.
         self.assert_contains('"Days": integer')
 

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -531,9 +531,12 @@ class TestDocGen(BaseArgProcessTest):
             }
         }
         argument_model = create_argument_model_from_schema(schema)
-        cli_argument = CustomArgument('test', argument_model=argument_model)
-
-        generated_example = self.get_generated_example_for(cli_argument)
+        m = model.DenormalizedStructureBuilder().with_members(OrderedDict([
+            ('Consistent', {'type': 'boolean'}),
+            ('Args', { 'type': 'list', 'member': { 'type': 'string', }}),
+        ])).build_model()
+        generated_example = self.shorthand_documenter.generate_shorthand_example(
+            '--foo', m)
         self.assertIn('Consistent=boolean,Args=string,string',
                       generated_example)
 

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -15,6 +15,7 @@ import json
 import mock
 from botocore import xform_name
 from botocore import model
+from botocore.compat import OrderedDict
 
 from awscli.testutils import unittest
 from awscli.testutils import BaseCLIDriverTest
@@ -577,20 +578,20 @@ class TestDocGen(BaseArgProcessTest):
         # recursion.
         struct_shape = {
             'type': 'structure',
-            'members': {
-                'Recurse': {'shape': 'SubShape'},
-                'Scalar': {'shape': 'String'},
-            }
+            'members': OrderedDict([
+                ('Recurse', {'shape': 'SubShape'}),
+                ('Scalar', {'shape': 'String'}),
+            ]),
         }
         shapes = {
             'Top': struct_shape,
             'String': {'type': 'string'},
             'SubShape': {
                 'type': 'structure',
-                'members': {
-                    'SubRecurse': {'shape': 'Top'},
-                    'Scalar': {'shape': 'String'},
-                },
+                'members': OrderedDict([
+                    ('SubRecurse', {'shape': 'Top'}),
+                    ('Scalar', {'shape': 'String'}),
+                ]),
             }
         }
         m = model.StructureShape(
@@ -600,8 +601,8 @@ class TestDocGen(BaseArgProcessTest):
         generated_example = self.shorthand_documenter.generate_shorthand_example(
             '--foo', m)
         self.assertIn(
-            'Scalar=string,Recurse='
-            '{Scalar=string,SubRecurse={Scalar=string,( ... recursive ... )}}',
+            'Recurse={SubRecurse={( ... recursive ... ),Scalar=string},'
+            'Scalar=string},Scalar=string',
             generated_example)
 
     def test_skip_deeply_nested_shorthand(self):

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -575,6 +575,40 @@ class TestDocGen(BaseArgProcessTest):
             '--foo', m)
         self.assertIn('A={KeyName1=string,KeyName2=string}', generated_example)
 
+    def test_list_of_structures_with_triple_dots(self):
+        list_shape = {
+            'type': 'list',
+            'member': {'shape': 'StructShape'},
+        }
+        shapes = {
+            'Top': list_shape,
+            'String': {'type': 'string'},
+            'StructShape': {
+                'type': 'structure',
+                'members': OrderedDict([
+                    ('A', {'shape': 'String'}),
+                    ('B', {'shape': 'String'}),
+                ])
+            }
+        }
+        m = model.ListShape(
+            shape_name='Top',
+            shape_model=list_shape,
+            shape_resolver=model.ShapeResolver(shapes))
+        generated_example = self.shorthand_documenter.generate_shorthand_example(
+            '--foo', m)
+        self.assertIn('A=string,B=string ...', generated_example)
+
+    def test_handle_special_case_value_struct_not_documented(self):
+        m = model.DenormalizedStructureBuilder().with_members({
+            'Value': {'type': 'string'}
+        }).build_model()
+        generated_example = self.shorthand_documenter.generate_shorthand_example(
+            '--foo', m)
+        # This is one of the special cases, we shouldn't generate any
+        # shorthand example for this shape.
+        self.assertIsNone(generated_example)
+
     def test_can_document_recursive_struct(self):
         # It's a little more work to set up a recursive
         # shape because DenormalizedStructureBuilder cannot handle


### PR DESCRIPTION
This PR updates the shorthand documenter to work with the latest changes to the shorthand code (https://github.com/aws/aws-cli/pull/1461).  Specifically:

* It does not use a hardcoded list of "shapes" like the previous approach did.
* It documents the newly supported syntax (nested dictionaries)

It also changes some small things in the way docs are generated:

* The `--argname` is removed in the shorthand example.  This is to make the shorthand syntax consistent with the JSON example syntax.
* The type names are added instead of generic `values`.  Before we'd have `Key=value,Foo=value`.   Now we'll have `Key=string,Foo=float`.
* The single sentence description has been removed.  It's not possible to automatically generate these.

And finally, there's a few areas of improvement I think we'll need to make in the future:

* Right now, shorthand examples are only generated for code of a stack depth of 3 or less.  This is because sufficiently complicated structures are not readable in shorthand syntax.  We'd need to come up with a way to break these across multiple lines.
* Recursive shapes are documented as `(... recursive ...)`, which is how JSON params are documented.  This might be an area for improvement.

cc @kyleknap @mtdowling @rayluo 