### PR TITLE
Port mv to s3transfer

### DIFF
--- a/.changes/next-release/feature-s3-82335.json
+++ b/.changes/next-release/feature-s3-82335.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "description": "Port mv to s3transfer.",
+  "category": "s3"
+}

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -73,7 +73,7 @@ FinalTotalSubmissionsResult = namedtuple(
 class BaseResultSubscriber(OnDoneFilteredSubscriber):
     TRANSFER_TYPE = None
 
-    def __init__(self, result_queue):
+    def __init__(self, result_queue, transfer_type=None):
         """Subscriber to send result notifications during transfer process
 
         :param result_queue: The queue to place results to be processed later
@@ -81,6 +81,9 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
         """
         self._result_queue = result_queue
         self._result_kwargs_cache = {}
+        self._transfer_type = transfer_type
+        if transfer_type is None:
+            self._transfer_type = self.TRANSFER_TYPE
 
     def on_queued(self, future, **kwargs):
         self._add_to_result_kwargs_cache(future)
@@ -111,7 +114,7 @@ class BaseResultSubscriber(OnDoneFilteredSubscriber):
     def _add_to_result_kwargs_cache(self, future):
         src, dest = self._get_src_dest(future)
         result_kwargs = {
-            'transfer_type': self.TRANSFER_TYPE,
+            'transfer_type': self._transfer_type,
             'src': src,
             'dest': dest,
             'total_transfer_size': future.meta.size

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -951,27 +951,26 @@ class CommandArchitecture(object):
         files = FileFormat().format(src, dest, self.parameters)
         rev_files = FileFormat().format(dest, src, self.parameters)
 
-        cmd_translation = {}
-        cmd_translation['locals3'] = {'cp': 'upload', 'sync': 'upload',
-                                      'mv': 'move'}
-        cmd_translation['s3s3'] = {'cp': 'copy', 'sync': 'copy', 'mv': 'move'}
-        cmd_translation['s3local'] = {'cp': 'download', 'sync': 'download',
-                                      'mv': 'move'}
-        cmd_translation['s3'] = {'rm': 'delete'}
+        cmd_translation = {
+            'locals3': 'upload',
+            's3s3': 'copy',
+            's3local': 'download',
+            's3': 'delete'
+        }
         result_queue = queue.Queue()
-        operation_name = cmd_translation[paths_type][self.cmd]
+        operation_name = cmd_translation[paths_type]
 
         fgen_kwargs = {
             'client': self._source_client, 'operation_name': operation_name,
             'follow_symlinks': self.parameters['follow_symlinks'],
             'page_size': self.parameters['page_size'],
-            'result_queue': result_queue
+            'result_queue': result_queue,
         }
         rgen_kwargs = {
             'client': self._client, 'operation_name': '',
             'follow_symlinks': self.parameters['follow_symlinks'],
             'page_size': self.parameters['page_size'],
-            'result_queue': result_queue
+            'result_queue': result_queue,
         }
 
         fgen_request_parameters = {}
@@ -1013,7 +1012,7 @@ class CommandArchitecture(object):
                               result_queue=result_queue)
 
         s3_transfer_handler = s3handler
-        if self.cmd in ['cp', 'rm', 'sync']:
+        if self.cmd in ['cp', 'rm', 'sync', 'mv']:
             s3_transfer_handler = S3TransferHandlerFactory(
                 self.parameters, self._runtime_config)(
                     self._client, result_queue)
@@ -1050,7 +1049,7 @@ class CommandArchitecture(object):
                             'file_generator': [file_generator],
                             'filters': [create_filter(self.parameters)],
                             'file_info_builder': [file_info_builder],
-                            's3_handler': [s3handler]}
+                            's3_handler': [s3_transfer_handler]}
 
         files = command_dict['setup']
         while self.instructions:
@@ -1107,6 +1106,10 @@ class CommandParameters(object):
             self.parameters['source_region'] = None
         if self.cmd in ['sync', 'mb', 'rb']:
             self.parameters['dir_op'] = True
+        if self.cmd == 'mv':
+            self.parameters['is_move'] = True
+        else:
+            self.parameters['is_move'] = False
 
     def add_paths(self, paths):
         """

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -283,6 +283,21 @@ class TestCopyResultSubscriber(TestUploadResultSubscriber):
         return FakeTransferFutureCallArgs(
             copy_source=self.copy_source, key=self.key, bucket=self.bucket)
 
+    def test_transfer_type_override(self):
+        new_transfer_type = 'move'
+        self.result_subscriber = CopyResultSubscriber(
+            self.result_queue, new_transfer_type)
+        self.result_subscriber.on_queued(self.future)
+        result = self.get_queued_result()
+        self.assert_result_queue_is_empty()
+        expected = QueuedResult(
+            transfer_type=new_transfer_type,
+            src=self.src,
+            dest=self.dest,
+            total_transfer_size=self.size
+        )
+        self.assertEqual(result, expected)
+
 
 class TestDeleteResultSubscriber(TestUploadResultSubscriber):
     def setUp(self):

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -469,10 +469,12 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 's3s3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None}
+                  'is_stream': False, 'source_region': None,
+                  'is_move': True}
         self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
                                   "LastModified": "2014-01-09T20:45:49.000Z"}]
-        cmd_arc = CommandArchitecture(self.session, 'mv', params)
+        config = RuntimeConfig().build_config()
+        cmd_arc = CommandArchitecture(self.session, 'mv', params, config)
         cmd_arc.set_clients()
         cmd_arc.create_instructions()
         self.patch_make_request()
@@ -684,6 +686,16 @@ class CommandParametersTest(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError,
                                      'only supported for copy operations'):
             cmd_param.add_paths(paths)
+
+    def test_adds_is_move(self):
+        params = {}
+        CommandParameters('mv', params, '')
+        self.assertTrue(params.get('is_move'))
+
+        # is_move should only be true for mv
+        params = {}
+        CommandParameters('cp', params, '')
+        self.assertFalse(params.get('is_move'))
 
 
 class HelpDocTest(BaseAWSHelpOutputTest):


### PR DESCRIPTION
This is dependant on boto/s3transfer#69

The one sticking point here is telling the transfer manager that the transfer is a move. Right now it's plumbed through the fileinfo object, but I don't like how much had to be done to get it there. Other options:

* Make the fileinfo do the translation and set that boolean so that it doesn't need to be plumbed through.
* Have the transfer handler do the translation and pass it in.
* Do no translation at all and base the RequestSubmitters on the source type and destinaiton type

cc @kyleknap @jamesls