### PR TITLE
Detect params that prefix builtins and fix existing cases

### DIFF
--- a/.changes/next-release/bugfix-route53domains-89897.json
+++ b/.changes/next-release/bugfix-route53domains-89897.json
@@ -1,0 +1,5 @@
+{
+  "category": "route53domains",
+  "type": "bugfix",
+  "description": "Rename `--end` to `--end-time` to fix a bug relating to argparse prefix expansion. Alias `--start` to `--start-time` to maintain a consistent interface while keeping the old parameter."
+}

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -47,7 +47,9 @@ ARGUMENT_RENAMES = {
     'route53.get-traffic-policy.version': 'traffic-policy-version',
     'route53.update-traffic-policy-comment.version': 'traffic-policy-version',
     'gamelift.create-build.version': 'build-version',
-    'gamelift.update-build.version': 'build-version'
+    'gamelift.update-build.version': 'build-version',
+    'route53domains.view-billing.start': 'start-time',
+    'route53domains.view-billing.end': 'end-time',
 }
 
 # Same format as ARGUMENT_RENAMES, but instead of renaming the arguments,
@@ -62,6 +64,7 @@ HIDDEN_ALIASES = {
     'storagegateway.describe-vtl-devices.vtl-device-arns': 'vtl-device-ar-ns',
     'storagegateway.describe-cached-iscsi-volumes.volume-arns': 'volume-ar-ns',
     'storagegateway.describe-stored-iscsi-volumes.volume-arns': 'volume-ar-ns',
+    'route53domains.view-billing.start-time': 'start',
 }
 
 

--- a/tests/functional/route53domains/__init__.py
+++ b/tests/functional/route53domains/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/route53domains/test_view_billing.py
+++ b/tests/functional/route53domains/test_view_billing.py
@@ -1,0 +1,39 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestViewBilling(BaseAWSCommandParamsTest):
+
+    prefix = 'route53domains view-billing'
+
+    def test_accepts_start(self):
+        command = self.prefix + ' --start 2'
+        expected_params = {
+            'Start': '2'
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_accepts_start_time(self):
+        command = self.prefix + ' --start-time 2'
+        expected_params = {
+            'Start': '2'
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_accepts_end_time(self):
+        command = self.prefix + ' --end-time 2'
+        expected_params = {
+            'End': '2'
+        }
+        self.assert_params_for_cmd(command, expected_params)


### PR DESCRIPTION
Argparse automatically expands prefixes of arguments, so something like
`--end` could expand to `--endpoint-url`. The parameter in question would
never be able to be passed in, even if the full parameter is also used.

This expands shadow detection to include prefix detection.

This also fixes the existing case, `end` in `route53domains`. While it
was initially just going to be `end`, it was expanded to include `start`
to keep the parameter naming consistent. `start` will continue to be
suppliable in addition to `start-time`. `end` was never suppliable in
the first place, so there is no effor to keep the alias.

cc @kyleknap @jamesls