### PR TITLE
Add pointer to help commands on error messages

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -24,7 +24,7 @@ HELP_BLURB = (
     "  aws <command> <subcommand> help\n"
 )
 USAGE = (
-    "aws [options] <command> <subcommand> [parameters]\n"
+    "aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\n"
     "%s" % HELP_BLURB
 )
 

--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -16,6 +16,19 @@ from awscli.compat import six
 from difflib import get_close_matches
 
 
+HELP_BLURB = (
+    "To see help text, you can run:\n"
+    "\n"
+    "  aws help\n"
+    "  aws <command> help\n"
+    "  aws <command> <subcommand> help\n"
+)
+USAGE = (
+    "aws [options] <command> <subcommand> [parameters]\n"
+    "%s" % HELP_BLURB
+)
+
+
 class CLIArgParser(argparse.ArgumentParser):
     Formatter = argparse.RawTextHelpFormatter
 
@@ -71,13 +84,13 @@ class MainArgParser(CLIArgParser):
     Formatter = argparse.RawTextHelpFormatter
 
     def __init__(self, command_table, version_string,
-                 description, usage, argument_table):
+                 description, argument_table):
         super(MainArgParser, self).__init__(
             formatter_class=self.Formatter,
             add_help=False,
             conflict_handler='resolve',
             description=description,
-            usage=usage)
+            usage=USAGE)
         self._build(command_table, version_string, argument_table)
 
     def _create_choice_help(self, choices):
@@ -98,14 +111,12 @@ class MainArgParser(CLIArgParser):
 
 class ServiceArgParser(CLIArgParser):
 
-    Usage = ("aws [options] <command> <subcommand> [parameters]")
-
     def __init__(self, operations_table, service_name):
         super(ServiceArgParser, self).__init__(
             formatter_class=argparse.RawTextHelpFormatter,
             add_help=False,
             conflict_handler='resolve',
-            usage=self.Usage)
+            usage=USAGE)
         self._build(operations_table)
         self._service_name = service_name
 
@@ -115,7 +126,6 @@ class ServiceArgParser(CLIArgParser):
 
 class ArgTableArgParser(CLIArgParser):
     """CLI arg parser based on an argument table."""
-    Usage = ("aws [options] <command> <subcommand> [parameters]")
 
     def __init__(self, argument_table, command_table=None):
         # command_table is an optional subcommand_table.  If it's passed
@@ -124,7 +134,7 @@ class ArgTableArgParser(CLIArgParser):
         super(ArgTableArgParser, self).__init__(
             formatter_class=self.Formatter,
             add_help=False,
-            usage=self.Usage,
+            usage=USAGE,
             conflict_handler='resolve')
         if command_table is None:
             command_table = {}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -27,6 +27,7 @@ from awscli.plugin import load_plugins
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.argparser import ArgTableArgParser
+from awscli.argparser import USAGE
 from awscli.help import ProviderHelpCommand
 from awscli.help import ServiceHelpCommand
 from awscli.help import OperationHelpCommand
@@ -157,7 +158,6 @@ class CLIDriver(object):
         parser = MainArgParser(
             command_table, self.session.user_agent(),
             cli_data.get('description', None),
-            cli_data.get('synopsis', None),
             self._get_argument_table())
         return parser
 
@@ -183,8 +183,9 @@ class CLIDriver(object):
             self._emit_session_event()
             return command_table[parsed_args.command](remaining, parsed_args)
         except UnknownArgumentError as e:
+            sys.stderr.write("usage: %s\n" % USAGE)
+            sys.stderr.write(str(e))
             sys.stderr.write("\n")
-            sys.stderr.write(str(e) + '\n')
             return 255
         except NoRegionError as e:
             msg = ('%s You can also configure your region by running '

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -30,6 +30,7 @@ from awscli.clidriver import ServiceCommand
 from awscli.clidriver import ServiceOperation
 from awscli.customizations.commands import BasicCommand
 from awscli import formatter
+from awscli.argparser import HELP_BLURB
 from botocore.hooks import HierarchicalEmitter
 
 
@@ -594,6 +595,26 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         # will result in 255 rc.
         rc = self.driver.main('ec2 describe-instances'.split())
         self.assertEqual(rc, 255)
+
+    def test_help_blurb_in_error_message(self):
+        with self.assertRaises(SystemExit):
+            self.driver.main([])
+        self.assertIn(HELP_BLURB, self.stderr.getvalue())
+
+    def test_help_blurb_in_service_error_message(self):
+        with self.assertRaises(SystemExit):
+            self.driver.main(['ec2'])
+        self.assertIn(HELP_BLURB, self.stderr.getvalue())
+
+    def test_help_blurb_in_operation_error_message(self):
+        with self.assertRaises(SystemExit):
+            self.driver.main(['ec2', 'run-instances'])
+        self.assertIn(HELP_BLURB, self.stderr.getvalue())
+
+    def test_help_blurb_in_unknown_argument_error_message(self):
+        with self.assertRaises(SystemExit):
+            self.driver.main(['ec2', 'run-instances', '--help'])
+        self.assertIn(HELP_BLURB, self.stderr.getvalue())
 
 
 class TestHowClientIsCreated(BaseAWSCommandParamsTest):

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -20,6 +20,7 @@ import mock
 from awscli.help import PosixHelpRenderer, ExecutableNotFoundError
 from awscli.help import WindowsHelpRenderer, ProviderHelpCommand, HelpCommand
 from awscli.help import TopicListerCommand, TopicHelpCommand
+from awscli.argparser import HELP_BLURB
 
 
 class HelpSpyMixin(object):
@@ -160,12 +161,12 @@ class TestHelpCommand(TestHelpCommandBase):
         self.assertTrue(self.renderer.render.called)
 
     def test_invalid_subcommand(self):
-        # This sole purpose of this patch is to remove errors from being
-        # printed to screen even when the test passes when running the test
-        # suite.
-        with mock.patch('sys.stderr'):
+        with mock.patch('sys.stderr') as f:
             with self.assertRaises(SystemExit):
                 self.cmd(['no-exist-command'], None)
+        # We should see the pointer to "aws help" in the error message.
+        error_message = ''.join(arg[0][0] for arg in f.write.call_args_list)
+        self.assertIn(HELP_BLURB, error_message)
 
 
 class TestProviderHelpCommand(TestHelpCommandBase):


### PR DESCRIPTION
These commands will now also include how you can look
at help text:

* aws
* aws <service>
* aws <service> <operation>
* aws <service> <operation> --unknown arg (including --help)

The plan is still to support --help eventually, but for now,
we can at least add pointers to how to get help with the
existing help commands.

```
$ aws
usage: aws [options] <command> <subcommand> [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: too few arguments


$ aws ec2
usage: aws [options] <command> <subcommand> [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: too few arguments

$ aws ec2 run-instances
usage: aws [options] <command> <subcommand> [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
aws: error: argument --image-id is required

$ aws ec2 describe-instances --help
usage: aws [options] <command> <subcommand> [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

Unknown options: --help
```

Closes #254.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 