### PR TITLE
Remove some logging statements

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -465,7 +465,6 @@ class ResultProcessor(threading.Thread):
                         'Shutdown request received in result processing '
                         'thread, shutting down result thread.')
                     break
-                LOGGER.debug('Received result: %s', result)
                 self._process_result(result)
             except queue.Empty:
                 pass
@@ -473,7 +472,6 @@ class ResultProcessor(threading.Thread):
     def _process_result(self, result):
         for result_handler in self._result_handlers:
             try:
-                LOGGER.debug('Processing %s with %s', result, result_handler)
                 result_handler(result)
             except Exception as e:
                 LOGGER.debug(


### PR DESCRIPTION
Logging every single result in the result queue has non-insignificant slow down on the transfer speed and pollutes the debug logs as well. So now just log if errors are encountered or the shutdown request is sent.

cc @jamesls @JordonPhillips 