### PR TITLE
Improve output when fatal errors encountered

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -17,6 +17,7 @@ from collections import namedtuple
 from collections import defaultdict
 
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import FatalError
 from s3transfer.subscribers import BaseSubscriber
 
 from awscli.compat import queue
@@ -95,9 +96,9 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
     def _on_failure(self, future, e):
         result_kwargs = self._on_done_pop_from_result_kwargs_cache(future)
         if isinstance(e, CancelledError):
-            error_result_cls = ErrorResult
-            if 'KeyboardInterrupt' in str(e):
-                error_result_cls = CntrlCResult
+            error_result_cls = CntrlCResult
+            if isinstance(e, FatalError):
+                error_result_cls = ErrorResult
             self._result_queue.put(error_result_cls(exception=e))
         else:
             self._result_queue.put(FailureResult(exception=e, **result_kwargs))

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -59,7 +59,7 @@ FailureResult = _create_new_result_cls('FailureResult', ['exception'])
 
 ErrorResult = namedtuple('ErrorResult', ['exception'])
 
-CntrlCResult = _create_new_result_cls('CntrlCResult', base_cls=ErrorResult)
+CtrlCResult = _create_new_result_cls('CtrlCResult', base_cls=ErrorResult)
 
 CommandResult = namedtuple(
     'CommandResult', ['num_tasks_failed', 'num_tasks_warned'])
@@ -96,7 +96,7 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
     def _on_failure(self, future, e):
         result_kwargs = self._on_done_pop_from_result_kwargs_cache(future)
         if isinstance(e, CancelledError):
-            error_result_cls = CntrlCResult
+            error_result_cls = CtrlCResult
             if isinstance(e, FatalError):
                 error_result_cls = ErrorResult
             self._result_queue.put(error_result_cls(exception=e))
@@ -322,7 +322,7 @@ class ResultPrinter(BaseResultHandler):
     ERROR_FORMAT = (
         'fatal error: {exception}'
     )
-    CNTRL_C_MSG = 'cancelled: ctrl-c received'
+    CTRL_C_MSG = 'cancelled: ctrl-c received'
 
     SRC_DEST_TRANSFER_LOCATION_FORMAT = '{src} to {dest}'
     SRC_TRANSFER_LOCATION_FORMAT = '{src}'
@@ -355,7 +355,7 @@ class ResultPrinter(BaseResultHandler):
             FailureResult: self._print_failure,
             WarningResult: self._print_warning,
             ErrorResult: self._print_error,
-            CntrlCResult: self._print_cntrl_c,
+            CtrlCResult: self._print_ctrl_c,
         }
 
     def __call__(self, result):
@@ -396,8 +396,8 @@ class ResultPrinter(BaseResultHandler):
         self._flush_error_statement(
             self.ERROR_FORMAT.format(exception=result.exception))
 
-    def _print_cntrl_c(self, result, **kwargs):
-        self._flush_error_statement(self.CNTRL_C_MSG)
+    def _print_ctrl_c(self, result, **kwargs):
+        self._flush_error_statement(self.CTRL_C_MSG)
 
     def _flush_error_statement(self, error_statement):
         error_statement = self._adjust_statement_padding(error_statement)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -22,6 +22,7 @@ from awscli.customizations.s3.results import ProgressResult
 from awscli.customizations.s3.results import SuccessResult
 from awscli.customizations.s3.results import FailureResult
 from awscli.customizations.s3.results import ErrorResult
+from awscli.customizations.s3.results import CntrlCResult
 from awscli.customizations.s3.results import UploadResultSubscriber
 from awscli.customizations.s3.results import UploadStreamResultSubscriber
 from awscli.customizations.s3.results import DownloadResultSubscriber
@@ -206,12 +207,34 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
         self.assert_result_queue_is_empty()
 
-        cancelled_exception = CancelledError('keyboard interrupt')
+        cancelled_exception = CancelledError('some error')
         cancelled_future = self.get_failed_transfer_future(cancelled_exception)
         self.result_subscriber.on_done(cancelled_future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()
         self.assertEqual(result, ErrorResult(exception=cancelled_exception))
+
+    def test_on_done_cancelled_for_cntrl_c(self):
+        # Simulate a queue result (i.e. submitting and processing the result)
+        # before processing the progress result.
+        self.result_subscriber.on_queued(self.future)
+        self.assertEqual(
+            self.get_queued_result(),
+            QueuedResult(
+                transfer_type=self.transfer_type,
+                src=self.src,
+                dest=self.dest,
+                total_transfer_size=self.size
+            )
+        )
+        self.assert_result_queue_is_empty()
+
+        cancelled_exception = CancelledError('KeyboardInterrupt()')
+        cancelled_future = self.get_failed_transfer_future(cancelled_exception)
+        self.result_subscriber.on_done(cancelled_future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        self.assertEqual(result, CntrlCResult(exception=cancelled_exception))
 
 
 class TestUploadStreamResultSubscriber(TestUploadResultSubscriber):
@@ -890,6 +913,11 @@ class TestResultPrinter(BaseResultPrinterTest):
     def test_error(self):
         self.result_printer(ErrorResult(Exception('my exception')))
         ref_error_statement = 'fatal error: my exception\n'
+        self.assertEqual(self.error_file.getvalue(), ref_error_statement)
+
+    def test_cntrl_c_error(self):
+        self.result_printer(CntrlCResult(Exception()))
+        ref_error_statement = 'cancelled: ctrl-c received\n'
         self.assertEqual(self.error_file.getvalue(), ref_error_statement)
 
     def test_error_while_progress(self):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from s3transfer.exceptions import CancelledError
+from s3transfer.exceptions import FatalError
 
 from awscli.testutils import unittest
 from awscli.testutils import mock
@@ -192,7 +193,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
             )
         )
 
