### PR TITLE
Reintroduce streams port to s3transfer

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -239,6 +239,8 @@ class CLIDriver(object):
                                            format_string=LOG_FORMAT)
             self.session.set_stream_logger('awscli', logging.DEBUG,
                                            format_string=LOG_FORMAT)
+            self.session.set_stream_logger('s3transfer', logging.DEBUG,
+                                           format_string=LOG_FORMAT)
             LOG.debug("CLI version: %s", self.session.user_agent())
             LOG.debug("Arguments entered to CLI: %s", sys.argv[1:])
 

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -37,7 +37,14 @@ except ImportError:
     ZIP_COMPRESSION_MODE = zipfile.ZIP_STORED
 
 
-class BinaryStdout(object):
+class NonTranslatedStdout(object):
+    """ This context manager sets the line-end translation mode for stdout.
+
+    It is deliberately set to binary mode so that `\r` does not get added to
+    the line ending. This can be useful when printing commands where a
+    windows style line ending would casuse errors.
+    """
+
     def __enter__(self):
         if sys.platform == "win32":
             import msvcrt
@@ -48,7 +55,7 @@ class BinaryStdout(object):
     def __exit__(self, type, value, traceback):
         if sys.platform == "win32":
             import msvcrt
-            msvcrt.setmode(sys.stdout.fileno(), self.previous_mode)                
+            msvcrt.setmode(sys.stdout.fileno(), self.previous_mode)
 
 
 if six.PY3:
@@ -58,6 +65,8 @@ if six.PY3:
     from urllib.error import URLError
 
     raw_input = input
+
+    binary_stdin = sys.stdin.buffer
 
     def get_stdout_text_writer():
         return sys.stdout
@@ -77,6 +86,20 @@ if six.PY3:
             encoding = locale.getpreferredencoding()
         return open(filename, mode, encoding=encoding)
 
+    def bytes_print(statement, stdout=None):
+        """
+        This function is used to write raw bytes to stdout.
+        """
+        if stdout is None:
+            stdout = sys.stdout
+
+        if getattr(stdout, 'buffer', None):
+            stdout.buffer.write(statement)
+        else:
+            # If it is not possible to write to the standard out buffer.
+            # The next best option is to decode and write to standard out.
+            stdout.write(statement.decode('utf-8'))
+
 else:
     import codecs
     import locale
@@ -86,6 +109,8 @@ else:
     from urllib2 import URLError
 
     raw_input = raw_input
+
+    binary_stdin = sys.stdin
 
     def get_stdout_text_writer():
         # In python3, all the sys.stdout/sys.stderr streams are in text
@@ -105,6 +130,12 @@ else:
         if 'b' not in mode:
             encoding = locale.getpreferredencoding()
         return io.open(filename, mode, encoding=encoding)
+
+    def bytes_print(statement, stdout=None):
+        if stdout is None:
+            stdout = sys.stdout
+
+        stdout.write(statement)
 
 
 def compat_input(prompt):

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -22,7 +22,7 @@ from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.compat import urlsplit
 from awscli.customizations.commands import BasicCommand
-from awscli.compat import BinaryStdout
+from awscli.compat import NonTranslatedStdout
 
 logger = logging.getLogger('botocore.credentials')
 
@@ -110,7 +110,7 @@ class CodeCommitGetCommand(BasicCommand):
             username += "%" + self._session.get_credentials().token
         # Python will add a \r to the line ending for a text stdout in Windows.
         # Git does not like the \r, so switch to binary
-        with BinaryStdout() as binary_stdout:
+        with NonTranslatedStdout() as binary_stdout:
             binary_stdout.write('username={0}\n'.format(username))
             logger.debug('username\n%s', username)
             binary_stdout.write('password={0}\n'.format(signature))

--- a/awscli/customizations/s3/executor.py
+++ b/awscli/customizations/s3/executor.py
@@ -15,10 +15,10 @@ import logging
 import sys
 import threading
 
-from awscli.customizations.s3.utils import uni_print, bytes_print, \
+from awscli.customizations.s3.utils import uni_print, \
     IORequest, IOCloseRequest, StablePriorityQueue, set_file_utime
 from awscli.customizations.s3.tasks import OrderableTask
