### PR TITLE
Add ResultPrinter

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -220,7 +220,7 @@ class ResultRecorder(object):
 class ResultPrinter(object):
     PROGRESS_FORMAT = (
         'Completed {bytes_completed}/{expected_bytes_completed} with '
-        '{remaining_files} files remaining.'
+        '{remaining_files} file(s) remaining.'
     )
     SUCCESS_FORMAT = (
         '{transfer_type}: {src} to {dest}'

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -478,7 +478,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         progress_result = self.get_progress_result()
         self.result_printer.print_result(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_progress_then_more_progress(self):
@@ -494,7 +494,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_printer.print_result(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
         # Add the second progress update
@@ -503,8 +503,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         # The result should be the combination of the two
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
-            'Completed 2.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
@@ -549,9 +549,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The success statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
-            'upload: file to s3://mybucket/mykey               \n'
-            'Completed 1.0 MiB/20.0 MiB with 2 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'upload: file to s3://mybucket/mykey                 \n'
+            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -607,9 +607,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The failure statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
             'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 4.0 MiB/20.0 MiB with 2 files remaining.\r'
+            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
         )
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
@@ -645,9 +645,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The warning statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
-            'warning: my warning                               \n'
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'warning: my warning                                 \n'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
         )
 
         self.assertEqual(shared_file.getvalue(), ref_statement)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
 from awscli.compat import queue
+from awscli.compat import StringIO
 from awscli.customizations.s3.results import QueuedResult
 from awscli.customizations.s3.results import ProgressResult
 from awscli.customizations.s3.results import SuccessResult
@@ -22,6 +23,8 @@ from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import DownloadStreamResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.results import ResultRecorder
+from awscli.customizations.s3.results import ResultPrinter
+from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
 from awscli.customizations.s3.utils import relative_path
 from awscli.customizations.s3.utils import WarningResult
 
@@ -434,3 +437,262 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertEqual(self.result_recorder.expected_bytes_transferred, 0)
         self.assertEqual(self.result_recorder.expected_files_transferred, 0)
         self.assertEqual(self.result_recorder.files_transferred, 0)
+
+
+class BaseResultPrinterTest(unittest.TestCase):
+    def setUp(self):
+        self.result_recorder = ResultRecorder()
+        self.out_file = StringIO()
+        self.error_file = StringIO()
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=self.out_file,
+            error_file=self.error_file
+        )
+
+    def get_progress_result(self):
+        # NOTE: The actual values are not important for the purpose
+        # of printing as the ResultPrinter only looks at the type and
+        # the ResultRecorder to determine what to print out on progress.
+        return ProgressResult(
+            transfer_type=None, src=None, dest=None, bytes_transferred=None,
+            total_transfer_size=None
+        )
+
+
+class TestResultPrinter(BaseResultPrinterTest):
+    def test_unknown_result_object(self):
+        self.result_printer.print_result(object())
+        # Nothing should have been printed because of it.
+        self.assertEqual(self.out_file.getvalue(), '')
+        self.assertEqual(self.error_file.getvalue(), '')
+
+    def test_progress(self):
+        mb = 1024 * 1024
+
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+
+        progress_result = self.get_progress_result()
+        self.result_printer.print_result(progress_result)
+        ref_progress_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_then_more_progress(self):
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+
+        self.result_printer.print_result(progress_result)
+        ref_progress_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+        # Add the second progress update
+        self.result_recorder.bytes_transferred += mb
+        self.result_printer.print_result(progress_result)
+
+        # The result should be the combination of the two
+        ref_progress_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 2.0 MiB/20.0 MiB with 3 files remaining.\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_success(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_printer.print_result(success_result)
+
+        ref_success_statement = (
+            'upload: file to s3://mybucket/mykey\n'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_success_statement)
+
+    def test_success_with_progress(self):
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+        self.result_printer.print_result(progress_result)
+
+        # Add a success result and print it out.
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_recorder.files_transferred += 1
+        self.result_printer.print_result(success_result)
+
+        # The statement should consist of:
+        # * The first progress statement
+        # * The success statement
+        # * And the progress again since the transfer is still ongoing
+        ref_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'upload: file to s3://mybucket/mykey               \n'
+            'Completed 1.0 MiB/20.0 MiB with 2 files remaining.\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
+
+    def test_failure(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_printer.print_result(failure_result)
+
+        ref_failure_statement = (
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+        )
+        self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
+
+    def test_failure_with_progress(self):
+        # Make errors and regular outprint go to the same file to track order.
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+        self.result_printer.print_result(progress_result)
+
+        # Add a success result and print it out.
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_recorder.bytes_failed_to_transfer = 3 * mb
+        self.result_recorder.files_transferred += 1
+        self.result_printer.print_result(failure_result)
+
+        # The statement should consist of:
+        # * The first progress statement
+        # * The failure statement
+        # * And the progress again since the transfer is still ongoing
+        ref_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+            'Completed 4.0 MiB/20.0 MiB with 2 files remaining.\r'
+        )
+        self.assertEqual(shared_file.getvalue(), ref_statement)
+
+    def test_warning(self):
+        self.result_printer.print_result(WarningResult('my warning'))
+        ref_warning_statement = 'warning: my warning\n'
+        self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
+
+    def test_warning_with_progress(self):
+        # Make errors and regular outprint go to the same file to track order.
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+        self.result_printer.print_result(progress_result)
+
+        self.result_printer.print_result(WarningResult('my warning'))
+
+        # The statement should consist of:
+        # * The first progress statement
+        # * The warning statement
+        # * And the progress again since the transfer is still ongoing
+        ref_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'warning: my warning                               \n'
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+        )
+
+        self.assertEqual(shared_file.getvalue(), ref_statement)
+
+
+class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
+    def setUp(self):
+        super(TestOnlyShowErrorsResultPrinter, self).setUp()
+        self.result_printer = OnlyShowErrorsResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=self.out_file,
+            error_file=self.error_file
+        )
+
+    def test_does_not_print_progress_result(self):
+        progress_result = self.get_progress_result()
+        self.result_printer.print_result(progress_result)
+        self.assertEqual(self.out_file.getvalue(), '')
+
+    def test_does_not_print_sucess_result(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_printer.print_result(success_result)
+        self.assertEqual(self.out_file.getvalue(), '')
+
+    def test_print_failure_result(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_printer.print_result(failure_result)
+
+        ref_failure_statement = (
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+        )
+        self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
+
+    def test_print_warnings_result(self):
+        self.result_printer.print_result(WarningResult('my warning'))
+        ref_warning_statement = 'warning: my warning\n'
+        self.assertEqual(self.error_file.getvalue(), ref_warning_statement)


### PR DESCRIPTION
This introduces an abstraction that will use ``ResultRecorder`` and ``Results`` received from the result queue to print out status statements.

Important Notes:
* The progress is slightly different now. Instead of printing parts we print number of bytes completed.
* There is no more ``...`` notation in progress. It will always print how many files/number of bytes it has currently seen go by. So there is a chance that the number of total expected bytes and number of remaining files can increase. This change I would like other's thoughts on. Not sure if it would be confusing to see the remaining files and total expected bytes to increase. Maybe I should add additional information to the progress statement when I know the count is not finalized? But I do know it is much more helpful than the ``...`` notation.
* To implement new types of progress, you create a new ``ResultPrinter`` class. I implemented  ``OnlyShowErrorsResultPrinter`` as an example.

Let me know what you think.

cc @jamesls @JordonPhillips 