### PR TITLE
Update doc building documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,5 @@ src/
 # CLI docs generation
 doc/source/aws_man_pages.json
 doc/source/reference
+doc/source/topic
 doc/source/tutorial/services.rst

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -2,9 +2,10 @@
 Building The Documentation
 ==========================
 
-Before building the documentation, make sure you have all the
-necessary dependencies installed.  You can do this by using
-the requirements.txt file at the root of this repo::
+Before building the documentation, make sure you have Python 2.7,
+the awscli, and all the necessary dependencies installed.  You can
+install dependencies by using the requirements.txt file at the
+root of this repo::
 
     pip install -r requirements.txt
 

--- a/doc/source/guzzle_sphinx_theme/__init__.py
+++ b/doc/source/guzzle_sphinx_theme/__init__.py
@@ -34,7 +34,7 @@ def create_sitemap(app, exception):
         return
 
     filename = app.outdir + "/sitemap.xml"
-    print "Generating sitemap.xml in %s" % filename
+    print("Generating sitemap.xml in %s" % filename)
 
     root = ET.Element("urlset")
     root.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")


### PR DESCRIPTION
Building the docs seems to require Python 2.7 and the awscli to be installed. I've added those to the README as requirements. I used this docker command to test the build in an isolated environment:

```
docker run -v $(pwd):/src python:2.7.10 /bin/bash -c \
  "cd /src && pip install -r requirements.txt && pip install awscli && cd doc && make clean && make html"
```

Building the docs also puts build artifacts in `doc/source/topic` so I've ignored that directory in `.gitignore`.

Finally, I fixed the syntax of `print` to work with Python 3. Though, building with different Python versions gives different html output (e.g. urls in links are root relative when building with Python 3).