### PR TITLE
Test fixes for Python 2.6 and 3.3

### DIFF
--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import base64
-import codecs
+import binascii
 import json
 import hashlib
 import logging
@@ -512,8 +512,6 @@ class Sha256RSADigestValidator(object):
     The result of validating the digest is inserted into the digest_data
     dictionary using the isValid key value pair.
     """
-    def __init__(self):
-        self.hex_decoder = codecs.getdecoder('hex')
 
     def validate(self, bucket, key, public_key, digest_data, inflated_digest):
         """Validates a digest file.
@@ -531,7 +529,7 @@ class Sha256RSADigestValidator(object):
             decoded_key = base64.b64decode(public_key)
             public_key = rsa.PublicKey.load_pkcs1(decoded_key, format='DER')
             to_sign = self._create_string_to_sign(digest_data, inflated_digest)
-            signature_bytes = self.hex_decoder(digest_data['_signature'])[0]
+            signature_bytes = binascii.unhexlify(digest_data['_signature'])
             rsa.verify(to_sign, signature_bytes, public_key)
         except PyAsn1Error:
             raise DigestError(

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -30,8 +30,9 @@ END_TIME_ARG = END_DATE.strftime(DATE_FORMAT)
 
 def _gz_compress(data):
     out = six.BytesIO()
-    with gzip.GzipFile(fileobj=out, mode="wb") as f:
-        f.write(data.encode())
+    f = gzip.GzipFile(fileobj=out, mode="wb")
+    f.write(data.encode())
+    f.close()
     return out.getvalue()
 
 

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -10,7 +10,7 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import codecs
+import binascii
 import base64
 import hashlib
 import json
@@ -287,8 +287,7 @@ class TestSha256RSADigestValidator(unittest.TestCase):
             sha256_hash.hexdigest(),
             self._digest_data['previousDigestSignature'])
         signature = rsa.sign(string_to_sign.encode(), private_key, 'SHA-256')
-        encoder = codecs.getencoder('hex')
-        self._digest_data['_signature'] = encoder(signature)[0]
+        self._digest_data['_signature'] = binascii.hexlify(signature)
         validator = Sha256RSADigestValidator()
         public_key_b64 = base64.b64encode(public_key.save_pkcs1(format='DER'))
         validator.validate('b', 'k', public_key_b64, self._digest_data,

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -405,8 +405,9 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
 
     def test_ensures_digest_has_proper_metadata(self):
         out = six.BytesIO()
-        with gzip.GzipFile(fileobj=out, mode="wb") as f:
-            f.write('{"foo":"bar"}'.encode())
+        f = gzip.GzipFile(fileobj=out, mode="wb")
+        f.write('{"foo":"bar"}'.encode())
+        f.close()
         gzipped_data = out.getvalue()
         s3_client = Mock()
         s3_client.get_object.return_value = {
@@ -428,8 +429,9 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
     def test_ensures_digests_can_be_json_parsed(self):
         json_str = '{{{'
         out = six.BytesIO()
-        with gzip.GzipFile(fileobj=out, mode="wb") as f:
-            f.write(json_str.encode())
+        f = gzip.GzipFile(fileobj=out, mode="wb")
+        f.write(json_str.encode())
+        f.close()
         gzipped_data = out.getvalue()
         s3_client = Mock()
         s3_client.get_object.return_value = {
@@ -442,8 +444,9 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
     def test_fetches_digests(self):
         json_str = '{"foo":"bar"}'
         out = six.BytesIO()
-        with gzip.GzipFile(fileobj=out, mode="wb") as f:
-            f.write(json_str.encode())
+        f = gzip.GzipFile(fileobj=out, mode="wb")
+        f.write(json_str.encode())
+        f.close()
         gzipped_data = out.getvalue()
         s3_client = Mock()
         s3_client.get_object.return_value = {


### PR DESCRIPTION
Python 2.6 does not support opening gzip files in a context handler, so just opening and closing manually now.

Python 3.3 has issue with the "hex" codec (see http://bugs.python.org/issue7475). Now using binascii instead.