### PR TITLE
Remove legacy error handler

### DIFF
--- a/awscli/customizations/cloudtrail/subscribe.py
+++ b/awscli/customizations/cloudtrail/subscribe.py
@@ -14,7 +14,7 @@ import json
 import logging
 import sys
 
-from .utils import get_account_id, remove_cli_error_event
+from .utils import get_account_id
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import s3_bucket_exists
 from botocore.exceptions import ClientError
@@ -83,7 +83,6 @@ class CloudTrailSubscribe(BasicCommand):
         self.iam = self._session.create_client('iam', **client_args)
         self.s3 = self._session.create_client('s3', **client_args)
         self.sns = self._session.create_client('sns', **client_args)
-        remove_cli_error_event(self.s3)
         self.region_name = self.s3.meta.region_name
 
         # If the endpoint is specified, it is designated for the cloudtrail

--- a/awscli/customizations/cloudtrail/utils.py
+++ b/awscli/customizations/cloudtrail/utils.py
@@ -30,13 +30,3 @@ def get_trail_by_arn(cloudtrail_client, trail_arn):
         if trail.get('TrailARN', None) == trail_arn:
             return trail
     raise ValueError('A trail could not be found for %s' % trail_arn)
-
-
-def remove_cli_error_event(client):
-    """This unregister call will go away once the client switchover
-    is done, but for now we're relying on S3 catching a ClientError
-    when we check if a bucket exists, so we need to ensure the
-    botocore ClientError is raised instead of the CLI's error handler.
-    """
-    client.meta.events.unregister(
-        'after-call', unique_id='awscli-error-handler')

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -26,7 +26,7 @@ from pyasn1.error import PyAsn1Error
 import rsa
 
 from awscli.customizations.cloudtrail.utils import get_trail_by_arn, \
-    get_account_id_from_arn, remove_cli_error_event
+    get_account_id_from_arn
 from awscli.customizations.commands import BasicCommand
 from botocore.exceptions import ClientError
 
@@ -166,7 +166,6 @@ class S3ClientProvider(object):
         if region_name not in self._client_cache:
             client = self._session.create_client('s3', region_name)
             # Remove the CLI error event that prevents exceptions.
-            remove_cli_error_event(client)
             self._client_cache[region_name] = client
         return self._client_cache[region_name]
 

--- a/awscli/customizations/codedeploy/deregister.py
+++ b/awscli/customizations/codedeploy/deregister.py
@@ -54,12 +54,10 @@ class Deregister(BasicCommand):
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
-        self.codedeploy.meta.events.unregister('after-call', unique_id='awscli-error-handler')
         self.iam = self._session.create_client(
             'iam',
             region_name=params.region
         )
