### PR TITLE
Fix bugs when aborting multipart uploads on failure

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -136,20 +136,12 @@ class S3Handler(object):
         self._remove_pending_downloads()
 
     def _abort_pending_multipart_uploads(self):
-        # For the purpose of aborting uploads, we consider any
-        # upload context with an upload id.
+        # precondition: this method is assumed to be called when there are no ongoing
+        # uploads (the executor has been shutdown).
         for upload, filename in self._multipart_uploads:
-            if upload.is_cancelled():
-                try:
-                    upload.wait_for_upload_id()
-                except tasks.UploadCancelledError:
-                    pass
-                else:
-                    # This means that the upload went from STARTED -> CANCELLED.
-                    # This could happen if a part thread decided to cancel the
-                    # upload.  We need to explicitly abort the upload here.
-                    self._cancel_upload(upload.wait_for_upload_id(), filename)
-            upload.cancel_upload(self._cancel_upload, args=(filename,))
+            if upload.is_cancelled() or upload.in_progress():
+                # Cancel any upload that's not unstarted and not complete.
+                upload.cancel_upload(self._cancel_upload, args=(filename,))
 
     def _remove_pending_downloads(self):
         # The downloads case is easier than the uploads case because we don't
@@ -342,6 +334,7 @@ class S3Handler(object):
             parameters=self.params,
             result_queue=self.result_queue, upload_context=upload_context)
         self.executor.submit(create_multipart_upload_task)
+        self._multipart_uploads.append((upload_context, filename))
         return upload_context
 
     def _enqueue_upload_tasks(self, num_uploads, chunksize, upload_context,
@@ -372,7 +365,6 @@ class S3Handler(object):
             session=self.session, filename=filename, parameters=self.params,
             result_queue=self.result_queue, upload_context=upload_context)
         self.executor.submit(complete_multipart_upload_task)
-        self._multipart_uploads.append((upload_context, filename))
 
 
 class S3StreamHandler(S3Handler):

--- a/awscli/customizations/s3/tasks.py
+++ b/awscli/customizations/s3/tasks.py
@@ -636,18 +636,17 @@ class MultipartUploadContext(object):
     def cancel_upload(self, canceller=None, args=None, kwargs=None):
         """Cancel the upload.
 
-        If the upload is already in progress (via ``self.in_progress()``)
-        you can provide a ``canceller`` argument that can be used to cancel
-        the multipart upload request (typically this would call something like
-        AbortMultipartUpload.  The canceller argument is a function that takes
-        a single argument, which is the upload id::
+        If the upload is not unstarted and not complete you can provide a
+        ``canceller`` argument that can be used to cancel the multipart upload
+        request (typically this would call something like AbortMultipartUpload.
+        The canceller argument is a function that takes a single argument,
+        which is the upload id::
 
             def my_canceller(upload_id):
-                cancel.upload(bucket, key, upload_id)
+                abort_multipart_upload(bucket, key, upload_id)
 
         The ``canceller`` callable will only be called if the
-        task is in progress.  If the task has not been started or is
-        complete, then ``canceller`` will not be called.
+        the task has not been started or is complete.
 
         Note that ``canceller`` is called while an exclusive lock is held,
         so you cannot make any calls into the MultipartUploadContext object
@@ -655,7 +654,15 @@ class MultipartUploadContext(object):
 
         """
         with self._lock:
-            if self._state == self._STARTED and canceller is not None:
+            # An easy way to think of this is the case where we want to abort
+            # any multipart uploads that have been started but not completed.
+            # There are two states that correspond to not being in progress:
+            # _UNSTARTED and _COMPLETED.  The reason _CANCELLED is not
+            # considered is because a part task can cancel an upload, yet does
+            # not have enough context to be able to abort the upload (other
+            # tasks may be executing upload parts).
+            if self._state not in [self._UNSTARTED, self._COMPLETED] and \
+                    canceller is not None:
                 if args is None:
                     args = ()
                 if kwargs is None:

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -54,7 +54,8 @@ class S3HandlerBaseTest(BaseAWSCommandParamsTest):
         return stdout, stderr, rc
 
     def assert_operations_for_s3_handler(self, s3_handler, tasks,
-                                         ref_operations):
+                                         ref_operations,
+                                         verify_no_failed_tasked=True):
         """Assert API operations based on tasks given to s3 handler
 
         :param s3_handler: A S3Handler object
@@ -64,7 +65,8 @@ class S3HandlerBaseTest(BaseAWSCommandParamsTest):
             parameters passed to it (as it would be passed to botocore).
         """
         stdout, stderr, rc = self.run_s3_handler(s3_handler, tasks)
