### PR TITLE
Add STANDARD_IA as a valid enum choice to s3 commands

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -163,10 +163,11 @@ SSE = {'name': 'sse', 'action': 'store_true',
 
 
 STORAGE_CLASS = {'name': 'storage-class', 'nargs': 1,
-                 'choices': ['STANDARD', 'REDUCED_REDUNDANCY'],
+                 'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA'],
                  'help_text': (
                      "The type of storage to use for the object. "
-                     "Valid choices are: STANDARD | REDUCED_REDUNDANCY. "
+                     "Valid choices are: STANDARD | REDUCED_REDUNDANCY "
+                     "| STANDARD_IA. "
                      "Defaults to 'STANDARD'")}
 
 

--- a/tests/unit/customizations/s3/test_copy_params.py
+++ b/tests/unit/customizations/s3/test_copy_params.py
@@ -71,6 +71,15 @@ class TestGetObject(BaseAWSCommandParamsTest):
                   'StorageClass': u'REDUCED_REDUNDANCY'}
         self.assert_params(cmdline, result)
 
+    def test_standard_ia_storage_class(self):
+        cmdline = self.prefix
+        cmdline += self.file_path
+        cmdline += ' s3://mybucket/mykey'
+        cmdline += ' --storage-class STANDARD_IA'
+        result = {'Bucket': u'mybucket', 'Key': u'mykey',
+                  'StorageClass': u'STANDARD_IA'}
+        self.assert_params(cmdline, result)
+
     def test_website_redirect(self):
         cmdline = self.prefix
         cmdline += self.file_path


### PR DESCRIPTION
This is supported in the s3api commands, but we need to
add the valid value up to the s3 commands.

cc @kyleknap @mtdowling @rayluo 