### PR TITLE
s3.sync: Do not stat files that don't match filters

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -18,6 +18,7 @@ from dateutil.parser import parse
 from dateutil.tz import tzlocal
 from botocore.exceptions import ClientError
 
+from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.utils import find_bucket_key, get_file_stat
 from awscli.customizations.s3.utils import BucketLister, create_warning, \
     find_dest_path_comp_key, EPOCH_TIME
@@ -116,7 +117,8 @@ class FileGenerator(object):
     ``FileInfo`` objects to send to a ``Comparator`` or ``S3Handler``.
     """
     def __init__(self, client, operation_name, follow_symlinks=True,
-                 page_size=None, result_queue=None, request_parameters=None):
+                 page_size=None, result_queue=None, request_parameters=None,
+                 file_filter=None):
         self._client = client
         self.operation_name = operation_name
         self.follow_symlinks = follow_symlinks
@@ -127,6 +129,7 @@ class FileGenerator(object):
         self.request_parameters = {}
         if request_parameters is not None:
             self.request_parameters = request_parameters
+        self.file_filter = file_filter
 
     def call(self, files):
         """
@@ -266,6 +269,10 @@ class FileGenerator(object):
                 # Trailing slash must be removed to check if it is a symlink.
                 path = path[:-1]
             if os.path.islink(path):
+                return True
+        if self.file_filter is not None:
+            # We received a file_filter. Let's see if the path matches:
+            if not list(self.file_filter.call([FileInfo(path)])):
                 return True
         warning_triggered = self.triggers_warning(path)
         if warning_triggered:

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -883,17 +883,22 @@ class CommandArchitecture(object):
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type][self.cmd]
 
+        file_filter = (create_filter(self.parameters)
+                       if 'filters' in self.parameters else None)
+
         fgen_kwargs = {
             'client': self._source_client, 'operation_name': operation_name,
             'follow_symlinks': self.parameters['follow_symlinks'],
             'page_size': self.parameters['page_size'],
-            'result_queue': result_queue
+            'result_queue': result_queue,
+            'file_filter': file_filter,
         }
         rgen_kwargs = {
             'client': self._client, 'operation_name': '',
             'follow_symlinks': self.parameters['follow_symlinks'],
             'page_size': self.parameters['page_size'],
-            'result_queue': result_queue
+            'result_queue': result_queue,
+            'file_filter': file_filter,
         }
 
         fgen_request_parameters = {}
@@ -947,8 +952,7 @@ class CommandArchitecture(object):
             command_dict = {'setup': [files, rev_files],
                             'file_generator': [file_generator,
                                                rev_generator],
-                            'filters': [create_filter(self.parameters),
-                                        create_filter(self.parameters)],
+                            'filters': [file_filter, file_filter],
                             'comparator': [Comparator(**sync_strategies)],
                             'file_info_builder': [file_info_builder],
                             's3_handler': [s3handler]}
@@ -958,19 +962,19 @@ class CommandArchitecture(object):
         elif self.cmd == 'cp':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],
-                            'filters': [create_filter(self.parameters)],
+                            'filters': [file_filter],
                             'file_info_builder': [file_info_builder],
                             's3_handler': [s3handler]}
         elif self.cmd == 'rm':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],
-                            'filters': [create_filter(self.parameters)],
+                            'filters': [file_filter],
                             'file_info_builder': [file_info_builder],
                             's3_handler': [s3handler]}
         elif self.cmd == 'mv':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],
-                            'filters': [create_filter(self.parameters)],
+                            'filters': [file_filter],
                             'file_info_builder': [file_info_builder],
                             's3_handler': [s3handler]}
         elif self.cmd == 'mb':


### PR DESCRIPTION
This probably helps on issue #1138.

I have a HUGE `~/src` directory that contains projects that I clone from various version control systems. Which makes me want to avoid backing them up on my personal S3 bucket to save some coins. For that, I used the `--exclude="src/*"` parameter (I also make sure the `aws` command is called from my `$HOME` directory, since I learned that the filters start matching from the current directory -- more details can be found in the #1588 issue). Although it worked, it still scanned and stat'ed the entire directory.

This patch changes the `FileGenerator` class to
1. take the filters from the command line as a parameter in its constructor
2. Use the `file_filter` parameter to match the path received by `.should_ignore_file` and figure out if the path received by the method is allowed by the filters.

This patch can be considered a work in progress because I only tested my specific need. It still needs proper tests. I didn't really write any because I wanted to ask if the strategy I chose is enough. If that's the case, I'd spend time writing the proper tests. Otherwise, I'd love to hear a better idea. I may be able to rework it if it's not too time consuming.
