### PR TITLE
Add Transfer Request Submitters

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -19,7 +19,8 @@ import sys
 from s3transfer.manager import TransferManager
 
 from awscli.customizations.s3.utils import (
-    find_chunksize, adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
+    find_chunksize, human_readable_size,
+    adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
     find_bucket_key, relative_path, PrintTask, create_warning,
     NonSeekableStream)
 from awscli.customizations.s3.executor import Executor
@@ -541,18 +542,21 @@ class BaseTransferRequestSubmitter(object):
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
         self._cli_params = cli_params
+        self._warning_hanlders = []
 
     def submit(self, fileinfo):
         """Submits a transfer request based on the FileInfo provided
 
+        There is no guarantee that the transfer request will be made on
+        behalf of the fileinfo as a fileinfo may be skipped based on
+        circumstances in which the transfer is not possible.
+
         :param fileinfo: The FileInfo to be used to submit a transfer
             request to the underlying transfer manager.
         """
-        extra_args = {}
-        self.REQUEST_MAPPER_METHOD(extra_args, self._cli_params)
-        subscribers = [self.RESULT_SUBSCRIBER_CLASS(self._result_queue)]
-        self._add_additional_subscribers(subscribers, fileinfo)
-        self._submit_transfer_request(fileinfo, extra_args, subscribers)
+        should_skip = self._warn_and_signal_if_skip(fileinfo)
+        if not should_skip:
+            self._do_submit(fileinfo)
 
     def is_valid_submission(self, fileinfo):
         """Checks whether it is valid to submit a particular FileInfo
@@ -565,17 +569,59 @@ class BaseTransferRequestSubmitter(object):
         """
         raise NotImplementedError('is_valid_to_submit()')
 
+    def _do_submit(self, fileinfo):
+        extra_args = {}
+        self.REQUEST_MAPPER_METHOD(extra_args, self._cli_params)
+        subscribers = [self.RESULT_SUBSCRIBER_CLASS(self._result_queue)]
+        self._add_additional_subscribers(subscribers, fileinfo)
+        self._submit_transfer_request(fileinfo, extra_args, subscribers)
+
     def _add_additional_subscribers(self, subscribers, fileinfo):
         pass
 
     def _submit_transfer_request(self, fileinfo, extra_args, subscribers):
         raise NotImplementedError('_submit_transfer_request()')
 
+    def _warn_and_signal_if_skip(self, fileinfo):
+        for warning_handler in self._get_warning_handlers():
+            if warning_handler(fileinfo):
+                # On the first warning handler that returns a signal to skip
+                # immediately propogate this signal and no longer check
+                # the other warning handlers as no matter what the file will
+                # be skipped.
+                return True
+
+    def _get_warning_handlers(self):
+        # Returns a list of warning handlers, which are callables that
+        # take in a single parameter representing a FileInfo. It will then
+        # add a warning to result_queue if needed and return True if
+        # that FileInfo should be skipped.
+        return []
+
     def _should_inject_content_type(self):
         return (
             self._cli_params.get('guess_mime_type') and
             not self._cli_params.get('content_type')
         )
+
+    def _warn_glacier(self, fileinfo):
+        if not self._cli_params.get('force_glacier_transfer'):
+            if not fileinfo.is_glacier_compatible():
+                LOGGER.debug(
+                    'Encountered glacier object s3://%s. Not performing '
+                    '%s on object.' % (fileinfo.src, fileinfo.operation_name))
+                if not self._cli_params.get('ignore_glacier_warnings'):
+                    warning = create_warning(
+                        's3://'+fileinfo.src,
+                        'Object is of storage class GLACIER. Unable to '
+                        'perform %s operations on GLACIER objects. You must '
+                        'restore the object to be able to the perform '
+                        'operation.' %
+                        fileinfo.operation_name
+                    )
+                    self._result_queue.put(warning)
+                return True
+        return False
 
 
 class UploadRequestSubmitter(BaseTransferRequestSubmitter):
@@ -597,6 +643,19 @@ class UploadRequestSubmitter(BaseTransferRequestSubmitter):
             extra_args=extra_args, subscribers=subscribers
         )
 
+    def _get_warning_handlers(self):
+        return [self._warn_if_too_large]
+
+    def _warn_if_too_large(self, fileinfo):
+        if getattr(fileinfo, 'size') and fileinfo.size > MAX_UPLOAD_SIZE:
+            file_path = relative_path(fileinfo.src)
+            warning_message = (
+                "File %s exceeds s3 upload limit of %s." % (
+                    file_path, human_readable_size(MAX_UPLOAD_SIZE)))
+            warning = create_warning(
+                file_path, warning_message, skip_file=False)
+            self._result_queue.put(warning)
+
 
 class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_get_object_params
@@ -617,6 +676,9 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
             fileobj=fileinfo.dest, bucket=bucket, key=key,
             extra_args=extra_args, subscribers=subscribers
         )
+
+    def _get_warning_handlers(self):
+        return [self._warn_glacier]
 
 
 class CopyRequestSubmitter(BaseTransferRequestSubmitter):
@@ -640,3 +702,6 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
             extra_args=extra_args, subscribers=subscribers,
             source_client=fileinfo.source_client
         )
+
+    def _get_warning_handlers(self):
+        return [self._warn_glacier]

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -527,11 +527,23 @@ class BaseTransferRequestSubmitter(object):
     RESULT_SUBSCRIBER_CLASS = None
 
     def __init__(self, transfer_manager, result_queue, cli_params):