-        self.iam.meta.events.unregister('after-call', unique_id='awscli-error-handler')
 
         try:
             self._get_instance_info(params)

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -108,22 +108,16 @@ class Push(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         self._validate_args(parsed_args)
-
         self.codedeploy = self._session.create_client(
             'codedeploy',
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
-        self.codedeploy.meta.events.unregister(
-            'after-call', unique_id='awscli-error-handler')
         self.s3 = self._session.create_client(
             's3',
             region_name=parsed_globals.region
         )
-        self.s3.meta.events.unregister('after-call',
-                                       unique_id='awscli-error-handler')
-
         self._push(parsed_args)
 
     def _validate_args(self, parsed_args):

--- a/awscli/customizations/configservice/subscribe.py
+++ b/awscli/customizations/configservice/subscribe.py
@@ -145,9 +145,6 @@ class S3BucketHelper(object):
         return bucket, key
 
     def _check_bucket_exists(self, bucket):
-        self._s3_client.meta.events.unregister(
-            'after-call',
-            unique_id='awscli-error-handler')
         return s3_bucket_exists(self._s3_client, bucket)
 
     def _create_bucket(self, bucket):

--- a/awscli/customizations/datapipeline/createdefaultroles.py
+++ b/awscli/customizations/datapipeline/createdefaultroles.py
@@ -23,7 +23,7 @@ from awscli.customizations.datapipeline.constants \
     DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.datapipeline.translator \
-    import display_response, dict_to_string, get_region, remove_cli_error_event
+    import display_response, dict_to_string, get_region
 from botocore.exceptions import ClientError
 
 LOG = logging.getLogger(__name__)
@@ -56,7 +56,6 @@ class CreateDefaultRoles(BasicCommand):
             endpoint_url=self._endpoint_url,
             verify=parsed_globals.verify_ssl
         )
-        remove_cli_error_event(self._iam_client)
         return self._create_default_roles(parsed_args, parsed_globals)
 
     def _create_role(self, role_name, role_arn, role_policy):

--- a/awscli/customizations/datapipeline/translator.py
+++ b/awscli/customizations/datapipeline/translator.py
@@ -37,16 +37,6 @@ def get_region(session, parsed_globals):
     return region
 
 
-def remove_cli_error_event(client):
-    """This unregister call will go away once the client switchover
-    is done, but for now we're relying on S3 catching a ClientError
-    when we check if a bucket exists, so we need to ensure the
-    botocore ClientError is raised instead of the CLI's error handler.
-    """
-    client.meta.events.unregister(
-        'after-call', unique_id='awscli-error-handler')
-
-
 # Method to display the response for a particular CLI operation
 def display_response(session, operation_name, result, parsed_globals):
     cli_operation_caller = CLIOperationCaller(session)

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -129,12 +129,8 @@ class OpsWorksRegister(BasicCommand):
 
     def _create_clients(self, args, parsed_globals):
         self.iam = self._session.create_client('iam')
-        self.iam.meta.events.unregister(
-            'after-call', unique_id='awscli-error-handler')
         self.opsworks = create_client_from_parsed_globals(
             self._session, 'opsworks', parsed_globals)
-        self.opsworks.meta.events.unregister(
-            'after-call', unique_id='awscli-error-handler')
 
     def _run_main(self, args, parsed_globals):
         self._create_clients(args, parsed_globals)

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -118,8 +118,6 @@ class FileGenerator(object):
     def __init__(self, client, operation_name, follow_symlinks=True,
                  page_size=None, result_queue=None, request_parameters=None):
         self._client = client
-        self._client.meta.events.unregister(
-            'after-call', unique_id='awscli-error-handler')
         self.operation_name = operation_name
         self.follow_symlinks = follow_symlinks
         self.page_size = page_size

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -16,11 +16,11 @@ import stat
 
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
+from botocore.exceptions import ClientError
 
 from awscli.customizations.s3.utils import find_bucket_key, get_file_stat
 from awscli.customizations.s3.utils import BucketLister, create_warning, \
     find_dest_path_comp_key, EPOCH_TIME
-from awscli.errorhandler import ClientError
 from awscli.compat import six
 from awscli.compat import queue
 
@@ -118,6 +118,8 @@ class FileGenerator(object):
     def __init__(self, client, operation_name, follow_symlinks=True,
                  page_size=None, result_queue=None, request_parameters=None):
         self._client = client
+        self._client.meta.events.unregister(
+            'after-call', unique_id='awscli-error-handler')
         self.operation_name = operation_name
         self.follow_symlinks = follow_symlinks
         self.page_size = page_size
@@ -345,19 +347,13 @@ class FileGenerator(object):
             # We want to try to give a more helpful error message.
             # This is what the customer is going to see so we want to
             # give as much detail as we have.
-            copy_fields = e.__dict__.copy()
-            if not e.error_message == 'Not Found':
+            if not e.response['Error']['Code'] == '404':
                 raise
-            if e.http_status_code == 404:
-                # The key does not exist so we'll raise a more specific
-                # error message here.
-                copy_fields['error_message'] = 'Key "%s" does not exist' % key
-            else:
-                reason = six.moves.http_client.responses[
-                    e.http_status_code]
-                copy_fields['error_code'] = reason
-                copy_fields['error_message'] = reason
-            raise ClientError(**copy_fields)
+            # The key does not exist so we'll raise a more specific
+            # error message here.
+            response = e.response.copy()
+            response['Error']['Message'] = 'Key "%s" does not exist' % key
+            raise ClientError(response, 'HeadObject')
         response['Size'] = int(response.pop('ContentLength'))
         last_update = parse(response['LastModified'])
         response['LastModified'] = last_update.astimezone(tzlocal())

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -198,8 +198,6 @@ class WaiterCaller(object):
         self._waiter_name = waiter_name
 
     def invoke(self, service_name, operation_name, parameters, parsed_globals):
-        self._session.unregister(
-            'after-call', unique_id='awscli-error-handler')
         client = self._session.create_client(
             service_name, region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -70,7 +70,6 @@ from awscli.customizations.sessendemail import register_ses_send_email
 from awscli.customizations.streamingoutputarg import add_streaming_output_arg
 from awscli.customizations.toplevelbool import register_bool_params
 from awscli.customizations.waiters import register_add_waiters
-from awscli.errorhandler import ErrorHandler
 
 
 def awscli_initialize(event_handlers):
@@ -80,9 +79,6 @@ def awscli_initialize(event_handlers):
     # The s3 error mesage needs to registered before the
     # generic error handler.
     register_s3_error_msg(event_handlers)
-    error_handler = ErrorHandler()
-    event_handlers.register('after-call', error_handler,
-                            unique_id='awscli-error-handler')
 #    # The following will get fired for every option we are
 #    # documenting.  It will attempt to add an example_fn on to
 #    # the parameter object if the parameter supports shorthand

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -180,9 +180,6 @@ def create_bucket(session, name=None, region=None):
     if region != 'us-east-1':
         params['CreateBucketConfiguration'] = {'LocationConstraint': region}
     try:
-        # To disable the (obsolete) awscli.errorhandler.ClientError behavior
-        client.meta.events.unregister(
-            'after-call', unique_id='awscli-error-handler')
         client.create_bucket(**params)
     except ClientError as e:
         if e.response['Error'].get('Code') == 'BucketAlreadyOwnedByYou':

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -473,7 +473,7 @@ class TestCp(BaseS3IntegrationTest):
         p = aws('s3 cp s3://jasoidfjasdjfasdofijasdf/foo.txt foo.txt')
         self.assertEqual(p.rc, 1)
         expected_err_msg = (
-            'A client error (404) occurred when calling the '
+            'An error occurred (404) when calling the '
             'HeadObject operation: Key "foo.txt" does not exist')
         self.assertIn(expected_err_msg, p.stderr)
 
@@ -1100,7 +1100,7 @@ class TestLs(BaseS3IntegrationTest):
         p = aws('s3 ls s3://foobara99842u4wbts829381')
         self.assertEqual(p.rc, 255)
         self.assertIn(
-            ('A client error (NoSuchBucket) occurred when calling the '
+            ('An error occurred (NoSuchBucket) when calling the '
              'ListObjects operation: The specified bucket does not exist'),
             p.stderr)
         # There should be no stdout if we can't find the bucket.

--- a/tests/unit/customizations/cloudtrail/test_subscribe.py
+++ b/tests/unit/customizations/cloudtrail/test_subscribe.py
@@ -100,10 +100,6 @@ class TestCloudTrailCommand(unittest.TestCase):
                 call('cloudtrail', verify=None, region_name=None),
             ]
         )
-        # We should also remove the error handler for S3.
-        # This can be removed once the client switchover is done.
-        subscribe_command.s3.meta.events.unregister.assert_called_with(
-            'after-call', unique_id='awscli-error-handler')
 
     def test_endpoint_url_is_only_used_for_cloudtrail(self):
         endpoint_url = 'https://mycloudtrail.awsamazon.com/'

--- a/tests/unit/customizations/cloudtrail/test_utils.py
+++ b/tests/unit/customizations/cloudtrail/test_utils.py
@@ -28,14 +28,6 @@ class TestCloudTrailUtils(unittest.TestCase):
         arn = 'foo:bar:baz:qux:1234'
         self.assertEqual('1234', utils.get_account_id_from_arn(arn))
 
-    def test_removes_cli_error_event(self):
-        mock_events = Mock()
-        mock_client = Mock()
-        mock_client.meta.events = mock_events
-        utils.remove_cli_error_event(mock_client)
-        mock_events.unregister.assert_called_with(
-            'after-call', unique_id='awscli-error-handler')
-
     def test_gets_trail_by_arn(self):
         cloudtrail_client = Mock()
         cloudtrail_client.describe_trails.return_value = {'trailList': [

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -837,5 +837,3 @@ class TestS3ClientProvider(BaseAWSCommandParamsTest):
         s3_client.get_bucket_location.return_value = {'LocationConstraint': ''}
         provider = S3ClientProvider(session)
         client = provider.get_client('foo')
-        client.meta.events.unregister.assert_called_with(
-            'after-call', unique_id='awscli-error-handler')

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -16,9 +16,9 @@ import awscli
 from argparse import Namespace
 from mock import MagicMock, patch, ANY, call
 from six import StringIO
+from botocore.exceptions import ClientError
 
 from awscli.customizations.codedeploy.push import Push
-from awscli.errorhandler import ClientError
 from awscli.testutils import unittest
 from awscli.compat import ZIP_COMPRESSION_MODE
 
@@ -282,11 +282,8 @@ class TestPush(unittest.TestCase):
         self.bundle_mock.tell.return_value = (6 << 20)
         self.bundle_mock.read.return_value = b'a' * (6 << 20)
         self.push.s3.upload_part.side_effect = ClientError(
-            error_code='Error',
-            error_message='Error',
-            error_type='error',
-            operation_name='UploadPart',
-            http_status_code=400
+            {'Error': {'Code': 'Error', 'Message': 'Error'}},
+            'UploadPart'
         )
         with self.assertRaises(ClientError):
             self.push._upload_to_s3(self.args, self.bundle_mock)

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -19,10 +19,10 @@ import tempfile
 import shutil
 import socket
 
+from botocore.exceptions import ClientError
 from awscli.compat import six
 import mock
 
-from awscli.errorhandler import ClientError
 from awscli.customizations.s3.filegenerator import FileGenerator, \
     FileDecodingError, FileStat, is_special_file, is_readable
 from awscli.customizations.s3.utils import get_file_stat, EPOCH_TIME
@@ -524,7 +524,10 @@ class S3FileGeneratorTest(BaseAWSCommandParamsTest):
         params = {'region': 'us-east-1'}
         self.client = mock.Mock()
         self.client.head_object.side_effect = \
-            ClientError(404, 'Not Found', '404', 'HeadObject', 404)
+                ClientError(
+                    {'Error': {'Code': '404', 'Message': 'Not Found'}},
+                    'HeadObject',
+                )
         file_gen = FileGenerator(self.client, '')
         files = file_gen.call(input_s3_file)
         # The error should include 404 and should include the key name.

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -379,7 +379,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         # Also, we need to verify that the error message is on the *same* line
         # as the upload failed line, to make it easier to track.
         output_str = (
-            "upload failed: %s to %s A client error" % (
+            "upload failed: %s to %s An error" % (
                 rel_local_file, s3_file))
         self.assertIn(output_str, self.err_output.getvalue())
 

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -16,6 +16,8 @@ import datetime
 import json
 import mock
 
+from botocore.exceptions import ClientError
+
 from awscli.customizations import opsworks
 from awscli.testutils import unittest
 
@@ -234,8 +236,9 @@ class TestOpsWorksRegister(TestOpsWorksBase):
             self.register._stack = dict(
                 StackId="STACKID", Name="STACKNAME", Arn="ARN")
             self.register._name_for_iam = "HOSTNAME"
-            mock_iam.create_group.side_effect = opsworks.ClientError(
-                "EntityAlreadyExists", None, None, None, None)
+            mock_iam.create_group.side_effect = ClientError(
+                {'Error': {'Code': 'EntityAlreadyExists', 'Message': ''}},
+                'CreateGroup')
 
             self.register.create_iam_entities()
 
@@ -258,10 +261,14 @@ class TestOpsWorksRegister(TestOpsWorksBase):
             self.register._name_for_iam = "HOSTNAME"
             mock_iam.create_user = mock.Mock(
                 side_effect=[
-                    opsworks.ClientError(
-                        "EntityAlreadyExists", None, None, None, None),
-                    opsworks.ClientError(
-                        "EntityAlreadyExists", None, None, None, None),
+                    ClientError(
+                        {'Error': {'Code': 'EntityAlreadyExists', 'Message': ''}},
+                        'CreateUser'
+                    ),
+                    ClientError(
+                        {'Error': {'Code': 'EntityAlreadyExists', 'Message': ''}},
+                        'CreateUser'
+                    ),
                     None
                 ])
 


### PR DESCRIPTION
This PR cleans up some technical debt and removes the error legacy handling code used in the CLI.

The background on this:

In the pre-client era, you were always returned a response, even in the case of errors.  You then had to check if the response was an error response and take appropriate action.  To simplify some of the handlers, we wrote an error handler that would just raise an exception if it saw an error response.

This is no longer necessary in client code.  Clients will automatically raise an exception on errors.  However we never went back and removed the old error handler.  This code consists of primarily two changes:

* Converting the old exceptions to the new client error interface.
* Removing any code that unregistered the event handler.  This was how newer customizations could "work around" the technical debt and get real client errors.  We no longer need that.

cc @kyleknap @JordonPhillips 