### PR TITLE
Use the list index as key name when visiting list types

### DIFF
--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -373,8 +373,8 @@ class ModelVisitor(object):
     def _visit_list(self, parent, shape, name, value):
         if not isinstance(value, list):
             return
-        for element in value:
-            self._visit(value, shape.member, '', element)
+        for i, element in enumerate(value):
+            self._visit(value, shape.member, i, element)
 
     def _visit_map(self, parent, shape, name, value):
         if not isinstance(value, dict):

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -241,3 +241,19 @@ class TestModelVisitor(unittest.TestCase):
         params = {}
         b.visit(params, m)
         self.assertEqual(params, {})
+
+    def test_can_convert_list_of_integers(self):
+        m = model.DenormalizedStructureBuilder().with_members({
+            'A': {
+                'type': 'list',
+                'member': {
+                    'type': 'integer',
+                },
+            },
+        }).build_model()
+        b = shorthand.BackCompatVisitor()
+        params = {'A': ['1', '2']}
+        b.visit(params, m)
+        # We should have converted each list element to an integer
+        # because the type of the list member is integer.
+        self.assertEqual(params, {'A': [1, 2]})


### PR DESCRIPTION
In the backwards compatible shorthand visitor, we need to
pass the list index as the key into the parent structure
when we visit sub elements in the list.  This is necessary
in the case where we need to modify a child element and
reinsert it back into the parent structure.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 