### PR TITLE
Display if total expected are still being calculated in progress

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -198,7 +198,7 @@ class ResultRecorder(BaseResultHandler):
         self.errors = 0
         self.expected_bytes_transferred = 0
         self.expected_files_transferred = 0
-        self._final_expected_files_transferred = None
+        self.final_expected_files_transferred = None
 
         self._ongoing_progress = defaultdict(int)
         self._ongoing_total_sizes = {}
@@ -215,7 +215,7 @@ class ResultRecorder(BaseResultHandler):
 
     def expected_totals_are_final(self):
         return (
-            self._final_expected_files_transferred ==
+            self.final_expected_files_transferred ==
             self.expected_files_transferred
         )
 
@@ -310,7 +310,7 @@ class ResultRecorder(BaseResultHandler):
         self.errors += 1
 
     def _record_final_expected_files(self, result, **kwargs):
-        self._final_expected_files_transferred = result.total_submissions
+        self.final_expected_files_transferred = result.total_submissions
 
 
 class ResultPrinter(BaseResultHandler):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -507,11 +507,15 @@ class S3TransferHandler(object):
         """
         with self._result_command_recorder:
             with self._transfer_manager:
+                total_submissions = 0
                 for fileinfo in fileinfos:
                     for submitter in self._submitters:
                         if submitter.can_submit(fileinfo):
-                            submitter.submit(fileinfo)
+                            if submitter.submit(fileinfo):
+                                total_submissions += 1
                             break
+                self._result_command_recorder.notify_total_submissions(
+                    total_submissions)
         return self._result_command_recorder.get_command_result()
 
 

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -659,6 +659,8 @@ class ResultRecorderTest(unittest.TestCase):
             )
         )
         self.result_recorder(FinalTotalSubmissionsResult(1))
+        self.assertEqual(
+            self.result_recorder.final_expected_files_transferred, 1)
         self.assertTrue(self.result_recorder.expected_totals_are_final())
 
     def test_expected_totals_are_final_reaches_final_after_notification(self):
@@ -673,6 +675,8 @@ class ResultRecorderTest(unittest.TestCase):
         self.assertTrue(self.result_recorder.expected_totals_are_final())
 
     def test_expected_totals_are_final_is_false_with_no_notification(self):
+        self.assertIsNone(
+            self.result_recorder.final_expected_files_transferred)
         self.assertFalse(self.result_recorder.expected_totals_are_final())
         self.result_recorder(
             QueuedResult(
@@ -680,8 +684,11 @@ class ResultRecorderTest(unittest.TestCase):
                 dest=self.dest, total_transfer_size=self.total_transfer_size
             )
         )
-        # It should still be False because it has not yet been notified
+        # It should still be None because it has not yet been notified
         # of finals.
+        self.assertIsNone(
+            self.result_recorder.final_expected_files_transferred)
+        # This should remain False as well.
         self.assertFalse(self.result_recorder.expected_totals_are_final())
 
     def test_unknown_result_object(self):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -733,6 +733,7 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 
@@ -745,6 +746,7 @@ class TestResultPrinter(BaseResultPrinterTest):
     def test_progress_with_no_expected_transfer_bytes(self):
         self.result_recorder.files_transferred = 1
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = 0
         self.result_recorder.expected_bytes_transferred = 0
 
@@ -762,6 +764,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 
@@ -779,6 +782,33 @@ class TestResultPrinter(BaseResultPrinterTest):
             'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
             'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining\r'
         )
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_still_calculating_totals(self):
+        mb = 1024 * 1024
+
+        self.result_recorder.expected_bytes_transferred = 20 * mb
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = mb
+        self.result_recorder.files_transferred = 1
+
+        progress_result = self.get_progress_result()
+        self.result_printer(progress_result)
+        ref_progress_statement = (
+            'Completed 1.0 MiB/~20.0 MiB with ~3 file(s) '
+            'remaining (calculating...)\r')
+        self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
+
+    def test_progress_still_calculating_totals_no_bytes(self):
+        self.result_recorder.expected_bytes_transferred = 0
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.bytes_transferred = 0
+        self.result_recorder.files_transferred = 1
+
+        progress_result = self.get_progress_result()
+        self.result_printer(progress_result)
+        ref_progress_statement = (
+            'Completed 1 file(s) with ~3 file(s) remaining (calculating...)\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_success(self):
@@ -803,6 +833,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
@@ -872,6 +903,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
@@ -934,6 +966,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         # Add the first progress update and print it out
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
         self.result_printer(progress_result)
@@ -966,6 +999,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         mb = 1024 * 1024
         self.result_recorder.expected_bytes_transferred = 20 * mb
         self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.final_expected_files_transferred = 4
         self.result_recorder.bytes_transferred = mb
         self.result_recorder.files_transferred = 1
 

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -1068,8 +1068,10 @@ class TestS3TransferHandler(unittest.TestCase):
                          operation_name='download'))
 
         self.s3_transfer_handler.call(fileinfos)
-        self.result_recorder.expected_files_transferred = num_transfers
-        self.assertTrue(self.result_recorder.expected_totals_are_final())
+        self.assertEqual(
+            self.result_recorder.final_expected_files_transferred,
+            num_transfers
+        )
 
     def test_notifies_total_submissions_accounts_for_skips(self):
         fileinfos = []
@@ -1088,8 +1090,10 @@ class TestS3TransferHandler(unittest.TestCase):
         # Since the last glacier download was skipped the final expected
         # total should be equal to the number of transfers provided in the
         # for loop.
-        self.result_recorder.expected_files_transferred = num_transfers
-        self.assertTrue(self.result_recorder.expected_totals_are_final())
+        self.assertEqual(
+            self.result_recorder.final_expected_files_transferred,
+            num_transfers
+        )
 
 
 class BaseTransferRequestSubmitterTest(unittest.TestCase):


### PR DESCRIPTION
Builds off of this PR: https://github.com/aws/aws-cli/pull/2173 to avoid possible merge conflicts. So this is like the very last PR that should be looked at, but if you want to try out the complete revamp of progress use this branch.

This adds details on whether we are still determining the total expected bytes and total expected files. The progress now looks like this if we do not have an exact number yet:
```
Completed 5.0MB/~7.0MB with ~1004 file(s) remaining (calculating...)
```

Let me know what you think.

cc @jamesls @JordonPhillips 