### PR TITLE
Integrate streaming with new S3TransferHandler architecture

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -19,8 +19,7 @@ from s3transfer.manager import TransferManager
 
 from awscli.customizations.s3.utils import (
     find_chunksize, human_readable_size,
-    adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
-    find_bucket_key, relative_path, PrintTask, create_warning,
+    MAX_UPLOAD_SIZE, find_bucket_key, relative_path, PrintTask, create_warning,
     NonSeekableStream)
 from awscli.customizations.s3.executor import Executor
 from awscli.customizations.s3 import tasks
@@ -44,7 +43,6 @@ from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideCopyContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideLastModifiedTimeSubscriber
 from awscli.customizations.s3.utils import DirectoryCreatorSubscriber
-from awscli.customizations.s3.utils import uni_print
 from awscli.compat import queue
 from awscli.compat import binary_stdin
 
@@ -393,138 +391,6 @@ class S3Handler(BaseS3Handler):
             session=self.session, filename=filename, parameters=self.params,
             result_queue=self.result_queue, upload_context=upload_context)
         self.executor.submit(complete_multipart_upload_task)
-
-
-class S3TransferStreamHandler(BaseS3Handler):
-    """
-    This class is an alternative ``S3Handler`` to be used when the operation
-    involves a stream since the logic is different when uploading and
-    downloading streams.
-    """
-    MAX_IN_MEMORY_CHUNKS = 6
-
-    def __init__(self, session, params, result_queue=None,
-                 runtime_config=None, manager=None):
-        super(S3TransferStreamHandler, self).__init__(
-            session, params, result_queue, runtime_config)
-        self.config = create_transfer_config_from_runtime_config(
-            self._runtime_config)
-
-        # Restrict the maximum chunks to 1 per thread.
-        self.config.max_in_memory_upload_chunks = \
-            self.MAX_IN_MEMORY_CHUNKS
-        self.config.max_in_memory_download_chunks = \
-            self.MAX_IN_MEMORY_CHUNKS
-
-        self._manager = manager
-
-    def call(self, files):
-        # There is only ever one file in a stream transfer.
-        file = files[0]
-        if self._manager is not None:
-            manager = self._manager
-        else:
-            manager = TransferManager(file.client, self.config)
-
-        if file.operation_name == 'upload':
-            bucket, key = find_bucket_key(file.dest)
-            return self._upload(manager, bucket, key)
-        elif file.operation_name == 'download':
-            bucket, key = find_bucket_key(file.src)
-            return self._download(manager, bucket, key)
-
-    def _download(self, manager, bucket, key):
-        """
-        Download the specified object and print it to stdout.
-
-        :type manager: s3transfer.manager.TransferManager
-        :param manager: The transfer manager to use for the download.
-
-        :type bucket: str
-        :param bucket: The bucket to download the object from.
-
-        :type key: str
-        :param key: The name of the key to download.
-
-        :return: A CommandResult representing the download status.
-        """
-        params = {}
-        # `download` performs the head_object as well, but the params are
-        # the same for both operations, so there's nothing missing here.
-        RequestParamsMapper.map_get_object_params(params, self.params)
-
-        with manager:
-            future = manager.download(
-                fileobj=StdoutBytesWriter(), bucket=bucket,
-                key=key, extra_args=params)
-
-            return self._process_transfer(future)
-
-    def _upload(self, manager, bucket, key):
-        """
-        Upload stdin using to the specified location.
-
-        :type manager: s3transfer.manager.TransferManager
-        :param manager: The transfer manager to use for the upload.
-
-        :type bucket: str
-        :param bucket: The bucket to upload the stream to.
-
-        :type key: str
-        :param key: The name of the key to upload the stream to.
-
-        :return: A CommandResult representing the upload status.
-        """
-        expected_size = self.params.get('expected_size', None)
-        subscribers = None
-        if expected_size is not None:
-            # `expected_size` comes in as a string
-            expected_size = int(expected_size)
-
-            # set the size of the transfer if we know it ahead of time.
-            subscribers = [ProvideSizeSubscriber(expected_size)]
-
-            # TODO: remove when this happens in s3transfer
-            # If we have the expected size, we can calculate an appropriate
-            # chunksize based on max parts and chunksize limits
-            chunksize = find_chunksize(
-                expected_size, self.config.multipart_chunksize)
-        else:
-            # TODO: remove when this happens in s3transfer
-            # Otherwise, we can still adjust for chunksize limits
-            chunksize = adjust_chunksize_to_upload_limits(
-                self.config.multipart_chunksize)
-        self.config.multipart_chunksize = chunksize
-
-        params = {}
-        RequestParamsMapper.map_put_object_params(params, self.params)
-
-        fileobj = NonSeekableStream(binary_stdin)
-        with manager:
-            future = manager.upload(
-                fileobj=fileobj, bucket=bucket,
-                key=key, extra_args=params, subscribers=subscribers)
-
-            return self._process_transfer(future)
-
-    def _process_transfer(self, future):
-        """
-        Execute and process a transfer future.
-
-        :type future: s3transfer.futures.TransferFuture
-        :param future: A future representing an S3 Transfer
-
-        :return: A CommandResult representing the transfer status.
-        """
-        try:
-            future.result()
-            return CommandResult(0, 0)
-        except Exception as e:
-            LOGGER.debug('Exception caught during task execution: %s',
-                         str(e), exc_info=True)
-            # TODO: Update when S3Handler is refactored
-            uni_print("Transfer failed: %s \n" % str(e))
-            return CommandResult(1, 0)
 
 
 class S3TransferHandlerFactory(object):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -28,7 +28,6 @@ from awscli.customizations.s3.filegenerator import FileGenerator
 from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
 from awscli.customizations.s3.filters import create_filter
 from awscli.customizations.s3.s3handler import S3Handler
