### PR TITLE
Truncate file before writing role cache contents

### DIFF
--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -80,6 +80,7 @@ class JSONFileCache(object):
             os.makedirs(self._working_dir)
         with os.fdopen(os.open(full_key,
                                os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
+            f.truncate()
             f.write(file_content)
 
     def _convert_cache_key(self, cache_key):

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -107,6 +107,13 @@ class TestJSONCache(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.cache['foo']
 
+    def test_file_is_truncated_before_writing(self):
+        self.cache['mykey'] = {
+            'really long key in the cache': 'really long value in cache'}
+        # Now overwrite it with a smaller value.
+        self.cache['mykey'] = {'a': 'b'}
+        self.assertEqual(self.cache['mykey'], {'a': 'b'})
+
     @skip_if_windows('File permissions tests not supported on Windows.')
     def test_permissions_for_file_restricted(self):
         self.cache['mykey'] = {'foo': 'bar'}


### PR DESCRIPTION
Fixes #1684.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 