### PR TITLE
Make builds fail if pr to master is made

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ python:
 
 sudo: false
 
+before_install:
+  - if [ "$TRAVIS_PULL_REQUEST" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+      echo "No pull requests can be sent to the master branch" 1>&2;
+      exit 1;
+    fi
 install:
   - python scripts/ci/install
 script: python scripts/ci/run-tests


### PR DESCRIPTION
I think this is working: https://github.com/aws/aws-cli/pull/1755 and erroring out with this sample build: https://travis-ci.org/aws/aws-cli/jobs/105521867

Here are environment variable references that Travis uses: https://docs.travis-ci.com/user/environment-variables/

cc @jamesls @mtdowling @rayluo @JordonPhillips 