-from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.utils import find_bucket_key, uni_print, \
     AppendFilter, find_dest_path_comp_key, human_readable_size, \
@@ -942,8 +941,6 @@ class CommandArchitecture(object):
         s3handler = S3Handler(self.session, self.parameters,
                               runtime_config=self._runtime_config,
                               result_queue=result_queue)
-        s3_stream_handler = S3TransferStreamHandler(
-            self.session, self.parameters, result_queue=result_queue)
 
         s3_transfer_handler = s3handler
         if self.cmd == 'cp' and not self.parameters.get('dryrun'):
@@ -965,7 +962,7 @@ class CommandArchitecture(object):
                             's3_handler': [s3handler]}
         elif self.cmd == 'cp' and self.parameters['is_stream']:
             command_dict = {'setup': [stream_file_info],
-                            's3_handler': [s3_stream_handler]}
+                            's3_handler': [s3_transfer_handler]}
         elif self.cmd == 'cp':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -502,13 +502,13 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
         binary_stdin = six.BytesIO(b'foo\n')
         location = "awscli.customizations.s3.s3handler.binary_stdin"
         with mock.patch(location, binary_stdin):
-            stdout, _, _ = self.run_cmd(command, expected_rc=1)
+            _, stderr, _ = self.run_cmd(command, expected_rc=1)
 
         error_message = (
-            'Transfer failed: An error occurred (NoSuchBucket) when calling '
+            'An error occurred (NoSuchBucket) when calling '
             'the PutObject operation: The specified bucket does not exist'
         )
-        self.assertIn(error_message, stdout)
+        self.assertIn(error_message, stderr)
 
     def test_streaming_download(self):
         command = "s3 cp s3://bucket/streaming.txt -"
@@ -552,9 +552,9 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
         }]
         self.http_response.status_code = 404
 
-        stdout, _, _ = self.run_cmd(command, expected_rc=1)
+        _, stderr, _ = self.run_cmd(command, expected_rc=1)
         error_message = (
-            'Transfer failed: An error occurred (NoSuchBucket) when calling '
+            'An error occurred (NoSuchBucket) when calling '
             'the HeadObject operation: The specified bucket does not exist'
         )
-        self.assertIn(error_message, stdout)
+        self.assertIn(error_message, stderr)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -16,15 +16,14 @@ import random
 import sys
 
 import mock
-from s3transfer.manager import TransferManager, TransferFuture
+from s3transfer.manager import TransferManager
 
 import awscli.customizations.s3.utils
-from awscli.testutils import unittest, capture_input
+from awscli.testutils import unittest
 from awscli import EnvironmentVariables
 from awscli.compat import six
 from awscli.compat import queue
 from awscli.customizations.s3.s3handler import S3Handler
-from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandler
 from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.s3handler import UploadRequestSubmitter
