### PR TITLE
Add support for arbitrary metadata with the cp command

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -65,7 +65,7 @@ class S3Handler(object):
             'content_disposition': None, 'content_encoding': None,
             'content_language': None, 'expires': None, 'grants': None,
             'only_show_errors': False, 'is_stream': False,
-            'paths_type': None, 'expected_size': None,
+            'paths_type': None, 'expected_size': None, 'metadata': None,
             'metadata_directive': None, 'ignore_glacier_warnings': False
         }
         self.params['region'] = params['region']

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -307,9 +307,10 @@ METADATA = {
     },
     'help_text': (
         "A map of metadata to store with the objects in S3. This will be "
-        "applied to every object which is part of this request. When copying "
-        "between two s3 locations, the metadata-directive argument will default"
-        " to 'REPLACE' unless otherwise specified."
+        "applied to every object which is part of this request. In a sync, this"
+        "means that files which haven't changed won't receive the new metadata."
+        " When copying between two s3 locations, the metadata-directive "
+        "argument will default to 'REPLACE' unless otherwise specified."
     )
 }
 
@@ -401,6 +402,7 @@ def get_client(session, region, endpoint_url, verify, config=None):
     return session.create_client('s3', region_name=region,
                                  endpoint_url=endpoint_url, verify=verify,
                                  config=config)
+
 
 class S3Command(BasicCommand):
     def _run_main(self, parsed_args, parsed_globals):
@@ -675,8 +677,8 @@ class MvCommand(S3TransferCommand):
     USAGE = "<LocalPath> <S3Uri> or <S3Uri> <LocalPath> " \
             "or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
-                  'synopsis': USAGE}] + TRANSFER_ARGS + [METADATA_DIRECTIVE,
-                                                         RECURSIVE]
+                  'synopsis': USAGE}] + TRANSFER_ARGS +\
+                [METADATA, METADATA_DIRECTIVE, RECURSIVE]
 
 class RmCommand(S3TransferCommand):
     NAME = 'rm'
@@ -696,7 +698,8 @@ class SyncCommand(S3TransferCommand):
     USAGE = "<LocalPath> <S3Uri> or <S3Uri> " \
             "<LocalPath> or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
-                  'synopsis': USAGE}] + TRANSFER_ARGS
+                  'synopsis': USAGE}] + TRANSFER_ARGS + \
+                [METADATA, METADATA_DIRECTIVE]
 
 
 class MbCommand(S3TransferCommand):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -298,6 +298,22 @@ EXPIRES = {
 }
 
 