+        """Submits transfer requests to the TransferManager
+
+        Given a FileInfo object and provided CLI parameters, it will add the
+        necessary extra arguments and subscribers in making a call to the
+        TransferManager.
+
+        :param transfer_manager: The underlying transfer manager
+        :param result queue: The result queue to use
+        :param cli_params: The associated CLI parameters passed in to the
+            command.
+        """
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
         self._cli_params = cli_params
 
     def submit(self, fileinfo):
+        """Submits a transfer request based on the FileInfo provided"""
         extra_args = {}
         self.REQUEST_MAPPER_METHOD(extra_args, self._cli_params)
         subscribers = [self.RESULT_SUBSCRIBER_CLASS(self._result_queue)]

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -534,10 +534,15 @@ class BaseTransferRequestSubmitter(object):
         necessary extra arguments and subscribers in making a call to the
         TransferManager.
 
+        :type transfer_manager: s3transfer.manager.TransferManager
         :param transfer_manager: The underlying transfer manager
+
+        :type result_queue: queue.Queue
         :param result queue: The result queue to use
+
+        :type cli_params: dict
         :param cli_params: The associated CLI parameters passed in to the
-            command.
+            command as a dictionary.
         """
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
@@ -550,6 +555,7 @@ class BaseTransferRequestSubmitter(object):
         behalf of the fileinfo as a fileinfo may be skipped based on
         circumstances in which the transfer is not possible.
 
+        :type fileinfo: awscli.customizations.s3.fileinfo.FileInfo
         :param fileinfo: The FileInfo to be used to submit a transfer
             request to the underlying transfer manager.
         """
@@ -560,6 +566,7 @@ class BaseTransferRequestSubmitter(object):
     def is_valid_submission(self, fileinfo):
         """Checks whether it is valid to submit a particular FileInfo
 
+        :type fileinfo: awscli.customizations.s3.fileinfo.FileInfo
         :param fileinfo: The FileInfo to check if the transfer request
             submitter can handle.
 

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -542,7 +542,6 @@ class BaseTransferRequestSubmitter(object):
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
         self._cli_params = cli_params
-        self._warning_hanlders = []
 
     def submit(self, fileinfo):
         """Submits a transfer request based on the FileInfo provided
@@ -567,7 +566,7 @@ class BaseTransferRequestSubmitter(object):
         :returns: True if it can use the provided FileInfo to make a transfer
             request to the underlying transfer manager. False, otherwise.
         """
-        raise NotImplementedError('is_valid_to_submit()')
+        raise NotImplementedError('is_valid_submission()')
 
     def _do_submit(self, fileinfo):
         extra_args = {}

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1127,6 +1127,16 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = UploadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
+    def test_is_valid_submission(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key,
+            operation_name='upload')
+        self.assertTrue(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+
     def test_submit(self):
         fileinfo = FileInfo(
             src=self.filename, dest=self.bucket+'/'+self.key)
@@ -1203,6 +1213,16 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = DownloadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
+    def test_is_valid_submission(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download')
+        self.assertTrue(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+
     def test_submit(self):
         fileinfo = FileInfo(
             src=self.bucket+'/'+self.key, dest=self.filename)
@@ -1249,6 +1269,16 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.source_key = 'mysourcekey'
         self.transfer_request_submitter = CopyRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_is_valid_submission(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key, operation_name='copy')
+        self.assertTrue(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1152,8 +1152,8 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
-            ProvideUploadContentTypeSubscriber,
             ProvideSizeSubscriber,
+            ProvideUploadContentTypeSubscriber,
             UploadResultSubscriber
         ]
         actual_subscribers = upload_call_kwargs['subscribers']
@@ -1251,9 +1251,9 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
-            ProvideLastModifiedTimeSubscriber,
-            DirectoryCreatorSubscriber,
             ProvideSizeSubscriber,
+            DirectoryCreatorSubscriber,
+            ProvideLastModifiedTimeSubscriber,
             DownloadResultSubscriber
         ]
         actual_subscribers = download_call_kwargs['subscribers']
@@ -1384,8 +1384,8 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
-            ProvideCopyContentTypeSubscriber,
             ProvideSizeSubscriber,
+            ProvideCopyContentTypeSubscriber,
             CopyResultSubscriber
         ]
         actual_subscribers = copy_call_kwargs['subscribers']


### PR DESCRIPTION
This is the second to last PR that is needed to integrate ``cp`` and ``cp --recursive``. It also integrates the [PR involving subscribers](https://github.com/aws/aws-cli/pull/2117) so you will still see the diff from the that PR until it gets merged. I would recommend looking at the linked PR first but you can use this PR to understand how I am trying to integrate them.

The main reason for this abstraction is that the original ``S3Handler`` class was really large and had a lot of branching logic especially related to how enqueuing works which made it difficult to follow, difficult to expand, and difficult to test. It really seemed that it should have been abstraction by itself. By having the concept of individual transfer request submitters for each type of transfer, it helps solve these issues.

After this PR, I plan to make a version of ``S3Handler`` that glues all the result processor and the transfer submitters together and serves essentially as a dispatcher to the various transfer submitters depending on the fileinfo received.

Let me know what you think about this PR and my plan.

cc @jamesls @JordonPhillips 