### PR TITLE
Add test to verify that CLI examples only contain ascii

### DIFF
--- a/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
@@ -50,4 +50,4 @@ To return a specific number of Auto Scaling groups, use the ``max-items`` parame
 
 If the output includes a ``NextToken`` field, there are more groups. To get the additional groups, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-auto-scaling-groups —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-auto-scaling-groups --starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-auto-scaling-instances.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-instances.rst
@@ -39,4 +39,4 @@ The following is example output::
 
 If the output includes a ``NextToken`` field, there are more instances. To get the additional instances, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-auto-scaling-instances —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-auto-scaling-instances --starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-launch-configurations.rst
+++ b/awscli/examples/autoscaling/describe-launch-configurations.rst
@@ -65,4 +65,4 @@ The following is example output::
 
 If the output includes a ``NextToken`` field, there are more launch configurations. To get the additional launch configurations, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-launch-configurations —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-launch-configurations --starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-notification-configurations.rst
+++ b/awscli/examples/autoscaling/describe-notification-configurations.rst
@@ -40,7 +40,7 @@ The following is example output::
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get additional notification configurations::
 
-    aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-notification-configurations --auto-scaling-group-name my-auto-scaling-group --starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Getting Notifications When Your Auto Scaling Group Changes`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-policies.rst
+++ b/awscli/examples/autoscaling/describe-policies.rst
@@ -55,7 +55,7 @@ The following is example output::
 
 If the output includes a ``NextToken`` field, use the value of this field with the ``starting-token`` parameter in a subsequent call to get the additional policies::
 
-    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-policies --auto-scaling-group-name my-auto-scaling-group --starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Dynamic Scaling`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-scaling-activities.rst
+++ b/awscli/examples/autoscaling/describe-scaling-activities.rst
@@ -32,4 +32,4 @@ To return a specific number of activities, use the ``max-items`` parameter::
 
 If the output includes a ``NextToken`` field, there are more activities. To get the additional activities, use the value of this field with the ``starting-token`` parameter in a subsequent call as follows::
 
-    aws autoscaling describe-scaling-activities —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-scaling-activities --starting-token Z3M3LMPEXAMPLE

--- a/awscli/examples/autoscaling/describe-scheduled-actions.rst
+++ b/awscli/examples/autoscaling/describe-scheduled-actions.rst
@@ -57,7 +57,7 @@ The following is example output::
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get the additional scheduled actions::
 
-    aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-scheduled-actions --auto-scaling-group-name my-auto-scaling-group --starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Scheduled Scaling`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/autoscaling/describe-tags.rst
+++ b/awscli/examples/autoscaling/describe-tags.rst
@@ -50,7 +50,7 @@ The following is example output::
 
 Use the ``NextToken`` field with the ``starting-token`` parameter in a subsequent call to get the additional tags::
 
-    aws autoscaling describe-tags --filters Name=auto-scaling-group,Values=my-auto-scaling-group —-starting-token Z3M3LMPEXAMPLE
+    aws autoscaling describe-tags --filters Name=auto-scaling-group,Values=my-auto-scaling-group --starting-token Z3M3LMPEXAMPLE
 
 For more information, see `Tagging Auto Scaling Groups and Instances`_ in the *Auto Scaling Developer Guide*.
 

--- a/awscli/examples/route53/list-health-checks.rst
+++ b/awscli/examples/route53/list-health-checks.rst
@@ -10,6 +10,6 @@ If you have more than 100 health checks, or if you want to list them in groups s
 
 To view the next health check, take the value of ``NextToken`` from the response to the previous command, and include it in the ``--starting-token`` parameter, for example::
 
-  aws route53 list-health-checks --max-items 1 —-starting-token Z3M3LMPEXAMPLE
+  aws route53 list-health-checks --max-items 1 --starting-token Z3M3LMPEXAMPLE
 
 

--- a/awscli/examples/route53/list-resource-record-sets.rst
+++ b/awscli/examples/route53/list-resource-record-sets.rst
@@ -10,5 +10,5 @@ If the hosted zone contains more than 100 resource record sets, or if you want t
 
 To view information about the next resource record set in the hosted zone, take the value of ``NextToken`` from the response to the previous command, and include it in the ``--starting-token`` parameter, for example::
 
-  aws route53 list-resource-record-sets --hosted-zone-id Z2LD58HEXAMPLE --max-items 1 —-starting-token Z3M3LMPEXAMPLE
+  aws route53 list-resource-record-sets --hosted-zone-id Z2LD58HEXAMPLE --max-items 1 --starting-token Z3M3LMPEXAMPLE
 


### PR DESCRIPTION
As part of this change I also fixed all the examples that failed
as a result of this test being added (https://github.com/aws/aws-cli/pull/1873).

Also gives decent failure messages:

```
======================================================================
FAIL: tests.functional.docs.test_examples.test_all_examples_have_only_ascii('aws-cli/awscli/examples/autoscaling/describe-tags.rst',)
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".virtualenvs/aws-cli/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "aws-cli/tests/functional/docs/test_examples.py", line 84, in verify_has_only_ascii_chars
    "\n\n%s\n" % (filename, line_number, error_text))
AssertionError: Non ascii characters found in the examples file aws-cli/awscli/examples/autoscaling/describe-tags.rst, line 53:

-auto-scaling-group —-starting-token Z
                    ^
```

cc @kyleknap @JordonPhillips 