### PR TITLE
Apigateway

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Next Release (TBD)
 * bugfix:``aws configservice subscribe``: Fix an issue when creating a
   new S3 bucket
   (`issue 1593 <https://github.com/aws/aws-cli/pull/1593>`__)
+* bugfix:``aws apigateway put-integration``: Fix issue with
+  ``--uri`` and ``--integration-http-method`` parameters
+  (`issue 1605 <https://github.com/aws/aws-cli/issues/1605>`_)
 
 
 1.9.1

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # refers to an actual URI of some sort and we don't want to actually
 # download the content (i.e TemplateURL in cloudformation).
 PARAMFILE_DISABLED = set([
+    'apigateway.put-integration.uri',
     'cloudformation.create-stack.template-url',
     'cloudformation.update-stack.template-url',
     'cloudformation.validate-template.template-url',

--- a/tests/functional/apigateway/__init__.py
+++ b/tests/functional/apigateway/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/apigateway/test_put_integration.py
+++ b/tests/functional/apigateway/test_put_integration.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestPutIntegration(BaseAWSCommandParamsTest):
+
+    prefix = 'apigateway put-integration '
+
+    def test_stack_policy_during_update_url(self):
+        cmdline = self.prefix
+        cmdline += '--rest-api-id api-id '
+        cmdline += '--resource-id resource-id '
+        cmdline += '--http-method GET '
+        cmdline += '--type HTTP '
+        cmdline += '--integration-http-method GET '
+        cmdline += '--uri https://api.endpoint.com'
+        result = {
+            'restApiId': 'api-id', 'resourceId': 'resource-id',
+            'httpMethod': 'GET', 'type': 'HTTP',
+            'integrationHttpMethod': 'GET',
+            'uri': 'https://api.endpoint.com'
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/apigateway/test_put_integration.py
+++ b/tests/functional/apigateway/test_put_integration.py
@@ -17,7 +17,7 @@ class TestPutIntegration(BaseAWSCommandParamsTest):
 
     prefix = 'apigateway put-integration '
 
-    def test_stack_policy_during_update_url(self):
+    def test_put_integration(self):
         cmdline = self.prefix
         cmdline += '--rest-api-id api-id '
         cmdline += '--resource-id resource-id '


### PR DESCRIPTION
Fix an issue with ``--uri`` not being black-listed. Noticed it when writing integration tests in this [file](https://github.com/kyleknap/botocore/blob/apigateway-fix/tests/integration/test_apigateway.py)

cc @jamesls @mtdowling @rayluo @JordonPhillips 