### PR TITLE
Fix formating issues for autoscaling documentation

### DIFF
--- a/awscli/examples/autoscaling/complete-lifecycle-action.rst
+++ b/awscli/examples/autoscaling/complete-lifecycle-action.rst
@@ -2,4 +2,4 @@
 
 This example notifies Auto Scaling that the specified lifecycle action is complete so that it can finish launching or terminating the instance::
 
-   aws autoscaling complete-lifecycle-action --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group --lifecycle-action-result CONTINUE --lifecycle-action-token bcd2f1b8-9a78-44d3-8a7a-4dd07d7cf635
+    aws autoscaling complete-lifecycle-action --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group --lifecycle-action-result CONTINUE --lifecycle-action-token bcd2f1b8-9a78-44d3-8a7a-4dd07d7cf635

--- a/awscli/examples/autoscaling/create-auto-scaling-group.rst
+++ b/awscli/examples/autoscaling/create-auto-scaling-group.rst
@@ -2,7 +2,7 @@
 
 This example creates an Auto Scaling group in a VPC::
 
-     aws autoscaling create-auto-scaling-group --auto-scaling-group-name my-auto-scaling-group --launch-configuration-name my-launch-config --min-size 1 --max-size 3 --vpc-zone-identifier subnet-41767929c
+    aws autoscaling create-auto-scaling-group --auto-scaling-group-name my-auto-scaling-group --launch-configuration-name my-launch-config --min-size 1 --max-size 3 --vpc-zone-identifier subnet-41767929c
 
 This example creates an Auto Scaling group and configures it to use an Elastic Load Balancing load balancer::
 

--- a/awscli/examples/autoscaling/create-launch-configuration.rst
+++ b/awscli/examples/autoscaling/create-launch-configuration.rst
@@ -2,7 +2,7 @@
 
 This example creates a launch configuration::
 
-     aws autoscaling create-launch-configuration --launch-configuration-name my-launch-config --image-id ami-c6169af6 --instance-type m1.medium
+    aws autoscaling create-launch-configuration --launch-configuration-name my-launch-config --image-id ami-c6169af6 --instance-type m1.medium
 
 This example creates a launch configuration that uses Spot Instances::
 
@@ -20,16 +20,16 @@ Add the following parameter to add an Amazon EBS volume with the device name ``/
 
 Parameter::
 
-  --block-device-mappings "[{\"DeviceName\": \"/dev/sdh\",\"Ebs\":{\"VolumeSize\":100}}]"
+    --block-device-mappings "[{\"DeviceName\": \"/dev/sdh\",\"Ebs\":{\"VolumeSize\":100}}]"
 
 Add the following parameter to add ``ephemeral1`` as an instance store volume with the device name ``/dev/sdc``.
 
 Parameter::
 
-  --block-device-mappings "[{\"DeviceName\": \"/dev/sdc\",\"VirtualName\":\"ephemeral1\"}]"
+    --block-device-mappings "[{\"DeviceName\": \"/dev/sdc\",\"VirtualName\":\"ephemeral1\"}]"
 
 Add the following parameter to omit a device included on the instance (for example, ``/dev/sdf``).
 
 Parameter::
 
-  --block-device-mappings "[{\"DeviceName\": \"/dev/sdf\",\"NoDevice\":\"\"}]"
+    --block-device-mappings "[{\"DeviceName\": \"/dev/sdf\",\"NoDevice\":\"\"}]"

--- a/awscli/examples/autoscaling/create-or-update-tags.rst
+++ b/awscli/examples/autoscaling/create-or-update-tags.rst
@@ -2,4 +2,4 @@
 
 This example adds two tags to the specified Auto Scaling group::
 
-	aws autoscaling create-or-update-tags --tags ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=Role,Value=WebServer,PropagateAtLaunch=true ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=Dept,Value=Research,PropagateAtLaunch=true
+    aws autoscaling create-or-update-tags --tags ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=Role,Value=WebServer,PropagateAtLaunch=true ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=Dept,Value=Research,PropagateAtLaunch=true

--- a/awscli/examples/autoscaling/delete-launch-configuration.rst
+++ b/awscli/examples/autoscaling/delete-launch-configuration.rst
@@ -2,7 +2,7 @@
 
 This example deletes the specified launch configuration::
 
-	aws autoscaling delete-launch-configuration --launch-configuration-name my-launch-config
+    aws autoscaling delete-launch-configuration --launch-configuration-name my-launch-config
 
 For more information, see `Shut Down Auto Scaling Processes`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/delete-lifecycle-hook.rst
+++ b/awscli/examples/autoscaling/delete-lifecycle-hook.rst
@@ -2,4 +2,4 @@
 
 This example deletes the specified lifecycle hook::
 
-   aws autoscaling delete-lifecycle-hook --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group
+    aws autoscaling delete-lifecycle-hook --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group

--- a/awscli/examples/autoscaling/delete-notification-configuration.rst
+++ b/awscli/examples/autoscaling/delete-notification-configuration.rst
@@ -2,9 +2,8 @@
 
 This example deletes the specified notification from the specified Auto Scaling group::
 
-	aws autoscaling delete-notification-configuration --auto-scaling-group-name my-auto-scaling-group --topic-arn arn:aws:sns:us-west-2:123456789012:my-sns-topic
+    aws autoscaling delete-notification-configuration --auto-scaling-group-name my-auto-scaling-group --topic-arn arn:aws:sns:us-west-2:123456789012:my-sns-topic
 
 For more information, see `Delete the Notification Configuration`_ in the *Auto Scaling Developer Guide*.
 
 .. _`Delete the Notification Configuration`: http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/ASGettingNotifications.html#delete-settingupnotifications
-

--- a/awscli/examples/autoscaling/delete-policy.rst
+++ b/awscli/examples/autoscaling/delete-policy.rst
@@ -2,4 +2,4 @@
 
 This example deletes the specified Auto Scaling policy::
 
-	aws autoscaling delete-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScaleIn
+    aws autoscaling delete-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScaleIn

--- a/awscli/examples/autoscaling/delete-scheduled-action.rst
+++ b/awscli/examples/autoscaling/delete-scheduled-action.rst
@@ -2,4 +2,4 @@
 
 This example deletes the specified scheduled action from the specified Auto Scaling group::
 
-	aws autoscaling delete-scheduled-action --auto-scaling-group-name my-auto-scaling-group --scheduled-action-name my-scheduled-action
+    aws autoscaling delete-scheduled-action --auto-scaling-group-name my-auto-scaling-group --scheduled-action-name my-scheduled-action

--- a/awscli/examples/autoscaling/delete-tags.rst
+++ b/awscli/examples/autoscaling/delete-tags.rst
@@ -2,7 +2,7 @@
 
 This example deletes the specified tag from the specified Auto Scaling group::
 
-	aws autoscaling delete-tags --tags ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=Dept,Value=Research
+    aws autoscaling delete-tags --tags ResourceId=my-auto-scaling-group,ResourceType=auto-scaling-group,Key=Dept,Value=Research
 
 For more information, see `Tagging Auto Scaling Groups and Instances`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-account-limits.rst
