### PR TITLE
Adding IoT command args to save keys and certs

### DIFF
--- a/awscli/customizations/iot.py
+++ b/awscli/customizations/iot.py
@@ -1,0 +1,52 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+This customization makes it easier to save various pieces of data
+returned from iot commands that would typically need to be saved to a
+file. This customization adds the following options:
+
+- aws iot create-certificate-from-csr
+  - ``--certificate-pem-outfile``: certificatePem
+- aws iot create-keys-and-certificate
+  - ``--certificate-pem-outfile``: certificatePem
+  - ``--public-key-outfile``: keyPair.PublicKey
+  - ``--private-key-outfile``: keyPair.PrivateKey
+"""
+from awscli.customizations.arguments import QueryOutFileArgument
+
+
+def register_create_keys_and_cert_arguments(session, argument_table, **kwargs):
+    """Add outfile save arguments to create-keys-and-certificate
+
+    - ``--certificate-pem-outfile``
+    - ``--public-key-outfile``
+    - ``--private-key-outfile``
+    """
+    after_event = 'after-call.iot.CreateKeysAndCertificate'
+    argument_table['certificate-pem-outfile'] = QueryOutFileArgument(
+        session=session, name='certificate-pem-outfile',
+        query='certificatePem', after_call_event=after_event)
+    argument_table['public-key-outfile'] = QueryOutFileArgument(
+        session=session, name='public-key-outfile', query='keyPair.PublicKey',
+        after_call_event=after_event)
+    argument_table['private-key-outfile'] = QueryOutFileArgument(
+        session=session, name='private-key-outfile',
+        query='keyPair.PrivateKey', after_call_event=after_event)
+
+
+def register_create_keys_from_csr_arguments(session, argument_table, **kwargs):
+    """Add certificate-pem-outfile to create-certificate-from-csr"""
+    argument_table['certificate-pem-outfile'] = QueryOutFileArgument(
+        session=session, name='certificate-pem-outfile',
+        query='certificatePem',
+        after_call_event='after-call.iot.CreateCertificateFromCsr')

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -66,6 +66,8 @@ from awscli.customizations.kms import register_fix_kms_create_grant_docs
 from awscli.customizations.route53 import register_create_hosted_zone_doc_fix
 from awscli.customizations.codecommit import initialize as codecommit_init
 from awscli.customizations.iot_data import register_custom_endpoint_note
+from awscli.customizations.iot import register_create_keys_and_cert_arguments
+from awscli.customizations.iot import register_create_keys_from_csr_arguments
 
 
 def awscli_initialize(event_handlers):
@@ -132,3 +134,9 @@ def awscli_initialize(event_handlers):
     register_modify_put_configuration_recorder(event_handlers)
     codecommit_init(event_handlers)
     register_custom_endpoint_note(event_handlers)
+    event_handlers.register(
+        'building-argument-table.iot.create-keys-and-certificate',
+        register_create_keys_and_cert_arguments)
+    event_handlers.register(
+        'building-argument-table.iot.create-certificate-from-csr',
+        register_create_keys_from_csr_arguments)

--- a/tests/functional/iam/test_create_virtual_mfa_device.py
+++ b/tests/functional/iam/test_create_virtual_mfa_device.py
@@ -22,6 +22,10 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
     def setUp(self):
         super(TestCreateVirtualMFADevice, self).setUp()
         self.parsed_response = {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+                'RequestId': 'requset-id'
+            },
             "VirtualMFADevice": {
                 "Base32StringSeed": (
                     "VFpYTVc2V1lIUFlFRFczSVhLUlpRUTJRVFdUSFRNRDNTQ0c3"

--- a/tests/functional/iot/__init__.py
+++ b/tests/functional/iot/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/iot/test_outfile.py
+++ b/tests/functional/iot/test_outfile.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+import os
+
+
+class TestOutFileQueryArguments(BaseAWSCommandParamsTest):
+    def setUp(self):
+        self.files = FileCreator()
+        super(TestOutFileQueryArguments, self).setUp()
+
+    def tearDown(self):
+        self.files.remove_all()
+        super(TestOutFileQueryArguments, self).tearDown()
+
+    def test_saves_cert_to_file_for_create_certificate_from_csr(self):
+        self.parsed_response = {
+            'certificatePem': 'cert...',
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+                'RequestId': 'request-id'
+            }
+        }
+        outfile = self.files.full_path('cert.pem')
+        cmdline = 'iot create-certificate-from-csr'
+        cmdline += ' --certificate-signing-request "abc"'
+        cmdline += ' --certificate-pem-outfile ' + outfile
+        self.run_cmd(cmdline, 0)
+        self.assertTrue(os.path.exists(outfile))
+        with open(outfile) as fp:
+            self.assertEquals('cert...', fp.read())
+
+    def test_saves_files_for_create_keys_and_cert(self):
+        self.parsed_response = {
+            'certificatePem': 'cert...',
+            'keyPair': {
+                'PublicKey': 'public',
+                'PrivateKey': 'private'
+            },
+            'ResponseMetadata': {
+                'HTTPStatusCode': 200,
+                'RequestId': 'request-id'
+            }
+        }
+        out_cert = self.files.full_path('cert.pem')
+        out_pub = self.files.full_path('key_rsa.pub')
+        out_priv = self.files.full_path('key_rsa')
+        cmdline = 'iot create-keys-and-certificate'
+        cmdline += ' --certificate-pem-outfile ' + out_cert
+        cmdline += ' --public-key-outfile ' + out_pub
+        cmdline += ' --private-key-outfile ' + out_priv
+        self.run_cmd(cmdline, 0)
+        self.assertTrue(os.path.exists(out_cert))
+        self.assertTrue(os.path.exists(out_pub))
+        self.assertTrue(os.path.exists(out_priv))
+        with open(out_cert) as fp:
+            self.assertEquals('cert...', fp.read())
+        with open(out_pub) as fp:
+            self.assertEquals('public', fp.read())
+        with open(out_priv) as fp:
+            self.assertEquals('private', fp.read())
+
+    def test_bad_response(self):
+        outfile = self.files.full_path('cert.pem')
+        self.parsed_response = {
+            'Error': {'Code': 'v1', 'Message': 'v2', 'Type': 'v3'},
+            'ResponseMetadata': {
+                'HTTPStatusCode': 403,
+                'RequestId': 'request-id'
+            }
+        }
+        self.http_response.status_code = 403
+        cmdline = 'iot create-certificate-from-csr'
+        cmdline += ' --certificate-signing-request "abc"'
+        cmdline += ' --certificate-pem-outfile ' + outfile
+        # The error message should be in the stderr.
+        self.assert_params_for_cmd(
+            cmdline,
+            stderr_contains=self.parsed_response['Error']['Message'],
+            expected_rc=255)
+
+    def test_ensures_file_is_writable_before_sending(self):
+        outfile = os.sep.join(['', 'does', 'not', 'exist_', 'file.txt'])
+        self.parsed_response = {}
+        cmdline = 'iot create-certificate-from-csr'
+        cmdline += ' --certificate-signing-request "abc"'
+        cmdline += ' --certificate-pem-outfile ' + outfile
+        self.assert_params_for_cmd(
+            cmdline,
+            stderr_contains='Unable to write to file: ',
+            expected_rc=255)

--- a/tests/unit/customizations/test_arguments.py
+++ b/tests/unit/customizations/test_arguments.py
@@ -10,10 +10,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import mock
 
-from awscli.testutils import unittest
+from awscli.testutils import unittest, FileCreator
 from awscli.customizations.arguments import OverrideRequiredArgsArgument
+from awscli.customizations.arguments import StatefulArgument
+from awscli.customizations.arguments import QueryOutFileArgument
+from awscli.customizations.arguments import resolve_given_outfile_path
+from awscli.customizations.arguments import is_parsed_result_successful
 
 
 class TestOverrideRequiredArgsArgument(unittest.TestCase):
@@ -43,3 +48,95 @@ class TestOverrideRequiredArgsArgument(unittest.TestCase):
         args = []
         self.argument.override_required_args(self.argument_table, args)
         self.assertTrue(self.mock_arg.required)
+
+
+class TestStatefulArgument(unittest.TestCase):
+    def test_persists_value_when_added_to_params(self):
+        self.session = mock.Mock()
+        arg = StatefulArgument('test')
+        arg.add_to_params({}, 'foo')
+        self.assertEqual('foo', arg.value)
+
+
+class TestArgumentHelpers(unittest.TestCase):
+    def setUp(self):
+        self.files = FileCreator()
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    def test_only_validates_filename_when_set(self):
+        resolve_given_outfile_path(None)
+
+    def test_works_with_valid_filename(self):
+        filename = self.files.create_file('valid', '')
+        self.assertEquals(filename, resolve_given_outfile_path(filename))
+
+    def test_works_with_relative_filename(self):
+        filename = '../valid'
+        self.assertEquals(filename, resolve_given_outfile_path(filename))
+
+    def test_raises_when_cannot_write_to_file(self):
+        filename = os.sep.join(['_path', 'not', '_exist_', 'file.xyz'])
+        with self.assertRaises(ValueError):
+            resolve_given_outfile_path(filename)
+
+    def test_checks_if_valid_result(self):
+        result = {'ResponseMetadata': {'HTTPStatusCode': 200}}
+        self.assertTrue(is_parsed_result_successful(result))
+
+    def test_checks_if_invalid_result(self):
+        result = {'ResponseMetadata': {'HTTPStatusCode': 300}}
+        self.assertFalse(is_parsed_result_successful(result))
+
+
+class TestQueryFileArgument(unittest.TestCase):
+    def setUp(self):
+        self.files = FileCreator()
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    def test_proxies_to_super_ctor(self):
+        session = mock.Mock()
+        arg = QueryOutFileArgument(session, 'foo', 'bar.baz', 'event')
+        self.assertEqual('foo', arg.name)
+        self.assertEqual('bar.baz', arg.query)
+
+    def test_adds_default_help_text(self):
+        session = mock.Mock()
+        arg = QueryOutFileArgument(session, 'foo', 'bar.baz', 'event')
+        self.assertEqual(('Saves the command output contents of bar.baz '
+                          'to the given filename'), arg.documentation)
+
+    def test_does_not_add_help_text_if_set(self):
+        session = mock.Mock()
+        arg = QueryOutFileArgument(session, 'foo', 'bar.baz', 'event',
+                                   help_text='abc')
+        self.assertEqual('abc', arg.documentation)
+
+    def test_saves_query_to_file(self):
+        outfile = self.files.create_file('not-empty-test', '')
+        session = mock.Mock()
+        arg = QueryOutFileArgument(session, 'foo', 'baz', 'event')
+        arg.add_to_params({}, outfile)
+        arg.save_query({'ResponseMetadata': {'HTTPStatusCode': 200},
+                        'baz': 'abc123'})
+        with open(outfile) as fp:
+            self.assertEquals('abc123', fp.read())
+        self.assertEquals(1, session.register.call_count)
+        session.register.assert_called_with('event', arg.save_query)
+
+    def test_does_not_save_when_not_set(self):
+        session = mock.Mock()
+        QueryOutFileArgument(session, 'foo', 'baz', 'event')
+        self.assertEquals(0, session.register.call_count)
+
+    def test_saves_query_to_file_as_empty_string_when_none_result(self):
+        outfile = self.files.create_file('none-test', '')
+        session = mock.Mock()
+        arg = QueryOutFileArgument(session, 'foo', 'baz', 'event')
+        arg.add_to_params({}, outfile)
+        arg.save_query({'ResponseMetadata': {'HTTPStatusCode': 200}})
+        with open(outfile) as fp:
+            self.assertEquals('', fp.read())


### PR DESCRIPTION
This customization makes it easier to save various pieces of data
returned from iot commands that would typically need to be saved to a
file. This customization adds the following options:

- aws iot create-certificate-from-csr
  - --certificate-pem-outfile: certificatePem
- aws iot create-keys-and-certificate
  - --certificate-pem-outfile: certificatePem
  - --public-key-outfile: keyPair.PublicKey
  - --private-key-outfile: keyPair.PrivateKey

@jamesls @kyleknap @JordonPhillips @rayluo 