### PR TITLE
Propagate error on S3 range download failures

### DIFF
--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -358,6 +358,11 @@ class DownloadPartTask(OrderableTask):
             LOGGER.debug(
                 'Exception caught downloading byte range: %s',
                 e, exc_info=True)
+            message = print_operation(self._filename, failed=True,
+                                      dryrun=False)
+            message += '\n' + str(e)
+            result = {'message': message, 'error': True}
+            self._result_queue.put(PrintTask(**result))
             self._context.cancel()
             raise e
 


### PR DESCRIPTION
When we download a file in parts, the DownloadPartTask
was not adding a print task error on the result queue.
As a result, the request would appear to succeed, not print
any error message, and exit with an rc of 0.

I also audited all the ``except Exception`` clauses in tasks.py
and made sure every other place was adding an ``failed=True`` task.
DownloadPartTask was the only one missing this.

cc @kyleknap @JordonPhillips 