### PR TITLE
Remove coveralls from README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,11 +23,8 @@ contributions as well:
   Any code you submit will be released under that license.
 * We maintain a high percentage of code coverage in our unit tests.  As
   a general rule of thumb, code changes should not lower the overall
-  code coverage percentage for the project.  To help with this,
-  we use `coveralls <https://coveralls.io/r/boto/botocore>`__, which will
-  comment on changes in code coverage for every pull request.
-  In practice, this means that **every bug fix and feature addition should
-  include unit tests.**
+  code coverage percentage for the project.  In practice, this means that
+  **every bug fix and feature addition should include unit tests.**
 * Code should follow `pep 8 <https://www.python.org/dev/peps/pep-0008/>`__,
   although if you are modifying an existing module, it is more important
   for the code to be consistent if there are any discrepancies.

--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,6 @@ aws-cli
    :alt: Build Status
 
 
-.. image:: https://coveralls.io/repos/aws/aws-cli/badge.svg
-  :target: https://coveralls.io/r/aws/aws-cli
-
-
 This package provides a unified command line interface to Amazon Web Services.
 
 The aws-cli package works on Python versions:


### PR DESCRIPTION
We no longer use coveralls, so it should no longer be mentioned in our docs.

cc @kyleknap @jamesls 