### PR TITLE
Fix test failures from mock 1.3.0 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ docutils>=0.10
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.0
 colorama>=0.2.5,<=0.3.3
-mock==1.0.1
+mock==1.3.0
 rsa>=3.1.2,<=3.3.0
 wheel==0.24.0

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -262,7 +262,7 @@ class TestPublicKeyProvider(unittest.TestCase):
             'c': {'Fingerprint': 'c', 'OtherData': 'c', 'Value': 'c'},
         }, keys)
         cloudtrail_client.list_public_keys.assert_has_calls(
-            call(EndTime=end_date, StartTime=start_date))
+            [call(EndTime=end_date, StartTime=start_date)])
 
 
 class TestSha256RSADigestValidator(unittest.TestCase):

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -478,7 +478,13 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             self.assertEqual(rc, 0)
 
             # Make sure uri_param was called
-            uri_param_mock.assert_called()
+            uri_param_mock.assert_any_call(
+                event_name='load-cli-arg.ec2.describe-instances.unknown-arg',
+                operation_name='describe-instances',
+                param=mock.ANY,
+                service_name='ec2',
+                value='file:///foo',
+            )
             # Make sure it was called with our passed-in URI
             self.assertEqual('file:///foo',
                              uri_param_mock.call_args_list[-1][1]['value'])
@@ -496,7 +502,13 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
 
             self.assertEqual(rc, 0)
 
-            uri_param_mock.assert_called()
+            uri_param_mock.assert_any_call(
+                event_name='load-cli-arg.custom.foo.bar',
+                operation_name='foo',
+                param=mock.ANY,
+                service_name='custom',
+                value='file:///foo',
+            )
 
     @unittest.skip
     def test_custom_arg_no_paramfile(self):


### PR DESCRIPTION
This upgrades mock to version 1.3.0 which is what's used
in botocore and boto3.

This was causing subtle test falures depending on if you installed
CLI->botocore vs. botocore->CLI.

The latest version of mock, 1.3.0, is more strict in error validation.
Specifically, any mock method that starts with "assert" will now
raise AttributeErrors if they don't exist on the mock object.

Our code was using a couple of non-existent assertion methods that were
inadvertently passing (because they just returned a new mock object).

cc @kyleknap @mtdowling @rayluo @JordonPhillips 