### PR TITLE
Cloudfront create-distribution and update-distribution customization

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -146,9 +146,9 @@ class OriginDomainName(ExclusiveArgument):
 
 
 class CreateDefaultRootObject(ExclusiveArgument):
-    def __init__(self, argument_table):
+    def __init__(self, argument_table, help_text=''):
         super(CreateDefaultRootObject, self).__init__(
-            'default-root-object', argument_table, help_text=(
+            'default-root-object', argument_table, help_text=help_text or (
                 'The object that you want CloudFront to return (for example, '
                 'index.html) when a viewer request points to your root URL.'))
 
@@ -161,7 +161,12 @@ class CreateDefaultRootObject(ExclusiveArgument):
 
 class UpdateDefaultRootObject(CreateDefaultRootObject):
     def __init__(self, context, argument_table):
-        super(UpdateDefaultRootObject, self).__init__(argument_table)
+        super(UpdateDefaultRootObject, self).__init__(
+            argument_table, help_text=(
+                'The object that you want CloudFront to return (for example, '
+                'index.html) when a viewer request points to your root URL. '
+                'CLI will automatically make a get-distribution-config call '
+                'to load and preserve your other settings.'))
         self.context = context
 
     def add_to_params(self, parameters, value):

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -135,7 +135,7 @@ def _create_distribution(call_parameters, **kwargs):
                     "Cookies": {"Forward": "none"},
                 },
                 "TrustedSigners": {
-                    "Enabled": True,
+                    "Enabled": False,
                     "Quantity": 0
                 },
                 "ViewerProtocolPolicy": "allow-all",

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -17,7 +17,6 @@ import random
 import rsa
 from botocore.utils import parse_to_aware_datetime
 from botocore.signers import CloudFrontSigner
-from botocore.session import Session
 
 from awscli.arguments import CustomArgument
 from awscli.customizations.utils import validate_mutually_exclusive_handler

--- a/awscli/examples/cloudfront/create-distribution.rst
+++ b/awscli/examples/cloudfront/create-distribution.rst
@@ -1,4 +1,14 @@
-The following command creates a CloudFront web distribution::
+You can create a CloudFront web distribution for an S3 domain (such as
+my-bucket.s3.amazonaws.com) or for a custom domain (such as example.com).
+The following command shows an example for an S3 domain, and optionally also
+specifies a default root object::
+
+  aws cloudfront create-distribution \
+    --origin-domain-name my-bucket.s3.amazonaws.com \
+    --default-root-object index.html
+
+Or you can use the following command together with a JSON document to do the
+same thing::
 
   aws cloudfront create-distribution --distribution-config file://distconfig.json
 
@@ -9,7 +19,7 @@ The file ``distconfig.json`` is a JSON document in the current folder that defin
     "Aliases": {
       "Quantity": 0
     },
