### PR TITLE
Catch a bug in mimetype library

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import sys
 import time
 from functools import partial
@@ -11,6 +12,9 @@ from dateutil.tz import tzlocal
 from botocore.compat import quote
 from awscli.customizations.s3.utils import find_bucket_key, \
     uni_print, guess_content_type, MD5Error, bytes_print
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class CreateDirectoryError(Exception):
@@ -266,7 +270,22 @@ class FileInfo(TaskInfo):
 
     def _inject_content_type(self, params, filename):
         # Add a content type param if we can guess the type.
-        guessed_type = guess_content_type(filename)
+        guessed_type = None
+        try:
+            guessed_type = guess_content_type(filename)
+        # This catches a bug in the mimetype libary where some MIME types
+        # specifically on windows machines cause a UnicodeDecodeError
+        # because the MIME type in the Windows registery has an encoding
+        # that cannot be properly encoded using the default system encoding.
+        # https://bugs.python.org/issue9291
+        #
+        # So instead of hard failing, just log the issue and fall back to the
+        # default guessed content type of None.
+        except UnicodeDecodeError:
+            LOGGER.debug(
+                'Unable to guess content type for %s due to '
+                'UnicodeDecodeError: ', filename, exc_info=True
+            )
         if guessed_type is not None:
             params['ContentType'] = guessed_type
 

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -270,9 +270,10 @@ class FileInfo(TaskInfo):
 
     def _inject_content_type(self, params, filename):
         # Add a content type param if we can guess the type.
-        guessed_type = None
         try:
             guessed_type = guess_content_type(filename)
+            if guessed_type is not None:
+                params['ContentType'] = guessed_type
         # This catches a bug in the mimetype libary where some MIME types
         # specifically on windows machines cause a UnicodeDecodeError
         # because the MIME type in the Windows registery has an encoding
@@ -286,8 +287,6 @@ class FileInfo(TaskInfo):
                 'Unable to guess content type for %s due to '
                 'UnicodeDecodeError: ', filename, exc_info=True
             )
-        if guessed_type is not None:
-            params['ContentType'] = guessed_type
 
     def download(self):
         """

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -163,6 +163,15 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_cp_succeeds_with_mimetype_errors(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
+        self.parsed_responses = [
+            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        with mock.patch('mimetypes.guess_type') as mock_guess_type:
+            # This should throw a UnicodeDecodeError.
+            mock_guess_type.side_effect = lambda x: b'\xe2'.decode('ascii')
+            self.run_cmd(cmdline, expected_rc=0)
+        # Because of the decoding error the command should have succeeded
+        # just that there was no content type added.
+        self.assertNotIn('ContentType', self.last_kwargs)


### PR DESCRIPTION
Issue was that on windows some MIME types in the Windows library could not be encoded using the system default encoding. This has been fixed in later versions of python, but we should not hard fail if the user is using a python version without the fix. Instead just catch the exception and not set the content type.

Fixes https://github.com/aws/aws-cli/issues/774

cc @jamesls @mtdowling @rayluo @JordonPhillips 