### PR TITLE
Swap back shadow args when pagination is disabled

### DIFF
--- a/.changes/next-release/bugfix-Pagination-10609.json
+++ b/.changes/next-release/bugfix-Pagination-10609.json
@@ -1,0 +1,5 @@
+{
+  "category": "Pagination", 
+  "type": "bugfix", 
+  "description": "Fix validation error when providing ``--no-paginate`` with normalized paging argument."
+}

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -174,19 +174,18 @@ def check_should_enable_pagination(input_tokens, shadowed_args, argument_table,
                          "Automatically setting --no-paginate.")
             parsed_globals.paginate = False
 
-            # Because pagination is now disabled, there's a chance that
-            # we were shadowing arguments.  For example, we inject a
-            # --max-items argument in unify_paging_params().  If the
-            # the operation also provides its own MaxItems (which we
-            # expose as --max-items) then our custom pagination arg
-            # was shadowing the customers arg.  When we turn pagination
-            # off we need to put back the original argument which is
-            # what we're doing here.
-            for key, value in shadowed_args.items():
-                argument_table[key] = value
-
     if not parsed_globals.paginate:
         ensure_paging_params_not_set(parsed_args, shadowed_args)
+        # Because pagination is now disabled, there's a chance that
+        # we were shadowing arguments.  For example, we inject a
+        # --max-items argument in unify_paging_params().  If the
+        # the operation also provides its own MaxItems (which we
+        # expose as --max-items) then our custom pagination arg
+        # was shadowing the customers arg.  When we turn pagination
+        # off we need to put back the original argument which is
+        # what we're doing here.
+        for key, value in shadowed_args.items():
+            argument_table[key] = value
 
 
 def ensure_paging_params_not_set(parsed_args, shadowed_args):

--- a/tests/functional/iam/test_list_access_keys.py
+++ b/tests/functional/iam/test_list_access_keys.py
@@ -1,0 +1,26 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateOpenIDConnectProvider(BaseAWSCommandParamsTest):
+
+    prefix = 'iam list-access-keys'
+
+    def test_create_open_id_connect_provider(self):
+        cmdline = self.prefix
+        cmdline += '  --no-paginate --max-items 1'
+        result = {
+            'MaxItems': 1,
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -256,6 +256,21 @@ class TestShouldEnablePagination(TestPaginateBase):
         self.assertTrue(self.parsed_globals.paginate,
                         "Pagination was not enabled.")
 
+    def test_fall_back_to_original_max_items_when_pagination_turned_off(self):
+        input_tokens = ['max-items']
+        # User specifies --no-paginate.
+        self.parsed_globals.paginate = False
+        # But also specifies --max-items 10, which is normally a pagination arg
+        # we replace.  However, because they've explicitly turned off
+        # pagination, we should put back the original arg.
+        self.parsed_args.max_items = 10
+        shadowed_args = {'max-items': mock.sentinel.ORIGINAL_ARG}
+        arg_table = {'max-items': mock.sentinel.PAGINATION_ARG}
+
+        paginate.check_should_enable_pagination(
+            input_tokens, shadowed_args, arg_table,
+            self.parsed_args, self.parsed_globals)
+
     def test_shadowed_args_are_replaced_when_pagination_turned_off(self):
         input_tokens = ['foo', 'bar']
         self.parsed_globals.paginate = True


### PR DESCRIPTION
This check was previously only triggered if the user
implicitly disabled pagination by providing a hidden
pagination argument.  This logic now accounts for when
a user explicitly turns off pagination via `--no-paginate`.

Before you'd get:

```
$ aws iam list-access-keys --no-paginate --max-items 1

Parameter validation failed:
Unknown parameter in input: "PaginationConfig", must be one of: UserName, Marker, MaxItems
```

cc @kyleknap @JordonPhillips 