+++ b/awscli/examples/autoscaling/describe-account-limits.rst
@@ -2,16 +2,16 @@
 
 This example describes the Auto Scaling limits for your AWS account::
 
-	aws autoscaling describe-account-limits
+    aws autoscaling describe-account-limits
 
 The following is example output::
 
-	{
-	  "NumberOfLaunchConfigurations": 5,
-		"MaxNumberOfLaunchConfigurations": 100,
-		"NumberOfAutoScalingGroups": 3,
-		"MaxNumberOfAutoScalingGroups": 20
-	}
+    {
+        "NumberOfLaunchConfigurations": 5,
+        "MaxNumberOfLaunchConfigurations": 100,
+        "NumberOfAutoScalingGroups": 3,
+        "MaxNumberOfAutoScalingGroups": 20
+    }
 
 For more information, see `Auto Scaling Limits`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-adjustment-types.rst
+++ b/awscli/examples/autoscaling/describe-adjustment-types.rst
@@ -2,23 +2,23 @@
 
 This example describes the available adjustment types::
 
-	aws autoscaling describe-adjustment-types
+    aws autoscaling describe-adjustment-types
 
 The following is example output::
 
-  {
-    "AdjustmentTypes": [
-      {
-        "AdjustmentType": "ChangeInCapacity"
-      }
-      {
-        "AdjustmentType": "ExactCapcity"
-      }
-      {
-        "AdjustmentType": "PercentChangeInCapacity"
-      }
-    ]
-  }
+    {
+        "AdjustmentTypes": [
+            {
+                "AdjustmentType": "ChangeInCapacity"
+            }
+            {
+                "AdjustmentType": "ExactCapcity"
+            }
+            {
+                "AdjustmentType": "PercentChangeInCapacity"
+            }
+        ]
+    }
 
 For more information, see `Scaling Adjustment Types`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
@@ -8,39 +8,39 @@ The following is example output::
 
     {
         "AutoScalingGroups": [
-           {
-              "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/my-auto-scaling-group",
-              "HealthCheckGracePeriod": 300,
-              "SuspendedProcesses": [],
-              "DesiredCapacity": 1,
-              "Tags": [],
-              "EnabledMetrics": [],
-              "LoadBalancerNames": [],
-              "AutoScalingGroupName": "my-auto-scaling-group",
-              "DefaultCooldown": 300,
-              "MinSize": 0,
-              "Instances": [
-                  {
-                      "InstanceId": "i-4ba0837f",
-                      "AvailabilityZone": "us-west-2c",
-                      "HealthStatus": "Healthy",
-                      "LifecycleState": "InService",
-                      "LaunchConfigurationName": "my-launch-config"
-                   }
-               ],
-               "MaxSize": 1,
-               "VPCZoneIdentifier": null,
-               "TerminationPolicies": [
-                     "Default"
-               ],
-               "LaunchConfigurationName": "my-launch-config",
-               "CreatedTime": "2013-08-19T20:53:25.584Z",
-               "AvailabilityZones": [
-                   "us-west-2c"
-               ],
-               "HealthCheckType": "EC2",
-               "NewInstancesProtectedFromScaleIn": false
-           }
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/my-auto-scaling-group",
+                "HealthCheckGracePeriod": 300,
+                "SuspendedProcesses": [],
+                "DesiredCapacity": 1,
+                "Tags": [],
+                "EnabledMetrics": [],
+                "LoadBalancerNames": [],
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "DefaultCooldown": 300,
+                "MinSize": 0,
+                "Instances": [
+                    {
+                        "InstanceId": "i-4ba0837f",
+                        "AvailabilityZone": "us-west-2c",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "my-launch-config"
+                    }
+                ],
+                "MaxSize": 1,
+                "VPCZoneIdentifier": null,
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "LaunchConfigurationName": "my-launch-config",
+                "CreatedTime": "2013-08-19T20:53:25.584Z",
+                "AvailabilityZones": [
+                    "us-west-2c"
+                ],
+                "HealthCheckType": "EC2",
+                "NewInstancesProtectedFromScaleIn": false
+            }
         ]
     }
 

--- a/awscli/examples/autoscaling/describe-auto-scaling-instances.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-instances.rst
@@ -6,36 +6,36 @@ This example describes the specified instance::
 
 The following is example output::
 
-  {
-    "AutoScalingInstances": [
-        {
-            "InstanceId": "i-4ba0837f",
-            "HealthStatus": "HEALTHY",
-            "AvailabilityZone": "us-west-2c",
-            "AutoScalingGroupName": "my-auto-scaling-group",
-            "LifecycleState": "InService"
-        }
-    ]
-  }
+    {
+        "AutoScalingInstances": [
+            {
+                "InstanceId": "i-4ba0837f",
+                "HealthStatus": "HEALTHY",
+                "AvailabilityZone": "us-west-2c",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "LifecycleState": "InService"
+            }
+        ]
+    }
 
 This example uses the ``max-items`` parameter to specify how many instances to return with this call::
 
-	aws autoscaling describe-auto-scaling-instances --max-items 1
+    aws autoscaling describe-auto-scaling-instances --max-items 1
 
 The following is example output::
 
-  {
-    "NextToken": "None___1",
-    "AutoScalingInstances": [
-        {
-            "InstanceId": "i-4ba0837f",
-            "HealthStatus": "HEALTHY",
-            "AvailabilityZone": "us-west-2c",
-            "AutoScalingGroupName": "my-auto-scaling-group",
-            "LifecycleState": "InService"
-        }
-    ]
-  }
+    {
+        "NextToken": "None___1",
+        "AutoScalingInstances": [
+            {
+                "InstanceId": "i-4ba0837f",
+                "HealthStatus": "HEALTHY",
+                "AvailabilityZone": "us-west-2c",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "LifecycleState": "InService"
+            }
+        ]
+    }
 
 If the output includes a ``NextToken`` field, there are more instances. To get the additional instances, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 

--- a/awscli/examples/autoscaling/describe-auto-scaling-notification-types.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-notification-types.rst
@@ -2,19 +2,19 @@
 
 This example describes the available notification types::
 
-	aws autoscaling describe-auto-scaling-notification-types
+    aws autoscaling describe-auto-scaling-notification-types
 
 The following is example output::
 
-	{
-		"AutoScalingNotificationTypes": [
-			"autoscaling:EC2_INSTANCE_LAUNCH",
-			"autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
-			"autoscaling:EC2_INSTANCE_TERMINATE",
-			"autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
-			"autoscaling:TEST_NOTIFICATION"
-		]
-	}
+    {
+        "AutoScalingNotificationTypes": [
+            "autoscaling:EC2_INSTANCE_LAUNCH",
+            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+            "autoscaling:EC2_INSTANCE_TERMINATE",
+            "autoscaling:EC2_INSTANCE_TERMINATE_ERROR",
+            "autoscaling:TEST_NOTIFICATION"
+        ]
+    }
 
 For more information, see `Configure Your Auto Scaling Group to Send Notifications`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-launch-configurations.rst
