### PR TITLE
Add compression for pushed files on platforms that support zlib

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import sys
 import os
+import zipfile
 
 from botocore.compat import six
 #import botocore.compat
@@ -25,6 +26,15 @@ queue = six.moves.queue
 shlex_quote = six.moves.shlex_quote
 StringIO = six.StringIO
 urlopen = six.moves.urllib.request.urlopen
+
+# Most, but not all, python installations will have zlib. This is required to
+# compress any files we send via a push. If we can't compress, we can still
+# package the files in a zip container.
+try:
+    import zlib
+    ZIP_COMPRESSION_MODE = zipfile.ZIP_DEFLATED
+except ImportError:
+    ZIP_COMPRESSION_MODE = zipfile.ZIP_STORED
 
 
 class BinaryStdout(object):

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -22,6 +22,7 @@ from awscli.compat import six
 from awscli.customizations.codedeploy.utils import validate_s3_location
 from awscli.customizations.commands import BasicCommand
 from awscli.errorhandler import ServerError, ClientError
+from awscli.compat import ZIP_COMPRESSION_MODE
 
 
 ONE_MB = 1 << 20
@@ -199,7 +200,7 @@ class Push(BasicCommand):
                         arcname = filename[len(source_path) + 1:]
                         if filename == appspec_path:
                             contains_appspec = True
-                        zf.write(filename, arcname)
+                        zf.write(filename, arcname, ZIP_COMPRESSION_MODE)
                 if not contains_appspec:
                     raise RuntimeError(
                         '{0} was not found'.format(appspec_path)

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -20,6 +20,7 @@ from six import StringIO
 from awscli.customizations.codedeploy.push import Push
 from awscli.errorhandler import ClientError
 from awscli.testutils import unittest
+from awscli.compat import ZIP_COMPRESSION_MODE
 
 
 class TestPush(unittest.TestCase):
@@ -218,7 +219,8 @@ class TestPush(unittest.TestCase):
                 self.args.ignore_hidden_files):
             zf().write.assert_called_with(
                 '/tmp/appspec.yml',
-                self.appspec
+                self.appspec,
+                ZIP_COMPRESSION_MODE
             )
 
     def test_upload_to_s3_with_put_object(self):


### PR DESCRIPTION
Closes #1371

The user's python must have access to the zlib module which is default on the vast majority of python installations. A small number of linux distributions may not have it by default. If they don't have it, we fall back to storage mode.