### PR TITLE
Allow pound sign for key in short hand

### DIFF
--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -162,8 +162,8 @@ class ShorthandParser(object):
         return {key: values}
 
     def _key(self):
-        # key = 1*(alpha / %x30-39 / %x5f / %x2e)  ; [a-zA-Z0-9\-_.]
-        valid_chars = string.ascii_letters + string.digits + '-_.'
+        # key = 1*(alpha / %x30-39 / %x5f / %x2e / %x23)  ; [a-zA-Z0-9\-_.#]
+        valid_chars = string.ascii_letters + string.digits + '-_.#'
         start = self._index
         while not self._at_eof():
             if self._current() not in valid_chars:

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -56,6 +56,9 @@ def test_parse():
     # Dots are allowed.
     yield (_can_parse, 'with.dot=bar', {'with.dot': 'bar'})
 
+    # Pound signs are allowed.
+    yield (_can_parse, '#key=value', {'#key': 'value'})
+
     # Explicit lists.
     yield (_can_parse, 'foo=[]', {'foo': []})
     yield (_can_parse, 'foo=[a]', {'foo': ['a']})


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/1848

cc @jamesls @JordonPhillips 