+++ b/awscli/examples/autoscaling/describe-launch-configurations.rst
@@ -2,66 +2,66 @@
 
 This example describes the specified launch configuration::
 
-	aws autoscaling describe-launch-configurations --launch-configuration-names my-launch-config
+    aws autoscaling describe-launch-configurations --launch-configuration-names my-launch-config
 
 The following is example output::
 
-	{
-		"LaunchConfigurations": [
-			{
-				"UserData": null,
-				"EbsOptimized": false,
-				"LaunchConfigurationARN": "arn:aws:autoscaling:us-west-2:123456789012:launchConfiguration:98d3b196-4cf9-4e88-8ca1-8547c24ced8b:launchConfigurationName/my-launch-config",
-				"InstanceMonitoring": {
-					"Enabled": true
-				},
-				"ImageId": "ami-043a5034",
-				"CreatedTime": "2014-05-07T17:39:28.599Z",
-				"BlockDeviceMappings": [],
-				"KeyName": null,
-				"SecurityGroups": [
-					"sg-67ef0308"
-				],
-				"LaunchConfigurationName": "my-launch-config",
-				"KernelId": null,
-				"RamdiskId": null,
-				"InstanceType": "t1.micro",
-				"AssociatePublicIpAddress": true
-			}
-		]
-	}
+    {
+        "LaunchConfigurations": [
+            {
+                "UserData": null,
+                "EbsOptimized": false,
+                "LaunchConfigurationARN": "arn:aws:autoscaling:us-west-2:123456789012:launchConfiguration:98d3b196-4cf9-4e88-8ca1-8547c24ced8b:launchConfigurationName/my-launch-config",
+                "InstanceMonitoring": {
+                    "Enabled": true
+                },
+                "ImageId": "ami-043a5034",
+                "CreatedTime": "2014-05-07T17:39:28.599Z",
+                "BlockDeviceMappings": [],
+                "KeyName": null,
+                "SecurityGroups": [
+                    "sg-67ef0308"
+                ],
+                "LaunchConfigurationName": "my-launch-config",
+                "KernelId": null,
+                "RamdiskId": null,
+                "InstanceType": "t1.micro",
+                "AssociatePublicIpAddress": true
+            }
+        ]
+    }
 
 To return a specific number of launch configurations, use the ``max-items`` parameter::
 
-	aws autoscaling describe-launch-configurations --max-items 1
+    aws autoscaling describe-launch-configurations --max-items 1
 
 The following is example output::
 
-	{
-		"NextToken": "None___1",
-		"LaunchConfigurations": [
-			{
-				"UserData": null,
-				"EbsOptimized": false,
-				"LaunchConfigurationARN": "arn:aws:autoscaling:us-west-2:123456789012:launchConfiguration:98d3b196-4cf9-4e88-8ca1-8547c24ced8b:launchConfigurationName/my-launch-config",
-				"InstanceMonitoring": {
-					"Enabled": true
-				},
-				"ImageId": "ami-043a5034",
-				"CreatedTime": "2014-05-07T17:39:28.599Z",
-				"BlockDeviceMappings": [],
-				"KeyName": null,
-				"SecurityGroups": [
-					"sg-67ef0308"
-				],
-				"LaunchConfigurationName": "my-launch-config",
-				"KernelId": null,
-				"RamdiskId": null,
-				"InstanceType": "t1.micro",
-				"AssociatePublicIpAddress": true
-			}
-		]
-	}
+    {
+        "NextToken": "None___1",
+        "LaunchConfigurations": [
+            {
+                "UserData": null,
+                "EbsOptimized": false,
+                "LaunchConfigurationARN": "arn:aws:autoscaling:us-west-2:123456789012:launchConfiguration:98d3b196-4cf9-4e88-8ca1-8547c24ced8b:launchConfigurationName/my-launch-config",
+                "InstanceMonitoring": {
+                    "Enabled": true
+                },
+                "ImageId": "ami-043a5034",
+                "CreatedTime": "2014-05-07T17:39:28.599Z",
+                "BlockDeviceMappings": [],
+                "KeyName": null,
+                "SecurityGroups": [
+                    "sg-67ef0308"
+                ],
+                "LaunchConfigurationName": "my-launch-config",
+                "KernelId": null,
+                "RamdiskId": null,
+                "InstanceType": "t1.micro",
+                "AssociatePublicIpAddress": true
+            }
+        ]
+    }
 
 If the output includes a ``NextToken`` field, there are more launch configurations. To get the additional launch configurations, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 

--- a/awscli/examples/autoscaling/describe-lifecycle-hook-types.rst
+++ b/awscli/examples/autoscaling/describe-lifecycle-hook-types.rst
@@ -2,13 +2,13 @@
 
 This example describes the available lifecycle hook types::
 
-   aws autoscaling describe-lifecycle-hook-types
-   
+    aws autoscaling describe-lifecycle-hook-types
+
 The following is example output::
 
-  {
-    "LifecycleHookTypes": [
-        "autoscaling:EC2_INSTANCE_LAUNCHING",
-        "autoscaling:EC2_INSTANCE_TERMINATING"
-    ]
-  }
+    {
+        "LifecycleHookTypes": [
+            "autoscaling:EC2_INSTANCE_LAUNCHING",
+            "autoscaling:EC2_INSTANCE_TERMINATING"
+        ]
+    }

--- a/awscli/examples/autoscaling/describe-lifecycle-hooks.rst
+++ b/awscli/examples/autoscaling/describe-lifecycle-hooks.rst
@@ -2,21 +2,21 @@
 
 This example describes the lifecycle hooks for the specified Auto Scaling group::
 
-   aws autoscaling describe-lifecycle-hooks --auto-scaling-group-name my-auto-scaling-group
-   
+    aws autoscaling describe-lifecycle-hooks --auto-scaling-group-name my-auto-scaling-group
+
 The following is example output::
 
-  {
-    "LifecycleHooks": [
-        {
-            "GlobalTimeout": 172800,
-            "HeartbeatTimeout": 3600,
-            "RoleARN": "arn:aws:iam::123456789012:role/my-auto-scaling-role",
-            "AutoScalingGroupName": "my-auto-scaling-group",
-            "LifecycleHookName": "my-lifecycle-hook",
-            "DefaultResult": "ABANDON",
-            "NotificationTargetARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic",
-            "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING"
-        }
-    ]
-  }
+    {
+        "LifecycleHooks": [
+            {
+                "GlobalTimeout": 172800,
+                "HeartbeatTimeout": 3600,
+                "RoleARN": "arn:aws:iam::123456789012:role/my-auto-scaling-role",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "LifecycleHookName": "my-lifecycle-hook",
+                "DefaultResult": "ABANDON",
+                "NotificationTargetARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic",
+                "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING"
+            }
+        ]
+    }

--- a/awscli/examples/autoscaling/describe-load-balancers.rst
+++ b/awscli/examples/autoscaling/describe-load-balancers.rst
@@ -2,15 +2,15 @@
 
 This example describes the load balancers for the specified Auto Scaling group::
 
