### PR TITLE
Update tests after region and endpoint change

### DIFF
--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -677,8 +677,8 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             'ec2 describe-instances --region us-west-2',
             expected_rc=0)
-        self.assertEqual(self.create_endpoint.call_args[0],
-                         (mock.ANY, 'us-west-2'))
+        self.assertEqual(
+            self.create_endpoint.call_args[1]['region_name'], 'us-west-2')
 
     def test_aws_with_verify_false(self):
         self.assert_params_for_cmd(
@@ -687,7 +687,6 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
         # Because we used --no-verify-ssl, create_endpoint should be
         # called with verify=False
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[0], (mock.ANY, 'us-east-1'))
         self.assertFalse(call_args[1]['verify'])
 
     def test_aws_with_cacert_env_var(self):
@@ -696,7 +695,6 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
             'ec2 describe-instances --region us-east-1',
             expected_rc=0)
         call_args = self.create_endpoint.call_args
-        self.assertEqual(call_args[0], (mock.ANY, 'us-east-1'))
         self.assertEqual(call_args[1]['verify'], '/path/cacert.pem')
 
     def test_aws_with_read_timeout(self):


### PR DESCRIPTION
cc @jamesls @JordonPhillips 

I was considering to remove the patching of the endpoint and make it rely on the client, but that would be a little bit out of the scope as I am just fixing the build. Let me know if you want me to switch the endpoint patching to be client patching.