### PR TITLE
Warn and skip on glacier objects that may fail for s3 commands

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -164,11 +164,16 @@ class FileInfo(TaskInfo):
     :param dest_type: string
     :param parameters: a dictionary of important values this is assigned in
         the ``BasicTask`` object.
+    :param associated_response_data: The response data used by
+        the ``FileGenerator`` to create this task. It is either an dictionary
+        from the list of a ListObjects or the response from a HeadObject. It
+        will only be filled if the task was generated from an S3 bucket.
     """
     def __init__(self, src, dest=None, compare_key=None, size=None,
                  last_update=None, src_type=None, dest_type=None,
                  operation_name=None, client=None, parameters=None,
-                 source_client=None, is_stream=False):
+                 source_client=None, is_stream=False,
+                 associated_response_data=None):
         super(FileInfo, self).__init__(src, src_type=src_type,
                                        operation_name=operation_name,
                                        client=client)
@@ -185,6 +190,7 @@ class FileInfo(TaskInfo):
                                'sse': None}
         self.source_client = source_client
         self.is_stream = is_stream
+        self.associated_response_data = associated_response_data
 
     def set_size_from_s3(self):
         """

--- a/awscli/customizations/s3/fileinfobuilder.py
+++ b/awscli/customizations/s3/fileinfobuilder.py
@@ -44,6 +44,7 @@ class FileInfoBuilder(object):
         file_info_attr['operation_name'] = file_base.operation_name
         file_info_attr['parameters'] = self._parameters
         file_info_attr['is_stream'] = self._is_stream
+        file_info_attr['associated_response_data'] = file_base.response_data
 
         # This is a bit quirky. The below conditional hinges on the --delete
         # flag being set, which only occurs during a sync command. The source

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -187,6 +187,9 @@ class S3Handler(object):
                 self.result_queue.put(warning)
             # Warn and skip over glacier incompatible tasks.
             elif not is_glacier_compatible_operation(filename):
+                LOGGER.debug(
+                    'Encountered glacier object s3://%s. Not performing '
+                    '%s on object.' % (filename.src, filename.operation_name))
                 if not self.params['ignore_glacier_warnings']:
                     warning = create_warning(
                         's3://'+filename.src,

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -17,8 +17,7 @@ import os
 import sys
 
 from awscli.customizations.s3.utils import find_chunksize, \
-    find_bucket_key, relative_path, PrintTask, create_warning, \
-    is_glacier_compatible_operation
+    find_bucket_key, relative_path, PrintTask, create_warning
 from awscli.customizations.s3.executor import Executor
 from awscli.customizations.s3 import tasks
 from awscli.customizations.s3.transferconfig import RuntimeConfig
@@ -186,7 +185,7 @@ class S3Handler(object):
                                          message=warning_message)
                 self.result_queue.put(warning)
             # Warn and skip over glacier incompatible tasks.
-            elif not is_glacier_compatible_operation(filename):
+            elif not filename.is_glacier_compatible():
                 LOGGER.debug(
                     'Encountered glacier object s3://%s. Not performing '
                     '%s on object.' % (filename.src, filename.operation_name))

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -290,12 +290,23 @@ PAGE_SIZE = {'name': 'page-size', 'cli_type_name': 'integer',
                  'Using a lower value may help if an operation times out.')}
 
 
+IGNORE_GLACIER_WARNINGS = {
+    'name': 'ignore-glacier-warnings', 'action': 'store_true',
+    'help_text': (
+        'Turns off glacier warnings. Warnings about operations that cannot '
+        'be performed because it involves copying, downloading, or moving '
+        'a glacier object will no longer be printed to standard error and '
+        'cause the return code of the command to be ``2``.'
+    )
+}
+
+
 TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  FOLLOW_SYMLINKS, NO_FOLLOW_SYMLINKS, NO_GUESS_MIME_TYPE,
                  SSE, STORAGE_CLASS, GRANTS, WEBSITE_REDIRECT, CONTENT_TYPE,
                  CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_ENCODING,
                  CONTENT_LANGUAGE, EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS,
