### PR TITLE
Remove reference to old starting token format in docs

### DIFF
--- a/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
@@ -50,4 +50,4 @@ To return a specific number of Auto Scaling groups, use the ``max-items`` parame
 
 If the output includes a ``NextToken`` field, there are more groups. To get the additional groups, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-auto-scaling-groups --starting-token None___1
+    aws autoscaling describe-auto-scaling-groups —-starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-auto-scaling-instances.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-instances.rst
@@ -25,7 +25,7 @@ This example uses the ``max-items`` parameter to specify how many instances to r
 The following is example output::
 
     {
-        "NextToken": "None___1",
+        "NextToken": "Z3M3LMPEXAMPLE",
         "AutoScalingInstances": [
             {
                 "InstanceId": "i-4ba0837f",
@@ -39,4 +39,4 @@ The following is example output::
 
 If the output includes a ``NextToken`` field, there are more instances. To get the additional instances, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-auto-scaling-instances --starting-token None___1
+    aws autoscaling describe-auto-scaling-instances —-starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-launch-configurations.rst
+++ b/awscli/examples/autoscaling/describe-launch-configurations.rst
@@ -38,7 +38,7 @@ To return a specific number of launch configurations, use the ``max-items`` para
 The following is example output::
 
     {
-        "NextToken": "None___1",
+        "NextToken": "Z3M3LMPEXAMPLE",
         "LaunchConfigurations": [
             {
                 "UserData": null,
@@ -65,4 +65,4 @@ The following is example output::
 
 If the output includes a ``NextToken`` field, there are more launch configurations. To get the additional launch configurations, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-launch-configurations --starting-token None___1
+    aws autoscaling describe-launch-configurations —-starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-notification-configurations.rst
+++ b/awscli/examples/autoscaling/describe-notification-configurations.rst
@@ -28,7 +28,7 @@ To return a specific number of notification configurations, use the ``max-items`
 The following is example output::
 
     {
-        "NextToken": "None___1",
+        "NextToken": "Z3M3LMPEXAMPLE",
         "NotificationConfigurations": [
             {
                 "AutoScalingGroupName": "my-auto-scaling-group",
@@ -40,7 +40,7 @@ The following is example output::
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get additional notification configurations::
 
-    aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group --starting-token None___1
+    aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Getting Notifications When Your Auto Scaling Group Changes`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-policies.rst
+++ b/awscli/examples/autoscaling/describe-policies.rst
@@ -50,12 +50,12 @@ The following is example output::
                 "ScalingAdjustment": -1
             }
         ],
-        "NextToken": "None___1"
+        "NextToken": "Z3M3LMPEXAMPLE"
     }
 
 If the output includes a ``NextToken`` field, use the value of this field with the ``starting-token`` parameter in a subsequent call to get the additional policies::
 
-    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group --starting-token None___1
+    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Dynamic Scaling`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-scaling-activities.rst
+++ b/awscli/examples/autoscaling/describe-scaling-activities.rst
@@ -32,4 +32,4 @@ To return a specific number of activities, use the ``max-items`` parameter::
 
 If the output includes a ``NextToken`` field, there are more activities. To get the additional activities, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-scaling-activities --starting-token None___1
+    aws autoscaling describe-scaling-activities —-starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-scheduled-actions.rst
+++ b/awscli/examples/autoscaling/describe-scheduled-actions.rst
@@ -45,7 +45,7 @@ To return a specific number of scheduled actions, use the ``max-items`` paramete
 The following is example output::
 
     {
-        "NextToken": "None___1",
+        "NextToken": "Z3M3LMPEXAMPLE",
         "NotificationConfigurations": [
             {
                 "AutoScalingGroupName": "my-auto-scaling-group",
@@ -57,7 +57,7 @@ The following is example output::
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get the additional scheduled actions::
 
-    aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group --starting-token None___1
+    aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Scheduled Scaling`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-tags.rst
+++ b/awscli/examples/autoscaling/describe-tags.rst
@@ -36,7 +36,7 @@ To return a specific number of tags, use the ``max-items`` parameter::
 The following is example output::
 
     {
-        "NextToken": "None___1",
+        "NextToken": "Z3M3LMPEXAMPLE",
         "Tags": [
             {
                 "ResourceType": "auto-scaling-group",
@@ -50,7 +50,7 @@ The following is example output::
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get the additional tags::
 
-    aws autoscaling describe-tags --filters Name=auto-scaling-group,Values=my-auto-scaling-group --starting-token None___1
+    aws autoscaling describe-tags --filters Name=auto-scaling-group,Values=my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Tagging Auto Scaling Groups and Instances`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/route53/list-health-checks.rst
+++ b/awscli/examples/route53/list-health-checks.rst
@@ -10,6 +10,6 @@ If you have more than 100 health checks, or if you want to list them in groups s
 
 To view the next health check, take the value of ``NextToken`` from the response to the previous command, and include it in the ``--starting-token`` parameter, for example::
 
-  aws route53 list-health-checks --max-items 1 --starting-token 02ec8401-9879-4259-91fa-094674111111
+  aws route53 list-health-checks --max-items 1 —-starting-token Z3M3LMPEXAMPLE
 
 

--- a/awscli/examples/route53/list-resource-record-sets.rst
+++ b/awscli/examples/route53/list-resource-record-sets.rst
@@ -10,5 +10,5 @@ If the hosted zone contains more than 100 resource record sets, or if you want t
 
 To view information about the next resource record set in the hosted zone, take the value of ``NextToken`` from the response to the previous command, and include it in the ``--starting-token`` parameter, for example::
 
-  aws route53 list-resource-record-sets --hosted-zone-id Z2LD58HEXAMPLE --max-items 1 --starting-token None___None___None___1
+  aws route53 list-resource-record-sets --hosted-zone-id Z2LD58HEXAMPLE --max-items 1 —-starting-token Z3M3LMPEXAMPLE
 


### PR DESCRIPTION
There is one last remaining bit of the old world left, the RDS docs mentioned in #1835. There is a pr up at boto/botocore#849 to fix the code bug there, but the doc here is a bit challenging. 

RDS is using the `Marker` value `0` to indicate that it will start at the beginning of the logs. I'm not sure how I feel about transforming our docs to show `--starting-token eyJNYXJrZXIiOiAiMCJ9` or showing `--Marker 0` instead. We could also potentially make another flag (`--start-at-beginning`) to suit this scenario. What do you guys think?

cc @kyleknap @jamesls 