### PR TITLE
Add back support for CloudFormation estimate-template-cost

### DIFF
--- a/awscli/customizations/removals.py
+++ b/awscli/customizations/removals.py
@@ -32,8 +32,6 @@ def register_removals(event_handler):
                                         'verify-email-address'])
     cmd_remover.remove(on_event='building-command-table.ec2',
                        remove_commands=['import-instance', 'import-volume'])
-    cmd_remover.remove(on_event='building-command-table.cloudformation',
-                       remove_commands=['estimate-template-cost'])
     cmd_remover.remove(on_event='building-command-table.emr',
                        remove_commands=['run-job-flow', 'describe-job-flows',
                                         'add-job-flow-steps',

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -214,12 +214,6 @@ class TestRemoveDeprecatedCommands(BaseAWSHelpOutputTest):
         self.assert_command_does_not_exist(
             'ec2', 'import-volume')
 
-    def test_cloudformation(self):
-        self.driver.main(['cloudformation', 'help'])
-        self.assert_not_contains('estimate-template-cost')
-        self.assert_command_does_not_exist(
-            'cloudformation', 'estimate-template-cost')
-
     def test_boolean_param_documented(self):
         self.driver.main(['autoscaling',
                           'terminate-instance-in-auto-scaling-group', 'help'])


### PR DESCRIPTION
Example:

```
aws cloudformation estimate-template-cost --template-url https://s3-us-west-2.amazonaws.com/cloudformation-templates-us-west-2/AutoScalingRollingUpdates.template --parameters ParameterKey=KeyName,ParameterValue=b --query Url --output text
```

Result

```
http://calculator.s3.amazonaws.com/calc5.html?key=cloudformation/b7d2a78f-fedd-4ae1-80d2-0e430ef727d7
```