### PR TITLE
Remove extra ARN path string for registering on premise instance

### DIFF
--- a/awscli/customizations/codedeploy/register.py
+++ b/awscli/customizations/codedeploy/register.py
@@ -117,7 +117,7 @@ class Register(BasicCommand):
         sys.stdout.write('Creating the IAM user... ')
         params.user_name = params.instance_name
         response = self.iam.create_user(
-            Path='/AWS/CodeDeploy/',
+            Path='/',
             UserName=params.user_name
         )
         params.iam_user_arn = response['User']['Arn']


### PR DESCRIPTION
When attempting to register an on premise instance for code deploy.  The ARN generated contains a path that does not exist in IAM, which raises the InvalidIamUserArnException error.

```
aws1:~$ aws deploy register --instance-name `hostname`
Creating the IAM user... DONE
IamUserArn: arn:aws:iam::XXXXXXXXXXXX:user/AWS/CodeDeploy/aws1
Creating the IAM user access key... DONE
Creating the IAM user policy... DONE
PolicyName: codedeploy-agent
Creating the on-premises instance configuration file named codedeploy.onpremises.yml...DONE
Registering the on-premises instance... ERROR
A client error (InvalidIamUserArnException) occurred when calling the RegisterOnPremisesInstance operation: Iam User ARN arn:aws:iam::XXXXXXXXXXXX:user/AWS/CodeDeploy/aws1 is not in a valid format
Register the on-premises instance by following the instructions in "Configure Existing On-Premises Instances by Using AWS CodeDeploy" in the AWS CodeDeploy User Guide.
```
Changing and specifying the ARN without the "AWS/CodeDeploy/" portion allows the instance to be registered.