### PR TITLE
Integrate cp with s3transfer

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -631,7 +631,7 @@ class S3TransferHandler(object):
             with self._transfer_manager:
                 for fileinfo in fileinfos:
                     for submitter in self._submitters:
-                        if submitter.is_valid_submission(fileinfo):
+                        if submitter.can_submit(fileinfo):
                             submitter.submit(fileinfo)
                             break
         return self._result_command_recorder.get_command_result()
@@ -677,8 +677,8 @@ class BaseTransferRequestSubmitter(object):
         if not should_skip:
             self._do_submit(fileinfo)
 
-    def is_valid_submission(self, fileinfo):
-        """Checks whether it is valid to submit a particular FileInfo
+    def can_submit(self, fileinfo):
+        """Checks whether it can submit a particular FileInfo
 
         :type fileinfo: awscli.customizations.s3.fileinfo.FileInfo
         :param fileinfo: The FileInfo to check if the transfer request
@@ -687,7 +687,7 @@ class BaseTransferRequestSubmitter(object):
         :returns: True if it can use the provided FileInfo to make a transfer
             request to the underlying transfer manager. False, otherwise.
         """
-        raise NotImplementedError('is_valid_submission()')
+        raise NotImplementedError('can_submit()')
 
     def _do_submit(self, fileinfo):
         extra_args = {}
@@ -752,7 +752,7 @@ class UploadRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_put_object_params
     RESULT_SUBSCRIBER_CLASS = UploadResultSubscriber
 
-    def is_valid_submission(self, fileinfo):
+    def can_submit(self, fileinfo):
         return fileinfo.operation_name == 'upload'
 
     def _add_additional_subscribers(self, subscribers, fileinfo):
@@ -785,7 +785,7 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_get_object_params
     RESULT_SUBSCRIBER_CLASS = DownloadResultSubscriber
 
-    def is_valid_submission(self, fileinfo):
+    def can_submit(self, fileinfo):
         return fileinfo.operation_name == 'download'
 
     def _add_additional_subscribers(self, subscribers, fileinfo):
@@ -809,7 +809,7 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_copy_object_params
     RESULT_SUBSCRIBER_CLASS = CopyResultSubscriber
 
-    def is_valid_submission(self, fileinfo):
+    def can_submit(self, fileinfo):
         return fileinfo.operation_name == 'copy'
 
     def _add_additional_subscribers(self, subscribers, fileinfo):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -17,7 +17,6 @@ import sys
 from botocore.client import Config
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
-from s3transfer.manager import TransferManager
 
 from awscli.compat import six
 from awscli.compat import queue
@@ -28,22 +27,15 @@ from awscli.customizations.s3.fileformat import FileFormat
 from awscli.customizations.s3.filegenerator import FileGenerator
 from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
 from awscli.customizations.s3.filters import create_filter
-from awscli.customizations.s3.results import ResultRecorder
-from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
-from awscli.customizations.s3.results import ResultPrinter
-from awscli.customizations.s3.results import ResultProcessor
-from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
-from awscli.customizations.s3.s3handler import S3TransferHandler
+from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.utils import find_bucket_key, uni_print, \
     AppendFilter, find_dest_path_comp_key, human_readable_size, \
     RequestParamsMapper
 from awscli.customizations.s3.syncstrategy.base import MissingFileSync, \
     SizeAndLastModifiedSync, NeverSync
 from awscli.customizations.s3 import transferconfig
-from awscli.customizations.s3.transferconfig import \
-    create_transfer_config_from_runtime_config
 
 
 LOGGER = logging.getLogger(__name__)
@@ -953,9 +945,11 @@ class CommandArchitecture(object):
         s3_stream_handler = S3TransferStreamHandler(
             self.session, self.parameters, result_queue=result_queue)
 
-        s3_transfer_hanlder = s3handler
+        s3_transfer_handler = s3handler
         if self.cmd == 'cp' and not self.parameters.get('dryrun'):
-            s3_transfer_hanlder = self._get_s3_transfer_handler(result_queue)
+            s3_transfer_handler = S3TransferHandlerFactory(
+                self.parameters, self._runtime_config)(
+                    self._client, result_queue)
 
         sync_strategies = self.choose_sync_strategies()
 
@@ -977,7 +971,7 @@ class CommandArchitecture(object):
                             'file_generator': [file_generator],
                             'filters': [create_filter(self.parameters)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3_transfer_hanlder]}
+                            's3_handler': [s3_transfer_handler]}
         elif self.cmd == 'rm':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],
@@ -1024,37 +1018,6 @@ class CommandArchitecture(object):
         if files[0].num_tasks_warned > 0:
             rc = 2
         return rc
-
-    def _get_s3_transfer_handler(self, result_queue):
-        transfer_config = create_transfer_config_from_runtime_config(
-            self._runtime_config)
-        transfer_manager = TransferManager(self._client, transfer_config)
-
-        LOGGER.debug(
-            "Using a multipart threshold of %s and a part size of %s",
-            transfer_config.multipart_threshold,
-            transfer_config.multipart_chunksize
-        )
-        result_recorder = ResultRecorder()
-        result_processor_handlers = [result_recorder]
-        self._add_result_printer(result_recorder, result_processor_handlers)
-        result_processor = ResultProcessor(
-            result_queue, result_processor_handlers)
-        command_result_recorder = CommandResultRecorder(
-            result_queue, result_recorder, result_processor)
-
-        return S3TransferHandler(
-            transfer_manager, self.parameters, command_result_recorder)
-
-    def _add_result_printer(self, result_recorder, result_processor_handlers):
-        result_printer = None
-        if self.parameters.get('quiet'):
-            return
-        elif self.parameters.get('only_show_errors'):
-            result_printer = OnlyShowErrorsResultPrinter(result_recorder)
-        else:
-            result_printer = ResultPrinter(result_recorder)
-        result_processor_handlers.append(result_printer)
 
 
 class CommandParameters(object):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -32,6 +32,7 @@ from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
 from awscli.customizations.s3.results import ResultPrinter
 from awscli.customizations.s3.results import ResultProcessor
+from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandler
@@ -1039,11 +1040,11 @@ class CommandArchitecture(object):
         self._add_result_printer(result_recorder, result_processor_handlers)
         result_processor = ResultProcessor(
             result_queue, result_processor_handlers)
+        command_result_recorder = CommandResultRecorder(
+            result_queue, result_recorder, result_processor)
 
         return S3TransferHandler(
-            transfer_manager, self.parameters, result_queue, result_recorder,
-            result_processor
-        )
+            transfer_manager, self.parameters, command_result_recorder)
 
     def _add_result_printer(self, result_recorder, result_processor_handlers):
         result_printer = None

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -233,7 +233,7 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         ]
         with mock.patch('os.utime') as mock_utime:
             mock_utime.side_effect = OSError(1, '')
-            _, err, _ = self.run_cmd(cmdline, expected_rc=1)
+            _, err, _ = self.run_cmd(cmdline, expected_rc=2)
             self.assertIn('attempting to modify the utime', err)
 
     def test_recursive_glacier_download_with_force_glacier(self):

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -420,7 +420,9 @@ class TestCp(BaseS3IntegrationTest):
         self.put_object(bucket_name, key_name='foo.txt',
                         contents=foo_contents)
         local_foo_txt = self.files.full_path('foo.txt')
-        process = aws('s3 cp s3://%s/foo.txt %s' %
+        # --quiet is added to make sure too much output is not communicated
+        # to the PIPE, causing a deadlock when not consumed.
+        process = aws('s3 cp s3://%s/foo.txt %s --quiet' %
                       (bucket_name, local_foo_txt), wait_for_finish=False)
         # Give it some time to start up and enter it's main task loop.
         time.sleep(2)
@@ -442,8 +444,9 @@ class TestCp(BaseS3IntegrationTest):
         with open(foo_txt, 'wb') as f:
             for i in range(20):
                 f.write(b'a' * 1024 * 1024)
-
-        process = aws('s3 cp %s s3://%s/' % (foo_txt, bucket_name),
+        # --quiet is added to make sure too much output is not communicated
+        # to the PIPE, causing a deadlock when not consumed.
+        process = aws('s3 cp %s s3://%s/ --quiet' % (foo_txt, bucket_name),
                       wait_for_finish=False)
         time.sleep(3)
         # The process has 60 seconds to finish after being sent a Ctrl+C,

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -37,6 +37,7 @@ from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import ResultProcessor
+from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
 from awscli.customizations.s3.utils import StablePriorityQueue
 from awscli.customizations.s3.utils import WarningResult
@@ -1124,14 +1125,16 @@ class TestS3TransferHandler(unittest.TestCase):
             self.result_queue,
             [self.result_recorder, self.processed_results.append]
         )
+        self.command_result_recorder = CommandResultRecorder(
+            self.result_queue, self.result_recorder, self.result_processor)
 
         self.transfer_manager = mock.Mock(spec=TransferManager)
         self.transfer_manager.__enter__ = mock.Mock()
         self.transfer_manager.__exit__ = mock.Mock()
         self.parameters = {}
         self.s3_transfer_handler = S3TransferHandler(
-            self.transfer_manager, self.parameters, self.result_queue,
-            self.result_recorder, self.result_processor
+            self.transfer_manager, self.parameters,
+            self.command_result_recorder
         )
 
     def test_call_return_command_result(self):

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1225,15 +1225,15 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = UploadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
-    def test_is_valid_submission(self):
+    def test_can_submit(self):
         fileinfo = FileInfo(
             src=self.filename, dest=self.bucket+'/'+self.key,
             operation_name='upload')
         self.assertTrue(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
         fileinfo.operation_name = 'foo'
         self.assertFalse(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(
@@ -1325,15 +1325,15 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = DownloadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
-    def test_is_valid_submission(self):
+    def test_can_submit(self):
         fileinfo = FileInfo(
             src=self.bucket+'/'+self.key, dest=self.filename,
             operation_name='download')
         self.assertTrue(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
         fileinfo.operation_name = 'foo'
         self.assertFalse(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(
@@ -1454,15 +1454,15 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = CopyRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
-    def test_is_valid_submission(self):
+    def test_can_submit(self):
         fileinfo = FileInfo(
             src=self.source_bucket+'/'+self.source_key,
             dest=self.bucket+'/'+self.key, operation_name='copy')
         self.assertTrue(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
         fileinfo.operation_name = 'foo'
         self.assertFalse(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -26,6 +26,7 @@ from awscli.compat import queue
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandler
+from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.s3handler import UploadRequestSubmitter
 from awscli.customizations.s3.s3handler import DownloadRequestSubmitter
 from awscli.customizations.s3.s3handler import CopyRequestSubmitter
@@ -1114,6 +1115,20 @@ class TestS3HandlerInitialization(unittest.TestCase):
 
         self.assertEqual(handler.chunksize, 1000)
         self.assertEqual(handler.multi_threshold, 10000)
+
+
+class TestS3TransferHandlerFactory(unittest.TestCase):
+    def setUp(self):
+        self.cli_params = {}
+        self.runtime_config = runtime_config()
+        self.client = mock.Mock()
+        self.result_queue = queue.Queue()
+
+    def test_call(self):
+        factory = S3TransferHandlerFactory(
+            self.cli_params, self.runtime_config)
+        self.assertIsInstance(
+            factory(self.client, self.result_queue), S3TransferHandler)
 
 
 class TestS3TransferHandler(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -25,6 +25,7 @@ from awscli.compat import six
 from awscli.compat import queue
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
+from awscli.customizations.s3.s3handler import S3TransferHandler
 from awscli.customizations.s3.s3handler import UploadRequestSubmitter
 from awscli.customizations.s3.s3handler import DownloadRequestSubmitter
 from awscli.customizations.s3.s3handler import CopyRequestSubmitter
@@ -34,6 +35,8 @@ from awscli.customizations.s3.tasks import CreateMultipartUploadTask, \
 from awscli.customizations.s3.results import UploadResultSubscriber
 from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
+from awscli.customizations.s3.results import ResultRecorder
+from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
 from awscli.customizations.s3.utils import StablePriorityQueue
 from awscli.customizations.s3.utils import WarningResult
@@ -918,9 +921,9 @@ class S3HandlerTestBucket(S3HandlerBaseTest):
                                               ref_calls)
 
 
-class TestS3TransferHandler(S3HandlerBaseTest):
+class TestS3TransferStreamHandler(S3HandlerBaseTest):
     def setUp(self):
-        super(TestS3TransferHandler, self).setUp()
+        super(TestS3TransferStreamHandler, self).setUp()
         self.params = {'is_stream': True, 'region': 'us-east-1'}
         self.transfer_manager = mock.Mock(spec=TransferManager)
         self.transfer_manager.__enter__ = mock.Mock()
@@ -1110,6 +1113,82 @@ class TestS3HandlerInitialization(unittest.TestCase):
 
         self.assertEqual(handler.chunksize, 1000)
         self.assertEqual(handler.multi_threshold, 10000)
+
+
+class TestS3TransferHandler(unittest.TestCase):
+    def setUp(self):
+        self.result_queue = queue.Queue()
+        self.result_recorder = ResultRecorder()
+        self.processed_results = []
+        self.result_processor = ResultProcessor(
+            self.result_queue,
+            [self.result_recorder, self.processed_results.append]
+        )
+
+        self.transfer_manager = mock.Mock(spec=TransferManager)
+        self.transfer_manager.__enter__ = mock.Mock()
+        self.transfer_manager.__exit__ = mock.Mock()
+        self.parameters = {}
+        self.s3_transfer_handler = S3TransferHandler(
+            self.transfer_manager, self.parameters, self.result_queue,
+            self.result_recorder, self.result_processor
+        )
+
+    def test_call_return_command_result(self):
+        num_failures = 5
+        num_warnings = 3
+        self.result_recorder.files_failed = num_failures
+        self.result_recorder.files_warned = num_warnings
+        command_result = self.s3_transfer_handler.call([])
+        self.assertEqual(command_result, (num_failures, num_warnings))
+
+    def test_enqueue_uploads(self):
+        fileinfos = []
+        num_transfers = 5
+        for _ in range(num_transfers):
+            fileinfos.append(
+                FileInfo(src='filename', dest='bucket/key',
+                         operation_name='upload'))
+
+        self.s3_transfer_handler.call(fileinfos)
+        self.assertEqual(
+            self.transfer_manager.upload.call_count, num_transfers)
+
+    def test_enqueue_downloads(self):
+        fileinfos = []
+        num_transfers = 5
+        for _ in range(num_transfers):
+            fileinfos.append(
+                FileInfo(src='bucket/key', dest='filename',
+                         operation_name='download'))
+
+        self.s3_transfer_handler.call(fileinfos)
+        self.assertEqual(
+            self.transfer_manager.download.call_count, num_transfers)
+
+    def test_enqueue_copies(self):
+        fileinfos = []
+        num_transfers = 5
+        for _ in range(num_transfers):
+            fileinfos.append(
+                FileInfo(src='sourcebucket/sourcekey', dest='bucket/key',
+                         operation_name='copy'))
+
+        self.s3_transfer_handler.call(fileinfos)
+        self.assertEqual(
+            self.transfer_manager.copy.call_count, num_transfers)
+
+    def test_exception_when_enqueuing(self):
+        fileinfos = [
+            FileInfo(src='filename', dest='bucket/key',
+                     operation_name='upload')
+        ]
+        self.transfer_manager.__exit__.side_effect = Exception(
+            'some exception')
+        command_result = self.s3_transfer_handler.call(fileinfos)
+        # Exception should have been raised casing the command result to
+        # have failed results of one.
+        self.assertEqual(command_result, (1, 0))
 
 
 class BaseTransferRequestSubmitterTest(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -22,6 +22,7 @@ from awscli.customizations.s3.s3 import S3
 from awscli.customizations.s3.subcommands import CommandParameters, \
     CommandArchitecture, CpCommand, SyncCommand, ListCommand, \
     RbCommand, get_client
+from awscli.customizations.s3.transferconfig import RuntimeConfig
 from awscli.customizations.s3.syncstrategy.base import \
     SizeAndLastModifiedSync, NeverSync, MissingFileSync
 from awscli.testutils import unittest, BaseAWSHelpOutputTest, \
@@ -371,7 +372,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         self.parsed_responses = [{'Error': {
                                   'Code': 'BucketNotExists',
                                   'Message': 'Bucket does not exist'}}]
-        cmd_arc = CommandArchitecture(self.session, 'cp', params)
+        cmd_arc = CommandArchitecture(
+            self.session, 'cp', params, RuntimeConfig().build_config())
         cmd_arc.set_clients()
         cmd_arc.create_instructions()
         self.patch_make_request()


### PR DESCRIPTION
This is the last pull request in integrating s3transfer with ``cp`` and ``cp --recursive``.

All of the test pass with minimal changes to the existing test suite so that is good. If you want to know why a particular test may have changed, I would recommend checking out the commit. I tried to be detailed on why I changed particular tests.

While this PR is smaller than some of my previous PR's, this is probably a good one to start trying to address any design feedback or ideas of the complete port of cp and how it affects ports of future commands.

For example, two larger design questions that I would like some conversation on include:

* How to manage submitters? Should these be injected into a general S3Handler? Should they be built into the S3Handler and you create various S3Handler subclasses? Or should there be one S3TransferHandler class with all of the submitters built in (which I chose because it is simplest given what is currently supported)?

* Thoughts on introducing builders for the various components in the future? For example having an S3TransferHandler builder and maybe eventually a FileGenerator, Filter, etc builders so that not all of this logic is not under CommandArchitecture. I only do that right now because the builder abstraction is not really needed as there is not too many different parameters that needs to be taken into account, but there may be in the future (you can already see it sort of forming with the result printer).

Let me know what you think.

cc @jamesls @JordonPhillips 