### PR TITLE
Update existing examples for KMS

### DIFF
--- a/awscli/examples/kms/create-alias.rst
+++ b/awscli/examples/kms/create-alias.rst
@@ -1,5 +1,7 @@
-The following command creates an alias for a customer master key::
+The following command creates an alias named ``example-alias`` for the customer master key (CMK) identified by key ID ``1234abcd-12ab-34cd-56ef-1234567890ab``.
 
-    $ aws kms create-alias --alias-name alias/my-alias --target-key-id arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012
+.. code::
 
-Note that all alias names must begin with ``alias/``.
+    aws kms create-alias --alias-name alias/example-alias --target-key-id 1234abcd-12ab-34cd-56ef-1234567890ab
+
+Alias names must begin with ``alias/``. Do not use alias names that begin with ``alias/aws``; these are reserved for use by AWS.

--- a/awscli/examples/kms/decrypt.rst
+++ b/awscli/examples/kms/decrypt.rst
@@ -1,9 +1,39 @@
-The following command decrypts a KMS encrypted, binary encoded version of a 256 bit key named ``encryptedkey-binary`` in the current folder::
+The following command demonstrates the recommended way to decrypt data with the AWS CLI.
 
-  aws kms decrypt --ciphertext-blob fileb://encryptedkey-binary
+.. code::
 
-The fileb:// prefix instructs the AWS CLI not to attempt to decode the binary data in the file.
-  
-The output of this command includes the ID of the key used to decrypt the key, and a base64 encoded version of the decrypted key. Use ``base64 -d`` to reverse the base64 encoding and view the original hexadecimal (or otherwise encoded) version of the key. The following command uses an AWS CLI query to isolate the base64 plaintext and pipe it into ``base64``::
+    aws kms decrypt --ciphertext-blob fileb://ExampleEncryptedFile --output text --query Plaintext | base64 --decode > ExamplePlaintextFile
 
-  aws kms decrypt --ciphertext-blob fileb://encryptedkey-binary --query Plaintext --output text | base64 -d
+The command does several things:
+
+#. Uses the ``fileb://`` prefix to specify the ``--ciphertext-blob`` parameter.
+
+    The ``fileb://`` prefix instructs the CLI to read the encrypted data, called the *ciphertext*, from a file and pass the file's contents to the command's ``--ciphertext-blob`` parameter.  If the file is not in the current directory, type the full path to file. For example: ``fileb:///var/tmp/ExampleEncryptedFile`` or ``fileb://C:\Temp\ExampleEncryptedFile``.
+
+    For more information about reading AWS CLI parameter values from a file, see `Loading Parameters from a File <https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-file>`_ in the *AWS Command Line Interface User Guide* and `Best Practices for Local File Parameters <https://blogs.aws.amazon.com/cli/post/TxLWWN1O25V1HE/Best-Practices-for-Local-File-Parameters>`_ on the AWS Command Line Tool Blog.
+
+    The command assumes the ciphertext in ``ExampleEncryptedFile`` is binary data. The `encrypt examples <encrypt.html#examples>`_ demonstrate how to save a ciphertext this way.
+
+#. Uses the ``--output`` and ``--query`` parameters to control the command's output.
+
+    These parameters extract the decrypted data, called the *plaintext*, from the command's output. For more information about controlling output, see `Controlling Command Output <https://docs.aws.amazon.com/cli/latest/userguide/controlling-output.html>`_ in the *AWS Command Line Interface User Guide*.
+
+#. Uses the ``base64`` utility.
+
+    This utility decodes the extracted plaintext to binary data. The plaintext that is returned by a successful ``decrypt`` command is base64-encoded text. You must decode this text to obtain the original plaintext.
+
+#. Saves the binary plaintext to a file.
+
+    The final part of the command (``> ExamplePlaintextFile``) saves the binary plaintext data to a file.
+
+**Example: Using the AWS CLI to decrypt data from the Windows command prompt**
+
+The preceding example assumes the ``base64`` utility is available, which is commonly the case on Linux and Mac OS X. For the Windows command prompt, use ``certutil`` instead of ``base64``. This requires two commands, as shown in the following examples.
+
+.. code::
+
+    aws kms decrypt --ciphertext-blob fileb://ExampleEncryptedFile --output text --query Plaintext > ExamplePlaintextFile.base64
+
+.. code::
+
+    certutil -decode ExamplePlaintextFile.base64 ExamplePlaintextFile