+METADATA = {
+    'name': 'metadata', 'cli_type_name': 'map',
+    'schema': {
+        'type': 'map',
+        'key': {'type': 'string'},
+        'value': {'type': 'string'}
+    },
+    'help_text': (
+        "A map of metadata to store with the objects in S3. This will be "
+        "applied to every object which is part of this request. When copying "
+        "between two s3 locations, the metadata-directive argument will default"
+        " to 'REPLACE' unless otherwise specified."
+    )
+}
+
+
 METADATA_DIRECTIVE = {
     'name': 'metadata-directive', 'choices': ['COPY', 'REPLACE'],
     'help_text': (
@@ -649,7 +665,7 @@ class CpCommand(S3TransferCommand):
             "or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
+                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
 
 
 class MvCommand(S3TransferCommand):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -566,6 +566,7 @@ class RequestParamsMapper(object):
         cls._set_general_object_params(request_params, cli_params)
         cls._set_metadata_directive_param(request_params, cli_params)
         cls._set_metadata_params(request_params, cli_params)
+        cls._auto_populate_metadata_directive(request_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_and_copy_source_request_params(
             request_params, cli_params)
@@ -581,6 +582,7 @@ class RequestParamsMapper(object):
         cls._set_general_object_params(request_params, cli_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
+        cls._set_metadata_params(request_params, cli_params)
 
     @classmethod
     def map_upload_part_params(cls, request_params, cli_params):
@@ -643,8 +645,12 @@ class RequestParamsMapper(object):
     def _set_metadata_params(cls, request_params, cli_params):
         if cli_params.get('metadata'):
             request_params['Metadata'] = cli_params['metadata']
-            if not cli_params.get('metadata-directive'):
-                request_params['MetadataDirective'] = 'REPLACE'
+
+    @classmethod
+    def _auto_populate_metadata_directive(cls, request_params):
+        if request_params.get('Metadata') and \
+                not request_params.get('MetadataDirective'):
+            request_params['MetadataDirective'] = 'REPLACE'
 
     @classmethod
     def _set_metadata_directive_param(cls, request_params, cli_params):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -551,6 +551,7 @@ class RequestParamsMapper(object):
     def map_put_object_params(cls, request_params, cli_params):
         """Map CLI params to PutObject request params"""
         cls._set_general_object_params(request_params, cli_params)
+        cls._set_metadata_params(request_params, cli_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
 
@@ -564,6 +565,7 @@ class RequestParamsMapper(object):
         """Map CLI params to CopyObject request params"""
         cls._set_general_object_params(request_params, cli_params)
         cls._set_metadata_directive_param(request_params, cli_params)
+        cls._set_metadata_params(request_params, cli_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_and_copy_source_request_params(
             request_params, cli_params)
@@ -636,6 +638,13 @@ class RequestParamsMapper(object):
             return 'GrantWriteACP'
         raise ValueError('permission must be one of: '
                          'read|readacl|writeacl|full')
+
+    @classmethod
+    def _set_metadata_params(cls, request_params, cli_params):
+        if cli_params.get('metadata'):
+            request_params['Metadata'] = cli_params['metadata']
+            if not cli_params.get('metadata-directive'):
+                request_params['MetadataDirective'] = 'REPLACE'
 
     @classmethod
     def _set_metadata_directive_param(cls, request_params, cli_params):

--- a/awscli/schema.py
+++ b/awscli/schema.py
@@ -96,6 +96,8 @@ class SchemaTransformer(object):
             shapes[shape_name] = self._transform_structure(schema, shapes)
         elif schema['type'] == 'array':
             shapes[shape_name] = self._transform_list(schema, shapes)
+        elif schema['type'] == 'map':
+            shapes[shape_name] = self._transform_map(schema, shapes)
         else:
             shapes[shape_name] = self._transform_scalar(schema)
         return shapes
@@ -122,6 +124,15 @@ class SchemaTransformer(object):
         structure_shape['members'] = members
         if required_members:
             structure_shape['required'] = required_members
+        return structure_shape
+
+    def _transform_map(self, schema, shapes):
+        structure_shape = self._populate_initial_shape(schema)
+        for attribute in ['key', 'value']:
+            type_name = self._json_schema_to_aws_type(schema[attribute])
+            shape_name = self._shape_namer.new_shape_name(type_name)
+            structure_shape[attribute] = {'shape': shape_name}
+            self._transform(schema[attribute], shapes, shape_name)
         return structure_shape
 
     def _transform_list(self, schema, shapes):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -136,6 +136,21 @@ class TestCPCommand(BaseAWSCommandParamsTest):
             'http://someserver'
         )
 
+    def test_metadata_copy(self):
+        self.parsed_responses = [
+            {"ContentLength": "100", "LastModified": "00:00:00Z"},
+            {'ETag': '"foo-1"'},
+        ]
+        cmdline = ('%s s3://bucket/key.txt s3://bucket/key2.txt'
+                   ' --metadata KeyName=Value' % self.prefix)
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2,
+                         self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'CopyObject')
+        self.assertEqual(self.operations_called[1][1]['Metadata'],
+                         {'KeyName': 'Value'})
+
     def test_metadata_directive_copy(self):
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -439,6 +439,20 @@ class TestCp(BaseS3CLICommand):
         self.assert_no_errors(p)
         self.assertTrue(self.key_exists(bucket_name, key_name='foo.txt'))
 
+    def test_copy_metadata(self):
+        # Copy the same style of parsing as the CLI session. This is needed
+        # For comparing expires timestamp.
+        add_scalar_parsers(self.session)
+        bucket_name = self.create_bucket()
+        key = 'foo.txt'
+        filename = self.files.create_file(key, contents='')
+        p = aws('s3 cp %s s3://%s/%s --metadata keyname=value' %
+                (filename, bucket_name, key))
+        self.assert_no_errors(p)
+        response = self.head_object(bucket_name, key)
+        # These values should have the metadata of the source object
+        self.assertEqual(response['Metadata'].get('keyname'), 'value')
+
     def test_copy_metadata_directive(self):
         # Copy the same style of parsing as the CLI session. This is needed
         # For comparing expires timestamp.

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -361,7 +361,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None}
+                  'is_stream': False, 'source_region': None, 'metadata': None}
         self.http_response.status_code = 400
         self.parsed_responses = [{'Error': {
                                   'Code': 'BucketNotExists',

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -90,7 +90,7 @@ COMPLETIONS = [
                              '--content-encoding', '--content-language',
                              '--expires', '--grants', '--only-show-errors',
                              '--expected-size', '--page-size',
-                             '--metadata-directive',
+                             '--metadata', '--metadata-directive',
                              '--ignore-glacier-warnings']
                             + GLOBALOPTS)),
     ('aws s3 cp --quiet -', -1, set(['--no-guess-mime-type', '--dryrun',
@@ -105,7 +105,8 @@ COMPLETIONS = [
                                      '--sse-c-key',
                                      '--sse-kms-key-id',
                                      '--exclude', '--include',
-                                     '--source-region', '--metadata-directive',
+                                     '--source-region', '--metadata',
+                                     '--metadata-directive',
                                      '--grants', '--only-show-errors',
                                      '--expected-size', '--page-size',
                                      '--ignore-glacier-warnings']

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -167,6 +167,24 @@ class TestSchemaTransformer(unittest.TestCase):
             }
         )
 
+    def test_transforms_map(self):
+        self.assert_schema_transforms_to(
+            schema={
+                "type": "map",
+                "key": {"type": "string"},
+                "value": {"type": "string"}
+            },
+            transforms_to={
+                'InputShape': {
+                    "type": "map",
+                    "key": {"shape": "StringType1"},
+                    "value": {"shape": "StringType2"}
+                },
+                'StringType1': {'type': 'string'},
+                'StringType2': {'type': 'string'},
+            }
+        )
+
     def test_description_on_shape_type(self):
         self.assert_schema_transforms_to(
             schema={


### PR DESCRIPTION
This will allow a `--metadata` flag for `aws s3 cp` with the same interface as `aws s3api put-object --metadata`.

Example Usage:
```sh
$ aws s3 cp ~/test.txt s3://test-bucket/ --metadata some=value
upload: test.txt to s3://test-bucket/test.txt
$ aws s3api head-object --bucket test-bucket --key test.txt
{
    "AcceptRanges": "bytes",
    "ContentType": "text/plain",
    "LastModified": "Fri, 20 Nov 2015 21:13:12 GMT",
    "ContentLength": 13,
    "ETag": "\"ETAG\"",
    "Metadata": {
        "some": "value"
    }
}
$ aws s3 cp ~/test2.txt s3://test-bucket/ --metadata '{"other":"value"}'
upload: test2.txt to s3://test-bucket/test2.txt
$ aws s3api head-object --bucket test-bucket --key test2.txt
{
    "AcceptRanges": "bytes",
    "ContentType": "text/plain",
    "LastModified": "Fri, 20 Nov 2015 21:15:04 GMT",
    "ContentLength": 13,
    "ETag": "\"ETAG\"",
    "Metadata": {
        "other": "value"
    }
}
```