### PR TITLE
Set default page size for some EC2 operations

### DIFF
--- a/.changes/next-release/bugfix-ec2-2415.json
+++ b/.changes/next-release/bugfix-ec2-2415.json
@@ -1,0 +1,5 @@
+{
+  "description": "Set MaxResults to 1000 by default for DescribeSnapshots and DescribeVolumes.",
+  "type": "bugfix",
+  "category": "ec2"
+}

--- a/awscli/customizations/ec2/paginate.py
+++ b/awscli/customizations/ec2/paginate.py
@@ -1,0 +1,92 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+class EC2PageSizeInjector(object):
+
+    DEFAULT_TARGET_OPERATIONS = {
+        "describe-volumes": [],
+        "describe-snapshots": ['owner-ids', 'restorable_by_user_ids']
+    }
+
+    DEFAULT_GLOBAL_WHITELIST = [
+        'cli_input_json', 'generate_cli_skeleton', 'help', 'max_items',
+        'next_token', 'dry_run', 'starting_token'
+    ]
+
+    def __init__(self, default_page_size=1000, target_operations=None,
+                 global_whitelist=None):
+        """
+        :type default_page_size: int
+        :param default_page_size: The value to inject for page_size.
+
+        :type target_operations: dict
+        :param target_operations: A dictionary whose keys are operations and
+            whose values are parameters that are white-listed for that
+            operation. If a parameter is specified that is not in that list,
+            page_size will not be set.
+
+        :type global_whitelist: list of str
+        :param global_whitelist: A list of parameters that should be
+            whitelisted for every operation.
+        """
+        self._default_page_size = default_page_size
+        self._target_operations = target_operations
+        if self._target_operations is None:
+            self._target_operations = self.DEFAULT_TARGET_OPERATIONS
+        self._global_whitelist = global_whitelist
+        if self._global_whitelist is None:
+            self._global_whitelist = self.DEFAULT_GLOBAL_WHITELIST
+
+    def register(self, event_emitter):
+        """ Register `inject` for each target operation. """
+        event_template = "operation-args-parsed.ec2.%s"
+        for operation in self._target_operations.keys():
+            event = event_template % operation
+            event_emitter.register(event, self.inject)
+
+    def inject(self, event_name, parsed_args, parsed_globals, **kwargs):
+        """ Conditionally inject page_size. """
+        if not parsed_globals.paginate:
+            return
+
+        operation_name = event_name.split('.')[-1]
+
+        whitelisted_params = self._target_operations.get(operation_name, None)
+        if whitelisted_params is None:
+            return
+
+        whitelisted_params += self._global_whitelist
+        specified_params = self._get_specified_params(parsed_args)
+
+        for param in specified_params:
+            if param not in whitelisted_params:
+                return
+
+        parsed_args.page_size = self._default_page_size
+
+    def _get_specified_params(self, namespace):
+        attrs = dir(namespace)
+        params = []
+        for attr in attrs:
+            # The default value of generate_cli_skeleton is False where
+            # usually a boolean argument still defaults to None. Therefore
+            # it must be specifically ignored.
+            if attr == 'generate_cli_skeleton':
+                continue
+
+            if attr[0] != '_' and getattr(namespace, attr) is not None:
+                params.append(attr)
+
+        return params
+

--- a/awscli/customizations/ec2/paginate.py
+++ b/awscli/customizations/ec2/paginate.py
@@ -16,7 +16,7 @@ class EC2PageSizeInjector(object):
 
     DEFAULT_TARGET_OPERATIONS = {
         "describe-volumes": [],
-        "describe-snapshots": ['owner-ids', 'restorable_by_user_ids']
+        "describe-snapshots": ['owner_ids', 'restorable_by_user_ids']
     }
 
     DEFAULT_GLOBAL_WHITELIST = [
@@ -79,12 +79,6 @@ class EC2PageSizeInjector(object):
         attrs = dir(namespace)
         params = []
         for attr in attrs:
-            # The default value of generate_cli_skeleton is False where
-            # usually a boolean argument still defaults to None. Therefore
-            # it must be specifically ignored.
-            if attr == 'generate_cli_skeleton':
-                continue
-
             if attr[0] != '_' and getattr(namespace, attr) is not None:
                 params.append(attr)
 

--- a/awscli/customizations/ec2/paginate.py
+++ b/awscli/customizations/ec2/paginate.py
@@ -28,7 +28,7 @@ class EC2PageSizeInjector(object):
     }
 
     # Parameters which should be whitelisted for every operation.