-from awscli.compat import queue
+from awscli.compat import queue, bytes_print
 
 
 LOGGER = logging.getLogger(__name__)

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -10,6 +10,7 @@ from botocore.compat import MD5_AVAILABLE
 from awscli.customizations.s3.utils import (
     find_bucket_key, guess_content_type, MD5Error, bytes_print, set_file_utime,
     RequestParamsMapper)
+from awscli.compat import bytes_print
 
 
 LOGGER = logging.getLogger(__name__)

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -20,7 +20,8 @@ from s3transfer.manager import TransferManager
 
 from awscli.customizations.s3.utils import (
     find_chunksize, adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
-    find_bucket_key, relative_path, PrintTask, create_warning)
+    find_bucket_key, relative_path, PrintTask, create_warning,
+    NonSeekableStream)
 from awscli.customizations.s3.executor import Executor
 from awscli.customizations.s3 import tasks
 from awscli.customizations.s3.transferconfig import RuntimeConfig, \
@@ -486,9 +487,10 @@ class S3TransferStreamHandler(BaseS3Handler):
         params = {}
         RequestParamsMapper.map_put_object_params(params, self.params)
 
+        fileobj = NonSeekableStream(binary_stdin)
         with manager:
             future = manager.upload(
-                fileobj=binary_stdin, bucket=bucket,
+                fileobj=fileobj, bucket=bucket,
                 key=key, extra_args=params, subscribers=subscribers)
 
             return self._process_transfer(future)

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -16,14 +16,21 @@ import math
 import os
 import sys
 
+from s3transfer.manager import TransferManager
+
 from awscli.customizations.s3.utils import (
     find_chunksize, adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
     find_bucket_key, relative_path, PrintTask, create_warning)
 from awscli.customizations.s3.executor import Executor
 from awscli.customizations.s3 import tasks
-from awscli.customizations.s3.transferconfig import RuntimeConfig
-from awscli.compat import six
+from awscli.customizations.s3.transferconfig import RuntimeConfig, \
+    create_transfer_config_from_runtime_config
+from awscli.customizations.s3.utils import RequestParamsMapper
+from awscli.customizations.s3.utils import StdoutBytesWriter
+from awscli.customizations.s3.utils import ProvideSizeSubscriber
+from awscli.customizations.s3.utils import uni_print
 from awscli.compat import queue
+from awscli.compat import binary_stdin
 
 
 LOGGER = logging.getLogger(__name__)
@@ -32,27 +39,17 @@ CommandResult = namedtuple('CommandResult',
                            ['num_tasks_failed', 'num_tasks_warned'])
 
 
-class S3Handler(object):
-    """
-    This class sets up the process to perform the tasks sent to it.  It
-    sources the ``self.executor`` from which threads inside the
-    class pull tasks from to complete.
-    """
-    MAX_IO_QUEUE_SIZE = 20
-
+class BaseS3Handler(object):
     def __init__(self, session, params, result_queue=None,
                  runtime_config=None):
         self.session = session
         if runtime_config is None:
             runtime_config = RuntimeConfig.defaults()
         self._runtime_config = runtime_config
-        # The write_queue has potential for optimizations, so the constant
-        # for maxsize is scoped to this class (as opposed to constants.py)
-        # so we have the ability to change this value later.
-        self.write_queue = queue.Queue(maxsize=self.MAX_IO_QUEUE_SIZE)
         self.result_queue = result_queue
         if not self.result_queue:
             self.result_queue = queue.Queue()
