### PR TITLE
Don't print tracebacks on Ctrl-C

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
+import signal
 import logging
 
 import botocore.session
@@ -197,6 +198,12 @@ class CLIDriver(object):
                    '"aws configure".' % e)
             self._show_error(msg)
             return 255
+        except KeyboardInterrupt:
+            # Shell standard for signals that terminate
+            # the process is to return 128 + signum, in this case
+            # SIGINT=2, so we'll have an RC of 130.
+            sys.stdout.write("\n")
+            return 128 + signal.SIGINT
         except Exception as e:
             LOG.debug("Exception caught in main()", exc_info=True)
             LOG.debug("Exiting with rc 255")

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -31,6 +31,7 @@ from awscli.clidocs import TopicDocumentEventHandler
 from awscli.argprocess import ParamShorthand
 from awscli.argparser import ArgTableArgParser
 from awscli.topictags import TopicTagDB
+from awscli.utils import ignore_ctrl_c
 
 
 LOG = logging.getLogger('awscli.help')
@@ -110,6 +111,24 @@ class PosixHelpRenderer(PagingHelpRenderer):
         p3 = self._popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         groff_output = p3.communicate(input=man_contents)[0]
         return groff_output
+
+    def _send_output_to_pager(self, output):
+        cmdline = self.get_pager_cmdline()
+        LOG.debug("Running command: %s", cmdline)
+        with ignore_ctrl_c():
+            # We can't rely on the KeyboardInterrupt from
+            # the CLIDriver being caught because when we
+            # send the output to a pager it will use various
+            # control characters that need to be cleaned
+            # up gracefully.  Otherwise if we simply catch
+            # the Ctrl-C and exit, it will likely leave the
+            # users terminals in a bad state and they'll need
+            # to manually run ``reset`` to fix this issue.
+            # Ignoring Ctrl-C solves this issue.  It's also
+            # the default behavior of less (you can't ctrl-c
+            # out of a manpage).
+            p = self._popen(cmdline, stdin=PIPE)
+            p.communicate(input=output)
 
     def _exists_on_path(self, name):
         # Since we're only dealing with POSIX systems, we can

--- a/awscli/topics/return-codes.rst
+++ b/awscli/topics/return-codes.rst
@@ -29,6 +29,8 @@ of a CLI command:
   block special device, FIFO's, or sockets, and files that the user cannot
   read from.
 
+* ``130`` -- The process received a SIGINT (Ctrl-C).
+
 * ``255`` -- Command failed. There were errors thrown by either the CLI or
   by the service the request was made to.
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -11,7 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import csv
+import signal
 import datetime
+import contextlib
 
 from awscli.compat import six
 
@@ -115,3 +117,10 @@ def json_encoder(obj):
         return obj
 
 
+@contextlib.contextmanager
+def ignore_ctrl_c():
+    original = signal.signal(signal.SIGINT, signal.SIG_IGN)
+    try:
+        yield
+    finally:
+        signal.signal(signal.SIGINT, original)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -261,7 +261,7 @@ class TestCliDriver(unittest.TestCase):
         expected = {'log_level': logging.ERROR, 'logger_name': 'awscli'}
         self.assertEqual(driver.session.stream_logger_args[1], expected)
 
-    def test_ctrl_s_is_handled(self):
+    def test_ctrl_c_is_handled(self):
         driver = CLIDriver(session=self.session)
         fake_client = mock.Mock()
         fake_client.list_objects.side_effect = KeyboardInterrupt

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -261,6 +261,15 @@ class TestCliDriver(unittest.TestCase):
         expected = {'log_level': logging.ERROR, 'logger_name': 'awscli'}
         self.assertEqual(driver.session.stream_logger_args[1], expected)
 
+    def test_ctrl_s_is_handled(self):
+        driver = CLIDriver(session=self.session)
+        fake_client = mock.Mock()
+        fake_client.list_objects.side_effect = KeyboardInterrupt
+        fake_client.can_paginate.return_value = False
+        driver.session.create_client = mock.Mock(return_value=fake_client)
+        rc = driver.main('s3 list-objects --bucket foo'.split())
+        self.assertEqual(rc, 130)
+
 
 class TestCliDriverHooks(unittest.TestCase):
     # These tests verify the proper hooks are emitted in clidriver.

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -132,9 +132,11 @@ class TestHelpPager(unittest.TestCase):
                 return 'less' in args[0]
 
         renderer = CtrlCRenderer()
-        renderer.mock_popen.communicate.return_value = ('rendered', '')
+        renderer.mock_popen.communicate.return_value = ('send to pager', '')
         renderer.exists_on_path['groff'] = True
         renderer.render('foo')
+        last_call = renderer.mock_popen.communicate.call_args_list[-1]
+        self.assertEqual(last_call, mock.call(input='send to pager'))
 
 
 class TestHelpCommandBase(unittest.TestCase):

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest, FileCreator
 import signal
+import platform
 import json
 import sys
 import os
@@ -118,6 +119,8 @@ class TestHelpPager(unittest.TestCase):
         renderer.render('foo')
         self.assertEqual(renderer.popen_calls[-1][0], (['more'],))
 
+    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
+                    "Ctrl-C not valid on windows.")
     def test_can_handle_ctrl_c(self):
         class CtrlCRenderer(FakePosixHelpRenderer):
             def _popen(self, *args, **kwargs):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import signal
+import platform
 import os
 
 from awscli.testutils import unittest
@@ -90,6 +91,8 @@ class TestCSVSplit(unittest.TestCase):
                          ['foo', 'bar=foo,*[biz]*,baz'])
 
 
+@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
+                 "Ctrl-C not valid on windows.")
 class TestIgnoreCtrlC(unittest.TestCase):
     def test_ctrl_c_is_ignored(self):
         with ignore_ctrl_c():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,9 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest
+import signal
+import os
 
-from awscli.utils import split_on_commas
+from awscli.testutils import unittest
+from awscli.utils import split_on_commas, ignore_ctrl_c
 
 
 class TestCSVSplit(unittest.TestCase):
@@ -86,3 +88,13 @@ class TestCSVSplit(unittest.TestCase):
     def test_end_bracket_in_value(self):
         self.assertEqual(split_on_commas('foo,bar=[foo,*[biz]*,baz]'),
                          ['foo', 'bar=foo,*[biz]*,baz'])
+
+
+class TestIgnoreCtrlC(unittest.TestCase):
+    def test_ctrl_c_is_ignored(self):
+        with ignore_ctrl_c():
+            # Should have the noop signal handler installed.
+            self.assertEqual(signal.getsignal(signal.SIGINT), signal.SIG_IGN)
+            # And if we actually try to sigint ourselves, an exception
+            # should not propogate.
+            os.kill(os.getpid(), signal.SIGINT)


### PR DESCRIPTION
This adds two new changes:

* Ctrl-C by the user does not print a traceback.  We just exit the process with a 130 RC
* Ctrl-C is ignored when piping help output to a pager.  This is needed so we avoid putting the terminal in a bad state if we immediately exit on a ctrl-c.  It's also consistent with the behavior of `man somecommand`, `git commit --help`, etc.


cc @kyleknap @mtdowling @rayluo @JordonPhillips 