### PR TITLE
Add needed subscribers for cp

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -8,16 +8,12 @@ import hashlib
 
 from botocore.compat import MD5_AVAILABLE
 from awscli.customizations.s3.utils import (
-    find_bucket_key, guess_content_type, MD5Error, bytes_print, set_file_utime,
-    RequestParamsMapper)
+    find_bucket_key, guess_content_type, CreateDirectoryError, MD5Error,
+    bytes_print, set_file_utime, RequestParamsMapper)
 from awscli.compat import bytes_print
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-class CreateDirectoryError(Exception):
-    pass
 
 
 def read_file(filename):

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -272,23 +272,9 @@ class FileInfo(TaskInfo):
             return
         filename = self.src
         # Add a content type param if we can guess the type.
-        try:
-            guessed_type = guess_content_type(filename)
-            if guessed_type is not None:
-                params['ContentType'] = guessed_type
-        # This catches a bug in the mimetype libary where some MIME types
-        # specifically on windows machines cause a UnicodeDecodeError
-        # because the MIME type in the Windows registery has an encoding
-        # that cannot be properly encoded using the default system encoding.
-        # https://bugs.python.org/issue9291
-        #
-        # So instead of hard failing, just log the issue and fall back to the
-        # default guessed content type of None.
-        except UnicodeDecodeError:
-            LOGGER.debug(
-                'Unable to guess content type for %s due to '
-                'UnicodeDecodeError: ', filename, exc_info=True
-            )
+        guessed_type = guess_content_type(filename)
+        if guessed_type is not None:
+            params['ContentType'] = guessed_type
 
     def download(self):
         """

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -81,12 +81,12 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
             self.TRANSFER_TYPE, src, dest, bytes_transferred, future.meta.size)
         self._result_queue.put(progress_result)
 
-    def on_success(self, future):
+    def _on_success(self, future):
         src, dest = self._get_src_dest(future)
         self._result_queue.put(
             SuccessResult(self.TRANSFER_TYPE, src, dest))
 
-    def on_failure(self, future, e):
+    def _on_failure(self, future, e):
         src, dest = self._get_src_dest(future)
         self._result_queue.put(
             FailureResult(self.TRANSFER_TYPE, src, dest, e))

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -23,6 +23,7 @@ from awscli.customizations.s3.utils import relative_path
 from awscli.customizations.s3.utils import human_readable_size
 from awscli.customizations.s3.utils import uni_print
 from awscli.customizations.s3.utils import WarningResult
+from awscli.customizations.s3.utils import OnDoneFilteredSubscriber
 
 
 LOGGER = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ CommandResult = namedtuple(
     'CommandResult', ['num_tasks_failed', 'num_tasks_warned'])
 
 
-class BaseResultSubscriber(BaseSubscriber):
+class BaseResultSubscriber(OnDoneFilteredSubscriber):
     TRANSFER_TYPE = None
 
     def __init__(self, result_queue):
@@ -80,15 +81,15 @@ class BaseResultSubscriber(BaseSubscriber):
             self.TRANSFER_TYPE, src, dest, bytes_transferred, future.meta.size)
         self._result_queue.put(progress_result)
 
-    def on_done(self, future, **kwargs):
+    def on_success(self, future):
         src, dest = self._get_src_dest(future)
-        try:
-            future.result()
-            self._result_queue.put(
-                SuccessResult(self.TRANSFER_TYPE, src, dest))
-        except Exception as e:
-            self._result_queue.put(
-                FailureResult(self.TRANSFER_TYPE, src, dest, e))
+        self._result_queue.put(
+            SuccessResult(self.TRANSFER_TYPE, src, dest))
+
+    def on_failure(self, future, e):
+        src, dest = self._get_src_dest(future)
+        self._result_queue.put(
+            FailureResult(self.TRANSFER_TYPE, src, dest, e))
 
     def _get_src_dest(self, future):
         raise NotImplementedError('_get_src_dest()')

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -818,7 +818,7 @@ class BaseProvideContentTypeSubscriber(BaseSubscriber):
             future.meta.call_args.extra_args['ContentType'] = guessed_type
 
     def _get_filename(self, future):
-        raise NotImplementedError('must implement _get_filename()')
+        raise NotImplementedError('_get_filename()')
 
 
 class ProvideUploadContentTypeSubscriber(BaseProvideContentTypeSubscriber):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -433,7 +433,21 @@ def guess_content_type(filename):
 
     If the type cannot be guessed, a value of None is returned.
     """
-    return mimetypes.guess_type(filename)[0]
+    try:
+        return mimetypes.guess_type(filename)[0]
+    # This catches a bug in the mimetype libary where some MIME types
+    # specifically on windows machines cause a UnicodeDecodeError
+    # because the MIME type in the Windows registery has an encoding
+    # that cannot be properly encoded using the default system encoding.
+    # https://bugs.python.org/issue9291
+    #
+    # So instead of hard failing, just log the issue and fall back to the
+    # default guessed content type of None.
+    except UnicodeDecodeError:
+        LOGGER.debug(
+            'Unable to guess content type for %s due to '
+            'UnicodeDecodeError: ', filename, exc_info=True
+        )
 
 
 def relative_path(filename, start=os.path.curdir):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -760,6 +760,33 @@ class ProvideSizeSubscriber(BaseSubscriber):
         future.meta.provide_transfer_size(self.size)
 
 
