### PR TITLE
Update config-vars.rst

### DIFF
--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -217,7 +217,7 @@ Example configuration::
   # In ~/.aws/credentials:
   [development]
   aws_access_key_id=foo
-  aws_access_key_id=bar
+  aws_secret_access_key=bar
 
   # In ~/.aws/config
   [profile crossaccount]


### PR DESCRIPTION
Config example mistake where the aws_secret_access_key is missing