### PR TITLE
Add backcompat args for argument renames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,15 @@ CHANGELOG
 
 Next Release (TBD)
 ==================
+
 * bugfix:``aws s3``: Fix some local path validation issues
   (`issue 1575 <https://github.com/aws/aws-cli/pull/1575>`__)
+* bugfix:``aws storagegateway``:  Fix ``--tape-ar-ns``,
+  ``--volume-ar-ns``, and ``--vtl-device-ar-ns`` to
+  ``--tape-arns``, ``--volume-arns``, and ``--vtl-device-arns``,
+  respectively.  The old arguments are still supported for backwards
+  compatibility, but are no longer documented.
+  (`issue 1599 <https://github.com/aws/aws-cli/pull/1599>`__)
 
 
 1.9.1

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -44,12 +44,30 @@ ARGUMENT_RENAMES = {
     'codepipeline.delete-custom-action-type.version': 'action-version',
 }
 
+# Same format as ARGUMENT_RENAMES, but instead of renaming the arguments,
+# an alias is created to the original arugment and marked as undocumented.
+# This is useful when you need to change the name of an argument but you
+# still need to support the old argument.
+HIDDEN_ALIASES = {
+    'cognito-identity.create-identity-pool.open-id-connect-provider-arns':
+        'open-id-connect-provider-ar-ns',
+    'storagegateway.describe-tapes.tape-arns': 'tape-ar-ns',
+    'storagegateway.describe-tape-archives.tape-arns': 'tape-ar-ns',
+    'storagegateway.describe-vtl-devices.vtl-device-arns': 'vtl-device-ar-ns',
+    'storagegateway.describe-cached-iscsi-volumes.volume-arns': 'volume-ar-ns',
+    'storagegateway.describe-stored-iscsi-volumes.volume-arns': 'volume-ar-ns',
+}
+
 
 def register_arg_renames(cli):
     for original, new_name in ARGUMENT_RENAMES.items():
         event_portion, original_arg_name = original.rsplit('.', 1)
         cli.register('building-argument-table.%s' % event_portion,
                      rename_arg(original_arg_name, new_name))
+    for original, new_name in HIDDEN_ALIASES.items():
+        event_portion, original_arg_name = original.rsplit('.', 1)
+        cli.register('building-argument-table.%s' % event_portion,
+                     hidden_alias(original_arg_name, new_name))
 
 
 def rename_arg(original_arg_name, new_name):
@@ -57,3 +75,10 @@ def rename_arg(original_arg_name, new_name):
         if original_arg_name in argument_table:
             utils.rename_argument(argument_table, original_arg_name, new_name)
     return _rename_arg
