### PR TITLE
Clean source directory on mv upkeep

### DIFF
--- a/scripts/performance/benchmark-mv
+++ b/scripts/performance/benchmark-mv
@@ -17,10 +17,14 @@ def benchmark_mv(args):
             clean(destination, args.recursive)
         clean(backup_path, args.recursive)
 
+    def upkeep():
+        clean(args.source, args.recursive)
+        copy(backup_path, args.source, args.recursive)
+
     benchmark_command(
         command, args.benchmark_script,  args.summarize_script,
         args.result_dir, args.num_iterations, args.dry_run,
-        upkeep=lambda: copy(backup_path, args.source, args.recursive),
+        upkeep=upkeep,
         cleanup=cleanup
     )
 


### PR DESCRIPTION
Mv doesn't delete directories, so we need to get rid of them
manually before we copy over the backup.

cc @kyleknap @jamesls