### PR TITLE
Update git urls to use HTTPS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ docutils>=0.10
 # botocore and the awscli packages are typically developed
 # in tandem, so we're requiring the latest develop
 # branch of botocore when working on the awscli.
--e git://github.com/boto/botocore.git@develop#egg=botocore
--e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
--e git://github.com/boto/jmespath.git@develop#egg=jmespath
+-e git+https://github.com/boto/botocore.git@develop#egg=botocore
+-e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer
+-e git+https://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.0
 colorama>=0.2.5,<=0.3.7
 mock==1.3.0


### PR DESCRIPTION
This seems to be recommended by pypi since it's the only scheme they document: https://pip.pypa.io/en/stable/user_guide/#requirements-files

cc @kyleknap @jamesls