### PR TITLE
Integrate s3transfer with cp and rm

### DIFF
--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -261,23 +261,9 @@ class FileInfo(TaskInfo):
             return
         filename = self.src
         # Add a content type param if we can guess the type.
-        try:
-            guessed_type = guess_content_type(filename)
-            if guessed_type is not None:
-                params['ContentType'] = guessed_type
-        # This catches a bug in the mimetype libary where some MIME types
-        # specifically on windows machines cause a UnicodeDecodeError
-        # because the MIME type in the Windows registery has an encoding
-        # that cannot be properly encoded using the default system encoding.
-        # https://bugs.python.org/issue9291
-        #
-        # So instead of hard failing, just log the issue and fall back to the
-        # default guessed content type of None.
-        except UnicodeDecodeError:
-            LOGGER.debug(
-                'Unable to guess content type for %s due to '
-                'UnicodeDecodeError: ', filename, exc_info=True
-            )
+        guessed_type = guess_content_type(filename)
+        if guessed_type is not None:
+            params['ContentType'] = guessed_type
 
     def download(self):
         """

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -8,16 +8,12 @@ import hashlib
 
 from botocore.compat import MD5_AVAILABLE
 from awscli.customizations.s3.utils import (
-    find_bucket_key, guess_content_type, MD5Error, bytes_print, set_file_utime,
-    RequestParamsMapper)
+    find_bucket_key, guess_content_type, CreateDirectoryError, MD5Error,
+    bytes_print, set_file_utime, RequestParamsMapper)
 from awscli.compat import bytes_print
 
 
 LOGGER = logging.getLogger(__name__)
-
-
-class CreateDirectoryError(Exception):
-    pass
 
 
 def read_file(filename):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -81,12 +81,12 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
             self.TRANSFER_TYPE, src, dest, bytes_transferred, future.meta.size)
         self._result_queue.put(progress_result)
 
-    def on_success(self, future):
+    def _on_success(self, future):
         src, dest = self._get_src_dest(future)
         self._result_queue.put(
             SuccessResult(self.TRANSFER_TYPE, src, dest))
 
-    def on_failure(self, future, e):
+    def _on_failure(self, future, e):
         src, dest = self._get_src_dest(future)
         self._result_queue.put(
             FailureResult(self.TRANSFER_TYPE, src, dest, e))

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -22,20 +22,21 @@ from awscli.customizations.s3.utils import WarningResult
 LOGGER = logging.getLogger(__name__)
 
 
-def _create_new_result_cls(name, extra_fields=None):
+BaseResult = namedtuple('BaseResult', ['transfer_type', 'src', 'dest'])
+
+
+def _create_new_result_cls(name, extra_fields=None, base_cls=BaseResult):
     # Creates a new namedtuple class that subclasses from BaseResult for the
     # benefit of filtering by type and ensuring particular base attrs.
 
     # NOTE: _fields is a public attribute that has an underscore to avoid
     # naming collisions for namedtuples:
     # https://docs.python.org/2/library/collections.html#collections.somenamedtuple._fields
-    fields = list(BaseResult._fields)
+    fields = list(base_cls._fields)
     if extra_fields:
         fields += extra_fields
-    return type(name, (namedtuple(name, fields), BaseResult), {})
+    return type(name, (namedtuple(name, fields), base_cls), {})
 
-
-BaseResult = namedtuple('BaseResult', ['transfer_type', 'src', 'dest'])
 
 QueuedResult = _create_new_result_cls('QueuedResult', ['total_transfer_size'])
 

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -245,6 +245,8 @@ class ResultPrinter(BaseResultHandler):
     FAILURE_FORMAT = (
         '{transfer_type} failed: {src} to {dest} {exception}'
     )
+    # TODO: Add "warning: " prefix once all commands are converted to using
+    # result printer and remove "warning: " prefix from ``create_warning``.
     WARNING_FORMAT = (
         '{message}'
     )

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -465,7 +465,6 @@ class ResultProcessor(threading.Thread):
                         'Shutdown request received in result processing '
                         'thread, shutting down result thread.')
                     break
-                LOGGER.debug('Received result: %s', result)
                 self._process_result(result)
             except queue.Empty:
                 pass
@@ -473,7 +472,6 @@ class ResultProcessor(threading.Thread):
     def _process_result(self, result):
         for result_handler in self._result_handlers:
             try:
-                LOGGER.debug('Processing %s with %s', result, result_handler)
                 result_handler(result)
             except Exception as e:
                 LOGGER.debug(

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -163,12 +163,8 @@ class ResultRecorder(BaseResultHandler):
         self.expected_bytes_transferred = 0
         self.expected_files_transferred = 0
 
-        # Keys: result from _get_progress_cache_key()
-        # Values: number of bytes that have been transferred for that key
-        self._progress_cache = defaultdict(int)
-        # Keys: result from _get_progress_cache_key()
-        # Values: number of bytes that is expected for the particular transfer
-        self._total_size_cache = {}
+        self._ongoing_progress = defaultdict(int)
+        self._ongoing_total_sizes = {}
 
         self._result_handler_map = {
             QueuedResult: self._record_queued_result,
@@ -184,18 +180,18 @@ class ResultRecorder(BaseResultHandler):
         self._result_handler_map.get(type(result), self._record_noop)(
             result=result)
 
-    def _get_cache_key(self, result):
+    def _get_ongoing_dict_key(self, result):
         if not isinstance(result, BaseResult):
             raise ValueError(
-                'Any result using _get_cache_key must subclass from '
+                'Any result using _get_ongoing_dict_key must subclass from '
                 'BaseResult. Provided result is of type: %s' % type(result)
             )
         return ':'.join([result.transfer_type, result.src, result.dest])
 
-    def _pop_result_from_caches(self, result):
-        cache_key = self._get_cache_key(result)
-        total_progress = self._progress_cache.pop(cache_key, 0)
-        total_file_size = self._total_size_cache.pop(cache_key, None)
+    def _pop_result_from_ongoing_dicts(self, result):
+        ongoing_key = self._get_ongoing_dict_key(result)
+        total_progress = self._ongoing_progress.pop(ongoing_key, 0)
+        total_file_size = self._ongoing_total_sizes.pop(ongoing_key, None)
         return total_progress, total_file_size
 
     def _record_noop(self, **kwargs):
@@ -204,8 +200,8 @@ class ResultRecorder(BaseResultHandler):
 
     def _record_queued_result(self, result, **kwargs):
         total_transfer_size = result.total_transfer_size
-        self._total_size_cache[
-            self._get_cache_key(result)] = total_transfer_size
+        self._ongoing_total_sizes[
+            self._get_ongoing_dict_key(result)] = total_transfer_size
         # The total transfer size can be None if we do not know the size
         # immediately so do not add to the total right away.
         if total_transfer_size:
@@ -215,28 +211,29 @@ class ResultRecorder(BaseResultHandler):
     def _record_progress_result(self, result, **kwargs):
         bytes_transferred = result.bytes_transferred
         self._account_for_updated_total_transfer_size_if_needed(result)
-        self._progress_cache[self._get_cache_key(result)] += bytes_transferred
+        self._ongoing_progress[
+            self._get_ongoing_dict_key(result)] += bytes_transferred
         self.bytes_transferred += bytes_transferred
 
     def _account_for_updated_total_transfer_size_if_needed(self, result):
         # This is a special case when the transfer size was previous not
         # known but was provided in a progress result.
-        cache_key = self._get_cache_key(result)
+        ongoing_key = self._get_ongoing_dict_key(result)
 
         # First, check if the total size is None, meaning its size is
         # currently unknown.
-        if self._total_size_cache[cache_key] is None:
+        if self._ongoing_total_sizes[ongoing_key] is None:
             total_transfer_size = result.total_transfer_size
             # If the total size is no longer None that means we just learned
             # of the size so let's update the appropriate places with this
             # knowledge
             if result.total_transfer_size is not None:
-                self._total_size_cache[cache_key] = total_transfer_size
+                self._ongoing_total_sizes[ongoing_key] = total_transfer_size
                 # Figure out how many bytes have been unaccounted for as
                 # the recorder has been keeping track of how many bytes
                 # it has seen so far and add it to the total expected amount.
-                unaccounted_bytes = total_transfer_size - self._progress_cache[
-                    cache_key]
+                ongoing_progress = self._ongoing_progress[ongoing_key]
+                unaccounted_bytes = total_transfer_size - ongoing_progress
                 self.expected_bytes_transferred += unaccounted_bytes
             # If we still do not know what the total transfer size is
             # just update the expected bytes with the know bytes transferred
@@ -245,14 +242,15 @@ class ResultRecorder(BaseResultHandler):
                 self.expected_bytes_transferred += result.bytes_transferred
 
     def _record_success_result(self, result, **kwargs):
-        self._pop_result_from_caches(result)
+        self._pop_result_from_ongoing_dicts(result)
         self.files_transferred += 1
 
     def _record_failure_result(self, result, **kwargs):
         # If there was a failure, we want to account for the failure in
         # the count for bytes transferred by just adding on the remaining bytes
         # that did not get transferred.
-        total_progress, total_file_size = self._pop_result_from_caches(result)
+        total_progress, total_file_size = self._pop_result_from_ongoing_dicts(
+            result)
         if total_file_size is not None:
             progress_left = total_file_size - total_progress
             self.bytes_failed_to_transfer += progress_left

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -23,6 +23,7 @@ from awscli.customizations.s3.utils import relative_path
 from awscli.customizations.s3.utils import human_readable_size
 from awscli.customizations.s3.utils import uni_print
 from awscli.customizations.s3.utils import WarningResult
+from awscli.customizations.s3.utils import OnDoneFilteredSubscriber
 
 
 LOGGER = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ CommandResult = namedtuple(
     'CommandResult', ['num_tasks_failed', 'num_tasks_warned'])
 
 
-class BaseResultSubscriber(BaseSubscriber):
+class BaseResultSubscriber(OnDoneFilteredSubscriber):
     TRANSFER_TYPE = None
 
     def __init__(self, result_queue):
@@ -80,15 +81,15 @@ class BaseResultSubscriber(BaseSubscriber):
             self.TRANSFER_TYPE, src, dest, bytes_transferred, future.meta.size)
         self._result_queue.put(progress_result)
 
-    def on_done(self, future, **kwargs):
+    def on_success(self, future):
         src, dest = self._get_src_dest(future)
-        try:
-            future.result()
-            self._result_queue.put(
-                SuccessResult(self.TRANSFER_TYPE, src, dest))
-        except Exception as e:
-            self._result_queue.put(
-                FailureResult(self.TRANSFER_TYPE, src, dest, e))
+        self._result_queue.put(
+            SuccessResult(self.TRANSFER_TYPE, src, dest))
+
+    def on_failure(self, future, e):
+        src, dest = self._get_src_dest(future)
+        self._result_queue.put(
+            FailureResult(self.TRANSFER_TYPE, src, dest, e))
 
     def _get_src_dest(self, future):
         raise NotImplementedError('_get_src_dest()')

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -141,7 +141,13 @@ class CopyResultSubscriber(BaseResultSubscriber):
         return src, dest
 
 
-class ResultRecorder(object):
+class BaseResultHandler(object):
+    """Base handler class to be called in the ResultProcessor"""
+    def __call__(self, result):
+        raise NotImplementedError('__call__()')
+
+
+class ResultRecorder(BaseResultHandler):
     """Records and track transfer statistics based on results receieved"""
     def __init__(self):
         self.bytes_transferred = 0
@@ -164,7 +170,7 @@ class ResultRecorder(object):
             WarningResult: self._record_warning_result,
         }
 
-    def record_result(self, result):
+    def __call__(self, result):
         """Record the result of an individual Result object"""
         self._result_handler_map.get(type(result), self._record_noop)(
             result=result)
@@ -220,7 +226,7 @@ class ResultRecorder(object):
         self.files_warned += 1
 
 
-class ResultPrinter(object):
+class ResultPrinter(BaseResultHandler):
     PROGRESS_FORMAT = (
         'Completed {bytes_completed}/{expected_bytes_completed} with '
         '{remaining_files} file(s) remaining.'
@@ -263,7 +269,7 @@ class ResultPrinter(object):
             WarningResult: self._print_warning,
         }
 
-    def print_result(self, result):
+    def __call__(self, result):
         """Print the progress of the ongoing transfer based on a result"""
         self._result_handler_map.get(type(result), self._print_noop)(
             result=result)

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 from collections import defaultdict
 
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import FatalError
 from s3transfer.subscribers import BaseSubscriber
 
 from awscli.compat import queue
@@ -95,9 +96,9 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
     def _on_failure(self, future, e):
         result_kwargs = self._on_done_pop_from_result_kwargs_cache(future)
         if isinstance(e, CancelledError):
-            error_result_cls = ErrorResult
-            if 'KeyboardInterrupt' in str(e):
-                error_result_cls = CntrlCResult
+            error_result_cls = CntrlCResult
+            if isinstance(e, FatalError):
+                error_result_cls = ErrorResult
             self._result_queue.put(error_result_cls(exception=e))
         else:
             self._result_queue.put(FailureResult(exception=e, **result_kwargs))

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -74,7 +74,7 @@ class BaseResultSubscriber(BaseSubscriber):
                 FailureResult(self.TRANSFER_TYPE, src, dest, e))
 
     def _get_src_dest(self, future):
-        raise NotImplementedError('must implement _get_src_dest()')
+        raise NotImplementedError('_get_src_dest()')
 
 
 class UploadResultSubscriber(BaseResultSubscriber):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -198,7 +198,7 @@ class ResultRecorder(BaseResultHandler):
         self.errors = 0
         self.expected_bytes_transferred = 0
         self.expected_files_transferred = 0
-        self._final_expected_files_transferred = None
+        self.final_expected_files_transferred = None
 
         self._ongoing_progress = defaultdict(int)
         self._ongoing_total_sizes = {}
@@ -215,7 +215,7 @@ class ResultRecorder(BaseResultHandler):
 
     def expected_totals_are_final(self):
         return (
-            self._final_expected_files_transferred ==
+            self.final_expected_files_transferred ==
             self.expected_files_transferred
         )
 
@@ -310,7 +310,7 @@ class ResultRecorder(BaseResultHandler):
         self.errors += 1
 
     def _record_final_expected_files(self, result, **kwargs):
-        self._final_expected_files_transferred = result.total_submissions
+        self.final_expected_files_transferred = result.total_submissions
 
 
 class ResultPrinter(BaseResultHandler):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -220,7 +220,7 @@ class ResultRecorder(object):
 class ResultPrinter(object):
     PROGRESS_FORMAT = (
         'Completed {bytes_completed}/{expected_bytes_completed} with '
-        '{remaining_files} files remaining.'
+        '{remaining_files} file(s) remaining.'
     )
     SUCCESS_FORMAT = (
         '{transfer_type}: {src} to {dest}'

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -195,10 +195,8 @@ class ResultRecorder(BaseResultHandler):
                 'Any result using _get_ongoing_dict_key must subclass from '
                 'BaseResult. Provided result is of type: %s' % type(result)
             )
-        key_components = [result.transfer_type, result.src]
-        if result.dest is not None:
-            key_components.append(result.dest)
-        return ':'.join(key_components)
+        return ':'.join(
+            str(el) for el in [result.transfer_type, result.src, result.dest])
 
     def _pop_result_from_ongoing_dicts(self, result):
         ongoing_key = self._get_ongoing_dict_key(result)
@@ -283,10 +281,10 @@ class ResultPrinter(BaseResultHandler):
         '{remaining_files} file(s) remaining.'
     )
     SUCCESS_FORMAT = (
-        '{transfer_type}: {direction}'
+        '{transfer_type}: {transfer_location}'
     )
     FAILURE_FORMAT = (
-        '{transfer_type} failed: {direction} {exception}'
+        '{transfer_type} failed: {transfer_location} {exception}'
     )
     # TODO: Add "warning: " prefix once all commands are converted to using
     # result printer and remove "warning: " prefix from ``create_warning``.
@@ -297,8 +295,8 @@ class ResultPrinter(BaseResultHandler):
         '{exception}'
     )
 
-    TWO_WAY_DIRECTION_FORMAT = '{src} to {dest}'
-    ONE_WAY_DIRECTION_FORMAT = '{src}'
+    SRC_DEST_TRANSFER_LOCATION_FORMAT = '{src} to {dest}'
+    SRC_TRANSFER_LOCATION_FORMAT = '{src}'
 
     def __init__(self, result_recorder, out_file=None, error_file=None):
         """Prints status of ongoing transfer
