### PR TITLE
Fix shorthand parser regressions in 1.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,17 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+
+* bugfix:Shorthand Parser: Fix regression where '-' character was not accepted
+  as a key name in a shorthand value
+  (`issue 1470 <https://github.com/aws/aws-cli/issues/1470>`__)
+* bugfix:Shorthand Parser: Fix regression where spaces in unquoted values
+  were not being accepted
+  (`issue 1471 <https://github.com/aws/aws-cli/issues/1471>`__)
+
+
 1.8.0
 =====
 

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -94,14 +94,26 @@ class ShorthandParser(object):
 
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
+    _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
+    _FIRST_FOLLOW_CHARS = u'\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
+    _SECOND_FOLLOW_CHARS = u'\!\#-&\(-\+\--\<\>-\uffff'
+    _ESCAPED_COMMA = '(\\\\,)'
     _FIRST_VALUE = _NamedRegex(
         'first',
-        u'((\\\\,)|[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff])'
-        u'((\\\\,)|[\!\#-&\(-\+\--\\\\\^-\|~-\uffff])*')
+        u'({escaped_comma}|[{start_word}])'
+        u'({escaped_comma}|[{follow_chars}])*'.format(
+            escaped_comma=_ESCAPED_COMMA,
+            start_word=_START_WORD,
+            follow_chars=_FIRST_FOLLOW_CHARS,
+        ))
     _SECOND_VALUE = _NamedRegex(
         'second',
-        u'((\\\\,)|[\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff])'
-        u'((\\\\,)|[\!\#-&\(-\+\--\<\>-\uffff])*')
+        u'({escaped_comma}|[{start_word}])'
+        u'({escaped_comma}|[{follow_chars}])*'.format(
+            escaped_comma=_ESCAPED_COMMA,
+            start_word=_START_WORD,
+            follow_chars=_SECOND_FOLLOW_CHARS,
+        ))
 
     def __init__(self):
         self._tokens = []

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -95,8 +95,8 @@ class ShorthandParser(object):
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
     _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
-    _FIRST_FOLLOW_CHARS = u'\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
-    _SECOND_FOLLOW_CHARS = u'\!\#-&\(-\+\--\<\>-\uffff'
+    _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
+    _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
     _ESCAPED_COMMA = '(\\\\,)'
     _FIRST_VALUE = _NamedRegex(
         'first',
@@ -225,7 +225,7 @@ class ShorthandParser(object):
         result = self._FIRST_VALUE.match(self._input_value[self._index:])
         if result is not None:
             consumed = self._consume_matched_regex(result)
-            return consumed.replace('\\,', ',')
+            return consumed.replace('\\,', ',').rstrip()
         return ''
 
     def _explicit_list(self):
@@ -297,7 +297,7 @@ class ShorthandParser(object):
             return self._double_quoted_value()
         else:
             consumed = self._must_consume_regex(self._SECOND_VALUE)
-            return consumed.replace('\\,', ',')
+            return consumed.replace('\\,', ',').rstrip()
 
     def _expect(self, char, consume_whitespace=False):
         if consume_whitespace:

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -153,8 +153,8 @@ class ShorthandParser(object):
         return {key: values}
 
     def _key(self):
-        # key = 1*(alpha / %x30-39)  ; [a-zA-Z0-9]
-        valid_chars = string.ascii_letters + string.digits
+        # key = 1*(alpha / %x30-39)  ; [a-zA-Z0-9\-]
+        valid_chars = string.ascii_letters + string.digits + '-'
         start = self._index
         while not self._at_eof():
             if self._current() not in valid_chars:

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -39,6 +39,15 @@ def test_parse():
                                            'bar': ['c', 'd']})
     yield (_can_parse, 'foo=a,b,c,bar=d,e,f',
            {'foo': ['a', 'b', 'c'], 'bar': ['d', 'e', 'f']})
+    # Spaces in values are allowed.
+    yield (_can_parse, 'foo=a,b=with space', {'foo': 'a', 'b': 'with space'})
+    # Trailing spaces are still ignored.
+    yield (_can_parse, 'foo=a,b=with trailing space  ',
+           {'foo': 'a', 'b': 'with trailing space'})
+    yield (_can_parse, 'foo=first space',
+           {'foo': 'first space'})
+    yield (_can_parse, 'foo=a space,bar=a space,baz=a space',
+           {'foo': 'a space', 'bar': 'a space', 'baz': 'a space'})
 
     # Explicit lists.
     yield (_can_parse, 'foo=[]', {'foo': []})

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -49,6 +49,9 @@ def test_parse():
     yield (_can_parse, 'foo=a space,bar=a space,baz=a space',
            {'foo': 'a space', 'bar': 'a space', 'baz': 'a space'})
 
+    # Dashes are allowed in key names.
+    yield (_can_parse, 'with-dash=bar', {'with-dash': 'bar'})
+
     # Explicit lists.
     yield (_can_parse, 'foo=[]', {'foo': []})
     yield (_can_parse, 'foo=[a]', {'foo': ['a']})

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import decimal
-
 from awscli import shorthand
 from awscli.testutils import unittest
 


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/1471  (unquoted values with spaces should be allowed).
Fixes https://github.com/aws/aws-cli/issues/1470 (dash in key name should be allowed).

Added unit tests for these so we don't regress in the future.


cc @kyleknap @mtdowling @rayluo 