### PR TITLE
Bump RSA package to support 3.2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import awscli
 requires = ['botocore==1.2.4',
             'colorama>=0.2.5,<=0.3.3',
             'docutils>=0.10',
-            'rsa>=3.1.2,<=3.1.4']
+            'rsa>=3.1.2,<=3.3.0']
 
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
The diff didn't have any functional changes.
Given that, I think it makes sense to keep the
min version unchanged for now to give downstream
consumers time to upgrade.  We should eventually
just lock to 3.2.x only.

cc @kyleknap @mtdowling @rayluo 