### PR TITLE
Use dictionary form for CopySource arg

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -308,7 +308,8 @@ class FileInfo(TaskInfo):
         """
         Copies a object in s3 to another location in s3.
         """
-        copy_source = self.src
+        source_bucket, source_key = find_bucket_key(self.src)
+        copy_source = {'Bucket': source_bucket, 'Key': source_key}
         bucket, key = find_bucket_key(self.dest)
         params = {'Bucket': bucket,
                   'CopySource': copy_source, 'Key': key}

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -161,7 +161,7 @@ class CopyPartTask(OrderableTask):
             params = {'Bucket': bucket, 'Key': key,
                       'PartNumber': self._part_number,
                       'UploadId': upload_id,
-                      'CopySource': '%s/%s' % (src_bucket, src_key),
+                      'CopySource': {'Bucket': src_bucket, 'Key': key},
                       'CopySourceRange': range_param}
             RequestParamsMapper.map_upload_part_copy_params(
                 params, self._params)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -392,7 +392,11 @@ class S3HandlerTestMvS3S3(S3HandlerBaseTest):
         ref_calls = [
             ('CopyObject',
              {'Bucket': self.bucket, 'Key': u'\u2713',
-              'CopySource': self.bucket2 + '/' + u'\u2713', 'ACL': 'private'}),
+              # Implementation detail, but the botocore handler
+              # now fixes up CopySource in before-call so it will
+              # show up in the operations_called.
+              'CopySource': u'mybucket2/%E2%9C%93',
+              'ACL': 'private'}),
             ('DeleteObject',
              {'Bucket': self.bucket2, 'Key': u'\u2713'})
         ]


### PR DESCRIPTION
Ensures we never run into any issues trying to encoding
the S3 keys for the user when copying objects.

This should be a (mostly) transparent change to the CLI because the unit tests still run through the `before-call` handlers in the tests, so we should still see the serialized header version as the expected result.  Only small change to the tests was that we also perform URL encoding in `before-call` so there was a unicode test case that needed to be updated.


Depends on https://github.com/boto/botocore/pull/758.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 