### PR TITLE
Making preview text more clear.

### DIFF
--- a/awscli/customizations/preview.py
+++ b/awscli/customizations/preview.py
@@ -126,7 +126,8 @@ class PreviewModeCommandMixin(object):
         aws configure set preview.{service} true
 
     """)
-    HELP_SNIPPET = "This service is only available as a preview service.\n"
+    HELP_SNIPPET = ("AWS CLI support for this service is only "
+                    "available in a preview stage.\n")
 
     def __init__(self, *args, **kwargs):
         self._is_enabled = kwargs.pop('is_enabled')


### PR DESCRIPTION
The purpose of this change is to communicate more clearly that preview
services are in a preview state in the CLI and not necessarily a service
that is marked as preview (or pre-GA).