### PR TITLE
Support "-no-verify-ssl" for opsworks register command

### DIFF
--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -131,6 +131,8 @@ class OpsWorksRegister(BasicCommand):
             endpoint_args['region_name'] = parsed_globals.region
         if 'endpoint_url' in parsed_globals:
             endpoint_args['endpoint_url'] = parsed_globals.endpoint_url
+        if 'verify_ssl' in parsed_globals:
+            endpoint_args['verify'] = parsed_globals.verify_ssl
         self.iam = self._session.create_client('iam')
         self.opsworks = self._session.create_client(
             'opsworks', **endpoint_args)

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -83,6 +83,23 @@ class TestOpsWorksRegister(TestOpsWorksBase):
             mock.call("opsworks", endpoint_url="http://xxx/"),
         ])
 
+    def test_create_clients_with_verify_ssl(self):
+        """Should pass verify-ssl to OpsWorks, but not to IAM clients."""
+
+        self.register._create_clients(
+            self._build_args(), argparse.Namespace(verify_ssl=False))
+        self.mock_session.create_client.assert_has_calls([
+            mock.call("iam"),
+            mock.call("opsworks", verify=False),
+        ])
+
+        self.register._create_clients(
+            self._build_args(), argparse.Namespace(verify_ssl="/path/to/ca"))
+        self.mock_session.create_client.assert_has_calls([
+            mock.call("iam"),
+            mock.call("opsworks", verify="/path/to/ca"),
+        ])
+
     @mock.patch.object(opsworks, "platform")
     def test_prevalidate_arguments_invalid_hostnames(self, mock_platform):
         """Should only accept valid hostnames."""


### PR DESCRIPTION
Add support "-no-verify-ssl" for opsworks register command. 

Unit passed. Rebuild and test locally looks good.

```
awscli.customizations.opsworks - DEBUG - Retrieving stack and provisioning parameters
botocore.endpoint - DEBUG - Making request for <botocore.model.OperationModel object at 0x7f119957bad0> (verify_ssl=False) with params:
```