### PR TITLE
Handle empty sections when using configure set command

### DIFF
--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -298,6 +298,22 @@ class TestConfigureCommand(unittest.TestCase):
         self.assertEqual(p.rc, 1)
         self.assertEqual(p.stdout, '')
 
+    def test_can_handle_empty_section(self):
+        self.set_config_file_contents(
+            '[default]\n'
+        )
+        p = aws('configure set preview.cloudfront true',
+                env_vars=self.env_vars)
+        p = aws('configure set region us-west-2',
+                env_vars=self.env_vars)
+        self.assertEqual(
+            '[default]\n'
+            'region = us-west-2\n'
+            '[preview]\n'
+            'cloudfront = true\n',
+            self.get_config_file_contents(),
+        )
+
 
 class TestConfigureHasArgTable(unittest.TestCase):
     def test_configure_command_has_arg_table(self):

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -336,3 +336,17 @@ class TestConfigFileWriter(unittest.TestCase):
             '    signature_version = newval\n'
             '[profile foo]\n'
             'foo = bar\n')
+
+    def test_can_handle_empty_section(self):
+        original = (
+            '[default]\n'
+            '[preview]\n'
+            'cloudfront = true\n'
+        )
+        self.assert_update_config(
+            original, {'region': 'us-west-2', '__section__': 'default'},
+            '[default]\n'
+            'region = us-west-2\n'
+            '[preview]\n'
+            'cloudfront = true\n'
+        )


### PR DESCRIPTION
We were writing out a config value in the *next* section of the config file whenever there's an existing section that had no entries.

cc @kyleknap  @rayluo @JordonPhillips 