### PR TITLE
Update describe-internet-gateways.rst

### DIFF
--- a/awscli/examples/ec2/describe-internet-gateways.rst
+++ b/awscli/examples/ec2/describe-internet-gateways.rst
@@ -34,7 +34,7 @@ This example describes the Internet gateway for the specified VPC.
 
 Command::
 
-  aws ec2 describe-subnets --filters "Name=attachment.vpc-id,Values=vpc-a01106c2"
+  aws ec2 describe-internet-gateways --filters "Name=attachment.vpc-id,Values=vpc-a01106c2"
 
 Output::
 


### PR DESCRIPTION
The command to filter internet-gateway for a specific vpc should start as 'describe-internet-gateways --filters' and not as 'describe-subnets --filters'.