### PR TITLE
Fixed include / exclude filters in bucket to bucket sync

### DIFF
--- a/awscli/customizations/s3/filters.py
+++ b/awscli/customizations/s3/filters.py
@@ -36,12 +36,16 @@ def create_filter(parameters):
             # the bucket to be the root dir.
             src_rootdir = _get_s3_root(source_location,
                                        parameters['dir_op'])
-            dst_rootdir = _get_local_root(parameters['dest'],
-                                          parameters['dir_op'])
         else:
             src_rootdir = _get_local_root(parameters['src'], parameters['dir_op'])
+
+        destination_location = parameters['dest']
+        if destination_location.startswith('s3://'):
             dst_rootdir = _get_s3_root(parameters['dest'],
                                        parameters['dir_op'])
+        else:
+            dst_rootdir = _get_local_root(parameters['dest'],
+                                          parameters['dir_op'])
 
         return Filter(real_filters, src_rootdir, dst_rootdir)
     else:

--- a/tests/unit/customizations/s3/test_filters.py
+++ b/tests/unit/customizations/s3/test_filters.py
@@ -202,6 +202,26 @@ class FiltersTest(unittest.TestCase):
         filtered = list(s3_filter.call(s3_files))
         self.assertEqual(len(filtered), 0)
 
+    def test_create_filter_s3_to_s3(self):
+        source = 'bucket/'
+        destination = 'bucket-2/'
+        pattern = '*'
+        parameters = {'filters': [['--exclude', pattern],
+                                  ['--include', '*.jpg']],
+                      'dir_op': True,
+                      'src': 's3://' + source,
+                      'dest': 's3://' + destination}
+        s3_filter = self.create_filter(parameters=parameters)
+
+        source_pattern = s3_filter.patterns[0][1]
+        destination_pattern = s3_filter.dst_patterns[0][1]
+        self.assertEquals(source_pattern, source + pattern)
+        self.assertEquals(destination_pattern, destination + pattern)
+
+        filtered = list(s3_filter.call(self.s3_files))
+        self.assertEquals(len(filtered), 2)
+        for filtered_file in filtered:
+            self.assertFalse('.txt' in filtered_file.src)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
closes #1481 

The logic for setting the root directory for filters only supported s3-local and local-s3 syncs, not s3-s3, causing the filters to fail when applied to the destination bucket in s3-s3 since it was assumed the destination was  a local directory.