+
         self.params = {
             'dryrun': False, 'quiet': False, 'acl': None,
             'guess_mime_type': True, 'sse_c_copy_source': None,
@@ -71,6 +68,24 @@ class S3Handler(object):
         for key in self.params.keys():
             if key in params:
                 self.params[key] = params[key]
+
+
+class S3Handler(BaseS3Handler):
+    """
+    This class sets up the process to perform the tasks sent to it.  It
+    sources the ``self.executor`` from which threads inside the
+    class pull tasks from to complete.
+    """
+    MAX_IO_QUEUE_SIZE = 20
+
+    def __init__(self, session, params, result_queue=None,
+                 runtime_config=None):
+        super(S3Handler, self).__init__(
+            session, params, result_queue, runtime_config)
+        # The write_queue has potential for optimizations, so the constant
+        # for maxsize is scoped to this class (as opposed to constants.py)
+        # so we have the ability to change this value later.
+        self.write_queue = queue.Queue(maxsize=self.MAX_IO_QUEUE_SIZE)
         self.multi_threshold = self._runtime_config['multipart_threshold']
         self.chunksize = self._runtime_config['multipart_chunksize']
         LOGGER.debug("Using a multipart threshold of %s and a part size of %s",
@@ -367,169 +382,132 @@ class S3Handler(object):
         self.executor.submit(complete_multipart_upload_task)
 
 
-class S3StreamHandler(S3Handler):
+class S3TransferStreamHandler(BaseS3Handler):
     """
     This class is an alternative ``S3Handler`` to be used when the operation
     involves a stream since the logic is different when uploading and
     downloading streams.
     """
-    # This ensures that the number of multipart chunks waiting in the
-    # executor queue and in the threads is limited.
-    MAX_EXECUTOR_QUEUE_SIZE = 2
-    EXECUTOR_NUM_THREADS = 6
+    MAX_IN_MEMORY_CHUNKS = 6
 
     def __init__(self, session, params, result_queue=None,
-                 runtime_config=None):
-        if runtime_config is None:
-            # Rather than using the .defaults(), streaming
-            # has different default values so that it does not
-            # consume large amounts of memory.
-            runtime_config = RuntimeConfig().build_config(
-                max_queue_size=self.MAX_EXECUTOR_QUEUE_SIZE,
-                max_concurrent_requests=self.EXECUTOR_NUM_THREADS)
-        super(S3StreamHandler, self).__init__(session, params, result_queue,
-                                              runtime_config)
+                 runtime_config=None, manager=None):
+        super(S3TransferStreamHandler, self).__init__(
+            session, params, result_queue, runtime_config)
+        self.config = create_transfer_config_from_runtime_config(
+            self._runtime_config)
 
-    def _enqueue_tasks(self, files):
-        total_files = 0
-        total_parts = 0
-        for filename in files:
-            num_uploads = 1
-            # If uploading stream, it is required to read from the stream
-            # to determine if the stream needs to be multipart uploaded.
-            payload = None
-            if filename.operation_name == 'upload':
-                payload, is_multipart_task = \
-                    self._pull_from_stream(self.multi_threshold)
-            else:
-                # Set the file size for the ``FileInfo`` object since
-                # streams do not use a ``FileGenerator`` that usually
-                # determines the size.
-                filename.set_size_from_s3()
-                is_multipart_task = self._is_multipart_task(filename)
-            if is_multipart_task and not self.params['dryrun']:
-                # If we're in dryrun mode, then we don't need the
-                # real multipart tasks.  We can just use a BasicTask
-                # in the else clause below, which will print out the
-                # fact that it's transferring a file rather than
-                # the specific part tasks required to perform the
-                # transfer.
-                num_uploads = self._enqueue_multipart_tasks(filename, payload)
-            else:
-                task = tasks.BasicTask(
-                    session=self.session, filename=filename,
-                    parameters=self.params,
-                    result_queue=self.result_queue,
-                    payload=payload)
-                self.executor.submit(task)
-            total_files += 1
-            total_parts += num_uploads
-        return total_files, total_parts
+        # Restrict the maximum chunks to 1 per thread.
+        self.config.max_in_memory_upload_chunks = \
+            self.MAX_IN_MEMORY_CHUNKS
+        self.config.max_in_memory_download_chunks = \
+            self.MAX_IN_MEMORY_CHUNKS
 
-    def _pull_from_stream(self, amount_requested):
+        self._manager = manager
+
+    def call(self, files):
+        # There is only ever one file in a stream transfer.
+        file = files[0]
+        if self._manager is not None:
+            manager = self._manager
+        else:
+            manager = TransferManager(file.client, self.config)
+
+        if file.operation_name == 'upload':
+            bucket, key = find_bucket_key(file.dest)
+            return self._upload(manager, bucket, key)
+        elif file.operation_name == 'download':
+            bucket, key = find_bucket_key(file.src)
+            return self._download(manager, bucket, key)
+
+    def _download(self, manager, bucket, key):
         """
-        This function pulls data from stdin until it hits the amount
-        requested or there is no more left to pull in from stdin.  The
-        function wraps the data into a ``BytesIO`` object that is returned
-        along with a boolean telling whether the amount requested is
-        the amount returned.
+        Download the specified object and print it to stdout.
+
+        :type manager: s3transfer.manager.TransferManager
+        :param manager: The transfer manager to use for the download.
+
+        :type bucket: str
+        :param bucket: The bucket to download the object from.
+
+        :type key: str
+        :param key: The name of the key to download.
+
+        :return: A CommandResult representing the download status.
         """
-        stream_filein = sys.stdin
-        if six.PY3:
-            stream_filein = sys.stdin.buffer
-        payload = stream_filein.read(amount_requested)
-        payload_file = six.BytesIO(payload)
-        return payload_file, len(payload) == amount_requested
+        params = {}
+        # `download` performs the head_object as well, but the params are
+        # the same for both operations, so there's nothing missing here.
+        RequestParamsMapper.map_get_object_params(params, self.params)
 
-    def _enqueue_multipart_tasks(self, filename, payload=None):
-        num_uploads = 1
-        if filename.operation_name == 'upload':
-            num_uploads = self._enqueue_multipart_upload_tasks(filename,
-                                                               payload=payload)
-        elif filename.operation_name == 'download':
-            num_uploads = self._enqueue_range_download_tasks(filename)
-        return num_uploads
+        with manager:
+            future = manager.download(
+                fileobj=StdoutBytesWriter(), bucket=bucket,
+                key=key, extra_args=params)
 
-    def _enqueue_range_download_tasks(self, filename, remove_remote_file=False):
+            return self._process_transfer(future)
 
-        # Create the context for the multipart download.
-        num_downloads = int(filename.size / self.chunksize)
-        context = tasks.MultipartDownloadContext(num_downloads)
+    def _upload(self, manager, bucket, key):
+        """
+        Upload stdin using to the specified location.
 
-        # No file is needed for downloading a stream.  So just announce
-        # that it has been made since it is required for the context to
-        # begin downloading.
-        context.announce_file_created()
+        :type manager: s3transfer.manager.TransferManager
+        :param manager: The transfer manager to use for the upload.
 
-        # Submit download part tasks to the executor.
-        self._do_enqueue_range_download_tasks(
-            filename=filename, chunksize=self.chunksize,
-            num_downloads=num_downloads, context=context,
-            remove_remote_file=remove_remote_file
-        )
-        return num_downloads
+        :type bucket: str
+        :param bucket: The bucket to upload the stream to.
 
-    def _enqueue_multipart_upload_tasks(self, filename, payload=None):
-        # First we need to create a CreateMultipartUpload task,
-        # then create UploadTask objects for each of the parts.
-        # And finally enqueue a CompleteMultipartUploadTask.
-        if self.params['expected_size']:
+        :type key: str
+        :param key: The name of the key to upload the stream to.
+
+        :return: A CommandResult representing the upload status.
+        """
+        expected_size = self.params.get('expected_size', None)
+        subscribers = None
+        if expected_size is not None:
+            # `expected_size` comes in as a string
+            expected_size = int(expected_size)
+
+            # set the size of the transfer if we know it ahead of time.
+            subscribers = [ProvideSizeSubscriber(expected_size)]
+
+            # TODO: remove when this happens in s3transfer
             # If we have the expected size, we can calculate an appropriate
             # chunksize based on max parts and chunksize limits
-            chunksize = find_chunksize(int(self.params['expected_size']),
-                                       self.chunksize)
+            chunksize = find_chunksize(
+                expected_size, self.config.multipart_chunksize)
         else:
+            # TODO: remove when this happens in s3transfer
             # Otherwise, we can still adjust for chunksize limits
-            chunksize = adjust_chunksize_to_upload_limits(self.chunksize)
+            chunksize = adjust_chunksize_to_upload_limits(
+                self.config.multipart_chunksize)
+        self.config.multipart_chunksize = chunksize
 
-        num_uploads = '...'
+        params = {}
+        RequestParamsMapper.map_put_object_params(params, self.params)
 
-        # Submit a task to begin the multipart upload.
-        upload_context = self._enqueue_upload_start_task(
-            chunksize, num_uploads, filename)
+        with manager:
+            future = manager.upload(
+                fileobj=binary_stdin, bucket=bucket,
+                key=key, extra_args=params, subscribers=subscribers)
 
-        # Now submit a task to upload the initial chunk of data pulled
-        # from the stream that was used to determine if a multipart upload
-        # was needed.
-        self._enqueue_upload_single_part_task(
-            part_number=1, chunk_size=chunksize,
-            upload_context=upload_context, filename=filename,
-            task_class=tasks.UploadPartTask, payload=payload
-        )
+            return self._process_transfer(future)
 
-        # Submit tasks to upload the rest of the chunks of the data coming in
-        # from standard input.
-        num_uploads = self._enqueue_upload_tasks(
-            num_uploads, chunksize, upload_context,
-            filename, tasks.UploadPartTask
-        )
+    def _process_transfer(self, future):
+        """
+        Execute and process a transfer future.
 
-        # Submit a task to notify the multipart upload is complete.
-        self._enqueue_upload_end_task(filename, upload_context)
+        :type future: s3transfer.futures.TransferFuture
+        :param future: A future representing an S3 Transfer
 
-        return num_uploads
-
-    def _enqueue_upload_tasks(self, num_uploads, chunksize, upload_context,
-                              filename, task_class):
-        # The previous upload occured right after the multipart
-        # upload started for a stream.
-        num_uploads = 1
-        while True:
-            # Pull more data from standard input.
-            payload, is_remaining = self._pull_from_stream(chunksize)
-            # Submit an upload part task for the recently pulled data.
-            self._enqueue_upload_single_part_task(
-                part_number=num_uploads+1,
-                chunk_size=chunksize,
-                upload_context=upload_context,
-                filename=filename,
-                task_class=task_class,
-                payload=payload
-            )
-            num_uploads += 1
-            if not is_remaining:
-                break
-        # Once there is no more data left, announce to the context how
-        # many parts are being uploaded so it knows when it can quit.
-        upload_context.announce_total_parts(num_uploads)
-        return num_uploads
+        :return: A CommandResult representing the transfer status.
+        """
+        try:
+            future.result()
+            return CommandResult(0, 0)
+        except Exception as e:
+            LOGGER.debug('Exception caught during task execution: %s',
+                         str(e), exc_info=True)
+            # TODO: Update when S3Handler is refactored
+            uni_print("Transfer failed: %s \n" % str(e))
+            return CommandResult(1, 0)

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -26,7 +26,8 @@ from awscli.customizations.s3.fileformat import FileFormat
 from awscli.customizations.s3.filegenerator import FileGenerator
 from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
 from awscli.customizations.s3.filters import create_filter
-from awscli.customizations.s3.s3handler import S3Handler, S3StreamHandler
+from awscli.customizations.s3.s3handler import S3Handler
+from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.utils import find_bucket_key, uni_print, \
     AppendFilter, find_dest_path_comp_key, human_readable_size, \
     RequestParamsMapper
@@ -936,8 +937,8 @@ class CommandArchitecture(object):
         s3handler = S3Handler(self.session, self.parameters,
                               runtime_config=self._runtime_config,
                               result_queue=result_queue)
-        s3_stream_handler = S3StreamHandler(self.session, self.parameters,
-                                            result_queue=result_queue)
+        s3_stream_handler = S3TransferStreamHandler(
+            self.session, self.parameters, result_queue=result_queue)
 
         sync_strategies = self.choose_sync_strategies()
 

--- a/awscli/customizations/s3/transferconfig.py
+++ b/awscli/customizations/s3/transferconfig.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from s3transfer.manager import TransferConfig
+
 from awscli.customizations.s3.utils import human_readable_to_bytes
 from awscli.compat import six
 # If the user does not specify any overrides,
@@ -75,3 +77,26 @@ class RuntimeConfig(object):
     def _error_positive_value(self, name, value):
         raise InvalidConfigError(
             "Value for %s must be a positive integer: %s" % (name, value))
+
+
+def create_transfer_config_from_runtime_config(runtime_config):
+    """
+    Creates an equivalent s3transfer TransferConfig
+
+    :type runtime_config: dict
+    :argument runtime_config: A valid RuntimeConfig-generated dict.
+
+    :returns: A TransferConfig with the same configuration as the runtime
+        config.
+    """
+    translation_map = {
+        'max_concurrent_requests': 'max_request_concurrency',
+        'max_queue_size': 'max_request_queue_size'
+    }
+    kwargs = {}
+
+    for key, value in runtime_config.items():
+        new_key = translation_map.get(key, key)
+        kwargs[new_key] = value
+
+    return TransferConfig(**kwargs)

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -25,9 +25,9 @@ from functools import partial
 from dateutil.parser import parse
 from dateutil.tz import tzlocal, tzutc
 from botocore.compat import unquote_str
+from s3transfer.subscribers import BaseSubscriber
 
-from awscli.compat import six
-from awscli.compat import PY3
+from awscli.compat import bytes_print
 from awscli.compat import queue
 
 LOGGER = logging.getLogger(__name__)
@@ -406,19 +406,21 @@ def uni_print(statement, out_file=None):
     out_file.flush()
 
 
-def bytes_print(statement):
+class StdoutBytesWriter(object):
     """
-    This function is used to properly write bytes to standard out.
+    This class acts as a file-like object that performs the bytes_print
+    function on write.
     """
-    if PY3:
-        if getattr(sys.stdout, 'buffer', None):
-            sys.stdout.buffer.write(statement)
-        else:
-            # If it is not possible to write to the standard out buffer.
-            # The next best option is to decode and write to standard out.
-            sys.stdout.write(statement.decode('utf-8'))
-    else:
-        sys.stdout.write(statement)
+    def __init__(self, stdout=None):
+        self._stdout = stdout
+
+    def write(self, b):
+        """
+        Writes data to stdout as bytes.
+
+        :param b: data to write
+        """
+        bytes_print(b, self._stdout)
 
 
 def guess_content_type(filename):
@@ -744,3 +746,14 @@ class RequestParamsMapper(object):
                                                   cli_params):
         cls._set_sse_c_request_params(request_params, cli_params)
         cls._set_sse_c_copy_source_request_params(request_params, cli_params)
