### PR TITLE
Add pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+Thanks for contacting us! Before you submit your issue, please fill out all the
+information below:
+
+- Please provide a detailed description of your problem:
+
+- What version of the CLI are you using? (Tip: Use `aws --version` to find out.)
+  If you are not using the [latest release](https://github.com/aws/aws-cli/releases),
+  please try updating to see if your issue has already been fixed.
+
+- What exact commands are you using? Please provide the debug logs for these
+  commands by appending the `--debug` flag to them:
+
+- Please provide any additional steps to reproduce your issue:

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,15 @@
 Thanks for contacting us! Before you submit your issue, please fill out all the
 information below:
 
-- Please provide a detailed description of your problem:
-
 - What version of the CLI are you using? (Tip: Use `aws --version` to find out.)
   If you are not using the [latest release](https://github.com/aws/aws-cli/releases),
   please try updating to see if your issue has already been fixed.
 
-- What exact commands are you using? Please provide the debug logs for these
-  commands by appending the `--debug` flag to them:
+- What is a minimal set of steps, with exact CLI commands, to reproduce the issue?
 
-- Please provide any additional steps to reproduce your issue:
+  1.
+  2.
+  3.
+
+- Please provide the debug logs for any commands you used by appending the
+  `--debug` flag to them:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,9 @@
 Thanks for submitting a pull request! Before pressing that tempting green submit
 button, please make sure you check off all the following boxes:
 
-- [ ] All existing unit tests pass in all supported Python versions (2.6, 2.7,
-      and 3.3+)
+- [ ] All existing unit tests pass
 - [ ] New tests have been added to verify the new functionality / bug fix
-- [ ] All code works on at least Windows, Mac OS X, and Linux
 - [ ] All code follows [PEP 8](https://www.python.org/dev/peps/pep-0008/), or
-      remains consistent with existing code.
-- [ ] You agree to release all submitted code under the
-      [Apache 2.0 License](http://aws.amazon.com/apache2.0/)
+  remains consistent with existing code. You can use the
+  [`pep8`](https://pypi.python.org/pypi/pep8) tool to check this.
+- [ ] Please explain your motivation and any use cases for this change:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+Thanks for submitting a pull request! Before pressing that tempting green submit
+button, please make sure you check off all the following boxes:
+
+- [ ] All existing unit tests pass in all supported Python versions (2.6, 2.7,
+      and 3.3+)
+- [ ] New tests have been added to verify the new functionality / bug fix
+- [ ] All code works on at least Windows, Mac OS X, and Linux
+- [ ] All code follows [PEP 8](https://www.python.org/dev/peps/pep-0008/), or
+      remains consistent with existing code.
+- [ ] You agree to release all submitted code under the
+      [Apache 2.0 License](http://aws.amazon.com/apache2.0/)


### PR DESCRIPTION
GitHub [released a feature today](https://github.com/blog/2111-issue-and-pull-request-templates) which allows repo owners to set templates for pull requests and issues. I think this will help boost the quality of the issues / pr's we receive.

I more-or less copied this info from the contributing guide. One thing that I think we might consider is adding the cc list as well, but I wasn't sure we should tie any files to the current maintainers.

To give you an idea of what this looks like, I'll paste and fill out the pull request template below.

cc @jamesls @kyleknap @rayluo 

Pull Request Template
------

Thanks for submitting a pull request! Before pressing that tempting green submit
button, please make sure you check off all the following boxes:

- [x] All existing unit tests pass
- [ ] New tests have been added to verify the new functionality / bug fix
- [x] All code follows [PEP 8](https://www.python.org/dev/peps/pep-0008/), or
  remains consistent with existing code. You can use the
  [`pep8`](https://pypi.python.org/pypi/pep8) tool to check this.
- [x] Please explain your motivation and any use cases for this change:

This will hopefully increase the quality of issues and pull requests.

Issue Template
------

Thanks for contacting us! Before you submit your issue, please fill out all the
information below:

- What version of the CLI are you using? (Tip: Use `aws --version` to find out.)
  If you are not using the [latest release](https://github.com/aws/aws-cli/releases),
  please try updating to see if your issue has already been fixed.

`aws-cli/1.10.5 Python/2.7.11 Darwin/14.5.0 botocore/1.3.26`

- What is a minimal set of steps, with exact CLI commands, to reproduce the issue?

  1. Raise issue or pull request
  2. There is no guidance
  3. Issue is low quality

- Please provide the debug logs for any commands you used by appending the
  `--debug` flag to them: