### PR TITLE
Add read timeout argument

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -21,6 +21,7 @@ from botocore import xform_name
 from botocore.compat import copy_kwargs, OrderedDict
 from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import NoRegionError
+from botocore.client import Config
 
 from awscli import EnvironmentVariables, __version__
 from awscli.formatter import get_formatter
@@ -141,7 +142,8 @@ class CLIDriver(object):
             default=option_params.get('default'),
             action=option_params.get('action'),
             required=option_params.get('required'),
-            choices=option_params.get('choices'))
+            choices=option_params.get('choices'),
+            cli_type_name=option_params.get('type'))
 
     def create_help_command(self):
         cli_data = self._get_cli_data()
@@ -656,10 +658,15 @@ class CLIOperationCaller(object):
             value is returned.
 
         """
+        if parsed_globals.read_timeout is not None:
+            config = Config(read_timeout=parsed_globals.read_timeout)
+        else:
+            config = Config()
         client = self._session.create_client(
             service_name, region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
-            verify=parsed_globals.verify_ssl)
+            verify=parsed_globals.verify_ssl,
+            config=config)
         py_operation_name = xform_name(operation_name)
         if client.can_paginate(py_operation_name) and parsed_globals.paginate:
             paginator = client.get_paginator(py_operation_name)

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -23,6 +23,7 @@ def register_parse_global_args(cli):
     cli.register('top-level-args-parsed', resolve_types)
     cli.register('top-level-args-parsed', no_sign_request)
     cli.register('top-level-args-parsed', resolve_verify_ssl)
+    cli.register('top-level-args-parsed', resolve_cli_read_timeout)
 
 
 def resolve_types(parsed_args, **kwargs):
@@ -77,3 +78,11 @@ def no_sign_request(parsed_args, session, **kwargs):
         # In order to make signing disabled for all requests
         # we need to use botocore's ``disable_signing()`` handler.
         session.register('choose-signer', disable_signing)
+
+
+def resolve_cli_read_timeout(parsed_args, session, **kwargs):
+    arg_name = 'read_timeout'
+    arg_value = getattr(parsed_args, arg_name, None)
+
+    if arg_value is not None:
+        setattr(parsed_args, arg_name, int(arg_value))

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -52,8 +52,13 @@
             "help": "<p>Do not sign requests.  Credentials will not be loaded if this argument is provided.</p>"
         },
         "ca-bundle": {
-                "dest": "ca_bundle",
-                "help": "<p>The CA certificate bundle to use when verifying SSL certificates. Overrides config/env settings.</p>"
+            "dest": "ca_bundle",
+            "help": "<p>The CA certificate bundle to use when verifying SSL certificates. Overrides config/env settings.</p>"
+        },
+        "cli-read-timeout": {
+            "dest": "read_timeout",
+            "type": "int",
+            "help": "<p>The maximum socket read time in seconds.</p>"
         }
     }
 }

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -193,3 +193,9 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         globalargs.resolve_types(parsed_args)
         self.assertEqual(parsed_args.endpoint_url,
                          'http://custom-endpoint.com')
+
+    def test_cli_read_timeout(self):
+        parsed_args = FakeParsedArgs(read_timeout='60')
+        session = mock.Mock()
+        globalargs.resolve_cli_read_timeout(parsed_args, session)
+        self.assertEqual(parsed_args.read_timeout, 60)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -80,6 +80,10 @@ GET_DATA = {
                 "type": "int",
                 "help": "",
             },
+            "read-timeout": {
+                "type": "int",
+                "help": ""
+            }
         }
     },
 }
@@ -678,6 +682,13 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
         call_args = self.create_endpoint.call_args
         self.assertEqual(call_args[0], (mock.ANY, 'us-east-1'))
         self.assertEqual(call_args[1]['verify'], '/path/cacert.pem')
+
+    def test_aws_with_read_timeout(self):
+        self.assert_params_for_cmd(
+            'lambda invoke --function-name foo out.log --cli-read-timeout 90',
+            expected_rc=0)
+        call_args = self.create_endpoint.call_args
+        self.assertEqual(call_args[1]['timeout'][1], 90)
 
 
 class TestHTTPParamFileDoesNotExist(BaseAWSCommandParamsTest):

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -25,7 +25,8 @@ LOG = logging.getLogger(__name__)
 
 GLOBALOPTS = ['--debug', '--endpoint-url', '--no-verify-ssl', '--no-paginate',
               '--output', '--profile', '--region', '--version', '--color',
-              '--query', '--no-sign-request', '--ca-bundle']
+              '--query', '--no-sign-request', '--ca-bundle',
+              '--cli-read-timeout']
 
 COMPLETIONS = [
     ('aws ', -1, set(['apigateway', 'autoscaling', 'cloudformation', 'cloudfront',
@@ -72,7 +73,7 @@ COMPLETIONS = [
           '--no-verify-ssl', '--no-paginate', '--no-sign-request', '--output',
           '--profile', '--starting-token', '--max-items', '--page-size',
           '--region', '--version', '--color', '--query', '--ca-bundle',
-          '--generate-cli-skeleton', '--cli-input-json'])),
+          '--generate-cli-skeleton', '--cli-input-json', '--cli-read-timeout'])),
     ('aws s3', -1, set(['cp', 'mv', 'rm', 'mb', 'rb', 'ls', 'sync', 'website'])),
     ('aws s3 m', -1, set(['mv', 'mb'])),
     ('aws s3 cp -', -1, set(['--no-guess-mime-type', '--dryrun',


### PR DESCRIPTION
This will set the socket read timeout on the default client, enabling calls to long Lambda functions. It is called with `--cli-read-timeout` which takes the timeout in seconds.