+
+
+class ProvideSizeSubscriber(BaseSubscriber):
+    """
+    A subscriber which provides the transfer size before it's queued.
+    """
+    def __init__(self, size):
+        self.size = size
+
+    def on_queued(self, future, **kwargs):
+        future.meta.provide_transfer_size(self.size)

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -757,3 +757,31 @@ class ProvideSizeSubscriber(BaseSubscriber):
 
     def on_queued(self, future, **kwargs):
         future.meta.provide_transfer_size(self.size)
+
+
+class NonSeekableStream(object):
+    """Wrap a file like object as a non seekable stream.
+
+    This class is used to wrap an existing file like object
+    such that it only has a ``.read()`` method.
+
+    There are some file like objects that aren't truly seekable
+    but appear to be.  For example, on windows, sys.stdin has
+    a ``seek()`` method, and calling ``seek(0)`` even appears
+    to work.  However, subsequent ``.read()`` calls will just
+    return an empty string.
+
+    Consumers of these file like object have no way of knowing
+    if these files are truly seekable or not, so this class
+    can be used to force non-seekable behavior when you know
+    for certain that a fileobj is non seekable.
+
+    """
+    def __init__(self, fileobj):
+        self._fileobj = fileobj
+
+    def read(self, amt=None):
+        if amt is None:
+            return self._fileobj.read()
+        else:
+            return self._fileobj.read(amt)

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -289,6 +289,19 @@ def capture_output():
             yield CapturedOutput(stdout, stderr)
 
 
