### PR TITLE
Change groff command

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -106,7 +106,7 @@ class PosixHelpRenderer(PagingHelpRenderer):
         man_contents = publish_string(contents, writer=manpage.Writer())
         if not self._exists_on_path('groff'):
             raise ExecutableNotFoundError('groff')
-        cmdline = ['groff', '-man', '-T', 'ascii']
+        cmdline = ['groff', '-m', 'man', '-T', 'ascii']
         LOG.debug("Running command: %s", cmdline)
         p3 = self._popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         groff_output = p3.communicate(input=man_contents)[0]


### PR DESCRIPTION
Some systems have issues which cause `-man` to fail, while `-m man` still works, even though the first is an alias of the second.

Since this isn't really possible to write a test for, I ran both versions on the following systems to verify that no functionality is lost:

* OSX, with groff from pkgsrc, homebrew, and the default install
* FreeBSD
* Amazon Linux
* RHEL
* Ubuntu

Closes #1798 

cc @jamesls @kyleknap 