### PR TITLE
Fix write permissions tests

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -818,6 +818,9 @@ class TestUnableToWriteToFile(BaseS3CLICommand):
 
     @skip_if_windows('Write permissions tests only supported on mac/linux')
     def test_no_write_access_small_file(self):
+        if os.geteuid() == 0:
+            self.skipTest(
+                'Cannot completely remove write access as root user.')
         os.chmod(self.files.rootdir, 0o444)
         self.put_object(self.bucket_name, 'foo.txt',
                         contents='Hello world')
@@ -828,6 +831,9 @@ class TestUnableToWriteToFile(BaseS3CLICommand):
 
     @skip_if_windows('Write permissions tests only supported on mac/linux')
     def test_no_write_access_large_file(self):
+        if os.geteuid() == 0:
+            self.skipTest(
+                'Cannot completely remove write access as root user.')
         # We have to use a file like object because using a string
         # would result in the header + body sent as a single packet
         # which effectively disables the expect 100 continue logic.

--- a/tests/unit/customizations/s3/test_tasks.py
+++ b/tests/unit/customizations/s3/test_tasks.py
@@ -353,11 +353,11 @@ class TestCreateLocalFileTask(unittest.TestCase):
         self.context.announce_file_created.assert_called_with()
         self.assertTrue(self.result_queue.empty())
 
-    @skip_if_windows('Write permissions tests only supported on mac/linux')
     def test_cancel_command_on_exception(self):
-        # Set destination directory to read-only
-        os.chmod(self.tempdir, 0o444)
-        self.task()
+        with mock.patch('awscli.customizations.s3.tasks.open',
+                        create=True) as mock_open:
+            mock_open.side_effect = OSError("Fake permissions error")
+            self.task()
         self.assertFalse(os.path.isfile(self.filename.dest))
         self.context.cancel.assert_called_with()
         self.assertFalse(self.result_queue.empty())


### PR DESCRIPTION
These tests currently fail if you run them as a superuser.  This is because the tests rely on being able to take away write permission for a particular directory and verify the expected behavior.

However if you're root, you'll always have access to this directory, regardless of the `chmod` call.

This fix skips the test if we detect you're running as a superuser.

The unit test has the same problem, but instead I patched out the open call to raise an exception, so we can verify the expected behavior instead of having to skip the test.  This also has the benefit that the unit test can now run on windows.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 