-	aws autoscaling describe-load-balancers --auto-scaling-group-name my-auto-scaling-group
+    aws autoscaling describe-load-balancers --auto-scaling-group-name my-auto-scaling-group
 
 The following is example output::
 
-  {
-    "LoadBalancers": [
-      {
-        "State": "Added",
-        "LoadBalancerName": "my-load-balancer"
-      }
-    ]
-  }
+    {
+        "LoadBalancers": [
+            {
+                "State": "Added",
+                "LoadBalancerName": "my-load-balancer"
+            }
+        ]
+    }

--- a/awscli/examples/autoscaling/describe-metric-collection-types.rst
+++ b/awscli/examples/autoscaling/describe-metric-collection-types.rst
@@ -2,42 +2,41 @@
 
 This example describes the available metric collection types::
 
-	aws autoscaling describe-metric-collection-types
+    aws autoscaling describe-metric-collection-types
 
 The following is example output::
 
-  {
-    "Metrics": [
-      {
-        "Metric": "GroupMinSize"
-      },
-      {
-        "Metric": "GroupMaxSize"
-      },
-      {
-        "Metric": "GroupDesiredCapacity"
-      },
-      {
-        "Metric": "GroupInServiceInstances"
-      },
-      {
-        "Metric": "GroupPendingInstances"
-      },
-      {
-        "Metric": "GroupTerminatingInstances"
-      },
-      {
-        "Metric": "GroupTotalInstances"
-      }
-    ],
-    "Granularities": [
-      {
-        "Granularity": "1Minute"
-      }
-    ]
-  }
+    {
+        "Metrics": [
+            {
+                "Metric": "GroupMinSize"
+            },
+            {
+                "Metric": "GroupMaxSize"
+            },
+            {
+                "Metric": "GroupDesiredCapacity"
+            },
+            {
+                "Metric": "GroupInServiceInstances"
+            },
+            {
+                "Metric": "GroupPendingInstances"
+            },
+            {
+                "Metric": "GroupTerminatingInstances"
+            },
+            {
+                "Metric": "GroupTotalInstances"
+            }
+        ],
+        "Granularities": [
+            {
+                "Granularity": "1Minute"
+            }
+        ]
+    }
 
 For more information, see `Enable Auto Scaling Group Metrics`_ in the *Auto Scaling Developer Guide*.
 
 .. _`Enable Auto Scaling Group Metrics`: http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-instance-monitoring.html#as-group-metrics
-

--- a/awscli/examples/autoscaling/describe-notification-configurations.rst
+++ b/awscli/examples/autoscaling/describe-notification-configurations.rst
@@ -2,41 +2,41 @@
 
 This example describes the notification configurations for the specified Auto Scaling group::
 
-	aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group
+    aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group
 
 The following is example output::
 
-  {
-    "NotificationConfigurations": [
-      {
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "NotificationType": "autoscaling:TEST_NOTIFICATION",
-        "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic-2"
-      },
-      {
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "NotificationType": "autoscaling:TEST_NOTIFICATION",
-        "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic"
-      }
-    ]
-  }
+    {
+        "NotificationConfigurations": [
+            {
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "NotificationType": "autoscaling:TEST_NOTIFICATION",
+                "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic-2"
+            },
+            {
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "NotificationType": "autoscaling:TEST_NOTIFICATION",
+                "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic"
+            }
+        ]
+    }
 
 To return a specific number of notification configurations, use the ``max-items`` parameter::
 
-	aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group --max-items 1
+    aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group --max-items 1
 
 The following is example output::
 
-  {
-    "NextToken": "None___1",
-    "NotificationConfigurations": [
-      {
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "NotificationType": "autoscaling:TEST_NOTIFICATION",
-        "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic-2"
-      }
-    ]
-  }
+    {
+        "NextToken": "None___1",
+        "NotificationConfigurations": [
+            {
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "NotificationType": "autoscaling:TEST_NOTIFICATION",
+                "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic-2"
+            }
+        ]
+    }
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get additional notification configurations::
 

--- a/awscli/examples/autoscaling/describe-policies.rst
+++ b/awscli/examples/autoscaling/describe-policies.rst
@@ -2,56 +2,56 @@
 
 This example describes the policies for the specified Auto Scaling group::
 
-	aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group
+    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group
 
 The following is example output::
 
-  {
-    "ScalingPolicies": [
-      {
-        "PolicyName": "ScaleIn",
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2233f3d7-6290-403b-b632-93c553560106:autoScalingGroupName/my-auto-scaling-group:policyName/ScaleIn",
-        "AdjustmentType": "ChangeInCapacity",
-        "Alarms": [],
-        "ScalingAdjustment": -1
-      },
-      {
-        "PolicyName": "ScalePercentChange",
-        "MinAdjustmentStep": 2,
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2b435159-cf77-4e89-8c0e-d63b497baad7:autoScalingGroupName/my-auto-scaling-group:policyName/ScalePercentChange",
-        "Cooldown": 60,
-        "AdjustmentType": "PercentChangeInCapacity",
-        "Alarms": [],
-        "ScalingAdjustment": 25
-      }
-    ]
-  }
+    {
+        "ScalingPolicies": [
+            {
+                "PolicyName": "ScaleIn",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2233f3d7-6290-403b-b632-93c553560106:autoScalingGroupName/my-auto-scaling-group:policyName/ScaleIn",
+                "AdjustmentType": "ChangeInCapacity",
+                "Alarms": [],
+                "ScalingAdjustment": -1
+            },
+            {
+                "PolicyName": "ScalePercentChange",
+                "MinAdjustmentStep": 2,
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2b435159-cf77-4e89-8c0e-d63b497baad7:autoScalingGroupName/my-auto-scaling-group:policyName/ScalePercentChange",
+                "Cooldown": 60,
+                "AdjustmentType": "PercentChangeInCapacity",
+                "Alarms": [],
+                "ScalingAdjustment": 25
+            }
+        ]
+    }
 
 To return specific scaling policies, use the ``policy-names`` parameter::
 
-	aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group --policy-names ScaleIn
+    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group --policy-names ScaleIn
 
 To return a specific number of policies, use the ``max-items`` parameter::
 
-	aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group --max-items 1
+    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group --max-items 1
 
 The following is example output::
 
-  {
-    "ScalingPolicies": [
-      {
-        "PolicyName": "ScaleIn",
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2233f3d7-6290-403b-b632-93c553560106:autoScalingGroupName/my-auto-scaling-group:policyName/ScaleIn",
-        "AdjustmentType": "ChangeInCapacity",
-        "Alarms": [],
-        "ScalingAdjustment": -1
-      }
-    ],
-    "NextToken": "None___1"
-  }
+    {
+        "ScalingPolicies": [
+            {
+                "PolicyName": "ScaleIn",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2233f3d7-6290-403b-b632-93c553560106:autoScalingGroupName/my-auto-scaling-group:policyName/ScaleIn",
+                "AdjustmentType": "ChangeInCapacity",
+                "Alarms": [],
+                "ScalingAdjustment": -1
+            }
+        ],
+        "NextToken": "None___1"
+    }
 
 If the output includes a ``NextToken`` field, use the value of this field with the ``starting-token`` parameter in a subsequent call to get the additional policies::
 

