### PR TITLE
Add integration tests for #1646 (permission issues on local files)

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -260,8 +260,9 @@ class S3Handler(object):
         chunksize = find_chunksize(filename.size, self.chunksize)
         num_downloads = int(filename.size / chunksize)
         context = tasks.MultipartDownloadContext(num_downloads)
-        create_file_task = tasks.CreateLocalFileTask(context=context,
-                                                     filename=filename)
+        create_file_task = tasks.CreateLocalFileTask(
+            context=context, filename=filename,
+            result_queue=self.result_queue)
         self.executor.submit(create_file_task)
         self._do_enqueue_range_download_tasks(
             filename=filename, chunksize=chunksize,

--- a/tests/unit/customizations/s3/test_tasks.py
+++ b/tests/unit/customizations/s3/test_tasks.py
@@ -35,6 +35,7 @@ from awscli.customizations.s3.tasks import print_operation
 from awscli.customizations.s3.tasks import RetriesExeededError
 from awscli.customizations.s3.executor import ShutdownThreadRequest
 from awscli.customizations.s3.utils import StablePriorityQueue
+from awscli.testutils import skip_if_windows
 
 
 class TestMultipartUploadContext(unittest.TestCase):
@@ -352,6 +353,7 @@ class TestCreateLocalFileTask(unittest.TestCase):
         self.context.announce_file_created.assert_called_with()
         self.assertTrue(self.result_queue.empty())
 
+    @skip_if_windows('Read permissions tests only supported on mac/linux')
     def test_cancel_command_on_exception(self):
         # Set destination directory to read-only
         os.chmod(self.tempdir, 444)

--- a/tests/unit/customizations/s3/test_tasks.py
+++ b/tests/unit/customizations/s3/test_tasks.py
@@ -353,10 +353,10 @@ class TestCreateLocalFileTask(unittest.TestCase):
         self.context.announce_file_created.assert_called_with()
         self.assertTrue(self.result_queue.empty())
 
-    @skip_if_windows('Read permissions tests only supported on mac/linux')
+    @skip_if_windows('Write permissions tests only supported on mac/linux')
     def test_cancel_command_on_exception(self):
         # Set destination directory to read-only
-        os.chmod(self.tempdir, 444)
+        os.chmod(self.tempdir, 0o444)
         self.task()
         self.assertFalse(os.path.isfile(self.filename.dest))
         self.context.cancel.assert_called_with()


### PR DESCRIPTION
This PR pulls in #1646 and adds an additional commit that includes integration tests for extra test coverage.  It also shows we have consistent behavior from multipart vs. non-multipart uploads.  Would like a quick review on the integration tests.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 