### PR TITLE
Print better error when using pagination params and no paginate

### DIFF
--- a/.changes/next-release/bugfix-Paginator.json
+++ b/.changes/next-release/bugfix-Paginator.json
@@ -1,0 +1,5 @@
+{
+  "description": "Print a better error when pagination params are supplied along with no-paginate.",
+  "category": "Paginator",
+  "type": "bugfix"
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -516,8 +516,9 @@ class ServiceOperation(object):
                                                  self._name)
         self._emit(event, parsed_args=parsed_args,
                    parsed_globals=parsed_globals)
-        call_parameters = self._build_call_parameters(parsed_args,
-                                                      self.arg_table)
+        call_parameters = self._build_call_parameters(
+            parsed_args, self.arg_table)
+
         event = 'calling-command.%s.%s' % (self._parent_name,
                                            self._name)
         override = self._emit_first_non_none_response(

--- a/tests/functional/s3api/test_list_objects.py
+++ b/tests/functional/s3api/test_list_objects.py
@@ -81,3 +81,12 @@ class TestListObjects(BaseAWSCommandParamsTest):
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+
+    def test_pagination_params_cannot_be_supplied_with_no_paginate(self):
+        cmdline = self.prefix + ' --bucket mybucket --no-paginate ' \
+                                '--max-items 100'
+        self.assert_params_for_cmd(
+            cmdline, expected_rc=255,
+            stderr_contains="Error during pagination: Cannot specify "
+                            "--no-paginate along with pagination arguments: "
+                            "--max-items")


### PR DESCRIPTION
This makes the error message when pagination paramters are passed in
along with --no-paginate more helpful.

cc @kyleknap @jamesls