### PR TITLE
Overlay streaming-specific config on non-streaming defaults

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -381,12 +381,13 @@ class S3StreamHandler(S3Handler):
     def __init__(self, session, params, result_queue=None,
                  runtime_config=None):
         if runtime_config is None:
-            # Rather than using the .defaults(), streaming
-            # has different default values so that it does not
-            # consume large amounts of memory.
-            runtime_config = RuntimeConfig().build_config(
-                max_queue_size=self.MAX_EXECUTOR_QUEUE_SIZE,
-                max_concurrent_requests=self.EXECUTOR_NUM_THREADS)
+            runtime_config = RuntimeConfig.defaults()
+        # Streaming needs different default values so that it does
+        # not consume large amounts of memory. These are overlaid
+        # on the specified runtime_config.
+        runtime_config.update(
+            max_queue_size=self.MAX_EXECUTOR_QUEUE_SIZE,
+            max_concurrent_requests=self.EXECUTOR_NUM_THREADS)
         super(S3StreamHandler, self).__init__(session, params, result_queue,
                                               runtime_config)
 

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -936,8 +936,9 @@ class CommandArchitecture(object):
         s3handler = S3Handler(self.session, self.parameters,
                               runtime_config=self._runtime_config,
                               result_queue=result_queue)
-        s3_stream_handler = S3StreamHandler(self.session, self.parameters,
-                                            result_queue=result_queue)
+        s3_stream_handler = S3StreamHandler(
+            self.session, self.parameters, runtime_config=self._runtime_config,
+            result_queue=result_queue)
 
         sync_strategies = self.choose_sync_strategies()
 

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1125,5 +1125,38 @@ class TestS3HandlerInitialization(unittest.TestCase):
         self.assertEqual(handler.multi_threshold, 10000)
 
 
+class TestS3StreamHandlerInitialization(unittest.TestCase):
+
+    def setUp(self):
+        self.arbitrary_params = {'region': 'us-west-2'}
+
+    def test_runtime_config_overlay_plumbed_through(self):
+        """Streaming-specific options are overlaid on given config."""
+        config = runtime_config(
+            multipart_chunksize=1000,
+            multipart_threshold=10000)
+        handler = S3StreamHandler(session=None, params=self.arbitrary_params,
+                                  runtime_config=config)
+
+        self.assertEqual(handler.chunksize, 1000)
+        self.assertEqual(handler.multi_threshold, 10000)
+        self.assertEqual(
+            handler.executor.queue.maxsize,
+            S3StreamHandler.MAX_EXECUTOR_QUEUE_SIZE)
+        self.assertEqual(
+            handler.executor.num_threads, S3StreamHandler.EXECUTOR_NUM_THREADS)
+
+    def test_runtime_config_default_overlay_plumbed_through(self):
+        """Streaming-specific options are overlaid on default config."""
+        handler = S3StreamHandler(session=None, params=self.arbitrary_params,
+                                  runtime_config=runtime_config())
+
+        self.assertEqual(
+            handler.executor.queue.maxsize,
+            S3StreamHandler.MAX_EXECUTOR_QUEUE_SIZE)
+        self.assertEqual(
+            handler.executor.num_threads, S3StreamHandler.EXECUTOR_NUM_THREADS)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -377,7 +377,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         self.patch_make_request()
         cmd_arc.run()
         output_str = "Completed 1 part(s) with ... file(s) remaining"
-        self.assertIn("nono", self.output.getvalue())
+        self.assertIn(output_str, self.output.getvalue())
 
     def test_error_on_same_line_as_status(self):
         s3_file = 's3://' + 'bucket-does-not-exist' + '/' + 'text1.txt'

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -27,6 +27,7 @@ from awscli.customizations.s3.syncstrategy.base import \
 from awscli.testutils import unittest, BaseAWSHelpOutputTest, \
     BaseAWSCommandParamsTest, FileCreator
 from tests.unit.customizations.s3 import make_loc_files, clean_loc_files
+from awscli.customizations.s3.transferconfig import RuntimeConfig
 from awscli.compat import StringIO
 
 
@@ -355,6 +356,28 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         cmd_arc.run()
         output_str = "(dryrun) upload: %s to %s" % (rel_local_file, s3_file)
         self.assertIn(output_str, self.output.getvalue())
+
+    @patch('sys.stdin', new_callable=StringIO)
+    def test_run_cp_streaming_put(self, mock_stdin):
+        s3_file = 's3://' + self.bucket + '/' + 'text1.txt'
+        local_file = self.loc_files[0]
+        mock_stdin.write(open(local_file).read())
+        filters = [['--include', '*']]
+        params = {'dir_op': False, 'dryrun': True, 'quiet': False,
+                  'src': '-', 'dest': s3_file, 'filters': filters,
+                  'paths_type': 'locals3', 'region': 'us-east-1',
+                  'endpoint_url': None, 'verify_ssl': None,
+                  'follow_symlinks': True, 'page_size': None,
+                  'is_stream': True}
+        config = RuntimeConfig().build_config(
+            multipart_threshold=1, multipart_chunksize=2)
+        cmd_arc = CommandArchitecture(
+            self.session, 'cp', params, runtime_config=config)
+        cmd_arc.create_instructions()
+        self.patch_make_request()
+        cmd_arc.run()
+        output_str = "Completed 1 part(s) with ... file(s) remaining"
+        self.assertIn("nono", self.output.getvalue())
 
     def test_error_on_same_line_as_status(self):
         s3_file = 's3://' + 'bucket-does-not-exist' + '/' + 'text1.txt'


### PR DESCRIPTION
Without this change, users cannot configure multipart chunk size for streaming uploads.

When running `aws --debug s3 cp` I noticed that configuration of `multipart_chunksize` (as documented at http://docs.aws.amazon.com/cli/latest/topic/s3-config.html) had no effect for streaming uploads in awscli 1.10.26; no matter the value a chunk size of 8MB was always in effect and streaming uploads > 80GB were effectively prohibited. This PR makes larger streaming uploads possible.
