### PR TITLE
Fix issue when using only show errors printer

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -519,8 +519,7 @@ class ResultPrinter(BaseResultHandler):
         uni_print(statement, self._error_file)
 
     def _clear_progress_if_no_more_expected_transfers(self, **kwargs):
-        if self._result_recorder.final_expected_files_transferred \
-                and not self._has_remaining_progress():
+        if self._progress_length and not self._has_remaining_progress():
             uni_print(self._adjust_statement_padding(''), self._out_file)
 
 

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -1349,6 +1349,29 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         ref_warning_statement = 'warning: my warning\n'
         self.assertEqual(self.error_file.getvalue(), ref_warning_statement)
 
+    def test_final_total_does_not_try_to_clear_empty_progress(self):
+        transfer_type = 'upload'
+        src = 'file'
+        dest = 's3://mybucket/mykey'
+
+        mb = 1024 * 1024
+        self.result_recorder.expected_files_transferred = 1
+        self.result_recorder.files_transferred = 1
+        self.result_recorder.expected_bytes_transferred = mb
+        self.result_recorder.bytes_transferred = mb
+
+        success_result = SuccessResult(
+            transfer_type=transfer_type, src=src, dest=dest)
+        self.result_printer(success_result)
+        ref_statement = ''
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
+
+        self.result_recorder.final_expected_files_transferred = 1
+        self.result_printer(FinalTotalSubmissionsResult(1))
+        # The final total submission result should be a noop and
+        # not print anything out.
+        self.assertEqual(self.out_file.getvalue(), ref_statement)
+
 
 class TestResultProcessor(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The final submission task would at times print out just a single newline with no padding as the logic before was to clear the progress bar if the final expected files transferred was not 0 and it was the last result that the would be processed. Instead the logic should be if there is even progress displayed in the first place and if it is the final processed result; there is no reason to be trying to clear the progress if there is no progress displayed in the first place. Also note it handles the case of when the final expected files transferred is 0 because if no transfers happened there will never have been progress.

cc @jamesls @JordonPhillips 