### PR TITLE
Use absolute paths for local dirs

### DIFF
--- a/scripts/ci/install-benchmark
+++ b/scripts/ci/install-benchmark
@@ -20,7 +20,9 @@ GIT_OWNER = os.environ.get('GIT_OWNER', 'boto')
 # is set by jenkins to the branch that's been checked out via
 # git.
 PERF_BRANCH = os.environ.get('PERF_BRANCH', 'develop')
-WORKDIR = os.environ.get('PERF_WORKDIR', 'workdir')
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKDIR = os.environ.get('PERF_WORKDIR', os.path.join(REPO_ROOT, 'workdir'))
 
 
 def clone_s3_transfer_repo():
@@ -36,7 +38,7 @@ def pip_install_s3transfer_and_deps():
     check_call('cd s3transfer && pip install -r requirements-dev.txt',
                shell=True)
     check_call('pip install "caf>=0.1.0,<1.0.0"', shell=True)
-    check_call('cd ../ && pip install -e .', shell=True)
+    check_call('cd %s && pip install -e .' % REPO_ROOT, shell=True)
 
 
 def create_workdir():

--- a/scripts/ci/run-benchmark
+++ b/scripts/ci/run-benchmark
@@ -19,7 +19,9 @@ import s3transfer
 
 
 TEST_BUCKET = os.environ.get('PERF_TEST_BUCKET')
-WORKDIR = os.environ.get('PERF_WORKDIR', 'workdir')
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKDIR = os.environ.get('PERF_WORKDIR', os.path.join(REPO_ROOT, 'workdir'))
 MANY_FILES_DIR = 'many'
 LARGE_FILE_DIR = 'large'
 

--- a/scripts/ci/upload-benchmark
+++ b/scripts/ci/upload-benchmark
@@ -5,7 +5,10 @@ import argparse
 from datetime import datetime
 from subprocess import check_call
 
-WORKDIR = os.environ.get('PERF_WORKDIR', 'workdir')
+
+REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+WORKDIR = os.environ.get('PERF_WORKDIR', os.path.join(REPO_ROOT, 'workdir'))
 DEFAULT_BUCKET = os.environ.get('PERF_RESULTS_BUCKET')
 DATE_FORMAT = "%Y-%m-%d-%H-%M-%S-"
 


### PR DESCRIPTION
This puts results and working files in a consistent
location regardless of where the script is run.

This also fixes a bug when the install-benchmark
script is not run from the repo root.

cc @kyleknap @JordonPhillips 