### PR TITLE
Better ec2 run-instances --cli-input-json support

### DIFF
--- a/awscli/customizations/ec2addcount.py
+++ b/awscli/customizations/ec2addcount.py
@@ -20,12 +20,13 @@ from awscli.arguments import BaseCLIArgument
 logger = logging.getLogger(__name__)
 
 
+DEFAULT = 1
 HELP = """
 <p>Number of instances to launch. If a single number is provided, it
-is assumed to be the minimum to launch (defaults to 1).  If a range is
+is assumed to be the minimum to launch (defaults to %d).  If a range is
 provided in the form <code>min:max</code> then the first number is
 interpreted as the minimum number of instances to launch and the second
-is interpreted as the maximum number of instances to launch.</p>"""
+is interpreted as the maximum number of instances to launch.</p>""" % DEFAULT
 
 
 def ec2_add_count(argument_table, **kwargs):
@@ -64,9 +65,15 @@ class CountArgument(BaseCLIArgument):
     def add_to_parser(self, parser):
         parser.add_argument(self.cli_name, metavar=self.py_name,
                             help='Number of instances to launch',
-                            default='1')
+                            ## We will delegate the default value logic to
+                            ## ec2runinstances.py:_fix_args()
+                            # default=str(DEFAULT)
+                            )
 
     def add_to_params(self, parameters, value):
+        if value is None:
+            # NO-OP if value is not explicitly set by user
+            return
         try:
             if ':' in value:
                 minstr, maxstr = value.split(':')

--- a/awscli/customizations/ec2runinstances.py
+++ b/awscli/customizations/ec2runinstances.py
@@ -23,7 +23,6 @@ This functionality (and much more) is also available using the
 the most commonly used features available more easily.
 """
 from awscli.arguments import CustomArgument
-from awscli.customizations.ec2addcount import DEFAULT
 
 # --secondary-private-ip-address
 SECONDARY_PRIVATE_IP_ADDRESSES_DOCS = (
@@ -106,8 +105,6 @@ def _fix_args(params, **kwargs):
                            'Primary': True}
                 ni[0]['PrivateIpAddresses'] = [ip_addr]
                 del params['PrivateIpAddress']
-    params.setdefault('MaxCount', DEFAULT)
-    params.setdefault('MinCount', DEFAULT)
 
 
 EVENTS = [

--- a/awscli/customizations/ec2runinstances.py
+++ b/awscli/customizations/ec2runinstances.py
@@ -23,6 +23,7 @@ This functionality (and much more) is also available using the
 the most commonly used features available more easily.
 """
 from awscli.arguments import CustomArgument
+from awscli.customizations.ec2addcount import DEFAULT
 
 # --secondary-private-ip-address
 SECONDARY_PRIVATE_IP_ADDRESSES_DOCS = (
@@ -105,6 +106,8 @@ def _fix_args(params, **kwargs):
                            'Primary': True}
                 ni[0]['PrivateIpAddresses'] = [ip_addr]
                 del params['PrivateIpAddress']
+    params.setdefault('MaxCount', DEFAULT)
+    params.setdefault('MinCount', DEFAULT)
 
 
 EVENTS = [

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -22,7 +22,7 @@ from awscli.errorhandler import ErrorHandler
 from awscli.customizations.streamingoutputarg import add_streaming_output_arg
 from awscli.customizations.addexamples import add_examples
 from awscli.customizations.removals import register_removals
-from awscli.customizations.ec2addcount import ec2_add_count
+from awscli.customizations.ec2addcount import register_count_events
 from awscli.customizations.paginate import register_pagination
 from awscli.customizations.ec2decryptpassword import ec2_add_priv_launch_key
 from awscli.customizations.ec2secgroupsimplify import register_secgroup
@@ -92,8 +92,7 @@ def awscli_initialize(event_handlers):
     register_cli_input_json(event_handlers)
     event_handlers.register('building-argument-table.*',
                             add_streaming_output_arg)
-    event_handlers.register('building-argument-table.ec2.run-instances',
-                            ec2_add_count)
+    register_count_events(event_handlers)
     event_handlers.register('building-argument-table.ec2.get-password-data',
                             ec2_add_priv_launch_key)
     register_parse_global_args(event_handlers)

--- a/tests/functional/ec2/test_run_instances.py
+++ b/tests/functional/ec2/test_run_instances.py
@@ -68,6 +68,19 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(args_list, result)
 
+    def test_count_in_json_only(self):
+        input_json = '{"ImageId":"ami-xxxx","MaxCount":9,"MinCount":5}'
+        args_list = (self.prefix + ' --cli-input-json ' + input_json).split()
+        result = {'ImageId': 'ami-xxxx', 'MaxCount': 9, 'MinCount': 5}
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_count_in_cli_and_in_json(self):
+        input_json = '{"ImageId":"ami-xxxx","MaxCount":9,"MinCount":5}'
+        args_list = (
+            self.prefix + ' --count 3 --cli-input-json ' + input_json).split()
+        result = {'ImageId': 'ami-xxxx', 'MaxCount': 3, 'MinCount': 3}
+        self.assert_params_for_cmd(args_list, result)
+
     def test_block_device_mapping(self):
         args = ' --image-id ami-foobar --count 1'
         args_list = (self.prefix + args).split()


### PR DESCRIPTION
Now the MaxCount and MinCount setting in --cli-input-json will NOT be overridden by a default value.
This fixes #1524