### PR TITLE
Update Sphinx version to 1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tox==1.4
 docutils>=0.10
-Sphinx==1.1.3
+Sphinx==1.3.1
 # botocore and the awscli packages are typically developed
 # in tandem, so we're requiring the latest develop
 # branch of botocore when working on the awscli.


### PR DESCRIPTION
Got errors building `make man` and `make text` on 1.1.3, fixed by updating Sphinx to 1.3.1