### PR TITLE
Cache result kwargs for storing params for Results

### DIFF
--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -31,9 +31,10 @@ class FakeTransferFuture(object):
 
 
 class FakeTransferFutureMeta(object):
-    def __init__(self, size=None, call_args=None):
+    def __init__(self, size=None, call_args=None, transfer_id=None):
         self.size = size
         self.call_args = call_args
+        self.transfer_id = transfer_id
 
 
 class FakeTransferFutureCallArgs(object):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -108,7 +108,15 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
-        self.get_queued_result()
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
         self.assert_result_queue_is_empty()
 
         ref_bytes_transferred = 1024 * 1024  # 1MB
@@ -130,7 +138,15 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
-        self.get_queued_result()
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
         self.assert_result_queue_is_empty()
 
         self.result_subscriber.on_done(self.future)
@@ -149,7 +165,15 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
-        self.get_queued_result()
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
         self.assert_result_queue_is_empty()
 
         self.result_subscriber.on_done(self.failure_future)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -105,6 +105,12 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
 
     def test_on_progress(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.get_queued_result()
+        self.assert_result_queue_is_empty()
+
         ref_bytes_transferred = 1024 * 1024  # 1MB
         self.result_subscriber.on_progress(self.future, ref_bytes_transferred)
         result = self.get_queued_result()
@@ -121,6 +127,12 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
 
     def test_on_done_success(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.get_queued_result()
+        self.assert_result_queue_is_empty()
+
         self.result_subscriber.on_done(self.future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()
@@ -134,6 +146,12 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
 
     def test_on_done_failure(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.get_queued_result()
+        self.assert_result_queue_is_empty()
+
         self.result_subscriber.on_done(self.failure_future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()


### PR DESCRIPTION
Some of the values needed to create the results are expensive especially if the progress callback is happening many times. So we want to record as many as the result kwargs as we can so the ``on_progress`` callbacks become essentially looking up values in a dictionary, creating a ``Result`` object, and placing it on the result queue. From the CLI side of the slow performance, this is pretty beneficial by not having to call ``relative_path`` for every progress update for uploads and downloads. Profiling this it looks like it definitely helps out with that.

cc @jamesls @JordonPhillips 