### PR TITLE
Result updates based on CLI integration

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -245,6 +245,8 @@ class ResultPrinter(BaseResultHandler):
     FAILURE_FORMAT = (
         '{transfer_type} failed: {src} to {dest} {exception}'
     )
+    # TODO: Add "warning: " prefix once all commands are converted to using
+    # result printer and remove "warning: " prefix from ``create_warning``.
     WARNING_FORMAT = (
         '{message}'
     )

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -242,26 +242,27 @@ class ResultPrinter(BaseResultHandler):
         'warning: {message}'
     )
 
-    def __init__(self, result_recorder, out_file=sys.stdout,
-                 error_file=sys.stderr):
+    def __init__(self, result_recorder, out_file=None, error_file=None):
         """Prints status of ongoing transfer
 
         :type result_recorder: ResultRecorder
         :param result_recorder: The associated result recorder
 
-        :type only_show_errors: bool
-        :param only_show_errors: True if to only print out errors. Otherwise,
-            print out everything.
-
         :type out_file: file-like obj
-        :param out_file: Location to write progress and success statements
+        :param out_file: Location to write progress and success statements.
+            By default, the location is sys.stdout.
 
         :type error_file: file-like obj
-        :param error_file: Location to write warnings and errors
+        :param error_file: Location to write warnings and errors.
+            By default, the location is sys.stderr.
         """
         self._result_recorder = result_recorder
         self._out_file = out_file
+        if self._out_file is None:
+            self._out_file = sys.stdout
         self._error_file = error_file
+        if self._error_file is None:
+            self._error_file = sys.stderr
         self._progress_length = 0
         self._result_handler_map = {
             ProgressResult: self._print_progress,

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -246,7 +246,7 @@ class ResultPrinter(BaseResultHandler):
         '{transfer_type} failed: {src} to {dest} {exception}'
     )
     WARNING_FORMAT = (
-        'warning: {message}'
+        '{message}'
     )
     ERROR_FORMAT = (
         '{exception}'

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -601,7 +601,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
     def test_warning(self):
-        self.result_printer(WarningResult('my warning'))
+        self.result_printer(WarningResult('warning: my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 
@@ -625,7 +625,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
 
-        self.result_printer(WarningResult('my warning'))
+        self.result_printer(WarningResult('warning: my warning'))
 
         # The statement should consist of:
         # * The first progress statement
@@ -699,7 +699,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
 
     def test_print_warnings_result(self):
-        self.result_printer(WarningResult('my warning'))
+        self.result_printer(WarningResult('warning: my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 


### PR DESCRIPTION
When working on integrating ``s3transfer`` into the ``cp`` there were a few more changes that I needed to make to get the functional/integration tests to pass:

1) Set the default out_file and error_file of the ResultPrinter to ``None`` instead of ``sys.stdout`` and ``sys.stdout`` and then set it when the ResultPrinter is instantiated. The problem with making it in the signature is that all of the functional tests could not patch out standard out and standard error because it happens after the class get defined. Note I was not too big of a fan of doing this but I am not sure if there is a better option to get the functional tests to pass with minimal changes to the functional tests.

2) Create an ``ErrorResult`` this is to handle the general exception case that is thrown anywhere outside of an individual transfer such as in the file generators

3) Noticed a duplication of the ``"warning: "`` prefix when printing. This is because ``create_warning`` already adds the "``warning: "`` prefix to the message it creates.

Let me know what you think.

cc @jamesls @JordonPhillips 