### PR TITLE
Enable local file deletes from fileinfos

### DIFF
--- a/.changes/next-release/bugfix-s3syncdelete-69638.json
+++ b/.changes/next-release/bugfix-s3syncdelete-69638.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3 sync --delete``", 
+  "type": "bugfix", 
+  "description": "Fix regression where ``--delete`` would not delete local files"
+}

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -148,3 +148,19 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         self.assertEqual(len(self.operations_called), 2, self.operations_called)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
         self.assertEqual(self.operations_called[1][0].name, 'PutObject')
+
+    def test_sync_with_delete_on_downloads(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s s3://bucket %s --delete' % (
+            self.prefix, self.files.rootdir)
+        self.parsed_responses = [
+            {"CommonPrefixes": [], "Contents": []},
+            {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+
+        # The only operations we should have called are ListObjects.
+        self.assertEqual(len(self.operations_called), 1, self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+
+        self.assertFalse(os.path.exists(full_path))

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -793,6 +793,22 @@ class TestSync(BaseS3IntegrationTest):
         self.assertFalse(self.key_exists(src_bucket, dst_key_name))
         self.assertFalse(self.key_exists(dst_bucket, dst_key_name))
 
+    def test_sync_delete_locally(self):
+        bucket_name = _SHARED_BUCKET
+        file_to_delete = self.files.create_file(
+            'foo.txt', contents='foo contents')
+        self.put_object(bucket_name, 'bar.txt', contents='bar contents')
+
+        p = aws('s3 sync s3://%s/ %s --delete' % (
+            bucket_name, self.files.rootdir))
+        self.assert_no_errors(p)
+
+        # Make sure the uploaded file got downloaded and the previously
+        # existing local file got deleted
+        self.assertTrue(os.path.exists(
+            os.path.join(self.files.rootdir, 'bar.txt')))
+        self.assertFalse(os.path.exists(file_to_delete))
+
 
 class TestSourceRegion(BaseS3IntegrationTest):
     def extra_setup(self):


### PR DESCRIPTION
This is specifically done for sync --delete downloads. The
implementation is a bit quirky because the functionality is needed
for the CLI but does not really belong in s3transfer. Essentially
what happens if a local delete is seen, the CLI will submit the
transfer request and immediately delete the file in the main thread
as a part of the submission. While it is not ideal to be
doing that in the main thread because it will slow down the process,
it is acceptable as deleting a local file is pretty quick.

Fixes https://github.com/aws/aws-cli/issues/2233

cc @jamesls @JordonPhillips  