@@ -342,7 +340,7 @@ class ResultPrinter(BaseResultHandler):
     def _print_success(self, result, **kwargs):
         success_statement = self.SUCCESS_FORMAT.format(
             transfer_type=result.transfer_type,
-            direction=self._get_direction(result)
+            transfer_location=self._get_transfer_location(result)
         )
         success_statement = self._adjust_statement_padding(success_statement)
         self._print_to_out_file(success_statement)
@@ -351,7 +349,7 @@ class ResultPrinter(BaseResultHandler):
     def _print_failure(self, result, **kwargs):
         failure_statement = self.FAILURE_FORMAT.format(
             transfer_type=result.transfer_type,
-            direction=self._get_direction(result),
+            transfer_location=self._get_transfer_location(result),
             exception=result.exception
         )
         failure_statement = self._adjust_statement_padding(failure_statement)
@@ -369,10 +367,10 @@ class ResultPrinter(BaseResultHandler):
         error_statement = self._adjust_statement_padding(error_statement)
         self._print_to_error_file(error_statement)
 
-    def _get_direction(self, result):
+    def _get_transfer_location(self, result):
         if result.dest is None:
-            return self.ONE_WAY_DIRECTION_FORMAT.format(src=result.src)
-        return self.TWO_WAY_DIRECTION_FORMAT.format(
+            return self.SRC_TRANSFER_LOCATION_FORMAT.format(src=result.src)
+        return self.SRC_DEST_TRANSFER_LOCATION_FORMAT.format(
             src=result.src, dest=result.dest)
 
     def _redisplay_progress(self):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -59,7 +59,7 @@ FailureResult = _create_new_result_cls('FailureResult', ['exception'])
 
 ErrorResult = namedtuple('ErrorResult', ['exception'])
 
-CntrlCResult = _create_new_result_cls('CntrlCResult', base_cls=ErrorResult)
+CtrlCResult = _create_new_result_cls('CtrlCResult', base_cls=ErrorResult)
 
 CommandResult = namedtuple(
     'CommandResult', ['num_tasks_failed', 'num_tasks_warned'])
@@ -96,7 +96,7 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
     def _on_failure(self, future, e):
         result_kwargs = self._on_done_pop_from_result_kwargs_cache(future)
         if isinstance(e, CancelledError):
-            error_result_cls = CntrlCResult
+            error_result_cls = CtrlCResult
             if isinstance(e, FatalError):
                 error_result_cls = ErrorResult
             self._result_queue.put(error_result_cls(exception=e))
@@ -322,7 +322,7 @@ class ResultPrinter(BaseResultHandler):
     ERROR_FORMAT = (
         'fatal error: {exception}'
     )
-    CNTRL_C_MSG = 'cancelled: ctrl-c received'
+    CTRL_C_MSG = 'cancelled: ctrl-c received'
 
     SRC_DEST_TRANSFER_LOCATION_FORMAT = '{src} to {dest}'
     SRC_TRANSFER_LOCATION_FORMAT = '{src}'
@@ -355,7 +355,7 @@ class ResultPrinter(BaseResultHandler):
             FailureResult: self._print_failure,
             WarningResult: self._print_warning,
             ErrorResult: self._print_error,
-            CntrlCResult: self._print_cntrl_c,
+            CtrlCResult: self._print_ctrl_c,
         }
 
     def __call__(self, result):
@@ -396,8 +396,8 @@ class ResultPrinter(BaseResultHandler):
         self._flush_error_statement(
             self.ERROR_FORMAT.format(exception=result.exception))
 
-    def _print_cntrl_c(self, result, **kwargs):
-        self._flush_error_statement(self.CNTRL_C_MSG)
+    def _print_ctrl_c(self, result, **kwargs):
+        self._flush_error_statement(self.CTRL_C_MSG)
 
     def _flush_error_statement(self, error_statement):
         error_statement = self._adjust_statement_padding(error_statement)

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -242,26 +242,27 @@ class ResultPrinter(BaseResultHandler):
         'warning: {message}'
     )
 
-    def __init__(self, result_recorder, out_file=sys.stdout,
-                 error_file=sys.stderr):
+    def __init__(self, result_recorder, out_file=None, error_file=None):
         """Prints status of ongoing transfer
 
         :type result_recorder: ResultRecorder
         :param result_recorder: The associated result recorder
 
-        :type only_show_errors: bool
-        :param only_show_errors: True if to only print out errors. Otherwise,
-            print out everything.
-
         :type out_file: file-like obj
-        :param out_file: Location to write progress and success statements
+        :param out_file: Location to write progress and success statements.
+            By default, the location is sys.stdout.
 
         :type error_file: file-like obj
-        :param error_file: Location to write warnings and errors
+        :param error_file: Location to write warnings and errors.
+            By default, the location is sys.stderr.
         """
         self._result_recorder = result_recorder
         self._out_file = out_file
+        if self._out_file is None:
+            self._out_file = sys.stdout
         self._error_file = error_file
+        if self._error_file is None:
+            self._error_file = sys.stderr
         self._progress_length = 0
         self._result_handler_map = {
             ProgressResult: self._print_progress,

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -49,7 +49,6 @@ class BaseResultSubscriber(BaseSubscriber):
             on.
         """
         self._result_queue = result_queue
-        self._transfer_type = None
 
     def on_queued(self, future, **kwargs):
         src, dest = self._get_src_dest(future)

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -1,0 +1,124 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+from collections import namedtuple
+
+from s3transfer.subscribers import BaseSubscriber
+
+from awscli.customizations.s3.utils import relative_path
+
+
+LOGGER = logging.getLogger(__name__)
+
+QueuedResult = namedtuple(
+    'QueuedResult',
+    ['transfer_type', 'src', 'dest', 'total_transfer_size']
+)
+ProgressResult = namedtuple(
+    'ProgressResult',
+    ['transfer_type', 'src', 'dest', 'bytes_transferred',
+     'total_transfer_size']
+)
+SuccessResult = namedtuple(
+    'SuccessResult', ['transfer_type', 'src', 'dest']
+)
+FailureResult = namedtuple(
+    'FailureResult', ['transfer_type', 'src', 'dest', 'exception']
+)
+CommandResult = namedtuple(
+    'CommandResult', ['num_tasks_failed', 'num_tasks_warned'])
+
+
+class BaseResultSubscriber(BaseSubscriber):
+    TRANSFER_TYPE = None
+
+    def __init__(self, result_queue):
+        """Subscriber to send result notifications during transfer process
+
+        :param result_queue: The queue to place results to be processed later
+            on.
+        """
+        self._result_queue = result_queue
+        self._transfer_type = None
+
+    def on_queued(self, future, **kwargs):
+        src, dest = self._get_src_dest(future)
+        queued_result = QueuedResult(
+            self.TRANSFER_TYPE, src, dest, future.meta.size)
+        self._result_queue.put(queued_result)
+
+    def on_progress(self, future, bytes_transferred, **kwargs):
+        src, dest = self._get_src_dest(future)
+        progress_result = ProgressResult(
+            self.TRANSFER_TYPE, src, dest, bytes_transferred, future.meta.size)
+        self._result_queue.put(progress_result)
+
+    def on_done(self, future, **kwargs):
+        src, dest = self._get_src_dest(future)
+        try:
+            future.result()
+            self._result_queue.put(
+                SuccessResult(self.TRANSFER_TYPE, src, dest))
+        except Exception as e:
+            self._result_queue.put(
+                FailureResult(self.TRANSFER_TYPE, src, dest, e))
+
+    def _get_src_dest(self, future):
+        raise NotImplementedError('must implement _get_src_dest()')
+
+
+class UploadResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'upload'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        src = self._get_src(call_args.fileobj)
+        dest = 's3://' + call_args.bucket + '/' + call_args.key
+        return src, dest
+
+    def _get_src(self, fileobj):
+        return relative_path(fileobj)
+
+
+class UploadStreamResultSubscriber(UploadResultSubscriber):
+    def _get_src(self, fileobj):
+        return '-'
+
+
+class DownloadResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'download'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        src = 's3://' + call_args.bucket + '/' + call_args.key
+        dest = self._get_dest(call_args.fileobj)
+        return src, dest
+
+    def _get_dest(self, fileobj):
+        return relative_path(fileobj)
+
+
+class DownloadStreamResultSubscriber(DownloadResultSubscriber):
+    def _get_dest(self, fileobj):
+        return '-'
+
+
+class CopyResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'copy'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        copy_source = call_args.copy_source
+        src = 's3://' + copy_source['Bucket'] + '/' + copy_source['Key']
+        dest = 's3://' + call_args.bucket + '/' + call_args.key
+        return src, dest

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -246,7 +246,7 @@ class ResultPrinter(BaseResultHandler):
         '{transfer_type} failed: {src} to {dest} {exception}'
     )
     WARNING_FORMAT = (
-        'warning: {message}'
+        '{message}'
     )
     ERROR_FORMAT = (
         '{exception}'

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -210,12 +210,12 @@ class ResultRecorder(BaseResultHandler):
 
     def _record_progress_result(self, result, **kwargs):
         bytes_transferred = result.bytes_transferred
-        self._account_for_updated_total_transfer_size_if_needed(result)
+        self._update_ongoing_transfer_size_if_unknown(result)
         self._ongoing_progress[
             self._get_ongoing_dict_key(result)] += bytes_transferred
         self.bytes_transferred += bytes_transferred
 
-    def _account_for_updated_total_transfer_size_if_needed(self, result):
+    def _update_ongoing_transfer_size_if_unknown(self, result):
         # This is a special case when the transfer size was previous not
         # known but was provided in a progress result.
         ongoing_key = self._get_ongoing_dict_key(result)

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -478,7 +478,7 @@ class CommandResultRecorder(object):
         :param result_processor: The result processor to process results
             placed on the queue
         """
-        self._result_queue = result_queue
+        self.result_queue = result_queue
         self._result_recorder = result_recorder
         self._result_processor = result_processor
 
@@ -486,7 +486,7 @@ class CommandResultRecorder(object):
         self._result_processor.start()
 
     def shutdown(self):
-        self._result_queue.put(ShutdownThreadRequest())
+        self.result_queue.put(ShutdownThreadRequest())
         self._result_processor.join()
 
     def get_command_result(self):
@@ -509,7 +509,7 @@ class CommandResultRecorder(object):
         if exc_type:
             LOGGER.debug('Exception caught during command execution: %s',
                          exc_value, exc_info=True)
-            self._result_queue.put(ErrorResult(exception=exc_value))
+            self.result_queue.put(ErrorResult(exception=exc_value))
             self.shutdown()
             return True
         self.shutdown()

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -145,6 +145,15 @@ class CopyResultSubscriber(BaseResultSubscriber):
         return src, dest
 
 
+class DeleteResultSubscriber(BaseResultSubscriber):
+    TRANSFER_TYPE = 'delete'
+
+    def _get_src_dest(self, future):
+        call_args = future.meta.call_args
+        src = 's3://' + call_args.bucket + '/' + call_args.key
+        return src, None
+
+
 class BaseResultHandler(object):
     """Base handler class to be called in the ResultProcessor"""
     def __call__(self, result):
@@ -186,7 +195,10 @@ class ResultRecorder(BaseResultHandler):
                 'Any result using _get_ongoing_dict_key must subclass from '
                 'BaseResult. Provided result is of type: %s' % type(result)
             )
-        return ':'.join([result.transfer_type, result.src, result.dest])
+        key_components = [result.transfer_type, result.src]
+        if result.dest is not None:
+            key_components.append(result.dest)
+        return ':'.join(key_components)
 
     def _pop_result_from_ongoing_dicts(self, result):
         ongoing_key = self._get_ongoing_dict_key(result)
@@ -271,10 +283,10 @@ class ResultPrinter(BaseResultHandler):
         '{remaining_files} file(s) remaining.'
     )
     SUCCESS_FORMAT = (
-        '{transfer_type}: {src} to {dest}'
+        '{transfer_type}: {direction}'
     )
     FAILURE_FORMAT = (
-        '{transfer_type} failed: {src} to {dest} {exception}'
+        '{transfer_type} failed: {direction} {exception}'
     )
     # TODO: Add "warning: " prefix once all commands are converted to using
     # result printer and remove "warning: " prefix from ``create_warning``.
@@ -284,6 +296,9 @@ class ResultPrinter(BaseResultHandler):
     ERROR_FORMAT = (
         '{exception}'
     )
+
+    TWO_WAY_DIRECTION_FORMAT = '{src} to {dest}'
+    ONE_WAY_DIRECTION_FORMAT = '{src}'
 
     def __init__(self, result_recorder, out_file=None, error_file=None):
         """Prints status of ongoing transfer
@@ -326,16 +341,19 @@ class ResultPrinter(BaseResultHandler):
 
     def _print_success(self, result, **kwargs):
         success_statement = self.SUCCESS_FORMAT.format(
-            transfer_type=result.transfer_type, src=result.src,
-            dest=result.dest)
+            transfer_type=result.transfer_type,
+            direction=self._get_direction(result)
+        )
         success_statement = self._adjust_statement_padding(success_statement)
         self._print_to_out_file(success_statement)
         self._redisplay_progress()
 
     def _print_failure(self, result, **kwargs):
         failure_statement = self.FAILURE_FORMAT.format(
-            transfer_type=result.transfer_type, src=result.src,
-            dest=result.dest, exception=result.exception)
+            transfer_type=result.transfer_type,
+            direction=self._get_direction(result),
+            exception=result.exception
+        )
         failure_statement = self._adjust_statement_padding(failure_statement)
         self._print_to_error_file(failure_statement)
         self._redisplay_progress()
@@ -350,6 +368,12 @@ class ResultPrinter(BaseResultHandler):
         error_statement = self.ERROR_FORMAT.format(exception=result.exception)
         error_statement = self._adjust_statement_padding(error_statement)
         self._print_to_error_file(error_statement)
+
+    def _get_direction(self, result):
+        if result.dest is None:
+            return self.ONE_WAY_DIRECTION_FORMAT.format(src=result.src)
+        return self.TWO_WAY_DIRECTION_FORMAT.format(
+            src=result.src, dest=result.dest)
 
     def _redisplay_progress(self):
         # Reset to zero because done statements are printed with new lines

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -19,7 +19,8 @@ import sys
 from s3transfer.manager import TransferManager
 
 from awscli.customizations.s3.utils import (
-    find_chunksize, adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
+    find_chunksize, human_readable_size,
+    adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
     find_bucket_key, relative_path, PrintTask, create_warning,
     NonSeekableStream)
 from awscli.customizations.s3.executor import Executor
@@ -541,18 +542,21 @@ class BaseTransferRequestSubmitter(object):
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
         self._cli_params = cli_params
+        self._warning_hanlders = []
 
     def submit(self, fileinfo):
         """Submits a transfer request based on the FileInfo provided
 
+        There is no guarantee that the transfer request will be made on
+        behalf of the fileinfo as a fileinfo may be skipped based on
+        circumstances in which the transfer is not possible.
+
         :param fileinfo: The FileInfo to be used to submit a transfer
             request to the underlying transfer manager.
         """
-        extra_args = {}
-        self.REQUEST_MAPPER_METHOD(extra_args, self._cli_params)
-        subscribers = [self.RESULT_SUBSCRIBER_CLASS(self._result_queue)]
-        self._add_additional_subscribers(subscribers, fileinfo)
-        self._submit_transfer_request(fileinfo, extra_args, subscribers)
+        should_skip = self._warn_and_signal_if_skip(fileinfo)
+        if not should_skip:
+            self._do_submit(fileinfo)
 
     def is_valid_submission(self, fileinfo):
         """Checks whether it is valid to submit a particular FileInfo
