### PR TITLE
Describe and enforce multipart chunksize/threshold minimum.

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -17,7 +17,7 @@ import os
 import sys
 
 from awscli.customizations.s3.utils import (
-    find_chunksize, adjust_chunksize_to_upload_limits,
+    find_chunksize, adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
     find_bucket_key, relative_path, PrintTask, create_warning)
 from awscli.customizations.s3.executor import Executor
 from awscli.customizations.s3 import tasks
@@ -27,9 +27,6 @@ from awscli.compat import queue
 
 
 LOGGER = logging.getLogger(__name__)
-# Maximum object size allowed in S3.
-# See: http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
-MAX_UPLOAD_SIZE = 5 * (1024 ** 4)
 
 CommandResult = namedtuple('CommandResult',
                            ['num_tasks_failed', 'num_tasks_warned'])

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -29,6 +29,7 @@ LOGGER = logging.getLogger(__name__)
 # Maximum object size allowed in S3.
 # See: http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 MAX_UPLOAD_SIZE = 5 * (1024 ** 4)
+MIN_UPLOAD_CHUNKSIZE = 5 * (1024 ** 2)
 
 CommandResult = namedtuple('CommandResult',
                            ['num_tasks_failed', 'num_tasks_warned'])
@@ -203,14 +204,18 @@ class S3Handler(object):
                     )
                     self.result_queue.put(warning)
                 continue
