### PR TITLE
Improve progress for s3 commands

### DIFF
--- a/.changes/next-release/feature-s3-7129.json
+++ b/.changes/next-release/feature-s3-7129.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "feature", 
+  "description": "Output progress even when discovering new files to transfer"
+}

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -446,7 +446,7 @@ class ResultPrinter(BaseResultHandler):
         self._add_progress_if_needed()
 
     def _add_progress_if_needed(self):
-        if not self._has_remaining_progress():
+        if self._has_remaining_progress():
             self._print_progress()
 
     def _print_progress(self, **kwargs):
@@ -504,9 +504,11 @@ class ResultPrinter(BaseResultHandler):
         return print_statement + ending_char
 
     def _has_remaining_progress(self):
+        if not self._result_recorder.expected_totals_are_final():
+            return True
         actual = self._result_recorder.files_transferred
         expected = self._result_recorder.expected_files_transferred
-        return actual == expected
+        return actual != expected
 
     def _print_to_out_file(self, statement):
         uni_print(statement, self._out_file)

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -377,6 +377,8 @@ class ResultPrinter(BaseResultHandler):
             ErrorResult: self._print_error,
             CtrlCResult: self._print_ctrl_c,
             DryRunResult: self._print_dry_run,
+            FinalTotalSubmissionsResult:
+                self._clear_progress_if_no_more_expected_transfers,
         }
 
     def __call__(self, result):
@@ -515,6 +517,11 @@ class ResultPrinter(BaseResultHandler):
 
     def _print_to_error_file(self, statement):
         uni_print(statement, self._error_file)
+
+    def _clear_progress_if_no_more_expected_transfers(self, **kwargs):
+        if self._result_recorder.final_expected_files_transferred \
+                and not self._has_remaining_progress():
+            uni_print(self._adjust_statement_padding(''), self._out_file)
 
 
 class OnlyShowErrorsResultPrinter(ResultPrinter):

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -820,6 +820,13 @@ class TestResultPrinter(BaseResultPrinterTest):
         transfer_type = 'upload'
         src = 'file'
         dest = 's3://mybucket/mykey'
+
+        # Pretend that this is the final result in the result queue that
+        # is processed.
+        self.result_recorder.final_expected_files_transferred = 1
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
         success_result = SuccessResult(
             transfer_type=transfer_type, src=src, dest=dest)
 