+@contextlib.contextmanager
+def capture_input(input_bytes=b''):
+    input_data = six.BytesIO(input_bytes)
+    if six.PY3:
+        mock_object = mock.Mock()
+        mock_object.buffer = input_data
+    else:
+        mock_object = input_data
+
+    with mock.patch('sys.stdin', mock_object):
+        yield input_data
+
+
 class BaseAWSCommandParamsTest(unittest.TestCase):
     maxDiff = None
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -11,9 +11,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
-
 import mock
+
+from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+from awscli.testutils import capture_input
 from awscli.compat import six
 
 
@@ -440,3 +441,120 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertIn(
             'Streaming currently is only compatible with non-recursive cp '
             'commands', stderr)
+
+
+class TestStreamingCPCommand(BaseAWSCommandParamsTest):
+    def test_streaming_upload(self):
+        command = "s3 cp - s3://bucket/streaming.txt"
+        self.parsed_responses = [{
+            'ETag': '"c8afdb36c52cf4727836669019e69222"'
+        }]
+
+        binary_stdin = six.BytesIO(b'foo\n')
+        location = "awscli.customizations.s3.s3handler.binary_stdin"
+        with mock.patch(location, binary_stdin):
+            self.run_cmd(command)
+
+        self.assertEqual(len(self.operations_called), 1)
+        model, args = self.operations_called[0]
+        expected_args = {
+            'Bucket': 'bucket',
+            'Key': 'streaming.txt',
+            'Body': mock.ANY
+        }
+
+        self.assertEqual(model.name, 'PutObject')
+        self.assertEqual(args, expected_args)
+
+    def test_streaming_upload_with_expected_size(self):
+        command = "s3 cp - s3://bucket/streaming.txt --expected-size 4"
+        self.parsed_responses = [{
+            'ETag': '"c8afdb36c52cf4727836669019e69222"'
+        }]
+
+        binary_stdin = six.BytesIO(b'foo\n')
+        location = "awscli.customizations.s3.s3handler.binary_stdin"
+        with mock.patch(location, binary_stdin):
+            self.run_cmd(command)
+
+        self.assertEqual(len(self.operations_called), 1)
+        model, args = self.operations_called[0]
+        expected_args = {
+            'Bucket': 'bucket',
+            'Key': 'streaming.txt',
+            'Body': mock.ANY
+        }
+
+        self.assertEqual(model.name, 'PutObject')
+        self.assertEqual(args, expected_args)
+
+    def test_streaming_upload_error(self):
+        command = "s3 cp - s3://bucket/streaming.txt"
+        self.parsed_responses = [{
+            'Error': {
+                'Code': 'NoSuchBucket',
+                'Message': 'The specified bucket does not exist',
+                'BucketName': 'bucket'
+            }
+        }]
+        self.http_response.status_code = 404
+
+        binary_stdin = six.BytesIO(b'foo\n')
+        location = "awscli.customizations.s3.s3handler.binary_stdin"
+        with mock.patch(location, binary_stdin):
+            stdout, _, _ = self.run_cmd(command, expected_rc=1)
+
+        error_message = (
+            'Transfer failed: An error occurred (NoSuchBucket) when calling '
+            'the PutObject operation: The specified bucket does not exist'
+        )
+        self.assertIn(error_message, stdout)
+
+    def test_streaming_download(self):
+        command = "s3 cp s3://bucket/streaming.txt -"
+        self.parsed_responses = [
+            {
+                "AcceptRanges": "bytes",
+                "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
+                "ContentLength": 4,
+                "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
+                "Metadata": {},
+                "ContentType": "binary/octet-stream"
+            },
+            {
+                "AcceptRanges": "bytes",
+                "Metadata": {},
+                "ContentType": "binary/octet-stream",
+                "ContentLength": 4,
+                "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
+                "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
+                "Body": six.BytesIO(b'foo\n')
+            }
+        ]
+
+        stdout, stderr, rc = self.run_cmd(command)
+        self.assertEqual(stdout, 'foo\n')
+
+        # Ensures no extra operations were called
+        self.assertEqual(len(self.operations_called), 2)
+        ops = [op[0].name for op in self.operations_called]
+        expected_ops = ['HeadObject', 'GetObject']
+        self.assertEqual(ops, expected_ops)
+
+    def test_streaming_download_error(self):
+        command = "s3 cp s3://bucket/streaming.txt -"
+        self.parsed_responses = [{
+            'Error': {
+                'Code': 'NoSuchBucket',
+                'Message': 'The specified bucket does not exist',
+                'BucketName': 'bucket'
+            }
+        }]
+        self.http_response.status_code = 404
+
+        stdout, _, _ = self.run_cmd(command, expected_rc=1)
+        error_message = (
+            'Transfer failed: An error occurred (NoSuchBucket) when calling '
+            'the HeadObject operation: The specified bucket does not exist'
+        )
+        self.assertIn(error_message, stdout)

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -12,8 +12,6 @@
 # language governing permissions and limitations under the License.
 import os
 
