### PR TITLE
Fix the example validate-template command

### DIFF
--- a/awscli/examples/cloudformation/validate-template.rst
+++ b/awscli/examples/cloudformation/validate-template.rst
@@ -1,8 +1,8 @@
 **To validate an AWS CloudFormation template**
 
-The following ``validate-template`` command validates the ``sampletemplate.json`` template::
+The following ``validate-template`` command validates the ``sampletemplate.json`` template in the Amazon S3 bucket named ``sample``::
 
-  aws cloudformation validate-template --template-body file:////home//local//test//sampletemplate.json
+  aws cloudformation validate-template --template-url https://s3.amazonaws.com/sample/sample.template
 
 Output::
 


### PR DESCRIPTION
- The original example referenced a local file URL, which is not
  supported by the validate-template command. Switched to use an
  S3 URL.

Fixes aws/aws-cli#1489.