@@ -565,17 +569,59 @@ class BaseTransferRequestSubmitter(object):
         """
         raise NotImplementedError('is_valid_to_submit()')
 
+    def _do_submit(self, fileinfo):
+        extra_args = {}
+        self.REQUEST_MAPPER_METHOD(extra_args, self._cli_params)
+        subscribers = [self.RESULT_SUBSCRIBER_CLASS(self._result_queue)]
+        self._add_additional_subscribers(subscribers, fileinfo)
+        self._submit_transfer_request(fileinfo, extra_args, subscribers)
+
     def _add_additional_subscribers(self, subscribers, fileinfo):
         pass
 
     def _submit_transfer_request(self, fileinfo, extra_args, subscribers):
         raise NotImplementedError('_submit_transfer_request()')
 
+    def _warn_and_signal_if_skip(self, fileinfo):
+        for warning_handler in self._get_warning_handlers():
+            if warning_handler(fileinfo):
+                # On the first warning handler that returns a signal to skip
+                # immediately propogate this signal and no longer check
+                # the other warning handlers as no matter what the file will
+                # be skipped.
+                return True
+
+    def _get_warning_handlers(self):
+        # Returns a list of warning handlers, which are callables that
+        # take in a single parameter representing a FileInfo. It will then
+        # add a warning to result_queue if needed and return True if
+        # that FileInfo should be skipped.
+        return []
+
     def _should_inject_content_type(self):
         return (
             self._cli_params.get('guess_mime_type') and
             not self._cli_params.get('content_type')
         )
+
+    def _warn_glacier(self, fileinfo):
+        if not self._cli_params.get('force_glacier_transfer'):
+            if not fileinfo.is_glacier_compatible():
+                LOGGER.debug(
+                    'Encountered glacier object s3://%s. Not performing '
+                    '%s on object.' % (fileinfo.src, fileinfo.operation_name))
+                if not self._cli_params.get('ignore_glacier_warnings'):
+                    warning = create_warning(
+                        's3://'+fileinfo.src,
+                        'Object is of storage class GLACIER. Unable to '
+                        'perform %s operations on GLACIER objects. You must '
+                        'restore the object to be able to the perform '
+                        'operation.' %
+                        fileinfo.operation_name
+                    )
+                    self._result_queue.put(warning)
+                return True
+        return False
 
 
 class UploadRequestSubmitter(BaseTransferRequestSubmitter):
@@ -597,6 +643,19 @@ class UploadRequestSubmitter(BaseTransferRequestSubmitter):
             extra_args=extra_args, subscribers=subscribers
         )
 
+    def _get_warning_handlers(self):
+        return [self._warn_if_too_large]
+
+    def _warn_if_too_large(self, fileinfo):
+        if getattr(fileinfo, 'size') and fileinfo.size > MAX_UPLOAD_SIZE:
+            file_path = relative_path(fileinfo.src)
+            warning_message = (
+                "File %s exceeds s3 upload limit of %s." % (
+                    file_path, human_readable_size(MAX_UPLOAD_SIZE)))
+            warning = create_warning(
+                file_path, warning_message, skip_file=False)
+            self._result_queue.put(warning)
+
 
 class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_get_object_params
@@ -617,6 +676,9 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
             fileobj=fileinfo.dest, bucket=bucket, key=key,
             extra_args=extra_args, subscribers=subscribers
         )
+
+    def _get_warning_handlers(self):
+        return [self._warn_glacier]
 
 
 class CopyRequestSubmitter(BaseTransferRequestSubmitter):
@@ -640,3 +702,6 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
             extra_args=extra_args, subscribers=subscribers,
             source_client=fileinfo.source_client
         )
+
+    def _get_warning_handlers(self):
+        return [self._warn_glacier]

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -527,11 +527,23 @@ class BaseTransferRequestSubmitter(object):
     RESULT_SUBSCRIBER_CLASS = None
 
     def __init__(self, transfer_manager, result_queue, cli_params):
+        """Submits transfer requests to the TransferManager
+
+        Given a FileInfo object and provided CLI parameters, it will add the
+        necessary extra arguments and subscribers in making a call to the
+        TransferManager.
+
+        :param transfer_manager: The underlying transfer manager
+        :param result queue: The result queue to use
+        :param cli_params: The associated CLI parameters passed in to the
+            command.
+        """
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
         self._cli_params = cli_params
 
     def submit(self, fileinfo):
+        """Submits a transfer request based on the FileInfo provided"""
         extra_args = {}
         self.REQUEST_MAPPER_METHOD(extra_args, self._cli_params)
         subscribers = [self.RESULT_SUBSCRIBER_CLASS(self._result_queue)]

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -493,6 +493,7 @@ class S3TransferHandler(object):
             UploadRequestSubmitter(*submitter_args),
             DownloadRequestSubmitter(*submitter_args),
             CopyRequestSubmitter(*submitter_args),
+            DeleteRequestSubmitter(*submitter_args),
         ]
 
     def call(self, fileinfos):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -19,8 +19,7 @@ from s3transfer.manager import TransferManager
 
 from awscli.customizations.s3.utils import (
     find_chunksize, human_readable_size,
-    adjust_chunksize_to_upload_limits, MAX_UPLOAD_SIZE,
-    find_bucket_key, relative_path, PrintTask, create_warning,
+    MAX_UPLOAD_SIZE, find_bucket_key, relative_path, PrintTask, create_warning,
     NonSeekableStream)
 from awscli.customizations.s3.executor import Executor
 from awscli.customizations.s3 import tasks
@@ -44,7 +43,6 @@ from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideCopyContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideLastModifiedTimeSubscriber
 from awscli.customizations.s3.utils import DirectoryCreatorSubscriber
-from awscli.customizations.s3.utils import uni_print
 from awscli.compat import queue
 from awscli.compat import binary_stdin
 
@@ -393,138 +391,6 @@ class S3Handler(BaseS3Handler):
             session=self.session, filename=filename, parameters=self.params,
             result_queue=self.result_queue, upload_context=upload_context)
         self.executor.submit(complete_multipart_upload_task)
-
-
-class S3TransferStreamHandler(BaseS3Handler):
-    """
-    This class is an alternative ``S3Handler`` to be used when the operation
-    involves a stream since the logic is different when uploading and
-    downloading streams.
-    """
-    MAX_IN_MEMORY_CHUNKS = 6
-
-    def __init__(self, session, params, result_queue=None,
-                 runtime_config=None, manager=None):
-        super(S3TransferStreamHandler, self).__init__(
-            session, params, result_queue, runtime_config)
-        self.config = create_transfer_config_from_runtime_config(
-            self._runtime_config)
-
-        # Restrict the maximum chunks to 1 per thread.
-        self.config.max_in_memory_upload_chunks = \
-            self.MAX_IN_MEMORY_CHUNKS
-        self.config.max_in_memory_download_chunks = \
-            self.MAX_IN_MEMORY_CHUNKS
-
-        self._manager = manager
-
-    def call(self, files):
-        # There is only ever one file in a stream transfer.
-        file = files[0]
-        if self._manager is not None:
-            manager = self._manager
-        else:
-            manager = TransferManager(file.client, self.config)
-
-        if file.operation_name == 'upload':
-            bucket, key = find_bucket_key(file.dest)
-            return self._upload(manager, bucket, key)
-        elif file.operation_name == 'download':
-            bucket, key = find_bucket_key(file.src)
-            return self._download(manager, bucket, key)
-
-    def _download(self, manager, bucket, key):
-        """
-        Download the specified object and print it to stdout.
-
-        :type manager: s3transfer.manager.TransferManager
-        :param manager: The transfer manager to use for the download.
-
-        :type bucket: str
-        :param bucket: The bucket to download the object from.
-
-        :type key: str
-        :param key: The name of the key to download.
-
-        :return: A CommandResult representing the download status.
-        """
-        params = {}
-        # `download` performs the head_object as well, but the params are
-        # the same for both operations, so there's nothing missing here.
-        RequestParamsMapper.map_get_object_params(params, self.params)
-
-        with manager:
-            future = manager.download(
-                fileobj=StdoutBytesWriter(), bucket=bucket,
-                key=key, extra_args=params)
-
-            return self._process_transfer(future)
-
-    def _upload(self, manager, bucket, key):
-        """
-        Upload stdin using to the specified location.
-
-        :type manager: s3transfer.manager.TransferManager
-        :param manager: The transfer manager to use for the upload.
-
-        :type bucket: str
-        :param bucket: The bucket to upload the stream to.
-
-        :type key: str
-        :param key: The name of the key to upload the stream to.
-
-        :return: A CommandResult representing the upload status.
-        """
-        expected_size = self.params.get('expected_size', None)
-        subscribers = None
-        if expected_size is not None:
-            # `expected_size` comes in as a string
-            expected_size = int(expected_size)
-
-            # set the size of the transfer if we know it ahead of time.
-            subscribers = [ProvideSizeSubscriber(expected_size)]
-
-            # TODO: remove when this happens in s3transfer
-            # If we have the expected size, we can calculate an appropriate
-            # chunksize based on max parts and chunksize limits
-            chunksize = find_chunksize(
-                expected_size, self.config.multipart_chunksize)
-        else:
-            # TODO: remove when this happens in s3transfer
-            # Otherwise, we can still adjust for chunksize limits
-            chunksize = adjust_chunksize_to_upload_limits(
-                self.config.multipart_chunksize)
-        self.config.multipart_chunksize = chunksize
-
-        params = {}
-        RequestParamsMapper.map_put_object_params(params, self.params)
-
-        fileobj = NonSeekableStream(binary_stdin)
-        with manager:
-            future = manager.upload(
-                fileobj=fileobj, bucket=bucket,
-                key=key, extra_args=params, subscribers=subscribers)
-
-            return self._process_transfer(future)
-
-    def _process_transfer(self, future):
-        """
-        Execute and process a transfer future.
-
-        :type future: s3transfer.futures.TransferFuture
-        :param future: A future representing an S3 Transfer
-
-        :return: A CommandResult representing the transfer status.
-        """
-        try:
-            future.result()
-            return CommandResult(0, 0)
-        except Exception as e:
-            LOGGER.debug('Exception caught during task execution: %s',
-                         str(e), exc_info=True)
-            # TODO: Update when S3Handler is refactored
-            uni_print("Transfer failed: %s \n" % str(e))
-            return CommandResult(1, 0)
 
 
 class S3TransferHandlerFactory(object):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -507,11 +507,15 @@ class S3TransferHandler(object):
         """
         with self._result_command_recorder:
             with self._transfer_manager:
+                total_submissions = 0
                 for fileinfo in fileinfos:
                     for submitter in self._submitters:
                         if submitter.can_submit(fileinfo):
-                            submitter.submit(fileinfo)
+                            if submitter.submit(fileinfo):
+                                total_submissions += 1
                             break
+                self._result_command_recorder.notify_total_submissions(
+                    total_submissions)
         return self._result_command_recorder.get_command_result()
 
 

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -631,7 +631,7 @@ class S3TransferHandler(object):
             with self._transfer_manager:
                 for fileinfo in fileinfos:
                     for submitter in self._submitters:
-                        if submitter.is_valid_submission(fileinfo):
+                        if submitter.can_submit(fileinfo):
                             submitter.submit(fileinfo)
                             break
         return self._result_command_recorder.get_command_result()
@@ -677,8 +677,8 @@ class BaseTransferRequestSubmitter(object):
         if not should_skip:
             self._do_submit(fileinfo)
 
-    def is_valid_submission(self, fileinfo):
-        """Checks whether it is valid to submit a particular FileInfo
+    def can_submit(self, fileinfo):
+        """Checks whether it can submit a particular FileInfo
 
         :type fileinfo: awscli.customizations.s3.fileinfo.FileInfo
         :param fileinfo: The FileInfo to check if the transfer request
@@ -687,7 +687,7 @@ class BaseTransferRequestSubmitter(object):
         :returns: True if it can use the provided FileInfo to make a transfer
             request to the underlying transfer manager. False, otherwise.
         """
-        raise NotImplementedError('is_valid_submission()')
+        raise NotImplementedError('can_submit()')
 
     def _do_submit(self, fileinfo):
         extra_args = {}
@@ -752,7 +752,7 @@ class UploadRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_put_object_params
     RESULT_SUBSCRIBER_CLASS = UploadResultSubscriber
 
-    def is_valid_submission(self, fileinfo):
+    def can_submit(self, fileinfo):
         return fileinfo.operation_name == 'upload'
 
     def _add_additional_subscribers(self, subscribers, fileinfo):
@@ -785,7 +785,7 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_get_object_params
     RESULT_SUBSCRIBER_CLASS = DownloadResultSubscriber
 
-    def is_valid_submission(self, fileinfo):
+    def can_submit(self, fileinfo):
         return fileinfo.operation_name == 'download'
 
     def _add_additional_subscribers(self, subscribers, fileinfo):
@@ -809,7 +809,7 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
     REQUEST_MAPPER_METHOD = RequestParamsMapper.map_copy_object_params
     RESULT_SUBSCRIBER_CLASS = CopyResultSubscriber
 
-    def is_valid_submission(self, fileinfo):
+    def can_submit(self, fileinfo):
         return fileinfo.operation_name == 'copy'
 
     def _add_additional_subscribers(self, subscribers, fileinfo):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -534,10 +534,15 @@ class BaseTransferRequestSubmitter(object):
         necessary extra arguments and subscribers in making a call to the
         TransferManager.
 
+        :type transfer_manager: s3transfer.manager.TransferManager
         :param transfer_manager: The underlying transfer manager
+
+        :type result_queue: queue.Queue
         :param result queue: The result queue to use
+
+        :type cli_params: dict
         :param cli_params: The associated CLI parameters passed in to the
-            command.
+            command as a dictionary.
         """
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
@@ -550,6 +555,7 @@ class BaseTransferRequestSubmitter(object):
         behalf of the fileinfo as a fileinfo may be skipped based on
         circumstances in which the transfer is not possible.
 
+        :type fileinfo: awscli.customizations.s3.fileinfo.FileInfo
         :param fileinfo: The FileInfo to be used to submit a transfer
             request to the underlying transfer manager.
         """
@@ -560,6 +566,7 @@ class BaseTransferRequestSubmitter(object):
     def is_valid_submission(self, fileinfo):
         """Checks whether it is valid to submit a particular FileInfo
 
+        :type fileinfo: awscli.customizations.s3.fileinfo.FileInfo
         :param fileinfo: The FileInfo to check if the transfer request
             submitter can handle.
 

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -13,7 +13,6 @@
 import logging
 import math
 import os
-import sys
 
 from s3transfer.manager import TransferManager
 
@@ -447,7 +446,6 @@ class S3TransferHandlerFactory(object):
             transfer_manager, self._cli_params, command_result_recorder)
 
     def _add_result_printer(self, result_recorder, result_processor_handlers):
-        result_printer = None
         if self._cli_params.get('quiet'):
             return
         elif self._cli_params.get('only_show_errors'):
@@ -532,7 +530,7 @@ class BaseTransferRequestSubmitter(object):
         :param transfer_manager: The underlying transfer manager
 
         :type result_queue: queue.Queue
-        :param result queue: The result queue to use
+        :param result_queue: The result queue to use
 
         :type cli_params: dict
         :param cli_params: The associated CLI parameters passed in to the

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -542,7 +542,6 @@ class BaseTransferRequestSubmitter(object):
         self._transfer_manager = transfer_manager
         self._result_queue = result_queue
         self._cli_params = cli_params
-        self._warning_hanlders = []
 
     def submit(self, fileinfo):
         """Submits a transfer request based on the FileInfo provided
@@ -567,7 +566,7 @@ class BaseTransferRequestSubmitter(object):
         :returns: True if it can use the provided FileInfo to make a transfer
             request to the underlying transfer manager. False, otherwise.
         """
-        raise NotImplementedError('is_valid_to_submit()')
+        raise NotImplementedError('is_valid_submission()')
 
     def _do_submit(self, fileinfo):
         extra_args = {}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -995,7 +995,7 @@ class CommandArchitecture(object):
                               result_queue=result_queue)
 
         s3_transfer_handler = s3handler