-    GLOBAL_WHITELIST = ['NextToken', 'DryRun', 'PaginationConfig']
+    UNIVERSAL_WHITELIST = ['NextToken', 'DryRun', 'PaginationConfig']
 
     DEFAULT_PAGE_SIZE = 1000
 
@@ -54,7 +54,7 @@ class EC2PageSizeInjector(object):
         if whitelisted_params is None:
             return
 
-        whitelisted_params = whitelisted_params + self.GLOBAL_WHITELIST
+        whitelisted_params = whitelisted_params + self.UNIVERSAL_WHITELIST
 
         for param in call_parameters:
             if param not in whitelisted_params:

--- a/awscli/customizations/ec2/paginate.py
+++ b/awscli/customizations/ec2/paginate.py
@@ -54,7 +54,7 @@ class EC2PageSizeInjector(object):
         if whitelisted_params is None:
             return
 
-        whitelisted_params += self.GLOBAL_WHITELIST
+        whitelisted_params = whitelisted_params + self.GLOBAL_WHITELIST
 
         for param in call_parameters:
             if param not in whitelisted_params:
@@ -62,4 +62,3 @@ class EC2PageSizeInjector(object):
 
         pagination_config['PageSize'] = self.DEFAULT_PAGE_SIZE
         call_parameters['PaginationConfig'] = pagination_config
-

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -44,7 +44,7 @@ from awscli.customizations.ec2.decryptpassword import ec2_add_priv_launch_key
 from awscli.customizations.ec2.protocolarg import register_protocol_args
 from awscli.customizations.ec2.runinstances import register_runinstances
 from awscli.customizations.ec2.secgroupsimplify import register_secgroup
-from awscli.customizations.ec2.paginate import EC2PageSizeInjector
+from awscli.customizations.ec2.paginate import register_ec2_page_size_injector
 from awscli.customizations.ecr import register_ecr_commands
 from awscli.customizations.emr.emr import emr_initialize
 from awscli.customizations.gamelift import register_gamelift_commands
@@ -143,4 +143,4 @@ def awscli_initialize(event_handlers):
         register_create_keys_from_csr_arguments)
     register_cloudfront(event_handlers)
     register_gamelift_commands(event_handlers)
-    EC2PageSizeInjector().register(event_handlers)
+    register_ec2_page_size_injector(event_handlers)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -44,6 +44,7 @@ from awscli.customizations.ec2.decryptpassword import ec2_add_priv_launch_key
 from awscli.customizations.ec2.protocolarg import register_protocol_args
 from awscli.customizations.ec2.runinstances import register_runinstances
 from awscli.customizations.ec2.secgroupsimplify import register_secgroup
+from awscli.customizations.ec2.paginate import EC2PageSizeInjector
 from awscli.customizations.ecr import register_ecr_commands
 from awscli.customizations.emr.emr import emr_initialize
 from awscli.customizations.gamelift import register_gamelift_commands
@@ -142,3 +143,4 @@ def awscli_initialize(event_handlers):
         register_create_keys_from_csr_arguments)
     register_cloudfront(event_handlers)
     register_gamelift_commands(event_handlers)
+    EC2PageSizeInjector().register(event_handlers)

--- a/tests/functional/ec2/test_describe_snapshots.py
+++ b/tests/functional/ec2/test_describe_snapshots.py
@@ -1,0 +1,43 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestDescribeSnapshots(BaseAWSCommandParamsTest):
+
+    prefix = 'ec2 describe-snapshots'
+
+    def test_max_results_set_by_default(self):
+        command = self.prefix
+        params = {'MaxResults': 1000}
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_not_set_with_snapshot_ids(self):
+        command = self.prefix + ' --snapshot-ids snap-example'
+        params = {'SnapshotIds': ['snap-example']}
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_not_set_with_filter(self):
+        command = self.prefix + ' --filters Name=snapshot-id,Values=snap-snap'
+        params = {'Filters': [{
+            'Name': 'snapshot-id', 'Values': ['snap-snap']
+        }]}
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_not_overwritten(self):
+        command = self.prefix + ' --max-results 5'
+        params = {'MaxResults': 5}
+        self.assert_params_for_cmd(command, params)
+
+        command = self.prefix + ' --page-size 5'
+        self.assert_params_for_cmd(command, params)

