### PR TITLE
Refactor rb

### DIFF
--- a/.changes/next-release/bugfix-s3-27594.json
+++ b/.changes/next-release/bugfix-s3-27594.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "description": "Refactor rb into its own command. In addition, validate that no key is supplied regardless of whether or not the force argument is supplied.",
+  "category": "s3"
+}

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -103,53 +103,12 @@ def _is_multipart_etag(etag):
     return '-' in etag
 
 
-class TaskInfo(object):
-    """
-    This class contains important details related to performing a task.  This
-    object is usually only used for creating buckets, removing buckets, and
-    listing objects/buckets.  This object contains the attributes and
-    functions needed to perform the task.  Note that just instantiating one
-    of these objects will not be enough to run a listing or bucket command.
-    unless ``session`` and ``region`` are specified upon instantiation.
+class FileInfo(object):
+    """This class contains important details related to performing a task.
 
-    :param src: the source path
-    :type src: string
-    :param src_type: if the source file is s3 or local.
-    :type src_type: string
-    :param operation: the operation being performed.
-    :type operation: string
-    :param session: ``botocore.session`` object
-    :param region: The region for the endpoint
-
-    Note that a local file will always have its absolute path, and a s3 file
-    will have its path in the form of bucket/key
-    """
-    def __init__(self, src, src_type, operation_name, client):
-        self.src = src
-        self.src_type = src_type
-        self.operation_name = operation_name
-        self.client = client
-
-    def remove_bucket(self):
-        """
-        This operation removes a bucket.
-        """
-        bucket, key = find_bucket_key(self.src)
-        self.client.delete_bucket(Bucket=bucket)
-
-    def is_glacier_compatible(self):
-        # These operations do not involving transferring glacier objects
-        # so they are always glacier compatible.
-        return True
-
-
-class FileInfo(TaskInfo):
-    """
-    This is a child object of the ``TaskInfo`` object.  It can perform more
-    operations such as ``upload``, ``download``, ``copy``, ``delete``,
-    ``move``.  Similiarly to
-    ``TaskInfo`` objects attributes like ``session`` need to be set in order
-    to perform operations.
+    It can perform operations such as ``upload``, ``download``, ``copy``,
+    ``delete``, ``move``.  Similarly to ``TaskInfo`` objects attributes
+    like ``session`` need to be set in order to perform operations.
 
     :param dest: the destination path
     :type dest: string
@@ -175,9 +134,10 @@ class FileInfo(TaskInfo):
                  operation_name=None, client=None, parameters=None,
                  source_client=None, is_stream=False,
                  associated_response_data=None):
-        super(FileInfo, self).__init__(src, src_type=src_type,
-                                       operation_name=operation_name,
-                                       client=client)
+        self.src = src
+        self.src_type = src_type
+        self.operation_name = operation_name
+        self.client = client
         self.dest = dest
         self.dest_type = dest_type
         self.compare_key = compare_key

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -25,7 +25,7 @@ from awscli.customizations.s3.comparator import Comparator
 from awscli.customizations.s3.fileinfobuilder import FileInfoBuilder
 from awscli.customizations.s3.fileformat import FileFormat
 from awscli.customizations.s3.filegenerator import FileGenerator
-from awscli.customizations.s3.fileinfo import TaskInfo, FileInfo
+from awscli.customizations.s3.fileinfo import FileInfo
 from awscli.customizations.s3.filters import create_filter
 from awscli.customizations.s3.s3handler import S3Handler
 from awscli.customizations.s3.s3handler import S3TransferHandlerFactory

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -799,14 +799,11 @@ class RbCommand(S3Command):
             raise TypeError("%s\nError: Invalid argument type" % self.USAGE)
         bucket, key = split_s3_bucket_key(parsed_args.path)
 
+        if key:
+            raise ValueError('Please specify a valid bucket name only.'
+                             ' E.g. s3://%s' % bucket)
+
         if parsed_args.force:
-            # TODO: always validate or never validate
-            # This is currently placed here to preserve behavior with the
-            # previous implementation which only validated key existence when
-            # --force is provided.
-            if key:
-                raise ValueError('Please specify a valid bucket name only.'
-                                 ' E.g. s3://%s' % bucket)
             self._force(parsed_args.path, parsed_globals)
 
         try:

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -897,10 +897,7 @@ class CommandArchitecture(object):
         self.instructions.append('s3_handler')
 
     def needs_filegenerator(self):
