### PR TITLE
[Fix] `s3 ls` command fails when UTF-8 is piped

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -396,6 +396,10 @@ def uni_print(statement, out_file=None):
         # we want to pick an encoding that has the highest
         # chance of printing successfully.
         new_encoding = getattr(out_file, 'encoding', 'ascii')
+        # When the output of the aws command is being piped,
+        # ``sys.stdout.encoding`` is ``None``.
+        if new_encoding is None:
+            new_encoding = 'ascii'
         new_statement = statement.encode(
             new_encoding, 'replace').decode(new_encoding)
         out_file.write(new_statement)


### PR DESCRIPTION
Piping the output of the `aws s3 ls` command when used on a bucket that has keys with UTF-8 characters in it, will raise an exception, exit the program and not list all files.

E.g. `aws s3 ls s3://<BUCKET-WITH-UTF8> | wc -l` will print the error `encode() argument 1 must be string, not None` and exit, upon reaching the UTF-8 key.

It fails because when stdout is being piped `sys.stdout.encoding` is `None`.

I am aware that the `PYTHONIOENCODING` environment variable can be set in order to change that, but it seems that the current code is trying to default to `ascii` and simply failing to default: [awscli/customizations/s3/utils.py, line 398](https://github.com/aws/aws-cli/blob/22a8404d8d064073034ffcb1641e0d320a74db53/awscli/customizations/s3/utils.py#L398) (latest commit on develop)