### PR TITLE
Feature/support private clusters

### DIFF
--- a/awscli/customizations/emr/describecluster.py
+++ b/awscli/customizations/emr/describecluster.py
@@ -47,11 +47,16 @@ class DescribeCluster(Command):
             cluster_id=parsed_args.cluster_id,
             parsed_globals=parsed_globals)
 
+        master_private_dns = self._find_master_private_dns(
+            cluster_id=parsed_args.cluster_id,
+            parsed_globals=parsed_globals)
+
         constructed_result = self._construct_result(
             describe_cluster_result,
             list_instance_groups_result,
             list_bootstrap_actions_result,
-            master_public_dns)
+            master_public_dns,
+            master_private_dns)
 
         emrutils.display_response(self._session, 'describe_cluster',
                                   constructed_result, parsed_globals)
@@ -60,6 +65,11 @@ class DescribeCluster(Command):
 
     def _find_master_public_dns(self, cluster_id, parsed_globals):
         return emrutils.find_master_public_dns(
+            session=self._session, cluster_id=cluster_id,
+            parsed_globals=parsed_globals)
+
+    def _find_master_private_dns(self, cluster_id, parsed_globals):
+        return emrutils.find_master_private_dns(
             session=self._session, cluster_id=cluster_id,
             parsed_globals=parsed_globals)
 
@@ -78,9 +88,10 @@ class DescribeCluster(Command):
 
     def _construct_result(
             self, describe_cluster_result, list_instance_groups_result,
-            list_bootstrap_actions_result, master_public_dns):
+            list_bootstrap_actions_result, master_public_dns, master_private_dns):
         result = describe_cluster_result
         result['Cluster']['MasterPublicDnsName'] = master_public_dns
+        result['Cluster']['MasterPrivateDnsName'] = master_private_dns
         result['Cluster']['InstanceGroups'] = []
         result['Cluster']['BootstrapActions'] = []
 

--- a/awscli/customizations/emr/emrutils.py
+++ b/awscli/customizations/emr/emrutils.py
@@ -230,6 +230,17 @@ def find_master_public_dns(session, parsed_globals, cluster_id):
     else:
         return master_instance.get('PublicDnsName')
 
+def find_master_private_dns(session, parsed_globals, cluster_id):
+    """
+    Returns the private_instance's 'PrivateDnsName'
+    """
+    master_instance = _find_master_instance(
+        session, parsed_globals, cluster_id)
+    if master_instance is None:
+        return ""
+    else:
+        return master_instance.get('PrivateDnsName')
+
 
 def which(program):
     for path in os.environ["PATH"].split(os.pathsep):

--- a/awscli/customizations/emr/sshutils.py
+++ b/awscli/customizations/emr/sshutils.py
@@ -27,8 +27,8 @@ def validate_and_find_master_dns(session, parsed_globals, cluster_id):
     Check if the cluster to be connected to is
      terminated or being terminated.
     Check if the cluster is running.
-    Find master instance public dns of a given cluster.
-    Return the latest created master instance public dns name.
+    Find master instance public dns or private dns of a given cluster.
+    Return the latest created master instance  dns name.
     Throw MasterDNSNotAvailableError or ClusterTerminatedError.
     """
     cluster_state = emrutils.get_cluster_state(
@@ -47,9 +47,16 @@ def validate_and_find_master_dns(session, parsed_globals, cluster_id):
     except WaiterError:
         raise exceptions.MasterDNSNotAvailableError
 
-    return emrutils.find_master_public_dns(
+    master_dns = emrutils.find_master_public_dns(
         session=session, cluster_id=cluster_id,
         parsed_globals=parsed_globals)
+
+    if master_dns == "":
+        master_dns = emrutils.find_master_private_dns(
+            session=session, cluster_id=cluster_id,
+            parsed_globals=parsed_globals)
+
+
 
 
 def validate_ssh_with_key_file(key_file):

--- a/awscli/customizations/emr/sshutils.py
+++ b/awscli/customizations/emr/sshutils.py
@@ -27,7 +27,8 @@ def validate_and_find_master_dns(session, parsed_globals, cluster_id):
     Check if the cluster to be connected to is
      terminated or being terminated.
     Check if the cluster is running.
-    Find master instance public dns or private dns of a given cluster.
+    Find master instance public dns or if that isn't
+    available the private dns of a given cluster.
     Return the latest created master instance  dns name.
     Throw MasterDNSNotAvailableError or ClusterTerminatedError.
     """
