### PR TITLE
Use BytesIO to fix py3 test failure

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -927,7 +927,7 @@ class TestUnableToWriteToFile(BaseS3IntegrationTest):
         # which effectively disables the expect 100 continue logic.
         # This will result in a test error because we won't follow
         # the temporary redirect for the newly created bucket.
-        contents = six.StringIO('a' * 10 * 1024 * 1024)
+        contents = six.BytesIO(b'a' * 10 * 1024 * 1024)
         self.put_object(bucket_name, 'foo.txt',
                         contents=contents)
         os.chmod(self.files.rootdir, 0o444)


### PR DESCRIPTION
This test is skipped if you are running as root,
but on a dev machine, this test fails on python3.

Try this on py3: `nosetests tests/integration/customizations/s3/test_plugin.py:TestUnableToWriteToFile`

cc @kyleknap @JordonPhillips 