### PR TITLE
Don't print bytes remaining if none are expected

### DIFF
--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -650,7 +650,19 @@ class TestResultPrinter(BaseResultPrinterTest):
         progress_result = self.get_progress_result()
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_with_no_expected_transfer_bytes(self):
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = 0
+        self.result_recorder.expected_bytes_transferred = 0
+
+        progress_result = self.get_progress_result()
+        self.result_printer(progress_result)
+        ref_progress_statement = (
+            'Completed 1 file(s) with 3 file(s) remaining\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_progress_then_more_progress(self):
@@ -666,7 +678,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r')
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
         # Add the second progress update
@@ -675,8 +687,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         # The result should be the combination of the two
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
-            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
@@ -721,9 +733,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The success statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
-            'upload: file to s3://mybucket/mykey                 \n'
-            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'upload: file to s3://mybucket/mykey                \n'
+            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -792,9 +804,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The failure statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
             'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining.\r'
+            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining\r'
         )
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
@@ -844,9 +856,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The warning statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
-            'warning: my warning                                 \n'
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining.\r'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'warning: my warning                                \n'
+            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
         )
 
         self.assertEqual(shared_file.getvalue(), ref_statement)


### PR DESCRIPTION
Previously when you were doing a recursive rm you would get a progress result like so: `Completed 0 Bytes/0 Bytes with 5 file(s) remaining.` This was somewhat confusing since rm doesn't actually delete bytes. So this removes the bytes part of the message when there is no expected byte transfer. I've also removed the period from the end of the message to be more consistent with the other messages. So now it would look like this: `Completed 1 file(s) with 5 file(s) remaining`

cc @kyleknap @jamesls 