### PR TITLE
Fix bug where previous files were not being removed

### DIFF
--- a/scripts/ci/run-benchmark
+++ b/scripts/ci/run-benchmark
@@ -133,10 +133,12 @@ def benchmark(bucket, results_dir, num_iterations=1):
         run(benchmark_rm + ' --recursive --num-iterations %s '
             '--target %s --result-dir %s' % (
                 num_iterations, s3_location, results))
-    except Exception:
-        # Just in case
+    finally:
+        # Note that the delete-10k-small benchmark restores
+        # the files it's deleted once the script is finished.
+        # Therefore we need to explicitly cleanup any files
+        # we've created.
         run('aws s3 rm --recursive ' + s3_location)
-        raise
 
     s3_location = bucket + '/' + LARGE_FILE_DIR
     local_dir = os.path.join(WORKDIR, LARGE_FILE_DIR)


### PR DESCRIPTION
The benchmark-rm file creates a backup of the files
it's about to delete.  After each iteration of the running
the "aws rm" command, it copies files from the backup location
over to the original location.  This allows multiple iterations
of the script to run.

However, this also means that after running `benchmark-rm`, the
files in s3 still exist and need to be cleaned up once the script
has finished running.  If you don't clean them up
(which is what was happening here), then the subsequent run
will 'rm' both the files from the current
perf run as well as the files from the *previous* perf run.

cc @kyleknap @JordonPhillips 