### PR TITLE
Add example to list resource record sets by name

### DIFF
--- a/awscli/examples/route53/list-resource-record-sets.rst
+++ b/awscli/examples/route53/list-resource-record-sets.rst
@@ -12,3 +12,7 @@ To view information about the next resource record set in the hosted zone, take 
 
   aws route53 list-resource-record-sets --hosted-zone-id Z2LD58HEXAMPLE --max-items 1 --starting-token Z3M3LMPEXAMPLE
 
+To view all the resource record sets of a particular name, use the ``--query`` parameter to filter them out. For example::
+
+  aws route53 list-resource-record-sets --hosted-zone-id Z2LD58HEXAMPLE --query "ResourceRecordSets[?Name == 'example.domain.']"
+


### PR DESCRIPTION
This is to clear up some confusion with the route53 api in the CLI

cc @jamesls @kyleknap