### PR TITLE
Override package deps when building wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,11 @@
 [wheel]
 universal = 1
+
+
+[metadata]
+requires-dist =
+	botocore==1.2.5
+	colorama>=0.2.5,<=0.3.3
+	docutils>=0.10
+	rsa>=3.1.2,<=3.3.0
+	argparse>=1.1; python_version=="2.6"


### PR DESCRIPTION
Make sure that argparse has the env marker of
python2.6 only when creating a wheel.  Same
fix as https://github.com/boto/boto3/pull/282.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 