### PR TITLE
Adding better utime error messages.

### DIFF
--- a/awscli/customizations/s3/executor.py
+++ b/awscli/customizations/s3/executor.py
@@ -16,7 +16,7 @@ import sys
 import threading
 
 from awscli.customizations.s3.utils import uni_print, bytes_print, \
-    IORequest, IOCloseRequest, StablePriorityQueue
+    IORequest, IOCloseRequest, StablePriorityQueue, set_file_utime
 from awscli.customizations.s3.tasks import OrderableTask
 from awscli.compat import queue
 
@@ -181,8 +181,7 @@ class IOWriterThread(threading.Thread):
             fileobj.close()
             del self.fd_descriptor_cache[task.filename]
         if task.desired_mtime is not None:
-            os.utime(task.filename, (task.desired_mtime,
-                                     task.desired_mtime))
+            set_file_utime(task.filename, task.desired_mtime)
 
     def _handle_stream_task(self, data):
         fileobj = sys.stdout

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -11,7 +11,7 @@ from dateutil.tz import tzlocal
 
 from botocore.compat import quote
 from awscli.customizations.s3.utils import find_bucket_key, \
-    uni_print, guess_content_type, MD5Error, bytes_print
+    uni_print, guess_content_type, MD5Error, bytes_print, set_file_utime
 
 
 LOGGER = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ def save_file(filename, response_data, last_update, is_stream=False):
     if not is_stream:
         last_update_tuple = last_update.timetuple()
         mod_timestamp = time.mktime(last_update_tuple)
-        os.utime(filename, (int(mod_timestamp), int(mod_timestamp)))
+        set_file_utime(filename, int(mod_timestamp))
     else:
         # Now write the output to stdout since the md5 is correct.
         bytes_print(payload)

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -353,6 +353,30 @@ def relative_path(filename, start=os.path.curdir):
         return os.path.abspath(filename)
 
 
+def set_file_utime(filename, desired_time):
+    """
+    Set the utime of a file, and if it fails, raise a more explicit error.
+
+    :param filename: the file to modify
+    :param desired_time: the epoch timestamp to set for atime and mtime.
+    :raises: SetFileUtimeError: if you do not have permission (errno 1)
+    :raises: OSError: for all errors other than errno 1
+    """
+    try:
+        os.utime(filename, (desired_time, desired_time))
+    except OSError as e:
+        # Only raise a more explicit exception when errno is 1
+        if e.errno is not 1:
+            raise e
+        raise SetFileUtimeError(
+            ("The file was downloaded, but attempting to modify the "
+             "utime of the file failed. Is the file owned by another user?"))
+
+
+class SetFileUtimeError(Exception):
+    pass
+
+
 class ReadFileChunk(object):
     def __init__(self, filename, start_byte, size):
         self._filename = filename

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -15,6 +15,7 @@ from datetime import datetime
 import mimetypes
 import hashlib
 import math
+import errno
 import os
 import sys
 from collections import namedtuple, deque
@@ -365,8 +366,8 @@ def set_file_utime(filename, desired_time):
     try:
         os.utime(filename, (desired_time, desired_time))
     except OSError as e:
-        # Only raise a more explicit exception when errno is 1
-        if e.errno is not 1:
+        # Only raise a more explicit exception when it is a permission issue.
+        if e.errno != errno.EPERM:
             raise e
         raise SetFileUtimeError(
             ("The file was downloaded, but attempting to modify the "


### PR DESCRIPTION
This commit updates the s3 commands to give a more descriptive error message when attempting to set the utime of a file fails due to a "1" OS erro number (operation not permitted).

Note that if this error is encountered, the CLI will print the descriptive error message and continue downloading other files until finally exiting with an error.

Closes #1322

@jamesls @kyleknap @rayluo @JordonPhillips 