-        self.assertEqual(rc.num_tasks_failed, 0)
+        if verify_no_failed_tasked:
+            self.assertEqual(rc.num_tasks_failed, 0)
         self.assertEqual(len(self.operations_called), len(ref_operations))
         for i, ref_operation in enumerate(ref_operations):
             self.assertEqual(self.operations_called[i][0].name,

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -24,8 +24,9 @@ from awscli.compat import six
 from awscli.customizations.s3.s3handler import S3Handler, S3StreamHandler
 from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.tasks import CreateMultipartUploadTask, \
-    UploadPartTask, CreateLocalFileTask
+    UploadPartTask, CreateLocalFileTask, CompleteMultipartUploadTask
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
+from awscli.customizations.s3.utils import StablePriorityQueue
 from awscli.customizations.s3.transferconfig import RuntimeConfig
 from tests.unit.customizations.s3 import make_loc_files, clean_loc_files, \
     MockStdIn, S3HandlerBaseTest
@@ -33,6 +34,18 @@ from tests.unit.customizations.s3 import make_loc_files, clean_loc_files, \
 
 def runtime_config(**kwargs):
     return RuntimeConfig().build_config(**kwargs)
+
+
+# The point of this class is some condition where an error
+# occurs during the enqueueing of tasks.
+class CompleteTaskNotAllowedQueue(StablePriorityQueue):
+    def _put(self, item):
+        if isinstance(item, CompleteMultipartUploadTask):
+            # Raising this exception will trigger the
+            # "error" case shutdown in the executor.
+            raise RuntimeError(
+                "Forced error on enqueue of complete task.")
+        return StablePriorityQueue._put(self, item)
 
 
 class S3HandlerTestDelete(S3HandlerBaseTest):
@@ -277,19 +290,19 @@ class S3HandlerTestUpload(S3HandlerBaseTest):
             # This will cause a failure for the second part upload because
             # it does not have an ETag.
             {},
+            # This is for the final AbortMultipartUpload call.
+            {},
         ]
         stdout, stderr, rc = self.run_s3_handler(self.s3_handler_multi, tasks)
         self.assertEqual(rc.num_tasks_failed, 1)
 
     def test_multiupload_abort_in_s3_handler(self):
-        files = [self.loc_files[0]]
-        tasks = []
-        for i in range(len(files)):
-            tasks.append(FileInfo(
-                src=self.loc_files[i],
-                dest=self.s3_files[i], size=15,
-                operation_name='upload',
-                client=self.client))
+        tasks = [
+            FileInfo(src=self.loc_files[0],
+                     dest=self.s3_files[0], size=15,
+                     operation_name='upload',
+                     client=self.client)
+        ]
         self.parsed_responses = [
             {'UploadId': 'foo'},
             {'ETag': '"120ea8a25e5d487bf68b5f7096440019"'},
@@ -298,16 +311,49 @@ class S3HandlerTestUpload(S3HandlerBaseTest):
             {},
             {}
         ]
-        context_path = 'awscli.customizations.s3.tasks.MultipartUploadContext'
-        with mock.patch(context_path) as mock_context:
-            mock_context.return_value.wait_for_upload_id.return_value = 'foo'
-            stdout, stderr, rc = self.run_s3_handler(self.s3_handler_multi,
-                                                     tasks)
-            # Ensure multipart upload is called in case cancelling of
-            # task in s3handler if the task is in the middle of transitioning
-            # from STARTED -> COMPLETED
-            self.assertEqual(self.operations_called[-1][0].name,
-                             'AbortMultipartUpload')
+        expected_calls = [
+            ('CreateMultipartUpload',
+             {'Bucket': 'mybucket', 'ContentType': 'text/plain',
+              'Key': 'text1.txt', 'ACL': 'private'}),
+            ('UploadPart',
+             {'Body': mock.ANY, 'Bucket': 'mybucket', 'PartNumber': 1,
+              'UploadId': 'foo', 'Key': 'text1.txt'}),
+            # Here we'll see an error because of a msising ETag.
+            ('UploadPart',
+             {'Body': mock.ANY, 'Bucket': 'mybucket', 'PartNumber': 2,
+              'UploadId': 'foo', 'Key': 'text1.txt'}),
+            # And we should have the final call be an AbortMultipartUpload.
+            ('AbortMultipartUpload',
+             {'Bucket': 'mybucket', 'Key': 'text1.txt', 'UploadId': 'foo'}),
+        ]
+        self.assert_operations_for_s3_handler(self.s3_handler_multi, tasks,
+                                              expected_calls,
+                                              verify_no_failed_tasked=False)
+
+    def test_multipart_abort_for_half_queues(self):
+        self.s3_handler_multi.executor.queue = CompleteTaskNotAllowedQueue()
+        tasks = [
+            FileInfo(src=self.loc_files[0],
+                     dest=self.s3_files[0], size=15,
+                     operation_name='upload',
+                     client=self.client)
+        ]
+        self.parsed_responses = [
+            {'UploadId': 'foo'},
+            {}
+        ]
+        expected_calls = [
+            ('CreateMultipartUpload',
+             {'Bucket': 'mybucket', 'ContentType': 'text/plain',
+              'Key': 'text1.txt', 'ACL': 'private'}),
+            # Because the CreateMultipartUpload started, we should expect
+            # to see an AbortMultipartUpload call as well.
+            ('AbortMultipartUpload',
+             {'Bucket': 'mybucket', 'Key': 'text1.txt', 'UploadId': 'foo'}),
+        ]
+        self.assert_operations_for_s3_handler(self.s3_handler_multi, tasks,
+                                              expected_calls,
+                                              verify_no_failed_tasked=False)
 
 
 class S3HandlerTestMvLocalS3(S3HandlerBaseTest):


### PR DESCRIPTION
There were two issues I fixed when aborting multipart uploads.

First, we were not invoking the cancel callback passed to the
multipart upload context when a part task has requested that
an upload is cancelled.  This happens when the UploadPart API
call fails (due to a timeout for example).  This is because
the cancel callback is only invoked when the context state
is in _STARTED.  It doesn't account for contexts in the
_CANCELLED state that haven't had their uploads aborted.

The second issue is a less likely case.  We were only tracking
a multipart upload after we queued the complete multipart upload
task.  This means that if something in the Main
thread (which does the enqueuing) generates an exception after
the create upload task is queued but before the complete task
is queued, the S3 handler won't be tracking this upload yet
so it won't know to abort the upload.  Now we add an upload
to our list of tracked uploads as soon as we queue a create
upload task.

cc @kyleknap @JordonPhillips 