### PR TITLE
Unhide Route53 semantic pagination token

### DIFF
--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -35,6 +35,9 @@ from awscli.arguments import BaseCLIArgument
 
 logger = logging.getLogger(__name__)
 
+# There are some services where the pagination params need to be unhiden
+PUBLIC_PAGINATION_TOKENS = {'route53': ['start-record-name']}
+
 
 STARTING_TOKEN_HELP = """
 <p>A token to specify where to start paginating.  This is the
@@ -112,7 +115,12 @@ def unify_paging_params(argument_table, operation_model, event_name,
         return
     logger.debug("Modifying paging parameters for operation: %s",
                  operation_model.name)
-    _remove_existing_paging_arguments(argument_table, paginator_config)
+
+    service_name = operation_model.service_model.service_name
+    public_tokens = PUBLIC_PAGINATION_TOKENS.get(service_name, [])
+    _remove_existing_paging_arguments(
+        argument_table, paginator_config, public_tokens)
+
     parsed_args_event = event_name.replace('building-argument-table.',
                                            'operation-args-parsed.')
     shadowed_args = {}
@@ -185,9 +193,11 @@ def check_should_enable_pagination(input_tokens, shadowed_args, argument_table,
                 argument_table[key] = value
 
 
-def _remove_existing_paging_arguments(argument_table, pagination_config):
+def _remove_existing_paging_arguments(
+        argument_table, pagination_config, public_arguments):
     for cli_name in _get_all_cli_input_tokens(pagination_config):
-        argument_table[cli_name]._UNDOCUMENTED = True
+        if cli_name not in public_arguments:
+            argument_table[cli_name]._UNDOCUMENTED = True
 
 
 def _get_all_cli_input_tokens(pagination_config):

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -326,6 +326,7 @@ class TestParamRename(BaseAWSHelpOutputTest):
         self.assert_not_contains('no-no-reboot')
         self.assert_contains('--reboot')
 
+
 class TestCustomCommandDocsFromFile(BaseAWSHelpOutputTest):
     def test_description_from_rst_file(self):
         # The description for the configure command
@@ -336,6 +337,7 @@ class TestCustomCommandDocsFromFile(BaseAWSHelpOutputTest):
         self.assert_contains('metadata_service_timeout')
         self.assert_contains('metadata_service_num_attempts')
         self.assert_contains('aws_access_key_id')
+
 
 class TestEnumDocsArentDuplicated(BaseAWSHelpOutputTest):
     def test_enum_docs_arent_duplicated(self):

--- a/tests/functional/docs/test_paginate.py
+++ b/tests/functional/docs/test_paginate.py
@@ -1,0 +1,19 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSHelpOutputTest
+
+
+class TestPaginateDocs(BaseAWSHelpOutputTest):
+    def test_semantic_token_not_hidden(self):
+        self.driver.main(['route53', 'list-resource-record-sets', 'help'])
+        self.assert_contains('start-record-name')

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -54,15 +54,14 @@ class TestArgumentTableModifications(TestPaginateBase):
             'foo': mock.Mock(),
             'bar': mock.Mock(),
         }
-        # Default to false
-        argument_table['foo']._UNDOCUMENTED = False
         paginate.unify_paging_params(argument_table, self.operation_model,
                                      'building-argument-table.foo.bar',
                                      self.session)
-        # We should mark the built in input_token as 'hidden'.
-        self.assertTrue(argument_table['foo']._UNDOCUMENTED)
-        # Also need to hide the limit key.
-        self.assertTrue(argument_table['bar']._UNDOCUMENTED)
+        # Using assertEqual here rather than assertTrue because we want the
+        # literal value 'True', not just any truthy value.
+        self.assertEqual(argument_table['foo']._UNDOCUMENTED, True)
+        self.assertEqual(argument_table['bar']._UNDOCUMENTED, True)
+
         # We also need to inject startin-token and max-items.
         self.assertIn('starting-token', argument_table)
         self.assertIn('max-items', argument_table)
@@ -81,7 +80,6 @@ class TestArgumentTableModifications(TestPaginateBase):
             'bar': mock.Mock(),
         }
 
-        # Default to false
         argument_table['foo']._UNDOCUMENTED = False
         service_name = 'foo_service'
         self.operation_model.service_model.service_name = service_name
@@ -90,8 +88,10 @@ class TestArgumentTableModifications(TestPaginateBase):
             paginate.unify_paging_params(
                 argument_table, self.operation_model,
                 'building-argument-table.foo.bar', self.session)
-        # This time it should not be marked as hidden
-        self.assertFalse(argument_table['foo']._UNDOCUMENTED)
+
+        # Using assertEqual here rather than assertTrue because we want the
+        # literal value 'False', not just any falsey value.
+        self.assertEqual(argument_table['foo']._UNDOCUMENTED, False)
 
     def test_operation_with_no_paginate(self):
         # Operations that don't paginate are left alone.

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -54,6 +54,8 @@ class TestArgumentTableModifications(TestPaginateBase):
             'foo': mock.Mock(),
             'bar': mock.Mock(),
         }
+        # Default to false
+        argument_table['foo']._UNDOCUMENTED = False
         paginate.unify_paging_params(argument_table, self.operation_model,
                                      'building-argument-table.foo.bar',
                                      self.session)
@@ -72,6 +74,24 @@ class TestArgumentTableModifications(TestPaginateBase):
                               paginate.PageArgument)
         self.assertIsInstance(argument_table['page-size'],
                               paginate.PageArgument)
+
+    def test_shows_public_paging_args(self):
+        argument_table = {
+            'foo': mock.Mock(),
+            'bar': mock.Mock(),
+        }
+
+        # Default to false
+        argument_table['foo']._UNDOCUMENTED = False
+        service_name = 'foo_service'
+        self.operation_model.service_model.service_name = service_name
+        public_args = 'awscli.customizations.paginate.PUBLIC_PAGINATION_TOKENS'
+        with mock.patch(public_args, {service_name: ['foo']}):
+            paginate.unify_paging_params(
+                argument_table, self.operation_model,
+                'building-argument-table.foo.bar', self.session)
+        # This time it should not be marked as hidden
+        self.assertFalse(argument_table['foo']._UNDOCUMENTED)
 
     def test_operation_with_no_paginate(self):
         # Operations that don't paginate are left alone.


### PR DESCRIPTION
The only way to list a single record set requires using this argument, so it should be un-hid from the docs.

cc @jamesls @kyleknap 