### PR TITLE
Use urlopen from compat in gamelift.

### DIFF
--- a/awscli/customizations/gamelift/getlog.py
+++ b/awscli/customizations/gamelift/getlog.py
@@ -13,7 +13,7 @@
 import sys
 from functools import partial
 
-from six.moves.urllib.request import urlopen
+from awscli.compat import urlopen
 from awscli.customizations.commands import BasicCommand
 
 


### PR DESCRIPTION
I noticed we were manually calling out urlopen rather than taking it
from compat.py. This seems to be the only instance where we're doing
this.

cc @kyleknap @jamesls