-    def test_on_done_cancelled(self):
+    def test_on_done_unexpected_cancelled(self):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
@@ -207,7 +208,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         )
         self.assert_result_queue_is_empty()
 
-        cancelled_exception = CancelledError('some error')
+        cancelled_exception = FatalError('some error')
         cancelled_future = self.get_failed_transfer_future(cancelled_exception)
         self.result_subscriber.on_done(cancelled_future)
         result = self.get_queued_result()

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -23,7 +23,7 @@ from awscli.customizations.s3.results import ProgressResult
 from awscli.customizations.s3.results import SuccessResult
 from awscli.customizations.s3.results import FailureResult
 from awscli.customizations.s3.results import ErrorResult
-from awscli.customizations.s3.results import CntrlCResult
+from awscli.customizations.s3.results import CtrlCResult
 from awscli.customizations.s3.results import UploadResultSubscriber
 from awscli.customizations.s3.results import UploadStreamResultSubscriber
 from awscli.customizations.s3.results import DownloadResultSubscriber
@@ -215,7 +215,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         self.assert_result_queue_is_empty()
         self.assertEqual(result, ErrorResult(exception=cancelled_exception))
 
-    def test_on_done_cancelled_for_cntrl_c(self):
+    def test_on_done_cancelled_for_ctrl_c(self):
         # Simulate a queue result (i.e. submitting and processing the result)
         # before processing the progress result.
         self.result_subscriber.on_queued(self.future)
@@ -235,7 +235,7 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
         self.result_subscriber.on_done(cancelled_future)
         result = self.get_queued_result()
         self.assert_result_queue_is_empty()
-        self.assertEqual(result, CntrlCResult(exception=cancelled_exception))
+        self.assertEqual(result, CtrlCResult(exception=cancelled_exception))
 
 
 class TestUploadStreamResultSubscriber(TestUploadResultSubscriber):
@@ -916,8 +916,8 @@ class TestResultPrinter(BaseResultPrinterTest):
         ref_error_statement = 'fatal error: my exception\n'
         self.assertEqual(self.error_file.getvalue(), ref_error_statement)
 
-    def test_cntrl_c_error(self):
-        self.result_printer(CntrlCResult(Exception()))
+    def test_ctrl_c_error(self):
+        self.result_printer(CtrlCResult(Exception()))
         ref_error_statement = 'cancelled: ctrl-c received\n'
         self.assertEqual(self.error_file.getvalue(), ref_error_statement)
 


### PR DESCRIPTION
Now if a fatal error is encountered it will print out the fatal error and stop printing out any more updates it may receive as it cleans up. It was really confusing when all of the transfers
cancelled by Cntrl-C would show up in results as failures. Here is an example of how this looks now:
```

$ aws s3 cp aws-cli s3://kyleknap-dump/aws-cli --recursive
upload: aws-cli/.changes/1.10.13.json to s3://kyleknap-dump/aws-cli/.changes/1.10.13.json
upload: aws-cli/.changes/1.10.14.json to s3://kyleknap-dump/aws-cli/.changes/1.10.14.json
upload: aws-cli/.changes/1.10.11.json to s3://kyleknap-dump/aws-cli/.changes/1.10.11.json
upload: aws-cli/.changes/1.10.10.json to s3://kyleknap-dump/aws-cli/.changes/1.10.10.json
upload: aws-cli/.changes/1.1.2.json to s3://kyleknap-dump/aws-cli/.changes/1.1.2.json
upload: aws-cli/.changes/1.1.1.json to s3://kyleknap-dump/aws-cli/.changes/1.1.1.json
upload: aws-cli/.changes/1.10.17.json to s3://kyleknap-dump/aws-cli/.changes/1.10.17.json
upload: aws-cli/.changes/1.10.18.json to s3://kyleknap-dump/aws-cli/.changes/1.10.18.json
upload: aws-cli/.changes/1.10.2.json to s3://kyleknap-dump/aws-cli/.changes/1.10.2.json
upload: aws-cli/.changes/1.10.19.json to s3://kyleknap-dump/aws-cli/.changes/1.10.19.json
upload: aws-cli/.changes/1.10.16.json to s3://kyleknap-dump/aws-cli/.changes/1.10.16.json
upload: aws-cli/.changes/1.10.20.json to s3://kyleknap-dump/aws-cli/.changes/1.10.20.json
upload: aws-cli/.changes/1.10.15.json to s3://kyleknap-dump/aws-cli/.changes/1.10.15.json
upload: aws-cli/.changes/1.1.0.json to s3://kyleknap-dump/aws-cli/.changes/1.1.0.json
upload: aws-cli/.changes/1.10.12.json to s3://kyleknap-dump/aws-cli/.changes/1.10.12.json
fatal error: keyboard interrupt                       
$ 
```
I decided not to include the cleaning up bit because now Cntrl-C's are really fast and is not needed plus I think it looks a little better.

Note that this PR builds off of this one: https://github.com/boto/s3transfer/pull/56. So tests may fail until the linked PR is merged.

cc @jamesls @JordonPhillips 