### PR TITLE
SAML forms-based authentication in CLI

### DIFF
--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -3,8 +3,6 @@ import json
 import logging
 
 from botocore.exceptions import ProfileNotFound
-from botocore.compat import six
-from six.moves import input as raw_input
 
 LOG = logging.getLogger(__name__)
 
@@ -39,40 +37,7 @@ def inject_assume_role_provider_cache(session, **kwargs):
                   "JSONFileCache for assume-role.")
         return
     cred_chain.get_provider('assume-role').cache = JSONFileCache()
-    saml_provider = cred_chain.get_provider('assume-role-with-saml')
-    saml_provider.cache = JSONFileCache()
-    saml_provider.role_selector = role_selector
-
-
-def role_selector(role_arn, roles):
-    if role_arn:
-        chosen_roles = [r for r in roles if r['RoleArn']==role_arn]
-        if not chosen_roles:
-            raise ValueError(
-                'Your specified role %s does not exist in IdP roles list: %s'
-                % (role_arn, [r['RoleArn'] for r in roles]))
-        role = chosen_roles[0]
-    else:
-        # So end user has not yet configured a role_arn.
-        # If IdP provides more than one role, ask the user to choose one,
-        # otherwise just proceed.
-        if len(roles) > 1:
-            options = [(str(i), role) for i, role in enumerate(roles, start=1)]
-            prompt = "\n".join(
-                "[%s]: %s" % (i, role['RoleArn']) for i, role in options)
-            choice = raw_input(
-                "Please choose the role you would like to assume:\n"
-                "(You can preconfigure the role_arn in your profile)\n"
-                "%s\n"
-                "Selection: " % prompt)
-            role = dict(options).get(choice)
-            if not role:
-                raise ValueError('You selected an invalid role index.')
-        elif roles:
-            role = roles[0]
-        else:
-            raise ValueError('There is no role to choose')
-    return role
+    cred_chain.get_provider('assume-role-with-saml').cache = JSONFileCache()
 
 
 class JSONFileCache(object):

--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -36,8 +36,8 @@ def inject_assume_role_provider_cache(session, **kwargs):
                   "assume-role cred provider cache.  Not configuring "
                   "JSONFileCache for assume-role.")
         return
-    provider = cred_chain.get_provider('assume-role')
-    provider.cache = JSONFileCache()
+    cred_chain.get_provider('assume-role').cache = JSONFileCache()
+    cred_chain.get_provider('assume-role-with-saml').cache = JSONFileCache()
 
 
 class JSONFileCache(object):

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -238,12 +238,15 @@ retrieve AWS credentials for you. You do not need to configure any credentials.
 You can specify the following configuration values for configuring an SAML role
 in the AWS CLI config file:
 
-* ``saml_endpoint`` - The URL of the login page of your SAML IdP
+* ``saml_endpoint`` - The HTTPS URL of the login page of your SAML IdP
 * ``saml_authentication_type`` - The authentication type of your SAML IdP.
-  So far, the only valid setting is `form`, means forms-based authentication.
+  So far, the only valid setting is ``form``, means forms-based authentication.
 * ``saml_provider`` - This tells CLI what kind of login page will be used.
-  The valid settings is `adfs` for Active Directory Federation Services (AD FS)
-  and `okta` for Okta.
+  The valid settings are:
+
+  - ``adfs`` for Active Directory Federation Services (AD FS)
+  - ``okta`` for Okta.
+
 * ``saml_username`` - The username you use to login on your SAML IdP.
   It is optional. If absent, the CLI will prompt for your input.
 * ``role_arn`` - The ARN of the role you want to assume.

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -225,6 +225,47 @@ Example configuration::
   source_profile=development
 
 
+Support for Federated Users Using SAML 2.0
+------------------------------------------
+
+AWS CLI supports the use of federated user accounts through Security Assertion
+Markup Language (SAML) Identity Providers (IdP) which provides forms-based
+authentication.
+
+The AWS CLI will automatically authenticate you against the SAML IdP, and then
+retrieve AWS credentials for you. You do not need to configure any credentials.
+
+You can specify the following configuration values for configuring an SAML role
+in the AWS CLI config file:
+
+* ``saml_endpoint`` - The URL of the login page of your SAML IdP
+* ``saml_authentication_type`` - The authentication type of your SAML IdP.
+  So far, the only valid setting is `form`, means forms-based authentication.
+* ``saml_provider`` - This tells CLI what kind of login page will be used.
+  The valid settings is `adfs` for Active Directory Federation Services (AD FS)
+  and `okta` for Okta.
+* ``saml_username`` - The username you use to login on your SAML IdP.
+  It is optional. If absent, the CLI will prompt for your input.
+* ``role_arn`` - The ARN of the role you want to assume.
+
+When you specify a profile that has SAML authentication configuration,
+the AWS CLI will authenticate you against the SAML IdP, and make an
+``AssumeRoleWithSAML`` call to retrieve temporary credentials.  These
+credentials are then stored (in ``~/.aws/cache``).
+Subsequent AWS CLI commands will use the cached temporary credentials until
+they expire, in which case you will be re-prompted for your password.
+
+Example configuration::
+
+  # In ~/.aws/config
+  [profile your_profile_name]
+  saml_endpoint = https://...
+  saml_authentication_type = form
+  saml_provider = adfs
+  saml_username = johndoe@example.com
+  role_arn=arn:aws:iam:...
+
+
 Service Specific Configuration
 ==============================
 

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -61,19 +61,6 @@ class TestAssumeRolePlugin(unittest.TestCase):
         self.assertFalse(credential_provider.get_provider.called)
 
 
-class TestRoleSelector(unittest.TestCase):
-    dev = {'RoleArn': 'dev', 'PrincipalArn': 'ExampleOrganization'}
-    prd = {'RoleArn': 'prd', 'PrincipalArn': 'ExampleOrganization'}
-    roles = [dev, prd]
-
-    def test_choose_one_matching_role(self):
-        self.assertEqual(assumerole.role_selector('dev', self.roles), self.dev)
-
-    def test_no_matching_role(self):
-        self.assertRaises(
-            ValueError, assumerole.role_selector, 'other', self.roles)
-
-
 class TestJSONCache(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()


### PR DESCRIPTION
Now customers can configure a profile to authenticate against a SAML Identity Provider (IdP). Only forms-based authentication is supported so far.
- You will need to configure your profile, which looks like the example in boto/botocore#783
- `saml_username` can be prompted by CLI, so it is optional in the configuration.
- ~~you don't have to specify the role_arn, CLI will prompt and ask for your input~~ You STILL NEED to specify the role_arn in config.

Relies on boto/botocore#783
