### PR TITLE
Fix bug in S3 handler for copying objects

### DIFF
--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -161,7 +161,7 @@ class CopyPartTask(OrderableTask):
             params = {'Bucket': bucket, 'Key': key,
                       'PartNumber': self._part_number,
                       'UploadId': upload_id,
-                      'CopySource': {'Bucket': src_bucket, 'Key': key},
+                      'CopySource': {'Bucket': src_bucket, 'Key': src_key},
                       'CopySourceRange': range_param}
             RequestParamsMapper.map_upload_part_copy_params(
                 params, self._params)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -539,6 +539,7 @@ class S3HandlerTestCpS3S3(S3HandlerBaseTest):
     def test_multi_copy(self):
         # Create file info objects to perform move.
         tasks = []
+        self.s3_files2[0] = 'mybucket2/destkey2.txt'
         tasks.append(FileInfo(src=self.s3_files[0], src_type='s3',
                               dest=self.s3_files2[0], dest_type='s3',
                               operation_name='copy', size=15,
@@ -554,20 +555,20 @@ class S3HandlerTestCpS3S3(S3HandlerBaseTest):
 
         ref_calls = [
             ('CreateMultipartUpload',
-             {'Bucket': self.bucket2, 'Key': 'text1.txt',
+             {'Bucket': self.bucket2, 'Key': 'destkey2.txt',
               'ContentType': 'text/plain'}),
             ('UploadPartCopy',
-             {'Bucket': self.bucket2, 'Key': 'text1.txt',
+             {'Bucket': self.bucket2, 'Key': 'destkey2.txt',
               'PartNumber': 1, 'UploadId': 'foo',
               'CopySourceRange': 'bytes=0-4',
               'CopySource': self.bucket + '/text1.txt'}),
             ('UploadPartCopy',
-             {'Bucket': self.bucket2, 'Key': 'text1.txt',
+             {'Bucket': self.bucket2, 'Key': 'destkey2.txt',
               'PartNumber': 2, 'UploadId': 'foo',
               'CopySourceRange': 'bytes=5-9',
               'CopySource': self.bucket + '/text1.txt'}),
             ('UploadPartCopy',
-             {'Bucket': self.bucket2, 'Key': 'text1.txt',
+             {'Bucket': self.bucket2, 'Key': 'destkey2.txt',
               'PartNumber': 3, 'UploadId': 'foo',
               'CopySourceRange': 'bytes=10-14',
               'CopySource': self.bucket + '/text1.txt'}),
@@ -578,7 +579,7 @@ class S3HandlerTestCpS3S3(S3HandlerBaseTest):
                                              'ETag': mock.ANY},
                                             {'PartNumber': 3,
                                              'ETag': mock.ANY}]},
-              'Bucket': self.bucket2, 'UploadId': 'foo', 'Key': 'text1.txt'})
+              'Bucket': self.bucket2, 'UploadId': 'foo', 'Key': 'destkey2.txt'})
         ]
 
         # Perform the copy.


### PR DESCRIPTION
Need to use the source key not the destination key.

This wasn't caught because the unit test was using the same
key name for source and destination.  I've updated the unit
tests so we can catch this going forward.

I've also confirmed the failing integration tests now pass.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 