+
+
+def hidden_alias(original_arg_name, alias_name):
+    def _alias_arg(argument_table, **kwargs):
+        if original_arg_name in argument_table:
+            utils.make_hidden_alias(argument_table, original_arg_name, alias_name)
+    return _alias_arg

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -14,6 +14,7 @@
 Utility functions to make it easier to work with customizations.
 
 """
+import copy
 
 from botocore.exceptions import ClientError
 
@@ -23,6 +24,25 @@ def rename_argument(argument_table, existing_name, new_name):
     argument_table[new_name] = current
     current.name = new_name
     del argument_table[existing_name]
+
+
+def make_hidden_alias(argument_table, existing_name, alias_name):
+    """Create a hidden alias for an existing argument.
+
+    This will copy an existing argument object in an arg table,
+    and add a new entry to the arg table with a different name.
+    The new argument will also be undocumented.
+
+    This is needed if you want to check an existing argument,
+    but you still need the other one to work for backwards
+    compatibility reasons.
+
+    """
+    current = argument_table[existing_name]
+    copy_arg = copy.copy(current)
+    copy_arg._UNDOCUMENTED = True
+    copy_arg.name = alias_name
+    argument_table[alias_name] = copy_arg
 
 
 def rename_command(command_table, existing_name, new_name):

--- a/tests/functional/cognito_identity/__init__.py
+++ b/tests/functional/cognito_identity/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/cognito_identity/test_create_identity_pool.py
+++ b/tests/functional/cognito_identity/test_create_identity_pool.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateIdentityPool(BaseAWSCommandParamsTest):
+
+    PREFIX = 'cognito-identity create-identity-pool'
+
+    def test_accepts_old_argname(self):
+        cmdline = (
+            self.PREFIX + ' --identity-pool-name foo '
+            '--allow-unauthenticated-identities ' +
+            '--open-id-connect-provider-ar-ns aaaabbbbccccddddeeee'
+        )
+        params = {
+            'AllowUnauthenticatedIdentities': True,
+            'IdentityPoolName': 'foo',
+            'OpenIdConnectProviderARNs': ['aaaabbbbccccddddeeee']
+        }
+        self.assert_params_for_cmd(cmdline, params)
+
+    def test_accepts_fixed_param_name(self):
+        cmdline = (
+            self.PREFIX + ' --identity-pool-name foo '
+            '--allow-unauthenticated-identities ' +
+            '--open-id-connect-provider-arns aaaabbbbccccddddeeee'
+        )
+        params = {
+            'AllowUnauthenticatedIdentities': True,
+            'IdentityPoolName': 'foo',
+            'OpenIdConnectProviderARNs': ['aaaabbbbccccddddeeee']
+        }
+        self.assert_params_for_cmd(cmdline, params)

--- a/tests/functional/storagegateway/__init__.py
+++ b/tests/functional/storagegateway/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/storagegateway/test_describe_tapes.py
+++ b/tests/functional/storagegateway/test_describe_tapes.py
@@ -1,0 +1,42 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestDescribeTapes(BaseAWSCommandParamsTest):
+
+    PREFIX = 'storagegateway describe-tapes'
+
+    def test_accepts_old_argname(self):
+        foo_arn = 'a' * 50
+        bar_arn = 'b' * 50
+        cmdline = (
+            self.PREFIX + ' --gateway-arn %s --tape-ar-ns %s'
+        ) % (foo_arn, bar_arn)
+        params = {
+            'GatewayARN': foo_arn,
+            'TapeARNs': [bar_arn],
+        }
+        self.assert_params_for_cmd(cmdline, params)
+
+    def test_accepts_fixed_param_name(self):
+        foo_arn = 'a' * 50
+        bar_arn = 'b' * 50
+        cmdline = (
+            self.PREFIX + ' --gateway-arn %s --tape-arns %s'
+        ) % (foo_arn, bar_arn)
+        params = {
+            'GatewayARN': foo_arn,
+            'TapeARNs': [bar_arn],
+        }
+        self.assert_params_for_cmd(cmdline, params)

--- a/tests/unit/customizations/test_argrename.py
+++ b/tests/unit/customizations/test_argrename.py
@@ -1,0 +1,45 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.customizations import argrename
+from awscli.customizations import arguments
+
+from botocore import model
+
+
+class TestArgumenManipulations(unittest.TestCase):
+    def setUp(self):
+        self.argument_table = {}
+
+    def test_can_rename_argument(self):
+        arg = arguments.CustomArgument('foo')
+        self.argument_table['foo'] = arg
+        handler = argrename.rename_arg('foo', 'bar')
+        handler(self.argument_table)
+
+        self.assertIn('bar', self.argument_table)
+        self.assertNotIn('foo', self.argument_table)
+        self.assertEqual(arg.name, 'bar')
+
+    def test_can_alias_an_argument(self):
+        arg = arguments.CustomArgument(
+            'foo', dest='foo',
+            argument_model=model.Shape('FooArg', {'type': 'string'}))
+        self.argument_table['foo'] = arg
+        handler = argrename.hidden_alias('foo', 'alias-name')
+
+        handler(self.argument_table)
+
+        self.assertIn('alias-name', self.argument_table)
+        self.assertIn('foo', self.argument_table)
+        self.assertEqual(self.argument_table['alias-name'].name, 'alias-name')


### PR DESCRIPTION
In boto/botocore#703, there were some correction made
to the CamelCase->snake_case conversions.

However, in the CLI, we still need to support these arguments.

This fix for this is to:

* Add a copy of the correct arg into the arg table with the
  "wrong" name.
* Mark the "wrong" name entry as undocumented.

There were no unit tests for this module, so I added a few.
I also added some functional tests for some (but not all)
the rename cases, just to ensure the end to end functionality
is working as we expect.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 