### PR TITLE
Remove instance id length check for opsworks customization

### DIFF
--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -35,7 +35,7 @@ IAM_USER_POLICY_TIMEOUT = datetime.timedelta(minutes=15)
 IAM_PATH = '/AWS/OpsWorks/'
 
 HOSTNAME_RE = re.compile(r"^(?!-)[a-z0-9-]{1,63}(?<!-)$", re.I)
-INSTANCE_ID_RE = re.compile(r"^i-[0-9a-f]{8}$")
+INSTANCE_ID_RE = re.compile(r"^i-[0-9a-f]+$")
 IP_ADDRESS_RE = re.compile(r"^\d+\.\d+\.\d+\.\d+$")
 
 IDENTITY_URL = \

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -801,19 +801,19 @@ class TestOpsWorksRegisterEc2(TestOpsWorksBase):
             mock_ec2.describe_instances.return_value = {
                 "Reservations": [{
                     "Instances": [{
-                        "InstanceId": "i-12345678",
+                        "InstanceId": "i-12345678910",
                     }]
                 }]
             }
             self.register.retrieve_stack(self._build_args(
-                stack_id="STACKID", target="i-12345678"
+                stack_id="STACKID", target="i-12345678910"
             ))
             mock_ec2.describe_instances.assert_called_with(
-                InstanceIds=["i-12345678"], Filters=[]
+                InstanceIds=["i-12345678910"], Filters=[]
             )
             self.assertEqual(
                 self.register._ec2_instance["InstanceId"],
-                "i-12345678")
+                "i-12345678910")
 
     def test_retrieve_stack_target_ip_address(self):
         """Should find an EC2 instance by IP address."""


### PR DESCRIPTION
Needed to work with the longer Amazon EC2 instance ids.

cc @kyleknap @mtdowling @rayluo @JordonPhillips 