-        if self.cmd == 'rb' or self.parameters['is_stream']:
-            return False
-        else:
-            return True
+        return not self.parameters['is_stream']
 
     def choose_sync_strategies(self):
         """Determines the sync strategy for the command.
@@ -963,10 +960,7 @@ class CommandArchitecture(object):
         cmd_translation['s3s3'] = {'cp': 'copy', 'sync': 'copy', 'mv': 'move'}
         cmd_translation['s3local'] = {'cp': 'download', 'sync': 'download',
                                       'mv': 'move'}
-        cmd_translation['s3'] = {
-            'rm': 'delete',
-            'rb': 'remove_bucket'
-        }
+        cmd_translation['s3'] = {'rm': 'delete'}
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type][self.cmd]
 
@@ -1006,10 +1000,6 @@ class CommandArchitecture(object):
 
         file_generator = FileGenerator(**fgen_kwargs)
         rev_generator = FileGenerator(**rgen_kwargs)
-        taskinfo = [TaskInfo(src=files['src']['path'],
-                             src_type='s3',
-                             operation_name=operation_name,
-                             client=self._client)]
         stream_dest_path, stream_compare_key = find_dest_path_comp_key(files)
         stream_file_info = [FileInfo(src=files['src']['path'],
                                      dest=stream_dest_path,
@@ -1063,9 +1053,6 @@ class CommandArchitecture(object):
                             'file_generator': [file_generator],
                             'filters': [create_filter(self.parameters)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3handler]}
-        elif self.cmd == 'rb':
-            command_dict = {'setup': [taskinfo],
                             's3_handler': [s3handler]}
 
         files = command_dict['setup']

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -823,8 +823,8 @@ class RbCommand(S3Command):
         rc = rm([path, '--recursive'], parsed_globals)
         if rc != 0:
             raise RuntimeError(
-                "Unable to delete all objects in the bucket, "
-                "bucket will not be deleted.")
+                "remove_bucket failed: Unable to delete all objects in the "
+                "bucket, bucket will not be deleted.")
 
 
 class CommandArchitecture(object):

--- a/tests/functional/s3/test_rb_command.py
+++ b/tests/functional/s3/test_rb_command.py
@@ -67,6 +67,5 @@ class TestRb(BaseAWSCommandParamsTest):
         command = self.prefix + 's3://bucket/key --force'
         self.run_cmd(command, expected_rc=255)
 
-        # Currently we allow a key to be specified when force isn't provided.
         command = self.prefix + 's3://bucket/key'
-        self.run_cmd(command, expected_rc=0)
+        self.run_cmd(command, expected_rc=255)

--- a/tests/functional/s3/test_rb_command.py
+++ b/tests/functional/s3/test_rb_command.py
@@ -10,82 +10,63 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseCLIDriverTest, capture_output
-
-from awscli.customizations.s3.subcommands import RbCommand
+from awscli.testutils import BaseAWSCommandParamsTest
 
 
-class FakeArgs(object):
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)
-
-    def __contains__(self, key):
-        return hasattr(self, key)
-
-
-class StatusCode(object):
-    def __init__(self, status_code):
-        self.status_code = status_code
-
-
-class TestRbCommand(BaseCLIDriverTest):
+class TestRb(BaseAWSCommandParamsTest):
 
     prefix = 's3 rb '
 
-    def setUp(self):
-        super(TestRbCommand, self).setUp()
-        self.responses = {}
-        self.method_calls = []
+    def test_rb(self):
+        command = self.prefix + 's3://bucket'
+        self.run_cmd(command)
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DeleteBucket')
 
-    def tearDown(self):
-        super(TestRbCommand, self).tearDown()
+    def test_rb_force_empty_bucket(self):
+        command = self.prefix + 's3://bucket --force'
+        self.run_cmd(command)
+        self.assertEqual(len(self.operations_called), 2)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+        self.assertEqual(self.operations_called[1][0].name, 'DeleteBucket')
 
-    def handler(self, model, **kwargs):
-        name = model.name
-        if name in self.responses:
-            self.method_calls.append(name)
-            return self.responses[name].pop()
-        raise RuntimeError("No response for: %s" % name)
+    def test_rb_force_non_empty_bucket(self):
+        command = self.prefix + 's3://bucket --force'
+        self.parsed_responses = [{
+            'Contents': [
+                {
+                    'Key': 'foo',
+                    'Size': 100,
+                    'LastModified': '2016-03-01T23:50:13.000Z'
+                }
+            ]
+        }, {}, {}]
+        self.run_cmd(command)
+        self.assertEqual(len(self.operations_called), 3)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+        self.assertEqual(self.operations_called[1][0].name, 'DeleteObject')
+        self.assertEqual(self.operations_called[2][0].name, 'DeleteBucket')
 
-    def test_rb_force_deletes_bucket_on_success(self):
-        cmd = RbCommand(self.session)
-        self.session.register('before-call', self.handler)
+    def test_rb_failed_rc(self):
+        command = self.prefix + 's3://bucket'
+        self.http_response.status_code = 500
+        self.run_cmd(command, expected_rc=1)
 
-        self.responses['ListObjects'] = [
-            (StatusCode(200), {'Contents': [
-                {'Key': 'foo',
-                 'Size': 100,
-                 'LastModified': '2016-03-01T23:50:13.000Z'}]})
-        ]
-        self.responses['DeleteObject'] = [
-            (StatusCode(200), {})
-        ]
-        self.responses['DeleteBucket'] = [
-            (StatusCode(200), {})
-        ]
+    def test_rb_force_with_failed_rm(self):
+        command = self.prefix + 's3://bucket --force'
+        self.http_response.status_code = 500
+        self.run_cmd(command, expected_rc=255)
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
 
-        global_args = FakeArgs(endpoint_url=None,
-                               region=None,
-                               verify_ssl=None)
-        rc = cmd(['s3://bucket/', '--force'], global_args)
-        self.assertEqual(self.method_calls,
-                         ['ListObjects', 'DeleteObject', 'DeleteBucket'])
-        self.assertEqual(rc, 0)
+    def test_nonzero_exit_if_uri_scheme_not_provided(self):
+        command = self.prefix + 'bucket'
+        self.run_cmd(command, expected_rc=255)
 
-    def test_rb_force_does_not_delete_bucket_on_failure(self):
-        cmd = RbCommand(self.session)
-        self.session.register('before-call', self.handler)
-        self.responses['ListObjects'] = [
-            (StatusCode(500), {})
-        ]
+    def test_nonzero_exit_if_key_provided(self):
+        command = self.prefix + 's3://bucket/key --force'
+        self.run_cmd(command, expected_rc=255)
 
-        global_args = FakeArgs(endpoint_url=None,
-                               region=None,
-                               verify_ssl=None)
-        with self.assertRaisesRegexp(
-                RuntimeError, "Unable to delete all objects in the bucket"):
-            with capture_output():
-                cmd(['s3://bucket/', '--force'], global_args)
-        # Note there's no DeleteObject nor DeleteBucket calls
-        # because the ListOBjects call failed.
-        self.assertEqual(self.method_calls, ['ListObjects'])
+        # Currently we allow a key to be specified when force isn't provided.
+        command = self.prefix + 's3://bucket/key'
+        self.run_cmd(command, expected_rc=0)

--- a/tests/functional/s3/test_rb_command.py
+++ b/tests/functional/s3/test_rb_command.py
@@ -50,12 +50,14 @@ class TestRb(BaseAWSCommandParamsTest):
     def test_rb_failed_rc(self):
         command = self.prefix + 's3://bucket'
         self.http_response.status_code = 500
-        self.run_cmd(command, expected_rc=1)
+        _, stderr, _ = self.run_cmd(command, expected_rc=1)
+        self.assertIn('remove_bucket failed:', stderr)
 
     def test_rb_force_with_failed_rm(self):
         command = self.prefix + 's3://bucket --force'
         self.http_response.status_code = 500
-        self.run_cmd(command, expected_rc=255)
+        _, stderr, _ = self.run_cmd(command, expected_rc=255)
+        self.assertIn('remove_bucket failed:', stderr)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
 

--- a/tests/integration/customizations/s3/test_s3handler.py
+++ b/tests/integration/customizations/s3/test_s3handler.py
@@ -350,46 +350,5 @@ class S3HandlerTestDownload(unittest.TestCase):
             self.assertEqual(filename.read(), b'This is another test.')
 
 
-class S3HandlerTestBucket(unittest.TestCase):
-    """
-    Test the ability to make a bucket then remove it.
-    """
-    def setUp(self):
-        self.session = botocore.session.get_session(EnvironmentVariables)
-        self.client = self.session.create_client('s3', 'us-west-2')
-        self.source_client = self.session.create_client('s3', 'us-west-2')
-        self.params = {'region': 'us-west-2'}
-        self.s3_handler = S3Handler(self.session, self.params)
-        self.bucket = None
-
-    def tearDown(self):
-        s3_cleanup(self.bucket, self.session)
-
-    def test_bucket(self):
-        rand1 = random.randrange(5000)
-        rand2 = random.randrange(5000)
-        self.bucket = str(rand1) + 'mybucket' + str(rand2)
-
-        self.client.create_bucket(
-            Bucket=self.bucket,
-            CreateBucketConfiguration={
-                'LocationConstraint': 'us-west-2'
-            }
-        )
-        buckets_list = []
-        for bucket in self.client.list_buckets().get('Buckets', []):
-            buckets_list.append(bucket['Name'])
-        self.assertIn(self.bucket, buckets_list)
-
-        file_info = FileInfo(
-            src=self.bucket, operation_name='remove_bucket', size=0,
-            client=self.client, source_client=self.source_client)
-        S3Handler(self.session, self.params).call([file_info])
-        buckets_list = []
-        for bucket in self.client.list_buckets().get('Buckets', []):
-            buckets_list.append(bucket['Name'])
-        self.assertNotIn(self.bucket, buckets_list)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_fileinfo.py
+++ b/tests/unit/customizations/s3/test_fileinfo.py
@@ -22,7 +22,6 @@ from awscli.testutils import unittest
 from awscli.customizations.s3 import fileinfo
 from awscli.customizations.s3.utils import MD5Error
 from awscli.customizations.s3.fileinfo import FileInfo
-from awscli.customizations.s3.fileinfo import TaskInfo
 
 
 class TestSaveFile(unittest.TestCase):
@@ -172,10 +171,6 @@ class TestIsGlacierCompatible(unittest.TestCase):
     def test_response_missing_storage_class(self):
         self.file_info.associated_response_data = {'Key': 'Foo'}
         self.assertTrue(self.file_info.is_glacier_compatible())
-
-    def test_task_info_glacier_compatibility(self):
-        task_info = TaskInfo('bucket/key', 's3', 'remove_bucket', None)
-        self.assertTrue(task_info.is_glacier_compatible())
 
     def test_restored_object_is_glacier_compatible(self):
         self.file_info.operation_name = 'download'

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -879,28 +879,6 @@ class S3HandlerTestDownload(S3HandlerBaseTest):
             self.assertEqual(filename.read(), b'This is a test.')
 
 
-class S3HandlerTestBucket(S3HandlerBaseTest):
-    """
-    Test the ability to make a bucket then remove it.
-    """
-    def setUp(self):
-        super(S3HandlerTestBucket, self).setUp()
-        self.params = {'region': 'us-east-1'}
-        self.bucket = 'mybucket'
-
-    def test_remove_bucket(self):
-        file_info = FileInfo(
-            src=self.bucket,
-            operation_name='remove_bucket',
-            size=0, client=self.client)
-        s3_handler = S3Handler(self.session, self.params)
-        ref_calls = [
-            ('DeleteBucket', {'Bucket': self.bucket})
-        ]
-        self.assert_operations_for_s3_handler(s3_handler, [file_info],
-                                              ref_calls)
-
-
 class TestS3HandlerInitialization(unittest.TestCase):
     def setUp(self):
         self.arbitrary_params = {'region': 'us-west-2'}

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -54,7 +54,7 @@ class TestRbCommand(unittest.TestCase):
         self.session = mock.Mock()
         self.session.get_scoped_config.return_value = {}
         self.rb_command = RbCommand(self.session)
-        self.parsed_args = FakeArgs(paths='s3://mybucket/',
+        self.parsed_args = FakeArgs(path='s3://mybucket/',
                                     force=True, dir_op=False)
         self.parsed_globals = FakeArgs(region=None, endpoint_url=None,
                                        verify_ssl=None)
@@ -70,15 +70,15 @@ class TestRbCommand(unittest.TestCase):
                 # success.
                 rm_command.return_value.return_value = 0
                 self.rb_command._run_main(self.parsed_args,
-                                    parsed_globals=self.parsed_globals)
+                                          parsed_globals=self.parsed_globals)
             # Because of --force we should have called the
             # rm_command with the --recursive option.
             rm_command.return_value.assert_called_with(
-                ['s3://mybucket', '--recursive'], mock.ANY)
+                ['s3://mybucket/', '--recursive'], mock.ANY)
 
     def test_rb_command_with_force_requires_strict_path(self):
         with self.assertRaises(ValueError):
-            self.parsed_args.paths = 's3://mybucket/mykey'
+            self.parsed_args.path = 's3://mybucket/mykey'
             self.rb_command._run_main(self.parsed_args,
                                       parsed_globals=self.parsed_globals)
 

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -271,7 +271,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         This tests to make sure the instructions for any command is generated
         properly.
         """