--- a/tests/functional/ec2/test_describe_volumes.py
+++ b/tests/functional/ec2/test_describe_volumes.py
@@ -1,0 +1,41 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestDescribeVolumes(BaseAWSCommandParamsTest):
+
+    prefix = 'ec2 describe-volumes'
+
+    def test_max_results_set_by_default(self):
+        command = self.prefix
+        params = {'MaxResults': 1000}
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_not_set_with_volume_ids(self):
+        command = self.prefix + ' --volume-ids id-volume'
+        params = {'VolumeIds': ['id-volume']}
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_not_set_with_filter(self):
+        command = self.prefix + ' --filters Name=volume-id,Values=id-volume'
+        params = {'Filters': [{'Name': 'volume-id', 'Values': ['id-volume']}]}
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_not_overwritten(self):
+        command = self.prefix + ' --max-results 5'
+        params = {'MaxResults': 5}
+        self.assert_params_for_cmd(command, params)
+
+        command = self.prefix + ' --page-size 5'
+        self.assert_params_for_cmd(command, params)

--- a/tests/unit/customizations/ec2/__init__.py
+++ b/tests/unit/customizations/ec2/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/customizations/ec2/test_paginate.py
+++ b/tests/unit/customizations/ec2/test_paginate.py
@@ -70,7 +70,7 @@ class TestEC2PageSizeInjector(unittest.TestCase):
     def test_global_whitelist(self):
         target_operations = {'foo': []}
         injector = EC2PageSizeInjector()
-        injector.GLOBAL_WHITELIST = ['bar']
+        injector.UNIVERSAL_WHITELIST = ['bar']
         injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=True)
         call_parameters = {'baz': True}
@@ -86,7 +86,7 @@ class TestEC2PageSizeInjector(unittest.TestCase):
     def test_operation_whitelist(self):
         target_operations = {'foo': ['bar']}
         injector = EC2PageSizeInjector()
-        injector.GLOBAL_WHITELIST = []
+        injector.UNIVERSAL_WHITELIST = []
         injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=True)
         call_parameters = {'baz': True}

--- a/tests/unit/customizations/ec2/test_paginate.py
+++ b/tests/unit/customizations/ec2/test_paginate.py
@@ -23,7 +23,8 @@ class TestEC2PageSizeInjector(unittest.TestCase):
             'foo': [],
             'bar': []
         }
-        injector = EC2PageSizeInjector(target_operations=target_operations)
+        injector = EC2PageSizeInjector()
+        injector.TARGET_OPERATIONS = target_operations
         event_emitter = mock.Mock()
         injector.register(event_emitter)
 
@@ -37,10 +38,9 @@ class TestEC2PageSizeInjector(unittest.TestCase):
 
     def test_inject(self):
         target_operations = {'foo': []}
-        injector = EC2PageSizeInjector(
-            target_operations=target_operations,
-            default_page_size=5
-        )
+        injector = EC2PageSizeInjector()
+        injector.DEFAULT_PAGE_SIZE = 5
+        injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=True)
         parsed_args = Namespace(page_size=None)
         event_name = 'operation-args-parsed.ec2.foo'
@@ -49,7 +49,8 @@ class TestEC2PageSizeInjector(unittest.TestCase):
 
     def test_no_paginate(self):
         target_operations = {'foo': []}
-        injector = EC2PageSizeInjector(target_operations=target_operations)
+        injector = EC2PageSizeInjector()
+        injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=False)
         parsed_args = Namespace(page_size=None)
         event_name = 'operation-args-parsed.ec2.foo'
@@ -58,10 +59,9 @@ class TestEC2PageSizeInjector(unittest.TestCase):
 
     def test_global_whitelist(self):
         target_operations = {'foo': []}
-        injector = EC2PageSizeInjector(
-            target_operations=target_operations,
-            global_whitelist=['bar']
-        )
+        injector = EC2PageSizeInjector()
+        injector.GLOBAL_WHITELIST = ['bar']
+        injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=True)
         parsed_args = Namespace(page_size=None, baz=True)
         event_name = 'operation-args-parsed.ec2.foo'
@@ -70,10 +70,9 @@ class TestEC2PageSizeInjector(unittest.TestCase):
 
     def test_operation_whitelist(self):
         target_operations = {'foo': ['bar']}
