### PR TITLE
Update ZipFile parameter documentation to be consistent.

### DIFF
--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -392,6 +392,7 @@ class CLIArgument(BaseCLIArgument):
         self._required = is_required
         self._operation_model = operation_model
         self._event_emitter = event_emitter
+        self._documentation = argument_model.documentation
 
     @property
     def py_name(self):
@@ -407,7 +408,11 @@ class CLIArgument(BaseCLIArgument):
 
     @property
     def documentation(self):
-        return self.argument_model.documentation
+        return self._documentation
+
+    @documentation.setter
+    def documentation(self, value):
+        self._documentation = value
 
     @property
     def cli_type_name(self):

--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -59,7 +59,7 @@ def _extract_code_and_zip_file_arguments(session, argument_table, **kwargs):
 
 def _modify_zipfile_docstring(session, argument_table, **kwargs):
     if 'zip-file' in argument_table:
-        argument_table['zip-file'].argument_model.documentation = ZIP_DOCSTRING
+        argument_table['zip-file'].documentation = ZIP_DOCSTRING
 
 
 def _should_contain_zip_content(value):

--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -23,10 +23,15 @@ ERROR_MSG = (
     "--zip-file must be a file with the fileb:// prefix.\n"
     "Example usage:  --zip-file fileb://path/to/file.zip")
 
+ZIP_DOCSTRING = ('<p>The path to the zip file of the code you are uploading. '
+                 'Example: fileb://code.zip</p>')
+
 
 def register_lambda_create_function(cli):
     cli.register('building-argument-table.lambda.create-function',
                  _extract_code_and_zip_file_arguments)
+    cli.register('building-argument-table.lambda.update-function-code',
+                 _modify_zipfile_docstring)
     cli.register('process-cli-arg.lambda.update-function-code',
                  validate_is_zip_file)
 
@@ -38,9 +43,7 @@ def validate_is_zip_file(cli_argument, value, **kwargs):
 
 def _extract_code_and_zip_file_arguments(session, argument_table, **kwargs):
     argument_table['zip-file'] = ZipFileArgument(
-        'zip-file', help_text=('The path to the zip file of the code you '
-                               'are uploading. Example: fileb://code.zip'),
-        cli_type_name='blob')
+        'zip-file', help_text=ZIP_DOCSTRING, cli_type_name='blob')
     code_argument = argument_table['code']
     code_model = copy.deepcopy(code_argument.argument_model)
     del code_model.members['ZipFile']
@@ -52,6 +55,11 @@ def _extract_code_and_zip_file_arguments(session, argument_table, **kwargs):
         event_emitter=session.get_component('event_emitter'),
         serialized_name='Code'
     )
+
+
+def _modify_zipfile_docstring(session, argument_table, **kwargs):
+    if 'zip-file' in argument_table:
+        argument_table['zip-file'].argument_model.documentation = ZIP_DOCSTRING
 
 
 def _should_contain_zip_content(value):


### PR DESCRIPTION
When we pull ZipFile out of the Code argument in CreateFunction we give it a docstring relevant to the CLI, but we don't give that doc string in UpdateFunctionCode. This causes confusion for the customer because the service documentation mentions you have to base64 encode the .zip, which we handle for the customer.

Closes #1704

cc @rayluo @kyleknap @mtdowling @jamesls 