--- a/awscli/examples/autoscaling/describe-scaling-activities.rst
+++ b/awscli/examples/autoscaling/describe-scaling-activities.rst
@@ -6,29 +6,29 @@ This example describes the scaling activities for the specified Auto Scaling gro
 
 The following is example output::
 
-      {
-          "Activities": [
-              {
-                  "Description": "Launching a new EC2 instance: i-4ba0837f",
-                  "AutoScalingGroupName": "my-auto-scaling-group",
-                  "ActivityId": "f9f2d65b-f1f2-43e7-b46d-d86756459699",
-                  "Details": "{"Availability Zone":"us-west-2c"}",
-                  "StartTime": "2013-08-19T20:53:29.930Z",
-                  "Progress": 100,
-                  "EndTime": "2013-08-19T20:54:02Z",
-                  "Cause": "At 2013-08-19T20:53:25Z a user request created an AutoScalingGroup changing the desired capacity from 0 to 1.  At 2013-08-19T20:53:29Z an instance was started in response to a difference between desired and actual capa city, increasing the capacity from 0 to 1.",
-                  "StatusCode": "Successful"
-              }
-         ]
-      }
+    {
+        "Activities": [
+            {
+                "Description": "Launching a new EC2 instance: i-4ba0837f",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "ActivityId": "f9f2d65b-f1f2-43e7-b46d-d86756459699",
+                "Details": "{"Availability Zone":"us-west-2c"}",
+                "StartTime": "2013-08-19T20:53:29.930Z",
+                "Progress": 100,
+                "EndTime": "2013-08-19T20:54:02Z",
+                "Cause": "At 2013-08-19T20:53:25Z a user request created an AutoScalingGroup changing the desired capacity from 0 to 1.  At 2013-08-19T20:53:29Z an instance was started in response to a difference between desired and actual capa city, increasing the capacity from 0 to 1.",
+                "StatusCode": "Successful"
+            }
+        ]
+    }
 
 To describe a specific scaling activity, use the ``activity-ids`` parameter::
 
-	aws autoscaling describe-scaling-activities --activity-ids b55c7b67-c8aa-4d10-b240-730ff91d8895
+    aws autoscaling describe-scaling-activities --activity-ids b55c7b67-c8aa-4d10-b240-730ff91d8895
 
 To return a specific number of activities, use the ``max-items`` parameter::
 
-	aws autoscaling describe-scaling-activities --max-items 1
+    aws autoscaling describe-scaling-activities --max-items 1
 
 If the output includes a ``NextToken`` field, there are more activities. To get the additional activities, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 

--- a/awscli/examples/autoscaling/describe-scaling-process-types.rst
+++ b/awscli/examples/autoscaling/describe-scaling-process-types.rst
@@ -2,38 +2,38 @@
 
 This example describes the Auto Scaling process types::
 
-	aws autoscaling describe-scaling-process-types
+    aws autoscaling describe-scaling-process-types
 
 The following is example output::
 
-  {
-    "Processes": [
-      {
-        "ProcessName": "AZRebalance"
-      },
-      {
-        "ProcessName": "AddToLoadBalancer"
-      },
-      {
-        "ProcessName": "AlarmNotification"
-      },
-      {
-        "ProcessName": "HealthCheck"
-      },
-      {
-        "ProcessName": "Launch"
-      },
-      {
-        "ProcessName": "ReplaceUnhealthy"
-      },
-      {
-        "ProcessName": "ScheduledActions"
-      },
-      {
-        "ProcessName": "Terminate"
-      }
-    ]
-  }
+    {
+        "Processes": [
+            {
+                "ProcessName": "AZRebalance"
+            },
+            {
+                "ProcessName": "AddToLoadBalancer"
+            },
+            {
+                "ProcessName": "AlarmNotification"
+            },
+            {
+                "ProcessName": "HealthCheck"
+            },
+            {
+                "ProcessName": "Launch"
+            },
+            {
+                "ProcessName": "ReplaceUnhealthy"
+            },
+            {
+                "ProcessName": "ScheduledActions"
+            },
+            {
+                "ProcessName": "Terminate"
+            }
+        ]
+    }
 
 For more information, see `Suspend and Resume Auto Scaling Processes`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-scheduled-actions.rst
+++ b/awscli/examples/autoscaling/describe-scheduled-actions.rst
@@ -2,58 +2,58 @@
 
 This example describes all your scheduled actions::
 
-	aws autoscaling describe-scheduled-actions
+    aws autoscaling describe-scheduled-actions
 
 The following is example output::
 
-  {
-    "ScheduledUpdateGroupActions": [
-      {
-        "MinSize": 2,
-        "DesiredCapacity": 4,
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "MaxSize": 6,
-        "Recurrence": "30 0 1 12 0",
-        "ScheduledActionARN": "arn:aws:autoscaling:us-west-2:123456789012:scheduledUpdateGroupAction:8e86b655-b2e6-4410-8f29-b4f094d6871c:autoScalingGroupName/my-auto-scaling-group:scheduledActionName/my-scheduled-action",
-        "ScheduledActionName": "my-scheduled-action",
-        "StartTime": "2019-12-01T00:30:00Z",
-        "Time": "2019-12-01T00:30:00Z"
-      }
-    ]
-  }
+    {
+        "ScheduledUpdateGroupActions": [
+            {
+                "MinSize": 2,
+                "DesiredCapacity": 4,
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "MaxSize": 6,
+                "Recurrence": "30 0 1 12 0",
+                "ScheduledActionARN": "arn:aws:autoscaling:us-west-2:123456789012:scheduledUpdateGroupAction:8e86b655-b2e6-4410-8f29-b4f094d6871c:autoScalingGroupName/my-auto-scaling-group:scheduledActionName/my-scheduled-action",
+                "ScheduledActionName": "my-scheduled-action",
+                "StartTime": "2019-12-01T00:30:00Z",
+                "Time": "2019-12-01T00:30:00Z"
+            }
+        ]
+    }
 
 To describe the scheduled actions for a specific Auto Scaling group, use the ``auto-scaling-group-name`` parameter::
 
-	aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group
+    aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group
 
 To describe a specific scheduled action, use the ``scheduled-action-names`` parameter::
 
-	aws autoscaling describe-scheduled-actions --scheduled-action-names my-scheduled-action
+    aws autoscaling describe-scheduled-actions --scheduled-action-names my-scheduled-action
 
 To describe the scheduled actions that start at a specific time, use the ``start-time`` parameter::
 
-	aws autoscaling describe-scheduled-actions --start-time "2019-12-01T00:30:00Z"
+    aws autoscaling describe-scheduled-actions --start-time "2019-12-01T00:30:00Z"
 
 To describe the scheduled actions that end at a specific time, use the ``end-time`` parameter::
 
-	aws autoscaling describe-scheduled-actions --end-time "2022-12-01T00:30:00Z"
+    aws autoscaling describe-scheduled-actions --end-time "2022-12-01T00:30:00Z"
 
 To return a specific number of scheduled actions, use the ``max-items`` parameter::
 
