### PR TITLE
Adding help information about pagination.

### DIFF
--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -74,6 +74,8 @@ def get_paginator_config(session, service_name, operation_name):
 
 
 def add_paging_description(help_command, **kwargs):
+    # This customization is only applied to the description of
+    # Operations, so we must filter out all other events.
     if not isinstance(help_command.obj, model.OperationModel):
         return
     service_name = help_command.obj.service_model.service_name
@@ -81,9 +83,10 @@ def add_paging_description(help_command, **kwargs):
         help_command.session, service_name, help_command.obj.name)
     if not paginator_config:
         return
+    help_command.doc.style.new_paragraph()
     help_command.doc.writeln(
-        ('\n\n``%s`` is a paginated operation. Multiple API calls may be '
-         'issued in order to retrieve the entire data set of results. You can '
+        ('``%s`` is a paginated operation. Multiple API calls may be issued '
+         'in order to retrieve the entire data set of results. You can '
          'disable pagination by providing the ``--no-paginate`` argument.')
         % help_command.name)
     # Only include result key information if it is present.

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -261,6 +261,12 @@ class TestPagingParamDocs(BaseAWSHelpOutputTest):
         self.assert_not_contains('``--next-token``')
         self.assert_not_contains('``--max-keys``')
 
+    def test_paging_documentation_added(self):
+        self.driver.main(['s3api', 'list-objects', 'help'])
+        self.assert_contains('``list-objects`` is a paginated operation')
+        self.assert_contains('When using ``--output text`` and the')
+        self.assert_contains('following query expressions: ')
+
 
 class TestMergeBooleanGroupArgs(BaseAWSHelpOutputTest):
     def test_merge_bool_args(self):


### PR DESCRIPTION
Adds help information about pagination, including how to prevent
pagination and what result keys are used for an operation.

Closes #1404 

![image](https://cloud.githubusercontent.com/assets/190930/10534405/faccb3f2-738c-11e5-83de-d3c0755efa55.png)

![image](https://cloud.githubusercontent.com/assets/190930/10534420/33fe649a-738d-11e5-86d0-915f0b7a1e59.png)

@kyleknap @jamesls @JordonPhillips @rayluo 