### PR TITLE
Add note about "s3:PutObjectAcl" requirement for IAM policy

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -122,7 +122,10 @@ ACL = {'name': 'acl', 'nargs': 1,
                    'bucket-owner-full-control', 'log-delivery-write'],
        'help_text': (
            "Sets the ACL for the object when the command is "
-           "performed.  Only accepts values of ``private``, ``public-read``, "
+           "performed.  If you use this parameter you must have the "
+           '"s3:PutObjectAcl" permission included in the list of actions '
+           "for your IAM policy. "
+           "Only accepts values of ``private``, ``public-read``, "
            "``public-read-write``, ``authenticated-read``, "
            "``bucket-owner-read``, ``bucket-owner-full-control`` and "
            "``log-delivery-write``.")}

--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -90,6 +90,34 @@ Output::
 
     copy: s3://mybucket/test.txt to s3://mybucket/test2.txt
 
+Note that if you're using the ``--acl`` option, ensure that any associated IAM
+policies include the ``"s3:PutObjectAcl"`` action::
+
+    aws iam get-user-policy --user-name myuser --policy-name mypolicy
+
+Output::
+
+    {
+        "UserName": "myuser",
+        "PolicyName": "mypolicy",
+        "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": [
+                        "s3:PutObject",
+                        "s3:PutObjectAcl"
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::mybucket/*"
+                    ],
+                    "Effect": "Allow",
+                    "Sid": "Stmt1234567891234"
+                }
+            ]
+        }
+    }
+
 **Granting permissions for an S3 object**
 
 The following ``cp`` command illustrates the use of the ``--grants`` option to grant read access to all users and full


### PR DESCRIPTION
Also updated one of the ``s3 cp`` examples using the
``--acl`` option to show an example policy.

Closes #813.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 