### PR TITLE
Make . a valid character key for shorthand

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+Next Release (TBD)
+==================
+* bugfix:shorthand: Allow ``.`` as a valid key character.
+  (`issue 1628 <https://github.com/aws/aws-cli/pull/1628>`__)
+
+
 1.9.5
 =====
 * bugfix:``aws help``: Gracefully handle Ctrl-C interrupts.

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -162,8 +162,8 @@ class ShorthandParser(object):
         return {key: values}
 
     def _key(self):
-        # key = 1*(alpha / %x30-39 / %x5f)  ; [a-zA-Z0-9\-_]
-        valid_chars = string.ascii_letters + string.digits + '-_'
+        # key = 1*(alpha / %x30-39 / %x5f / %x2e)  ; [a-zA-Z0-9\-_.]
+        valid_chars = string.ascii_letters + string.digits + '-_.'
         start = self._index
         while not self._at_eof():
             if self._current() not in valid_chars:

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -53,6 +53,9 @@ def test_parse():
     # Underscore are also allowed.
     yield (_can_parse, 'with_underscore=bar', {'with_underscore': 'bar'})
 
+    # Dots are allowed.
+    yield (_can_parse, 'with.dot=bar', {'with.dot': 'bar'})
+
     # Explicit lists.
     yield (_can_parse, 'foo=[]', {'foo': []})
     yield (_can_parse, 'foo=[a]', {'foo': ['a']})


### PR DESCRIPTION
I know we had discussions about making the ``.`` part of the shorthand syntax. This changes will prevent us from using it in a backward compatible way. But is needed for the shorthand syntax to be supported for this elasticsearch operation:
http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-configuration-api.html#es-configuration-api-actions-updateelasticsearchdomainconfig

However, I think we decided we are not going to include ``.`` in the syntax because it does not really simplify/condense the syntax. I just wanted to make sure everyone was aware of this.

Fixes https://github.com/aws/aws-cli/issues/1615

cc @jamesls @mtdowling @rayluo @JordonPhillips 