### PR TITLE
Don't index empty lists

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Next Release (TBD)
 * feature:Assume Role: Add ``role_session_name`` config variable
   to control the ``RoleSessionName`` when assuming roles
   (`issue 1389 <https://github.com/aws/aws-cli/pull/1389>`__)
+* bug:Argument Parsing: Handle case when empty list parameter
+  was specified with no value
+  (`issue 838 <https://github.com/aws/aws-cli/issues/838>`__)
 
 1.8.13
 ======

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -349,7 +349,7 @@ class ParamShorthand(object):
         # We first need to make sure this is a parameter that qualifies
         # for simplification.  The first short-circuit case is if it looks
         # like json we immediately return.
-        if isinstance(value, list):
+        if value and isinstance(value, list):
             check_val = value[0]
         else:
             check_val = value

--- a/tests/functional/cloudformation/test_create_stack.py
+++ b/tests/functional/cloudformation/test_create_stack.py
@@ -14,7 +14,7 @@
 from awscli.testutils import BaseAWSCommandParamsTest
 
 
-class TestDescribeInstances(BaseAWSCommandParamsTest):
+class TestCreateStack(BaseAWSCommandParamsTest):
 
     prefix = 'cloudformation create-stack'
 
@@ -55,4 +55,11 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
                   'Parameters': [{'ParameterKey': 'foo',
                                   'ParameterValue': 'one,two'}]}
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_can_handle_empty_parameters(self):
+        cmdline = self.prefix
+        cmdline += ' --stack-name test --parameters --template-url http://foo'
+        result = {'StackName': 'test', 'TemplateURL': 'http://foo',
+                  'Parameters': []}
         self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -265,6 +265,12 @@ class TestParamShorthand(BaseArgProcessTest):
 
         self.assertEqual(simplified, expected)
 
+    def test_empty_value_of_list_structure(self):
+        p = self.get_param_model('emr.ModifyInstanceGroups.InstanceGroups')
+        expected = []
+        simplified = self.simplify(p, [])
+        self.assertEqual(simplified, expected)
+
     def test_list_structure_list_multiple_scalar(self):
         p = self.get_param_model(
             'emr.ModifyInstanceGroups.InstanceGroups')


### PR DESCRIPTION
Fixes #838.

The new behavior is that an empty list will be parsed, and we'll
rely on botocore's min/max validation for lists to check whether
or not a list can be empty.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 