### PR TITLE
Validate build directory gamelift

### DIFF
--- a/awscli/customizations/gamelift/getlog.py
+++ b/awscli/customizations/gamelift/getlog.py
@@ -13,7 +13,6 @@
 import sys
 from functools import partial
 
-from botocore.compat import six
 from six.moves.urllib.request import urlopen
 from awscli.customizations.commands import BasicCommand
 
@@ -47,7 +46,7 @@ class GetGameSessionLogCommand(BasicCommand):
             'Downloading log archive for game session %s...\r' %
             args.game_session_id
         )
- 
+
         with open(args.save_as, 'wb') as f:
             for chunk in iter(partial(contents.read, 1024), b''):
                 f.write(chunk)

--- a/awscli/customizations/gamelift/uploadbuild.py
+++ b/awscli/customizations/gamelift/uploadbuild.py
@@ -41,6 +41,15 @@ class UploadBuildCommand(BasicCommand):
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
+        # Validate a build directory
+        if not validate_directory(args.build_root):
+            sys.stderr.write(
+                'Fail to upload %s. '
+                'The build root directory is empty or does not exist.\n'
+                % (args.build_root)
+            )
+
+            return 255
         # Create a build.
         response = gamelift_client.create_build(
             Name=args.name, Version=args.build_version)
@@ -100,6 +109,13 @@ def zip_directory(zipfile_name, source_root):
                     relative_path = os.path.relpath(
                         full_path, source_root)
                     zf.write(full_path, relative_path)
+
+
+def validate_directory(source_root):
+    for path, dirs, files in os.walk(source_root):
+        if files:
+            return True
+    return False
 
 
 # TODO: Remove this class once available to CLI from s3transfer

--- a/awscli/customizations/gamelift/uploadbuild.py
+++ b/awscli/customizations/gamelift/uploadbuild.py
@@ -112,6 +112,8 @@ def zip_directory(zipfile_name, source_root):
 
 
 def validate_directory(source_root):
+    # We walk the root because we want to validate there's at least one file
+    # that exists recursively from the root directory
     for path, dirs, files in os.walk(source_root):
         if files:
             return True


### PR DESCRIPTION
The build directory needs to exist and be nonempty to upload builds to GameLift.

cc @jamesls @JordonPhillips 