### PR TITLE
Add results module and subscribers to add results

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -1,0 +1,124 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+from collections import namedtuple
+
+from s3transfer.subscribers import BaseSubscriber
+
+from awscli.customizations.s3.utils import relative_path
+
+
+LOGGER = logging.getLogger(__name__)
+
+QueuedResult = namedtuple(
+    'QueuedResult',
+    ['transfer_type', 'src', 'dest', 'total_transfer_size']
+)
+ProgressResult = namedtuple(
+    'ProgressResult',
+    ['transfer_type', 'src', 'dest', 'bytes_transferred',
+     'total_transfer_size']
+)
+SuccessResult = namedtuple(
+    'SuccessResult', ['transfer_type', 'src', 'dest']
+)
+FailureResult = namedtuple(
+    'FailureResult', ['transfer_type', 'src', 'dest', 'exception']
+)
+CommandResult = namedtuple(
+    'CommandResult', ['num_tasks_failed', 'num_tasks_warned'])
+
+
+class BaseResultSubscriber(BaseSubscriber):
+    TRANSFER_TYPE = None
+
+    def __init__(self, result_queue):
+        """Subscriber to send result notifications during transfer process
+
+        :param result_queue: The queue to place results to be processed later
+            on.
+        """
+        self._result_queue = result_queue
+        self._transfer_type = None
+
+    def on_queued(self, future, **kwargs):
+        src, dest = self._get_src_dest(future)
+        queued_result = QueuedResult(
+            self.TRANSFER_TYPE, src, dest, future.meta.size)
+        self._result_queue.put(queued_result)
+
+    def on_progress(self, future, bytes_transferred, **kwargs):
+        src, dest = self._get_src_dest(future)
+        progress_result = ProgressResult(
+            self.TRANSFER_TYPE, src, dest, bytes_transferred, future.meta.size)
+        self._result_queue.put(progress_result)
+
+    def on_done(self, future, **kwargs):
+        src, dest = self._get_src_dest(future)
+        try:
+            future.result()
+            self._result_queue.put(
+                SuccessResult(self.TRANSFER_TYPE, src, dest))
+        except Exception as e:
+            self._result_queue.put(
+                FailureResult(self.TRANSFER_TYPE, src, dest, e))
+
+    def _get_src_dest(self, future):
+        raise NotImplementedError('must implement _get_src_dest()')
+
+
+class UploadResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'upload'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        src = self._get_src(call_args.fileobj)
+        dest = 's3://' + call_args.bucket + '/' + call_args.key
+        return src, dest
+
+    def _get_src(self, fileobj):
+        return relative_path(fileobj)
+
+
+class UploadStreamResultSubscriber(UploadResultSubscriber):
+    def _get_src(self, fileobj):
+        return '-'
+
+
+class DownloadResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'download'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        src = 's3://' + call_args.bucket + '/' + call_args.key
+        dest = self._get_dest(call_args.fileobj)
+        return src, dest
+
+    def _get_dest(self, fileobj):
+        return relative_path(fileobj)
+
+
+class DownloadStreamResultSubscriber(DownloadResultSubscriber):
+    def _get_dest(self, fileobj):
+        return '-'
+
+
+class CopyResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'copy'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        copy_source = call_args.copy_source
+        src = 's3://' + copy_source['Bucket'] + '/' + copy_source['Key']
+        dest = 's3://' + call_args.bucket + '/' + call_args.key
+        return src, dest

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -1,0 +1,204 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.compat import queue
+from awscli.customizations.s3.results import QueuedResult
+from awscli.customizations.s3.results import ProgressResult
+from awscli.customizations.s3.results import SuccessResult
+from awscli.customizations.s3.results import FailureResult
+from awscli.customizations.s3.results import UploadResultSubscriber
+from awscli.customizations.s3.results import UploadStreamResultSubscriber
+from awscli.customizations.s3.results import DownloadResultSubscriber
+from awscli.customizations.s3.results import DownloadStreamResultSubscriber
+from awscli.customizations.s3.results import CopyResultSubscriber
+from awscli.customizations.s3.utils import relative_path
+
+
+class FakeTransferFuture(object):
+    def __init__(self, result=None, exception=None, meta=None):
+        self._result = result
+        self._exception = exception
+        self.meta = meta
+
+    def result(self):
+        if self._exception:
+            raise self._exception
+        return self._result
+
+
+class FakeTransferFutureMeta(object):
+    def __init__(self, size=None, call_args=None):
+        self.size = size
+        self.call_args = call_args
+
+
+class FakeTransferFutureCallArgs(object):
+    def __init__(self, **kwargs):
+        for kwarg, val in kwargs.items():
+            setattr(self, kwarg, val)
+
+
+class BaseResultSubscriberTest(unittest.TestCase):
+    def setUp(self):
+        self.result_queue = queue.Queue()
+
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.filename = 'myfile'
+        self.size = 20 * (1024 * 1024)  # 20 MB
+
+        self.ref_exception = Exception()
+        self.set_ref_transfer_futures()
+
+        self.src = None
+        self.dest = None
+        self.transfer_type = None
+
+    def set_ref_transfer_futures(self):
+        self.future = self.get_success_transfer_future('foo')
+        self.failure_future = self.get_failed_transfer_future(
+            self.ref_exception)
+
+    def get_success_transfer_future(self, result):
+        return self._get_transfer_future(result=result)
+
+    def get_failed_transfer_future(self, exception):
+        return self._get_transfer_future(exception=exception)
+
+    def _get_transfer_future(self, result=None, exception=None):
+        call_args = self._get_transfer_future_call_args()
+        meta = FakeTransferFutureMeta(size=self.size, call_args=call_args)
+        return FakeTransferFuture(
+            result=result, exception=exception, meta=meta)
+
+    def _get_transfer_future_call_args(self):
+        return FakeTransferFutureCallArgs(
+            fileobj=self.filename, key=self.key, bucket=self.bucket)
+
+    def get_queued_result(self):
+        return self.result_queue.get(block=False)
+
+    def assert_result_queue_is_empty(self):
+        self.assertTrue(self.result_queue.empty())
+
+    def assert_expected_transfer_type(self, result):
+        self.assertEqual(result.transfer_type, self.transfer_type)
+
+    def assert_expected_src_and_dest(self, result):
+        self.assertEqual(result.src, self.src)
+        self.assertEqual(result.dest, self.dest)
+
+    def assert_expected_total_transfer_size(self, result):
+        self.assertEqual(result.total_transfer_size, self.size)
+
+    def assert_correct_queued_result(self, result):
+        self.assertIsInstance(result, QueuedResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+        self.assert_expected_total_transfer_size(result)
+
+    def assert_correct_progress_result(self, result, ref_bytes_transferred):
+        self.assertIsInstance(result, ProgressResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+        self.assertEqual(result.bytes_transferred, ref_bytes_transferred)
+        self.assert_expected_total_transfer_size(result)
+
+    def assert_correct_success_result(self, result):
+        self.assertIsInstance(result, SuccessResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+
+    def assert_correct_exception_result(self, result, ref_exception):
+        self.assertIsInstance(result, FailureResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+        self.assertEqual(result.exception, ref_exception)
+
+
+class TestUploadResultSubscriber(BaseResultSubscriberTest):
+    def setUp(self):
+        super(TestUploadResultSubscriber, self).setUp()
+        self.src = relative_path(self.filename)
+        self.dest = 's3://' + self.bucket + '/' + self.key
+        self.transfer_type = 'upload'
+        self.result_subscriber = UploadResultSubscriber(self.result_queue)
+
+    def test_on_queued(self):
+        self.result_subscriber.on_queued(self.future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_queued_result(result)
+
+    def test_on_progress(self):
+        ref_bytes_transferred = 1024 * 1024  # 1MB
+        self.result_subscriber.on_progress(self.future, ref_bytes_transferred)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_progress_result(result, ref_bytes_transferred)
+
+    def test_on_done_success(self):
+        self.result_subscriber.on_done(self.future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_success_result(result)
+
+    def test_on_done_failure(self):
+        self.result_subscriber.on_done(self.failure_future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_exception_result(result, self.ref_exception)
+
+
+class TestUploadStreamResultSubscriber(TestUploadResultSubscriber):
+    def setUp(self):
+        super(TestUploadStreamResultSubscriber, self).setUp()
+        self.src = '-'
+        self.result_subscriber = UploadStreamResultSubscriber(
+            self.result_queue)
+
+
+class TestDownloadResultSubscriber(TestUploadResultSubscriber):
+    def setUp(self):
+        super(TestDownloadResultSubscriber, self).setUp()
+        self.src = 's3://' + self.bucket + '/' + self.key
+        self.dest = relative_path(self.filename)
+        self.transfer_type = 'download'
+        self.result_subscriber = DownloadResultSubscriber(self.result_queue)
+
+
+class TestDownloadStreamResultSubscriber(TestDownloadResultSubscriber):
+    def setUp(self):
+        super(TestDownloadStreamResultSubscriber, self).setUp()
+        self.dest = '-'
+        self.result_subscriber = DownloadStreamResultSubscriber(
+            self.result_queue)
+
+
+class TestCopyResultSubscriber(TestUploadResultSubscriber):
+    def setUp(self):
+        self.source_bucket = 'sourcebucket'
+        self.source_key = 'sourcekey'
+        self.copy_source = {
+            'Bucket': self.source_bucket,
+            'Key': self.source_key,
+        }
+        super(TestCopyResultSubscriber, self).setUp()
+        self.src = 's3://' + self.source_bucket + '/' + self.source_key
+        self.dest = 's3://' + self.bucket + '/' + self.key
+        self.transfer_type = 'copy'
+        self.result_subscriber = CopyResultSubscriber(self.result_queue)
+
+    def _get_transfer_future_call_args(self):
+        return FakeTransferFutureCallArgs(
+            copy_source=self.copy_source, key=self.key, bucket=self.bucket)


### PR DESCRIPTION
So in integrating ``s3transfer`` with the CLI, one of the larger integration work we need done is the integration of subscribers, really the only way to get status on transfers, with the progress tracking and printing of the CLI.

This is just an initial part that implements the subscribers needed to produce namedtuple results that will be processed later by the components that track and print transfer progress. But in the end, I am trying to completely remove the current code base of ``executor.PrintThread()`` to make a more expandable, testable, and maintainable version of the general implementation.

So my implementation plan is as follows:

Introduce the following abstractions:

1) ``Results`` --> namedtuples that represent progress updates generated by subcriber callbacks
2) ``ResultSubscriber`` --> Subscribers that are invoked on the various status callbacks of ``s3transfer``. The subscriber will create the ``Results`` and then place it on a result queue to be consumed.
3) ``ResultProcessor`` --> A separate thread that pulls results off of the result queue. It will have components injected into it based on various parameters provided (i.e. ones that keep track of statistics and printing. By having the single thread queue consumer model, we do not have to worry about locking if the necessary components all live inside the single thread. The processor will pass the consumed result to each necessary component that was injected into it
4) ``ResultRecorder`` --> A component that is injected into the result processor that records results that was passed to it. It will record stuff like total bytes and files transferred for now.
5) ``ResultPrinter`` --> A component that is injected into the result processor that will print progress based on the result passed to it and the current numbers from the result recorder.


Here is a rough diagram of how this would look:
```
------------------------------------------------------------------------
ResultSubscribers (using on_queued, on_progress, on_done callbacks)
------------------------------------------------------------------------
    |
    |
    |
put Result in ResultQueue 
     |
---------------
ResultQueue
---------------
    |
    |
 get Result from ResultQueue
    |
---------------------------------------
ResultProcessor(threading.Thread)
    |
passes Result on
    |
    |
* component: ResultRecord (records result)
    |
passes Result on
    |
    |
* component: ResultPrinter (prints progress)
    |
    |
    passes Result onto any other components we may want to add...
----------------------------------------
```

Let me know what you think of this direction. Just wanted to give you a higher level picture of my plan to help with the review and not just put down a massive PR with all of the components. 

cc @jamesls @JordonPhillips 