### PR TITLE
Bump colorama version to <=0.3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ docutils>=0.10
 -e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.0
-colorama>=0.2.5,<=0.3.3
+colorama>=0.2.5,<=0.3.7
 mock==1.3.0
 rsa>=3.1.2,<=3.5.0
 wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 [metadata]
 requires-dist =
         botocore==1.4.31
-        colorama>=0.2.5,<=0.3.3
+        colorama>=0.2.5,<=0.3.7
         docutils>=0.10
         rsa>=3.1.2,<=3.5.0
         s3transfer==0.0.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import awscli
 
 
 requires = ['botocore==1.4.31',
-            'colorama>=0.2.5,<=0.3.3',
+            'colorama>=0.2.5,<=0.3.7',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
             's3transfer==0.0.1']


### PR DESCRIPTION
Implements #1742 
Colorama differences between 0.3.3 and 0.3.7 are mostly bug fixes.
For what it's worth, I have been using colorama 0.3.7 with aws-cli for a while now without problems.