### PR TITLE
Evade ValueError exception on ShorthandParserError

### DIFF
--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -160,7 +160,7 @@ def test_error_parsing():
     yield (_is_error, "foo={bar}")
     yield (_is_error, "foo={bar=bar")
     yield (_is_error, "foo=bar,")
-
+    yield (_is_error, "foo==bar,\nbar=baz")
 
 def _is_error(expr):
     try:


### PR DESCRIPTION
When giving shorthand options like `foo=bar',\nbar=bar"`, aws-cli got `ValueError` with message `substring not found` raised by [`string.rindex`](https://docs.python.org/2/library/string.html#string.rindex) instead of `ShorthandParserError` message.

This pull request includes test code to reproduce, and evades raising `ValueError` and changes `ShorthandParserError` message format a little bit.