### PR TITLE
Fix ordering issue with tests

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -211,13 +211,8 @@ class BaseCLIDriverTest(unittest.TestCase):
         }
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
-        emitter = HierarchicalEmitter()
-        session = Session(EnvironmentVariables, emitter)
-        session.register_component('data_loader', _LOADER)
-        load_plugins({}, event_hooks=emitter)
-        driver = CLIDriver(session=session)
-        self.session = session
-        self.driver = driver
+        self.driver = create_clidriver()
+        self.session = self.driver.session
 
     def tearDown(self):
         self.environ_patch.stop()


### PR DESCRIPTION
Fixes an regression introduced in
16a59ac0b55a40aa81428844d48659ea76ea91f4.

The loaders are not being configured with the data path needed to
load the CLI data files.  This means that if you try to run any
test that used the base class where this loader was created,
you'll get DataNotFound errors.

However, this is a shared object to speed up tests.
As long as something comes along and configures the loader
properly (another base class does this properly), then the
other tests will pass as expected.

The fix here is to use the create_clidriver() function which
abstracts this logic for you.

Now you can run individual unit/functional tests without
getting these errors.

Verified that the unit/functional test run times are about the same.

cc @kyleknap @JordonPhillips 