### PR TITLE
Correct dir name in documentation about recursive copying to an S3 bucket

### DIFF
--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -65,7 +65,7 @@ this example, the directory ``myDir`` has the files ``test1.txt`` and ``test2.jp
 
 Output::
 
-    upload: myDir/test1.txt to s3://mybucket2/test1.txt
+    upload: myDir/test1.txt to s3://mybucket/test1.txt
 
 **Recursively copying S3 objects to another bucket**
 


### PR DESCRIPTION
I noticed this while reading the docs and, while it's entirely likely I'm wrong, it jumped out at me as a typo since I'm not sure how copying to `mybucket` would result in a file uploading to `mybucket2`. If this is unwarranted feel free to close the PR, but if not it could save someone else a couple minutes of confusion.