### PR TITLE
Use a shared bucket across all test_plugin tests

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -627,6 +627,7 @@ class BaseS3CLICommand(unittest.TestCase):
     and more streamlined.
 
     """
+
     def setUp(self):
         self.files = FileCreator()
         self.session = botocore.session.get_session()
@@ -646,6 +647,11 @@ class BaseS3CLICommand(unittest.TestCase):
     def extra_teardown(self):
         # Subclasses can use this to define extra teardown steps.
         pass
+
+    def create_client_for_bucket(self, bucket_name):
+        region = self.regions.get(bucket_name, self.region)
+        client = self.session.create_client('s3', region_name=region)
+        return client
 
     def assert_key_contents_equal(self, bucket, key, expected_contents):
         if isinstance(expected_contents, six.BytesIO):
@@ -667,8 +673,7 @@ class BaseS3CLICommand(unittest.TestCase):
         return bucket_name
 
     def put_object(self, bucket_name, key_name, contents='', extra_args=None):
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         call_args = {
             'Bucket': bucket_name,
             'Key': key_name, 'Body': contents
@@ -680,14 +685,12 @@ class BaseS3CLICommand(unittest.TestCase):
 
     def delete_bucket(self, bucket_name):
         self.remove_all_objects(bucket_name)
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         response = client.delete_bucket(Bucket=bucket_name)
-        del self.regions[bucket_name]
+        self.regions.pop(bucket_name, None)
 
     def remove_all_objects(self, bucket_name):
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         paginator = client.get_paginator('list_objects')
         pages = paginator.paginate(Bucket=bucket_name)
         key_names = []
@@ -697,19 +700,16 @@ class BaseS3CLICommand(unittest.TestCase):
             self.delete_key(bucket_name, key_name)
 
     def delete_key(self, bucket_name, key_name):
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         response = client.delete_object(Bucket=bucket_name, Key=key_name)
 
     def get_key_contents(self, bucket_name, key_name):
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         response = client.get_object(Bucket=bucket_name, Key=key_name)
         return response['Body'].read().decode('utf-8')
 
     def key_exists(self, bucket_name, key_name):
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         try:
             client.head_object(Bucket=bucket_name, Key=key_name)
             return True
@@ -725,8 +725,7 @@ class BaseS3CLICommand(unittest.TestCase):
         return parsed['ContentType']
 
     def head_object(self, bucket_name, key_name):
-        client = self.session.create_client(
-            's3', region_name=self.regions[bucket_name])
+        client = self.create_client_for_bucket(bucket_name)
         response = client.head_object(Bucket=bucket_name, Key=key_name)
         return response
 


### PR DESCRIPTION
This test adds a setup/teardown at the module level that
creates a bucket that all tests can use.  This change
was made for several reasons:

* Reduce number of resources created.  Considering multiple test runs
  on multiple python version, multiple platforms, etc.
* Have a more robust check in place for creating a bucket.  This
  better handles eventual consistency.
* Improve speed.  Rather than having to create/delete a bucket each
  test, we can reuse a bucket across all tests.  As part of this
  change, the shared bucket is emptied out before each test.
  From my testing, this shaves about 3 minutes off the test runs.

There are some tests that either require a specific bucket (a bucket
in a specific region) or multiple buckets.  This PR does not address
those cases.

cc @kyleknap @JordonPhillips 