### PR TITLE
Catch os errors for invalid timestamps

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -229,7 +229,7 @@ def get_file_stat(path):
 
     try:
         update_time = datetime.fromtimestamp(stats.st_mtime, tzlocal())
-    except ValueError:
+    except (ValueError, OSError):
         # Python's fromtimestamp raises value errors when the timestamp is out
         # of range of the platform's C localtime() function. This can cause
         # issues when syncing from systems with a wide range of valid timestamps

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -101,7 +101,7 @@ def set_invalid_utime(path):
     """Helper function to set an invalid last modified time"""
     try:
         os.utime(path, (-1, -100000000000))
-    except OSError:
+    except (OSError, OverflowError):
         # Some OS's such as Windows throws an error for trying to set a
         # last modified time of that size. So if an error is thrown, set it
         # to just a negative time which will trigger the warning as well for

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -367,6 +367,15 @@ class TestGetFileStat(unittest.TestCase):
                 size, update_time = get_file_stat(temp_file.name)
                 self.assertIsNone(update_time)
 
+    def test_get_file_stat_returns_epoch_on_invalid_timestamp_os_error(self):
+        patch_attribute = 'awscli.customizations.s3.utils.datetime'
+        with mock.patch(patch_attribute) as datetime_mock:
+            with temporary_file('w') as temp_file:
+                temp_file.write('foo')
+                temp_file.flush()
+                datetime_mock.fromtimestamp.side_effect = OSError()
+                size, update_time = get_file_stat(temp_file.name)
+                self.assertIsNone(update_time)
 
 
 class TestSetsFileUtime(unittest.TestCase):


### PR DESCRIPTION
The functional tests are actual failing now. For some reason, an OSError gets thrown in py3 instead of ValueError.
 
cc @jamesls @JordonPhillips 