### PR TITLE
Add --no-param-validation to disable parameter validation

### DIFF
--- a/.changes/next-release/feature-ParamValidation.json
+++ b/.changes/next-release/feature-ParamValidation.json
@@ -1,0 +1,5 @@
+{
+  "category": "Param Validation", 
+  "type": "feature", 
+  "description": "Add ``--no-param-validation`` option to disable parameter validation."
+}

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -27,6 +27,7 @@ def register_parse_global_args(cli):
     cli.register('top-level-args-parsed', resolve_verify_ssl)
     cli.register('top-level-args-parsed', resolve_cli_read_timeout)
     cli.register('top-level-args-parsed', resolve_cli_connect_timeout)
+    cli.register('top-level-args-parsed', resolve_cli_param_validation)
 
 
 def resolve_types(parsed_args, **kwargs):
@@ -91,6 +92,11 @@ def resolve_cli_connect_timeout(parsed_args, session, **kwargs):
 def resolve_cli_read_timeout(parsed_args, session, **kwargs):
     arg_name = 'read_timeout'
     _resolve_timeout(session, parsed_args, arg_name)
+
+
+def resolve_cli_param_validation(parsed_args, session, **kwargs):
+    if not parsed_args.param_validation:
+        _update_default_client_config(session, 'parameter_validation', False)
 
 
 def _resolve_timeout(session, parsed_args, arg_name):

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -15,6 +15,11 @@
             "dest": "verify_ssl",
             "help": "<p>By default, the AWS CLI uses SSL when communicating with AWS services.  For each SSL connection, the AWS CLI will verify SSL certificates.  This option overrides the default behavior of verifying SSL certificates.</p>"
         },
+        "no-param-validation": {
+            "action": "store_false",
+            "dest": "param_validation",
+            "help": "<p>Disable parameter validation (enabled by default).  Specifying this parameter will disable parameter validation.  You typically should not need to disable parameter validation.</p>"
+        },
         "no-paginate": {
             "action": "store_false",
             "help": "<p>Disable automatic pagination.</p>",

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -226,3 +226,11 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         self.assertEqual(parsed_args.connect_timeout, None)
         self.assertEqual(
             session.get_default_client_config().connect_timeout, None)
+
+    def test_disable_validation(self):
+        parsed_args = FakeParsedArgs(param_validation=False)
+        session = get_session()
+        globalargs.resolve_cli_param_validation(parsed_args, session)
+
+        self.assertFalse(
+            session.get_default_client_config().parameter_validation)


### PR DESCRIPTION
cc @kyleknap @JordonPhillips 