### PR TITLE
Changes to create a DataPipeline CLI create-default-roles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+* feature:``aws datapipeline create-default-roles``: Creates default IAM
+  roles for creating EMR clusters.
+  (`issue 1616 <https://github.com/aws/aws-cli/pull/1616>`__)
+
+
 1.9.3
 =====
 * feature:``aws iam``: Add support for resource-level policy simulation

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -5,6 +5,8 @@ from datetime import datetime, timedelta
 from awscli.arguments import CustomArgument
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.datapipeline import translator
+from awscli.customizations.datapipeline.createdefaultroles \
+    import CreateDefaultRoles
 
 
 DEFINITION_HELP_TEXT = """\
@@ -45,7 +47,6 @@ class ParameterDefinitionError(Exception):
         super(ParameterDefinitionError, self).__init__(full_msg)
         self.msg = msg
 
-
 def register_customizations(cli):
     cli.register(
         'building-argument-table.datapipeline.put-pipeline-definition',
@@ -66,6 +67,7 @@ def register_customizations(cli):
 
 def register_commands(command_table, session, **kwargs):
     command_table['list-runs'] = ListRunsCommand(session)
+    command_table['create-default-roles'] = CreateDefaultRoles(session)
 
 
 def document_translation(help_command, **kwargs):

--- a/awscli/customizations/datapipeline/constants.py
+++ b/awscli/customizations/datapipeline/constants.py
@@ -1,0 +1,52 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# Declare all the constants used by DataPipeline in this file
+
+# DataPipeline role names
+DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME = "DataPipelineDefaultRole"
+DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME = "DataPipelineDefaultResourceRole"
+
+# DataPipeline role arn names
+DATAPIPELINE_DEFAULT_SERVICE_ROLE_ARN = ("arn:aws:iam::aws:policy/"
+                                         "service-role/AWSDataPipelineRole")
+DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ARN = ("arn:aws:iam::aws:policy/"
+                                          "service-role/"
+                                          "AmazonEC2RoleforDataPipelineRole")
+
+# Assume Role Policy definitions for roles
+DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY = {
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {"Service": "ec2.amazonaws.com"},
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+
+DATAPIPELINE_DEFAULT_SERVICE_ROLE_ASSUME_POLICY = {
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {"Service": ["datapipeline.amazonaws.com",
+                                      "elasticmapreduce.amazonaws.com"]
+                          },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}

--- a/awscli/customizations/datapipeline/createdefaultroles.py
+++ b/awscli/customizations/datapipeline/createdefaultroles.py
@@ -1,0 +1,212 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+# Class to create default roles for datapipeline
+
+import logging
+from awscli.customizations.datapipeline.constants \
+    import DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME, \
+    DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME, \
+    DATAPIPELINE_DEFAULT_SERVICE_ROLE_ARN, \
+    DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ARN, \
+    DATAPIPELINE_DEFAULT_SERVICE_ROLE_ASSUME_POLICY, \
+    DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.datapipeline.translator \
+    import display_response, dict_to_string, get_region
+from botocore.exceptions import ClientError
+
+LOG = logging.getLogger(__name__)
+
+
+class CreateDefaultRoles(BasicCommand):
+
+    NAME = "create-default-roles"
+    DESCRIPTION = ('Creates the default IAM role ' +
+                   DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME + ' and ' +
+                   DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME +
+                   '\n which are used while creating an EMR cluster. '
+                   '\nIf the roles do not exist, create-default-roles '
+                   'will automatically create them and set their policies.'
+                   '\nIf these roles are already '
+                   'created create-default-roles'
+                   'will not update their policies.'
+                   '\n')
+
+    def __init__(self, session, formatter=None):
+        super(CreateDefaultRoles, self).__init__(session)
+
+    def _run_main(self, parsed_args, parsed_globals, **kwargs):
+        """Call to run the commands"""
+        self._region = get_region(self._session, parsed_globals)
+        self._endpoint_url = parsed_globals.endpoint_url
+        self._iam_client = self._session.create_client(
+            'iam', self._region, self._endpoint_url,
+            parsed_globals.verify_ssl)
+        return self._create_default_roles(parsed_args, parsed_globals)
+
+    def _create_role(self, role_name, role_arn, role_policy):
+        """Method to create a role for a given role name and arn
+        if it does not exist
+        """
+
+        role_result = None
+        role_policy_result = None
+        # Check if the role with the name exists
+        if self._check_if_role_exists(role_name):
+            LOG.debug('Role ' + role_name + ' exists.')
+        else:
+            LOG.debug('Role ' + role_name + ' does not exist.'
+                      ' Creating default role for EC2: ' + role_name)
+            # Create a create using the IAM Client with a particular triplet
+            # (role_name, role_arn, assume_role_policy)
+            role_result = self._create_role_with_role_policy(role_name,
+                                                             role_policy,
+                                                             role_arn)
+            role_policy_result = self._get_role_policy(role_arn)
+        return role_result, role_policy_result
+
+    def _construct_result(self, dpl_default_result,
+                          dpl_default_policy,
+                          dpl_default_res_result,
+                          dpl_default_res_policy):
+        """Method to create a resultant list of responses for create roles
+        for service and resource role
+        """
+
+        result = []
+        self._construct_role_and_role_policy_structure(result,
+                                                       dpl_default_result,
+                                                       dpl_default_policy)
+        self._construct_role_and_role_policy_structure(result,
+                                                       dpl_default_res_result,
+                                                       dpl_default_res_policy)
+        return result
+
+    def _create_default_roles(self, parsed_args, parsed_globals):
+
+        # Setting the role name and arn value
+        (datapipline_default_result,
+            datapipline_default_policy) = self._create_role(
+                DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME,
+                DATAPIPELINE_DEFAULT_SERVICE_ROLE_ARN,
+                DATAPIPELINE_DEFAULT_SERVICE_ROLE_ASSUME_POLICY)
+
+        (datapipline_default_resource_result,
+            datapipline_default_resource_policy) = self._create_role(
+                DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME,
+                DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ARN,
+                DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY)
+
+        # Check if the default EC2 Instance Profile for DataPipeline exists.
+        instance_profile_name = DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME
+        if self._check_if_instance_profile_exists(instance_profile_name):
+            LOG.debug('Instance Profile ' + instance_profile_name + ' exists.')
+        else:
+            LOG.debug('Instance Profile ' + instance_profile_name +
+                      'does not exist. Creating default Instance Profile ' +
+                      instance_profile_name)
+            self._create_instance_profile_with_role(instance_profile_name,
+                                                    instance_profile_name)
+
+        result = self._construct_result(datapipline_default_result,
+                                        datapipline_default_policy,
+                                        datapipline_default_resource_result,
+                                        datapipline_default_resource_policy)
+
+        display_response(self._session, 'create_role', result, parsed_globals)
+
+        return 0
+
+    def _get_role_policy(self, arn):
+        """Method to get the Policy for a particular ARN
+        This is used to display the policy contents to the user
+        """
+        pol_det = self._iam_client.get_policy(PolicyArn=arn)
+        policy_version_details = self._iam_client.get_policy_version(
+            PolicyArn=arn, VersionId=pol_det["Policy"]["DefaultVersionId"])
+        return policy_version_details["PolicyVersion"]["Document"]
+
+    def _create_role_with_role_policy(
+            self, role_name, assume_role_policy, role_arn):
+        """Method to create role with a given rolename, assume_role_policy
+        and role_arn
+        """
+        # Create a role using IAM client CreateRole API
+        create_role_response = self._iam_client.create_role(
+            RoleName=role_name, AssumeRolePolicyDocument=dict_to_string(
+                assume_role_policy))
+
+        # Create a role using IAM client AttachRolePolicy API
+        self._iam_client.attach_role_policy(PolicyArn=role_arn,
+                                            RoleName=role_name)
+
+        return create_role_response
+
+    def _construct_role_and_role_policy_structure(
+            self, list_val, response, policy):
+        """Method to construct the message to be displayed to the user"""
+        # If the response is not none they we get the role name
+        # from the response and
+        # append the policy information to the response
+        if response is not None and response['Role'] is not None:
+            list_val.append({'Role': response['Role'], 'RolePolicy': policy})
+            return list_val
+
+    def _check_if_instance_profile_exists(self, instance_profile_name):
+        """Method to verify if a particular role exists"""
+        try:
+            # Client call to get the instance profile with that name
+            self._iam_client.get_instance_profile(
+                InstanceProfileName=instance_profile_name)
+
+        except ClientError as e:
+            # If the instance profile does not exist then the error message
+            # would contain the required message
+            if e.response['Error']['Code'] == 'NoSuchEntity':
+                # No instance profile error.
+                return False
+            else:
+                # Some other error. raise.
+                raise e
+
+        return True
+
+    def _check_if_role_exists(self, role_name):
+        """Method to verify if a particular role exists"""
+        try:
+            # Client call to get the role
+            self._iam_client.get_role(RoleName=role_name)
+        except ClientError as e:
+            # If the role does not exist then the error message
+            # would contain the required message.
+            if e.response['Error']['Code'] == 'NoSuchEntity':
+                # No role error.
+                return False
+            else:
+                # Some other error. raise.
+                raise e
+
+        return True
+
+    def _create_instance_profile_with_role(self, instance_profile_name,
+                                           role_name):
+        """Method to create the instance profile with the role"""
+        # Setting the value for instance profile name
+        # Client call to create an instance profile
+        self._iam_client.create_instance_profile(
+            InstanceProfileName=instance_profile_name)
+
+        # Adding the role to the Instance Profile
+        self._iam_client.add_role_to_instance_profile(
+            InstanceProfileName=instance_profile_name, RoleName=role_name)

--- a/awscli/customizations/datapipeline/translator.py
+++ b/awscli/customizations/datapipeline/translator.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
+from awscli.clidriver import CLIOperationCaller
 
 
 class PipelineDefinitionError(Exception):
@@ -20,6 +21,29 @@ class PipelineDefinitionError(Exception):
         super(PipelineDefinitionError, self).__init__(full_msg)
         self.msg = msg
         self.definition = definition
+
+
+# Method to convert the dictionary input to a string
+# This is required for escaping
+def dict_to_string(dictionary, indent=2):
+    return json.dumps(dictionary, indent=indent)
+
+
+# Method to parse the arguments to get the region value
+def get_region(session, parsed_globals):
+    region = parsed_globals.region
+    if region is None:
+        region = session.get_config_variable('region')
+    return region
+
+
+# Method to display the response for a particular CLI operation
+def display_response(session, operation_name, result, parsed_globals):
+    cli_operation_caller = CLIOperationCaller(session)
+    # Calling a private method. Should be changed after the functionality
+    # is moved outside CliOperationCaller.
+    cli_operation_caller._display_response(
+        operation_name, result, parsed_globals)
 
 
 def api_to_definition(definition):

--- a/tests/unit/customizations/datapipeline/test_create_default_role.py
+++ b/tests/unit/customizations/datapipeline/test_create_default_role.py
@@ -1,0 +1,181 @@
+import mock
+import awscli.customizations.datapipeline.createdefaultroles \
+    as createdefaultroles
+from awscli.customizations.datapipeline.constants\
+    import DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME,\
+    DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME,\
+    DATAPIPELINE_DEFAULT_SERVICE_ROLE_ASSUME_POLICY,\
+    DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY
+
+from awscli.testutils import BaseAWSCommandParamsTest,\
+    unittest
+from awscli.customizations.datapipeline.translator import dict_to_string
+from botocore.compat import json
+
+
+class TestCreateDefaultRole(BaseAWSCommandParamsTest):
+    prefix = 'datapipeline create-default-roles'
+
+    DATAPIPELINE_ROLE_POLICY = {
+        "Statement": [
+            {
+                "Action": [
+                    "cloudwatch:*",
+                    "dynamodb:*",
+                    "ec2:Describe*",
+                    "elasticmapreduce:Describe*",
+                    "rds:Describe*",
+                    "s3:*",
+                    "sdb:*",
+                    "sns:*",
+                    "sqs:*"
+                    ],
+                "Effect": "Allow",
+                "Resource": ["*"]
+                }
+            ]
+    }
+
+    CREATE_DATAPIPELINE_ROLE_RESULT = {
+        "Role":  {
+            "AssumeRolePolicyDocument": {
+                "Version": "2008-10-17",
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRole",
+                        "Sid": "",
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": "ec2.amazonaws.com"
+                        }
+                    }
+                ]
+            },
+            "RoleId": "AROAJG7O4RNNSRINMF6DI",
+            "CreateDate": "2014-05-01T23:47:14.552Z",
+            "RoleName": DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME,
+            "Path": "/",
+            "Arn": "arn:aws:iam::176430881729:role/" +
+                    DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME
+        }
+    }
+
+    CONSTRUCTED_RESULT_OUTPUT = [
+        {
+            "Role": CREATE_DATAPIPELINE_ROLE_RESULT['Role'],
+            "RolePolicy": DATAPIPELINE_ROLE_POLICY
+        }
+    ]
+
+    # Use case: Default roles exists
+    # Expected results: No Operation performed for creation, except calls made
+    # for verifying existence of roles
+    def test_default_roles_exist(self):
+        cmdline = self.prefix
+
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 3)
+
+        self.assertEqual(self.operations_called[0][0].name, 'GetRole')
+        self.assertEqual(self.operations_called[0][1]['RoleName'],
+                         DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME)
+
+    # Use case: Default roles do not exist
+    # Expected results: Operations are performed by the client to verify
+    # existence of roles and then creation of roles (Service role,
+    # resource role and instance profile)
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._construct_result')
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._check_if_role_exists')
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._check_if_instance_profile_exists')
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._get_role_policy')
+    def test_default_roles_not_exist(self, get_rp_patch,
+                                     role_exists_patch,
+                                     instance_profile_exists_patch,
+                                     construct_result_patch):
+        get_rp_patch.return_value = False
+        instance_profile_exists_patch.return_value = False
+        role_exists_patch.return_value = False
+        construct_result_patch.return_value = []
+
+        self.run_cmd(self.prefix, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 6)
+
+        self.assertEqual(self.operations_called[0][0].name, 'CreateRole')
+        self.assertEqual(self.operations_called[0][1]['RoleName'],
+                         DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME)
+        self.assertEqual(
+            self.operations_called[0][1]['AssumeRolePolicyDocument'],
+            dict_to_string(DATAPIPELINE_DEFAULT_SERVICE_ROLE_ASSUME_POLICY))
+
+        self.assertEqual(self.operations_called[1][0].name,
+                         'AttachRolePolicy')
+        self.assertEqual(self.operations_called[1][1]['PolicyArn'],
+                         (createdefaultroles.
+                          DATAPIPELINE_DEFAULT_SERVICE_ROLE_ARN))
+        self.assertEqual(self.operations_called[1][1]['RoleName'],
+                         DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME)
+
+        self.assertEqual(self.operations_called[2][0].name, 'CreateRole')
+        self.assertEqual(self.operations_called[2][1]['RoleName'],
+                         DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME)
+        self.assertEqual(
+            self.operations_called[2][1]['AssumeRolePolicyDocument'],
+            dict_to_string(DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY))
+
+        self.assertEqual(self.operations_called[3][0].name, 'AttachRolePolicy')
+        self.assertEqual(self.operations_called[3][1]['PolicyArn'],
+                         (createdefaultroles.
+                          DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ARN))
+        self.assertEqual(self.operations_called[3][1]['RoleName'],
+                         DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME)
+
+        self.assertEqual(self.operations_called[4][0].name,
+                         'CreateInstanceProfile')
+        self.assertEqual(self.operations_called[4][1]['InstanceProfileName'],
+                         DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME)
+
+        self.assertEqual(self.operations_called[5][0].name,
+                         'AddRoleToInstanceProfile')
+        self.assertEqual(self.operations_called[5][1]['InstanceProfileName'],
+                         DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME)
+        self.assertEqual(self.operations_called[5][1]['RoleName'],
+                         DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME)
+
+    # Use case: Creating only DataPipeline service role
+    # Expected output: The service role is created displaying a message
+    # to the customer that a particular role with a policy has been created
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._get_role_policy')
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._create_role_with_role_policy')
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._check_if_instance_profile_exists')
+    @mock.patch('awscli.customizations.datapipeline.'
+                'CreateDefaultRoles._check_if_role_exists')
+    def test_constructed_result(self, role_exists_patch,
+                                instance_profile_exists_patch,
+                                create_role_patch,
+                                get_role_policy_patch):
+        role_exists_patch.side_effect = self.toggle_for_check_if_exists
+        instance_profile_exists_patch.return_value = True
+        create_role_patch.return_value = self.CREATE_DATAPIPELINE_ROLE_RESULT
+        get_role_policy_patch.return_value = self.DATAPIPELINE_ROLE_POLICY
+
+        result = self.run_cmd(self.prefix, 0)
+        expected_output = json.dumps(self.CONSTRUCTED_RESULT_OUTPUT,
+                                     indent=4) + '\n'
+        self.assertEquals(result[0], expected_output)
+
+    def toggle_for_check_if_exists(self, *args):
+        if args[0] == DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME:
+            return False
+        else:
+            return True
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This would create DataPipelineDefaultRole and
DataPipelineDefaultResourceRole in IAM for the account.

cc @jamesls @mtdowling @rayluo @JordonPhillips 