### PR TITLE
Fix regression with --no-paginate argument

### DIFF
--- a/.changes/next-release/bugfix-Pagination.json
+++ b/.changes/next-release/bugfix-Pagination.json
@@ -1,0 +1,5 @@
+{
+  "category": "Pagination", 
+  "type": "bugfix", 
+  "description": "Fix regression with --no-paginate introduced in `#1958 <https://github.com/aws/aws-cli/issues/1958>`__ (fixes `#1993 <https://github.com/aws/aws-cli/issues/1993>`__)"
+}

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -184,7 +184,7 @@ def check_should_enable_pagination(input_tokens, shadowed_args, argument_table,
             # what we're doing here.
             for key, value in shadowed_args.items():
                 argument_table[key] = value
-    
+
     if not parsed_globals.paginate:
         ensure_paging_params_not_set(parsed_args, shadowed_args)
 
@@ -193,7 +193,7 @@ def ensure_paging_params_not_set(parsed_args, shadowed_args):
     paging_params = ['starting_token', 'page_size', 'max_items']
     shadowed_params = [p.replace('-', '_') for p in shadowed_args.keys()]
     params_used = [p for p in paging_params if
-                   p not in shadowed_params and getattr(parsed_args, p)]
+                   p not in shadowed_params and getattr(parsed_args, p, None)]
 
     if len(params_used) > 0:
         converted_params = ', '.join(

--- a/tests/functional/cloudformation/test_describe_stacks.py
+++ b/tests/functional/cloudformation/test_describe_stacks.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestDescribeStacks(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudformation describe-stacks '
+
+    def test_can_single_argument(self):
+        cmdline = self.prefix + '--stack-name test-stack'
+        result = {'StackName': 'test-stack'}
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_can_specify_no_paginate(self):
+        cmdline = self.prefix + '--stack-name test-stack --no-paginate'
+        result = {'StackName': 'test-stack'}
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -303,3 +303,9 @@ class TestEnsurePagingParamsNotSet(TestPaginateBase):
 
         with self.assertRaises(PaginationError):
             paginate.ensure_paging_params_not_set(self.parsed_args, {})
+
+    def test_can_handle_missing_page_size(self):
+        # Not all pagination operations have a page_size.
+        del self.parsed_args.page_size
+        self.assertIsNone(paginate.ensure_paging_params_not_set(
+            self.parsed_args, {}))


### PR DESCRIPTION
Not all operations that can paginate have a page_size so we need
to handle the case where that param is not provided.

Fixes #1993.


cc @kyleknap @JordonPhillips 