-                 PAGE_SIZE]
+                 PAGE_SIZE, IGNORE_GLACIER_WARNINGS]
 
 
 def get_client(session, region, endpoint_url, verify):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -296,7 +296,7 @@ IGNORE_GLACIER_WARNINGS = {
         'Turns off glacier warnings. Warnings about operations that cannot '
         'be performed because it involves copying, downloading, or moving '
         'a glacier object will no longer be printed to standard error and '
-        'cause the return code of the command to be ``2``.'
+        'will no longer cause the return code of the command to be ``2``.'
     )
 }
 

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -469,7 +469,7 @@ class BucketLister(object):
                     source_path = bucket + '/' + content['Key']
                     size = content['Size']
                     last_update = self._date_parser(content['LastModified'])
-                    yield source_path, size, last_update
+                    yield source_path, size, last_update, content
 
     def _decode_keys(self, parsed, **kwargs):
         if 'Contents' in parsed:

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -467,9 +467,9 @@ class BucketLister(object):
                 contents = page.get('Contents', [])
                 for content in contents:
                     source_path = bucket + '/' + content['Key']
-                    size = content['Size']
-                    last_update = self._date_parser(content['LastModified'])
-                    yield source_path, size, last_update, content
+                    content['LastModified'] = self._date_parser(
+                        content['LastModified'])
+                    yield source_path, content
 
     def _decode_keys(self, parsed, **kwargs):
         if 'Contents' in parsed:

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -214,3 +214,18 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
         self.assertIn('GLACIER', stderr)
+
+    def test_turn_off_glacier_warnings(self):
+        self.parsed_responses = [
+            {'ContentLength': str(20 * (1024 ** 2)),
+             'LastModified': '00:00:00Z',
+             'StorageClass': 'GLACIER'},
+        ]
+        cmdline = (
+            '%s s3://bucket/key.txt . --ignore-glacier-warnings' % self.prefix)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=0)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual('', stderr)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -187,3 +187,30 @@ class TestCPCommand(BaseAWSCommandParamsTest):
             mock_utime.side_effect = OSError(1, '')
             _, err, _ = self.run_cmd(cmdline, expected_rc=1)
             self.assertIn('attempting to modify the utime', err)
