### PR TITLE
Fix invalid xml in the docs

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -154,7 +154,7 @@ GRANTS = {
         'writeacl, or full.</li><li><code>Grantee_Type</code> - '
         'Specifies how the grantee is to be identified, and can be set '
         'to uri, emailaddress, or id.</li><li><code>Grantee_ID</code> - '
-        'Specifies the grantee based on Grantee_Type.</li></ul>The '
+        'Specifies the grantee based on Grantee_Type. The '
         '<code>Grantee_ID</code> value can be one of:<ul><li><b>uri</b> '
         '- The group\'s URI. For more information, see '
         '<a href="http://docs.aws.amazon.com/AmazonS3/latest/dev/'


### PR DESCRIPTION
It caused the html parser to have an incorrect representation of the html tree which messed up the rendering of the docs. Here are the docs with the fix now:
<img width="559" alt="screen shot 2016-04-14 at 1 53 44 pm" src="https://cloud.githubusercontent.com/assets/4605355/14543338/62f3cec6-0248-11e6-8952-d5226adf5ca6.png">

Fixes https://github.com/aws/aws-cli/issues/1901

cc @jamesls @JordonPhillips 