### PR TITLE
Use better random char generation for tests

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -25,12 +25,12 @@ import copy
 import shutil
 import time
 import json
-import random
 import logging
 import tempfile
 import platform
 import contextlib
 import string
+import binascii
 from pprint import pformat
 from subprocess import Popen, PIPE
 
@@ -152,7 +152,7 @@ def temporary_file(mode):
 
     """
     temporary_directory = tempfile.mkdtemp()
-    basename = 'tmpfile-%s-%s' % (int(time.time()), random.randint(1, 1000))
+    basename = 'tmpfile-%s' % random_chars(8)
     full_filename = os.path.join(temporary_directory, basename)
     open(full_filename, 'w').close()
     try:
@@ -173,9 +173,7 @@ def create_bucket(session, name=None, region=None):
     if name:
         bucket_name = name
     else:
-        rand1 = ''.join(random.sample(string.ascii_lowercase + string.digits,
-                                      10))
-        bucket_name = 'awscli-s3test-' + str(rand1)
+        bucket_name = 'awscli-s3test-' + random_chars(10)
     params = {'Bucket': bucket_name}
     if region != 'us-east-1':
         params['CreateBucketConfiguration'] = {'LocationConstraint': region}
@@ -190,6 +188,15 @@ def create_bucket(session, name=None, region=None):
         else:
             raise
     return bucket_name
+
+
+def random_chars(num_chars):
+    """Returns random hex characters.
+
+    Useful for creating resources with random names.
+
+    """
+    return binascii.hexlify(os.urandom(int(num_chars / 2))).decode('ascii')
 
 
 class BaseCLIDriverTest(unittest.TestCase):

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -173,7 +173,7 @@ def create_bucket(session, name=None, region=None):
     if name:
         bucket_name = name
     else:
-        bucket_name = 'awscli-s3test-' + random_chars(10)
+        bucket_name = random_bucket_name()
     params = {'Bucket': bucket_name}
     if region != 'us-east-1':
         params['CreateBucketConfiguration'] = {'LocationConstraint': region}
@@ -197,6 +197,20 @@ def random_chars(num_chars):
 
     """
     return binascii.hexlify(os.urandom(int(num_chars / 2))).decode('ascii')
+
+
+def random_bucket_name(prefix='awscli-s3integ-', num_random=10):
+    """Generate a random S3 bucket name.
+
+    :param prefix: A prefix to use in the bucket name.  Useful
+        for tracking resources.  This default value makes it easy
+        to see which buckets were created from CLI integ tests.
+    :param num_random: Number of random chars to include in the bucket name.
+
+    :returns: The name of a randomly generated bucket name as a string.
+
+    """
+    return prefix + random_chars(num_random)
 
 
 class BaseCLIDriverTest(unittest.TestCase):

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -36,14 +36,14 @@ from awscli.testutils import unittest, get_stdout_encoding
 from awscli.testutils import skip_if_windows
 from awscli.testutils import aws as _aws
 from awscli.testutils import BaseS3CLICommand
-from awscli.testutils import random_chars
+from awscli.testutils import random_chars, random_bucket_name
 from awscli.customizations.s3.transferconfig import DEFAULTS
 from awscli.customizations.scalarparse import add_scalar_parsers
 
 
 # Using the same log name as testutils.py
 LOG = logging.getLogger('awscli.tests.integration')
-_SHARED_BUCKET = 'awscli-s3shared-' + random_chars(10)
+_SHARED_BUCKET = random_bucket_name()
 _DEFAULT_REGION = 'us-west-2'
 
 
@@ -1156,7 +1156,7 @@ class TestMbRb(BaseS3IntegrationTest):
     Tests primarily using ``rb`` and ``mb`` command.
     """
     def extra_setup(self):
-        self.bucket_name = 'awscli-s3integ-' + random_chars(10)
+        self.bucket_name = random_bucket_name()
 
     def test_mb_rb(self):
         p = aws('s3 mb s3://%s' % self.bucket_name)

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -16,7 +16,6 @@
 # It does not check every possible parameter that can be thrown as
 # those are checked by tests in other classes
 import os
-import random
 import platform
 import contextlib
 import time
@@ -37,14 +36,14 @@ from awscli.testutils import unittest, get_stdout_encoding
 from awscli.testutils import skip_if_windows
 from awscli.testutils import aws as _aws
 from awscli.testutils import BaseS3CLICommand
+from awscli.testutils import random_chars
 from awscli.customizations.s3.transferconfig import DEFAULTS
 from awscli.customizations.scalarparse import add_scalar_parsers
 
 
 # Using the same log name as testutils.py
 LOG = logging.getLogger('awscli.tests.integration')
-_SHARED_BUCKET = 'awscli-s3shared-' + ''.join(
-    random.sample(string.ascii_lowercase + string.digits, 10))
+_SHARED_BUCKET = 'awscli-s3shared-' + random_chars(10)
 _DEFAULT_REGION = 'us-west-2'
 
 
@@ -787,13 +786,11 @@ class TestSourceRegion(BaseS3IntegrationTest):
         # sequences of characters and joining them with a period and
         # adding a .com at the end.
         for i in range(2):
-            name_comp.append(''.join(random.sample(string.ascii_lowercase +
-                                                   string.digits, 10)))
+            name_comp.append(random_chars(10))
         self.src_name = '.'.join(name_comp + ['com'])
         name_comp = []
         for i in range(2):
-            name_comp.append(''.join(random.sample(string.ascii_lowercase +
-                                                   string.digits, 10)))
+            name_comp.append(random_chars(10))
         self.dest_name = '.'.join(name_comp + ['com'])
         self.src_region = 'us-west-1'
         self.dest_region = 'us-east-1'
@@ -1159,7 +1156,7 @@ class TestMbRb(BaseS3IntegrationTest):
     Tests primarily using ``rb`` and ``mb`` command.
     """
     def extra_setup(self):
-        self.bucket_name = 'awscli-s3integ-' + str(random.randint(1, 1000))
+        self.bucket_name = 'awscli-s3integ-' + random_chars(10)
 
     def test_mb_rb(self):
         p = aws('s3 mb s3://%s' % self.bucket_name)


### PR DESCRIPTION
We still occassionally run into issues where we're creating
pre-existing bucket names.  This gives a consistent interface
for creating random chars in all our tests.

cc @kyleknap @JordonPhillips 