--- a/awscli/examples/kms/encrypt.rst
+++ b/awscli/examples/kms/encrypt.rst
@@ -1,14 +1,39 @@
-This example shows how to encrypt the string ``"1\!2@3#4$5%6^7&8*9(0)-_=+"``
-and save the binary contents to a file::
+The following command demonstrates the recommended way to encrypt data with the AWS CLI.
 
-  aws kms encrypt --key-id my-key-id --plaintext "1\!2@3#4$5%6^7&8*9(0)-_=+" --query CiphertextBlob --output text | base64 --decode > /tmp/encrypted
+.. code::
 
+    aws kms encrypt --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext fileb://ExamplePlaintextFile --output text --query CiphertextBlob | base64 --decode > ExampleEncryptedFile
 
-If you want to decrypt the contents of the file above you can use this
-command::
+The command does several things:
 
-  echo "Decrypted is: $(aws kms decrypt --ciphertext-blob fileb:///tmp/encrypted  --output text --query Plaintext | base64 --decode)"
+#. Uses the ``fileb://`` prefix to specify the ``--plaintext`` parameter.
 
-Note the use of the ``fileb://`` prefix in the ``decrypt`` command above.  This
-indicates that the referenced file contains binary contents, and that the file
-contents are not decoded before being used.
+    The ``fileb://`` prefix instructs the CLI to read the data to encrypt, called the *plaintext*, from a file and pass the file's contents to the command's ``--plaintext`` parameter. If the file is not in the current directory, type the full path to file. For example: ``fileb:///var/tmp/ExamplePlaintextFile`` or ``fileb://C:\Temp\ExamplePlaintextFile``.
+
+    For more information about reading AWS CLI parameter values from a file, see `Loading Parameters from a File <https://docs.aws.amazon.com/cli/latest/userguide/cli-using-param.html#cli-using-param-file>`_ in the *AWS Command Line Interface User Guide* and `Best Practices for Local File Parameters <https://blogs.aws.amazon.com/cli/post/TxLWWN1O25V1HE/Best-Practices-for-Local-File-Parameters>`_ on the AWS Command Line Tool Blog.
+
+#. Uses the ``--output`` and ``--query`` parameters to control the command's output.
+
+    These parameters extract the encrypted data, called the *ciphertext*, from the command's output.
+
+    For more information about controlling output, see `Controlling Command Output <https://docs.aws.amazon.com/cli/latest/userguide/controlling-output.html>`_ in the *AWS Command Line Interface User Guide*.
+
+#. Uses the ``base64`` utility to decode the extracted output.
+
+    This utility decodes the extracted ciphertext to binary data. The ciphertext that is returned by a successful ``encrypt`` command is base64-encoded text. You must decode this text before you can use the AWS CLI to decrypt it.
+
+#. Saves the binary ciphertext to a file.
+
+    The final part of the command (``> ExampleEncryptedFile``) saves the binary ciphertext to a file to make decryption easier. For an example command that uses the AWS CLI to decrypt data, see the `decrypt examples <decrypt.html#examples>`_.
+
+**Example: Using the AWS CLI to encrypt data from the Windows command prompt**
+
+The preceding example assumes the ``base64`` utility is available, which is commonly the case on Linux and Mac OS X. For the Windows command prompt, use ``certutil`` instead of ``base64``. This requires two commands, as shown in the following examples.
+
+.. code::
+
+    aws kms encrypt --key-id 1234abcd-12ab-34cd-56ef-1234567890ab --plaintext fileb://ExamplePlaintextFile --output text --query CiphertextBlob > C:\Temp\ExampleEncryptedFile.base64
+
+.. code::
+
+    certutil -decode C:\Temp\ExampleEncryptedFile.base64 C:\Temp\ExampleEncryptedFile


### PR DESCRIPTION
The new examples demonstrate our recommended best practice for the `encrypt` and `decrypt` commands, and add small improvements to the example for `create-alias`.