### PR TITLE
Adding a few tweaks to the documenation

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -2,7 +2,7 @@
 
 {%- block nav_links %}
 <li><a href="{{ pathto(master_doc) }}">Home</a></li>
-<li><a href="http://aws.amazon.com/documentation/cli/">Documentation</a></li>
+<li><a href="http://docs.aws.amazon.com/cli/latest/userguide/">User Guide</a></li>
 <li><a href="https://forums.aws.amazon.com/forum.jspa?forumID=150">Forum</a></li>
 <li><a href="https://github.com/aws/aws-cli">GitHub</a></li>
 {%- endblock %}

--- a/doc/source/_templates/userguide.html
+++ b/doc/source/_templates/userguide.html
@@ -1,0 +1,6 @@
+<div class="left-bar-other">
+  <h3>User Guide</h3>
+  <p>First time using the AWS CLI? See the
+  <a href="http://docs.aws.amazon.com/cli/latest/userguide/">User Guide</a> for
+  help getting started.</p>
+</div>

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,7 +42,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'AWS CLI'
+project = u'AWS CLI Command Reference'
 copyright = u'2013, Amazon Web Services'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -108,7 +108,7 @@ pygments_style = 'guzzle_sphinx_theme.GuzzleStyle'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+html_title = "AWS CLI %s Command Reference" % release
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #html_short_title = None
@@ -137,7 +137,11 @@ html_static_path = ['_static']
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-  '**': ['sidebarlogo.html', 'localtoc.html', 'searchbox.html', 'feedback.html']
+  '**': ['sidebarlogo.html',
+         'localtoc.html',
+         'searchbox.html',
+         'feedback.html',
+         'userguide.html']
 }
 
 # Additional templates that should be rendered to pages, maps page names to
@@ -184,7 +188,7 @@ extensions.append("guzzle_sphinx_theme")
 
 html_theme_options = {
     # Set the name of the project to appear in the nav menu
-    "project_nav_name": "AWS CLI",
+    "project_nav_name": "AWS CLI Command Reference",
     # Set your GitHub user and repo to enable GitHub stars links
     "github_user": "aws",
     "github_repo": "aws-cli",

--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
@@ -134,15 +134,6 @@ a.internal em {
 /* Sphinx sidebar
 -------------------------------------------------- */
 
-div.sphinxsidebar a {
-  color: #444;
-  text-decoration: none;
-}
-
-div.sphinxsidebar a:hover {
-  border-bottom: 1px solid #999;
-}
-
 div.sphinxsidebar {
   font-size: 14px;
   line-height: 1.5;

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,6 @@
-*******
-AWS CLI
-*******
+*************************
+AWS CLI Command Reference
+*************************
 
 The AWS Command Line Interface is a unified tool that provides a consistent
 interface for interacting with all parts of AWS.


### PR DESCRIPTION
1. Updated the title to become `"AWS CLI %s Command Reference" %
   release`
2. Added a sidebar to the layout to link to the user guide.
3. Replaced "Documentation" in nav to "User Guide" to link directly to
   the User Guide.
4. Links in the left nav are no longer shown as black so that users
   actually know they are links.
5. Modified index.rst page title to be "AWS CLI Command Reference"
6. Modified the nav bar title to be "AWS CLI Command Reference".

![image](https://cloud.githubusercontent.com/assets/190930/10469426/ec19e250-71b9-11e5-985b-823f8ffbd185.png)

/cc @mwunderl 