### PR TITLE
Use service_name in process-cli-arg event

### DIFF
--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -456,7 +456,7 @@ class CLIArgument(BaseCLIArgument):
             parameters[self._serialized_name] = unpacked
 
     def _unpack_argument(self, value):
-        service_name = self._operation_model.service_model.endpoint_prefix
+        service_name = self._operation_model.service_model.service_name
         operation_name = xform_name(self._operation_model.name, '-')
         override = self._emit_first_response('process-cli-arg.%s.%s' % (
             service_name, operation_name), param=self.argument_model,

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -742,3 +742,18 @@ class BaseS3CLICommand(unittest.TestCase):
 class StringIOWithFileNo(StringIO):
     def fileno(self):
         return 0
+
+
+class TestEventHandler(object):
+    def __init__(self, handler=None):
+        self._handler = handler
+        self._called = False
+
+    @property
+    def called(self):
+        return self._called
+
+    def handler(self, **kwargs):
+        self._called = True
+        if self._handler is not None:
+            self._handler(**kwargs)

--- a/tests/functional/elb/test_register_instances_with_load_balancer.py
+++ b/tests/functional/elb/test_register_instances_with_load_balancer.py
@@ -11,7 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import BaseAWSCommandParamsTest, TestEventHandler
 import os
 
 
@@ -77,3 +77,13 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances i-12345678 i-87654321'
         self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
+
+    def test_unpack_event_uses_service_name(self):
+        cmdline = self.prefix
+        cmdline += ' --load-balancer-name my-lb'
+        cmdline += ' --instances {"InstanceId":"i-12345678"}'
+        handler = TestEventHandler()
+        event = 'process-cli-arg.elb.register-instances-with-load-balancer'
+        self.driver.session.register(event, handler.handler)
+        self.run_cmd(cmdline)
+        self.assertTrue(handler.called, "Expected event not called.")

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -10,8 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import mock
+
 from awscli.testutils import unittest
 from awscli import arguments
+from botocore.model import StringShape, OperationModel, ServiceModel
+
 
 class DemoArgument(arguments.CustomArgument):
     pass
@@ -23,3 +27,48 @@ class TestArgumentClasses(unittest.TestCase):
         self.assertFalse(arg.required)
         arg.required = True
         self.assertTrue(arg.required)
+
+
+class TestCLIArgument(unittest.TestCase):
+    def setUp(self):
+        self.service_name = 'baz'
+        self.service_model = ServiceModel({
+            'metadata': {
+                'endpointPrefix': 'bad',
+            },
+            'operations': {
+                'SampleOperation': {
+                    'name': 'SampleOperation',
+                    'input': {'shape': 'Input'}
+                }
+            },
+            'shapes': {
+                'StringShape': {'type': 'string'},
+                'Input': {
+                    'type': 'structure',
+                    'members': {
+                        'Foo': {'shape': 'StringShape'}
+                    }
+                }
+            }
+        }, self.service_name)
+        self.operation_model = self.service_model.operation_model(
+            'SampleOperation')
+        self.argument_model = self.operation_model.input_shape.members['Foo']
+        self.event_emitter = mock.Mock()
+
+    def create_argument(self):
+        return arguments.CLIArgument(
+            self.argument_model.name, self.argument_model,
+            self.operation_model, self.event_emitter)
+
+    def test_unpack_uses_service_name_in_event(self):
+        self.event_emitter.emit.return_value = ['value']
+        argument = self.create_argument()
+        params = {}
+        argument.add_to_params(params, 'value')
+        expected_event_name = 'process-cli-arg.%s.%s' % (
+            self.service_name, 'sample-operation')
+        actual_event_name = self.event_emitter.emit.call_args[0][0]
+        self.assertEqual(actual_event_name, expected_event_name)
+


### PR DESCRIPTION
Currently we use the endpoint prefix when generating this event, which means service whose names we have manually changed will emit events with the old name. For example, elb will emit as elasticloadbalancing. This makes registering event handlers confusing, especially since most other event handlers use the service name. Furthermore, multiple services can use the same endpoint, so this could be a source of bugs if not changed.

This changes the event from `process-cli-arg.endpoint-prefix.operation-name` to `process-cli-arg.service-name.operation-name`.

To make sure that no existing events handlers were broken, I wrote a script to find all the services whose service name is different from the endpoint prefix. Specifically, this only applies to modeled commands since CustomArgument does not inherit from CLIArgument. The result of that search is the following:

Service Name | Endpoint Prefix
------------ | ---------------
cloudwatch   | monitoring
dynamodbstreams | streams.dynamodb
efs | elasticfilesystem
elb | elasticloadbalancing
emr | elasticmapreduce
iot-data | data.iot
meteringmarketplace | metering.marketplace
ses | email

I then did a search through the source code to make sure we weren't registering any handlers against the process-cli-arg event for those services. Thankfully, we are not. Since the CLI isn't open for customization, we don't need to worry about trampling customers.

cc @kyleknap @jamesls