### PR TITLE
Replace IAM with STS in CreateSubscription

### DIFF
--- a/.changes/next-release/bugfix-cloudtrail-2075.json
+++ b/.changes/next-release/bugfix-cloudtrail-2075.json
@@ -1,0 +1,5 @@
+{
+  "category": "``cloudtrail``", 
+  "type": "bugfix", 
+  "description": "Use STS instead of IAM in CreateSubscription"
+}

--- a/awscli/customizations/cloudtrail/subscribe.py
+++ b/awscli/customizations/cloudtrail/subscribe.py
@@ -80,7 +80,7 @@ class CloudTrailSubscribe(BasicCommand):
 
         # Initialize services
         LOG.debug('Initializing S3, SNS and CloudTrail...')
-        self.iam = self._session.create_client('iam', **client_args)
+        self.sts = self._session.create_client('sts', **client_args)
         self.s3 = self._session.create_client('s3', **client_args)
         self.sns = self._session.create_client('sns', **client_args)
         self.region_name = self.s3.meta.region_name
@@ -187,7 +187,7 @@ class CloudTrailSubscribe(BasicCommand):
         sys.stdout.write(
             'Setting up new S3 bucket {bucket}...\n'.format(bucket=bucket))
 
-        account_id = get_account_id(self.iam)
+        account_id = get_account_id(self.sts)
 
         # Clean up the prefix - it requires a trailing slash if set
         if prefix and not prefix.endswith('/'):
@@ -239,7 +239,7 @@ class CloudTrailSubscribe(BasicCommand):
         sys.stdout.write(
             'Setting up new SNS topic {topic}...\n'.format(topic=topic))
 
-        account_id = get_account_id(self.iam)
+        account_id = get_account_id(self.sts)
 
         # Make sure topic doesn't already exist
         # Warn but do not fail if ListTopics permissions

--- a/awscli/customizations/cloudtrail/utils.py
+++ b/awscli/customizations/cloudtrail/utils.py
@@ -17,10 +17,10 @@ def get_account_id_from_arn(trail_arn):
     return trail_arn.split(':')[4]
 
 
-def get_account_id(iam_client):
-    """Retrieve the AWS account ID for the authenticated user"""
-    response = iam_client.get_user()
-    return get_account_id_from_arn(response['User']['Arn'])
+def get_account_id(sts_client):
+    """Retrieve the AWS account ID for the authenticated user or role"""
+    response = sts_client.get_caller_identity()
+    return response['Account']
 
 
 def get_trail_by_arn(cloudtrail_client, trail_arn):

--- a/tests/unit/customizations/cloudtrail/test_utils.py
+++ b/tests/unit/customizations/cloudtrail/test_utils.py
@@ -17,11 +17,11 @@ from awscli.testutils import unittest
 
 
 class TestCloudTrailUtils(unittest.TestCase):
-    def test_gets_iam_account_id(self):
-        mock_iam_client = Mock()
-        user_info = {'User': {'Arn': 'foo:bar:baz:qux:1234'}}
-        mock_iam_client.get_user.return_value = user_info
-        account_id = utils.get_account_id(mock_iam_client)
+    def test_gets_sts_account_id(self):
+        mock_sts_client = Mock()
+        user_info = {'Account': '1234'}
+        mock_sts_client.get_caller_identity.return_value = user_info
+        account_id = utils.get_account_id(mock_sts_client)
         self.assertEqual(account_id, '1234')
 
     def test_gets_account_id_from_arn(self):


### PR DESCRIPTION
IAM uses GetUser to extract the account the ID of the caller.
That does not work if the caller is assuming a role.
STS allows us to GetCallerIdentity, regardless of whether the
caller is a user or a role.