-from mock import patch, Mock
-
 import awscli.customizations.s3.utils as utils
 from awscli.compat import six
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, \
@@ -116,24 +114,3 @@ def compare_files(self, result_file, ref_file):
     self.assertEqual(result_file.src_type, ref_file.src_type)
     self.assertEqual(result_file.dest_type, ref_file.dest_type)
     self.assertEqual(result_file.operation_name, ref_file.operation_name)
-
-
-class MockStdIn(object):
-    """
-    This class patches stdin in order to write a stream of bytes into
-    stdin.
-    """
-    def __init__(self, input_bytes=b''):
-        input_data = six.BytesIO(input_bytes)
-        if six.PY3:
-            mock_object = Mock()
-            mock_object.buffer = input_data
-        else:
-            mock_object = input_data
-        self._patch = patch('sys.stdin', mock_object)
-
-    def __enter__(self):
-        self._patch.__enter__()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self._patch.__exit__()

--- a/tests/unit/customizations/s3/test_transferconfig.py
+++ b/tests/unit/customizations/s3/test_transferconfig.py
@@ -69,3 +69,19 @@ class TestTransferConfig(unittest.TestCase):
         runtime_config = self.build_config_with(
             multipart_threshold=long_value)
         self.assertEqual(runtime_config['multipart_threshold'], long_value)
