### PR TITLE
Bump colorama version max to 0.3.7

### DIFF
--- a/awscli/table.py
+++ b/awscli/table.py
@@ -161,9 +161,9 @@ class Styler(object):
 
 class ColorizedStyler(Styler):
     def __init__(self):
-        # autoreset allows us to not have to sent
-        # reset sequences for every string.
-        colorama.init(autoreset=True)
+        # `autoreset` allows us to not have to sent reset sequences for every
+        # string. `strip` lets us preserve color when redirecting.
+        colorama.init(autoreset=True, strip=False)
 
     def style_title(self, text):
         # Originally bold + underline

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ docutils>=0.10
 -e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.0
-colorama>=0.2.5,<=0.3.3
+colorama>=0.2.5,<=0.3.7
 mock==1.3.0
 rsa>=3.1.2,<=3.5.0
 wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 [metadata]
 requires-dist =
         botocore==1.4.36
-        colorama>=0.2.5,<=0.3.3
+        colorama>=0.2.5,<=0.3.7
         docutils>=0.10
         rsa>=3.1.2,<=3.5.0
         s3transfer==0.0.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import awscli
 
 
 requires = ['botocore==1.4.36',
-            'colorama>=0.2.5,<=0.3.3',
+            'colorama>=0.2.5,<=0.3.7',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
             's3transfer==0.0.1']

--- a/tests/functional/test_table.py
+++ b/tests/functional/test_table.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestColor(BaseAWSCommandParamsTest):
+
+    def test_pipe_color(self):
+        command = "s3api list-buckets --output table --color on"
+        self.parsed_response = {
+            "Owner": {
+                "DisplayName": "foo",
+                "ID": "bar"
+            },
+            "Buckets": [
+                {
+                    "CreationDate": "2016-06-15T16:49:44.000Z",
+                    "Name": "foo-bucket"
+                }
+            ]
+        }
+        stdout, stderr, rc = self.run_cmd(command, 0)
+        # `\x1b` is the ANSI color prefix character.
+        self.assertIn('\x1b', stdout)
+


### PR DESCRIPTION
This uses the `strip` argument to preserve the previous behavior
of colorizing when output is redirected.

Fixes #2043
Resolves #2037
Resolves #1742

cc @kyleknap @jamesls