+class OnDoneFilteredSubscriber(BaseSubscriber):
+    """Subscriber that differentiates between successes and failures
+
+    It is really a convenience class so developers do not have to have
+    to constantly remember to have a general try/except around future.result()
+    """
+    def on_done(self, future, **kwargs):
+        future_exception = None
+        try:
+
+            future.result()
+        except Exception as e:
+            future_exception = e
+        # If the result propogates an error, call the on_failure
+        # method instead.
+        if future_exception:
+            self.on_failure(future, future_exception)
+        else:
+            self.on_success(future)
+
+    def on_success(self, future):
+        pass
+
+    def on_failure(self, future, e):
+        pass
+
+
 class NonSeekableStream(object):
     """Wrap a file like object as a non seekable stream.
 

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -779,6 +779,9 @@ class ProvideSizeSubscriber(BaseSubscriber):
         future.meta.provide_transfer_size(self.size)
 
 
+# TODO: Eventually port this down to the BaseSubscriber or a new subscriber
+# class in s3transfer. The functionality is very convenient but may need
+# some further design decisions to make it a feature in s3transfer.
 class OnDoneFilteredSubscriber(BaseSubscriber):
     """Subscriber that differentiates between successes and failures
 
@@ -795,14 +798,14 @@ class OnDoneFilteredSubscriber(BaseSubscriber):
         # If the result propogates an error, call the on_failure
         # method instead.
         if future_exception:
-            self.on_failure(future, future_exception)
+            self._on_failure(future, future_exception)
         else:
-            self.on_success(future)
+            self._on_success(future)
 
-    def on_success(self, future):
+    def _on_success(self, future):
         pass
 
-    def on_failure(self, future, e):
+    def _on_failure(self, future, e):
         pass
 
 
@@ -834,7 +837,7 @@ class ProvideLastModifiedTimeSubscriber(OnDoneFilteredSubscriber):
         self._last_modified_time = last_modified_time
         self._result_queue = result_queue
 
