### PR TITLE
Add messaging on how to enable sigv4 for s3

### DIFF
--- a/awscli/customizations/s3errormsg.py
+++ b/awscli/customizations/s3errormsg.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 """Give better S3 error messages.
 """
-from awscli.customizations import utils
 
 
 REGION_ERROR_MSG = (
@@ -21,6 +20,11 @@ REGION_ERROR_MSG = (
     'environment variable, or the region variable in the AWS CLI '
     "configuration file.  You can get the bucket's location by "
     'running "aws s3api get-bucket-location --bucket BUCKET".'
+)
+
+ENABLE_SIGV4_MSG = (
+    ' You can enable AWS Signature Version 4 by running the command: \n'
+    'aws configure set s3.signature_version s3v4'
 )
 
 
@@ -45,6 +49,8 @@ def enhance_error_msg(parsed, **kwargs):
         new_message = message[:-1] + ': %s\n' % endpoint
         new_message += REGION_ERROR_MSG
         parsed['Error']['Message'] = new_message
+    elif _is_kms_sigv4_error_message(parsed):
+        parsed['Error']['Message'] += ENABLE_SIGV4_MSG
 
 
 def _is_sigv4_error_message(parsed):
@@ -54,3 +60,8 @@ def _is_sigv4_error_message(parsed):
 
 def _is_permanent_redirect_message(parsed):
     return parsed.get('Error', {}).get('Code', '') == 'PermanentRedirect'
+
+
+def _is_kms_sigv4_error_message(parsed):
+    return ('AWS KMS managed keys require AWS Signature Version 4' in
+            parsed.get('Error', {}).get('Message', ''))

--- a/tests/unit/customizations/test_s3errormsg.py
+++ b/tests/unit/customizations/test_s3errormsg.py
@@ -46,6 +46,23 @@ class TestGetRegionFromEndpoint(unittest.TestCase):
         error_message = parsed['Error']['Message']
         self.assertIn('myendpoint', error_message)
 
+    def test_kms_sigv4_error_message(self):
+        parsed = {
+            'Error': {
+                'Message': (
+                    'Requests specifying Server Side Encryption with '
+                    'AWS KMS managed keys require AWS Signature Version 4.')
+            }
+        }
+        s3errormsg.enhance_error_msg(parsed)
+        # We should say how you enable it.
+        self.assertIn('You can enable AWS Signature Version 4',
+                      parsed['Error']['Message'])
+        # We should mention the command that needs to be run.
+        self.assertIn(
+            'aws configure set s3.signature_version s3v4',
+            parsed['Error']['Message'])
+
     def test_error_message_not_enhanced(self):
         parsed = {
             'Error': {


### PR DESCRIPTION
Now the error will now look like this:
```
$ aws s3 cp s3://mybucketfoo/foo foo
download failed: s3://mybucketfoo/foo to ./foo A client error (InvalidArgument) occurred when calling the GetObject operation: Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4. You can enable AWS Signature Version 4 by running the command: 
aws configure set s3.signature_version s3v4
```
Was brought up in discussion of this PR: https://github.com/aws/aws-cli/pull/1623

cc @jamesls @mtdowling @rayluo @JordonPhillips 