### PR TITLE
Also include botocore version in "aws --version"

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -154,7 +154,8 @@ class CLIDriver(object):
         command_table['help'] = self.create_help_command()
         cli_data = self._get_cli_data()
         parser = MainArgParser(
-            command_table, self.session.user_agent(),
+            command_table,
+            "%s botocore/%s" % (self.session.user_agent(), botocore_version),
             cli_data.get('description', None),
             cli_data.get('synopsis', None),
             self._get_argument_table())

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -61,6 +61,7 @@ def create_clidriver():
 def _set_user_agent_for_session(session):
     session.user_agent_name = 'aws-cli'
     session.user_agent_version = __version__
+    session.user_agent_extra = 'botocore/%s' % botocore_version
 
 
 class CLIDriver(object):
@@ -154,8 +155,7 @@ class CLIDriver(object):
         command_table['help'] = self.create_help_command()
         cli_data = self._get_cli_data()
         parser = MainArgParser(
-            command_table,
-            "%s botocore/%s" % (self.session.user_agent(), botocore_version),
+            command_table, self.session.user_agent(),
             cli_data.get('description', None),
             cli_data.get('synopsis', None),
             self._get_argument_table())
@@ -230,9 +230,7 @@ class CLIDriver(object):
                                            format_string=LOG_FORMAT)
             self.session.set_stream_logger('awscli', logging.DEBUG,
                                            format_string=LOG_FORMAT)
-            LOG.debug("CLI version: %s, botocore version: %s",
-                      self.session.user_agent(),
-                      botocore_version)
+            LOG.debug("CLI version: %s", self.session.user_agent())
             LOG.debug("Arguments entered to CLI: %s", sys.argv[1:])
 
         else:


### PR DESCRIPTION
Although it may not happen often in end user's daily scenario,
I did occasionally get bitten by my aws-cli and botocore version becoming out
of sync.  Until now the only way to find out is to append "--debug" at a dummy
aws command line (typically "aws s3 ls") and observe the first line of output.
This commit adds botocore version into the canonical "aws --version" command.

I test it manually to see this output.

    $ aws --version
    aws-cli/1.8.12 Python/2.7.10 Darwin/14.5.0 botocore/1.2.10