@@ -927,164 +926,6 @@ class S3HandlerTestBucket(S3HandlerBaseTest):
         ]
         self.assert_operations_for_s3_handler(s3_handler, [file_info],
                                               ref_calls)
-
-
-class TestS3TransferStreamHandler(S3HandlerBaseTest):
-    def setUp(self):
-        super(TestS3TransferStreamHandler, self).setUp()
-        self.params = {'is_stream': True, 'region': 'us-east-1'}
-        self.transfer_manager = mock.Mock(spec=TransferManager)
-        self.transfer_manager.__enter__ = mock.Mock()
-        self.transfer_manager.__exit__ = mock.Mock()
-        self.transfer_future = mock.Mock(spec=TransferFuture)
-        self.transfer_manager.upload.return_value = self.transfer_future
-        self.transfer_manager.download.return_value = self.transfer_future
-
-        # This gets reset in S3HandlerBaseTest
-        awscli.customizations.s3.utils.MIN_UPLOAD_CHUNKSIZE = 5 * (1024 ** 2)
-
-    def assert_chunk_size_in_range(self, size, maximum=None, minimum=None):
-        """
-        Asserts that a given chunksize is within the desired range, with the
-        default range being the allowable chunk size range for UploadPart.
-        """
-        if maximum is None:
-            maximum = awscli.customizations.s3.utils.MAX_SINGLE_UPLOAD_SIZE
-        if minimum is None:
-            minimum = awscli.customizations.s3.utils.MIN_UPLOAD_CHUNKSIZE
-
-        self.assertLessEqual(size, maximum)
-        self.assertGreaterEqual(size, minimum)
-
-    def test_upload_stream(self):
-        handler = S3TransferStreamHandler(
-            self.session, self.params, manager=self.transfer_manager)
-        file = FileInfo('-', 'foo-bucket/bar.txt', is_stream=True,
-                        operation_name='upload')
-
-        with capture_input(b'foobar'):
-            response = handler.call([file])
-
-        self.assertEqual(response.num_tasks_failed, 0)
-        self.assertEqual(response.num_tasks_warned, 0)
-
-        upload_args = self.transfer_manager.upload.call_args[1]
-        self.assertEqual(upload_args['bucket'], 'foo-bucket')
-        self.assertEqual(upload_args['key'], 'bar.txt')
-
-    def test_upload_stream_with_expected_size(self):
-        expected_size = 6
-        self.params['expected_size'] = expected_size
-        handler = S3TransferStreamHandler(
-            self.session, self.params, manager=self.transfer_manager)
-        file = FileInfo('-', 'foo-bucket/bar.txt', is_stream=True,
-                        operation_name='upload')
-
-        with capture_input(b'foobar'):
-            handler.call([file])
-
-        # Assert that there is a subscriber.
-        call_args = self.transfer_manager.upload.call_args[1]
-        subscribers = call_args.get('subscribers', [])
-        self.assertTrue(len(subscribers) == 1)
-
-        # Make sure that subscriber is the right kind
-        subscriber = subscribers[0]
-        self.assertIsInstance(subscriber, ProvideSizeSubscriber)
-
-        # Validate that the size on the subscriber is the expected size
-        self.assertEqual(subscriber.size, expected_size)
-
-    def test_upload_modifies_chunksize_if_too_low(self):
-        config = runtime_config(multipart_chunksize=1)
-        handler = S3TransferStreamHandler(
-            self.session, self.params, runtime_config=config,
-            manager=self.transfer_manager)
-        file = FileInfo('-', 'foo-bucket/bar.txt', is_stream=True,
-                        operation_name='upload')
-
-        with capture_input(b'foobar'):
-            handler.call([file])
-
-        chunksize = handler.config.multipart_chunksize
-        self.assert_chunk_size_in_range(chunksize)
-
-    def test_upload_modifies_chunksize_if_too_high(self):
-        config = runtime_config(multipart_chunksize=6 * (1024 ** 3))
-        handler = S3TransferStreamHandler(
-            self.session, self.params, runtime_config=config,
-            manager=self.transfer_manager)
-        file = FileInfo('-', 'foo-bucket/bar.txt', is_stream=True,
-                        operation_name='upload')
-
-        with capture_input(b'foobar'):
-            handler.call([file])
-
-        chunksize = handler.config.multipart_chunksize
-        self.assert_chunk_size_in_range(chunksize)
-
-    def test_upload_modifies_chunksize_for_max_parts_if_size_known(self):
-        expected_size = 6 * (1024 ** 3)
-        max_parts = awscli.customizations.s3.utils.MAX_PARTS
-
-        # Set the chunksize to end up with way more than the max parts.
-        chunksize = int((expected_size / (max_parts * 2)) + 1)
-        self.params['expected_size'] = expected_size
-        config = runtime_config(multipart_chunksize=chunksize)
-        handler = S3TransferStreamHandler(
-            self.session, self.params, runtime_config=config,
-            manager=self.transfer_manager)
-        file = FileInfo('-', 'foo-bucket/bar.txt', is_stream=True,
-                        operation_name='upload')
-
-        with capture_input(b'foobar'):
-            handler.call([file])
-
-        # The chunksize should at least be large enough to fit within max parts
-        minimum_chunksize = int(expected_size / max_parts)
-        actual_chunksize = handler.config.multipart_chunksize
-        self.assert_chunk_size_in_range(
-            actual_chunksize, minimum=minimum_chunksize)
-
-    def test_upload_swallows_exceptions(self):
-        handler = S3TransferStreamHandler(
-            self.session, self.params, manager=self.transfer_manager)
-        file = FileInfo('-', 'foo-bucket/bar.txt', is_stream=True,
-                        operation_name='upload')
-
-        self.transfer_future.result.side_effect = Exception()
-
-        with capture_input(b'foobar'):
-            response = handler.call([file])
-
-        self.assertEqual(response.num_tasks_failed, 1)
-        self.assertEqual(response.num_tasks_warned, 0)
-
-    def test_download_stream(self):
-        handler = S3TransferStreamHandler(
-            self.session, self.params, manager=self.transfer_manager)
-        file = FileInfo('foo-bucket/bar.txt', '-', is_stream=True,
-                        operation_name='download')
-
-        response = handler.call([file])
-        self.assertEqual(response.num_tasks_failed, 0)
-        self.assertEqual(response.num_tasks_warned, 0)
-
-        download_args = self.transfer_manager.download.call_args[1]
-        self.assertEqual(download_args['bucket'], 'foo-bucket')
-        self.assertEqual(download_args['key'], 'bar.txt')
-
-    def test_download_swallows_exceptions(self):
-        handler = S3TransferStreamHandler(
-            self.session, self.params, manager=self.transfer_manager)
-        file = FileInfo('foo-bucket/bar.txt', '-', is_stream=True,
-                        operation_name='download')
-
-        self.transfer_future.result.side_effect = Exception()
-
-        response = handler.call([file])
-        self.assertEqual(response.num_tasks_failed, 1)
-        self.assertEqual(response.num_tasks_warned, 0)
 
 
 class TestS3HandlerInitialization(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -30,17 +30,23 @@ from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.s3handler import UploadRequestSubmitter
 from awscli.customizations.s3.s3handler import DownloadRequestSubmitter
 from awscli.customizations.s3.s3handler import CopyRequestSubmitter
+from awscli.customizations.s3.s3handler import UploadStreamRequestSubmitter
+from awscli.customizations.s3.s3handler import DownloadStreamRequestSubmitter
 from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.tasks import CreateMultipartUploadTask, \
     UploadPartTask, CreateLocalFileTask, CompleteMultipartUploadTask
 from awscli.customizations.s3.results import UploadResultSubscriber
 from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
+from awscli.customizations.s3.results import UploadStreamResultSubscriber
+from awscli.customizations.s3.results import DownloadStreamResultSubscriber
 from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
 from awscli.customizations.s3.utils import StablePriorityQueue
+from awscli.customizations.s3.utils import NonSeekableStream
+from awscli.customizations.s3.utils import StdoutBytesWriter
 from awscli.customizations.s3.utils import WarningResult
 from awscli.customizations.s3.utils import ProvideSizeSubscriber
 from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
@@ -1208,6 +1214,26 @@ class TestS3TransferHandler(unittest.TestCase):
         # have failed results of one.
         self.assertEqual(command_result, (1, 0))
 
+    def test_enqueue_upload_stream(self):
+        self.parameters['is_stream'] = True
+        self.s3_transfer_handler.call(
+            [FileInfo(src='-', dest='bucket/key', operation_name='upload')])
+        self.assertEqual(
+            self.transfer_manager.upload.call_count, 1)
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+        self.assertIsInstance(
+            upload_call_kwargs['fileobj'], NonSeekableStream)
+
+    def test_enqueue_dowload_stream(self):
+        self.parameters['is_stream'] = True
+        self.s3_transfer_handler.call(
+            [FileInfo(src='bucket/key', dest='-', operation_name='download')])
+        self.assertEqual(
+            self.transfer_manager.download.call_count, 1)
+        download_call_kwargs = self.transfer_manager.download.call_args[1]
+        self.assertIsInstance(
+            download_call_kwargs['fileobj'], StdoutBytesWriter)
+
 
 class BaseTransferRequestSubmitterTest(unittest.TestCase):
     def setUp(self):
@@ -1614,6 +1640,102 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.assertTrue(self.result_queue.empty())
         # But the transfer still should have been skipped.
         self.assertEqual(len(self.transfer_manager.copy.call_args_list), 0)
+
+
+class TestUploadStreamRequestSubmitter(BaseTransferRequestSubmitterTest):
+    def setUp(self):
+        super(TestUploadStreamRequestSubmitter, self).setUp()
+        self.filename = '-'
+        self.cli_params['is_stream'] = True
+        self.transfer_request_submitter = UploadStreamRequestSubmitter(
+            self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_can_submit(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key,
+            operation_name='upload')
+        self.assertTrue(
+            self.transfer_request_submitter.can_submit(fileinfo))
+        self.cli_params['is_stream'] = False
+        self.assertFalse(
+            self.transfer_request_submitter.can_submit(fileinfo))
+
+    def test_submit(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key)
+        self.transfer_request_submitter.submit(fileinfo)
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+        self.assertIsInstance(
+            upload_call_kwargs['fileobj'], NonSeekableStream)
+        self.assertEqual(upload_call_kwargs['bucket'], self.bucket)
+        self.assertEqual(upload_call_kwargs['key'], self.key)
+        self.assertEqual(upload_call_kwargs['extra_args'], {})
+
+        ref_subscribers = [
+            UploadStreamResultSubscriber
+        ]
+        actual_subscribers = upload_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_submit_with_expected_size_provided(self):
+        provided_size = 100
+        self.cli_params['expected_size'] = provided_size
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key)
+        self.transfer_request_submitter.submit(fileinfo)
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+
+        ref_subscribers = [
+            ProvideSizeSubscriber,
+            UploadStreamResultSubscriber
+        ]
+        actual_subscribers = upload_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+        # The ProvideSizeSubscriber should be providing the correct size
+        self.assertEqual(actual_subscribers[0].size, provided_size)
+
+
+class TestDownloadStreamRequestSubmitter(BaseTransferRequestSubmitterTest):
+    def setUp(self):
+        super(TestDownloadStreamRequestSubmitter, self).setUp()
+        self.filename = '-'
+        self.cli_params['is_stream'] = True
+        self.transfer_request_submitter = DownloadStreamRequestSubmitter(
+            self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_can_submit(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download')
+        self.assertTrue(
+            self.transfer_request_submitter.can_submit(fileinfo))
+        self.cli_params['is_stream'] = False
+        self.assertFalse(
+            self.transfer_request_submitter.can_submit(fileinfo))
+
+    def test_submit(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename)
+        self.transfer_request_submitter.submit(fileinfo)
+
+        download_call_kwargs = self.transfer_manager.download.call_args[1]
+        self.assertIsInstance(
+            download_call_kwargs['fileobj'], StdoutBytesWriter)
+        self.assertEqual(download_call_kwargs['bucket'], self.bucket)
+        self.assertEqual(download_call_kwargs['key'], self.key)
+        self.assertEqual(download_call_kwargs['extra_args'], {})
+
+        ref_subscribers = [
+            DownloadStreamResultSubscriber
+        ]
+        actual_subscribers = download_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now that the architecture for cp is all put in place, I am starting to move functionality over to the new architecture. In this PR, I moved all of the functionality for uploading from and downloading to a stream to the new ``S3TransferHandler`` and removed code that was no longer needed.

Note that I am now making the assumption that ``s3transfer`` will now handle adjusting chunksize for the proper amount of parts.

Also I found a bug where we were printing streaming errors to stdout instead of stderr. Moving over to the new architecture fixed that and I updated the functional tests appropriately because they were asserting for the wrong behavior as well.

cc @jamesls @JordonPhillips 