### PR TITLE
Switch test code over to skip_if_windows

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -81,6 +81,22 @@ INTEG_LOG = logging.getLogger('awscli.tests.integration')
 AWS_CMD = None
 
 
+def skip_if_windows(reason):
+    """Decorator to skip tests that should not be run on windows.
+
+    Example usage:
+
+        @skip_if_windows("Not valid")
+        def test_some_non_windows_stuff(self):
+            self.assertEqual(...)
+
+    """
+    def decorator(func):
+        return unittest.skipIf(
+            platform.system() not in ['Darwin', 'Linux'], reason)(func)
+    return decorator
+
+
 def create_clidriver():
     driver = awscli.clidriver.create_clidriver()
     session = driver.session

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -34,6 +34,7 @@ from awscli.compat import six
 from nose.plugins.attrib import attr
 
 from awscli.testutils import unittest, get_stdout_encoding
+from awscli.testutils import skip_if_windows
 from awscli.testutils import aws as _aws
 from awscli.testutils import BaseS3CLICommand
 from tests.integration.customizations.s3 import create_bucket as _create_bucket
@@ -221,8 +222,7 @@ class TestMoveCommand(BaseS3CLICommand):
 
 
 class TestRm(BaseS3CLICommand):
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'Newline in filename test not valid on windows.')
+    @skip_if_windows('Newline in filename test not valid on windows.')
     # Windows won't let you do this.  You'll get:
     # [Errno 22] invalid mode ('w') or filename:
     # 'c:\\windows\\temp\\tmp0fv8uu\\foo\r.txt'
@@ -341,8 +341,7 @@ class TestCp(BaseS3CLICommand):
                          len(foo_contents.getvalue()))
 
     @attr('slow')
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'SIGINT not supported on Windows.')
+    @skip_if_windows('SIGINT not supported on Windows.')
     def test_download_ctrl_c_does_not_hang(self):
         bucket_name = self.create_bucket()
         foo_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 20))
@@ -784,8 +783,7 @@ class TestWarnings(BaseS3CLICommand):
         self.assertIn('The user-provided path %s does not exist.' %
                       filename, p.stderr)
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'Read permissions tests only supported on mac/linux')
+    @skip_if_windows('Read permissions tests only supported on mac/linux')
     def test_no_read_access(self):
         if os.geteuid() == 0:
             self.skipTest('Cannot completely remove read access as root user.')
@@ -800,8 +798,7 @@ class TestWarnings(BaseS3CLICommand):
         self.assertIn('warning: Skipping file %s. File/Directory is '
                       'not readable.' % filename, p.stderr)
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'Special files only supported on mac/linux')
+    @skip_if_windows('Special files only supported on mac/linux')
     def test_is_special_file(self):
         file_path = os.path.join(self.files.rootdir, 'foo')
         # Use socket for special file.
@@ -814,8 +811,7 @@ class TestWarnings(BaseS3CLICommand):
                        "socket." % file_path), p.stderr)
 
 
-@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                 'Symlink tests only supported on mac/linux')
+@skip_if_windows('Symlink tests only supported on mac/linux')
 class TestSymlinks(BaseS3CLICommand):
     """
     This class test the ability to follow or not follow symlinks.
@@ -1203,8 +1199,7 @@ class TestDryrun(BaseS3CLICommand):
             "argument was not obeyed.")
 
 
-@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                 'Memory tests only supported on mac/linux')
+@skip_if_windows('Memory tests only supported on mac/linux')
 class TestMemoryUtilization(BaseS3CLICommand):
     # These tests verify the memory utilization and growth are what we expect.
     def extra_setup(self):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -20,6 +20,7 @@ import shutil
 import botocore.session
 from awscli.testutils import unittest, aws, BaseS3CLICommand
 from awscli.testutils import temporary_file
+from awscli.testutils import skip_if_windows
 from awscli.clidriver import create_clidriver
 
 
@@ -354,6 +355,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         p = aws('ec2 describe-instances', env_vars=environ)
         self.assertIn('must specify a region', p.stderr)
 
+    @skip_if_windows('Ctrl-C not supported on windows.')
     def test_ctrl_c_does_not_print_traceback(self):
         # Relying on the fact that this generally takes
         # more than 1 second to complete.

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -13,6 +13,7 @@
 import os
 import platform
 from awscli.testutils import unittest, FileCreator, BaseAWSCommandParamsTest
+from awscli.testutils import skip_if_windows
 import stat
 import tempfile
 import shutil
@@ -29,8 +30,7 @@ from tests.unit.customizations.s3 import make_loc_files, clean_loc_files, \
     compare_files
 
 
-@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                 'Special files only supported on mac/linux')
+@skip_if_windows('Special files only supported on mac/linux')
 class TestIsSpecialFile(unittest.TestCase):
     def setUp(self):
         self.files = FileCreator()
@@ -158,8 +158,7 @@ class LocalFileGeneratorTest(unittest.TestCase):
             compare_files(self, result_list[i], ref_list[i])
 
 
-@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                 'Symlink tests only supported on mac/linux')
+@skip_if_windows('Symlink tests only supported on mac/linux')
 class TestIgnoreFilesLocally(unittest.TestCase):
     """
     This class tests the ability to ignore particular files.  This includes
@@ -251,8 +250,7 @@ class TestThrowsWarning(unittest.TestCase):
                          ("warning: Skipping file %s. File/Directory is "
                           "not readable." % full_path))
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'Special files only supported on mac/linux')
+    @skip_if_windows('Special files only supported on mac/linux')
     def test_is_special_file_warning(self):
         file_gen = FileGenerator(self.client, '', False)
         file_path = os.path.join(self.files.rootdir, 'foo')
