### PR TITLE
cloudfront create-invalidation --paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Next Release (TBD)
 * feature:``aws configure add-model``: Added command for updating commands
   in the CLI and clients in boto3.
   (`issue 1664 <https://github.com/aws/aws-cli/pull/1664>`__)
+* feature:``aws cloudfront create-invalidation``: Add a new --paths option.
+  (`issue 1662 <https://github.com/aws/aws-cli/pull/1662>`__)
 
 
 1.9.11

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -34,12 +34,12 @@ def _add_paths(argument_table, **kwargs):
 class PathsArgument(CustomArgument):
 
     def __init__(self):
-        help = """The space-separated paths to be invalidated.
-            It will automatically generate a CallerReference for you."""
-        super(PathsArgument, self).__init__('paths', nargs='+', help_text=help)
+        doc = """The space-separated paths to be invalidated.
+            Note: --invalidation-batch and --paths are mututally exclusive."""
+        super(PathsArgument, self).__init__('paths', nargs='+', help_text=doc)
 
     def add_to_params(self, parameters, value):
-        if value:
+        if value is not None:
             parameters['InvalidationBatch'] = {
                 "CallerReference": datetime.utcnow().strftime('%Y%m%d%H%M%S'),
                 "Paths": {"Quantity": len(value), "Items": value},

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -1,0 +1,46 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from datetime import datetime
+
+from awscli.arguments import CustomArgument
+from awscli.customizations.utils import validate_mutually_exclusive_handler
+
+
+def register(event_handler):
+    """Provides a simpler --paths for ``aws cloudfront create-invalidation``"""
+
+    event_handler.register(
+        'building-argument-table.cloudfront.create-invalidation', _add_paths)
+    event_handler.register(
+        'operation-args-parsed.cloudfront.create-invalidation',
+        validate_mutually_exclusive_handler(['invalidation_batch'], ['paths']))
+
+
+def _add_paths(argument_table, **kwargs):
+    argument_table['invalidation-batch'].required = False
+    argument_table['paths'] = PathsArgument()
+
+
+class PathsArgument(CustomArgument):
+
+    def __init__(self):
+        help = """The space-separated paths to be invalidated.
+            It will automatically generate a CallerReference for you."""
+        super(PathsArgument, self).__init__('paths', nargs='+', help_text=help)
+
+    def add_to_params(self, parameters, value):
+        if value:
+            parameters['InvalidationBatch'] = {
+                "CallerReference": datetime.utcnow().strftime('%Y%m%d%H%M%S'),
+                "Paths": {"Quantity": len(value), "Items": value},
+                }

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -35,8 +35,10 @@ def _add_paths(argument_table, **kwargs):
 class PathsArgument(CustomArgument):
 
     def __init__(self):
-        doc = """The space-separated paths to be invalidated.
-            Note: --invalidation-batch and --paths are mututally exclusive."""
+        doc = (
+            'The space-separated paths to be invalidated.'
+            ' Note: --invalidation-batch and --paths are mututally exclusive.'
+        )
         super(PathsArgument, self).__init__('paths', nargs='+', help_text=doc)
 
     def add_to_params(self, parameters, value):

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -10,7 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from datetime import datetime
+import time
+import random
 
 from awscli.arguments import CustomArgument
 from awscli.customizations.utils import validate_mutually_exclusive_handler
@@ -40,7 +41,9 @@ class PathsArgument(CustomArgument):
 
     def add_to_params(self, parameters, value):
         if value is not None:
+            caller_reference = 'cli-%s-%s' % (
+                int(time.time()), random.randint(1, 1000000))
             parameters['InvalidationBatch'] = {
-                "CallerReference": datetime.utcnow().strftime('%Y%m%d%H%M%S'),
+                "CallerReference": caller_reference,
                 "Paths": {"Quantity": len(value), "Items": value},
                 }

--- a/awscli/examples/cloudfront/create-invalidation.rst
+++ b/awscli/examples/cloudfront/create-invalidation.rst
@@ -1,5 +1,10 @@
 The following command creates an invalidation for a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
 
+  aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD \
+    --paths /index.html /error.html
+
+Or you can use the following command to do the same thing. And you can have a chance to specify your own CallerReference here::
+
   aws cloudfront create-invalidation --invalidation-batch file://invbatch.json --distribution-id S11A16G5KZMEQD
 
 The distribution ID is available in the output of ``create-distribution`` and ``list-distributions``.
@@ -14,7 +19,7 @@ The file ``invbatch.json`` is a JSON document in the current folder that specifi
     "CallerReference": "my-invalidation-2015-09-01"
   }
 