-    "DefaultRootObject": "",
+    "DefaultRootObject": "index.html",
     "Origins": {
       "Quantity": 1,
       "Items": [

--- a/awscli/examples/cloudfront/update-distribution.rst
+++ b/awscli/examples/cloudfront/update-distribution.rst
@@ -1,4 +1,10 @@
-The following command updates a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
+The following command updates the Default Root Object to "index.html"
+for a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
+
+  aws cloudfront update-distribution --id S11A16G5KZMEQD \
+    --default-root-object index.html
+
+The following command disables a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront update-distribution --id S11A16G5KZMEQD --distribution-config file://distconfig-disabled.json --if-match E37HOT42DHPVYH
 

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -1,0 +1,125 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+
+from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
+    BaseAWSCommandParamsTest
+
+
+class TestCreateDistribution(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudfront create-distribution '
+
+    def test_origin_domain_name_with_custom_domain(self):
+        cmdline = self.prefix + '--origin-domain-name foo.com'
+        result = {
+            'DistributionConfig': {
+                'Origins': {
+                    'Quantity': 1,
+                    'Items': [{
+                        'CustomOriginConfig': mock.ANY,
+                        'DomainName': 'foo.com',
+                        'Id': mock.ANY,
+                        'OriginPath': '',
+                    }]
+                },
+                'CallerReference': mock.ANY,
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_origin_domain_name_with_s3_domain(self):
+        cmdline = self.prefix + '--origin-domain-name foo.s3.amazonaws.com'
+        result = {
+            'DistributionConfig': {
+                'Origins': {
+                    'Quantity': 1,
+                    'Items': [{
+                        'S3OriginConfig': mock.ANY,
+                        'DomainName': 'foo.s3.amazonaws.com',
+                        'Id': mock.ANY,
+                        'OriginPath': '',
+                    }]
+                },
+                'CallerReference': mock.ANY,
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_s3_domain_with_default_root_object(self):
+        cmdline = (self.prefix + '--origin-domain-name foo.s3.amazonaws.com '
+                   + '--default-root-object index.html')
+        result = {
+            'DistributionConfig': {
+                'Origins': {
+                    'Quantity': 1,
+                    'Items': [{
+                        'S3OriginConfig': mock.ANY,
+                        'DomainName': 'foo.s3.amazonaws.com',
+                        'Id': mock.ANY,
+                        'OriginPath': '',
+                    }]
+                },
+                'CallerReference': mock.ANY,
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                'DefaultRootObject': 'index.html',
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_distribution_config(self):
+        # To demonstrate the original --distribution-config still works
+        cmdline = self.prefix + ('--distribution-config '
+            'Origins={Quantity=0},'
+            'DefaultCacheBehavior={'
+                'TargetOriginId=foo,'
+                'ForwardedValues={QueryString=False,Cookies={Forward=none}},'
+                'TrustedSigners={Enabled=True,Quantity=0},'
+                'ViewerProtocolPolicy=allow-all,'
+                'MinTTL=0'
+                '},'
+            'CallerReference=abcd,'
+            'Enabled=True,'
+            'Comment='
+            )
+        result = {
+            'DistributionConfig': {
+                'Origins': {'Quantity': 0},  # Simplified
+                'CallerReference': 'abcd',
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_both_distribution_config_and_origin_domain_name(self):
+        self.assert_params_for_cmd(
+            self.prefix + '--distribution-config {} --origin-domain-name a.us',
+            expected_rc=255,
+            stderr_contains='cannot be specified when one of the following')
+
+    def test_no_input(self):
+        self.run_cmd(self.prefix, expected_rc=255)

--- a/tests/functional/cloudfront/test_update_distribution.py
+++ b/tests/functional/cloudfront/test_update_distribution.py
@@ -1,0 +1,93 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+
+from awscli.testutils import BaseAWSPreviewCommandParamsTest as \
+    BaseAWSCommandParamsTest
+
+
+class TestUpdateDistribution(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudfront update-distribution --id myid '
+
+    def test_default_root_object(self):
+        cmdline = self.prefix + '--default-root-object index.html'
+        self.parsed_response = {
+            # A get-distribution-config response, contains a minimal config
+            'ETag': '__etag__',
+            'DistributionConfig': {
+                'Origins': {'Quantity': 0},  # Simplified
+                'CallerReference': 'abcd',
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': {
+                    'TargetOriginId': 'foo',
+                    'ForwardedValues': {
+                        'QueryString': True, 'Cookies': {'Forward': 'none'}},
+                    'TrustedSigners': {'Enabled': True, 'Quantity': 0},
+                    'ViewerProtocolPolicy': 'allow-all',
+                    'MinTTL': 0,
+                    },
+                },
+            }
+        result = {
+            'DistributionConfig': {
+                'DefaultRootObject': 'index.html',
+                'Origins': {'Quantity': 0},  # Simplified
+                'CallerReference': 'abcd',
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            'Id': 'myid',
+            'IfMatch': '__etag__',
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_distribution_config(self):
+        # To demonstrate the original --distribution-config still works
+        cmdline = self.prefix + ('--distribution-config '
+            'Origins={Quantity=0},'
+            'DefaultCacheBehavior={'
+                'TargetOriginId=foo,'
+                'ForwardedValues={QueryString=False,Cookies={Forward=none}},'
+                'TrustedSigners={Enabled=True,Quantity=0},'
+                'ViewerProtocolPolicy=allow-all,'
+                'MinTTL=0'
+                '},'
+            'CallerReference=abcd,'
+            'Enabled=True,'
+            'Comment='
+            )
+        result = {
+            'DistributionConfig': {
+                'Origins': {'Quantity': 0},  # Simplified
+                'CallerReference': 'abcd',
+                'Comment': '',
+                'Enabled': True,
+                'DefaultCacheBehavior': mock.ANY,
+                },
+            'Id': 'myid',
+            }
+        self.run_cmd(cmdline)
+        self.assertEqual(self.last_kwargs, result)
+
+    def test_both_distribution_config_and_default_root_object(self):
+        self.assert_params_for_cmd(
+            self.prefix + '--distribution-config {} --default-root-object foo',
+            expected_rc=255,
+            stderr_contains='cannot be specified when one of the following')
+
+    def test_no_input(self):
+        self.run_cmd(self.prefix, expected_rc=255)


### PR DESCRIPTION
Implement a new optional `--origin-domain-name` parameter and `--default-root-object` for `aws cloudfront create-distribution`. The following command shows an example for an S3 domain::

    aws cloudfront create-distribution \
      --origin-domain-name my-bucket.s3.amazonaws.com --default-root-object index.html

Implement a new optional `--default-root-object` parameter for `aws cloudfront update-distribution`. The following command shows an example for changing default root object::

    aws cloudfront update-distribution --default-root-object index.html

Example in `aws cloudfront create-distribution help` and `aws cloudfront update-distribution help` has also been updated to reflect the new parameters.

This PR replaces #1728 and #1731.