### PR TITLE
Suppress error output if there is no file association for .py

### DIFF
--- a/bin/aws.cmd
+++ b/bin/aws.cmd
@@ -9,7 +9,7 @@ for %%i in (cmd bat exe) do (
         call :SetPythonExe "%%~$PATH:j"
     )
 )
-for /f "tokens=2 delims==" %%i in ('assoc .py') do (
+for /f "tokens=2 delims==" %%i in ('assoc .py 2^> nul') do (
     for /f "tokens=2 delims==" %%j in ('ftype %%i') do (
         for /f "tokens=1" %%k in ("%%j") do (
             call :SetPythonExe %%k


### PR DESCRIPTION
Previously, `assoc .py` would output an extraneous error message if there was no file association for .py files: `File association not found for extension .py`.

This commit suppresses the `assoc` error output. With python already in the path, the aws cli executes just fine, even without the file association, so this message just clutters the output.
