### PR TITLE
Update s3transfer dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,5 @@ requires-dist =
         colorama>=0.2.5,<=0.3.7
         docutils>=0.10
         rsa>=3.1.2,<=3.5.0
-        s3transfer>=0.1.0,<0.2.0
+        s3transfer>=0.1.5,<0.2.0
         argparse>=1.1; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requires = ['botocore==1.4.58',
             'colorama>=0.2.5,<=0.3.7',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
-            's3transfer>=0.1.0,<0.2.0']
+            's3transfer>=0.1.5,<0.2.0']
 
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
The CLI was using logic from 0.1.5 that did not exist in previous version so the version dependency range needed to be updated to make 0.1.5 the floor.

Fixes https://github.com/aws/aws-cli/issues/2216

cc @jamesls @JordonPhillips 