### PR TITLE
Integrate sync with s3transfer

### DIFF
--- a/.changes/next-release/feature-s3-61915.json
+++ b/.changes/next-release/feature-s3-61915.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "feature", 
+  "description": "Integrate sync command with s3transfer"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1013,7 +1013,7 @@ class CommandArchitecture(object):
                               result_queue=result_queue)
 
         s3_transfer_handler = s3handler
-        if self.cmd in ['cp', 'rm']:
+        if self.cmd in ['cp', 'rm', 'sync']:
             s3_transfer_handler = S3TransferHandlerFactory(
                 self.parameters, self._runtime_config)(
                     self._client, result_queue)
@@ -1029,7 +1029,7 @@ class CommandArchitecture(object):
                                         create_filter(self.parameters)],
                             'comparator': [Comparator(**sync_strategies)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3handler]}
+                            's3_handler': [s3_transfer_handler]}
         elif self.cmd == 'cp' and self.parameters['is_stream']:
             command_dict = {'setup': [stream_file_info],
                             's3_handler': [s3_transfer_handler]}

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -524,7 +524,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                 {"Key": "text1.txt", "Size": 100,
                  "LastModified": "2014-01-09T20:45:49.000Z"}]},
             {"CommonPrefixes": [], "Contents": []}]
-        cmd_arc = CommandArchitecture(self.session, 'sync', params)
+        config = RuntimeConfig().build_config()
+        cmd_arc = CommandArchitecture(self.session, 'sync', params, config)
         cmd_arc.create_instructions()
         cmd_arc.set_clients()
         self.patch_make_request()


### PR DESCRIPTION
So there is actually not much happening in this PR other than flipping sync to use the new architecture. Most of the code being added is actually from this PR: https://github.com/aws/aws-cli/pull/2147.

So I was actually surprised that had to make this little of a change to get this to work because I do not at all take into account source clients when I do sync across buckets of different regions with a ``--delete``. This is because we have auto-redirection now by default in botocore for sigv4. The question now becomes is the auto-redirection good enough to handle that use case? Also is there any other edge cases that I miss by not providing a source client for deletes. The only other edge case I could think of is kms, but for deletes of kms sigv4 is not needed.

The only reason I did not add support for providing support for a source client is that client's are attached to their TransferManager. There is currently no way to swap the two out. I thought about what I would do and these were the two best options I can think of:

1) Add ``future.meta.provide_client()`` to allow you to provide a different client for a particular transfer
2) Use two different transfer managers: one for the regular client and one for the source. Note I do not think that one is a good idea because we may be having separate executor thread pools which could break our configuration contract.

Option 1 or something along the lines of option 1 is the most realistic option. Option 2 is not really realistic at all.

Let me know what you think. Given that we cache the region at the client level and the integration test pass, I am fine with relying on redirection as opposed to having to add a new abstraction.

cc @jamesls @JordonPhillips 