### PR TITLE
Add support for recording progress of unknown size

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -163,12 +163,8 @@ class ResultRecorder(BaseResultHandler):
         self.expected_bytes_transferred = 0
         self.expected_files_transferred = 0
 
-        # Keys: result from _get_progress_cache_key()
-        # Values: number of bytes that have been transferred for that key
-        self._progress_cache = defaultdict(int)
-        # Keys: result from _get_progress_cache_key()
-        # Values: number of bytes that is expected for the particular transfer
-        self._total_size_cache = {}
+        self._ongoing_progress = defaultdict(int)
+        self._ongoing_total_sizes = {}
 
         self._result_handler_map = {
             QueuedResult: self._record_queued_result,
@@ -184,18 +180,18 @@ class ResultRecorder(BaseResultHandler):
         self._result_handler_map.get(type(result), self._record_noop)(
             result=result)
 
-    def _get_cache_key(self, result):
+    def _get_ongoing_dict_key(self, result):
         if not isinstance(result, BaseResult):
             raise ValueError(
-                'Any result using _get_cache_key must subclass from '
+                'Any result using _get_ongoing_dict_key must subclass from '
                 'BaseResult. Provided result is of type: %s' % type(result)
             )
         return ':'.join([result.transfer_type, result.src, result.dest])
 
-    def _pop_result_from_caches(self, result):
-        cache_key = self._get_cache_key(result)
-        total_progress = self._progress_cache.pop(cache_key, 0)
-        total_file_size = self._total_size_cache.pop(cache_key, None)
+    def _pop_result_from_ongoing_dicts(self, result):
+        ongoing_key = self._get_ongoing_dict_key(result)
+        total_progress = self._ongoing_progress.pop(ongoing_key, 0)
+        total_file_size = self._ongoing_total_sizes.pop(ongoing_key, None)
         return total_progress, total_file_size
 
     def _record_noop(self, **kwargs):
@@ -204,8 +200,8 @@ class ResultRecorder(BaseResultHandler):
 
     def _record_queued_result(self, result, **kwargs):
         total_transfer_size = result.total_transfer_size
-        self._total_size_cache[
-            self._get_cache_key(result)] = total_transfer_size
+        self._ongoing_total_sizes[
+            self._get_ongoing_dict_key(result)] = total_transfer_size
         # The total transfer size can be None if we do not know the size
         # immediately so do not add to the total right away.
         if total_transfer_size:
@@ -215,28 +211,29 @@ class ResultRecorder(BaseResultHandler):
     def _record_progress_result(self, result, **kwargs):
         bytes_transferred = result.bytes_transferred
         self._account_for_updated_total_transfer_size_if_needed(result)
-        self._progress_cache[self._get_cache_key(result)] += bytes_transferred
+        self._ongoing_progress[
+            self._get_ongoing_dict_key(result)] += bytes_transferred
         self.bytes_transferred += bytes_transferred
 
     def _account_for_updated_total_transfer_size_if_needed(self, result):
         # This is a special case when the transfer size was previous not
         # known but was provided in a progress result.
-        cache_key = self._get_cache_key(result)
+        ongoing_key = self._get_ongoing_dict_key(result)
 
         # First, check if the total size is None, meaning its size is
         # currently unknown.
-        if self._total_size_cache[cache_key] is None:
+        if self._ongoing_total_sizes[ongoing_key] is None:
             total_transfer_size = result.total_transfer_size
             # If the total size is no longer None that means we just learned
             # of the size so let's update the appropriate places with this
             # knowledge
             if result.total_transfer_size is not None:
-                self._total_size_cache[cache_key] = total_transfer_size
+                self._ongoing_total_sizes[ongoing_key] = total_transfer_size
                 # Figure out how many bytes have been unaccounted for as
                 # the recorder has been keeping track of how many bytes
                 # it has seen so far and add it to the total expected amount.
-                unaccounted_bytes = total_transfer_size - self._progress_cache[
-                    cache_key]
+                ongoing_progress = self._ongoing_progress[ongoing_key]
+                unaccounted_bytes = total_transfer_size - ongoing_progress
                 self.expected_bytes_transferred += unaccounted_bytes
             # If we still do not know what the total transfer size is
             # just update the expected bytes with the know bytes transferred
@@ -245,14 +242,15 @@ class ResultRecorder(BaseResultHandler):
                 self.expected_bytes_transferred += result.bytes_transferred
 
     def _record_success_result(self, result, **kwargs):
-        self._pop_result_from_caches(result)
+        self._pop_result_from_ongoing_dicts(result)
         self.files_transferred += 1
 
     def _record_failure_result(self, result, **kwargs):
         # If there was a failure, we want to account for the failure in
         # the count for bytes transferred by just adding on the remaining bytes
         # that did not get transferred.
-        total_progress, total_file_size = self._pop_result_from_caches(result)
+        total_progress, total_file_size = self._pop_result_from_ongoing_dicts(
+            result)
         if total_file_size is not None:
             progress_left = total_file_size - total_progress
             self.bytes_failed_to_transfer += progress_left

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -210,12 +210,12 @@ class ResultRecorder(BaseResultHandler):
 
     def _record_progress_result(self, result, **kwargs):
         bytes_transferred = result.bytes_transferred
-        self._account_for_updated_total_transfer_size_if_needed(result)
+        self._update_ongoing_transfer_size_if_unknown(result)
         self._ongoing_progress[
             self._get_ongoing_dict_key(result)] += bytes_transferred
         self.bytes_transferred += bytes_transferred
 
-    def _account_for_updated_total_transfer_size_if_needed(self, result):
+    def _update_ongoing_transfer_size_if_unknown(self, result):
         # This is a special case when the transfer size was previous not
         # known but was provided in a progress result.
         ongoing_key = self._get_ongoing_dict_key(result)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -299,7 +299,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        bytes_transferred = 1024 * 1024  # 1MB
+        bytes_transferred = 1024 * 1024
         self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
@@ -322,7 +322,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        bytes_transferred = 1024 * 1024  # 1MB
+        bytes_transferred = 1024 * 1024
         self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
@@ -492,7 +492,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        bytes_transferred = 1024 * 1024  # 1MB
+        bytes_transferred = 1024 * 1024
         self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,


### PR DESCRIPTION
I started looking into integrating the upload and download stream implementations into the cp integration: https://github.com/aws/aws-cli/pull/2132 and I ran into this as something I need to do the integration. I would recommend looking at the referenced PR first as while this PR is isolated from the referenced PR changes, that one is more important.

This is specifically needed for streaming uploads where the size may not be known a head of time but may be provided at any point. Currently the assumption is made that the total transfer size is known and is not ``None``, which will cause errors in trying to do arithmetic operation on ``None`` type objects. While it is not necessarily needed for supporting streaming uploads because we do not print out progress, it is useful if we ever wanted this statistic for something else like for the sake of tracking transfer speeds later on.

cc @jamesls @JordonPhillips 