### PR TITLE
Fixing Python 3 compatibility issue for OpsWorks register with --local flag

### DIFF
--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -278,7 +278,8 @@ class OpsWorksRegister(BasicCommand):
 
         if args.infrastructure_class == 'ec2' and args.local:
             # make sure the regions match
-            region = json.loads(urlopen(IDENTITY_URL).read())['region']
+            response = urlopen(IDENTITY_URL).read()
+            region = json.loads(response.decode("utf8") if type(response) == bytes else response)['region']
             if region != self._stack['Region']:
                 raise ValueError(
                     "The stack's and the instance's region must match.")


### PR DESCRIPTION
This fixes an issue that was encountered when trying to register an EC2 instance with OpsWorks using the CLI from the box itself using the `--local` flag, with the CLI running on Python 3.5.x.

In Python 3, urlopen(...).read() returns bytes, whereas in Python 2 it returns a String.  Only a String can be used with json.loads(...), which causes a line in `opsworks.py` to fail when running on Python 3.

This change ensures that a response read as bytes is converted to a String before passed to json.loads(...).

I would appreciate any feedback on whether this change is a good idea or if there is a better place to update the code and resolve this issue.

The original command and error message that indicated the problem as are follows:

```
aws opsworks register --infrastructure-class ec2 --region us-east-1 --stack-id [stack id] --local --debug
```

Which resulted in the following error:
```
the JSON object must be str, not 'bytes'
```

Full stack trace:
```
2016-09-30 11:55:49,433 - MainThread - botocore.hooks - DEBUG - Event needs-retry.opsworks.DescribeStackProvisioningParameters: calling handler <botocore.retryhandler.RetryHandler object at 0x7fe940c25ef0>
2016-09-30 11:55:49,433 - MainThread - botocore.retryhandler - DEBUG - No retry needed.
2016-09-30 11:55:49,435 - MainThread - awscli.clidriver - DEBUG - Exception caught in main()
Traceback (most recent call last):
  File "/home/ubuntu/.local/lib/python3.5/site-packages/awscli/clidriver.py", line 186, in main
    return command_table[parsed_args.command](remaining, parsed_args)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/awscli/clidriver.py", line 381, in __call__
    return command_table[parsed_args.operation](remaining, parsed_globals)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/awscli/customizations/commands.py", line 187, in __call__
    return self._run_main(parsed_args, parsed_globals)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/awscli/customizations/opsworks.py", line 144, in _run_main
    self.validate_arguments(args)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/awscli/customizations/opsworks.py", line 281, in validate_arguments
    region = json.loads(urlopen(IDENTITY_URL).read())['region']
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
2016-09-30 11:55:49,435 - MainThread - awscli.clidriver - DEBUG - Exiting with rc 255

the JSON object must be str, not 'bytes'
```