-	aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group --max-items 1
+    aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group --max-items 1
 
 The following is example output::
 
-  {
-    "NextToken": "None___1",
-    "NotificationConfigurations": [
-      {
-        "AutoScalingGroupName": "my-auto-scaling-group",
-        "NotificationType": "autoscaling:TEST_NOTIFICATION",
-        "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic"
-      }
-    ]
-  }
+    {
+        "NextToken": "None___1",
+        "NotificationConfigurations": [
+            {
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "NotificationType": "autoscaling:TEST_NOTIFICATION",
+                "TopicARN": "arn:aws:sns:us-west-2:123456789012:my-sns-topic"
+            }
+        ]
+    }
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get the additional scheduled actions::
 

--- a/awscli/examples/autoscaling/describe-tags.rst
+++ b/awscli/examples/autoscaling/describe-tags.rst
@@ -2,51 +2,51 @@
 
 This example describes all your tags::
 
-	aws autoscaling describe-tags
+    aws autoscaling describe-tags
 
 The following is example output::
 
-  {
-    "Tags": [
-      {
-        "ResourceType": "auto-scaling-group",
-        "ResourceId": "my-auto-scaling-group",
-        "PropagateAtLaunch": true,
-        "Value": "Research",
-        "Key": "Dept"
-      },
-      {
-        "ResourceType": "auto-scaling-group",
-        "ResourceId": "my-auto-scaling-group",
-        "PropagateAtLaunch": true,
-        "Value": "WebServer",
-        "Key": "Role"
-      }
-    ]
-  }
+    {
+        "Tags": [
+            {
+                "ResourceType": "auto-scaling-group",
+                "ResourceId": "my-auto-scaling-group",
+                "PropagateAtLaunch": true,
+                "Value": "Research",
+                "Key": "Dept"
+            },
+            {
+                "ResourceType": "auto-scaling-group",
+                "ResourceId": "my-auto-scaling-group",
+                "PropagateAtLaunch": true,
+                "Value": "WebServer",
+                "Key": "Role"
+            }
+        ]
+    }
 
 To describe tags for a specific Auto Scaling group, use the ``filters`` parameter::
 
-	aws autoscaling describe-tags --filters Name=auto-scaling-group,Values=my-auto-scaling-group
+    aws autoscaling describe-tags --filters Name=auto-scaling-group,Values=my-auto-scaling-group
 
 To return a specific number of tags, use the ``max-items`` parameter::
 
-	aws autoscaling describe-tags --max-items 1
+    aws autoscaling describe-tags --max-items 1
 
 The following is example output::
 
-  {
-    "NextToken": "None___1",
-    "Tags": [
-      {
-        "ResourceType": "auto-scaling-group",
-        "ResourceId": "my-auto-scaling-group",
-        "PropagateAtLaunch": true,
-        "Value": "Research",
-        "Key": "Dept"
-      }
-    ]
-  }
+    {
+        "NextToken": "None___1",
+        "Tags": [
+            {
+                "ResourceType": "auto-scaling-group",
+                "ResourceId": "my-auto-scaling-group",
+                "PropagateAtLaunch": true,
+                "Value": "Research",
+                "Key": "Dept"
+            }
+        ]
+    }
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get the additional tags::
 
@@ -55,4 +55,3 @@ Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequen
 For more information, see `Tagging Auto Scaling Groups and Instances`_ in the *Auto Scaling Developer Guide*.
 
 .. _`Tagging Auto Scaling Groups and Instances`: http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/ASTagging.html
-

--- a/awscli/examples/autoscaling/describe-termination-policy-types.rst
+++ b/awscli/examples/autoscaling/describe-termination-policy-types.rst
@@ -2,19 +2,19 @@
 
 This example describes the available termination policy types::
 
-	aws autoscaling describe-termination-policy-types
+    aws autoscaling describe-termination-policy-types
 
 The following is example output::
 
-  {
-    "TerminationPolicyTypes": [
-        "ClosestToNextInstanceHour",
-        "Default",
-        "NewestInstance",
-        "OldestInstance",
-        "OldestLaunchConfiguration"
-    ]
-  }
+    {
+        "TerminationPolicyTypes": [
+            "ClosestToNextInstanceHour",
+            "Default",
+            "NewestInstance",
+            "OldestInstance",
+            "OldestLaunchConfiguration"
+        ]
+    }
 
 For more information, see `Controlling Which Instances Auto Scaling Terminates During Scale In`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/detach-instances.rst
+++ b/awscli/examples/autoscaling/detach-instances.rst
@@ -2,21 +2,21 @@
 
 This example detaches the specified instance from the specified Auto Scaling group::
 
-   aws autoscaling detach-instances --instance-ids i-93633f9b --auto-scaling-group-name my-auto-scaling-group --should-decrement-desired-capacity
-   
+    aws autoscaling detach-instances --instance-ids i-93633f9b --auto-scaling-group-name my-auto-scaling-group --should-decrement-desired-capacity
+
 The following is example output::
 
-  {
-    "Activities": [
-        {
-            "Description": "Detaching EC2 instance: i-93633f9b",
-            "AutoScalingGroupName": "my-auto-scaling-group",
-            "ActivityId": "5091cb52-547a-47ce-a236-c9ccbc2cb2c9",
-            "Details": {"Availability Zone": "us-west-2a"},
-            "StartTime": "2015-04-12T15:02:16.179Z",
-            "Progress": 50,
-            "Cause": "At 2015-04-12T15:02:16Z instance i-93633f9b was detached in response to a user request, shrinking the capacity from 2 to 1.",
-            "StatusCode": "InProgress"
-        }
-    ]  
-  }
+    {
+        "Activities": [
+            {
+                "Description": "Detaching EC2 instance: i-93633f9b",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "ActivityId": "5091cb52-547a-47ce-a236-c9ccbc2cb2c9",
+                "Details": {"Availability Zone": "us-west-2a"},
+                "StartTime": "2015-04-12T15:02:16.179Z",
+                "Progress": 50,
+                "Cause": "At 2015-04-12T15:02:16Z instance i-93633f9b was detached in response to a user request, shrinking the capacity from 2 to 1.",
+                "StatusCode": "InProgress"
+            }
+        ]
+    }

--- a/awscli/examples/autoscaling/detach-load-balancers.rst
+++ b/awscli/examples/autoscaling/detach-load-balancers.rst
@@ -2,4 +2,4 @@
 
 This example detaches the specified load balancer from the specified Auto Scaling group::
 
-   aws autoscaling detach-load-balancers --load-balancer-names my-load-balancer --auto-scaling-group-name my-auto-scaling-group
+    aws autoscaling detach-load-balancers --load-balancer-names my-load-balancer --auto-scaling-group-name my-auto-scaling-group

--- a/awscli/examples/autoscaling/disable-metrics-collection.rst
+++ b/awscli/examples/autoscaling/disable-metrics-collection.rst
@@ -2,9 +2,8 @@
 
 This example disables collecting data for the ``GroupDesiredCapacity`` metric for the specified Auto Scaling group::
 
