### PR TITLE
Add more options for configuring timeouts

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -21,7 +21,6 @@ from botocore import xform_name
 from botocore.compat import copy_kwargs, OrderedDict
 from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import NoRegionError
-from botocore.client import Config
 
 from awscli import EnvironmentVariables, __version__
 from awscli.formatter import get_formatter
@@ -658,15 +657,10 @@ class CLIOperationCaller(object):
             value is returned.
 
         """
-        config_kwargs = {}
-        config_kwargs['read_timeout'] = parsed_globals.read_timeout
-        config_kwargs['connect_timeout'] = parsed_globals.connect_timeout
-        config = Config(**config_kwargs)
         client = self._session.create_client(
             service_name, region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
-            verify=parsed_globals.verify_ssl,
-            config=config)
+            verify=parsed_globals.verify_ssl)
         py_operation_name = xform_name(operation_name)
         if client.can_paginate(py_operation_name) and parsed_globals.paginate:
             paginator = client.get_paginator(py_operation_name)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -658,10 +658,12 @@ class CLIOperationCaller(object):
             value is returned.
 
         """
+        config_kwargs = {}
         if parsed_globals.read_timeout is not None:
-            config = Config(read_timeout=parsed_globals.read_timeout)
-        else:
-            config = Config()
+            config_kwargs['read_timeout'] = parsed_globals.read_timeout
+        if parsed_globals.connect_timeout is not None:
+            config_kwargs['connect_timeout'] = parsed_globals.connect_timeout
+        config = Config(**config_kwargs)
         client = self._session.create_client(
             service_name, region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -659,10 +659,8 @@ class CLIOperationCaller(object):
 
         """
         config_kwargs = {}
-        if parsed_globals.read_timeout is not None:
-            config_kwargs['read_timeout'] = parsed_globals.read_timeout
-        if parsed_globals.connect_timeout is not None:
-            config_kwargs['connect_timeout'] = parsed_globals.connect_timeout
+        config_kwargs['read_timeout'] = parsed_globals.read_timeout
+        config_kwargs['connect_timeout'] = parsed_globals.connect_timeout
         config = Config(**config_kwargs)
         client = self._session.create_client(
             service_name, region_name=parsed_globals.region,

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -24,6 +24,7 @@ def register_parse_global_args(cli):
     cli.register('top-level-args-parsed', no_sign_request)
     cli.register('top-level-args-parsed', resolve_verify_ssl)
     cli.register('top-level-args-parsed', resolve_cli_read_timeout)
+    cli.register('top-level-args-parsed', resolve_cli_connect_timeout)
 
 
 def resolve_types(parsed_args, **kwargs):
@@ -80,9 +81,17 @@ def no_sign_request(parsed_args, session, **kwargs):
         session.register('choose-signer', disable_signing)
 
 
+def resolve_cli_connect_timeout(parsed_args, session, **kwargs):
+    arg_name = 'connect_timeout'
+    _resolve_timeout(parsed_args, arg_name)
+
+
 def resolve_cli_read_timeout(parsed_args, session, **kwargs):
     arg_name = 'read_timeout'
-    arg_value = getattr(parsed_args, arg_name, None)
+    _resolve_timeout(parsed_args, arg_name)
 
+
+def _resolve_timeout(parsed_args, arg_name):
+    arg_value = getattr(parsed_args, arg_name, None)
     if arg_value is not None:
         setattr(parsed_args, arg_name, int(arg_value))

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -13,6 +13,7 @@
 import sys
 import os
 
+from botocore.endpoint import DEFAULT_TIMEOUT
 from botocore.handlers import disable_signing
 import jmespath
 
@@ -93,5 +94,9 @@ def resolve_cli_read_timeout(parsed_args, session, **kwargs):
 
 def _resolve_timeout(parsed_args, arg_name):
     arg_value = getattr(parsed_args, arg_name, None)
-    if arg_value is not None:
-        setattr(parsed_args, arg_name, int(arg_value))
+    if arg_value is None:
+        arg_value = DEFAULT_TIMEOUT
+    arg_value = int(arg_value)
+    if arg_value == -1:
+        arg_value = None
+    setattr(parsed_args, arg_name, arg_value)

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -98,7 +98,7 @@ def _resolve_timeout(session, parsed_args, arg_name):
     if arg_value is None:
         arg_value = DEFAULT_TIMEOUT
     arg_value = int(arg_value)
-    if arg_value == -1:
+    if arg_value == 0:
         arg_value = None
     setattr(parsed_args, arg_name, arg_value)
     # Update in the default client config so that the timeout will be used

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -59,6 +59,11 @@
             "dest": "read_timeout",
             "type": "int",
             "help": "<p>The maximum socket read time in seconds.</p>"
+        },
+        "cli-connect-timeout": {
+            "dest": "connect_timeout",
+            "type": "int",
+            "help": "<p>The maximum socket connect time in seconds.</p>"
         }
     }
 }

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -58,12 +58,12 @@
         "cli-read-timeout": {
             "dest": "read_timeout",
             "type": "int",
-            "help": "<p>The maximum socket read time in seconds. If the value is set to -1, the socket read will be blocking and not timeout.</p>"
+            "help": "<p>The maximum socket read time in seconds. If the value is set to 0, the socket read will be blocking and not timeout.</p>"
         },
         "cli-connect-timeout": {
             "dest": "connect_timeout",
             "type": "int",
-            "help": "<p>The maximum socket connect time in seconds. If the value is set to -1, the socket connect will be blocking and not timeout.</p>"
+            "help": "<p>The maximum socket connect time in seconds. If the value is set to 0, the socket connect will be blocking and not timeout.</p>"
         }
     }
 }

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -58,12 +58,12 @@
         "cli-read-timeout": {
             "dest": "read_timeout",
             "type": "int",
-            "help": "<p>The maximum socket read time in seconds.</p>"
+            "help": "<p>The maximum socket read time in seconds. If the value is set to -1, the socket read will be blocking and not timeout.</p>"
         },
         "cli-connect-timeout": {
             "dest": "connect_timeout",
             "type": "int",
-            "help": "<p>The maximum socket connect time in seconds.</p>"
+            "help": "<p>The maximum socket connect time in seconds. If the value is set to -1, the socket connect will be blocking and not timeout.</p>"
         }
     }
 }

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from botocore.session import get_session
 from botocore.handlers import disable_signing
 import os
 
@@ -196,24 +197,32 @@ class TestGlobalArgsCustomization(unittest.TestCase):
 
     def test_cli_read_timeout(self):
         parsed_args = FakeParsedArgs(read_timeout='60')
-        session = mock.Mock()
+        session = get_session()
         globalargs.resolve_cli_read_timeout(parsed_args, session)
         self.assertEqual(parsed_args.read_timeout, 60)
+        self.assertEqual(
+            session.get_default_client_config().read_timeout, 60)
 
     def test_cli_connect_timeout(self):
         parsed_args = FakeParsedArgs(connect_timeout='60')
-        session = mock.Mock()
+        session = get_session()
         globalargs.resolve_cli_connect_timeout(parsed_args, session)
         self.assertEqual(parsed_args.connect_timeout, 60)
+        self.assertEqual(
+            session.get_default_client_config().connect_timeout, 60)
 
     def test_cli_read_timeout_for_blocking(self):
         parsed_args = FakeParsedArgs(read_timeout='-1')
-        session = mock.Mock()
+        session = get_session()
         globalargs.resolve_cli_read_timeout(parsed_args, session)
         self.assertEqual(parsed_args.read_timeout, None)
+        self.assertEqual(
+            session.get_default_client_config().read_timeout, None)
 
     def test_cli_connect_timeout_for_blocking(self):
         parsed_args = FakeParsedArgs(connect_timeout='-1')
-        session = mock.Mock()
+        session = get_session()
         globalargs.resolve_cli_connect_timeout(parsed_args, session)
         self.assertEqual(parsed_args.connect_timeout, None)
+        self.assertEqual(
+            session.get_default_client_config().connect_timeout, None)

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -199,3 +199,9 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         session = mock.Mock()
         globalargs.resolve_cli_read_timeout(parsed_args, session)
         self.assertEqual(parsed_args.read_timeout, 60)
+
+    def test_cli_connect_timeout(self):
+        parsed_args = FakeParsedArgs(connect_timeout='60')
+        session = mock.Mock()
+        globalargs.resolve_cli_connect_timeout(parsed_args, session)
+        self.assertEqual(parsed_args.connect_timeout, 60)

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -212,7 +212,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
             session.get_default_client_config().connect_timeout, 60)
 
     def test_cli_read_timeout_for_blocking(self):
-        parsed_args = FakeParsedArgs(read_timeout='-1')
+        parsed_args = FakeParsedArgs(read_timeout='0')
         session = get_session()
         globalargs.resolve_cli_read_timeout(parsed_args, session)
         self.assertEqual(parsed_args.read_timeout, None)
@@ -220,7 +220,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
             session.get_default_client_config().read_timeout, None)
 
     def test_cli_connect_timeout_for_blocking(self):
-        parsed_args = FakeParsedArgs(connect_timeout='-1')
+        parsed_args = FakeParsedArgs(connect_timeout='0')
         session = get_session()
         globalargs.resolve_cli_connect_timeout(parsed_args, session)
         self.assertEqual(parsed_args.connect_timeout, None)

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -205,3 +205,15 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         session = mock.Mock()
         globalargs.resolve_cli_connect_timeout(parsed_args, session)
         self.assertEqual(parsed_args.connect_timeout, 60)
+
+    def test_cli_read_timeout_for_blocking(self):
+        parsed_args = FakeParsedArgs(read_timeout='-1')
+        session = mock.Mock()
+        globalargs.resolve_cli_read_timeout(parsed_args, session)
+        self.assertEqual(parsed_args.read_timeout, None)
+
+    def test_cli_connect_timeout_for_blocking(self):
+        parsed_args = FakeParsedArgs(connect_timeout='-1')
+        session = mock.Mock()
+        globalargs.resolve_cli_connect_timeout(parsed_args, session)
+        self.assertEqual(parsed_args.connect_timeout, None)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -692,7 +692,14 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             'lambda invoke --function-name foo out.log --cli-read-timeout 90',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[1]['timeout'][1], 90)
+        self.assertEqual(call_args[1]['timeout'], (60, 90))
+
+    def test_aws_with_blocking_read_timeout(self):
+        self.assert_params_for_cmd(
+            'lambda invoke --function-name foo out.log --cli-read-timeout -1',
+            expected_rc=0)
+        call_args = self.create_endpoint.call_args
+        self.assertEqual(call_args[1]['timeout'], (60, None))
 
     def test_aws_with_connnect_timeout(self):
         self.assert_params_for_cmd(
@@ -700,7 +707,15 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             '--cli-connect-timeout 90',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[1]['timeout'][0], 90)
+        self.assertEqual(call_args[1]['timeout'], (90, 60))
+
+    def test_aws_with_blocking_connect_timeout(self):
+        self.assert_params_for_cmd(
+            'lambda invoke --function-name foo out.log '
+            '--cli-connect-timeout -1',
+            expected_rc=0)
+        call_args = self.create_endpoint.call_args
+        self.assertEqual(call_args[1]['timeout'], (None, 60))
 
     def test_aws_with_read_and_connnect_timeout(self):
         self.assert_params_for_cmd(

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -696,7 +696,7 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
 
     def test_aws_with_blocking_read_timeout(self):
         self.assert_params_for_cmd(
-            'lambda invoke --function-name foo out.log --cli-read-timeout -1',
+            'lambda invoke --function-name foo out.log --cli-read-timeout 0',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
         self.assertEqual(call_args[1]['timeout'], (60, None))
@@ -712,7 +712,7 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
     def test_aws_with_blocking_connect_timeout(self):
         self.assert_params_for_cmd(
             'lambda invoke --function-name foo out.log '
-            '--cli-connect-timeout -1',
+            '--cli-connect-timeout 0',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
         self.assertEqual(call_args[1]['timeout'], (None, 60))

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -692,14 +692,14 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             'lambda invoke --function-name foo out.log --cli-read-timeout 90',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[1]['timeout'], (60, 90))
+        self.assertEqual(call_args[1]['timeout'][1], 90)
 
     def test_aws_with_blocking_read_timeout(self):
         self.assert_params_for_cmd(
             'lambda invoke --function-name foo out.log --cli-read-timeout 0',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[1]['timeout'], (60, None))
+        self.assertEqual(call_args[1]['timeout'][1], None)
 
     def test_aws_with_connnect_timeout(self):
         self.assert_params_for_cmd(
@@ -707,7 +707,7 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             '--cli-connect-timeout 90',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[1]['timeout'], (90, 60))
+        self.assertEqual(call_args[1]['timeout'][0], 90)
 
     def test_aws_with_blocking_connect_timeout(self):
         self.assert_params_for_cmd(
@@ -715,7 +715,7 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             '--cli-connect-timeout 0',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[1]['timeout'], (None, 60))
+        self.assertEqual(call_args[1]['timeout'][0], None)
 
     def test_aws_with_read_and_connnect_timeout(self):
         self.assert_params_for_cmd(

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -83,6 +83,10 @@ GET_DATA = {
             "read-timeout": {
                 "type": "int",
                 "help": ""
+            },
+            "connect-timeout": {
+                "type": "int",
+                "help": ""
             }
         }
     },
@@ -689,6 +693,22 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             expected_rc=0)
         call_args = self.create_endpoint.call_args
         self.assertEqual(call_args[1]['timeout'][1], 90)
+
+    def test_aws_with_connnect_timeout(self):
+        self.assert_params_for_cmd(
+            'lambda invoke --function-name foo out.log '
+            '--cli-connect-timeout 90',
+            expected_rc=0)
+        call_args = self.create_endpoint.call_args
+        self.assertEqual(call_args[1]['timeout'][0], 90)
+
+    def test_aws_with_read_and_connnect_timeout(self):
+        self.assert_params_for_cmd(
+            'lambda invoke --function-name foo out.log '
+            '--cli-read-timeout 70 --cli-connect-timeout 90',
+            expected_rc=0)
+        call_args = self.create_endpoint.call_args
+        self.assertEqual(call_args[1]['timeout'], (90, 70))
 
 
 class TestHTTPParamFileDoesNotExist(BaseAWSCommandParamsTest):

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 GLOBALOPTS = ['--debug', '--endpoint-url', '--no-verify-ssl', '--no-paginate',
               '--output', '--profile', '--region', '--version', '--color',
               '--query', '--no-sign-request', '--ca-bundle',
-              '--cli-read-timeout']
+              '--cli-read-timeout', '--cli-connect-timeout']
 
 COMPLETIONS = [
     ('aws ', -1, set(['apigateway', 'autoscaling', 'cloudformation', 'cloudfront',
@@ -73,7 +73,8 @@ COMPLETIONS = [
           '--no-verify-ssl', '--no-paginate', '--no-sign-request', '--output',
           '--profile', '--starting-token', '--max-items', '--page-size',
           '--region', '--version', '--color', '--query', '--ca-bundle',
-          '--generate-cli-skeleton', '--cli-input-json', '--cli-read-timeout'])),
+          '--generate-cli-skeleton', '--cli-input-json', '--cli-read-timeout',
+          '--cli-connect-timeout'])),
     ('aws s3', -1, set(['cp', 'mv', 'rm', 'mb', 'rb', 'ls', 'sync', 'website'])),
     ('aws s3 m', -1, set(['mv', 'mb'])),
     ('aws s3 cp -', -1, set(['--no-guess-mime-type', '--dryrun',


### PR DESCRIPTION
Add global options for ``--cli-connect-timeout``, ``--no-cli-read-timeout``, ``--no-cli-connect-timeout``. Also needed to plumb these into the s3 commands.

cc @jamesls @mtdowling @rayluo @JordonPhillips 