+
+
+class TestConvertToS3TransferConfig(unittest.TestCase):
+    def test_convert(self):
+        runtime_config = {
+            'multipart_threshold': 1,
+            'multipart_chunksize': 2,
+            'max_concurrent_requests': 3,
+            'max_queue_size': 4
+        }
+        result = transferconfig.create_transfer_config_from_runtime_config(
+            runtime_config)
+        self.assertEqual(result.multipart_threshold, 1)
+        self.assertEqual(result.multipart_chunksize, 2)
+        self.assertEqual(result.max_request_concurrency, 3)
+        self.assertEqual(result.max_request_queue_size, 4)

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -23,6 +23,7 @@ import io
 import mock
 from dateutil.tz import tzlocal
 from nose.tools import assert_equal
+from s3transfer.futures import TransferMeta, TransferFuture
 
 from botocore.hooks import HierarchicalEmitter
 from awscli.customizations.s3.utils import (
@@ -30,7 +31,8 @@ from awscli.customizations.s3.utils import (
     StablePriorityQueue, BucketLister, get_file_stat, AppendFilter,
     create_warning, human_readable_size, human_readable_to_bytes,
     MAX_SINGLE_UPLOAD_SIZE, MIN_UPLOAD_CHUNKSIZE, MAX_UPLOAD_SIZE,
-    set_file_utime, SetFileUtimeError, RequestParamsMapper, uni_print)
+    set_file_utime, SetFileUtimeError, RequestParamsMapper, uni_print,
+    StdoutBytesWriter, ProvideSizeSubscriber)
 
 
 def test_human_readable_size():
