### PR TITLE
Use a different utime for windows

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -97,6 +97,18 @@ def skip_if_windows(reason):
     return decorator
 
 
+def set_invalid_utime(path):
+    """Helper function to set an invalid last modified time"""
+    try:
+        os.utime(path, (-1, -100000000000))
+    except OSError:
+        # Some OS's such as Windows throws an error for trying to set a
+        # last modified time of that size. So if an error is thrown, set it
+        # to just a negative time which will trigger the warning as well for
+        # Windows.
+        os.utime(path, (-1, -1))
+
+
 def create_clidriver():
     driver = awscli.clidriver.create_clidriver()
     session = driver.session

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -134,7 +134,14 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
 
         # Set the update time to a value that will raise a ValueError when
         # converting to datetime
-        os.utime(full_path, (-1, -100000000000))
+        try:
+            os.utime(full_path, (-1, -100000000000))
+        except WindowsError:
+            # Windows throws an error for trying to set a last modified time
+            # of that size. So if an error is thrown, set it to just a
+            # negative time which will trigger the warning as well for
+            # Windows.
+            os.utime(full_path, (-1, -1))
         cmdline = '%s %s s3://bucket/key.txt' % \
                   (self.prefix, self.files.rootdir)
         self.parsed_responses = [

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.testutils import set_invalid_utime
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
 import os
 
@@ -134,14 +135,7 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
 
         # Set the update time to a value that will raise a ValueError when
         # converting to datetime
-        try:
-            os.utime(full_path, (-1, -100000000000))
-        except WindowsError:
-            # Windows throws an error for trying to set a last modified time
-            # of that size. So if an error is thrown, set it to just a
-            # negative time which will trigger the warning as well for
-            # Windows.
-            os.utime(full_path, (-1, -1))
+        set_invalid_utime(full_path)
         cmdline = '%s %s s3://bucket/key.txt' % \
                   (self.prefix, self.files.rootdir)
         self.parsed_responses = [


### PR DESCRIPTION
We run into WindowsErrors we when we try to set the utime that low so instead if an error occurs set the last modified time to -1 which will raise the warning as well for Windows. Also note that we cannot just use -1 for the entire test because it will not propogate an invalid timestamp warning on linux and cause the test to fail.

Note that I sent this to the integrate-s3transfer branch so we can get some clean test runs on that for Windows. Let me know if you want me to change that.

cc @jamesls @JordonPhillips 