-	aws autoscaling disable-metrics-collection --auto-scaling-group-name my-auto-scaling-group --metrics GroupDesiredCapacity
+    aws autoscaling disable-metrics-collection --auto-scaling-group-name my-auto-scaling-group --metrics GroupDesiredCapacity
 
 For more information, see `Monitoring Your Auto Scaling Instances and Groups`_ in the *Auto Scaling Developer Guide*.
 
 .. _`Monitoring Your Auto Scaling Instances and Groups`: http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-instance-monitoring.html
-

--- a/awscli/examples/autoscaling/enable-metrics-collection.rst
+++ b/awscli/examples/autoscaling/enable-metrics-collection.rst
@@ -2,11 +2,11 @@
 
 This example enables data collection for the specified Auto Scaling group::
 
-	aws autoscaling enable-metrics-collection --auto-scaling-group-name my-auto-scaling-group --granularity "1Minute"
+    aws autoscaling enable-metrics-collection --auto-scaling-group-name my-auto-scaling-group --granularity "1Minute"
 
 To collect data for a specific metric, use the ``metrics`` parameter::
 
-	aws autoscaling enable-metrics-collection --auto-scaling-group-name my-auto-scaling-group --metrics GroupDesiredCapacity --granularity "1Minute"
+    aws autoscaling enable-metrics-collection --auto-scaling-group-name my-auto-scaling-group --metrics GroupDesiredCapacity --granularity "1Minute"
 
 For more information, see `Monitoring Your Auto Scaling Instances and Groups`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/enter-standby.rst
+++ b/awscli/examples/autoscaling/enter-standby.rst
@@ -2,21 +2,21 @@
 
 This example puts the specified instance into standby mode::
 
-   aws autoscaling enter-standby --instance-ids i-93633f9b --auto-scaling-group-name my-auto-scaling-group --should-decrement-desired-capacity
-   
+    aws autoscaling enter-standby --instance-ids i-93633f9b --auto-scaling-group-name my-auto-scaling-group --should-decrement-desired-capacity
+
 The following is example output::
 
-  {
-    "Activities": [
-        {
-            "Description": "Moving EC2 instance to Standby: i-93633f9b",
-            "AutoScalingGroupName": "my-auto-scaling-group",
-            "ActivityId": "ffa056b4-6ed3-41ba-ae7c-249dfae6eba1",
-            "Details": {"Availability Zone": "us-west-2a"},
-            "StartTime": "2015-04-12T15:10:23.640Z",
-            "Progress": 50,
-            "Cause": "At 2015-04-12T15:10:23Z instance i-93633f9b was moved to standby in response to a user request, shrinking the capacity from 2 to 1.",
-            "StatusCode": "InProgress"
-        }
-    ]
-  }
+    {
+        "Activities": [
+            {
+                "Description": "Moving EC2 instance to Standby: i-93633f9b",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "ActivityId": "ffa056b4-6ed3-41ba-ae7c-249dfae6eba1",
+                "Details": {"Availability Zone": "us-west-2a"},
+                "StartTime": "2015-04-12T15:10:23.640Z",
+                "Progress": 50,
+                "Cause": "At 2015-04-12T15:10:23Z instance i-93633f9b was moved to standby in response to a user request, shrinking the capacity from 2 to 1.",
+                "StatusCode": "InProgress"
+            }
+        ]
+    }

--- a/awscli/examples/autoscaling/execute-policy.rst
+++ b/awscli/examples/autoscaling/execute-policy.rst
@@ -2,7 +2,7 @@
 
 This example executes the specified Auto Scaling policy for the specified Auto Scaling group::
 
-	aws autoscaling execute-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScaleIn --honor-cooldown
+    aws autoscaling execute-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScaleIn --honor-cooldown
 
 For more information, see `Dynamic Scaling`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/exit-standby.rst
+++ b/awscli/examples/autoscaling/exit-standby.rst
@@ -2,21 +2,21 @@
 
 This example moves the specified instance out of standby mode::
 
-   aws autoscaling exit-standby --instance-ids i-93633f9b --auto-scaling-group-name my-auto-scaling-group
-   
+    aws autoscaling exit-standby --instance-ids i-93633f9b --auto-scaling-group-name my-auto-scaling-group
+
 The following is example output::
 
-  {
-    "Activities": [
-        {
-            "Description": "Moving EC2 instance out of Standby: i-93633f9b",
-            "AutoScalingGroupName": "my-auto-scaling-group",
-            "ActivityId": "142928e1-a2dc-453a-9b24-b85ad6735928",
-            "Details": {"Availability Zone": "us-west-2a"},
-            "StartTime": "2015-04-12T15:14:29.886Z",
-            "Progress": 30,
-            "Cause": "At 2015-04-12T15:14:29Z instance i-93633f9b was moved out of standby in response to a user request, increasing the capacity from 1 to 2.",
-            "StatusCode": "PreInService"
-        }
-    ]
-  }
+    {
+        "Activities": [
+            {
+                "Description": "Moving EC2 instance out of Standby: i-93633f9b",
+                "AutoScalingGroupName": "my-auto-scaling-group",
+                "ActivityId": "142928e1-a2dc-453a-9b24-b85ad6735928",
+                "Details": {"Availability Zone": "us-west-2a"},
+                "StartTime": "2015-04-12T15:14:29.886Z",
+                "Progress": 30,
+                "Cause": "At 2015-04-12T15:14:29Z instance i-93633f9b was moved out of standby in response to a user request, increasing the capacity from 1 to 2.",
+                "StatusCode": "PreInService"
+            }
+        ]
+    }

--- a/awscli/examples/autoscaling/put-lifecycle-hook.rst
+++ b/awscli/examples/autoscaling/put-lifecycle-hook.rst
@@ -2,7 +2,7 @@
 
 This example creates a lifecycle hook::
 
-   aws autoscaling put-lifecycle-hook --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group --lifecycle-transition autoscaling:EC2_INSTANCE_LAUNCHING --notification-target-arn arn:aws:sns:us-west-2:123456789012:my-sns-topic --role-arn arn:aws:iam::123456789012:role/my-auto-scaling-role
+    aws autoscaling put-lifecycle-hook --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group --lifecycle-transition autoscaling:EC2_INSTANCE_LAUNCHING --notification-target-arn arn:aws:sns:us-west-2:123456789012:my-sns-topic --role-arn arn:aws:iam::123456789012:role/my-auto-scaling-role
 
 For more information, see `Adding Lifecycle Hooks`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/put-notification-configuration.rst
+++ b/awscli/examples/autoscaling/put-notification-configuration.rst
@@ -2,7 +2,7 @@
 
 This example adds the specified notification to the specified Auto Scaling group::
 