@@ -55,6 +56,8 @@ def validate_and_find_master_dns(session, parsed_globals, cluster_id):
         master_dns = emrutils.find_master_private_dns(
             session=session, cluster_id=cluster_id,
             parsed_globals=parsed_globals)
+
+    return master_dns
 
 
 

--- a/tests/unit/customizations/emr/test_describe_cluster.py
+++ b/tests/unit/customizations/emr/test_describe_cluster.py
@@ -241,11 +241,20 @@ class TestDescribeCluster(BaseAWSCommandParamsTest):
     @patch('awscli.customizations.emr.emr.DescribeCluster._construct_result')
     @patch('awscli.customizations.emr.emr.'
            'DescribeCluster._find_master_public_dns')
+    @patch('awscli.customizations.emr.emr.'
+           'DescribeCluster._find_master_private_dns')
+
     def test_operations_called(
             self, find_master_public_dns_patch,
+            find_master_private_dns_patch,
             construct_result_patch):
+
         find_master_public_dns_patch.return_value = \
             list_instances_result_mock["Instances"][0]['PublicDnsName']
+
+        find_master_private_dns_patch.return_value = \
+            list_instances_result_mock["Instances"][0]['PrivateDnsName']
+
         construct_result_patch.return_value = dict()
 
         args = ' --cluster-id j-ABCD'

--- a/tests/unit/customizations/emr/test_describe_cluster.py
+++ b/tests/unit/customizations/emr/test_describe_cluster.py
@@ -154,6 +154,7 @@ EXPECTED_RESULT = {
         "TerminationProtected": "false",
         "RunningAmiVersion": "2.4.2",
         "MasterPublicDnsName": "ec2-01-01-1-188.compute-1.amazonaws.com",
+        "MasterPrivateDnsName": "ec2-01-01-1-189.compute-1.amazonaws.com",
         "InstanceGroups": [
             {
                 "RequestedInstanceCount": 1,

--- a/tests/unit/customizations/emr/test_describe_cluster.py
+++ b/tests/unit/customizations/emr/test_describe_cluster.py
@@ -154,7 +154,7 @@ EXPECTED_RESULT = {
         "TerminationProtected": "false",
         "RunningAmiVersion": "2.4.2",
         "MasterPublicDnsName": "ec2-01-01-1-188.compute-1.amazonaws.com",
-        "MasterPrivateDnsName": "ec2-01-01-1-189.compute-1.amazonaws.com",
+        "MasterPrivateDnsName": "ip-10-10-10-177.ec2.internal",
         "InstanceGroups": [
             {
                 "RequestedInstanceCount": 1,


### PR DESCRIPTION
The use of a private cluster breaks the aws emr toolchain. The ssh subcommand will fail, because there is no public dns name associated with a private cluster. And in the subcommand describe-cluster the expectation is broken, that a cluster_id can be used to retrieve a dns name of the master node.

To reproduce the issues, start a cluster on a private subnet (as specified by the documentation of EMR), then run:

     aws emr ssh --cluster-id <cluster-id> --key-pair-file <your key>

It will fail, because it can't retrieve the dns name.

Furthermore there is no longer a way to translate a cluster_id into a hostname, when using a private cluster:

    aws emr describe-cluster --cluster-id <cluster-id>

MasterPublicDnsName is empty.

I added a field MasterPrivateDnsName to describe_cluster and let aws emr ssh use MasterPrivateDnsName as dns name in the case MasterPublicDnsName is an empty string.
