### PR TITLE
Fix issue with boolean argument translations

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -314,7 +314,8 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
                     # results in the new proposed cli argument name. If it
                     # does, we assume we have the postive form of the argument
                     # which is the name we want to use in doc translations.
-                    if previous_mapping.startswith('no-') and \
+                    if cli_argument.cli_type_name == 'boolean' and \
+                            previous_mapping.startswith('no-') and \
                             cli_name == previous_mapping[3:]:
                         d[argument_name] = cli_name
                 else:

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -304,7 +304,21 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         d = {}
         for cli_name, cli_argument in self.help_command.arg_table.items():
             if cli_argument.argument_model is not None:
-                d[cli_argument.argument_model.name] = cli_name
+                argument_name = cli_argument.argument_model.name
+                if argument_name in d:
+                    previous_mapping = d[argument_name]
+                    # If the argument name is a boolean argument, we want the
+                    # the translation to default to the one that does not start
+                    # with --no-. So we check if the cli parameter currently
+                    # being used starts with no- and if stripping off the no-
+                    # results in the new proposed cli argument name. If it
+                    # does, we assume we have the postive form of the argument
+                    # which is the name we want to use in doc translations.
+                    if previous_mapping.startswith('no-') and \
+                            cli_name == previous_mapping[3:]:
+                        d[argument_name] = cli_name
+                else:
+                    d[argument_name] = cli_name
         for operation_name in operation_model.service_model.operation_names:
             d[operation_name] = xform_name(operation_name, '-')
         return d

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -108,8 +108,10 @@ class TestTranslationMap(unittest.TestCase):
         }).build_model()
         argument_model = input_model.members['Flag']
         argument_model.name = 'Flag'
-        self.arg_table['flag'] = mock.Mock(argument_model=argument_model)
-        self.arg_table['no-flag'] = mock.Mock(argument_model=argument_model)
+        self.arg_table['flag'] = mock.Mock(
+            cli_type_name='boolean', argument_model=argument_model)
+        self.arg_table['no-flag'] = mock.Mock(
+            cli_type_name='boolean', argument_model=argument_model)
         # The --no-flag should not be used in the translation.
         self.assertEqual(
             self.operation_handler.build_translation_map(),


### PR DESCRIPTION
When building the translation table in the docs, the CLI may use the
negative version of boolean argument, which messes up the meaning of some
of the docs.

Here is an example for ``dynamodb get-item`` and ``consistent-read`` argument:

**Before:**
<img width="771" alt="screen shot 2016-04-14 at 3 35 44 pm" src="https://cloud.githubusercontent.com/assets/4605355/14545931/972a2dee-0256-11e6-8c66-cd28d736be32.png">


**After:**
<img width="562" alt="screen shot 2016-04-14 at 3 35 18 pm" src="https://cloud.githubusercontent.com/assets/4605355/14545936/9cc14af8-0256-11e6-84f8-a187604c9a90.png">

cc @jamesls @JordonPhillips 