### PR TITLE
Fix syncing across regions

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -298,7 +298,7 @@ class FileInfo(TaskInfo):
         Deletes the file from s3 or local.  The src file and type is used
         from the file info object.
         """
-        if (self.src_type == 's3'):
+        if self.src_type == 's3':
             bucket, key = find_bucket_key(self.src)
             params = {'Bucket': bucket, 'Key': key}
             self.source_client.delete_object(**params)

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -34,6 +34,21 @@ class TestFileInfoBuilder(unittest.TestCase):
             for key in attributes:
                 self.assertEqual(getattr(file_info, key), str(key))
 
+    def test_swaps_clients_for_sync_delete(self):
+        client_name = 'client'
+        source_client_name = 'source_client'
+        info_setter = FileInfoBuilder(client=client_name,
+                                      source_client=source_client_name,
+                                      parameters={'delete': True},
+                                      is_stream='is_stream')
+        files = [FileStat(src='src', dest='dest', compare_key='compare_key',
+                          size='size', last_update='last_update',
+                          src_type='src_type', dest_type='dest_type',
+                          operation_name='delete')]
+        file_infos = info_setter.call(files)
+        for file_info in file_infos:
+            self.assertEquals(file_info.client, source_client_name)
+            self.assertEquals(file_info.source_client, client_name)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Performing a sync operation between buckets in different regions while under sig4 was raising errors when the delete flag was added in. A client associated with the origin bucket's region was being used to make the delete request rather than a client associated with the destination bucket's region. This simply switched the two and adds in some tests to verify.