### PR TITLE
update tox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tox==1.4
+tox==2.3.1
 docutils>=0.10
 # botocore and the awscli packages are typically developed
 # in tandem, so we're requiring the latest develop


### PR DESCRIPTION
Update tox so that all environments are recognized.
py34, py35 environments aren't recognized with tox 1.4.

resolves #1781