### PR TITLE
Mark args as not required when aliasing

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -127,7 +127,8 @@ class CLIDocumentEventHandler(object):
             self._documented_arg_groups.append(argument.group_name)
         else:
             option_str = '%s <value>' % argument.cli_name
-        if not argument.required:
+        if not (argument.required
+                or getattr(argument, '_DOCUMENT_AS_REQUIRED', False)):
             option_str = '[%s]' % option_str
         doc.writeln('%s' % option_str)
 

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -42,8 +42,14 @@ def make_hidden_alias(argument_table, existing_name, alias_name):
     copy_arg = copy.copy(current)
     copy_arg._UNDOCUMENTED = True
     copy_arg.name = alias_name
-    copy_arg.required = False
-    current.required = False
+    if current.required:
+        # If the current argument is required, then
+        # we'll mark both as not required, but
+        # flag _DOCUMENT_AS_REQUIRED so our doc gen
+        # knows to still document this argument as required.
+        copy_arg.required = False
+        current.required = False
+        current._DOCUMENT_AS_REQUIRED = True
     argument_table[alias_name] = copy_arg
 
 

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -42,6 +42,8 @@ def make_hidden_alias(argument_table, existing_name, alias_name):
     copy_arg = copy.copy(current)
     copy_arg._UNDOCUMENTED = True
     copy_arg.name = alias_name
+    copy_arg.required = False
+    current.required = False
     argument_table[alias_name] = copy_arg
 
 

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -375,6 +375,19 @@ class TestParametersCanBeHidden(BaseAWSHelpOutputTest):
         self.assert_not_contains('--starting-sequence-number')
 
 
+class TestCanDocumentAsRequired(BaseAWSHelpOutputTest):
+    def test_can_doc_as_required(self):
+        # This param is already marked as required, but to be
+        # explicit this is repeated here to make it more clear.
+        def doc_as_required(argument_table, **kwargs):
+            arg = argument_table['volume-arns']
+        self.driver.session.register('building-argument-table',
+                                     doc_as_required)
+        self.driver.main(['storagegateway', 'describe-cached-iscsi-volumes',
+                          'help'])
+        self.assert_not_contains('[--volume-arns <value>]')
+
+
 class TestEC2AuthorizeSecurityGroupNotRendered(BaseAWSHelpOutputTest):
     def test_deprecated_args_not_documented(self):
         self.driver.main(['ec2', 'authorize-security-group-ingress', 'help'])

--- a/tests/functional/storagegateway/test_describe_cached_iscsi_volumes.py
+++ b/tests/functional/storagegateway/test_describe_cached_iscsi_volumes.py
@@ -1,0 +1,33 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestDescribeCachedISCSIVolumes(BaseAWSCommandParamsTest):
+
+    PREFIX = 'storagegateway describe-cached-iscsi-volumes'
+    VOLUME_ARN = 'a' * 50
+
+    def test_accepts_old_argname(self):
+        cmdline = (self.PREFIX + '  --volume-ar-ns %s') % (self.VOLUME_ARN,)
+        params = {
+            'VolumeARNs': [self.VOLUME_ARN],
+        }
+        self.assert_params_for_cmd(cmdline, params)
+
+    def test_accepts_fixed_param_name(self):
+        cmdline = (self.PREFIX + '  --volume-arns %s') % (self.VOLUME_ARN,)
+        params = {
+            'VolumeARNs': [self.VOLUME_ARN],
+        }
+        self.assert_params_for_cmd(cmdline, params)

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -41,7 +41,19 @@ class TestCommandTableRenames(BaseAWSHelpOutputTest):
 
 
 class TestHiddenAlias(unittest.TestCase):
-    def test_hidden_alias_makrs_as_not_required(self):
+    def test_not_marked_as_required_if_not_needed(self):
+        original_arg_required = mock.Mock()
+        original_arg_required.required = False
+        arg_table = {'original': original_arg_required}
+        utils.make_hidden_alias(arg_table, 'original', 'new-name')
+        self.assertIn('new-name', arg_table)
+        # Note: the _DOCUMENT_AS_REQUIRED is tested as a functional
+        # test because it only affects how the doc synopsis is
+        # rendered.
+        self.assertFalse(arg_table['original'].required)
+        self.assertFalse(arg_table['new-name'].required)
+
+    def test_hidden_alias_marks_as_not_required(self):
         original_arg_required = mock.Mock()
         original_arg_required.required = True
         arg_table = {'original': original_arg_required}

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -40,6 +40,17 @@ class TestCommandTableRenames(BaseAWSHelpOutputTest):
         self.assert_contains('run-instances')
 
 
+class TestHiddenAlias(unittest.TestCase):
+    def test_hidden_alias_makrs_as_not_required(self):
+        original_arg_required = mock.Mock()
+        original_arg_required.required = True
+        arg_table = {'original': original_arg_required}
+        utils.make_hidden_alias(arg_table, 'original', 'new-name')
+        self.assertIn('new-name', arg_table)
+        self.assertFalse(arg_table['original'].required)
+        self.assertFalse(arg_table['new-name'].required)
+
+
 class TestValidateMututuallyExclusiveGroups(unittest.TestCase):
     def test_two_single_groups(self):
         # The most basic example of mutually exclusive args.
@@ -53,7 +64,6 @@ class TestValidateMututuallyExclusiveGroups(unittest.TestCase):
         parsed = FakeParsedArgs(foo='one', bar='two')
         with self.assertRaises(ValueError):
             utils.validate_mutually_exclusive(parsed, ['foo'], ['bar'])
-
 
     def test_multiple_groups(self):
         groups = (['one', 'two', 'three'], ['foo', 'bar', 'baz'],
@@ -98,6 +108,7 @@ class TestS3BucketExists(unittest.TestCase):
         self.s3_client.head_bucket.side_effect = forbidden_error
         self.assertTrue(
             utils.s3_bucket_exists(self.s3_client, self.bucket_name))
+
 
 class TestClientCreationFromGlobals(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
If you have a required argument that you'd like to rename,
we were previously copying the argument and injecting
the copy into the arg table under a different name.

The problem is that the ``required`` field is also copied.
This will require the user to provide both arguments, which
defeats the point of aliasing the argument we want to hide.

The change here is to not make aliased args required.  That
way the user can specify either version.

Fixes #1790

cc @kyleknap @JordonPhillips 