-Output::
+Output of both commands::
 
   {
       "Invalidation": {

--- a/awscli/examples/cloudfront/create-invalidation.rst
+++ b/awscli/examples/cloudfront/create-invalidation.rst
@@ -3,9 +3,9 @@ The following command creates an invalidation for a CloudFront distribution with
   aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD \
     --paths /index.html /error.html
 
-The --paths will automatically generate a random CallerReference every time.
+The --paths will automatically generate a random ``CallerReference`` every time.
 
-Or you can use the following command to do the same thing, so that you can have a chance to specify your own CallerReference here::
+Or you can use the following command to do the same thing, so that you can have a chance to specify your own ``CallerReference`` here::
 
   aws cloudfront create-invalidation --invalidation-batch file://invbatch.json --distribution-id S11A16G5KZMEQD
 

--- a/awscli/examples/cloudfront/create-invalidation.rst
+++ b/awscli/examples/cloudfront/create-invalidation.rst
@@ -3,7 +3,9 @@ The following command creates an invalidation for a CloudFront distribution with
   aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD \
     --paths /index.html /error.html
 
-Or you can use the following command to do the same thing. And you can have a chance to specify your own CallerReference here::
+The --paths will automatically generate a random CallerReference every time.
+
+Or you can use the following command to do the same thing, so that you can have a chance to specify your own CallerReference here::
 
   aws cloudfront create-invalidation --invalidation-batch file://invbatch.json --distribution-id S11A16G5KZMEQD
 

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -33,6 +33,7 @@ from awscli.customizations.ec2runinstances import register_runinstances
 from awscli.customizations.rds import register_rds_modify_split
 from awscli.customizations.putmetricdata import register_put_metric_data
 from awscli.customizations.sessendemail import register_ses_send_email
+from awscli.customizations.cloudfront import register as cloudfront_register
 from awscli.customizations.iamvirtmfa import IAMVMFAWrapper
 from awscli.customizations.argrename import register_arg_renames
 from awscli.customizations.configure import register_configure_cmd
@@ -108,6 +109,7 @@ def awscli_initialize(event_handlers):
     register_rds_modify_split(event_handlers)
     register_put_metric_data(event_handlers)
     register_ses_send_email(event_handlers)
+    cloudfront_register(event_handlers)
     IAMVMFAWrapper(event_handlers)
     register_arg_renames(event_handlers)
     register_configure_cmd(event_handlers)

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -14,7 +14,6 @@ from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
     BaseAWSCommandParamsTest
 
 
-
 class TestCreateInvalidation(BaseAWSCommandParamsTest):
 
     prefix = 'cloudfront create-invalidation --distribution-id my_id '

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -1,0 +1,50 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateInvalidation(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudfront create-invalidation --distribution-id my_id' + ' '
+
+    def test_invalidation_batch_only(self):
+        batch = "Paths={Quantity=2,Items=[foo.txt,bar.txt]},CallerReference=ab"
+        cmdline = self.prefix + '--invalidation-batch ' + batch
+        result = {
+            'DistributionId': 'my_id',
+            'InvalidationBatch': {
+                'Paths': {'Items': ['foo.txt', 'bar.txt'], 'Quantity': 2},
+                'CallerReference': 'ab',
+                },
+            }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_paths_only(self):
+        cmdline = self.prefix + '--paths index.html foo.txt'
+        result = {
+            'DistributionId': 'my_id',
+            'InvalidationBatch': {
+                'Paths': {'Items': ['index.html', 'foo.txt'], 'Quantity': 2},
+                },
+            }
+        self.run_cmd(cmdline)
+        # There will be a CallerReference, but we don't really check it
+        del self.last_kwargs['InvalidationBatch']['CallerReference']
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_invalidation_batch_and_paths(self):
+        cmdline = self.prefix + '--invalidation-batch {} --paths foo'
+        self.run_cmd(cmdline, expected_rc=255)
+
+    def test_neither_invalidation_batch_or_paths(self):
+        self.run_cmd(self.prefix, expected_rc=255)

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import mock
+
 from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
     BaseAWSCommandParamsTest
 
@@ -36,11 +38,10 @@ class TestCreateInvalidation(BaseAWSCommandParamsTest):
             'DistributionId': 'my_id',
             'InvalidationBatch': {
                 'Paths': {'Items': ['index.html', 'foo.txt'], 'Quantity': 2},
+                'CallerReference': mock.ANY,
                 },
             }
         self.run_cmd(cmdline)
-        # There will be a CallerReference, but we don't really check it
-        del self.last_kwargs['InvalidationBatch']['CallerReference']
         self.assertEqual(self.last_kwargs, result)
 
     def test_invalidation_batch_and_paths(self):

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -17,7 +17,7 @@ from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
 
 class TestCreateInvalidation(BaseAWSCommandParamsTest):
 
-    prefix = 'cloudfront create-invalidation --distribution-id my_id' + ' '
+    prefix = 'cloudfront create-invalidation --distribution-id my_id '
 
     def test_invalidation_batch_only(self):
         batch = "Paths={Quantity=2,Items=[foo.txt,bar.txt]},CallerReference=ab"

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -10,7 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
+    BaseAWSCommandParamsTest
+
 
 
 class TestCreateInvalidation(BaseAWSCommandParamsTest):


### PR DESCRIPTION
Now `aws cloudfront create-invalidation` has a new parameter `--paths`.

    SYNOPSIS
            create-invalidation
          --distribution-id <value>
          [--invalidation-batch <value>]
          [--paths <value>]

    EXAMPLES
       The following command creates an invalidation for a CloudFront  distri-
       bution with the ID S11A16G5KZMEQD:

          aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD \
            --paths /index.html /error.html

This fixes #920