### PR TITLE
Result recorder

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -22,20 +22,21 @@ from awscli.customizations.s3.utils import WarningResult
 LOGGER = logging.getLogger(__name__)
 
 
-def _create_new_result_cls(name, extra_fields=None):
+BaseResult = namedtuple('BaseResult', ['transfer_type', 'src', 'dest'])
+
+
+def _create_new_result_cls(name, extra_fields=None, base_cls=BaseResult):
     # Creates a new namedtuple class that subclasses from BaseResult for the
     # benefit of filtering by type and ensuring particular base attrs.
 
     # NOTE: _fields is a public attribute that has an underscore to avoid
     # naming collisions for namedtuples:
     # https://docs.python.org/2/library/collections.html#collections.somenamedtuple._fields
-    fields = list(BaseResult._fields)
+    fields = list(base_cls._fields)
     if extra_fields:
         fields += extra_fields
-    return type(name, (namedtuple(name, fields), BaseResult), {})
+    return type(name, (namedtuple(name, fields), base_cls), {})
 
-
-BaseResult = namedtuple('BaseResult', ['transfer_type', 'src', 'dest'])
 
 QueuedResult = _create_new_result_cls('QueuedResult', ['total_transfer_size'])
 

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -277,8 +277,8 @@ def create_warning(path, error_message, skip_file=True):
     if skip_file:
         print_string = print_string + "Skipping file " + path + ". "
     print_string = print_string + error_message
-    warning_message = PrintTask(message=print_string, error=False,
-                                warning=True)
+    warning_message = WarningResult(message=print_string, error=False,
+                                    warning=True)
     return warning_message
 
 
@@ -568,6 +568,7 @@ class PrintTask(namedtuple('PrintTask',
         return super(PrintTask, cls).__new__(cls, message, error, total_parts,
                                              warning)
 
+WarningResult = PrintTask
 
 IORequest = namedtuple('IORequest',
                        ['filename', 'offset', 'data', 'is_stream'])


### PR DESCRIPTION
The abstraction tracks statistic based on ``Results`` passed to it

It currently tracks the following:
* Expected number of files that will be transferred 
* Expected number of bytes that will be transferred
* Number of bytes transferred so far
* Number of files transferred so far
* Number of warnings received so far
* Number of bytes failed to be transferred so far

I was not sure if it made sense to track number of bytes failed to be transferred so far and considered just combining it with number of bytes transferred, but that seemed a little weird. In the end I will need to account for that number when printing progress. So I am up for any suggestions.

I am also up for any other statistics to track, but I was just trying to keep it small for now.

cc @jamesls @JordonPhillips 