### PR TITLE
Use default value getattr when checking for paging params

### DIFF
--- a/.changes/next-release/bugfix-Paginator.json
+++ b/.changes/next-release/bugfix-Paginator.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fixed a bug where specifying `--no-paginate` on an operation without a page size parameter raised an error. Fixes `#1993 <https://github.com/aws/aws-cli/issues/1993>`__.",
+  "category": "Paginator",
+  "type": "bugfix"
+}

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -193,7 +193,7 @@ def ensure_paging_params_not_set(parsed_args, shadowed_args):
     paging_params = ['starting_token', 'page_size', 'max_items']
     shadowed_params = [p.replace('-', '_') for p in shadowed_args.keys()]
     params_used = [p for p in paging_params if
-                   p not in shadowed_params and getattr(parsed_args, p)]
+                   p not in shadowed_params and getattr(parsed_args, p, False)]
 
     if len(params_used) > 0:
         converted_params = ', '.join(

--- a/tests/functional/cloudformation/test_describe_stacks.py
+++ b/tests/functional/cloudformation/test_describe_stacks.py
@@ -1,0 +1,22 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestDescribeStacks(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudformation describe-stacks'
+
+    def test_no_paginate(self):
+        cmdline = self.prefix + ' --no-paginate'
+        self.assert_params_for_cmd(cmdline)


### PR DESCRIPTION
When checking to make sure that no paging params are set, we
did not account for the possibility that page size isn't present
for a given operation. Thus, errors would be raised when
`--no-paginate` was supplied on operations without it. This sets
a default value to the getattr call to prevent the error.

Fixes #1993

cc @kyleknap @jamesls