+
+    def test_warns_on_glacier_incompatible_operation(self):
+        self.parsed_responses = [
+            {'ContentLength': '100', 'LastModified': '00:00:00Z',
+             'StorageClass': 'GLACIER'},
+        ]
+        cmdline = ('%s s3://bucket/key.txt .' % self.prefix)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertIn('GLACIER', stderr)
+
+    def test_warns_on_glacier_incompatible_operation_for_multipart_file(self):
+        self.parsed_responses = [
+            {'ContentLength': str(20 * (1024 ** 2)),
+             'LastModified': '00:00:00Z',
+             'StorageClass': 'GLACIER'},
+        ]
+        cmdline = ('%s s3://bucket/key.txt .' % self.prefix)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertIn('GLACIER', stderr)

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -82,7 +82,7 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
     def test_handles_glacier_incompatible_operations(self):
         self.parsed_responses = [
             {'Contents': [
-                {'Key': 'foo', 'Size': '100',
+                {'Key': 'foo', 'Size': 100,
                  'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'}]}
         ]
         cmdline = '%s s3://bucket/ %s' % (
@@ -97,7 +97,7 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
     def test_turn_off_glacier_warnings(self):
         self.parsed_responses = [
             {'Contents': [
-                {'Key': 'foo', 'Size': '100',
+                {'Key': 'foo', 'Size': 100,
                  'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'}]}
         ]
         cmdline = '%s s3://bucket/ %s --ignore-glacier-warnings' % (

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -78,3 +78,18 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         # Make sure the file now exists.
         self.assertTrue(
             os.path.exists(os.path.join(non_existant_directory, key)))
+    
+    def test_handles_glacier_incompatible_operations(self):
+        self.parsed_responses = [
+            {'Contents': [
+                {'Key': 'foo', 'Size': '100',
+                 'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'}]}
+        ]
+        cmdline = '%s s3://bucket/ %s' % (
+            self.prefix, self.files.rootdir)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+        self.assertIn('GLACIER', stderr)

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -93,3 +93,18 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
         self.assertIn('GLACIER', stderr)
+
+    def test_turn_off_glacier_warnings(self):
+        self.parsed_responses = [
+            {'Contents': [
+                {'Key': 'foo', 'Size': '100',
+                 'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'}]}
+        ]
+        cmdline = '%s s3://bucket/ %s --ignore-glacier-warnings' % (
+            self.prefix, self.files.rootdir)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=0)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+        self.assertEqual('', stderr)

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -27,7 +27,8 @@ class TestFileInfoBuilder(unittest.TestCase):
         files = [FileStat(src='src', dest='dest', compare_key='compare_key',
                           size='size', last_update='last_update',
                           src_type='src_type', dest_type='dest_type',
-                          operation_name='operation_name')]
+                          operation_name='operation_name',
+                          response_data='associated_response_data')]
         file_infos = info_setter.call(files)
         for file_info in file_infos:
             attributes = file_info.__dict__.keys()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -292,20 +292,24 @@ class TestBucketList(unittest.TestCase):
     def test_list_objects(self):
         now = mock.sentinel.now
         self.client.get_paginator.return_value.paginate = self.fake_paginate
+        individual_response_elements = [
+            {'LastModified': '2014-02-27T04:20:38.000Z',
+             'Key': 'a', 'Size': 1},
+            {'LastModified': '2014-02-27T04:20:38.000Z',
+                 'Key': 'b', 'Size': 2},
+            {'LastModified': '2014-02-27T04:20:38.000Z',
+                 'Key': 'c', 'Size': 3}
+        ]
         self.responses = [
-            {'Contents': [
-                {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': 'a', 'Size': 1},
-                {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': 'b', 'Size': 2}]},
-            {'Contents': [
-                {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': 'c', 'Size': 3}]}
+            {'Contents': individual_response_elements[0:2]},
+            {'Contents': [individual_response_elements[2]]}
         ]
         lister = BucketLister(self.client, self.date_parser)
         objects = list(lister.list_objects(bucket='foo'))
-        self.assertEqual(objects, [('foo/a', 1, now), ('foo/b', 2, now),
-                                   ('foo/c', 3, now)])
+        self.assertEqual(objects,
+            [('foo/a', 1, now, individual_response_elements[0]),
+             ('foo/b', 2, now, individual_response_elements[1]),
+             ('foo/c', 3, now, individual_response_elements[2])])
 
     def test_urlencoded_keys(self):
         # In order to workaround control chars being in key names,
@@ -314,28 +318,32 @@ class TestBucketList(unittest.TestCase):
         # in bar.txt:
         now = mock.sentinel.now
         self.client.get_paginator.return_value.paginate = self.fake_paginate
+        individual_response_element = {
+            'LastModified': '2014-02-27T04:20:38.000Z',
+            'Key': 'bar%0D.txt', 'Size': 1}
         self.responses = [
-            {'Contents': [
-                {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': 'bar%0D.txt', 'Size': 1}]},
+            {'Contents': [individual_response_element]}
         ]
         lister = BucketLister(self.client, self.date_parser)
         objects = list(lister.list_objects(bucket='foo'))
         # And note how it's been converted to '\r'.
-        self.assertEqual(objects, [('foo/bar\r.txt', 1, now)])
+        self.assertEqual(
+            objects, [('foo/bar\r.txt', 1, now, individual_response_element)])
 
     def test_urlencoded_with_unicode_keys(self):
         now = mock.sentinel.now
         self.client.get_paginator.return_value.paginate = self.fake_paginate
+        individual_response_element = {
+            'LastModified': '2014-02-27T04:20:38.000Z',
+            'Key': '%E2%9C%93', 'Size': 1}
         self.responses = [
-            {'Contents': [
-                {'LastModified': '2014-02-27T04:20:38.000Z',
-                 'Key': '%E2%9C%93', 'Size': 1}]},
+            {'Contents': [individual_response_element]}
         ]
         lister = BucketLister(self.client, self.date_parser)
         objects = list(lister.list_objects(bucket='foo'))
         # And note how it's been converted to '\r'.
-        self.assertEqual(objects, [(u'foo/\u2713', 1, now)])
+        self.assertEqual(
+            objects, [(u'foo/\u2713', 1, now, individual_response_element)])
 
 
 class TestScopedEventHandler(unittest.TestCase):
@@ -408,7 +416,3 @@ class TestSetsFileUtime(unittest.TestCase):
             utime_mock.side_effect = OSError(2, '')
             with self.assertRaises(OSError):
                 set_file_utime('not_real_file', epoch_now)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -307,9 +307,11 @@ class TestBucketList(unittest.TestCase):
         lister = BucketLister(self.client, self.date_parser)
         objects = list(lister.list_objects(bucket='foo'))
         self.assertEqual(objects,
-            [('foo/a', 1, now, individual_response_elements[0]),
-             ('foo/b', 2, now, individual_response_elements[1]),
-             ('foo/c', 3, now, individual_response_elements[2])])
+            [('foo/a', individual_response_elements[0]),
+             ('foo/b', individual_response_elements[1]),
+             ('foo/c', individual_response_elements[2])])
+        for individual_response in individual_response_elements:
+            self.assertEqual(individual_response['LastModified'], now)
 
     def test_urlencoded_keys(self):
         # In order to workaround control chars being in key names,
@@ -328,7 +330,8 @@ class TestBucketList(unittest.TestCase):
         objects = list(lister.list_objects(bucket='foo'))
         # And note how it's been converted to '\r'.
         self.assertEqual(
-            objects, [('foo/bar\r.txt', 1, now, individual_response_element)])
+            objects, [('foo/bar\r.txt', individual_response_element)])
+        self.assertEqual(individual_response_element['LastModified'], now)
 
     def test_urlencoded_with_unicode_keys(self):
         now = mock.sentinel.now
@@ -343,7 +346,8 @@ class TestBucketList(unittest.TestCase):
         objects = list(lister.list_objects(bucket='foo'))
         # And note how it's been converted to '\r'.
         self.assertEqual(
-            objects, [(u'foo/\u2713', 1, now, individual_response_element)])
+            objects, [(u'foo/\u2713', individual_response_element)])
+        self.assertEqual(individual_response_element['LastModified'], now)
 
 
 class TestScopedEventHandler(unittest.TestCase):

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -85,7 +85,8 @@ COMPLETIONS = [
                              '--content-encoding', '--content-language',
                              '--expires', '--grants', '--only-show-errors',
                              '--expected-size', '--page-size',
-                             '--metadata-directive']
+                             '--metadata-directive',
+                             '--ignore-glacier-warnings']
                             + GLOBALOPTS)),
     ('aws s3 cp --quiet -', -1, set(['--no-guess-mime-type', '--dryrun',
                                      '--recursive', '--content-type',
@@ -97,7 +98,8 @@ COMPLETIONS = [
                                      '--exclude', '--include',
                                      '--source-region', '--metadata-directive',
                                      '--grants', '--only-show-errors',
-                                     '--expected-size', '--page-size']
+                                     '--expected-size', '--page-size',
+                                     '--ignore-glacier-warnings']
                                     + GLOBALOPTS)),
     ('aws emr ', -1, set(['add-instance-groups', 'add-steps', 'add-tags',
                           'create-cluster', 'create-default-roles',


### PR DESCRIPTION
This pull request does the following:
* Skips operations that involve transferring a glacier object. This includes downloading, copying, and moving an object when the source is a glacier object. If the glacier object is skipped, a warning is displayed causing the return code to be ``2``. The most important part of this functionality is that we will not even try performing an operation, which could slow down a command especially if you have a lot of or large glacier objects.
* Add ``--ignore-glacier-warnings`` argument that allows you to hide the glacier warnings and not cause the return code to be 2 if a glacier object is encountered. Note that glacier objects are still always skipped if the command involves downloading, copying, or moving an object when the source is a glacier object.

All of the integration tests pass.

Fixes https://github.com/aws/aws-cli/issues/748

cc @jamesls @mtdowling @rayluo @JordonPhillips 