-        if self.cmd == 'cp' and not self.parameters.get('dryrun'):
+        if self.cmd in ['cp', 'rm'] and not self.parameters.get('dryrun'):
             s3_transfer_handler = S3TransferHandlerFactory(
                 self.parameters, self._runtime_config)(
                     self._client, result_queue)
@@ -1026,7 +1026,7 @@ class CommandArchitecture(object):
                             'file_generator': [file_generator],
                             'filters': [create_filter(self.parameters)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3handler]}
+                            's3_handler': [s3_transfer_handler]}
         elif self.cmd == 'mv':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -32,6 +32,7 @@ from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
 from awscli.customizations.s3.results import ResultPrinter
 from awscli.customizations.s3.results import ResultProcessor
+from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandler
@@ -1088,11 +1089,11 @@ class CommandArchitecture(object):
         self._add_result_printer(result_recorder, result_processor_handlers)
         result_processor = ResultProcessor(
             result_queue, result_processor_handlers)
+        command_result_recorder = CommandResultRecorder(
+            result_queue, result_recorder, result_processor)
 
         return S3TransferHandler(
-            transfer_manager, self.parameters, result_queue, result_recorder,
-            result_processor
-        )
+            transfer_manager, self.parameters, command_result_recorder)
 
     def _add_result_printer(self, result_recorder, result_processor_handlers):
         result_printer = None

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -17,7 +17,6 @@ import sys
 from botocore.client import Config
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
-from s3transfer.manager import TransferManager
 
 from awscli.compat import six
 from awscli.compat import queue
@@ -28,22 +27,15 @@ from awscli.customizations.s3.fileformat import FileFormat
 from awscli.customizations.s3.filegenerator import FileGenerator
 from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
 from awscli.customizations.s3.filters import create_filter
-from awscli.customizations.s3.results import ResultRecorder
-from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
-from awscli.customizations.s3.results import ResultPrinter
-from awscli.customizations.s3.results import ResultProcessor
-from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
-from awscli.customizations.s3.s3handler import S3TransferHandler
+from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.utils import find_bucket_key, uni_print, \
     AppendFilter, find_dest_path_comp_key, human_readable_size, \
     RequestParamsMapper, split_s3_bucket_key
 from awscli.customizations.s3.syncstrategy.base import MissingFileSync, \
     SizeAndLastModifiedSync, NeverSync
 from awscli.customizations.s3 import transferconfig
-from awscli.customizations.s3.transferconfig import \
-    create_transfer_config_from_runtime_config
 
 
 LOGGER = logging.getLogger(__name__)
@@ -1005,9 +997,11 @@ class CommandArchitecture(object):
         s3_stream_handler = S3TransferStreamHandler(
             self.session, self.parameters, result_queue=result_queue)
 
-        s3_transfer_hanlder = s3handler
+        s3_transfer_handler = s3handler
         if self.cmd == 'cp' and not self.parameters.get('dryrun'):
-            s3_transfer_hanlder = self._get_s3_transfer_handler(result_queue)
+            s3_transfer_handler = S3TransferHandlerFactory(
+                self.parameters, self._runtime_config)(
+                    self._client, result_queue)
 
         sync_strategies = self.choose_sync_strategies()
 
@@ -1029,7 +1023,7 @@ class CommandArchitecture(object):
                             'file_generator': [file_generator],
                             'filters': [create_filter(self.parameters)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3_transfer_hanlder]}
+                            's3_handler': [s3_transfer_handler]}
         elif self.cmd == 'rm':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],
@@ -1073,37 +1067,6 @@ class CommandArchitecture(object):
         if files[0].num_tasks_warned > 0:
             rc = 2
         return rc
-
-    def _get_s3_transfer_handler(self, result_queue):
-        transfer_config = create_transfer_config_from_runtime_config(
-            self._runtime_config)
-        transfer_manager = TransferManager(self._client, transfer_config)
-
-        LOGGER.debug(
-            "Using a multipart threshold of %s and a part size of %s",
-            transfer_config.multipart_threshold,
-            transfer_config.multipart_chunksize
-        )
-        result_recorder = ResultRecorder()
-        result_processor_handlers = [result_recorder]
-        self._add_result_printer(result_recorder, result_processor_handlers)
-        result_processor = ResultProcessor(
-            result_queue, result_processor_handlers)
-        command_result_recorder = CommandResultRecorder(
-            result_queue, result_recorder, result_processor)
-
-        return S3TransferHandler(
-            transfer_manager, self.parameters, command_result_recorder)
-
-    def _add_result_printer(self, result_recorder, result_processor_handlers):
-        result_printer = None
-        if self.parameters.get('quiet'):
-            return
-        elif self.parameters.get('only_show_errors'):
-            result_printer = OnlyShowErrorsResultPrinter(result_recorder)
-        else:
-            result_printer = ResultPrinter(result_recorder)
-        result_processor_handlers.append(result_printer)
 
 
 class CommandParameters(object):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -28,7 +28,6 @@ from awscli.customizations.s3.filegenerator import FileGenerator
 from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
 from awscli.customizations.s3.filters import create_filter
 from awscli.customizations.s3.s3handler import S3Handler
-from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.utils import find_bucket_key, uni_print, \
     AppendFilter, find_dest_path_comp_key, human_readable_size, \
@@ -994,8 +993,6 @@ class CommandArchitecture(object):
         s3handler = S3Handler(self.session, self.parameters,
                               runtime_config=self._runtime_config,
                               result_queue=result_queue)
-        s3_stream_handler = S3TransferStreamHandler(
-            self.session, self.parameters, result_queue=result_queue)
 
         s3_transfer_handler = s3handler
         if self.cmd == 'cp' and not self.parameters.get('dryrun'):
@@ -1017,7 +1014,7 @@ class CommandArchitecture(object):
                             's3_handler': [s3handler]}
         elif self.cmd == 'cp' and self.parameters['is_stream']:
             command_dict = {'setup': [stream_file_info],
-                            's3_handler': [s3_stream_handler]}
+                            's3_handler': [s3_transfer_handler]}
         elif self.cmd == 'cp':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -11,11 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import logging
 import sys
 
 from botocore.client import Config
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
+from s3transfer.manager import TransferManager
 
 from awscli.compat import six
 from awscli.compat import queue
@@ -26,14 +28,24 @@ from awscli.customizations.s3.fileformat import FileFormat
 from awscli.customizations.s3.filegenerator import FileGenerator
 from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
 from awscli.customizations.s3.filters import create_filter
+from awscli.customizations.s3.results import ResultRecorder
+from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
+from awscli.customizations.s3.results import ResultPrinter
+from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
+from awscli.customizations.s3.s3handler import S3TransferHandler
 from awscli.customizations.s3.utils import find_bucket_key, uni_print, \
     AppendFilter, find_dest_path_comp_key, human_readable_size, \
     RequestParamsMapper, split_s3_bucket_key
 from awscli.customizations.s3.syncstrategy.base import MissingFileSync, \
     SizeAndLastModifiedSync, NeverSync
 from awscli.customizations.s3 import transferconfig
+from awscli.customizations.s3.transferconfig import \
+    create_transfer_config_from_runtime_config
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 RECURSIVE = {'name': 'recursive', 'action': 'store_true', 'dest': 'dir_op',
@@ -992,6 +1004,10 @@ class CommandArchitecture(object):
         s3_stream_handler = S3TransferStreamHandler(
             self.session, self.parameters, result_queue=result_queue)
 
+        s3_transfer_hanlder = s3handler
+        if self.cmd == 'cp' and not self.parameters.get('dryrun'):
+            s3_transfer_hanlder = self._get_s3_transfer_handler(result_queue)
+
         sync_strategies = self.choose_sync_strategies()
 
         command_dict = {}
@@ -1012,7 +1028,7 @@ class CommandArchitecture(object):
                             'file_generator': [file_generator],
                             'filters': [create_filter(self.parameters)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3handler]}
