### PR TITLE
Fix a bug when creating emr role with AWS_CA_BUNDLE

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* bugfix:``aws emr create-default-roles``: Fix the issue where the command
+  would fail to honor an existing AWS_CA_BUNDLE environment setting and end up
+  with "SSLError: object has no attribute"
+  (`issue 1468 <https://github.com/aws/aws-cli/pull/1468>`__)
+
+
 1.7.47
 ======
 

--- a/awscli/customizations/emr/createdefaultroles.py
+++ b/awscli/customizations/emr/createdefaultroles.py
@@ -298,6 +298,6 @@ class CreateDefaultRoles(Command):
 
     def _call_iam_operation(self, operation_name, parameters, parsed_globals):
         client = self._session.create_client(
-            'iam', self.region, self.iam_endpoint_url,
-            parsed_globals.verify_ssl)
+            'iam', region_name=self.region, endpoint_url=self.iam_endpoint_url,
+            verify=parsed_globals.verify_ssl)
         return getattr(client, xform_name(operation_name))(**parameters)

--- a/tests/unit/customizations/emr/test_create_default_role.py
+++ b/tests/unit/customizations/emr/test_create_default_role.py
@@ -233,22 +233,23 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
     def test_call_parameters(self, call_patch):
         cmdline = self.prefix + ' --region eu-west-1' + ' --no-verify-ssl'
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(call_patch.call_args[0][1], 'eu-west-1')
-        self.assertEquals(call_patch.call_args[0][3], False)
+        self.assertEquals(call_patch.call_args[1]['region_name'], 'eu-west-1')
+        self.assertEquals(call_patch.call_args[1]['verify'], False)
 
     @mock.patch('botocore.session.Session.create_client')
     def test_call_parameters_only_endpoint(self, call_patch):
         endpoint_arg = 'https://elasticmapreduce.us-unknown-1.amazonaws.com'
         cmdline = self.prefix + ' --endpoint ' + endpoint_arg
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(call_patch.call_args[0][2], None)
+        self.assertEquals(call_patch.call_args[1]['endpoint_url'], None)
 
     @mock.patch('botocore.session.Session.create_client')
     def test_call_parameters_only_iam_endpoint(self, call_patch):
         endpoint_arg = 'https://elasticmapreduce.us-unknown-1.amazonaws.com'
         cmdline = self.prefix + ' --iam-endpoint ' + endpoint_arg
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(call_patch.call_args[0][2], endpoint_arg)
+        self.assertEquals(call_patch.call_args[1]['endpoint_url'],
+                          endpoint_arg)
 
     @mock.patch('awscli.customizations.emr.emr.'
                 'CreateDefaultRoles._get_role_policy')


### PR DESCRIPTION
It is reported that there is a bug causing failure to create emr role,
when customer has an AWS_CA_BUNDLE setting in the environment.

When the bug occurs, running::

    aws emr create-default-roles

fails with "SSLError" object has no attribute.

This commit should be able to fix that, and also fix the incorrect test cases.