### PR TITLE
Set exit code on powershell

### DIFF
--- a/.changes/next-release/bugfix-Powershell-37739.json
+++ b/.changes/next-release/bugfix-Powershell-37739.json
@@ -1,0 +1,5 @@
+{
+  "description": "Properly set return code on Powershell.",
+  "category": "Powershell",
+  "type": "bugfix"
+}

--- a/bin/aws.cmd
+++ b/bin/aws.cmd
@@ -17,6 +17,7 @@ for /f "tokens=2 delims==" %%i in ('assoc .py') do (
     )
 )
 %PythonExe% -x %PythonExeFlags% "%~f0" %*
+exit /B %ERRORLEVEL%
 goto :EOF
 
 :SetPythonExe


### PR DESCRIPTION
Currently aws.cmd will not return a valid exit status in powershell.
So `echo $?` will always evaluate to `True` and `echo $LASTEXITCODE`
will always return `0`. This adds an explicit exit step which makes
sure that the return code is set properly.

cc @kyleknap @jamesls @stealthycoin