### PR TITLE
Take into account if a glacier object is restored for s3 downloads

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -289,14 +289,7 @@ class FileInfo(TaskInfo):
         # Returns True is this is a glacier object that has been
         # restored back to S3.
         # 'Restore' looks like: 'ongoing-request="false", expiry-date="..."'
-        result = re.search(r'ongoing-request="(.+?)"',
-                           response_data.get('Restore', ''))
-        if result is None:
-            return False
-        ongoing_request_value = result.group(1)
-        if ongoing_request_value == 'false':
-            return True
-        return False
+        return 'ongoing-request="false"' in response_data.get('Restore', '')
 
     def upload(self, payload=None):
         """

--- a/tests/unit/customizations/s3/test_fileinfo.py
+++ b/tests/unit/customizations/s3/test_fileinfo.py
@@ -148,3 +148,19 @@ class TestIsGlacierCompatible(unittest.TestCase):
     def test_task_info_glacier_compatibility(self):
         task_info = TaskInfo('bucket/key', 's3', 'remove_bucket', None)
         self.assertTrue(task_info.is_glacier_compatible())
+
+    def test_restored_object_is_glacier_compatible(self):
+        self.file_info.operation_name = 'download'
+        self.file_info.associated_response_data = {
+            'StorageClass': 'GLACIER',
+            'Restore': 'ongoing-request="false", expiry-date="..."'
+        }
+        self.assertTrue(self.file_info.is_glacier_compatible())
+
+    def test_ongoing_restore_is_not_glacier_compatible(self):
+        self.file_info.operation_name = 'download'
+        self.file_info.associated_response_data = {
+            'StorageClass': 'GLACIER',
+            'Restore': 'ongoing-request="true", expiry-date="..."'
+        }
+        self.assertFalse(self.file_info.is_glacier_compatible())


### PR DESCRIPTION
If a glacier object has been restored, we should be able
to download the file.

Fixes a regression introduced when we started ignoring the
GLACIER storage class.

This doesn't fix the issue for a recursive downloads/sync,
but that isn't possible because the Restore data isn't
in a ListObjects request.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 