### PR TITLE
Catch more specific exceptions in assume role provider

### DIFF
--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -11,6 +11,7 @@ from dateutil.tz import tzlocal
 from botocore import credentials
 from botocore.compat import total_seconds
 from botocore.exceptions import PartialCredentialsError
+from botocore.exceptions import UnknownCredentialError
 
 
 LOG = logging.getLogger(__name__)
@@ -40,11 +41,12 @@ def inject_assume_role_provider(session, **kwargs):
         # * ...
         cred_chain = session.get_component('credential_provider')
         cred_chain.insert_before('shared-credentials-file', provider)
-    except Exception:
+    except (ValueError, UnknownCredentialError):
+        # Only catch UnknownCredentialError and ValueError
         # This is ok, it just means that we couldn't create the credential
         # provider object.
         LOG.debug("Not registering assume-role provider, credential "
-                  "provider from session could not be created.")
+                  "provider from session could not be created.", exc_info=True)
 
 
 def create_assume_role_provider(session, provider_cls):

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -49,7 +49,9 @@ class TestAssumeRolePlugin(unittest.TestCase):
 
     def test_provider_not_registered_on_error(self):
         session = mock.Mock()
-        session.get_component.side_effect = Exception(
+        # This is the exception raised when we can't retrieve the component
+        # from the ComponentLocator.
+        session.get_component.side_effect = ValueError(
             "Couldn't get credential_provider.")
         assumerole.inject_assume_role_provider(
             session, event_name='building-command-table.foo')


### PR DESCRIPTION
To repro, call an aws command with an explicit ``--region`` and
a non-existent profile:

  aws ec2 describe-instances --region us-east-1 --profile does-not-exist

The issue was that the assume role provider was catching too general
of an exception so the profile does not exist error was not being
propogated.

There's also a bug in botocore with how we're handling failures
for lazily registered components.  This is why we're seeing the
"Unknown component" bug.  This will require a separate PR
to botocore.


Before:

```
$ aws ec2 describe-instances --profile does-not-exist --region us-east-1

Unknown component: credential_provider
```

After:

```
$ aws ec2 describe-instances --profile does-not-exist --region us-east-1

The config profile (does-not-exist) could not be found
```

cc @kyleknap @mtdowling @rayluo 