-	aws autoscaling put-notification-configuration --auto-scaling-group-name my-auto-scaling-group --topic-arn arn:aws:sns:us-west-2:123456789012:my-sns-topic --notification-type autoscaling:TEST_NOTIFICATION
+    aws autoscaling put-notification-configuration --auto-scaling-group-name my-auto-scaling-group --topic-arn arn:aws:sns:us-west-2:123456789012:my-sns-topic --notification-type autoscaling:TEST_NOTIFICATION
 
 For more information, see `Configure Your Auto Scaling Group to Send Notifications`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/put-scaling-policy.rst
+++ b/awscli/examples/autoscaling/put-scaling-policy.rst
@@ -2,18 +2,18 @@
 
 This example adds the specified policy to the specified Auto Scaling group::
 
-	aws autoscaling put-scaling-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScaleIn --scaling-adjustment -1 --adjustment-type ChangeInCapacity
+    aws autoscaling put-scaling-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScaleIn --scaling-adjustment -1 --adjustment-type ChangeInCapacity
 
 To change the size of the Auto Scaling group by a specific number of instances, set the ``adjustment-type`` parameter to ``PercentChangeInCapacity``. Then, assign a value to
 the ``min-adjustment-step`` parameter, where the value represents the number of instances the policy adds or removes from the Auto Scaling group::
 
-	aws autoscaling put-scaling-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScalePercentChange --scaling-adjustment 25 --adjustment-type PercentChangeInCapacity --cooldown 60 --min-adjustment-step 2
+    aws autoscaling put-scaling-policy --auto-scaling-group-name my-auto-scaling-group --policy-name ScalePercentChange --scaling-adjustment 25 --adjustment-type PercentChangeInCapacity --cooldown 60 --min-adjustment-step 2
 
 The output includes the ARN of the policy. The following is example output::
 
-	{
-		"PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2233f3d7-6290-403b-b632-93c553560106:autoScalingGroupName/my-auto-scaling-group:policyName/ScaleIn"
-	}
+    {
+        "PolicyARN": "arn:aws:autoscaling:us-west-2:123456789012:scalingPolicy:2233f3d7-6290-403b-b632-93c553560106:autoScalingGroupName/my-auto-scaling-group:policyName/ScaleIn"
+    }
 
 For more information, see `Dynamic Scaling`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/record-lifecycle-action-heartbeat.rst
+++ b/awscli/examples/autoscaling/record-lifecycle-action-heartbeat.rst
@@ -2,4 +2,4 @@
 
 This example records a lifecycle action heartbeat to keep the instance in a pending state::
 
-   aws autoscaling record-lifecycle-action-heartbeat --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group --lifecycle-action-token bcd2f1b8-9a78-44d3-8a7a-4dd07d7cf635
+    aws autoscaling record-lifecycle-action-heartbeat --lifecycle-hook-name my-lifecycle-hook --auto-scaling-group-name my-auto-scaling-group --lifecycle-action-token bcd2f1b8-9a78-44d3-8a7a-4dd07d7cf635

--- a/awscli/examples/autoscaling/resume-processes.rst
+++ b/awscli/examples/autoscaling/resume-processes.rst
@@ -2,7 +2,7 @@
 
 This example resumes the specified suspended scaling process for the specified Auto Scaling group::
 
-	aws autoscaling resume-processes --auto-scaling-group-name my-auto-scaling-group --scaling-processes AlarmNotification
+    aws autoscaling resume-processes --auto-scaling-group-name my-auto-scaling-group --scaling-processes AlarmNotification
 
 For more information, see `Suspend and Resume Auto Scaling Processes`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/set-desired-capacity.rst
+++ b/awscli/examples/autoscaling/set-desired-capacity.rst
@@ -2,4 +2,4 @@
 
 This example sets the desired capacity for the specified Auto Scaling group::
 
-	aws autoscaling set-desired-capacity --auto-scaling-group-name my-auto-scaling-group --desired-capacity 2 --honor-cooldown
+    aws autoscaling set-desired-capacity --auto-scaling-group-name my-auto-scaling-group --desired-capacity 2 --honor-cooldown

--- a/awscli/examples/autoscaling/set-instance-health.rst
+++ b/awscli/examples/autoscaling/set-instance-health.rst
@@ -2,4 +2,4 @@
 
 This example sets the health status of the specified instance to ``Unhealthy``::
 
-   aws autoscaling set-instance-health --instance-id i-93633f9b --health-status Unhealthy
+    aws autoscaling set-instance-health --instance-id i-93633f9b --health-status Unhealthy

--- a/awscli/examples/autoscaling/set-instance-protection.rst
+++ b/awscli/examples/autoscaling/set-instance-protection.rst
@@ -2,8 +2,8 @@
 
 This example enables instance protection for the specified instance::
 
-   aws autoscaling set-instance-protection --auto-scaling-group-name my-asg --instance-ids i-93633f9b --protected-from-scale-in
+    aws autoscaling set-instance-protection --instance-ids i-93633f9b --protected-from-scale-in
 
 This example disables instance protection for the specified instance::
 
-   aws autoscaling set-instance-protection --auto-scaling-group-name my-asg --instance-ids i-93633f9b --no-protected-from-scale-in
+    aws autoscaling set-instance-protection --instance-ids i-93633f9b --no-protected-from-scale-in

--- a/awscli/examples/autoscaling/suspend-processes.rst
+++ b/awscli/examples/autoscaling/suspend-processes.rst
@@ -2,7 +2,7 @@
 
 This example suspends the specified scaling process for the specified Auto Scaling group::
 
-	aws autoscaling suspend-processes --auto-scaling-group-name my-auto-scaling-group --scaling-processes AlarmNotification
+    aws autoscaling suspend-processes --auto-scaling-group-name my-auto-scaling-group --scaling-processes AlarmNotification
 
 For more information, see `Suspend and Resume Auto Scaling Processes`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/terminate-instance-in-auto-scaling-group.rst
+++ b/awscli/examples/autoscaling/terminate-instance-in-auto-scaling-group.rst
@@ -2,6 +2,6 @@
 
 This example terminates the specified instance from the specified Auto Scaling group without updating the size of the group::
 
-	aws autoscaling terminate-instance-in-auto-scaling-group --instance-id i-93633f9b --no-should-decrement-desired-capacity
+    aws autoscaling terminate-instance-in-auto-scaling-group --instance-id i-93633f9b --no-should-decrement-desired-capacity
 
 Auto Scaling launches a replacement instance after the specified instance terminates.

--- a/awscli/examples/autoscaling/update-auto-scaling-group.rst
+++ b/awscli/examples/autoscaling/update-auto-scaling-group.rst
@@ -15,7 +15,7 @@ This example updates the desired capacity, default cooldown, placement group, te
 This example enables the instance protection setting for the specified Auto Scaling group::
 
     aws autoscaling update-auto-scaling-group --auto-scaling-group-name my-auto-scaling-group --new-instances-protected-from-scale-in
-    
+
 This example disables the instance protection setting for the specified Auto Scaling group::
 
     aws autoscaling update-auto-scaling-group --auto-scaling-group-name my-auto-scaling-group --no-new-instances-protected-from-scale-in


### PR DESCRIPTION
- Remove trailing whitespace
- Replace tabs with spaces (fix indentation)
- It made with **4 spaces** indentation

Relates to #1834 