### PR TITLE
Add option to double check if glacier objects are restored

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -64,7 +64,8 @@ class S3Handler(object):
             'content_language': None, 'expires': None, 'grants': None,
             'only_show_errors': False, 'is_stream': False,
             'paths_type': None, 'expected_size': None, 'metadata': None,
-            'metadata_directive': None, 'ignore_glacier_warnings': False
+            'metadata_directive': None, 'ignore_glacier_warnings': False,
+            'force_glacier_transfer': False
         }
         self.params['region'] = params['region']
         for key in self.params.keys():
@@ -186,7 +187,8 @@ class S3Handler(object):
                                          message=warning_message)
                 self.result_queue.put(warning)
             # Warn and skip over glacier incompatible tasks.
-            elif not filename.is_glacier_compatible():
+            elif not self.params.get('force_glacier_transfer') and \
+                    not filename.is_glacier_compatible():
                 LOGGER.debug(
                     'Encountered glacier object s3://%s. Not performing '
                     '%s on object.' % (filename.src, filename.operation_name))

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -392,6 +392,15 @@ IGNORE_GLACIER_WARNINGS = {
 }
 
 
+FORCE_GLACIER_TRANSFER = {
+    'name': 'force-glacier-transfer', 'action': 'store_true',
+    'help_text': (
+        'Forces a transfer request on all Glacier objects in a sync or '
+        'recursive copy.'
+    )
+}
+
+
 TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  FOLLOW_SYMLINKS, NO_FOLLOW_SYMLINKS, NO_GUESS_MIME_TYPE,
                  SSE, SSE_C, SSE_C_KEY, SSE_KMS_KEY_ID, SSE_C_COPY_SOURCE,
@@ -399,7 +408,7 @@ TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  WEBSITE_REDIRECT, CONTENT_TYPE, CACHE_CONTROL,
                  CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE,
                  EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS,
-                 PAGE_SIZE, IGNORE_GLACIER_WARNINGS]
+                 PAGE_SIZE, IGNORE_GLACIER_WARNINGS, FORCE_GLACIER_TRANSFER]
 
 
 def get_client(session, region, endpoint_url, verify, config=None):

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -78,6 +78,26 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         # Make sure the file now exists.
         self.assertTrue(
             os.path.exists(os.path.join(non_existant_directory, key)))
+
+    def test_glacier_sync_with_force_glacier(self):
+        self.parsed_responses = [
+            {
+                'Contents': [
+                    {'Key': 'foo/bar.txt', 'ContentLength': '100',
+                     'LastModified': '00:00:00Z',
+                     'StorageClass': 'GLACIER',
+                     'Size': 100},
+                ],
+                'CommonPrefixes': []
+            },
+            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+        ]
+        cmdline = '%s s3://bucket/foo %s --force-glacier-transfer' % (
+            self.prefix, self.files.rootdir)
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2, self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObject')
     
     def test_handles_glacier_incompatible_operations(self):
         self.parsed_responses = [


### PR DESCRIPTION
This adds the option to force glacier downloads by performing a HEAD on each glacier object in the list objects call.

cc @kyleknap @jamesls 