-            elif is_multipart_task and not self.params['dryrun']:
-                # If we're in dryrun mode, then we don't need the
-                # real multipart tasks.  We can just use a BasicTask
-                # in the else clause below, which will print out the
-                # fact that it's transferring a file rather than
-                # the specific part tasks required to perform the
-                # transfer.
-                num_uploads = self._enqueue_multipart_tasks(filename)
+            elif is_multipart_task:
+                if self._is_upload(filename) and not \
+                        self._is_upload_chunksize_valid(filename):
+                    continue
+                if not self.params['dryrun']:
+                    # If we're in dryrun mode, then we don't need the
+                    # real multipart tasks.  We can just use a BasicTask
+                    # in the else clause below, which will print out the
+                    # fact that it's transferring a file rather than
+                    # the specific part tasks required to perform the
+                    # transfer.
+                    num_uploads = self._enqueue_multipart_tasks(filename)
             else:
                 task = tasks.BasicTask(
                     session=self.session, filename=filename,
@@ -234,6 +239,29 @@ class S3Handler(object):
                     return False
         else:
             return False
+
+    def _is_upload(self, filename):
+        if filename.operation_name in ['upload', 'copy']:
+            return True
+
+        if filename.operation_name == 'move':
+            if filename.src_type == 'local' and filename.dest_type == 's3':
+                return True
+            elif filename.src_type == 's3' and filename.dest_type == 's3':
+                return True
+
+        return False
+
+    def _is_upload_chunksize_valid(self, filename):
+        if self.chunksize < MIN_UPLOAD_CHUNKSIZE:
+            warning_message = ("Multipart chunksize for uploads must be at "
+                               "least 5MB, but is currently %s."
+                               % self.chunksize)
+            warning = create_warning(
+                    relative_path(filename.src), warning_message)
+            self.result_queue.put(warning)
+            return False
+        return True
 
     def _enqueue_multipart_tasks(self, filename):
         num_uploads = 1
@@ -476,8 +504,8 @@ class S3StreamHandler(S3Handler):
         # First we need to create a CreateMultipartUpload task,
         # then create UploadTask objects for each of the parts.
         # And finally enqueue a CompleteMultipartUploadTask.
-
         chunksize = self.chunksize
+
         # Determine an appropriate chunksize if given an expected size.
         if self.params['expected_size']:
             chunksize = find_chunksize(int(self.params['expected_size']),

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -39,6 +39,9 @@ EPOCH_TIME = datetime(1970, 1, 1, tzinfo=tzutc())
 # and: http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
 MAX_SINGLE_UPLOAD_SIZE = 5 * (1024 ** 3)
 MIN_UPLOAD_CHUNKSIZE = 5 * (1024 ** 2)
+# Maximum object size allowed in S3.
+# See: http://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+MAX_UPLOAD_SIZE = 5 * (1024 ** 4)
 SIZE_SUFFIX = {
     'kb': 1024,
     'mb': 1024 ** 2,
@@ -289,7 +292,10 @@ def find_chunksize(size, current_chunksize):
     :param current_chunksize: The currently configured chunksize
     :return: If the given chunksize is valid, it is returned. Otherwise a valid
         chunksize is calculated and returned.
+    :raises: ValueError: if the file size exceeds the max size of 5TB
     """
+    if size > MAX_UPLOAD_SIZE:
+        raise ValueError("File size exceeds maximum upload size.")
     size = adjust_chunksize_for_max_parts(size, current_chunksize)
     return adjust_chunksize_to_upload_limits(size)
 

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -110,7 +110,6 @@ multipart_threshold
 -------------------
 
 **Default** - ``8MB``
-**Minimum** - ``5MB``
 
 When uploading, downloading, or copying a file, the S3 commands
 will switch to multipart operations if the file reaches a given
@@ -128,7 +127,8 @@ multipart_chunksize
 -------------------
 
 **Default** - ``8MB``
-**Minimum** - ``5MB``
+
+**Minimum For Uploads** - ``5MB``
 
 Once the S3 commands have decided to use multipart operations, the
 file is divided into chunks.  This configuration option specifies what

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -110,6 +110,7 @@ multipart_threshold
 -------------------
 
 **Default** - ``8MB``
+**Minimum** - ``5MB``
 
 When uploading, downloading, or copying a file, the S3 commands
 will switch to multipart operations if the file reaches a given
@@ -127,6 +128,7 @@ multipart_chunksize
 -------------------
 
 **Default** - ``8MB``
+**Minimum** - ``5MB``
 
 Once the S3 commands have decided to use multipart operations, the
 file is divided into chunks.  This configuration option specifies what

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -12,7 +12,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
-import re
 
 import mock
 from awscli.compat import six

--- a/tests/integration/customizations/s3/__init__.py
+++ b/tests/integration/customizations/s3/__init__.py
@@ -14,10 +14,11 @@ import random
 import string
 
 from botocore.exceptions import ClientError
+from botocore.client import Config
 from awscli.testutils import create_bucket
 
 
-def make_s3_files(session, key1='text1.txt', key2='text2.txt'):
+def make_s3_files(session, key1='text1.txt', key2='text2.txt', size=None):
     """
     Creates a randomly generated bucket in s3 with the files text1.txt and
     another_directory/text2.txt inside. The directory is manually created
@@ -25,9 +26,16 @@ def make_s3_files(session, key1='text1.txt', key2='text2.txt'):
     """
     region = 'us-west-2'
     bucket = create_bucket(session)
-    string1 = "This is a test."
-    string2 = "This is another test."
-    client = session.create_client('s3', region_name=region)
+
+    if size:
+        string1 = "*" * size
+        string2 = string1
+    else:
+        string1 = "This is a test."
+        string2 = "This is another test."
+
+    config = Config(s3={"addressing_style": "path"})
+    client = session.create_client('s3', region_name=region, config=config)
     client.put_object(Bucket=bucket, Key=key1, Body=string1)
     if key2 is not None:
         client.put_object(Bucket=bucket, Key='another_directory/')

--- a/tests/integration/customizations/s3/__init__.py
+++ b/tests/integration/customizations/s3/__init__.py
@@ -30,7 +30,7 @@ def make_s3_files(session, key1='text1.txt', key2='text2.txt', size=None):
         string1 = "This is a test."
         string2 = "This is another test."
 
-    client = session.create_client('s3', region_name=region, config=config)
+    client = session.create_client('s3', region_name=region)
     client.put_object(Bucket=bucket, Key=key1, Body=string1)
     if key2 is not None:
         client.put_object(Bucket=bucket, Key='another_directory/')

--- a/tests/integration/customizations/s3/__init__.py
+++ b/tests/integration/customizations/s3/__init__.py
@@ -10,11 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import random
-import string
-
 from botocore.exceptions import ClientError
-from botocore.client import Config
 from awscli.testutils import create_bucket
 
 
@@ -34,7 +30,6 @@ def make_s3_files(session, key1='text1.txt', key2='text2.txt', size=None):
         string1 = "This is a test."
         string2 = "This is another test."
 
-    config = Config(s3={"addressing_style": "path"})
     client = session.create_client('s3', region_name=region, config=config)
     client.put_object(Bucket=bucket, Key=key1, Body=string1)
     if key2 is not None:

--- a/tests/integration/customizations/s3/test_s3handler.py
+++ b/tests/integration/customizations/s3/test_s3handler.py
@@ -25,7 +25,8 @@ from awscli.testutils import unittest, FileCreator
 
 from awscli import EnvironmentVariables
 from awscli.compat import StringIO
-from awscli.customizations.s3.s3handler import S3Handler, MIN_UPLOAD_CHUNKSIZE
+from awscli.customizations.s3.s3handler import S3Handler
+from awscli.customizations.s3.utils import MIN_UPLOAD_CHUNKSIZE
 from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.transferconfig import RuntimeConfig
 import botocore.session

--- a/tests/integration/customizations/s3/test_s3handler.py
+++ b/tests/integration/customizations/s3/test_s3handler.py
@@ -25,7 +25,7 @@ from awscli.testutils import unittest, FileCreator
 
 from awscli import EnvironmentVariables
 from awscli.compat import StringIO
-from awscli.customizations.s3.s3handler import S3Handler
+from awscli.customizations.s3.s3handler import S3Handler, MIN_UPLOAD_CHUNKSIZE
 from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.transferconfig import RuntimeConfig
 import botocore.session
@@ -36,6 +36,10 @@ from tests.integration.customizations.s3 import make_s3_files, s3_cleanup, \
 
 def runtime_config(**kwargs):
     return RuntimeConfig().build_config(**kwargs)
+
+
+def minimum_chunk_size():
+    return MIN_UPLOAD_CHUNKSIZE
 
 
 class S3HandlerTestDelete(unittest.TestCase):
@@ -122,18 +126,22 @@ class S3HandlerTestUpload(unittest.TestCase):
         self.client = self.session.create_client('s3', 'us-west-2')
         params = {'region': 'us-west-2', 'acl': 'private'}
         self.s3_handler = S3Handler(self.session, params)
+        self.chunk_size = minimum_chunk_size()
+        self.threshold = self.chunk_size + 1
         self.s3_handler_multi = S3Handler(
             self.session, params=params,
             runtime_config=runtime_config(
-                multipart_threshold=10, multipart_chunksize=2))
+                multipart_threshold=self.threshold,
+                multipart_chunksize=self.chunk_size))
         self.bucket = create_bucket(self.session)
         self.file_creator = FileCreator()
-        self.loc_files = make_loc_files(self.file_creator)
         self.s3_files = [self.bucket + '/text1.txt',
                          self.bucket + '/another_directory/text2.txt']
         self.output = StringIO()
         self.saved_stderr = sys.stderr
+        self.saved_stdout = sys.stdout
         sys.stderr = self.output
+        sys.stdout = self.output
 
     def tearDown(self):
         self.output.close()
@@ -142,6 +150,7 @@ class S3HandlerTestUpload(unittest.TestCase):
         s3_cleanup(self.bucket, self.session)
 
     def test_upload(self):
+        self.loc_files = make_loc_files(self.file_creator)
         # Confirm there are no objects in the bucket.
         response = self.client.list_objects(Bucket=self.bucket)
         self.assertEqual(len(response.get('Contents', [])), 0)
@@ -162,21 +171,26 @@ class S3HandlerTestUpload(unittest.TestCase):
         self.assertEqual(len(response.get('Contents', [])), 2)
 
     def test_multi_upload(self):
+        self.loc_files = make_loc_files(self.file_creator, self.threshold+1)
         files = [self.loc_files[0], self.loc_files[1]]
         tasks = []
         for i in range(len(files)):
             tasks.append(FileInfo(
                 src=self.loc_files[i],
-                dest=self.s3_files[i], size=15,
+                dest=self.s3_files[i],
+                size=self.threshold+1,
                 operation_name='upload',
                 client=self.client,
             ))
 
-        # Note nothing is uploaded because the file is too small
-        # a print statement will show up if it fails.
         self.s3_handler_multi.call(tasks)
-        print_op = "Your proposed upload is smaller than the minimum"
-        self.assertIn(print_op, self.output.getvalue())
+
+        # Confirm UploadPart was called
+        self.assertIn("Completed 4 of 4 part(s)", self.output.getvalue())
+
+        # Confirm the files were uploaded.
+        response = self.client.list_objects(Bucket=self.bucket)
+        self.assertEqual(len(response.get('Contents', [])), 2)
 
 
 class S3HandlerTestUnicodeMove(unittest.TestCase):

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -14,6 +14,7 @@ import os
 
 from mock import patch, Mock
 
+import awscli.customizations.s3.s3handler as s3handler
 from awscli.compat import six
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, \
     capture_output
@@ -29,6 +30,7 @@ class S3HandlerBaseTest(BaseAWSCommandParamsTest):
         self.client = self.session.create_client('s3', 'us-east-1')
         self.source_client = self.session.create_client('s3', 'us-east-1')
         self.file_creator = FileCreator()
+        s3handler.MIN_UPLOAD_CHUNKSIZE = 1
 
     def tearDown(self):
         super(S3HandlerBaseTest, self).tearDown()
@@ -68,13 +70,16 @@ class S3HandlerBaseTest(BaseAWSCommandParamsTest):
             self.assertEqual(self.operations_called[i][1], ref_operation[1])
 
 
-def make_loc_files(file_creator):
+def make_loc_files(file_creator, size=None):
     """
     This sets up the test by making a directory named some_directory.  It
     has the file text1.txt and the directory another_directory inside.  Inside
     of another_directory it creates the file text2.txt.
     """
-    body = 'This is a test.'
+    if size:
+        body = "*" * size
+    else:
+        body = 'This is a test.'
 
     filename1 = file_creator.create_file(
         os.path.join('some_directory', 'text1.txt'), body)

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -14,7 +14,7 @@ import os
 
 from mock import patch, Mock
 
-import awscli.customizations.s3.s3handler as s3handler
+import awscli.customizations.s3.utils as utils
 from awscli.compat import six
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, \
     capture_output
@@ -30,11 +30,13 @@ class S3HandlerBaseTest(BaseAWSCommandParamsTest):
         self.client = self.session.create_client('s3', 'us-east-1')
         self.source_client = self.session.create_client('s3', 'us-east-1')
         self.file_creator = FileCreator()
-        s3handler.MIN_UPLOAD_CHUNKSIZE = 1
+        self._saved_min_chunksize = utils.MIN_UPLOAD_CHUNKSIZE
+        utils.MIN_UPLOAD_CHUNKSIZE = 1
 
     def tearDown(self):
         super(S3HandlerBaseTest, self).tearDown()
         clean_loc_files(self.file_creator)
+        utils.MIN_UPLOAD_CHUNKSIZE = self._saved_min_chunksize
 
     def run_s3_handler(self, s3_handler, tasks):
         self.patch_make_request()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -23,7 +23,8 @@ from awscli.customizations.s3.utils import AppendFilter
 from awscli.customizations.s3.utils import create_warning
 from awscli.customizations.s3.utils import human_readable_size
 from awscli.customizations.s3.utils import human_readable_to_bytes
-from awscli.customizations.s3.utils import MAX_SINGLE_UPLOAD_SIZE, EPOCH_TIME
+from awscli.customizations.s3.utils import MAX_SINGLE_UPLOAD_SIZE
+from awscli.customizations.s3.utils import MIN_UPLOAD_CHUNKSIZE
 from awscli.customizations.s3.utils import set_file_utime, SetFileUtimeError
 from awscli.customizations.s3.utils import RequestParamsMapper
 from awscli.customizations.s3.utils import uni_print
@@ -113,7 +114,7 @@ class FindChunksizeTest(unittest.TestCase):
     This test ensures that the ``find_chunksize`` function works
     as expected.
     """
-    def test_small_chunk(self):
+    def test_valid_chunk(self):
         """
         This test ensures if the ``chunksize`` is appropriate to begin with,
         it does not change.
@@ -121,6 +122,15 @@ class FindChunksizeTest(unittest.TestCase):
         chunksize = 7 * (1024 ** 2)
         size = 8 * (1024 ** 2)
         self.assertEqual(find_chunksize(size, chunksize), chunksize)
+
+    def test_small_chunk(self):
+        """
+        This test ensures that if the ``chunksize`` is below the minimum
+        threshold, it is automatically raised to the minimum.
+        """
+        chunksize = MIN_UPLOAD_CHUNKSIZE - 1
+        size = 3 * MIN_UPLOAD_CHUNKSIZE
+        self.assertEqual(find_chunksize(size, chunksize), MIN_UPLOAD_CHUNKSIZE)
 
     def test_large_chunk(self):
         """

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -1,3 +1,15 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 from awscli.testutils import unittest, temporary_file
 import argparse
 import os
@@ -13,21 +25,12 @@ from dateutil.tz import tzlocal
 from nose.tools import assert_equal
 
 from botocore.hooks import HierarchicalEmitter
-from awscli.customizations.s3.utils import find_bucket_key, find_chunksize
-from awscli.customizations.s3.utils import ReadFileChunk
-from awscli.customizations.s3.utils import relative_path
-from awscli.customizations.s3.utils import StablePriorityQueue
-from awscli.customizations.s3.utils import BucketLister
-from awscli.customizations.s3.utils import get_file_stat
-from awscli.customizations.s3.utils import AppendFilter
-from awscli.customizations.s3.utils import create_warning
-from awscli.customizations.s3.utils import human_readable_size
-from awscli.customizations.s3.utils import human_readable_to_bytes
-from awscli.customizations.s3.utils import MAX_SINGLE_UPLOAD_SIZE
-from awscli.customizations.s3.utils import MIN_UPLOAD_CHUNKSIZE
-from awscli.customizations.s3.utils import set_file_utime, SetFileUtimeError
-from awscli.customizations.s3.utils import RequestParamsMapper
-from awscli.customizations.s3.utils import uni_print
+from awscli.customizations.s3.utils import (
+    find_bucket_key, find_chunksize, ReadFileChunk, relative_path,
+    StablePriorityQueue, BucketLister, get_file_stat, AppendFilter,
+    create_warning, human_readable_size, human_readable_to_bytes,
+    MAX_SINGLE_UPLOAD_SIZE, MIN_UPLOAD_CHUNKSIZE, MAX_UPLOAD_SIZE,
+    set_file_utime, SetFileUtimeError, RequestParamsMapper, uni_print)
 
 
 def test_human_readable_size():
@@ -152,6 +155,12 @@ class FindChunksizeTest(unittest.TestCase):
         size = MAX_SINGLE_UPLOAD_SIZE * 2
         self.assertEqual(find_chunksize(size, chunksize),
                          MAX_SINGLE_UPLOAD_SIZE)
+
+    def test_file_too_large(self):
+        size = MAX_UPLOAD_SIZE + 1
+        chunksize = 1
+        with self.assertRaises(ValueError):
+            find_chunksize(size, chunksize)
 
 
 class TestReadFileChunk(unittest.TestCase):


### PR DESCRIPTION
According to S3's [UploadPart docs](http://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadUploadPart.html):
> Each part must be at least 5 MB in size, except the last part.

This updates the S3 Configuration topic guide to mention that limitation, and then also the TransferConfig so that it is enforced. There were already tests enforcing a minimum, though it was blanket 1 across the board.

cc @rayluo @kyleknap @jamesls @mtdowling 