### PR TITLE
Add aws_bash_completer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,12 @@ Command Completion
 
 The aws-cli package includes a very useful command completion feature.
 This feature is not automatically installed so you need to configure it manually.
-To enable tab completion for bash use the built-in command ``complete``::
+To enable tab completion for bash either use the built-in command ``complete``::
 
     $ complete -C aws_completer aws
+
+Or add ``bin/aws_bash_completer`` file under ``/etc/bash_completion.d``,
+``/usr/local/etc/bash_completion.d`` or any other ``bash_completion.d`` location.
 
 For tcsh::
 

--- a/bin/aws_bash_completer
+++ b/bin/aws_bash_completer
@@ -1,0 +1,6 @@
+# Typically that would be added under /etc/bash_completion.d,
+# /usr/local/etc/bash_completion.d, etc.
+
+# Adopted from bash completion for ant
+have aws_completer && \
+     complete -C aws_completer aws

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_options = dict(
     packages=find_packages(exclude=['tests*']),
     package_data={'awscli': ['data/*.json', 'examples/*/*.rst',
                              'examples/*/*/*.rst', 'topics/*.rst',
-                             'topics/*.json']},
+                             'topics/*.json', 'bin/aws_bash_completer']},
     install_requires=requires,
     extras_require={
         ':python_version=="2.6"': [


### PR DESCRIPTION
Just to be fair (there is one for zsh already, right?), consistent with other tools that provide bash completer script out of the box and to help other projects like Homebrew (https://github.com/Homebrew/homebrew/issues/46781).