### PR TITLE
Add warning about streaming in PowerShell

### DIFF
--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -140,6 +140,8 @@ Output::
 
 **Uploading a local file stream to S3**
 
+WARNING:: PowerShell may alter the encoding of or add a CRLF to piped input.
+
 The following ``cp`` command uploads a local file stream from standard input to a specified bucket and key::
 
     aws s3 cp - s3://mybucket/stream.txt
@@ -147,6 +149,8 @@ The following ``cp`` command uploads a local file stream from standard input to 
 
 **Downloading an S3 object as a local file stream**
 
-The following ``cp`` command downloads a S3 object locally as a stream to standard output. Downloading as a stream is not currently compatible with the ``--recursive`` parameter::
+WARNING:: PowerShell may alter the encoding of or add a CRLF to piped or redirected output.
+
+The following ``cp`` command downloads an S3 object locally as a stream to standard output. Downloading as a stream is not currently compatible with the ``--recursive`` parameter::
 
     aws s3 cp s3://mybucket/stream.txt -


### PR DESCRIPTION
For those that are not intimately familiar with PowerShell, it may come as a
surprise when piping or redirecing results in data that isn't identical to
what they have stored in S3 or what they thought they stored. This adds a
warning to the CP streaming docs to let users know what is happening.

In more detail, what is happening is that the results become a .Net string
object, whose default encoding is a 16-bit encoding.

cc @kyleknap @jamesls