-    def on_success(self, future, **kwargs):
+    def _on_success(self, future, **kwargs):
         filename = future.meta.call_args.fileobj
         try:
             last_update_tuple = self._last_modified_time.timetuple()

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -211,19 +211,6 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
-    def test_cp_succeeds_with_mimetype_errors(self):
-        full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
-        self.parsed_responses = [
-            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
-        with mock.patch('mimetypes.guess_type') as mock_guess_type:
-            # This should throw a UnicodeDecodeError.
-            mock_guess_type.side_effect = lambda x: b'\xe2'.decode('ascii')
-            self.run_cmd(cmdline, expected_rc=0)
-        # Because of the decoding error the command should have succeeded
-        # just that there was no content type added.
-        self.assertNotIn('ContentType', self.last_kwargs)
-
     def test_cp_fails_with_utime_errors_but_continues(self):
         full_path = self.files.create_file('foo.txt', '')
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -211,6 +211,19 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
+    def test_cp_succeeds_with_mimetype_errors(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
+        self.parsed_responses = [
+            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        with mock.patch('mimetypes.guess_type') as mock_guess_type:
+            # This should throw a UnicodeDecodeError.
+            mock_guess_type.side_effect = lambda x: b'\xe2'.decode('ascii')
+            self.run_cmd(cmdline, expected_rc=0)
+        # Because of the decoding error the command should have succeeded
+        # just that there was no content type added.
+        self.assertNotIn('ContentType', self.last_kwargs)
+
     def test_cp_fails_with_utime_errors_but_continues(self):
         full_path = self.files.create_file('foo.txt', '')
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -18,6 +18,30 @@ from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, \
     capture_output
 
 
+class FakeTransferFuture(object):
+    def __init__(self, result=None, exception=None, meta=None):
+        self._result = result
+        self._exception = exception
+        self.meta = meta
+
+    def result(self):
+        if self._exception:
+            raise self._exception
+        return self._result
+
+
+class FakeTransferFutureMeta(object):
+    def __init__(self, size=None, call_args=None):
+        self.size = size
+        self.call_args = call_args
+
+
+class FakeTransferFutureCallArgs(object):
+    def __init__(self, **kwargs):
+        for kwarg, val in kwargs.items():
+            setattr(self, kwarg, val)
+
+
 class S3HandlerBaseTest(BaseAWSCommandParamsTest):
     def setUp(self):
         super(S3HandlerBaseTest, self).setUp()

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -30,30 +30,9 @@ from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
 from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.utils import relative_path
 from awscli.customizations.s3.utils import WarningResult
-
-
-class FakeTransferFuture(object):
-    def __init__(self, result=None, exception=None, meta=None):
-        self._result = result
-        self._exception = exception
-        self.meta = meta
-
-    def result(self):
-        if self._exception:
-            raise self._exception
-        return self._result
-
-
-class FakeTransferFutureMeta(object):
-    def __init__(self, size=None, call_args=None):
-        self.size = size
-        self.call_args = call_args
-
-
-class FakeTransferFutureCallArgs(object):
-    def __init__(self, **kwargs):
-        for kwarg, val in kwargs.items():
-            setattr(self, kwarg, val)
+from tests.unit.customizations.s3 import FakeTransferFuture
+from tests.unit.customizations.s3 import FakeTransferFutureMeta
+from tests.unit.customizations.s3 import FakeTransferFutureCallArgs
 
 
 class BaseResultSubscriberTest(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -585,10 +585,10 @@ class OnDoneFilteredRecordingSubscriber(OnDoneFilteredSubscriber):
         self.on_success_calls = []
         self.on_failure_calls = []
 
-    def on_success(self, future):
+    def _on_success(self, future):
         self.on_success_calls.append(future)
 
-    def on_failure(self, future, exception):
+    def _on_failure(self, future, exception):
         self.on_failure_calls.append((future, exception))
 
 
@@ -672,14 +672,14 @@ class TestProvideLastModifiedTimeSubscriber(BaseTestWithFileCreator):
         self.future = FakeTransferFuture(meta=meta)
 
     def test_on_success_modifies_utime(self):
-        self.subscriber.on_success(self.future)
+        self.subscriber.on_done(self.future)
         _, utime = get_file_stat(self.filename)
         self.assertEqual(utime, self.desired_utime)
 
     def test_on_success_failure_in_utime_mod_raises_warning(self):
         self.subscriber = ProvideLastModifiedTimeSubscriber(
             None, self.result_queue)
-        self.subscriber.on_success(self.future)
+        self.subscriber.on_done(self.future)
         # Because the time to provide was None it will throw an exception
         # which results in the a warning about the utime not being able
         # to be set being placed in the result queue.

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -32,7 +32,8 @@ from awscli.compat import queue
 from awscli.compat import StringIO
 from awscli.testutils import FileCreator
 from awscli.customizations.s3.utils import (
-    find_bucket_key, find_chunksize, ReadFileChunk, relative_path,
+    find_bucket_key, find_chunksize, ReadFileChunk,
+    guess_content_type, relative_path,
     StablePriorityQueue, BucketLister, get_file_stat, AppendFilter,
     create_warning, human_readable_size, human_readable_to_bytes,
     MAX_SINGLE_UPLOAD_SIZE, MIN_UPLOAD_CHUNKSIZE, MAX_UPLOAD_SIZE,
@@ -237,6 +238,20 @@ class TestReadFileChunk(unittest.TestCase):
         self.assertEqual(chunk.tell(), 3)
         chunk.seek(0)
         self.assertEqual(chunk.tell(), 0)
+
+
+class TestGuessContentType(unittest.TestCase):
+    def test_guess_content_type(self):
+        self.assertEqual(guess_content_type('foo.txt'), 'text/plain')
+
+    def test_guess_content_type_with_no_valid_matches(self):
+        self.assertEqual(guess_content_type('no-extension'), None)
+
+    def test_guess_content_type_with_unicode_error_returns_no_match(self):
+        with mock.patch('mimetypes.guess_type') as guess_type_patch:
+            # This should throw a UnicodeDecodeError.
+            guess_type_patch.side_effect = lambda x: b'\xe2'.decode('ascii')
+            self.assertEqual(guess_content_type('foo.txt'), None)
 
 
 class TestRelativePath(unittest.TestCase):


### PR DESCRIPTION
I am just trying to chunk out some of the code for review in integrating ``s3transfer`` with ``cp`` and ``cp --recursive``. This PR is mainly for the purpose of adding all of the additional logic that the CLI needs for performing transfers that is not by default in the ``TransferManager``.

Most of what I did was take logic from other parts of the code base and wrapped them into subscribers. For some of the ``on_queued`` subscribers, it is true that a subscriber is not necessarily needed but it is better to use a subscriber for some of the logic because if the logic is taking place before calling a ``TransferManager`` method there is a chance of 1) slowing down the enqueing of tasks and 2) having the entire transfer failing if there is an unhandled exception is thrown before being sent to the ``TransferManger``.

The custom logic that I implemented through subscribers include:
* Setting last modified time on downloads finishing. (Also note that this has a little different functionality now where instead of failing and not deleting the file when it cannot set utime, it now warns and does not delete the file, which I think is more appropriate)
* Injecting content type
* Creating directories for downloads where there is no presently existing directory

I also did a small amount of refactoring in the current code base as I saw places where I could improve the logic (i.e. creating ``OnDoneFilteredSubscriber`` and moving more error handling logic into ``guess_content_type``)

I would really recommend reviewing each of these commits one by one.

cc @jamesls @JordonPhillips 

