### PR TITLE
Fix py2 test failure on windows

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -152,7 +152,7 @@ def temporary_file(mode):
 
     """
     temporary_directory = tempfile.mkdtemp()
-    basename = 'tmpfile-%s' % random_chars(8)
+    basename = 'tmpfile-%s' % str(random_chars(8))
     full_filename = os.path.join(temporary_directory, basename)
     open(full_filename, 'w').close()
     try:


### PR DESCRIPTION
On python2 in windows you can't have environment variables
that are unicode types.  random_chars() returns unicode on py2,
which when added to 'tmpfile-%s' means the whole value is unicode.

Note: Windows on python3 you can't have env var values as bytes().

Verified failing tests now pass on windows.

cc @kyleknap @JordonPhillips 