### PR TITLE
Remove customizations in BucketLister that attach encoding_type

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -449,50 +449,19 @@ class BucketLister(object):
         self._date_parser = date_parser
 
     def list_objects(self, bucket, prefix=None, page_size=None):
-        kwargs = {'Bucket': bucket, 'EncodingType': 'url',
-                  'PaginationConfig': {'PageSize': page_size}}
+        kwargs = {'Bucket': bucket, 'PaginationConfig': {'PageSize': page_size}}
         if prefix is not None:
             kwargs['Prefix'] = prefix
-        # This event handler is needed because we use encoding_type url and
-        # we're paginating.  The pagination token is the last Key of the
-        # Contents list.  However, botocore does not know that the encoding
-        # type needs to be urldecoded.
-        with ScopedEventHandler(self._client.meta.events,
-                                'after-call.s3.ListObjects',
-                                self._decode_keys,
-                                'BucketListerDecodeKeys'):
-            paginator = self._client.get_paginator('list_objects')
-            pages = paginator.paginate(**kwargs)
-            for page in pages:
-                contents = page.get('Contents', [])
-                for content in contents:
-                    source_path = bucket + '/' + content['Key']
-                    content['LastModified'] = self._date_parser(
-                        content['LastModified'])
-                    yield source_path, content
 
-    def _decode_keys(self, parsed, **kwargs):
-        if 'Contents' in parsed:
-            for content in parsed['Contents']:
-                content['Key'] = unquote_str(content['Key'])
-
-
-class ScopedEventHandler(object):
-    """Register an event callback for the duration of a scope."""
-
-    def __init__(self, event_emitter, event_name, handler, unique_id=None):
-        self._event_emitter = event_emitter
-        self._event_name = event_name
-        self._handler = handler
-        self._unique_id = unique_id
-
-    def __enter__(self):
-        self._event_emitter.register(self._event_name, self._handler,
-                                     self._unique_id)
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self._event_emitter.unregister(self._event_name, self._handler,
-                                       self._unique_id)
+        paginator = self._client.get_paginator('list_objects')
+        pages = paginator.paginate(**kwargs)
+        for page in pages:
+            contents = page.get('Contents', [])
+            for content in contents:
+                source_path = bucket + '/' + content['Key']
+                content['LastModified'] = self._date_parser(
+                    content['LastModified'])
+                yield source_path, content
 
 
 class PrintTask(namedtuple('PrintTask',

--- a/tests/functional/s3api/test_list_objects.py
+++ b/tests/functional/s3api/test_list_objects.py
@@ -25,7 +25,8 @@ class TestListObjects(BaseAWSCommandParamsTest):
     def test_simple(self):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
-        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket'})
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
+                                             'EncodingType': 'url'})
 
     def test_max_items(self):
         cmdline = self.prefix
@@ -33,7 +34,8 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # The max-items is a customization and therefore won't
         # show up in the result params.
         cmdline += ' --max-items 100'
-        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket'})
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
+                                             'EncodingType': 'url'})
 
     def test_page_size(self):
         cmdline = self.prefix
@@ -42,7 +44,8 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # show up in the result params.
         cmdline += ' --page-size 100'
         self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
-                                              'MaxKeys': 100})
+                                             'MaxKeys': 100,
+                                             'EncodingType': 'url'})
 
     def test_starting_token(self):
         # We don't need to test this in depth because botocore
@@ -52,12 +55,14 @@ class TestListObjects(BaseAWSCommandParamsTest):
         cmdline += ' --bucket mybucket'
         cmdline += ' --starting-token foo___2'
         self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
-                                              'Marker': 'foo'})
+                                             'Marker': 'foo',
+                                             'EncodingType': 'url'})
 
     def test_no_paginate(self):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket --no-paginate'
-        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket'})
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
+                                             'EncodingType': 'url'})
 
     def test_max_keys_can_be_specified(self):
         cmdline = self.prefix
@@ -66,7 +71,8 @@ class TestListObjects(BaseAWSCommandParamsTest):
         # we will automatically see this and turn auto-pagination off.
         cmdline += ' --bucket mybucket --max-keys 1'
         self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket',
-                                              'MaxKeys': 1})
+                                             'MaxKeys': 1,
+                                             'EncodingType': 'url'})
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjects')


### PR DESCRIPTION
That functionality is moving to botocore as part of boto/botocore#726