@@ -523,3 +525,28 @@ class TestUniPrint(unittest.TestCase):
         # We replace the characters that can't be encoded
         # with '?'.
         self.assertEqual(buf.getvalue(), b'SomeChars??OtherChars')
+
+
+class TestBytesPrint(unittest.TestCase):
+    def setUp(self):
+        self.stdout = mock.Mock()
+        self.stdout.buffer = self.stdout
+
+    def test_stdout_wrapper(self):
+        wrapper = StdoutBytesWriter(self.stdout)
+        wrapper.write(b'foo')
+        self.assertTrue(self.stdout.write.called)
+        self.assertEqual(self.stdout.write.call_args[0][0], b'foo')
+
+
+class TestProvideSizeSubscriber(unittest.TestCase):
+    def setUp(self):
+        self.transfer_future = mock.Mock(spec=TransferFuture)
+        self.transfer_meta = TransferMeta()
+        self.transfer_future.meta = self.transfer_meta
+
+    def test_size_set(self):
+        self.transfer_meta.provide_transfer_size(5)
+        subscriber = ProvideSizeSubscriber(10)
+        subscriber.on_queued(self.transfer_future)
+        self.assertEqual(self.transfer_meta.size, 10)


### PR DESCRIPTION
This pulls in the original streams pull request and fixes the issue of hanging streaming uploads on windows.  The only new commit is https://github.com/aws/aws-cli/commit/2c483a12c2ccc1f5dd110f67f5f5c30ce8153d72 :


>Wrap sys.stdin to force non seekable behavior
>
>S3Transfer changes its upload logic based on whether or not
>a fileobj is seekable.
>
>On windows, seekable(sys.stdin) was returning True despite the
>fact that sys.stdin does not provide correct seekable behavior.
>
>This would result in streaming uploads hanging.
>
>The fix here is to ensure that seekable(fileobj) returns False
>for sys.stdin.  To accomplish this, sys.stdin is wrapped in
>an object that does not have a seek() method.  This ensures that
>S3Transfer will choose the correct code path, and streaming uploads
>on windows will not hang.


cc @kyleknap @JordonPhillips 