@@ -268,8 +266,7 @@ class TestThrowsWarning(unittest.TestCase):
                           "socket." % file_path))
 
 
-@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                 'Symlink tests only supported on mac/linux')
+@skip_if_windows('Symlink tests only supported on mac/linux')
 class TestSymlinksIgnoreFiles(unittest.TestCase):
     """
     This class tests the ability to list out the correct local files

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -21,7 +21,7 @@ from botocore.hooks import HierarchicalEmitter
 from botocore.exceptions import PartialCredentialsError
 from dateutil.tz import tzlocal
 
-from awscli.testutils import unittest
+from awscli.testutils import unittest, skip_if_windows
 from awscli.customizations import assumerole
 
 
@@ -400,8 +400,7 @@ class TestJSONCache(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.cache['foo']
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'File permissions tests not supported on Windows.')
+    @skip_if_windows('File permissions tests not supported on Windows.')
     def test_permissions_for_file_restricted(self):
         self.cache['mykey'] = {'foo': 'bar'}
         filename = os.path.join(self.tempdir, 'mykey.json')

--- a/tests/unit/customizations/test_configure.py
+++ b/tests/unit/customizations/test_configure.py
@@ -21,7 +21,7 @@ import mock
 from six import StringIO
 
 from awscli.customizations import configure
-from awscli.testutils import unittest
+from awscli.testutils import unittest, skip_if_windows
 
 
 class PrecannedPrompter(object):
@@ -419,8 +419,7 @@ class TestConfigFileWriter(unittest.TestCase):
             new_contents = f.read()
         self.assertEqual(new_contents, '[default]\nfoo = value\n')
 
-    @unittest.skipIf(sys.platform.lower().startswith('win'),
-                     "Test not valid on windows.")
+    @skip_if_windows("Test not valid on windows.")
     def test_permissions_on_new_file(self):
         self.writer.update_config({'foo': 'value'}, self.config_filename)
         with open(self.config_filename, 'r') as f:

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -18,6 +18,7 @@ from awscli.compat import six
 from awscli.formatter import JSONFormatter
 
 from awscli.testutils import BaseAWSCommandParamsTest, unittest
+from awscli.testutils import skip_if_windows
 from awscli.compat import get_stdout_text_writer
 
 
@@ -101,8 +102,7 @@ class TestListUsers(BaseAWSCommandParamsTest):
         self.environ['AWS_DEFAULT_OUTPUT'] = 'bad-output-type'
         self.run_cmd('iam list-users', expected_rc=255)
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                    'Encoding tests only supported on mac/linux')
+    @skip_if_windows('Encoding tests only supported on mac/linux')
     def test_json_prints_unicode_chars(self):
         self.parsed_response['Users'][1]['UserId'] = u'\u2713'
         output = self.run_cmd('iam list-users', expected_rc=0)[0]

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest, FileCreator
+from awscli.testutils import unittest, skip_if_windows, FileCreator
 import signal
 import platform
 import json
@@ -92,7 +92,7 @@ class TestHelpPager(unittest.TestCase):
         self.assertEqual(self.renderer.get_pager_cmdline(),
                          pager_cmd.split())
 
-    @unittest.skipIf(sys.platform.startswith('win'), "requires posix system")
+    @skip_if_windows('Requires posix system.')
     def test_no_groff_exists(self):
         renderer = FakePosixHelpRenderer()
         renderer.exists_on_path['groff'] = False
@@ -119,8 +119,7 @@ class TestHelpPager(unittest.TestCase):
         renderer.render('foo')
         self.assertEqual(renderer.popen_calls[-1][0], (['more'],))
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                    "Ctrl-C not valid on windows.")
+    @skip_if_windows("Ctrl-C not valid on windows.")
     def test_can_handle_ctrl_c(self):
         class CtrlCRenderer(FakePosixHelpRenderer):
             def _popen(self, *args, **kwargs):

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -15,6 +15,7 @@ import platform
 import mock
 from awscli.compat import six
 from awscli.testutils import unittest, FileCreator
+from awscli.testutils import skip_if_windows
 
 from awscli.paramfile import get_paramfile, ResourceLoadingError
 
@@ -42,9 +43,8 @@ class TestParamFile(unittest.TestCase):
         self.assertEqual(data, b'This is a test')
         self.assertIsInstance(data, six.binary_type)
 
-    @unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                     'Binary content error only occurs on '
-                     'non-Windows platforms.')
+    @skip_if_windows('Binary content error only occurs '
+                     'on non-Windows platforms.')
     def test_cannot_load_text_file(self):
         contents = b'\xbfX\xac\xbe'
         filename = self.files.create_file('foo', contents, mode='wb')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,7 +14,7 @@ import signal
 import platform
 import os
 
-from awscli.testutils import unittest
+from awscli.testutils import unittest, skip_if_windows
 from awscli.utils import split_on_commas, ignore_ctrl_c
 
 
@@ -91,8 +91,7 @@ class TestCSVSplit(unittest.TestCase):
                          ['foo', 'bar=foo,*[biz]*,baz'])
 
 
-@unittest.skipIf(platform.system() not in ['Darwin', 'Linux'],
-                 "Ctrl-C not valid on windows.")
+@skip_if_windows("Ctrl-C not supported on windows.")
 class TestIgnoreCtrlC(unittest.TestCase):
     def test_ctrl_c_is_ignored(self):
         with ignore_ctrl_c():


### PR DESCRIPTION
This fixes an issue with test_cli, where a test needed
to be annotated to be skipped on windows but was missed.

I've also added a test utility function for this and I've
updated all the existing skippable tests to use this decorator.
This also makes is easier in the future if we need to update
what qualifies as "not windows."

cc @kyleknap @mtdowling @rayluo @JordonPhillips 