@@ -864,9 +871,62 @@ class TestResultPrinter(BaseResultPrinterTest):
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
+    def test_success_with_files_remaining(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+
+        mb = 1024 * 1024
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_bytes_transferred = 4 * mb
+        self.result_recorder.bytes_transferred = mb
+
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_printer(success_result)
+
+        ref_success_statement = (
+            'upload: file to s3://mybucket/mykey\n'
+            'Completed 1.0 MiB/~4.0 MiB with ~3 file(s) remaining '
+            '(calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_success_statement)
+
+    def test_success_but_no_expected_files_transferred_provided(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+
+        mb = 1024 * 1024
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_bytes_transferred = mb
+        self.result_recorder.bytes_transferred = mb
+
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+
+        self.result_printer(success_result)
+
+        ref_success_statement = (
+            'upload: file to s3://mybucket/mykey\n'
+            'Completed 1.0 MiB/~1.0 MiB with ~0 file(s) remaining '
+            '(calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_success_statement)
+
     def test_success_for_delete(self):
         transfer_type = 'delete'
         src = 's3://mybucket/mykey'
+
+        # Pretend that this is the final result in the result queue that
+        # is processed.
+        self.result_recorder.final_expected_files_transferred = 1
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
         success_result = SuccessResult(
             transfer_type=transfer_type, src=src, dest=None)
 
@@ -877,10 +937,53 @@ class TestResultPrinter(BaseResultPrinterTest):
         )
         self.assertEqual(self.out_file.getvalue(), ref_success_statement)
 
+    def test_delete_success_with_files_remaining(self):
+        transfer_type = 'delete'
+        src = 's3://mybucket/mykey'
+
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.files_transferred = 1
+
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=None)
+
+        self.result_printer(success_result)
+
+        ref_success_statement = (
+            'delete: s3://mybucket/mykey\n'
+            'Completed 1 file(s) with ~3 file(s) remaining (calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_success_statement)
+
+    def test_delete_success_but_no_expected_files_transferred_provided(self):
+        transfer_type = 'delete'
+        src = 's3://mybucket/mykey'
+
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=None)
+
+        self.result_printer(success_result)
+
+        ref_success_statement = (
+            'delete: s3://mybucket/mykey\n'
+            'Completed 1 file(s) with ~0 file(s) remaining (calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_success_statement)
+
     def test_failure(self):
         transfer_type = 'upload'
         src = 'file'
         dest = 's3://mybucket/mykey'
+
+        # Pretend that this is the final result in the result queue that
+        # is processed.
+        self.result_recorder.final_expected_files_transferred = 1
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
         failure_result = FailureResult(
             transfer_type=transfer_type, src=src, dest=dest,
             exception=Exception('my exception'))
@@ -891,6 +994,69 @@ class TestResultPrinter(BaseResultPrinterTest):
             'upload failed: file to s3://mybucket/mykey my exception\n'
         )
         self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
+        self.assertEqual(self.out_file.getvalue(), '')
+
+    def test_failure_with_files_remaining(self):
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+
+        mb = 1024 * 1024
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_bytes_transferred = 4 * mb
+        self.result_recorder.bytes_transferred = mb
+
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_printer(failure_result)
+
+        ref_statement = (
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+            'Completed 1.0 MiB/~4.0 MiB with ~3 file(s) remaining '
+            '(calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
+
+    def test_failure_but_no_expected_files_transferred_provided(self):
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+
+        mb = 1024 * 1024
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_bytes_transferred = mb
+        self.result_recorder.bytes_transferred = mb
+
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=dest,
+            exception=Exception('my exception'))
+
+        self.result_printer(failure_result)
+
+        ref_statement = (
+            'upload failed: file to s3://mybucket/mykey my exception\n'
+            'Completed 1.0 MiB/~1.0 MiB with ~0 file(s) remaining '
+            '(calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
 
     def test_failure_with_progress(self):
         # Make errors and regular outprint go to the same file to track order.
@@ -939,6 +1105,13 @@ class TestResultPrinter(BaseResultPrinterTest):
     def test_failure_for_delete(self):
         transfer_type = 'delete'
         src = 's3://mybucket/mykey'
+
+        # Pretend that this is the final result in the result queue that
+        # is processed.
+        self.result_recorder.final_expected_files_transferred = 1
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
         failure_result = FailureResult(
             transfer_type=transfer_type, src=src, dest=None,
             exception=Exception('my exception'))
@@ -949,11 +1122,72 @@ class TestResultPrinter(BaseResultPrinterTest):
             'delete failed: s3://mybucket/mykey my exception\n'
         )
         self.assertEqual(self.error_file.getvalue(), ref_failure_statement)
+        self.assertEqual(self.out_file.getvalue(), '')
+
+    def test_delete_failure_with_files_remaining(self):
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        transfer_type = 'delete'
+        src = 's3://mybucket/mykey'
+
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.expected_files_transferred = 4
+        self.result_recorder.files_transferred = 1
+
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=None,
+            exception=Exception('my exception'))
+
+        self.result_printer(failure_result)
+
+        ref_statement = (
+            'delete failed: s3://mybucket/mykey my exception\n'
+            'Completed 1 file(s) with ~3 file(s) remaining (calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
+
+    def test_delete_failure_but_no_expected_files_transferred_provided(self):
+        shared_file = self.out_file
+        self.result_printer = ResultPrinter(
+            result_recorder=self.result_recorder,
+            out_file=shared_file,
+            error_file=shared_file
+        )
+
+        transfer_type = 'delete'
+        src = 's3://mybucket/mykey'
+
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
+        failure_result = FailureResult(
+            transfer_type=transfer_type, src=src, dest=None,
+            exception=Exception('my exception'))
+
+        self.result_printer(failure_result)
+
+        ref_statement = (
+            'delete failed: s3://mybucket/mykey my exception\n'
+            'Completed 1 file(s) with ~0 file(s) remaining (calculating...)\r'
+        )
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
 
     def test_warning(self):
+        # Pretend that this is the final result in the result queue that
+        # is processed.
+        self.result_recorder.final_expected_files_transferred = 1
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+
         self.result_printer(WarningResult('warning: my warning'))
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
+        self.assertEqual(self.out_file.getvalue(), '')
 
     def test_warning_with_progress(self):
         # Make errors and regular outprint go to the same file to track order.


### PR DESCRIPTION
Progress would only be outputted if the current number of queued transfers did not equal the number of completed transfers. This is an issue for commands like sync because the results queue can be completely processed for long periods of time causing the progress to disappear. So instead, print progress as well if there has not been a notification for the final expected files to be transferred.

I also noticed that we were missing a decent amount of tests for still calculating progress so I added those in adding my unit tests.

I tried it out with sync many files, but actually only needing to transfer some of them and it looks better now (i.e. the progress does not disappear for long periods).

cc @jamesls @JordonPhillips 