### PR TITLE
Fix issue with network interfaces

### DIFF
--- a/awscli/customizations/ec2runinstances.py
+++ b/awscli/customizations/ec2runinstances.py
@@ -91,20 +91,27 @@ def _fix_args(params, **kwargs):
     # allows them to specify the security group by name or by id.
     # However, in this scenario we can only support id because
     # we can't place a group name in the NetworkInterfaces structure.
+    network_interface_params = [
+        'PrivateIpAddresses',
+        'SecondaryPrivateIpAddressCount',
+        'AssociatePublicIpAddress'
+    ]
     if 'NetworkInterfaces' in params:
         ni = params['NetworkInterfaces']
-        if 'AssociatePublicIpAddress' in ni[0]:
-            if 'SubnetId' in params:
-                ni[0]['SubnetId'] = params['SubnetId']
-                del params['SubnetId']
-            if 'SecurityGroupIds' in params:
-                ni[0]['Groups'] = params['SecurityGroupIds']
-                del params['SecurityGroupIds']
-            if 'PrivateIpAddress' in params:
-                ip_addr = {'PrivateIpAddress': params['PrivateIpAddress'],
-                           'Primary': True}
-                ni[0]['PrivateIpAddresses'] = [ip_addr]
-                del params['PrivateIpAddress']
+        for network_interface_param in network_interface_params:
+            if network_interface_param in ni[0]:
+                if 'SubnetId' in params:
+                    ni[0]['SubnetId'] = params['SubnetId']
+                    del params['SubnetId']
+                if 'SecurityGroupIds' in params:
+                    ni[0]['Groups'] = params['SecurityGroupIds']
+                    del params['SecurityGroupIds']
+                if 'PrivateIpAddress' in params:
+                    ip_addr = {'PrivateIpAddress': params['PrivateIpAddress'],
+                               'Primary': True}
+                    ni[0]['PrivateIpAddresses'] = [ip_addr]
+                    del params['PrivateIpAddress']
+                return
 
 
 EVENTS = [

--- a/tests/functional/ec2/test_run_instances.py
+++ b/tests/functional/ec2/test_run_instances.py
@@ -107,17 +107,24 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         args += '--secondary-private-ip-addresses 10.0.2.106'
         args_list = (self.prefix + args).split()
         result = {
-            'NetworkInterface.1.DeviceIndex': 0,
-            'NetworkInterface.1.PrivateIpAddresses.1.Primary': 'false',
-            'NetworkInterface.1.PrivateIpAddresses.1.PrivateIpAddress': '10.0.2.106',
             'ImageId': 'ami-foobar',
+            'NetworkInterfaces': [
+                {'DeviceIndex': 0,
+                 'PrivateIpAddresses': [
+                     {'Primary': False, 'PrivateIpAddress': '10.0.2.106'}]}],
             'MaxCount': 1,
-            'MinCount': 1
-        }
+            'MinCount': 1}
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_secondary_ip_address_with_subnet(self):
+        args = ' --image-id ami-foobar --count 1 --subnet subnet-12345678 '
+        args += '--secondary-private-ip-addresses 10.0.2.106'
+        args_list = (self.prefix + args).split()
         result = {
             'ImageId': 'ami-foobar',
             'NetworkInterfaces': [
                 {'DeviceIndex': 0,
+                 'SubnetId': 'subnet-12345678',
                  'PrivateIpAddresses': [
                      {'Primary': False, 'PrivateIpAddress': '10.0.2.106'}]}],
             'MaxCount': 1,
@@ -145,6 +152,20 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         args_list = (self.prefix + args).split()
         result = {
             'NetworkInterfaces': [{'DeviceIndex': 0,
+                                   'SecondaryPrivateIpAddressCount': 4}],
+            'ImageId': 'ami-foobar',
+            'MaxCount': 1,
+            'MinCount': 1
+        }
+        self.assert_params_for_cmd(args_list, result)
+
+    def test_secondary_ip_address_count_with_subnet(self):
+        args = ' --image-id ami-foobar --count 1 --subnet subnet-12345678 '
+        args += '--secondary-private-ip-address-count 4'
+        args_list = (self.prefix + args).split()
+        result = {
+            'NetworkInterfaces': [{'DeviceIndex': 0,
+                                   'SubnetId': 'subnet-12345678',
                                    'SecondaryPrivateIpAddressCount': 4}],
             'ImageId': 'ami-foobar',
             'MaxCount': 1,


### PR DESCRIPTION
There were some customizations for ec2 run instances that used the NetworkInterfaces parameter but did not lower some of the legacy parameters to the NetworkInterfaces param causing server side validation errors.

If you do not do this, you get errors like this:
```
ClientError: A client error (InvalidParameterCombination) occurred when calling the RunInstances operation: Network interfaces and an instance-level subnet ID may not be specified on the same request
```

There is even a note about this: https://github.com/aws/aws-cli/blob/develop/awscli/customizations/ec2runinstances.py#L83 so it looks like these parameters just got missed because it now works for me.

cc @jamesls @JordonPhillips 