### PR TITLE
Don't print response only if an empty dict/list/str

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -23,6 +23,7 @@ advance_iterator = six.advance_iterator
 PY3 = six.PY3
 queue = six.moves.queue
 shlex_quote = six.moves.shlex_quote
+string_types = six.string_types
 StringIO = six.StringIO
 urlopen = six.moves.urllib.request.urlopen
 

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -23,7 +23,6 @@ advance_iterator = six.advance_iterator
 PY3 = six.PY3
 queue = six.moves.queue
 shlex_quote = six.moves.shlex_quote
-string_types = six.string_types
 StringIO = six.StringIO
 urlopen = six.moves.urllib.request.urlopen
 

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -92,11 +92,10 @@ class JSONFormatter(FullyBufferedFormatter):
         # the response will be an empty string.  We don't want to print
         # that out to the user but other "falsey" values like an empty
         # dictionary should be printed.
-        if isinstance(response, (dict, list) + string_types) and not response:
-            return
-        json.dump(response, stream, indent=4, default=json_encoder,
-                  ensure_ascii=False)
-        stream.write('\n')
+        if response != {}:
+            json.dump(response, stream, indent=4, default=json_encoder,
+                    ensure_ascii=False)
+            stream.write('\n')
 
 
 class TableFormatter(FullyBufferedFormatter):

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
-import sys
 from botocore.compat import json
 
 from botocore.utils import set_value_from_jmespath
@@ -20,7 +19,6 @@ from botocore.paginate import PageIterator
 from awscli.table import MultiTable, Styler, ColorizedStyler
 from awscli import text
 from awscli import compat
-from awscli.compat import string_types
 from awscli.utils import json_encoder
 
 

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -20,6 +20,7 @@ from botocore.paginate import PageIterator
 from awscli.table import MultiTable, Styler, ColorizedStyler
 from awscli import text
 from awscli import compat
+from awscli.compat import string_types
 from awscli.utils import json_encoder
 
 
@@ -91,10 +92,11 @@ class JSONFormatter(FullyBufferedFormatter):
         # the response will be an empty string.  We don't want to print
         # that out to the user but other "falsey" values like an empty
         # dictionary should be printed.
-        if response:
-            json.dump(response, stream, indent=4, default=json_encoder,
-                      ensure_ascii=False)
-            stream.write('\n')
+        if isinstance(response, (dict, list) + string_types) and not response:
+            return
+        json.dump(response, stream, indent=4, default=json_encoder,
+                  ensure_ascii=False)
+        stream.write('\n')
 
 
 class TableFormatter(FullyBufferedFormatter):

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -36,15 +36,15 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         stdout = self.run_cmd(self.COMMAND, expected_rc=0)[0]
         self.assertEqual(stdout, '')
 
-    def test_empty_list_prints_nothing(self):
+    def test_empty_list_prints_list(self):
         self.parsed_response = []
         stdout = self.run_cmd(self.COMMAND, expected_rc=0)[0]
-        self.assertEqual(stdout, '')
+        self.assertEqual(stdout, '[]\n')
 
     def test_empty_string_prints_nothing(self):
         self.parsed_response = ''
         stdout = self.run_cmd(self.COMMAND, expected_rc=0)[0]
-        self.assertEqual(stdout, '')
+        self.assertEqual(stdout, '""\n')
 
 
 class TestListUsers(BaseAWSCommandParamsTest):


### PR DESCRIPTION
The integer 0 should be printed as a result.  This can happen
from a JMESPath expression, e.g `length(something)`.

For example, currently:

```
$ aws ec2 describe-security-groups --query 'length(`[0,1]`)'
2
$ aws ec2 describe-security-groups --query 'length(`[0]`)'
1
$ aws ec2 describe-security-groups --query 'length(`[]`)'
<prints nothing>
$
```

Now you'll get:

```
$ aws ec2 describe-security-groups --query 'length(`[]`)'
0
```

cc @kyleknap @mtdowling @rayluo 