-        injector = EC2PageSizeInjector(
-            target_operations=target_operations,
-            global_whitelist=[]
-        )
+        injector = EC2PageSizeInjector()
+        injector.GLOBAL_WHITELIST = []
+        injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=True)
         parsed_args = Namespace(page_size=None, baz=True)
         event_name = 'operation-args-parsed.ec2.foo'
@@ -82,7 +81,8 @@ class TestEC2PageSizeInjector(unittest.TestCase):
 
     def test_non_target_operation(self):
         target_operations = {'foo': []}
-        injector = EC2PageSizeInjector(target_operations=target_operations)
+        injector = EC2PageSizeInjector()
+        injector.TARGET_OPERATIONS = target_operations
         parsed_globals = Namespace(paginate=True)
         parsed_args = Namespace(page_size=None)
         event_name = 'operation-args-parsed.ec2.bar'

--- a/tests/unit/customizations/ec2/test_paginate.py
+++ b/tests/unit/customizations/ec2/test_paginate.py
@@ -1,0 +1,90 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+from argparse import Namespace
+
+from awscli.testutils import unittest
+from awscli.customizations.ec2.paginate import EC2PageSizeInjector
+
+
+class TestEC2PageSizeInjector(unittest.TestCase):
+    def test_register(self):
+        target_operations = {
+            'foo': [],
+            'bar': []
+        }
+        injector = EC2PageSizeInjector(target_operations=target_operations)
+        event_emitter = mock.Mock()
+        injector.register(event_emitter)
+
+        call_args = event_emitter.register.call_args_list
+        events_registered = sorted([c[0][0] for c in call_args])
+        expected_events = sorted([
+            'operation-args-parsed.ec2.bar',
+            'operation-args-parsed.ec2.foo'
+        ])
+        self.assertEqual(events_registered, expected_events)
+
+    def test_inject(self):
+        target_operations = {'foo': []}
+        injector = EC2PageSizeInjector(
+            target_operations=target_operations,
+            default_page_size=5
+        )
+        parsed_globals = Namespace(paginate=True)
+        parsed_args = Namespace(page_size=None)
+        event_name = 'operation-args-parsed.ec2.foo'
+        injector.inject(event_name, parsed_args, parsed_globals)
+        self.assertEqual(parsed_args.page_size, 5)
+
+    def test_no_paginate(self):
+        target_operations = {'foo': []}
+        injector = EC2PageSizeInjector(target_operations=target_operations)
+        parsed_globals = Namespace(paginate=False)
+        parsed_args = Namespace(page_size=None)
+        event_name = 'operation-args-parsed.ec2.foo'
+        injector.inject(event_name, parsed_args, parsed_globals)
+        self.assertIsNone(parsed_args.page_size)
+
+    def test_global_whitelist(self):
+        target_operations = {'foo': []}
+        injector = EC2PageSizeInjector(
+            target_operations=target_operations,
+            global_whitelist=['bar']
+        )
+        parsed_globals = Namespace(paginate=True)
+        parsed_args = Namespace(page_size=None, baz=True)
+        event_name = 'operation-args-parsed.ec2.foo'
+        injector.inject(event_name, parsed_args, parsed_globals)
+        self.assertIsNone(parsed_args.page_size)
+
+    def test_operation_whitelist(self):
+        target_operations = {'foo': ['bar']}
+        injector = EC2PageSizeInjector(
+            target_operations=target_operations,
+            global_whitelist=[]
+        )
+        parsed_globals = Namespace(paginate=True)
+        parsed_args = Namespace(page_size=None, baz=True)
+        event_name = 'operation-args-parsed.ec2.foo'
+        injector.inject(event_name, parsed_args, parsed_globals)
+        self.assertIsNone(parsed_args.page_size)
+
+    def test_non_target_operation(self):
+        target_operations = {'foo': []}
+        injector = EC2PageSizeInjector(target_operations=target_operations)
+        parsed_globals = Namespace(paginate=True)
+        parsed_args = Namespace(page_size=None)
+        event_name = 'operation-args-parsed.ec2.bar'
+        injector.inject(event_name, parsed_args, parsed_globals)
+        self.assertIsNone(parsed_args.page_size)


### PR DESCRIPTION
When customers use max-results on EC2 operations, the entire
response will be returned and then the CLI will filter out what
the customer wants. This can cause significant pauses for what
seems like a simple request. This change will set the default
page size on describe-volumes and describe-snapshots if no
incompatible arguments are specified.

cc @kyleknap @jamesls