### PR TITLE
Cloudfront create distribution

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -90,6 +90,9 @@ class OriginDomainNameArgument(CustomArgument):
         origin_id = caller_reference(prefix='origin_id')
         item = {"Id": origin_id, "DomainName": value, "OriginPath": ""}
         if value.endswith('.s3.amazonaws.com'):
+            # We do not need to detect '.s3[\w-].amazonaws.com' as S3 buckets,
+            # because CloudFront treats GovCloud S3 buckets as custom domain.
+            # http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/setting-up-cloudfront.html
             item["S3OriginConfig"] = {"OriginAccessIdentity": ""}
         else:
             item["CustomOriginConfig"] = {

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -40,7 +40,7 @@ def register(event_handler):
     event_handler.register(
         'operation-args-parsed.cloudfront.create-distribution',
         validate_mutually_exclusive_handler(
-            ['origin-domain-name'], ['distribution-config']))
+            ['origin_domain_name'], ['distribution_config']))
 
 
 def caller_reference(prefix="cli"):

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -95,13 +95,13 @@ class OriginDomainNameArgument(CustomArgument):
             item["CustomOriginConfig"] = {
                 'HTTPPort': 80, 'HTTPSPort': 443,
                 'OriginProtocolPolicy': 'http-only'}
-        parameters['DistributionConfig'] = {  # The minimal config
+        parameters['DistributionConfig'] = {
             "CallerReference": caller_reference(),
             "Origins": {"Quantity": 1, "Items": [item]},
             "DefaultCacheBehavior": {
                 "TargetOriginId": origin_id,
                 "ForwardedValues": {
-                    "QueryString": True,
+                    "QueryString": False,
                     "Cookies": {
                         "Forward": "none"
                     }

--- a/awscli/examples/cloudfront/create-distribution.rst
+++ b/awscli/examples/cloudfront/create-distribution.rst
@@ -1,4 +1,12 @@
-The following command creates a CloudFront web distribution::
+You can create a CloudFront web distribution for an S3 domain (such as
+my-bucket.s3.amazonaws.com) or for a custom domain (such as example.com).
+The following command shows an example for an S3 domain::
+
+  aws cloudfront create-distribution \
+    --origin-domain-name my-bucket.s3.amazonaws.com
+
+Or you can use the following command together with a JSON document to do the
+same thing::
 
   aws cloudfront create-distribution --distribution-config file://distconfig.json
 

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -64,6 +64,33 @@ class TestCreateDistribution(BaseAWSCommandParamsTest):
         self.run_cmd(cmdline)
         self.assertEqual(self.last_kwargs, result)
 
+    def test_distribution_config(self):
+        # To demonstrate the original --distribution-config still works
+        cmdline = self.prefix + ('--distribution-config '
+            'Origins={Quantity=0},'
+            'DefaultCacheBehavior={'
+                'TargetOriginId=foo,'
+                'ForwardedValues={QueryString=False,Cookies={Forward=none}},'
+                'TrustedSigners={Enabled=True,Quantity=0},'
+                'ViewerProtocolPolicy=allow-all,'
+                'MinTTL=0'
+                '},'
+            'CallerReference=abcd,'
+            'Enabled=True,'
+            'Comment='
+            )
+        result = {
+            'DistributionConfig': {
+                'Origins': {'Quantity': 0},  # Simplified
+                'CallerReference': 'abcd',
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
     def test_both_distribution_config_and_origin_domain_name(self):
         self.assert_params_for_cmd(
             self.prefix + '--distribution-config {} --origin-domain-name a.us',

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -20,7 +20,7 @@ class TestCreateDistribution(BaseAWSCommandParamsTest):
 
     prefix = 'cloudfront create-distribution '
 
-    def test_origin_domain_name(self):
+    def test_origin_domain_name_with_custom_domain(self):
         cmdline = self.prefix + '--origin-domain-name foo.com'
         result = {
             'DistributionConfig': {
@@ -29,6 +29,28 @@ class TestCreateDistribution(BaseAWSCommandParamsTest):
                     'Items': [{
                         'CustomOriginConfig': mock.ANY,
                         'DomainName': 'foo.com',
+                        'Id': mock.ANY,
+                        'OriginPath': '',
+                    }]
+                },
+                'CallerReference': mock.ANY,
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_origin_domain_name_with_s3_domain(self):
+        cmdline = self.prefix + '--origin-domain-name foo.s3.amazonaws.com'
+        result = {
+            'DistributionConfig': {
+                'Origins': {
+                    'Quantity': 1,
+                    'Items': [{
+                        'S3OriginConfig': mock.ANY,
+                        'DomainName': 'foo.s3.amazonaws.com',
                         'Id': mock.ANY,
                         'OriginPath': '',
                     }]

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+
+from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
+    BaseAWSCommandParamsTest
+
+
+class TestCreateDistribution(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudfront create-distribution '
+
+    def test_origin_domain_name(self):
+        cmdline = self.prefix + '--origin-domain-name foo.com'
+        result = {
+            'DistributionConfig': {
+                'Origins': {
+                    'Quantity': 1,
+                    'Items': [{
+                        'CustomOriginConfig': mock.ANY,
+                        'DomainName': 'foo.com',
+                        'Id': mock.ANY,
+                        'OriginPath': '',
+                    }]
+                },
+                'CallerReference': mock.ANY,
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_both_distribution_config_and_origin_domain_name(self):
+        self.assert_params_for_cmd(
+            self.prefix + '--distribution-config {} --origin-domain-name a.us',
+            expected_rc=255,
+            stderr_contains='cannot be specified when one of the following')
+
+    def test_no_input(self):
+        self.run_cmd(self.prefix, expected_rc=255)


### PR DESCRIPTION
Implement a new optional `--origin-domain-name` parameter for `aws cloudfront create-distribution`.

The following command shows an example for an S3 domain::

    aws cloudfront create-distribution \
      --origin-domain-name my-bucket.s3.amazonaws.com

Example in `aws cloudfront create-distribution help` has also been updated to reflect the new parameter.