### PR TITLE
Don't use shared test bucket for website tests

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1413,7 +1413,7 @@ class TestMemoryUtilization(BaseS3IntegrationTest):
 
 class TestWebsiteConfiguration(BaseS3IntegrationTest):
     def test_create_website_index_configuration(self):
-        bucket_name = _SHARED_BUCKET
+        bucket_name = self.create_bucket()
         # Supply only --index-document argument.
         full_command = 's3 website %s --index-document index.html' % \
             (bucket_name)
@@ -1428,7 +1428,7 @@ class TestWebsiteConfiguration(BaseS3IntegrationTest):
         self.assertNotIn('RedirectAllRequestsTo', parsed)
 
     def test_create_website_index_and_error_configuration(self):
-        bucket_name = _SHARED_BUCKET
+        bucket_name = self.create_bucket()
         # Supply both --index-document and --error-document arguments.
         p = aws('s3 website %s --index-document index.html '
                 '--error-document error.html' % bucket_name)


### PR DESCRIPTION
This will produce false failures if the index_and_error
test runs before the index test.  To fix this is issue, I've
put back the old behavior for this test which is to create a bucket
per each of these tests.

cc @kyleknap @JordonPhillips 