-        cmds = ['cp', 'mv', 'rm', 'sync', 'rb']
+        cmds = ['cp', 'mv', 'rm', 'sync']
 
         instructions = {'cp': ['file_generator', 'file_info_builder',
                                's3_handler'],
@@ -280,8 +280,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                         'rm': ['file_generator', 'file_info_builder',
                                's3_handler'],
                         'sync': ['file_generator', 'comparator',
-                                 'file_info_builder', 's3_handler'],
-                        'rb': ['s3_handler']}
+                                 'file_info_builder', 's3_handler']}
 
         params = {'filters': True, 'region': 'us-east-1', 'endpoint_url': None,
                   'verify_ssl': None, 'is_stream': False}
@@ -527,43 +526,6 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         cmd_arc.run()
         output_str = "(dryrun) upload: %s to %s" % (rel_local_file, s3_file)
         self.assertIn(output_str, self.output.getvalue())
-
-    def test_run_rb(self):
-        # This ensures that the architecture sets up correctly for a ``rb``
-        # command.  It is just just a dry run, but all of the components need
-        # to be wired correctly for it to work.
-        s3_prefix = 's3://' + self.bucket + '/'
-        params = {'dir_op': True, 'dryrun': True, 'quiet': False,
-                  'src': s3_prefix, 'dest': s3_prefix, 'paths_type': 's3',
-                  'region': 'us-east-1', 'endpoint_url': None,
-                  'verify_ssl': None, 'follow_symlinks': True,
-                  'page_size': None, 'is_stream': False, 'source_region': None}
-        cmd_arc = CommandArchitecture(self.session, 'rb', params)
-        cmd_arc.create_instructions()
-        self.patch_make_request()
-        rc = cmd_arc.run()
-        output_str = "(dryrun) remove_bucket: %s" % s3_prefix
-        self.assertIn(output_str, self.output.getvalue())
-        self.assertEqual(rc, 0)
-
-    def test_run_rb_nonzero_rc(self):
-        # This ensures that the architecture sets up correctly for a ``rb``
-        # command.  It is just just a dry run, but all of the components need
-        # to be wired correctly for it to work.
-        s3_prefix = 's3://' + self.bucket + '/'
-        params = {'dir_op': True, 'dryrun': False, 'quiet': False,
-                  'src': s3_prefix, 'dest': s3_prefix, 'paths_type': 's3',
-                  'region': 'us-east-1', 'endpoint_url': None,
-                  'verify_ssl': None, 'follow_symlinks': True,
-                  'page_size': None, 'is_stream': False}
-        self.http_response.status_code = 400
-        cmd_arc = CommandArchitecture(self.session, 'rb', params)
-        cmd_arc.create_instructions()
-        self.patch_make_request()
-        rc = cmd_arc.run()
-        output_str = "remove_bucket failed: %s" % s3_prefix
-        self.assertIn(output_str, self.err_output.getvalue())
-        self.assertEqual(rc, 1)
 
 
 class CommandParametersTest(unittest.TestCase):


### PR DESCRIPTION
This pr extracts rb into its own command. I was able to remove a ***lot*** of code by doing so, so I broke the removal into several commits for ease of browsing. I also refactored the rb functional tests to more closely match other functional tests and added in several tests that either weren't present or lived in other places.

One thing I ran across was that rb had a validation on the s3 uri that only applied when using `--force`. I preserved that behavior, but I think we should consider expanding it to always apply or otherwise remove it entirely.

I decided not to try to shoehorn it into the new s3 transfer handler because that required abusing task submitters and would spin up threads for a single operation (`rm` is called directly, so its threads will be shutdown before it returns).

cc @kyleknap @jamesls 