+                            's3_handler': [s3_transfer_hanlder]}
         elif self.cmd == 'rm':
             command_dict = {'setup': [files],
                             'file_generator': [file_generator],
@@ -1056,6 +1072,37 @@ class CommandArchitecture(object):
         if files[0].num_tasks_warned > 0:
             rc = 2
         return rc
+
+    def _get_s3_transfer_handler(self, result_queue):
+        transfer_config = create_transfer_config_from_runtime_config(
+            self._runtime_config)
+        transfer_manager = TransferManager(self._client, transfer_config)
+
+        LOGGER.debug(
+            "Using a multipart threshold of %s and a part size of %s",
+            transfer_config.multipart_threshold,
+            transfer_config.multipart_chunksize
+        )
+        result_recorder = ResultRecorder()
+        result_processor_handlers = [result_recorder]
+        self._add_result_printer(result_recorder, result_processor_handlers)
+        result_processor = ResultProcessor(
+            result_queue, result_processor_handlers)
+
+        return S3TransferHandler(
+            transfer_manager, self.parameters, result_queue, result_recorder,
+            result_processor
+        )
+
+    def _add_result_printer(self, result_recorder, result_processor_handlers):
+        result_printer = None
+        if self.parameters.get('quiet'):
+            return
+        elif self.parameters.get('only_show_errors'):
+            result_printer = OnlyShowErrorsResultPrinter(result_recorder)
+        else:
+            result_printer = ResultPrinter(result_recorder)
+        result_processor_handlers.append(result_printer)
 
 
 class CommandParameters(object):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -277,8 +277,8 @@ def create_warning(path, error_message, skip_file=True):
     if skip_file:
         print_string = print_string + "Skipping file " + path + ". "
     print_string = print_string + error_message
-    warning_message = PrintTask(message=print_string, error=False,
-                                warning=True)
+    warning_message = WarningResult(message=print_string, error=False,
+                                    warning=True)
     return warning_message
 
 
@@ -570,6 +570,7 @@ class PrintTask(namedtuple('PrintTask',
         return super(PrintTask, cls).__new__(cls, message, error, total_parts,
                                              warning)
 
+WarningResult = PrintTask
 
 IORequest = namedtuple('IORequest',
                        ['filename', 'offset', 'data', 'is_stream'])

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -818,7 +818,7 @@ class BaseProvideContentTypeSubscriber(BaseSubscriber):
             future.meta.call_args.extra_args['ContentType'] = guessed_type
 
     def _get_filename(self, future):
-        raise NotImplementedError('must implement _get_filename()')
+        raise NotImplementedError('_get_filename()')
 
 
 class ProvideUploadContentTypeSubscriber(BaseProvideContentTypeSubscriber):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -433,7 +433,21 @@ def guess_content_type(filename):
 
     If the type cannot be guessed, a value of None is returned.
     """
-    return mimetypes.guess_type(filename)[0]
+    try:
+        return mimetypes.guess_type(filename)[0]
+    # This catches a bug in the mimetype libary where some MIME types
+    # specifically on windows machines cause a UnicodeDecodeError
+    # because the MIME type in the Windows registery has an encoding
+    # that cannot be properly encoded using the default system encoding.
+    # https://bugs.python.org/issue9291
+    #
+    # So instead of hard failing, just log the issue and fall back to the
+    # default guessed content type of None.
+    except UnicodeDecodeError:
+        LOGGER.debug(
+            'Unable to guess content type for %s due to '
+            'UnicodeDecodeError: ', filename, exc_info=True
+        )
 
 
 def relative_path(filename, start=os.path.curdir):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -760,6 +760,33 @@ class ProvideSizeSubscriber(BaseSubscriber):
         future.meta.provide_transfer_size(self.size)
 
 
+class OnDoneFilteredSubscriber(BaseSubscriber):
+    """Subscriber that differentiates between successes and failures
+
+    It is really a convenience class so developers do not have to have
+    to constantly remember to have a general try/except around future.result()
+    """
+    def on_done(self, future, **kwargs):
+        future_exception = None
+        try:
+
+            future.result()
+        except Exception as e:
+            future_exception = e
+        # If the result propogates an error, call the on_failure
+        # method instead.
+        if future_exception:
+            self.on_failure(future, future_exception)
+        else:
+            self.on_success(future)
+
+    def on_success(self, future):
+        pass
+
+    def on_failure(self, future, e):
+        pass
+
+
 class NonSeekableStream(object):
     """Wrap a file like object as a non seekable stream.
 

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -779,6 +779,9 @@ class ProvideSizeSubscriber(BaseSubscriber):
         future.meta.provide_transfer_size(self.size)
 
 
+# TODO: Eventually port this down to the BaseSubscriber or a new subscriber
+# class in s3transfer. The functionality is very convenient but may need
+# some further design decisions to make it a feature in s3transfer.
 class OnDoneFilteredSubscriber(BaseSubscriber):
     """Subscriber that differentiates between successes and failures
 
@@ -795,14 +798,14 @@ class OnDoneFilteredSubscriber(BaseSubscriber):
         # If the result propogates an error, call the on_failure
         # method instead.
         if future_exception:
-            self.on_failure(future, future_exception)
+            self._on_failure(future, future_exception)
         else:
-            self.on_success(future)
+            self._on_success(future)
 
-    def on_success(self, future):
+    def _on_success(self, future):
         pass
 
-    def on_failure(self, future, e):
+    def _on_failure(self, future, e):
         pass
 
 
@@ -834,7 +837,7 @@ class ProvideLastModifiedTimeSubscriber(OnDoneFilteredSubscriber):
         self._last_modified_time = last_modified_time
         self._result_queue = result_queue
 
-    def on_success(self, future, **kwargs):
+    def _on_success(self, future, **kwargs):
         filename = future.meta.call_args.fileobj
         try:
             last_update_tuple = self._last_modified_time.timetuple()

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -234,7 +234,7 @@ def get_file_stat(path):
 
     try:
         update_time = datetime.fromtimestamp(stats.st_mtime, tzlocal())
-    except ValueError:
+    except (ValueError, OSError):
         # Python's fromtimestamp raises value errors when the timestamp is out
         # of range of the platform's C localtime() function. This can cause
         # issues when syncing from systems with a wide range of valid timestamps

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -97,6 +97,18 @@ def skip_if_windows(reason):
     return decorator
 
 
+def set_invalid_utime(path):
+    """Helper function to set an invalid last modified time"""
+    try:
+        os.utime(path, (-1, -100000000000))
+    except OSError:
+        # Some OS's such as Windows throws an error for trying to set a
+        # last modified time of that size. So if an error is thrown, set it
+        # to just a negative time which will trigger the warning as well for
+        # Windows.
+        os.utime(path, (-1, -1))
+
+
 def create_clidriver():
     driver = awscli.clidriver.create_clidriver()
     session = driver.session

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -101,7 +101,7 @@ def set_invalid_utime(path):
     """Helper function to set an invalid last modified time"""
     try:
         os.utime(path, (-1, -100000000000))
-    except OSError:
+    except (OSError, OverflowError):
         # Some OS's such as Windows throws an error for trying to set a
         # last modified time of that size. So if an error is thrown, set it
         # to just a negative time which will trigger the warning as well for

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -233,7 +233,7 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         ]
         with mock.patch('os.utime') as mock_utime:
             mock_utime.side_effect = OSError(1, '')
-            _, err, _ = self.run_cmd(cmdline, expected_rc=1)
+            _, err, _ = self.run_cmd(cmdline, expected_rc=2)
             self.assertIn('attempting to modify the utime', err)
 
     def test_recursive_glacier_download_with_force_glacier(self):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -211,19 +211,6 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
-    def test_cp_succeeds_with_mimetype_errors(self):
-        full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
-        self.parsed_responses = [
-            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
-        with mock.patch('mimetypes.guess_type') as mock_guess_type:
-            # This should throw a UnicodeDecodeError.
-            mock_guess_type.side_effect = lambda x: b'\xe2'.decode('ascii')
-            self.run_cmd(cmdline, expected_rc=0)
-        # Because of the decoding error the command should have succeeded
-        # just that there was no content type added.
-        self.assertNotIn('ContentType', self.last_kwargs)
-
     def test_cp_fails_with_utime_errors_but_continues(self):
         full_path = self.files.create_file('foo.txt', '')
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -211,6 +211,19 @@ class TestCPCommand(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
+    def test_cp_succeeds_with_mimetype_errors(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
+        self.parsed_responses = [
+            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        with mock.patch('mimetypes.guess_type') as mock_guess_type:
+            # This should throw a UnicodeDecodeError.
+            mock_guess_type.side_effect = lambda x: b'\xe2'.decode('ascii')
+            self.run_cmd(cmdline, expected_rc=0)
+        # Because of the decoding error the command should have succeeded
+        # just that there was no content type added.
+        self.assertNotIn('ContentType', self.last_kwargs)
+
     def test_cp_fails_with_utime_errors_but_continues(self):
         full_path = self.files.create_file('foo.txt', '')
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -502,13 +502,13 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
         binary_stdin = six.BytesIO(b'foo\n')
         location = "awscli.customizations.s3.s3handler.binary_stdin"
         with mock.patch(location, binary_stdin):
-            stdout, _, _ = self.run_cmd(command, expected_rc=1)
+            _, stderr, _ = self.run_cmd(command, expected_rc=1)
 
         error_message = (
-            'Transfer failed: An error occurred (NoSuchBucket) when calling '
+            'An error occurred (NoSuchBucket) when calling '
             'the PutObject operation: The specified bucket does not exist'
         )
-        self.assertIn(error_message, stdout)
+        self.assertIn(error_message, stderr)
 
     def test_streaming_download(self):
         command = "s3 cp s3://bucket/streaming.txt -"
@@ -552,9 +552,9 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
         }]
         self.http_response.status_code = 404
 
-        stdout, _, _ = self.run_cmd(command, expected_rc=1)
+        _, stderr, _ = self.run_cmd(command, expected_rc=1)
         error_message = (
-            'Transfer failed: An error occurred (NoSuchBucket) when calling '
+            'An error occurred (NoSuchBucket) when calling '
             'the HeadObject operation: The specified bucket does not exist'
         )
-        self.assertIn(error_message, stdout)
+        self.assertIn(error_message, stderr)

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.testutils import set_invalid_utime
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
 import os
 
@@ -134,7 +135,7 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
 
         # Set the update time to a value that will raise a ValueError when
         # converting to datetime
-        os.utime(full_path, (-1, -100000000000))
+        set_invalid_utime(full_path)
         cmdline = '%s %s s3://bucket/key.txt' % \
                   (self.prefix, self.files.rootdir)
         self.parsed_responses = [

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -419,7 +419,9 @@ class TestCp(BaseS3IntegrationTest):
         self.put_object(bucket_name, key_name='foo.txt',
                         contents=foo_contents)
         local_foo_txt = self.files.full_path('foo.txt')
-        process = aws('s3 cp s3://%s/foo.txt %s' %
+        # --quiet is added to make sure too much output is not communicated
+        # to the PIPE, causing a deadlock when not consumed.
+        process = aws('s3 cp s3://%s/foo.txt %s --quiet' %
                       (bucket_name, local_foo_txt), wait_for_finish=False)
         # Give it some time to start up and enter it's main task loop.
         time.sleep(2)
@@ -441,8 +443,9 @@ class TestCp(BaseS3IntegrationTest):
         with open(foo_txt, 'wb') as f:
             for i in range(20):
                 f.write(b'a' * 1024 * 1024)
-
-        process = aws('s3 cp %s s3://%s/' % (foo_txt, bucket_name),
+        # --quiet is added to make sure too much output is not communicated
+        # to the PIPE, causing a deadlock when not consumed.
+        process = aws('s3 cp %s s3://%s/ --quiet' % (foo_txt, bucket_name),
                       wait_for_finish=False)
         time.sleep(3)
         # The process has 60 seconds to finish after being sent a Ctrl+C,

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -31,9 +31,10 @@ class FakeTransferFuture(object):
 
 
 class FakeTransferFutureMeta(object):
-    def __init__(self, size=None, call_args=None):
+    def __init__(self, size=None, call_args=None, transfer_id=None):
         self.size = size
         self.call_args = call_args
+        self.transfer_id = transfer_id
 
 
 class FakeTransferFutureCallArgs(object):

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -18,6 +18,30 @@ from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, \
     capture_output
 
 
+class FakeTransferFuture(object):
+    def __init__(self, result=None, exception=None, meta=None):
+        self._result = result
+        self._exception = exception
+        self.meta = meta
+
+    def result(self):
+        if self._exception:
+            raise self._exception
+        return self._result
+
+
+class FakeTransferFutureMeta(object):
+    def __init__(self, size=None, call_args=None):
+        self.size = size
+        self.call_args = call_args
+
+
+class FakeTransferFutureCallArgs(object):
+    def __init__(self, **kwargs):
+        for kwarg, val in kwargs.items():
+            setattr(self, kwarg, val)
+
+
 class S3HandlerBaseTest(BaseAWSCommandParamsTest):
     def setUp(self):
         super(S3HandlerBaseTest, self).setUp()

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -650,7 +650,19 @@ class TestResultPrinter(BaseResultPrinterTest):
         progress_result = self.get_progress_result()
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_with_no_expected_transfer_bytes(self):
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = 0
+        self.result_recorder.expected_bytes_transferred = 0
+
+        progress_result = self.get_progress_result()
+        self.result_printer(progress_result)
+        ref_progress_statement = (
+            'Completed 1 file(s) with 3 file(s) remaining\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_progress_then_more_progress(self):
@@ -666,7 +678,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
         # Add the second progress update
@@ -675,8 +687,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         # The result should be the combination of the two
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
-            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
@@ -721,9 +733,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The success statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
-            'upload: file to s3://mybucket/mykey                 \n'
-            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'upload: file to s3://mybucket/mykey                \n'
+            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -792,9 +804,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The failure statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
             'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
+            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining\r'
         )
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
@@ -844,9 +856,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The warning statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
-            'warning: my warning                                 \n'
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'warning: my warning                                \n'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
         )
 
         self.assertEqual(shared_file.getvalue(), ref_statement)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -30,30 +30,9 @@ from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
 from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.utils import relative_path
 from awscli.customizations.s3.utils import WarningResult
-
-
-class FakeTransferFuture(object):
-    def __init__(self, result=None, exception=None, meta=None):
-        self._result = result
-        self._exception = exception
-        self.meta = meta
-
-    def result(self):
-        if self._exception:
-            raise self._exception
-        return self._result
-
-
-class FakeTransferFutureMeta(object):
-    def __init__(self, size=None, call_args=None):
-        self.size = size
-        self.call_args = call_args
-
-
-class FakeTransferFutureCallArgs(object):
-    def __init__(self, **kwargs):
-        for kwarg, val in kwargs.items():
-            setattr(self, kwarg, val)
+from tests.unit.customizations.s3 import FakeTransferFuture
+from tests.unit.customizations.s3 import FakeTransferFutureMeta
+from tests.unit.customizations.s3 import FakeTransferFutureCallArgs
 
 
 class BaseResultSubscriberTest(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -1,0 +1,204 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.compat import queue
+from awscli.customizations.s3.results import QueuedResult
+from awscli.customizations.s3.results import ProgressResult
+from awscli.customizations.s3.results import SuccessResult
+from awscli.customizations.s3.results import FailureResult
+from awscli.customizations.s3.results import UploadResultSubscriber
+from awscli.customizations.s3.results import UploadStreamResultSubscriber
+from awscli.customizations.s3.results import DownloadResultSubscriber
+from awscli.customizations.s3.results import DownloadStreamResultSubscriber
+from awscli.customizations.s3.results import CopyResultSubscriber
+from awscli.customizations.s3.utils import relative_path
+
+
+class FakeTransferFuture(object):
+    def __init__(self, result=None, exception=None, meta=None):
+        self._result = result
+        self._exception = exception
+        self.meta = meta
+
+    def result(self):
+        if self._exception:
+            raise self._exception
+        return self._result
+
+
+class FakeTransferFutureMeta(object):
+    def __init__(self, size=None, call_args=None):
+        self.size = size
+        self.call_args = call_args
+
+
+class FakeTransferFutureCallArgs(object):
+    def __init__(self, **kwargs):
+        for kwarg, val in kwargs.items():
+            setattr(self, kwarg, val)
+
+
+class BaseResultSubscriberTest(unittest.TestCase):
+    def setUp(self):
+        self.result_queue = queue.Queue()
+
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.filename = 'myfile'
+        self.size = 20 * (1024 * 1024)  # 20 MB
+
+        self.ref_exception = Exception()
+        self.set_ref_transfer_futures()
+
+        self.src = None
+        self.dest = None
+        self.transfer_type = None
+
+    def set_ref_transfer_futures(self):
+        self.future = self.get_success_transfer_future('foo')
+        self.failure_future = self.get_failed_transfer_future(
+            self.ref_exception)
+
+    def get_success_transfer_future(self, result):
+        return self._get_transfer_future(result=result)
+
+    def get_failed_transfer_future(self, exception):
+        return self._get_transfer_future(exception=exception)
+
+    def _get_transfer_future(self, result=None, exception=None):
+        call_args = self._get_transfer_future_call_args()
+        meta = FakeTransferFutureMeta(size=self.size, call_args=call_args)
+        return FakeTransferFuture(
+            result=result, exception=exception, meta=meta)
+
+    def _get_transfer_future_call_args(self):
+        return FakeTransferFutureCallArgs(
+            fileobj=self.filename, key=self.key, bucket=self.bucket)
+
+    def get_queued_result(self):
+        return self.result_queue.get(block=False)
+
+    def assert_result_queue_is_empty(self):
+        self.assertTrue(self.result_queue.empty())
+
+    def assert_expected_transfer_type(self, result):
+        self.assertEqual(result.transfer_type, self.transfer_type)
+
+    def assert_expected_src_and_dest(self, result):
+        self.assertEqual(result.src, self.src)
+        self.assertEqual(result.dest, self.dest)
+
+    def assert_expected_total_transfer_size(self, result):
+        self.assertEqual(result.total_transfer_size, self.size)
+
+    def assert_correct_queued_result(self, result):
+        self.assertIsInstance(result, QueuedResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+        self.assert_expected_total_transfer_size(result)
+
+    def assert_correct_progress_result(self, result, ref_bytes_transferred):
+        self.assertIsInstance(result, ProgressResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+        self.assertEqual(result.bytes_transferred, ref_bytes_transferred)
+        self.assert_expected_total_transfer_size(result)
+
+    def assert_correct_success_result(self, result):
+        self.assertIsInstance(result, SuccessResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+
+    def assert_correct_exception_result(self, result, ref_exception):
+        self.assertIsInstance(result, FailureResult)
+        self.assert_expected_transfer_type(result)
+        self.assert_expected_src_and_dest(result)
+        self.assertEqual(result.exception, ref_exception)
+
+
+class TestUploadResultSubscriber(BaseResultSubscriberTest):
+    def setUp(self):
+        super(TestUploadResultSubscriber, self).setUp()
+        self.src = relative_path(self.filename)
+        self.dest = 's3://' + self.bucket + '/' + self.key
+        self.transfer_type = 'upload'
+        self.result_subscriber = UploadResultSubscriber(self.result_queue)
+
+    def test_on_queued(self):
+        self.result_subscriber.on_queued(self.future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_queued_result(result)
+
+    def test_on_progress(self):
+        ref_bytes_transferred = 1024 * 1024  # 1MB
+        self.result_subscriber.on_progress(self.future, ref_bytes_transferred)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_progress_result(result, ref_bytes_transferred)
+
+    def test_on_done_success(self):
+        self.result_subscriber.on_done(self.future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_success_result(result)
+
+    def test_on_done_failure(self):
+        self.result_subscriber.on_done(self.failure_future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assert_correct_exception_result(result, self.ref_exception)
+
+
+class TestUploadStreamResultSubscriber(TestUploadResultSubscriber):
+    def setUp(self):
+        super(TestUploadStreamResultSubscriber, self).setUp()
+        self.src = '-'
+        self.result_subscriber = UploadStreamResultSubscriber(
+            self.result_queue)
+
+
+class TestDownloadResultSubscriber(TestUploadResultSubscriber):
+    def setUp(self):
+        super(TestDownloadResultSubscriber, self).setUp()
+        self.src = 's3://' + self.bucket + '/' + self.key
+        self.dest = relative_path(self.filename)
+        self.transfer_type = 'download'
+        self.result_subscriber = DownloadResultSubscriber(self.result_queue)
+
+
+class TestDownloadStreamResultSubscriber(TestDownloadResultSubscriber):
+    def setUp(self):
+        super(TestDownloadStreamResultSubscriber, self).setUp()
+        self.dest = '-'
+        self.result_subscriber = DownloadStreamResultSubscriber(
+            self.result_queue)
+
+
+class TestCopyResultSubscriber(TestUploadResultSubscriber):
+    def setUp(self):
+        self.source_bucket = 'sourcebucket'
+        self.source_key = 'sourcekey'
+        self.copy_source = {
+            'Bucket': self.source_bucket,
+            'Key': self.source_key,
+        }
+        super(TestCopyResultSubscriber, self).setUp()
+        self.src = 's3://' + self.source_bucket + '/' + self.source_key
+        self.dest = 's3://' + self.bucket + '/' + self.key
+        self.transfer_type = 'copy'
+        self.result_subscriber = CopyResultSubscriber(self.result_queue)
+
+    def _get_transfer_future_call_args(self):
+        return FakeTransferFutureCallArgs(
+            copy_source=self.copy_source, key=self.key, bucket=self.bucket)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -108,7 +108,15 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
-        self.get_queued_result()
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
         self.assert_result_queue_is_empty()
 
         ref_bytes_transferred = 1024 * 1024  # 1MB
@@ -130,7 +138,15 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
-        self.get_queued_result()
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
         self.assert_result_queue_is_empty()
 
         self.result_subscriber.on_done(self.future)
@@ -149,7 +165,15 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
-        self.get_queued_result()
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
         self.assert_result_queue_is_empty()
 
         self.result_subscriber.on_done(self.failure_future)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -222,7 +222,7 @@ class ResultRecorderTest(unittest.TestCase):
         self.result_recorder = ResultRecorder()
 
     def test_queued_result(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             QueuedResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, total_transfer_size=self.total_transfer_size
@@ -237,7 +237,7 @@ class ResultRecorderTest(unittest.TestCase):
     def test_multiple_queued_results(self):
         num_results = 5
         for i in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 QueuedResult(
                     transfer_type=self.transfer_type,
                     src=self.src + str(i),
@@ -254,7 +254,7 @@ class ResultRecorderTest(unittest.TestCase):
             self.result_recorder.expected_files_transferred, num_results)
 
     def test_progress_result(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             QueuedResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, total_transfer_size=self.total_transfer_size
@@ -262,7 +262,7 @@ class ResultRecorderTest(unittest.TestCase):
         )
 
         bytes_transferred = 1024 * 1024  # 1MB
-        self.result_recorder.record_result(
+        self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
@@ -274,7 +274,7 @@ class ResultRecorderTest(unittest.TestCase):
             self.result_recorder.bytes_transferred, bytes_transferred)
 
     def test_multiple_progress_results(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             QueuedResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, total_transfer_size=self.total_transfer_size
@@ -284,7 +284,7 @@ class ResultRecorderTest(unittest.TestCase):
         bytes_transferred = 1024 * 1024  # 1MB
         num_results = 5
         for _ in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 ProgressResult(
                     transfer_type=self.transfer_type, src=self.src,
                     dest=self.dest, bytes_transferred=bytes_transferred,
@@ -298,14 +298,14 @@ class ResultRecorderTest(unittest.TestCase):
         )
 
     def test_success_result(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             QueuedResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, total_transfer_size=self.total_transfer_size
             )
         )
 
-        self.result_recorder.record_result(
+        self.result_recorder(
             SuccessResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest
@@ -317,7 +317,7 @@ class ResultRecorderTest(unittest.TestCase):
     def test_multiple_success_results(self):
         num_results = 5
         for i in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 QueuedResult(
                     transfer_type=self.transfer_type,
                     src=self.src + str(i),
@@ -327,7 +327,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
 
         for i in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 SuccessResult(
                     transfer_type=self.transfer_type,
                     src=self.src + str(i),
@@ -339,14 +339,14 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertEqual(self.result_recorder.files_failed, 0)
 
     def test_failure_result(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             QueuedResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, total_transfer_size=self.total_transfer_size
             )
         )
 
-        self.result_recorder.record_result(
+        self.result_recorder(
             FailureResult(
                 transfer_type=self.transfer_type, src=self.src, dest=self.dest,
                 exception=self.exception
@@ -363,7 +363,7 @@ class ResultRecorderTest(unittest.TestCase):
     def test_multiple_failure_results(self):
         num_results = 5
         for i in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 QueuedResult(
                     transfer_type=self.transfer_type,
                     src=self.src + str(i),
@@ -373,7 +373,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
 
         for i in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 FailureResult(
                     transfer_type=self.transfer_type,
                     src=self.src + str(i),
@@ -390,7 +390,7 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertEqual(self.result_recorder.bytes_transferred, 0)
 
     def test_failure_result_mid_progress(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             QueuedResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, total_transfer_size=self.total_transfer_size
@@ -398,7 +398,7 @@ class ResultRecorderTest(unittest.TestCase):
         )
 
         bytes_transferred = 1024 * 1024  # 1MB
-        self.result_recorder.record_result(
+        self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
@@ -406,7 +406,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        self.result_recorder.record_result(
+        self.result_recorder(
             FailureResult(
                 transfer_type=self.transfer_type, src=self.src, dest=self.dest,
                 exception=self.exception
@@ -422,19 +422,19 @@ class ResultRecorderTest(unittest.TestCase):
             self.result_recorder.bytes_transferred, bytes_transferred)
 
     def test_warning_result(self):
-        self.result_recorder.record_result(
+        self.result_recorder(
             WarningResult(message=self.warning_message))
         self.assertEqual(self.result_recorder.files_warned, 1)
 
     def test_multiple_warning_results(self):
         num_results = 5
         for _ in range(num_results):
-            self.result_recorder.record_result(
+            self.result_recorder(
                 WarningResult(message=self.warning_message))
         self.assertEqual(self.result_recorder.files_warned, num_results)
 
     def test_unknown_result_object(self):
-        self.result_recorder.record_result(object())
+        self.result_recorder(object())
         # Nothing should have been affected
         self.assertEqual(self.result_recorder.bytes_transferred, 0)
         self.assertEqual(self.result_recorder.expected_bytes_transferred, 0)
@@ -465,7 +465,7 @@ class BaseResultPrinterTest(unittest.TestCase):
 
 class TestResultPrinter(BaseResultPrinterTest):
     def test_unknown_result_object(self):
-        self.result_printer.print_result(object())
+        self.result_printer(object())
         # Nothing should have been printed because of it.
         self.assertEqual(self.out_file.getvalue(), '')
         self.assertEqual(self.error_file.getvalue(), '')
@@ -479,7 +479,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.files_transferred = 1
 
         progress_result = self.get_progress_result()
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
         ref_progress_statement = (
             'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
@@ -495,14 +495,14 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
         ref_progress_statement = (
             'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
         # Add the second progress update
         self.result_recorder.bytes_transferred += mb
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
 
         # The result should be the combination of the two
         ref_progress_statement = (
@@ -518,7 +518,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         success_result = SuccessResult(
             transfer_type=transfer_type, src=src, dest=dest)
 
-        self.result_printer.print_result(success_result)
+        self.result_printer(success_result)
 
         ref_success_statement = (
             'upload: file to s3://mybucket/mykey\n'
@@ -535,7 +535,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
 
         # Add a success result and print it out.
         transfer_type = 'upload'
@@ -545,7 +545,7 @@ class TestResultPrinter(BaseResultPrinterTest):
             transfer_type=transfer_type, src=src, dest=dest)
 
         self.result_recorder.files_transferred += 1
-        self.result_printer.print_result(success_result)
+        self.result_printer(success_result)
 
         # The statement should consist of:
         # * The first progress statement
@@ -566,7 +566,7 @@ class TestResultPrinter(BaseResultPrinterTest):
             transfer_type=transfer_type, src=src, dest=dest,
             exception=Exception('my exception'))
 
-        self.result_printer.print_result(failure_result)
+        self.result_printer(failure_result)
 
         ref_failure_statement = (
             'upload failed: file to s3://mybucket/mykey my exception\n'
@@ -591,7 +591,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
 
         # Add a success result and print it out.
         transfer_type = 'upload'
@@ -603,7 +603,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_recorder.bytes_failed_to_transfer = 3 * mb
         self.result_recorder.files_transferred += 1
-        self.result_printer.print_result(failure_result)
+        self.result_printer(failure_result)
 
         # The statement should consist of:
         # * The first progress statement
@@ -617,7 +617,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
     def test_warning(self):
-        self.result_printer.print_result(WarningResult('my warning'))
+        self.result_printer(WarningResult('my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 
@@ -639,9 +639,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
 
-        self.result_printer.print_result(WarningResult('my warning'))
+        self.result_printer(WarningResult('my warning'))
 
         # The statement should consist of:
         # * The first progress statement
@@ -667,7 +667,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
 
     def test_does_not_print_progress_result(self):
         progress_result = self.get_progress_result()
-        self.result_printer.print_result(progress_result)
+        self.result_printer(progress_result)
         self.assertEqual(self.out_file.getvalue(), '')
 
     def test_does_not_print_sucess_result(self):
@@ -677,7 +677,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         success_result = SuccessResult(
             transfer_type=transfer_type, src=src, dest=dest)
 
-        self.result_printer.print_result(success_result)
+        self.result_printer(success_result)
         self.assertEqual(self.out_file.getvalue(), '')
 
     def test_print_failure_result(self):
@@ -688,7 +688,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
             transfer_type=transfer_type, src=src, dest=dest,
             exception=Exception('my exception'))
 
-        self.result_printer.print_result(failure_result)
+        self.result_printer(failure_result)
 
         ref_failure_statement = (
             'upload failed: file to s3://mybucket/mykey my exception\n'
@@ -696,7 +696,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
 
     def test_print_warnings_result(self):
-        self.result_printer.print_result(WarningResult('my warning'))
+        self.result_printer(WarningResult('my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -478,7 +478,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         progress_result = self.get_progress_result()
         self.result_printer.print_result(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_progress_then_more_progress(self):
@@ -494,7 +494,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_printer.print_result(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
         # Add the second progress update
@@ -503,8 +503,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         # The result should be the combination of the two
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
-            'Completed 2.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
@@ -549,9 +549,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The success statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
-            'upload: file to s3://mybucket/mykey               \n'
-            'Completed 1.0 MiB/20.0 MiB with 2 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'upload: file to s3://mybucket/mykey                 \n'
+            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -607,9 +607,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The failure statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
             'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 4.0 MiB/20.0 MiB with 2 files remaining.\r'
+            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
         )
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
@@ -645,9 +645,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The warning statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
-            'warning: my warning                               \n'
-            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'warning: my warning                                 \n'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
         )
 
         self.assertEqual(shared_file.getvalue(), ref_statement)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -601,7 +601,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
     def test_warning(self):
-        self.result_printer(WarningResult('my warning'))
+        self.result_printer(WarningResult('warning: my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 
@@ -625,7 +625,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
 
-        self.result_printer(WarningResult('my warning'))
+        self.result_printer(WarningResult('warning: my warning'))
 
         # The statement should consist of:
         # * The first progress statement
@@ -699,7 +699,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
 
     def test_print_warnings_result(self):
-        self.result_printer(WarningResult('my warning'))
+        self.result_printer(WarningResult('warning: my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -22,6 +22,7 @@ from awscli.customizations.s3.results import ProgressResult
 from awscli.customizations.s3.results import SuccessResult
 from awscli.customizations.s3.results import FailureResult
 from awscli.customizations.s3.results import ErrorResult
+from awscli.customizations.s3.results import CntrlCResult
 from awscli.customizations.s3.results import UploadResultSubscriber
 from awscli.customizations.s3.results import UploadStreamResultSubscriber
 from awscli.customizations.s3.results import DownloadResultSubscriber
@@ -206,12 +207,34 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
         self.assert_result_queue_is_empty()
 
-        cancelled_exception = CancelledError('keyboard interrupt')
+        cancelled_exception = CancelledError('some error')
         cancelled_future = self.get_failed_transfer_future(cancelled_exception)
         self.result_subscriber.on_done(cancelled_future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()
         self.assertEqual(result, ErrorResult(exception=cancelled_exception))
+
+    def test_on_done_cancelled_for_cntrl_c(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
+        self.assert_result_queue_is_empty()
+
+        cancelled_exception = CancelledError('KeyboardInterrupt()')
+        cancelled_future = self.get_failed_transfer_future(cancelled_exception)
+        self.result_subscriber.on_done(cancelled_future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assertEqual(result, CntrlCResult(exception=cancelled_exception))
 
 
 class TestUploadStreamResultSubscriber(TestUploadResultSubscriber):
@@ -890,6 +913,11 @@ class TestResultPrinter(BaseResultPrinterTest):
     def test_error(self):
         self.result_printer(ErrorResult(Exception('my exception')))
         ref_error_statement = 'fatal error: my exception\n'
+        self.assertEqual(self.error_file.getvalue(), ref_error_statement)
+
+    def test_cntrl_c_error(self):
+        self.result_printer(CntrlCResult(Exception()))
+        ref_error_statement = 'cancelled: ctrl-c received\n'
         self.assertEqual(self.error_file.getvalue(), ref_error_statement)
 
     def test_error_while_progress(self):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -659,6 +659,8 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
         self.result_recorder(FinalTotalSubmissionsResult(1))
+        self.assertEqual(
+            self.result_recorder.final_expected_files_transferred, 1)
         self.assertTrue(self.result_recorder.expected_totals_are_final())
 
     def test_expected_totals_are_final_reaches_final_after_notification(self):
@@ -673,6 +675,8 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertTrue(self.result_recorder.expected_totals_are_final())
 
     def test_expected_totals_are_final_is_false_with_no_notification(self):
+        self.assertIsNone(
+            self.result_recorder.final_expected_files_transferred)
         self.assertFalse(self.result_recorder.expected_totals_are_final())
         self.result_recorder(
             QueuedResult(
@@ -680,8 +684,11 @@ class ResultRecorderTest(unittest.TestCase):
                 dest=self.dest, total_transfer_size=self.total_transfer_size
             )
         )
-        # It should still be False because it has not yet been notified
+        # It should still be None because it has not yet been notified
         # of finals.
+        self.assertIsNone(
+            self.result_recorder.final_expected_files_transferred)
+        # This should remain False as well.
         self.assertFalse(self.result_recorder.expected_totals_are_final())
 
     def test_unknown_result_object(self):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import FatalError
 
 from awscli.testutils import unittest
 from awscli.testutils import mock
@@ -192,7 +193,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
             )
         )
 
-    def test_on_done_cancelled(self):
+    def test_on_done_unexpected_cancelled(self):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
@@ -207,7 +208,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
         self.assert_result_queue_is_empty()
 
-        cancelled_exception = CancelledError('some error')
+        cancelled_exception = FatalError('some error')
         cancelled_future = self.get_failed_transfer_future(cancelled_exception)
         self.result_subscriber.on_done(cancelled_future)
         result = self.get_queued_result()

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -105,6 +105,12 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
 
     def test_on_progress(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.get_queued_result()
+        self.assert_result_queue_is_empty()
+
         ref_bytes_transferred = 1024 * 1024  # 1MB
         self.result_subscriber.on_progress(self.future, ref_bytes_transferred)
         result = self.get_queued_result()
@@ -121,6 +127,12 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
 
     def test_on_done_success(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.get_queued_result()
+        self.assert_result_queue_is_empty()
+
         self.result_subscriber.on_done(self.future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()
@@ -134,6 +146,12 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
 
     def test_on_done_failure(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.get_queued_result()
+        self.assert_result_queue_is_empty()
+
         self.result_subscriber.on_done(self.failure_future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -299,7 +299,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        bytes_transferred = 1024 * 1024  # 1MB
+        bytes_transferred = 1024 * 1024
         self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
@@ -322,7 +322,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        bytes_transferred = 1024 * 1024  # 1MB
+        bytes_transferred = 1024 * 1024
         self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
@@ -492,7 +492,7 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
 
-        bytes_transferred = 1024 * 1024  # 1MB
+        bytes_transferred = 1024 * 1024
         self.result_recorder(
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -733,6 +733,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 
@@ -745,6 +746,7 @@ class TestResultPrinter(BaseResultPrinterTest):
     def test_progress_with_no_expected_transfer_bytes(self):
         self.result_recorder.files_transferred = 1
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = 0
         self.result_recorder.expected_bytes_transferred = 0
 
@@ -762,6 +764,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 
@@ -779,6 +782,33 @@ class TestResultPrinter(BaseResultPrinterTest):
             'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
             'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining\r'
         )
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_still_calculating_totals(self):
+        mb = 1024 * 1024
+
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+
+        progress_result = self.get_progress_result()
+        self.result_printer(progress_result)
+        ref_progress_statement = (
+            'Completed 1.0 MiB/~20.0 MiB with ~3 file(s) '
+            'remaining (calculating...)\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_still_calculating_totals_no_bytes(self):
+        self.result_recorder.expected_bytes_transferred = 0
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = 0
+        self.result_recorder.files_transferred = 1
+
+        progress_result = self.get_progress_result()
+        self.result_printer(progress_result)
+        ref_progress_statement = (
+            'Completed 1 file(s) with ~3 file(s) remaining (calculating...)\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_success(self):
@@ -803,6 +833,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
@@ -872,6 +903,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
@@ -934,6 +966,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
@@ -966,6 +999,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         mb = 1024 * 1024
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
 from awscli.compat import queue
+from awscli.compat import StringIO
 from awscli.customizations.s3.results import QueuedResult
 from awscli.customizations.s3.results import ProgressResult
 from awscli.customizations.s3.results import SuccessResult
@@ -22,6 +23,8 @@ from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import DownloadStreamResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.results import ResultRecorder
+from awscli.customizations.s3.results import ResultPrinter
+from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
 from awscli.customizations.s3.utils import relative_path
 from awscli.customizations.s3.utils import WarningResult
 
@@ -434,3 +437,262 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertEqual(self.result_recorder.expected_bytes_transferred, 0)
         self.assertEqual(self.result_recorder.expected_files_transferred, 0)
         self.assertEqual(self.result_recorder.files_transferred, 0)
+
+
+class BaseResultPrinterTest(unittest.TestCase):
+    def setUp(self):
+        self.result_recorder = ResultRecorder()
+        self.out_file = StringIO()
+        self.error_file = StringIO()
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=self.out_file,
+            error_file=self.error_file
+        )
+
+    def get_progress_result(self):
+        # NOTE: The actual values are not important for the purpose
+        # of printing as the ResultPrinter only looks at the type and
+        # the ResultRecorder to determine what to print out on progress.
+        return ProgressResult(
+            transfer_type=None, src=None, dest=None, bytes_transferred=None,
+            total_transfer_size=None
+        )
+
+
+class TestResultPrinter(BaseResultPrinterTest):
+    def test_unknown_result_object(self):
+        self.result_printer.print_result(object())
+        # Nothing should have been printed because of it.
+        self.assertEqual(self.out_file.getvalue(), '')
+        self.assertEqual(self.error_file.getvalue(), '')
+
+    def test_progress(self):
+        mb = 1024 * 1024
+
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+
+        progress_result = self.get_progress_result()
+        self.result_printer.print_result(progress_result)
+        ref_progress_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_then_more_progress(self):
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+
+        self.result_printer.print_result(progress_result)
+        ref_progress_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+        # Add the second progress update
+        self.result_recorder.bytes_transferred += mb
+        self.result_printer.print_result(progress_result)
+
+        # The result should be the combination of the two
+        ref_progress_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'Completed 2.0 MiB/20.0 MiB with 3 files remaining.\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_success(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_printer.print_result(success_result)
+
+        ref_success_statement = (
+            'upload: file to s3://mybucket/mykey\n'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_success_statement)
+
+    def test_success_with_progress(self):
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+        self.result_printer.print_result(progress_result)
+
+        # Add a success result and print it out.
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_recorder.files_transferred += 1
+        self.result_printer.print_result(success_result)
+
+        # The statement should consist of:
+        # * The first progress statement
+        # * The success statement
+        # * And the progress again since the transfer is still ongoing
+        ref_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'upload: file to s3://mybucket/mykey               \n'
+            'Completed 1.0 MiB/20.0 MiB with 2 files remaining.\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
+
+    def test_failure(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_printer.print_result(failure_result)
+
+        ref_failure_statement = (
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+        )
+        self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
+
+    def test_failure_with_progress(self):
+        # Make errors and regular outprint go to the same file to track order.
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+        self.result_printer.print_result(progress_result)
+
+        # Add a success result and print it out.
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_recorder.bytes_failed_to_transfer = 3 * mb
+        self.result_recorder.files_transferred += 1
+        self.result_printer.print_result(failure_result)
+
+        # The statement should consist of:
+        # * The first progress statement
+        # * The failure statement
+        # * And the progress again since the transfer is still ongoing
+        ref_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+            'Completed 4.0 MiB/20.0 MiB with 2 files remaining.\r'
+        )
+        self.assertEqual(shared_file.getvalue(), ref_statement)
+
+    def test_warning(self):
+        self.result_printer.print_result(WarningResult('my warning'))
+        ref_warning_statement = 'warning: my warning\n'
+        self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
+
+    def test_warning_with_progress(self):
+        # Make errors and regular outprint go to the same file to track order.
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        mb = 1024 * 1024
+
+        progress_result = self.get_progress_result()
+
+        # Add the first progress update and print it out
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+        self.result_printer.print_result(progress_result)
+
+        self.result_printer.print_result(WarningResult('my warning'))
+
+        # The statement should consist of:
+        # * The first progress statement
+        # * The warning statement
+        # * And the progress again since the transfer is still ongoing
+        ref_statement = (
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+            'warning: my warning                               \n'
+            'Completed 1.0 MiB/20.0 MiB with 3 files remaining.\r'
+        )
+
+        self.assertEqual(shared_file.getvalue(), ref_statement)
+
+
+class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
+    def setUp(self):
+        super(TestOnlyShowErrorsResultPrinter, self).setUp()
+        self.result_printer = OnlyShowErrorsResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=self.out_file,
+            error_file=self.error_file
+        )
+
+    def test_does_not_print_progress_result(self):
+        progress_result = self.get_progress_result()
+        self.result_printer.print_result(progress_result)
+        self.assertEqual(self.out_file.getvalue(), '')
+
+    def test_does_not_print_sucess_result(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_printer.print_result(success_result)
+        self.assertEqual(self.out_file.getvalue(), '')
+
+    def test_print_failure_result(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_printer.print_result(failure_result)
+
+        ref_failure_statement = (
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+        )
+        self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
+
+    def test_print_warnings_result(self):
+        self.result_printer.print_result(WarningResult('my warning'))
+        ref_warning_statement = 'warning: my warning\n'
+        self.assertEqual(self.error_file.getvalue(), ref_warning_statement)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -23,7 +23,7 @@ from awscli.customizations.s3.results import ProgressResult
 from awscli.customizations.s3.results import SuccessResult
 from awscli.customizations.s3.results import FailureResult
 from awscli.customizations.s3.results import ErrorResult
-from awscli.customizations.s3.results import CntrlCResult
+from awscli.customizations.s3.results import CtrlCResult
 from awscli.customizations.s3.results import UploadResultSubscriber
 from awscli.customizations.s3.results import UploadStreamResultSubscriber
 from awscli.customizations.s3.results import DownloadResultSubscriber
@@ -215,7 +215,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         self.assert_result_queue_is_empty()
         self.assertEqual(result, ErrorResult(exception=cancelled_exception))
 
-    def test_on_done_cancelled_for_cntrl_c(self):
+    def test_on_done_cancelled_for_ctrl_c(self):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
@@ -235,7 +235,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         self.result_subscriber.on_done(cancelled_future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()
-        self.assertEqual(result, CntrlCResult(exception=cancelled_exception))
+        self.assertEqual(result, CtrlCResult(exception=cancelled_exception))
 
 
 class TestUploadStreamResultSubscriber(TestUploadResultSubscriber):
@@ -916,8 +916,8 @@ class TestResultPrinter(BaseResultPrinterTest):
         ref_error_statement = 'fatal error: my exception\n'
         self.assertEqual(self.error_file.getvalue(), ref_error_statement)
 
-    def test_cntrl_c_error(self):
-        self.result_printer(CntrlCResult(Exception()))
+    def test_ctrl_c_error(self):
+        self.result_printer(CtrlCResult(Exception()))
         ref_error_statement = 'cancelled: ctrl-c received\n'
         self.assertEqual(self.error_file.getvalue(), ref_error_statement)
 

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -37,6 +37,7 @@ from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import ResultProcessor
+from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
 from awscli.customizations.s3.utils import StablePriorityQueue
 from awscli.customizations.s3.utils import WarningResult
@@ -1095,14 +1096,16 @@ class TestS3TransferHandler(unittest.TestCase):
             self.result_queue,
             [self.result_recorder, self.processed_results.append]
         )
+        self.command_result_recorder = CommandResultRecorder(
+            self.result_queue, self.result_recorder, self.result_processor)
 
         self.transfer_manager = mock.Mock(spec=TransferManager)
         self.transfer_manager.__enter__ = mock.Mock()
         self.transfer_manager.__exit__ = mock.Mock()
         self.parameters = {}
         self.s3_transfer_handler = S3TransferHandler(
-            self.transfer_manager, self.parameters, self.result_queue,
-            self.result_recorder, self.result_processor
+            self.transfer_manager, self.parameters,
+            self.command_result_recorder
         )
 
     def test_call_return_command_result(self):

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -22,14 +22,25 @@ import awscli.customizations.s3.utils
 from awscli.testutils import unittest, capture_input
 from awscli import EnvironmentVariables
 from awscli.compat import six
+from awscli.compat import queue
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
+from awscli.customizations.s3.s3handler import UploadRequestSubmitter
+from awscli.customizations.s3.s3handler import DownloadRequestSubmitter
+from awscli.customizations.s3.s3handler import CopyRequestSubmitter
 from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.tasks import CreateMultipartUploadTask, \
     UploadPartTask, CreateLocalFileTask, CompleteMultipartUploadTask
+from awscli.customizations.s3.results import UploadResultSubscriber
+from awscli.customizations.s3.results import DownloadResultSubscriber
+from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
 from awscli.customizations.s3.utils import StablePriorityQueue
 from awscli.customizations.s3.utils import ProvideSizeSubscriber
+from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
+from awscli.customizations.s3.utils import ProvideCopyContentTypeSubscriber
+from awscli.customizations.s3.utils import ProvideLastModifiedTimeSubscriber
+from awscli.customizations.s3.utils import DirectoryCreatorSubscriber
 from awscli.customizations.s3.transferconfig import RuntimeConfig
 from tests.unit.customizations.s3 import make_loc_files, clean_loc_files, \
     S3HandlerBaseTest
@@ -1069,6 +1080,221 @@ class TestS3HandlerInitialization(unittest.TestCase):
 
         self.assertEqual(handler.chunksize, 1000)
         self.assertEqual(handler.multi_threshold, 10000)
+
+
+class BaseTransferRequestSubmitterTest(unittest.TestCase):
+    def setUp(self):
+        self.transfer_manager = mock.Mock(spec=TransferManager)
+        self.result_queue = queue.Queue()
+        self.cli_params = {}
+        self.filename = 'myfile'
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+
+
+class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
+    def setUp(self):
+        super(TestUploadRequestSubmitter, self).setUp()
+        self.transfer_request_submitter = UploadRequestSubmitter(
+            self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_submit(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key)
+        self.cli_params['guess_mime_type'] = True  # Default settings
+        self.transfer_request_submitter.submit(fileinfo)
+
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+        self.assertEqual(upload_call_kwargs['fileobj'], self.filename)
+        self.assertEqual(upload_call_kwargs['bucket'], self.bucket)
+        self.assertEqual(upload_call_kwargs['key'], self.key)
+        self.assertEqual(upload_call_kwargs['extra_args'], {})
+
+        # Make sure the subscriber applied are of the correct type and order
+        ref_subscribers = [
+            ProvideUploadContentTypeSubscriber,
+            ProvideSizeSubscriber,
+            UploadResultSubscriber
+        ]
+        actual_subscribers = upload_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_submit_with_extra_args(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key)
+        # Set some extra argument like storage_class to make sure cli
+        # params get mapped to request parameters.
+        self.cli_params['storage_class'] = 'STANDARD_IA'
+        self.transfer_request_submitter.submit(fileinfo)
+
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+        self.assertEqual(
+            upload_call_kwargs['extra_args'], {'StorageClass': 'STANDARD_IA'})
+
+    def test_submit_when_content_type_specified(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key)
+        self.cli_params['content_type'] = 'text/plain'
+        self.transfer_request_submitter.submit(fileinfo)
+
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+        self.assertEqual(
+            upload_call_kwargs['extra_args'], {'ContentType': 'text/plain'})
+        ref_subscribers = [
+            ProvideSizeSubscriber,
+            UploadResultSubscriber
+        ]
+        actual_subscribers = upload_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_submit_when_no_guess_content_mime_type(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key)
+        self.cli_params['guess_mime_type'] = False
+        self.transfer_request_submitter.submit(fileinfo)
+
+        upload_call_kwargs = self.transfer_manager.upload.call_args[1]
+        ref_subscribers = [
+            ProvideSizeSubscriber,
+            UploadResultSubscriber
+        ]
+        actual_subscribers = upload_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+
+class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
+    def setUp(self):
+        super(TestDownloadRequestSubmitter, self).setUp()
+        self.transfer_request_submitter = DownloadRequestSubmitter(
+            self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_submit(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename)
+        self.transfer_request_submitter.submit(fileinfo)
+
+        download_call_kwargs = self.transfer_manager.download.call_args[1]
+        self.assertEqual(download_call_kwargs['fileobj'], self.filename)
+        self.assertEqual(download_call_kwargs['bucket'], self.bucket)
+        self.assertEqual(download_call_kwargs['key'], self.key)
+        self.assertEqual(download_call_kwargs['extra_args'], {})
+
+        # Make sure the subscriber applied are of the correct type and order
+        ref_subscribers = [
+            ProvideLastModifiedTimeSubscriber,
+            DirectoryCreatorSubscriber,
+            ProvideSizeSubscriber,
+            DownloadResultSubscriber
+        ]
+        actual_subscribers = download_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_submit_with_extra_args(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename)
+        self.cli_params['sse_c'] = 'AES256'
+        self.cli_params['sse_c_key'] = 'mykey'
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # Set some extra argument like sse_c to make sure cli
+        # params get mapped to request parameters.
+        download_call_kwargs = self.transfer_manager.download.call_args[1]
+        self.assertEqual(
+            download_call_kwargs['extra_args'],
+            {'SSECustomerAlgorithm': 'AES256', 'SSECustomerKey': 'mykey'}
+        )
+
+
+class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
+    def setUp(self):
+        super(TestCopyRequestSubmitter, self).setUp()
+        self.source_bucket = 'mysourcebucket'
+        self.source_key = 'mysourcekey'
+        self.transfer_request_submitter = CopyRequestSubmitter(
+            self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_submit(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key)
+        self.cli_params['guess_mime_type'] = True  # Default settings
+        self.transfer_request_submitter.submit(fileinfo)
+
+        copy_call_kwargs = self.transfer_manager.copy.call_args[1]
+        self.assertEqual(
+            copy_call_kwargs['copy_source'],
+            {'Bucket': self.source_bucket, 'Key': self.source_key})
+        self.assertEqual(copy_call_kwargs['bucket'], self.bucket)
+        self.assertEqual(copy_call_kwargs['key'], self.key)
+        self.assertEqual(copy_call_kwargs['extra_args'], {})
+
+        # Make sure the subscriber applied are of the correct type and order
+        ref_subscribers = [
+            ProvideCopyContentTypeSubscriber,
+            ProvideSizeSubscriber,
+            CopyResultSubscriber
+        ]
+        actual_subscribers = copy_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_submit_with_extra_args(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key)
+        # Set some extra argument like storage_class to make sure cli
+        # params get mapped to request parameters.
+        self.cli_params['storage_class'] = 'STANDARD_IA'
+        self.transfer_request_submitter.submit(fileinfo)
+
+        copy_call_kwargs = self.transfer_manager.copy.call_args[1]
+        self.assertEqual(
+            copy_call_kwargs['extra_args'], {'StorageClass': 'STANDARD_IA'})
+
+    def test_submit_when_content_type_specified(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key)
+        self.cli_params['content_type'] = 'text/plain'
+        self.transfer_request_submitter.submit(fileinfo)
+
+        copy_call_kwargs = self.transfer_manager.copy.call_args[1]
+        self.assertEqual(
+            copy_call_kwargs['extra_args'], {'ContentType': 'text/plain'})
+        ref_subscribers = [
+            ProvideSizeSubscriber,
+            CopyResultSubscriber
+        ]
+        actual_subscribers = copy_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_submit_when_no_guess_content_mime_type(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key)
+        self.cli_params['guess_mime_type'] = False
+        self.transfer_request_submitter.submit(fileinfo)
+
+        copy_call_kwargs = self.transfer_manager.copy.call_args[1]
+        ref_subscribers = [
+            ProvideSizeSubscriber,
+            CopyResultSubscriber
+        ]
+        actual_subscribers = copy_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1098,6 +1098,16 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = UploadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
+    def test_is_valid_submission(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key,
+            operation_name='upload')
+        self.assertTrue(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+
     def test_submit(self):
         fileinfo = FileInfo(
             src=self.filename, dest=self.bucket+'/'+self.key)
@@ -1174,6 +1184,16 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = DownloadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
+    def test_is_valid_submission(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download')
+        self.assertTrue(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+
     def test_submit(self):
         fileinfo = FileInfo(
             src=self.bucket+'/'+self.key, dest=self.filename)
@@ -1220,6 +1240,16 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.source_key = 'mysourcekey'
         self.transfer_request_submitter = CopyRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_is_valid_submission(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key, operation_name='copy')
+        self.assertTrue(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.is_valid_submission(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1123,8 +1123,8 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
-            ProvideUploadContentTypeSubscriber,
             ProvideSizeSubscriber,
+            ProvideUploadContentTypeSubscriber,
             UploadResultSubscriber
         ]
         actual_subscribers = upload_call_kwargs['subscribers']
@@ -1222,9 +1222,9 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
-            ProvideLastModifiedTimeSubscriber,
-            DirectoryCreatorSubscriber,
             ProvideSizeSubscriber,
+            DirectoryCreatorSubscriber,
+            ProvideLastModifiedTimeSubscriber,
             DownloadResultSubscriber
         ]
         actual_subscribers = download_call_kwargs['subscribers']
@@ -1355,8 +1355,8 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
-            ProvideCopyContentTypeSubscriber,
             ProvideSizeSubscriber,
+            ProvideCopyContentTypeSubscriber,
             CopyResultSubscriber
         ]
         actual_subscribers = copy_call_kwargs['subscribers']

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -36,6 +36,7 @@ from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.utils import MAX_PARTS, MAX_UPLOAD_SIZE
 from awscli.customizations.s3.utils import StablePriorityQueue
+from awscli.customizations.s3.utils import WarningResult
 from awscli.customizations.s3.utils import ProvideSizeSubscriber
 from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideCopyContentTypeSubscriber
@@ -1177,6 +1178,20 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         for i, actual_subscriber in enumerate(actual_subscribers):
             self.assertIsInstance(actual_subscriber, ref_subscribers[i])
 
+    def test_warn_on_too_large_transfer(self):
+        fileinfo = FileInfo(
+            src=self.filename, dest=self.bucket+'/'+self.key,
+            size=MAX_UPLOAD_SIZE+1)
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have been submitted because it is too large.
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assertIn('exceeds s3 upload limit', warning_result.message)
+
+        # Make sure that the transfer was still attempted
+        self.assertEqual(len(self.transfer_manager.upload.call_args_list), 1)
+
 
 class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
     def setUp(self):
@@ -1231,6 +1246,78 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
             download_call_kwargs['extra_args'],
             {'SSECustomerAlgorithm': 'AES256', 'SSECustomerKey': 'mykey'}
         )
+
+    def test_warn_glacier_for_incompatible(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have been submitted because it is a non-restored
+        # glacier object.
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assertIn(
+            'Unable to perform download operations on GLACIER objects',
+            warning_result.message)
+
+        # The transfer should have been skipped.
+        self.assertEqual(len(self.transfer_manager.download.call_args_list), 0)
+
+    def test_not_warn_glacier_for_compatible(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+                'Restore': 'ongoing-request="false"'
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have not been submitted because it is a restored
+        # glacier object.
+        self.assertTrue(self.result_queue.empty())
+
+        # And the transfer should not have been skipped.
+        self.assertEqual(len(self.transfer_manager.download.call_args_list), 1)
+
+    def test_warn_glacier_force_glacier(self):
+        self.cli_params['force_glacier_transfer'] = True
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have not been submitted because it is glacier
+        # transfers were forced.
+        self.assertTrue(self.result_queue.empty())
+        self.assertEqual(len(self.transfer_manager.download.call_args_list), 1)
+
+    def test_warn_glacier_ignore_glacier_warnings(self):
+        self.cli_params['ignore_glacier_warnings'] = True
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=self.filename,
+            operation_name='download',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have not been submitted because it was specified
+        # to ignore glacier warnings.
+        self.assertTrue(self.result_queue.empty())
+        # But the transfer still should have been skipped.
+        self.assertEqual(len(self.transfer_manager.download.call_args_list), 0)
 
 
 class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
@@ -1325,6 +1412,82 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.assertEqual(len(ref_subscribers), len(actual_subscribers))
         for i, actual_subscriber in enumerate(actual_subscribers):
             self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+    def test_warn_glacier_for_incompatible(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key,
+            operation_name='copy',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have been submitted because it is a non-restored
+        # glacier object.
+        warning_result = self.result_queue.get()
+        self.assertIsInstance(warning_result, WarningResult)
+        self.assertIn(
+            'Unable to perform copy operations on GLACIER objects',
+            warning_result.message)
+
+        # The transfer should have been skipped.
+        self.assertEqual(len(self.transfer_manager.copy.call_args_list), 0)
+
+    def test_not_warn_glacier_for_compatible(self):
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key,
+            operation_name='copy',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+                'Restore': 'ongoing-request="false"'
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have not been submitted because it is a restored
+        # glacier object.
+        self.assertTrue(self.result_queue.empty())
+
+        # And the transfer should not have been skipped.
+        self.assertEqual(len(self.transfer_manager.copy.call_args_list), 1)
+
+    def test_warn_glacier_force_glacier(self):
+        self.cli_params['force_glacier_transfer'] = True
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key,
+            operation_name='copy',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have not been submitted because it is glacier
+        # transfers were forced.
+        self.assertTrue(self.result_queue.empty())
+        self.assertEqual(len(self.transfer_manager.copy.call_args_list), 1)
+
+    def test_warn_glacier_ignore_glacier_warnings(self):
+        self.cli_params['ignore_glacier_warnings'] = True
+        fileinfo = FileInfo(
+            src=self.source_bucket+'/'+self.source_key,
+            dest=self.bucket+'/'+self.key,
+            operation_name='copy',
+            associated_response_data={
+                'StorageClass': 'GLACIER',
+            }
+        )
+        self.transfer_request_submitter.submit(fileinfo)
+
+        # A warning should have not been submitted because it was specified
+        # to ignore glacier warnings.
+        self.assertTrue(self.result_queue.empty())
+        # But the transfer still should have been skipped.
+        self.assertEqual(len(self.transfer_manager.copy.call_args_list), 0)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1068,8 +1068,10 @@ class TestS3TransferHandler(unittest.TestCase):
                          operation_name='download'))
 
         self.s3_transfer_handler.call(fileinfos)
-        self.result_recorder.expected_files_transferred = num_transfers
-        self.assertTrue(self.result_recorder.expected_totals_are_final())
+        self.assertEqual(
+            self.result_recorder.final_expected_files_transferred,
+            num_transfers
+        )
 
     def test_notifies_total_submissions_accounts_for_skips(self):
         fileinfos = []
@@ -1088,8 +1090,10 @@ class TestS3TransferHandler(unittest.TestCase):
         # Since the last glacier download was skipped the final expected
         # total should be equal to the number of transfers provided in the
         # for loop.
-        self.result_recorder.expected_files_transferred = num_transfers
-        self.assertTrue(self.result_recorder.expected_totals_are_final())
+        self.assertEqual(
+            self.result_recorder.final_expected_files_transferred,
+            num_transfers
+        )
 
 
 class BaseTransferRequestSubmitterTest(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1196,15 +1196,15 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = UploadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
-    def test_is_valid_submission(self):
+    def test_can_submit(self):
         fileinfo = FileInfo(
             src=self.filename, dest=self.bucket+'/'+self.key,
             operation_name='upload')
         self.assertTrue(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
         fileinfo.operation_name = 'foo'
         self.assertFalse(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(
@@ -1296,15 +1296,15 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = DownloadRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
-    def test_is_valid_submission(self):
+    def test_can_submit(self):
         fileinfo = FileInfo(
             src=self.bucket+'/'+self.key, dest=self.filename,
             operation_name='download')
         self.assertTrue(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
         fileinfo.operation_name = 'foo'
         self.assertFalse(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(
@@ -1425,15 +1425,15 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter = CopyRequestSubmitter(
             self.transfer_manager, self.result_queue, self.cli_params)
 
-    def test_is_valid_submission(self):
+    def test_can_submit(self):
         fileinfo = FileInfo(
             src=self.source_bucket+'/'+self.source_key,
             dest=self.bucket+'/'+self.key, operation_name='copy')
         self.assertTrue(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
         fileinfo.operation_name = 'foo'
         self.assertFalse(
-            self.transfer_request_submitter.is_valid_submission(fileinfo))
+            self.transfer_request_submitter.can_submit(fileinfo))
 
     def test_submit(self):
         fileinfo = FileInfo(

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1048,6 +1048,17 @@ class TestS3TransferHandler(unittest.TestCase):
         self.assertIsInstance(
             download_call_kwargs['fileobj'], StdoutBytesWriter)
 
+    def test_enqueue_deletes(self):
+        fileinfos = []
+        num_transfers = 5
+        for _ in range(num_transfers):
+            fileinfos.append(
+                FileInfo(src='bucket/key', dest=None, operation_name='delete'))
+
+        self.s3_transfer_handler.call(fileinfos)
+        self.assertEqual(
+            self.transfer_manager.delete.call_count, num_transfers)
+
 
 class BaseTransferRequestSubmitterTest(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -31,6 +31,7 @@ from awscli.customizations.s3.s3handler import DownloadRequestSubmitter
 from awscli.customizations.s3.s3handler import CopyRequestSubmitter
 from awscli.customizations.s3.s3handler import UploadStreamRequestSubmitter
 from awscli.customizations.s3.s3handler import DownloadStreamRequestSubmitter
+from awscli.customizations.s3.s3handler import DeleteRequestSubmitter
 from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.tasks import CreateMultipartUploadTask, \
     UploadPartTask, CreateLocalFileTask, CompleteMultipartUploadTask
@@ -39,6 +40,7 @@ from awscli.customizations.s3.results import DownloadResultSubscriber
 from awscli.customizations.s3.results import CopyResultSubscriber
 from awscli.customizations.s3.results import UploadStreamResultSubscriber
 from awscli.customizations.s3.results import DownloadStreamResultSubscriber
+from awscli.customizations.s3.results import DeleteResultSubscriber
 from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.results import CommandResultRecorder
@@ -1545,6 +1547,40 @@ class TestDownloadStreamRequestSubmitter(BaseTransferRequestSubmitterTest):
             DownloadStreamResultSubscriber
         ]
         actual_subscribers = download_call_kwargs['subscribers']
+        self.assertEqual(len(ref_subscribers), len(actual_subscribers))
+        for i, actual_subscriber in enumerate(actual_subscribers):
+            self.assertIsInstance(actual_subscriber, ref_subscribers[i])
+
+
+class TestDeleteRequestSubmitter(BaseTransferRequestSubmitterTest):
+    def setUp(self):
+        super(TestDeleteRequestSubmitter, self).setUp()
+        self.transfer_request_submitter = DeleteRequestSubmitter(
+            self.transfer_manager, self.result_queue, self.cli_params)
+
+    def test_can_submit(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=None, operation_name='delete')
+        self.assertTrue(
+            self.transfer_request_submitter.can_submit(fileinfo))
+        fileinfo.operation_name = 'foo'
+        self.assertFalse(
+            self.transfer_request_submitter.can_submit(fileinfo))
+
+    def test_submit(self):
+        fileinfo = FileInfo(
+            src=self.bucket+'/'+self.key, dest=None, operation_name='delete')
+        self.transfer_request_submitter.submit(fileinfo)
+
+        delete_call_kwargs = self.transfer_manager.delete.call_args[1]
+        self.assertEqual(delete_call_kwargs['bucket'], self.bucket)
+        self.assertEqual(delete_call_kwargs['key'], self.key)
+        self.assertEqual(delete_call_kwargs['extra_args'], {})
+
+        ref_subscribers = [
+            DeleteResultSubscriber
+        ]
+        actual_subscribers = delete_call_kwargs['subscribers']
         self.assertEqual(len(ref_subscribers), len(actual_subscribers))
         for i, actual_subscriber in enumerate(actual_subscribers):
             self.assertIsInstance(actual_subscriber, ref_subscribers[i])

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -26,6 +26,7 @@ from awscli.compat import queue
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferStreamHandler
 from awscli.customizations.s3.s3handler import S3TransferHandler
+from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.s3handler import UploadRequestSubmitter
 from awscli.customizations.s3.s3handler import DownloadRequestSubmitter
 from awscli.customizations.s3.s3handler import CopyRequestSubmitter
@@ -1085,6 +1086,20 @@ class TestS3HandlerInitialization(unittest.TestCase):
 
         self.assertEqual(handler.chunksize, 1000)
         self.assertEqual(handler.multi_threshold, 10000)
+
+
+class TestS3TransferHandlerFactory(unittest.TestCase):
+    def setUp(self):
+        self.cli_params = {}
+        self.runtime_config = runtime_config()
+        self.client = mock.Mock()
+        self.result_queue = queue.Queue()
+
+    def test_call(self):
+        factory = S3TransferHandlerFactory(
+            self.cli_params, self.runtime_config)
+        self.assertIsInstance(
+            factory(self.client, self.result_queue), S3TransferHandler)
 
 
 class TestS3TransferHandler(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -22,6 +22,7 @@ from awscli.customizations.s3.s3 import S3
 from awscli.customizations.s3.subcommands import CommandParameters, \
     CommandArchitecture, CpCommand, SyncCommand, ListCommand, \
     RbCommand, get_client
+from awscli.customizations.s3.transferconfig import RuntimeConfig
 from awscli.customizations.s3.syncstrategy.base import \
     SizeAndLastModifiedSync, NeverSync, MissingFileSync
 from awscli.testutils import unittest, BaseAWSHelpOutputTest, \
@@ -370,7 +371,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         self.parsed_responses = [{'Error': {
                                   'Code': 'BucketNotExists',
                                   'Message': 'Bucket does not exist'}}]
-        cmd_arc = CommandArchitecture(self.session, 'cp', params)
+        cmd_arc = CommandArchitecture(
+            self.session, 'cp', params, RuntimeConfig().build_config())
         cmd_arc.set_clients()
         cmd_arc.create_instructions()
         self.patch_make_request()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -393,6 +393,15 @@ class TestGetFileStat(unittest.TestCase):
                 size, update_time = get_file_stat(temp_file.name)
                 self.assertIsNone(update_time)
 
+    def test_get_file_stat_returns_epoch_on_invalid_timestamp_os_error(self):
+        patch_attribute = 'awscli.customizations.s3.utils.datetime'
+        with mock.patch(patch_attribute) as datetime_mock:
+            with temporary_file('w') as temp_file:
+                temp_file.write('foo')
+                temp_file.flush()
+                datetime_mock.fromtimestamp.side_effect = OSError()
+                size, update_time = get_file_stat(temp_file.name)
+                self.assertIsNone(update_time)
 
 
 class TestSetsFileUtime(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -585,10 +585,10 @@ class OnDoneFilteredRecordingSubscriber(OnDoneFilteredSubscriber):
         self.on_success_calls = []
         self.on_failure_calls = []
 
-    def on_success(self, future):
+    def _on_success(self, future):
         self.on_success_calls.append(future)
 
-    def on_failure(self, future, exception):
+    def _on_failure(self, future, exception):
         self.on_failure_calls.append((future, exception))
 
 
@@ -672,14 +672,14 @@ class TestProvideLastModifiedTimeSubscriber(BaseTestWithFileCreator):
         self.future = FakeTransferFuture(meta=meta)
 
     def test_on_success_modifies_utime(self):
-        self.subscriber.on_success(self.future)
+        self.subscriber.on_done(self.future)
         _, utime = get_file_stat(self.filename)
         self.assertEqual(utime, self.desired_utime)
 
     def test_on_success_failure_in_utime_mod_raises_warning(self):
         self.subscriber = ProvideLastModifiedTimeSubscriber(
             None, self.result_queue)
-        self.subscriber.on_success(self.future)
+        self.subscriber.on_done(self.future)
         # Because the time to provide was None it will throw an exception
         # which results in the a warning about the utime not being able
         # to be set being placed in the result queue.

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -32,7 +32,8 @@ from awscli.compat import queue
 from awscli.compat import StringIO
 from awscli.testutils import FileCreator
 from awscli.customizations.s3.utils import (
-    find_bucket_key, find_chunksize, ReadFileChunk, relative_path,
+    find_bucket_key, find_chunksize, ReadFileChunk,
+    guess_content_type, relative_path,
     StablePriorityQueue, BucketLister, get_file_stat, AppendFilter,
     create_warning, human_readable_size, human_readable_to_bytes,
     MAX_SINGLE_UPLOAD_SIZE, MIN_UPLOAD_CHUNKSIZE, MAX_UPLOAD_SIZE,
@@ -237,6 +238,20 @@ class TestReadFileChunk(unittest.TestCase):
         self.assertEqual(chunk.tell(), 3)
         chunk.seek(0)
         self.assertEqual(chunk.tell(), 0)
+
+
+class TestGuessContentType(unittest.TestCase):
+    def test_guess_content_type(self):
+        self.assertEqual(guess_content_type('foo.txt'), 'text/plain')
+
+    def test_guess_content_type_with_no_valid_matches(self):
+        self.assertEqual(guess_content_type('no-extension'), None)
+
+    def test_guess_content_type_with_unicode_error_returns_no_match(self):
+        with mock.patch('mimetypes.guess_type') as guess_type_patch:
+            # This should throw a UnicodeDecodeError.
+            guess_type_patch.side_effect = lambda x: b'\xe2'.decode('ascii')
+            self.assertEqual(guess_content_type('foo.txt'), None)
 
 
 class TestRelativePath(unittest.TestCase):


### PR DESCRIPTION
This is a PR to take the work of integrating ``cp`` and ``rm`` with ``s3transfer`` and merging it into the develop branch. This will allow us to get any feedback before integrating the rest of the commands with ``s3transfer`` and avoid one big merge into the develop branch. Assuming the performance stays the same, this should be good to merge.

cc @jamesls @JordonPhillips 