### PR TITLE
Adding support for colorized JSON output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ docutils>=0.10
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.0
 colorama>=0.2.5,<=0.3.7
+pygments==2.1.3
 mock==1.3.0
 rsa>=3.1.2,<=3.5.0
 wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ universal = 1
 requires-dist =
         botocore==1.4.48
         colorama>=0.2.5,<=0.3.7
+        pygments==2.1.3
         docutils>=0.10
         rsa>=3.1.2,<=3.5.0
         s3transfer>=0.1.0,<0.2.0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import awscli
 
 requires = ['botocore==1.4.48',
             'colorama>=0.2.5,<=0.3.7',
+            'pygments==2.1.3',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
             's3transfer>=0.1.0,<0.2.0']

--- a/tests/unit/customizations/datapipeline/test_commands.py
+++ b/tests/unit/customizations/datapipeline/test_commands.py
@@ -173,6 +173,7 @@ class FakeParsedArgs(object):
         self.region = None
         self.verify_ssl = None
         self.output = None
+        self.color = None
         self.query = None
         self.__dict__.update(kwargs)
 


### PR DESCRIPTION
As an attempt to provide support for #2123 this contains JSON colorization.
Basically the only difference is additional dependency and updates to the JsonFormatter to pipe through Pygments before writing out to the stream.

This PR also takes into consideration color flag for output and defaults to off for backwards compatibility.

There might be a more efficient way of doing this - to be frank, Python is not my strongest side.
