### PR TITLE
Add support for aliases

### DIFF
--- a/.changes/next-release/feature-alias-49524.json
+++ b/.changes/next-release/feature-alias-49524.json
@@ -1,0 +1,5 @@
+{
+  "category": "alias", 
+  "type": "feature", 
+  "description": "Add ability to alias commands in the CLI"
+}

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -1,0 +1,206 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+import os
+import shlex
+import subprocess
+
+from botocore.configloader import raw_config_parse
+
+from awscli.utils import emit_top_level_args_parsed_event
+
+
+LOG = logging.getLogger(__name__)
+
+
+class InvalidAliasException(Exception):
+    pass
+
+
+class AliasLoader(object):
+    ALIAS_FILENAME = os.path.expanduser(
+        os.path.join('~', '.aws', 'cli', 'alias'))
+
+    def __init__(self, alias_filename=None):
+        """Interface for loading and interacting with alias file
+
+        :param alias_filename: The name of the file to load aliases from.
+            This file must be an INI file. If no filename is provided,
+            the value of ALIAS_FILENAME will be used.
+        """
+        self._filename = alias_filename
+        if alias_filename is None:
+            self._filename = self.ALIAS_FILENAME
+        self._aliases = self._load_aliases()
+        self._cleanup_alias_values()
+
+    def _load_aliases(self):
+        if os.path.exists(self._filename):
+            return raw_config_parse(
+                self._filename, parse_subsections=False)
+        return {'toplevel': {}}
+
+    def _cleanup_alias_values(self):
+        aliases = self.get_aliases()
+        for alias in aliases:
+            # Beginning and end line separators should not be included
+            # in the internal representation of the alias value.
+            aliases[alias] = aliases[alias].strip(os.linesep)
+
+    def get_aliases(self):
+        return self._aliases.get('toplevel', {})
+
+
+class BaseAliasCommand(object):
+    _UNDOCUMENTED = True
+
+    def __init__(self, alias_name, alias_value):
+        """Base class for alias command
+
+        :type alias_name: string
+        :param alias_name: The name of the alias
+
+        :type alias_value: string
+        :param alias_value: The parsed value of the alias. This can be
+            retrieved from `AliasLoader.get_aliases()[alias_name]`
+        """
+        self._alias_name = alias_name
+        self._alias_value = alias_value
+
+    def __call__(self, args, parsed_args):
+        raise NotImplementedError('__call__')
+
+    @property
+    def name(self):
+        return self._alias_name
+
+    @name.setter
+    def name(self, value):
+        self._alias_name = value
+
+
+class ServiceAliasCommand(BaseAliasCommand):
+    UNSUPPORTED_GLOBAL_PARAMETERS = [
+        'debug',
+        'profile'
+    ]
+
+    def __init__(self, alias_name, alias_value, session, command_table,
+                 parser):
+        """Command for a `toplevel` subcommand alias
+
+        :type alias_name: string
+        :param alias_name: The name of the alias
+
+        :type alias_value: string
+        :param alias_value: The parsed value of the alias. This can be
+            retrieved from `AliasLoader.get_aliases()[alias_name]`
+
+        :type session: botocore.session.Session
+        :param session: The botocore session
+
+        :type command_table: dict
+        :param command_table: The command table containing all of the
+            possible service command objects that a particular alias could
+            redirect to.
+
+        :type parser: awscli.argparser.MainArgParser
+        :param parser: The parser to parse commands provided at the top level
+            of a CLI command which includes service commands and global
+            parameters. This is used to parse the service commmand and any
+            global parameters from the alias's value.
+        """
+        super(ServiceAliasCommand, self).__init__(alias_name, alias_value)
+        self._session = session
+        self._command_table = command_table
+        self._parser = parser
+
+    def __call__(self, args, parsed_globals):
+        alias_args = self._get_alias_args()
+        parsed_alias_args, remaining = self._parser.parse_known_args(
+            alias_args)
+        self._update_parsed_globals(parsed_alias_args, parsed_globals)
+        # Take any of the remaining arguments that were not parsed out and
+        # prepend them to the remaining args provided to the alias.
+        remaining.extend(args)
+        LOG.debug(
+            'Alias %r passing on arguments: %r to %r command',
+            self._alias_name, remaining, parsed_alias_args.command)
+        # Pass the update remaing args and global args to the service command
+        # the alias proxied to.
+        return self._command_table[parsed_alias_args.command](
+            remaining, parsed_globals)
+
+    def _get_alias_args(self):
+        try:
+            alias_args = shlex.split(self._alias_value)
+        except ValueError as e:
+            raise InvalidAliasException(
+                'Value of alias "%s" could not be parsed. '
+                'Received error: %s when parsing:\n%s' % (
+                    self._alias_name, e, self._alias_value)
+            )
+
+        alias_args = [arg.strip(os.linesep) for arg in alias_args]
+        LOG.debug(
+            'Expanded subcommand alias %r with value: %r to: %r',
+            self._alias_name, self._alias_value, alias_args
+        )
+        return alias_args
+
+    def _update_parsed_globals(self, parsed_alias_args, parsed_globals):
+        global_params_to_update = self._get_global_parameters_to_update(
+            parsed_alias_args)
+        # Emit the top level args parsed event to ensure all possible
+        # customizations that typically get applied are applied to the
+        # global parameters provided in the alias before updating
+        # the original provided global parameter values
+        # and passing those onto subsequent commands.
+        emit_top_level_args_parsed_event(self._session, parsed_alias_args)
+        for param_name in global_params_to_update:
+            updated_param_value = getattr(parsed_alias_args, param_name)
+            setattr(parsed_globals, param_name, updated_param_value)
+
+    def _get_global_parameters_to_update(self, parsed_alias_args):
+        # Retrieve a list of global parameters that the newly parsed args
+        # from the alias will have to clobber from the originally provided
+        # parsed globals.
+        global_params_to_update = []
+        for parsed_param, value in vars(parsed_alias_args).items():
+            # To determine which parameters in the alias were global values
+            # compare the parsed parameter to its default as specified by
+            # the parser. If the parsed value differs from the default value
+            # that global parameter must have been provided.
+            if self._parser.get_default(parsed_param) != value:
+                if parsed_param in self.UNSUPPORTED_GLOBAL_PARAMETERS:
+                    raise InvalidAliasException(
+                        'Global parameter "--%s" detected in alias "%s" '
+                        'which is not support in subcommand aliases.' % (
+                            parsed_param, self._alias_name))
+                else:
+                    global_params_to_update.append(parsed_param)
+        return global_params_to_update
+
+
+class ExternalAliasCommand(BaseAliasCommand):
+    """Command for `toplevel` external alias"""
+    def __call__(self, args, parsed_globals):
+        command_components = [
+            self._alias_value.lstrip('!')
+        ]
+        command_components.extend(args)
+        command = ' '.join(command_components)
+        LOG.debug(
+            'Using external alias %r with value: %r to run: %r',
+            self._alias_name, self._alias_value, command)
+        return subprocess.call(command, shell=True)

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -248,7 +248,27 @@ class ServiceAliasCommand(BaseAliasCommand):
 
 
 class ExternalAliasCommand(BaseAliasCommand):
-    """Command for `toplevel` external alias"""
+    def __init__(self, alias_name, alias_value, invoker=subprocess.call):
+        """Command for external aliases
+
+        Executes command external of CLI as opposed to being a proxy
+        to another command.
+
+        :type alias_name: string
+        :param alias_name: The name of the alias
+
+        :type alias_value: string
+        :param alias_value: The parsed value of the alias. This can be
+            retrieved from `AliasLoader.get_aliases()[alias_name]`
+
+        :type invoker: callable
+        :param invoker: Callable to run arguments of external alias. The
+            signature should match that of ``subprocess.call``
+        """
+        self._alias_name = alias_name
+        self._alias_value = alias_value
+        self._invoker = invoker
+
     def __call__(self, args, parsed_globals):
         command_components = [
             self._alias_value[1:]
@@ -258,4 +278,4 @@ class ExternalAliasCommand(BaseAliasCommand):
         LOG.debug(
             'Using external alias %r with value: %r to run: %r',
             self._alias_name, self._alias_value, command)
-        return subprocess.call(command, shell=True)
+        return self._invoker(command, shell=True)

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -28,20 +28,20 @@ class InvalidAliasException(Exception):
 
 
 class AliasLoader(object):
-    ALIAS_FILENAME = os.path.expanduser(
-        os.path.join('~', '.aws', 'cli', 'alias'))
-
-    def __init__(self, alias_filename=None):
+    def __init__(self,
+                 alias_filename=os.path.expanduser(
+                     os.path.join('~', '.aws', 'cli', 'alias'))):
         """Interface for loading and interacting with alias file
 
         :param alias_filename: The name of the file to load aliases from.
             This file must be an INI file.
         """
         self._filename = alias_filename
-        if alias_filename is None:
-            self._filename = self.ALIAS_FILENAME
+        self._aliases = None
+
+    def _build_aliases(self):
         self._aliases = self._load_aliases()
-        self._cleanup_alias_values()
+        self._cleanup_alias_values(self._aliases['toplevel'])
 
     def _load_aliases(self):
         if os.path.exists(self._filename):
@@ -49,14 +49,15 @@ class AliasLoader(object):
                 self._filename, parse_subsections=False)
         return {'toplevel': {}}
 
-    def _cleanup_alias_values(self):
-        aliases = self.get_aliases()
+    def _cleanup_alias_values(self, aliases):
         for alias in aliases:
             # Beginning and end line separators should not be included
             # in the internal representation of the alias value.
             aliases[alias] = aliases[alias].strip(os.linesep)
 
     def get_aliases(self):
+        if self._aliases is None:
+            self._build_aliases()
         return self._aliases.get('toplevel', {})
 
 

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -17,6 +17,7 @@ import subprocess
 
 from botocore.configloader import raw_config_parse
 
+from awscli.commands import CLICommand
 from awscli.utils import emit_top_level_args_parsed_event
 
 
@@ -95,7 +96,7 @@ class AliasCommandInjector(object):
             command_table[alias_name] = alias_cmd
 
 
-class BaseAliasCommand(object):
+class BaseAliasCommand(CLICommand):
     _UNDOCUMENTED = True
 
     def __init__(self, alias_name, alias_value):

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -233,9 +233,10 @@ class ServiceAliasCommand(BaseAliasCommand):
         global_params_to_update = []
         for parsed_param, value in vars(parsed_alias_args).items():
             # To determine which parameters in the alias were global values
-            # compare the parsed parameter to its default as specified by
-            # the parser. If the parsed value differs from the default value
-            # that global parameter must have been provided.
+            # compare the parsed alias parameters to the default as
+            # specified by the parser. If the parsed values from the alias
+            # differs from the default value in the parser,
+            # that global parameter must have been provided in the alias.
             if self._parser.get_default(parsed_param) != value:
                 if parsed_param in self.UNSUPPORTED_GLOBAL_PARAMETERS:
                     raise InvalidAliasException(

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -41,7 +41,7 @@ class AliasLoader(object):
 
     def _build_aliases(self):
         self._aliases = self._load_aliases()
-        self._cleanup_alias_values(self._aliases['toplevel'])
+        self._cleanup_alias_values(self._aliases.get('toplevel', {}))
 
     def _load_aliases(self):
         if os.path.exists(self._filename):
@@ -53,7 +53,7 @@ class AliasLoader(object):
         for alias in aliases:
             # Beginning and end line separators should not be included
             # in the internal representation of the alias value.
-            aliases[alias] = aliases[alias].strip(os.linesep)
+            aliases[alias] = aliases[alias].strip()
 
     def get_aliases(self):
         if self._aliases is None:
@@ -250,7 +250,7 @@ class ExternalAliasCommand(BaseAliasCommand):
     """Command for `toplevel` external alias"""
     def __call__(self, args, parsed_globals):
         command_components = [
-            self._alias_value.lstrip('!')
+            self._alias_value[1:]
         ]
         command_components.extend(args)
         command = ' '.join(command_components)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -80,7 +80,7 @@ class CLIDriver(object):
         self._cli_data = None
         self._command_table = None
         self._argument_table = None
-        self._command_table_with_aliases = None
+        self.alias_loader = AliasLoader()
 
     def _get_cli_data(self):
         # Not crazy about this but the data in here is needed in
@@ -99,12 +99,6 @@ class CLIDriver(object):
         if self._argument_table is None:
             self._argument_table = self._build_argument_table()
         return self._argument_table
-
-    def _get_command_table_with_aliases(self):
-        if self._command_table_with_aliases is None:
-            self._command_table_with_aliases = \
-                self._build_command_table_with_aliases()
-        return self._command_table_with_aliases
 
     def _build_command_table(self):
         """
@@ -131,7 +125,6 @@ class CLIDriver(object):
         return commands
 
     def _add_aliases(self, command_table, parser):
-        alias_loader = AliasLoader()
         parser = self._create_parser(command_table)
         injector = AliasCommandInjector(
             self.session, self.alias_loader)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -25,6 +25,7 @@ from botocore.exceptions import NoRegionError
 from awscli import EnvironmentVariables, __version__
 from awscli.formatter import get_formatter
 from awscli.plugin import load_plugins
+from awscli.commands import CLICommand
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.argparser import ArgTableArgParser
@@ -256,64 +257,6 @@ class CLIDriver(object):
         else:
             self.session.set_stream_logger(logger_name='awscli',
                                            log_level=logging.ERROR)
-
-
-class CLICommand(object):
-
-    """Interface for a CLI command.
-
-    This class represents a top level CLI command
-    (``aws ec2``, ``aws s3``, ``aws config``).
-
-    """
-
-    @property
-    def name(self):
-        # Subclasses must implement a name.
-        raise NotImplementedError("name")
-
-    @name.setter
-    def name(self, value):
-        # Subclasses must implement setting/changing the cmd name.
-        raise NotImplementedError("name")
-
-    @property
-    def lineage(self):
-        # Represents how to get to a specific command using the CLI.
-        # It includes all commands that came before it and itself in
-        # a list.
-        return [self]
-
-    @property
-    def lineage_names(self):
-        # Represents the lineage of a command in terms of command ``name``
-        return [cmd.name for cmd in self.lineage]
-
-    def __call__(self, args, parsed_globals):
-        """Invoke CLI operation.
-
-        :type args: str
-        :param args: The remaining command line args.
-
-        :type parsed_globals: ``argparse.Namespace``
-        :param parsed_globals: The parsed arguments so far.
-
-        :rtype: int
-        :return: The return code of the operation.  This will be used
-            as the RC code for the ``aws`` process.
-
-        """
-        # Subclasses are expected to implement this method.
-        pass
-
-    def create_help_command(self):
-        # Subclasses are expected to implement this method if they want
-        # help docs.
-        return None
-
-    @property
-    def arg_table(self):
-        return {}
 
 
 class ServiceCommand(CLICommand):

--- a/awscli/commands.py
+++ b/awscli/commands.py
@@ -1,0 +1,70 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+class CLICommand(object):
+
+    """Interface for a CLI command.
+
+    This class represents a top level CLI command
+    (``aws ec2``, ``aws s3``, ``aws config``).
+
+    """
+
+    @property
+    def name(self):
+        # Subclasses must implement a name.
+        raise NotImplementedError("name")
+
+    @name.setter
+    def name(self, value):
+        # Subclasses must implement setting/changing the cmd name.
+        raise NotImplementedError("name")
+
+    @property
+    def lineage(self):
+        # Represents how to get to a specific command using the CLI.
+        # It includes all commands that came before it and itself in
+        # a list.
+        return [self]
+
+    @property
+    def lineage_names(self):
+        # Represents the lineage of a command in terms of command ``name``
+        return [cmd.name for cmd in self.lineage]
+
+    def __call__(self, args, parsed_globals):
+        """Invoke CLI operation.
+
+        :type args: str
+        :param args: The remaining command line args.
+
+        :type parsed_globals: ``argparse.Namespace``
+        :param parsed_globals: The parsed arguments so far.
+
+        :rtype: int
+        :return: The return code of the operation.  This will be used
+            as the RC code for the ``aws`` process.
+
+        """
+        # Subclasses are expected to implement this method.
+        pass
+
+    def create_help_command(self):
+        # Subclasses are expected to implement this method if they want
+        # help docs.
+        return None
+
+    @property
+    def arg_table(self):
+        return {}

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -48,7 +48,8 @@ def register(event_handler):
             'default-root-object', CreateDefaultRootObject(argument_table)))
 
     context = {}
-    event_handler.register('top-level-args-parsed', context.update)
+    event_handler.register(
+        'top-level-args-parsed', context.update, unique_id='cloudfront')
     event_handler.register(
         'operation-args-parsed.cloudfront.update-distribution',
         validate_mutually_exclusive_handler(

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -22,11 +22,16 @@ from awscli.compat import urlparse
 
 
 def register_parse_global_args(cli):
-    cli.register('top-level-args-parsed', resolve_types)
-    cli.register('top-level-args-parsed', no_sign_request)
-    cli.register('top-level-args-parsed', resolve_verify_ssl)
-    cli.register('top-level-args-parsed', resolve_cli_read_timeout)
-    cli.register('top-level-args-parsed', resolve_cli_connect_timeout)
+    cli.register('top-level-args-parsed', resolve_types,
+                 unique_id='resolve-types')
+    cli.register('top-level-args-parsed', no_sign_request,
+                 unique_id='no-sign')
+    cli.register('top-level-args-parsed', resolve_verify_ssl,
+                 unique_id='resolve-verify-ssl')
+    cli.register('top-level-args-parsed', resolve_cli_read_timeout,
+                 unique_id='resolve-cli-read-timeout')
+    cli.register('top-level-args-parsed', resolve_cli_connect_timeout,
+                 unique_id='resolve-cli-connect-timeout')
 
 
 def resolve_types(parsed_args, **kwargs):

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -85,7 +85,8 @@ def no_sign_request(parsed_args, session, **kwargs):
     if not parsed_args.sign_request:
         # In order to make signing disabled for all requests
         # we need to use botocore's ``disable_signing()`` handler.
-        session.register('choose-signer', disable_signing)
+        session.register(
+            'choose-signer', disable_signing, unique_id='disable-signing')
 
 
 def resolve_cli_connect_timeout(parsed_args, session, **kwargs):

--- a/awscli/customizations/s3endpoint.py
+++ b/awscli/customizations/s3endpoint.py
@@ -31,7 +31,8 @@ from botocore.utils import fix_s3_host
 
 def register_s3_endpoint(cli):
     handler = partial(on_top_level_args_parsed, event_handler=cli)
-    cli.register('top-level-args-parsed', handler)
+    cli.register(
+        'top-level-args-parsed', handler, unique_id='s3-endpoint')
 
 
 def on_top_level_args_parsed(parsed_args, event_handler, **kwargs):

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -141,3 +141,8 @@ def ignore_ctrl_c():
         yield
     finally:
         signal.signal(signal.SIGINT, original)
+
+
+def emit_top_level_args_parsed_event(session, args):
+    session.emit(
+        'top-level-args-parsed', parsed_args=args, session=session)

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -25,6 +25,7 @@ from awscli.testutils import BaseAWSHelpOutputTest
 from awscli.testutils import FileCreator
 
 from awscli.compat import six
+from awscli.alias import AliasLoader
 import mock
 
 
@@ -440,20 +441,11 @@ class TestAliases(BaseAWSHelpOutputTest):
         super(TestAliases, self).setUp()
         self.files = FileCreator()
         self.alias_file = self.files.create_file('alias', '[toplevel]\n')
-
-        # TODO: If an environment variable is ever exposed to
-        # modify the alias file location, remove this patch
-        # and use that environment variable because patching of specific
-        # classes properties should be avoided for functional tests but
-        # there is not really any other way to hook in...
-        self.alias_file_location_patch = mock.patch(
-            'awscli.alias.AliasLoader.ALIAS_FILENAME', self.alias_file)
-        self.alias_file_location_patch.start()
+        self.driver.alias_loader = AliasLoader(self.alias_file)
 
     def tearDown(self):
         super(TestAliases, self).tearDown()
         self.files.remove_all()
-        self.alias_file_location_patch.stop()
 
     def add_alias(self, alias_name, alias_value):
         with open(self.alias_file, 'a+') as f:

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -455,24 +455,3 @@ class TestAliases(BaseAWSHelpOutputTest):
         self.add_alias('my-alias', 'ec2 describe-regions')
         self.driver.main(['help'])
         self.assert_not_contains('my-alias')
-
-    def test_alias_proxies_to_service_help(self):
-        self.add_alias('my-alias', 'ec2')
-        self.driver.main(['my-alias', 'help'])
-        self.assert_contains('ec2')
-        self.assert_contains('run-instances')
-        self.assert_not_contains('my-alias')
-
-    def test_alias_then_operation_proxies_to_operation_help(self):
-        self.add_alias('my-alias', 'ec2')
-        self.driver.main(['my-alias', 'describe-regions', 'help'])
-        self.assert_contains('describe-regions')
-        self.assert_contains('--region-names')
-        self.assert_not_contains('my-alias')
-
-    def test_alias_with_operation_proxies_to_operation_help(self):
-        self.add_alias('my-alias', 'ec2 describe-regions')
-        self.driver.main(['my-alias', 'help'])
-        self.assert_contains('describe-regions')
-        self.assert_contains('--region-names')
-        self.assert_not_contains('my-alias')

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -1,0 +1,147 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+
+from awscli.testutils import mock
+from awscli.testutils import FileCreator
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestAliases(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestAliases, self).setUp()
+        self.files = FileCreator()
+        self.alias_file = self.files.create_file('alias', '[toplevel]\n')
+
+        # TODO: If an environment variable is ever exposed to
+        # modify the alias file location, remove this patch
+        # and use that environment variable because patching of specific
+        # classes properties should be avoided for functional tests but
+        # there is not really any other way to hook in...
+        self.alias_file_location_patch = mock.patch(
+            'awscli.alias.AliasLoader.ALIAS_FILENAME', self.alias_file)
+        self.alias_file_location_patch.start()
+
+    def tearDown(self):
+        super(TestAliases, self).tearDown()
+        self.files.remove_all()
+        self.alias_file_location_patch.stop()
+
+    def add_alias(self, alias_name, alias_value):
+        with open(self.alias_file, 'a+') as f:
+            f.write('%s = %s\n' % (alias_name, alias_value))
+
+    def test_subcommand_alias(self):
+        self.add_alias('my-alias', 'ec2 describe-regions')
+        cmdline = 'my-alias'
+        self.assert_params_for_cmd(cmdline, {})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
+
+    def test_subcommand_alias_with_additonal_params(self):
+        self.add_alias(
+            'my-alias', 'ec2 describe-regions --region-names us-east-1')
+        cmdline = 'my-alias'
+        self.assert_params_for_cmd(cmdline, {'RegionNames': ['us-east-1']})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
+
+    def test_subcommand_alias_then_additonal_params(self):
+        self.add_alias('my-alias', 'ec2')
+        cmdline = 'my-alias describe-regions --region-names us-east-1'
+        self.assert_params_for_cmd(cmdline, {'RegionNames': ['us-east-1']})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
+
+    def test_subcommand_alias_with_global_params(self):
+        self.add_alias(
+            'my-alias',
+            'ec2 describe-regions --query Regions[].RegionName --output text')
+        self.parsed_responses = [
+            {
+                'Regions': [
+                    {
+                        'Endpoint': 'ec2.us-east-1.amazonaws.com',
+                        'RegionName': 'us-east-1'
+                    }
+                ]
+            }
+        ]
+        cmdline = 'my-alias'
+        stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
+        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+
+    def test_subcommand_alias_then_global_params(self):
+        self.add_alias('my-alias', 'ec2 describe-regions')
+        self.parsed_responses = [
+            {
+                'Regions': [
+                    {
+                        'Endpoint': 'ec2.us-east-1.amazonaws.com',
+                        'RegionName': 'us-east-1'
+                    }
+                ]
+            }
+        ]
+        cmdline = 'my-alias '
+        cmdline += '--query=Regions[].RegionName '
+        cmdline += '--output=text'
+        stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
+        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+
+    def test_global_params_then_subcommand_alias(self):
+        self.add_alias('my-alias', 'ec2 describe-regions')
+        self.parsed_responses = [
+            {
+                'Regions': [
+                    {
+                        'Endpoint': 'ec2.us-east-1.amazonaws.com',
+                        'RegionName': 'us-east-1'
+                    }
+                ]
+            }
+        ]
+        cmdline = '--query=Regions[].RegionName '
+        cmdline += '--output=text '
+        cmdline += 'my-alias'
+        stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
+        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+
+    def test_alias_overrides_builtin_command(self):
+        self.add_alias('ec2', 's3api')
+        cmdline = 'ec2 list-buckets'
+        self.assert_params_for_cmd(cmdline, {})
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'ListBuckets')
+
+    def test_external_alias(self):
+        # The external alias is tested by using mkdir; a command that
+        # is universal for the various OS's we support
+        directory_to_make = os.path.join(self.files.rootdir, 'newdir')
+        self.add_alias('mkdir', '!mkdir %s' % directory_to_make)
+        self.run_cmd('mkdir')
+        self.assertTrue(os.path.isdir(directory_to_make))
+
+    def test_external_alias_then_additonal_args(self):
+        # The external alias is tested by using mkdir; a command that
+        # is universal for the various OS's we support
+        directory_to_make = os.path.join(self.files.rootdir, 'newdir')
+        self.add_alias('mkdir', '!mkdir')
+        self.run_cmd('mkdir %s' % directory_to_make)
+        self.assertTrue(os.path.isdir(directory_to_make))

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -22,20 +22,11 @@ class TestAliases(BaseAWSCommandParamsTest):
         super(TestAliases, self).setUp()
         self.files = FileCreator()
         self.alias_file = self.files.create_file('alias', '[toplevel]\n')
-
-        # TODO: If an environment variable is ever exposed to
-        # modify the alias file location, remove this patch
-        # and use that environment variable because patching of specific
-        # classes properties should be avoided for functional tests but
-        # there is not really any other way to hook in...
-        self.alias_file_location_patch = mock.patch(
-            'awscli.alias.AliasLoader.ALIAS_FILENAME', self.alias_file)
-        self.alias_file_location_patch.start()
+        self.driver.alias_loader = AliasLoader(self.alias_file)
 
     def tearDown(self):
         super(TestAliases, self).tearDown()
         self.files.remove_all()
-        self.alias_file_location_patch.stop()
 
     def add_alias(self, alias_name, alias_value):
         with open(self.alias_file, 'a+') as f:

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 
+from awscli.alias import AliasLoader
 from awscli.testutils import mock
 from awscli.testutils import FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
@@ -72,7 +73,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
-        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+        self.assertEqual(stdout.strip(), 'us-east-1')
 
     def test_subcommand_alias_then_global_params(self):
         self.add_alias('my-alias', 'ec2 describe-regions')
@@ -92,7 +93,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
-        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+        self.assertEqual(stdout.strip(), 'us-east-1')
 
     def test_global_params_then_subcommand_alias(self):
         self.add_alias('my-alias', 'ec2 describe-regions')
@@ -112,7 +113,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
-        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+        self.assertEqual(stdout.strip(), 'us-east-1')
 
     def test_alias_overrides_builtin_command(self):
         self.add_alias('ec2', 's3api')
@@ -156,7 +157,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
-        self.assertEqual(stdout.strip('\n'), 'us-east-1')
+        self.assertEqual(stdout.strip(), 'us-east-1')
 
     def test_external_alias(self):
         # The external alias is tested by using mkdir; a command that

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -13,7 +13,6 @@
 import os
 
 from awscli.alias import AliasLoader
-from awscli.testutils import mock
 from awscli.testutils import FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
 
@@ -38,6 +37,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline = 'my-alias'
         self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
     def test_subcommand_alias_with_additonal_params(self):
@@ -46,6 +49,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline = 'my-alias'
         self.assert_params_for_cmd(cmdline, {'RegionNames': ['us-east-1']})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
     def test_subcommand_alias_then_additonal_params(self):
@@ -53,6 +60,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline = 'my-alias describe-regions --region-names us-east-1'
         self.assert_params_for_cmd(cmdline, {'RegionNames': ['us-east-1']})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
     def test_subcommand_alias_with_global_params(self):
@@ -72,6 +83,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline = 'my-alias'
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
         self.assertEqual(stdout.strip(), 'us-east-1')
 
@@ -92,6 +107,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline += '--output=text'
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
         self.assertEqual(stdout.strip(), 'us-east-1')
 
@@ -112,6 +131,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline += 'my-alias'
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
         self.assertEqual(stdout.strip(), 'us-east-1')
 
@@ -127,6 +150,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline = 'ec2 describe-regions'
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
     def test_alias_chaining(self):
@@ -136,6 +163,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         cmdline = 'wrapper-alias'
         self.assert_params_for_cmd(cmdline, {'RegionNames': ['us-east-1']})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
     def test_alias_chaining_with_globals(self):
@@ -156,6 +187,10 @@ class TestAliases(BaseAWSCommandParamsTest):
         ]
         stdout, _, _ = self.assert_params_for_cmd(cmdline, {})
         self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(
+            self.operations_called[0][0].service_model.service_name,
+            'ec2'
+        )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
         self.assertEqual(stdout.strip(), 'us-east-1')
 

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -13,6 +13,7 @@
 import os
 
 from awscli.alias import AliasLoader
+from awscli.testutils import skip_if_windows
 from awscli.testutils import FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
 
@@ -207,5 +208,14 @@ class TestAliases(BaseAWSCommandParamsTest):
         # is universal for the various OS's we support
         directory_to_make = os.path.join(self.files.rootdir, 'newdir')
         self.add_alias('mkdir', '!mkdir')
+        self.run_cmd('mkdir %s' % directory_to_make)
+        self.assertTrue(os.path.isdir(directory_to_make))
+
+    @skip_if_windows('Windows does not support BASH functions')
+    def test_external_alias_with_wrapper_bash_function(self):
+        # The external alias is tested by using mkdir; a command that
+        # is universal for the various OS's we support
+        directory_to_make = os.path.join(self.files.rootdir, 'newdir')
+        self.add_alias('mkdir', '!f() { mkdir "${1}"; }; f')
         self.run_cmd('mkdir %s' % directory_to_make)
         self.assertTrue(os.path.isdir(directory_to_make))

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -174,7 +174,8 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         session = mock.Mock()
 
         globalargs.no_sign_request(args, session)
-        session.register.assert_called_with('choose-signer', disable_signing)
+        session.register.assert_called_with(
+            'choose-signer', disable_signing, unique_id='disable-signing')
 
     def test_request_signed_by_default(self):
         args = FakeParsedArgs(sign_request=True)

--- a/tests/unit/test_alias.py
+++ b/tests/unit/test_alias.py
@@ -1,0 +1,432 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+
+from awscli.testutils import unittest
+from awscli.testutils import mock
+from awscli.testutils import FileCreator
+from awscli.alias import InvalidAliasException
+from awscli.alias import AliasLoader
+from awscli.alias import BaseAliasCommand
+from awscli.alias import ServiceAliasCommand
+from awscli.alias import ExternalAliasCommand
+from awscli.argparser import MainArgParser
+
+
+class FakeParsedArgs(object):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __repr__(self):
+        return '%s(%s)' % (self.__class__.__name__, self.__dict__)
+
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __contains__(self, key):
+        return key in self.__dict__
+
+
+class TestAliasLoader(unittest.TestCase):
+    def setUp(self):
+        self.files = FileCreator()
+        self.alias_file = self.files.create_file('alias', '[toplevel]\n')
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    def test_get_aliases_non_existent_file(self):
+        nonexistent_file = os.path.join(self.files.rootdir, 'no-exists')
+        alias_interface = AliasLoader(nonexistent_file)
+        self.assertEqual(alias_interface.get_aliases(), {})
+
+    def test_get_aliases_empty_file(self):
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(alias_interface.get_aliases(), {})
+
+    def test_get_aliases_missing_toplevel(self):
+        with open(self.alias_file, 'w') as f:
+            f.write('[unrelated-section]\n')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(alias_interface.get_aliases(), {})
+
+    def test_get_aliases(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('my-alias = my-alias-value')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(
+            alias_interface.get_aliases(), {'my-alias': 'my-alias-value'})
+
+    def test_get_aliases_with_alias_that_includes_parameter(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('my-alias = my-alias-value --my-parameter my-value')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(
+            alias_interface.get_aliases(),
+            {'my-alias': 'my-alias-value --my-parameter my-value'})
+
+    def test_get_aliases_with_alias_that_includes_newlines(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('my-alias = my-alias-value\n')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(
+            alias_interface.get_aliases(), {'my-alias': 'my-alias-value'})
+
+    def test_get_aliases_with_alias_that_is_indented(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('my-alias = \n  my-alias-value\n')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(
+            alias_interface.get_aliases(), {'my-alias': 'my-alias-value'})
+
+    def test_get_aliases_with_multiple_lines(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write(
+                'my-alias = \n'
+                '  my-alias-value \ \n'
+                '  --parameter foo\n')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(
+            alias_interface.get_aliases(),
+            # The backslash and newline should be preserved, but
+            # still have the beginning and end newlines removed.
+            {'my-alias': 'my-alias-value \\\n--parameter foo'})
+
+    def test_get_aliases_with_multiple_aliases(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('my-alias = my-alias-value\n')
+            f.write('my-second-alias = my-second-alias-value\n')
+        alias_interface = AliasLoader(self.alias_file)
+        self.assertEqual(
+            alias_interface.get_aliases(),
+            {'my-alias': 'my-alias-value',
+             'my-second-alias': 'my-second-alias-value'})
+
+
+class TestBaseAliasCommand(unittest.TestCase):
+    def test_name(self):
+        alias_cmd = BaseAliasCommand('alias-name', 'alias-value')
+        self.assertEqual(alias_cmd.name, 'alias-name')
+        alias_cmd.name = 'new-alias-name'
+        self.assertEqual(alias_cmd.name, 'new-alias-name')
+
+
+class TestServiceAliasCommand(unittest.TestCase):
+    def setUp(self):
+        self.alias_name = 'myalias'
+        self.session = mock.Mock()
+
+    def create_command_table(self, services):
+        command_table = {}
+        for service in services:
+            command_table[service] = mock.Mock()
+        return command_table
+
+    def create_parser(self, command_table, extra_params=None):
+        parser = MainArgParser(
+            command_table=command_table,
+            version_string='version',
+            description='description',
+            argument_table={}
+        )
+        if extra_params:
+            for extra_param in extra_params:
+                parser.add_argument('--'+extra_param)
+        return parser
+
+    def test_alias_with_only_service_command(self):
+        alias_value = 'myservice'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            [], FakeParsedArgs(command='myservice'))
+
+    def test_alias_with_operation_command(self):
+        alias_value = 'myservice myoperation'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        parsed_globals = FakeParsedArgs(command=self.alias_name)
+        alias_cmd([], parsed_globals)
+        command_table['myservice'].assert_called_with(
+            ['myoperation'], FakeParsedArgs(command='myservice'))
+
+    def test_alias_then_help_command(self):
+        alias_value = 'myservice myoperation'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        parsed_globals = FakeParsedArgs(command=self.alias_name)
+        alias_cmd(['help'], parsed_globals)
+        command_table['myservice'].assert_called_with(
+            ['myoperation', 'help'], FakeParsedArgs(command='myservice'))
+
+    def test_alias_then_additional_parameters(self):
+        alias_value = 'myservice myoperation'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        parsed_globals = FakeParsedArgs(command=self.alias_name)
+        alias_cmd(['--parameter', 'val'], parsed_globals)
+        command_table['myservice'].assert_called_with(
+            ['myoperation', '--parameter', 'val'],
+            FakeParsedArgs(command='myservice')
+        )
+
+    def test_alias_with_operation_and_parameters(self):
+        alias_value = 'myservice myoperation --my-parameter val'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            ['myoperation', '--my-parameter', 'val'],
+            FakeParsedArgs(command='myservice')
+        )
+
+    def test_alias_with_operation_and_global_parameters(self):
+        alias_value = 'myservice myoperation --global-param val'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(
+            command_table, extra_params=['global-param'])
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            ['myoperation'],
+            FakeParsedArgs(command='myservice', global_param='val')
+        )
+
+    def test_maintains_global_defaults_when_missing_from_alias(self):
+        alias_value = 'myservice myoperation'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        parser.add_argument('--global-with-default', default='default')
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+        alias_cmd(
+            [],
+            FakeParsedArgs(
+                command=self.alias_name, global_with_default='default')
+        )
+        command_table['myservice'].assert_called_with(
+            ['myoperation'],
+            FakeParsedArgs(
+                command='myservice', global_with_default='default')
+        )
+
+    def test_sets_global_parameters_when_differs_from_defaults(self):
+        alias_value = 'myservice myoperation --global-with-default non-default'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        parser.add_argument('--global-with-default', default='default')
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            ['myoperation'],
+            FakeParsedArgs(
+                command='myservice', global_with_default='non-default')
+        )
+
+    def test_global_parameters_can_be_emitted_and_modified(self):
+        alias_value = 'myservice myoperation --global-param val'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(
+            command_table, extra_params=['global-param'])
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        def replace_global_param_value_with_foo(event_name, **kwargs):
+            parsed_args = kwargs['parsed_args']
+            parsed_args.global_param = 'foo'
+
+        self.session.emit.side_effect = replace_global_param_value_with_foo
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        self.session.emit.assert_called_with(
+            'top-level-args-parsed', parsed_args=mock.ANY,
+            session=self.session)
+
+        command_table['myservice'].assert_called_with(
+            ['myoperation'],
+            FakeParsedArgs(command='myservice', global_param='foo')
+        )
+
+    def test_properly_handles_multiple_spaces(self):
+        alias_value = (
+            'myservice myoperation    --my-parameter val'
+        )
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            ['myoperation', '--my-parameter', 'val'],
+            FakeParsedArgs(command='myservice')
+        )
+
+    def test_properly_parses_aliases_broken_by_multiple_lines(self):
+        alias_value = (
+            'myservice myoperation \\'
+            '\n--my-parameter val'
+        )
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            ['myoperation', '--my-parameter', 'val'],
+            FakeParsedArgs(command='myservice')
+        )
+
+    def test_properly_preserves_quoted_values(self):
+        alias_value = (
+            'myservice myoperation --my-parameter \' \n$""\''
+        )
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        alias_cmd([], FakeParsedArgs(command=self.alias_name))
+        command_table['myservice'].assert_called_with(
+            ['myoperation', '--my-parameter', ' \n$""'],
+            FakeParsedArgs(command='myservice')
+        )
+
+    def test_errors_when_service_command_is_invalid(self):
+        alias_value = 'non-existent-service myoperation'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        with self.assertRaises(SystemExit):
+            # Even though we catch the system exit, a message will always
+            # be forced to screen because it happened at system exit.
+            # The patch is to ensure it does not get displayed by nosetests.
+            with mock.patch('sys.stderr'):
+                alias_cmd([], FakeParsedArgs(command=self.alias_name))
+
+    def test_errors_when_no_service_command(self):
+        alias_value = '--global-param=val'
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(
+            command_table, extra_params=['global-param'])
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        with self.assertRaises(SystemExit):
+            # Even though we catch the system exit, a message will always
+            # be forced to screen because it happened at system exit.
+            # The patch is to ensure it does not get displayed by nosetests.
+            with mock.patch('sys.stderr'):
+                alias_cmd([], FakeParsedArgs(command=self.alias_name))
+
+    def test_errors_when_shell_cannot_parse_alias(self):
+        # Ending with a escape character that does not escape anything
+        # is invalid and cannot be properly parsed.
+        alias_value = (
+            'myservice myoperation \\'
+        )
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(command_table)
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        with self.assertRaises(InvalidAliasException):
+            alias_cmd([], FakeParsedArgs(command=self.alias_name))
+
+    def test_errors_when_unsupported_global_parameter_in_alias(self):
+        # Unsupported global parameters are: --profile and --debug
+        alias_value = (
+            'myservice myoperation --profile value'
+        )
+
+        command_table = self.create_command_table(['myservice'])
+        parser = self.create_parser(
+            command_table, extra_params=['profile'])
+        alias_cmd = ServiceAliasCommand(
+            self.alias_name, alias_value, self.session, command_table, parser)
+
+        with self.assertRaises(InvalidAliasException):
+            alias_cmd([], FakeParsedArgs(command=self.alias_name))
+
+
+class TestExternalAliasCommand(unittest.TestCase):
+    def test_run_external_command(self):
+        alias_value = '!ls'
+        alias_cmd = ExternalAliasCommand('alias-name', alias_value)
+        with mock.patch('subprocess.call') as subprocess_call:
+            alias_cmd([], FakeParsedArgs(command='alias-name'))
+            subprocess_call.assert_called_with('ls', shell=True)
+
+    def test_external_command_returns_rc_of_subprocess_call(self):
+        alias_value = '!ls'
+        alias_cmd = ExternalAliasCommand('alias-name', alias_value)
+        with mock.patch('subprocess.call') as subprocess_call:
+            subprocess_call.return_value = 1
+            self.assertEqual(
+                alias_cmd([], FakeParsedArgs(command='alias-name')), 1)
+
+    def test_external_command_uses_literal_alias_value(self):
+        alias_value = (
+            '!f () {\n'
+            '  ls .\n'
+            '}; f'
+        )
+        alias_cmd = ExternalAliasCommand('alias-name', alias_value)
+        with mock.patch('subprocess.call') as subprocess_call:
+            alias_cmd([], FakeParsedArgs(command='alias-name'))
+            subprocess_call.assert_called_with(alias_value[1:], shell=True)
+
+    def test_external_command_then_additional_args(self):
+        alias_value = '!f () { ls "$1" }; f'
+        alias_cmd = ExternalAliasCommand('alias-name', alias_value)
+        with mock.patch('subprocess.call') as subprocess_call:
+            alias_cmd(['extra'], FakeParsedArgs(command='alias-name'))
+            subprocess_call.assert_called_with(
+                'f () { ls "$1" }; f extra', shell=True)

--- a/tests/unit/test_alias.py
+++ b/tests/unit/test_alias.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import os
 
+from botocore.session import Session
+
 from awscli.testutils import unittest
 from awscli.testutils import mock
 from awscli.testutils import FileCreator
@@ -22,6 +24,7 @@ from awscli.alias import BaseAliasCommand
 from awscli.alias import ServiceAliasCommand
 from awscli.alias import ExternalAliasCommand
 from awscli.argparser import MainArgParser
+from awscli.commands import CLICommand
 
 
 class FakeParsedArgs(object):
@@ -119,7 +122,7 @@ class TestAliasCommandInjector(unittest.TestCase):
         self.files = FileCreator()
         self.alias_file = self.files.create_file('alias', '[toplevel]\n')
         self.alias_loader = AliasLoader(self.alias_file)
-        self.session = mock.Mock()
+        self.session = mock.Mock(spec=Session)
         self.alias_cmd_injector = AliasCommandInjector(
             self.session, self.alias_loader)
         self.command_table = {}
@@ -154,7 +157,7 @@ class TestAliasCommandInjector(unittest.TestCase):
             self.command_table['my-alias'], ExternalAliasCommand)
 
     def test_clobbers_builtins(self):
-        builtin_cmd = mock.Mock()
+        builtin_cmd = mock.Mock(spec=CLICommand)
         self.command_table['builtin'] = builtin_cmd
 
         with open(self.alias_file, 'a+') as f:
@@ -167,7 +170,7 @@ class TestAliasCommandInjector(unittest.TestCase):
             self.command_table['builtin'], ServiceAliasCommand)
 
     def test_shadow_proxy_command(self):
-        builtin_cmd = mock.Mock()
+        builtin_cmd = mock.Mock(spec=CLICommand)
         builtin_cmd.name = 'builtin'
         self.command_table['builtin'] = builtin_cmd
 
@@ -196,12 +199,12 @@ class TestBaseAliasCommand(unittest.TestCase):
 class TestServiceAliasCommand(unittest.TestCase):
     def setUp(self):
         self.alias_name = 'myalias'
-        self.session = mock.Mock()
+        self.session = mock.Mock(spec=Session)
 
     def create_command_table(self, services):
         command_table = {}
         for service in services:
-            command_table[service] = mock.Mock()
+            command_table[service] = mock.Mock(spec=CLICommand)
         return command_table
 
     def create_parser(self, command_table, extra_params=None):
@@ -232,7 +235,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         alias_value = 'some-service'
         self.alias_name = alias_value
 
-        shadow_proxy_command = mock.Mock()
+        shadow_proxy_command = mock.Mock(spec=CLICommand)
         shadow_proxy_command.name = alias_value
 
         command_table = {}
@@ -251,7 +254,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         alias_value = 'some-other-command'
         self.alias_name = 'some-service'
 
-        shadow_proxy_command = mock.Mock()
+        shadow_proxy_command = mock.Mock(spec=CLICommand)
         shadow_proxy_command.name = 'some-service'
 
         command_table = self.create_command_table([alias_value])

--- a/tests/unit/test_alias.py
+++ b/tests/unit/test_alias.py
@@ -219,7 +219,7 @@ class TestServiceAliasCommand(unittest.TestCase):
     def test_alias_with_only_service_command(self):
         alias_value = 'myservice'
 
-        command_table = self.create_command_table(['myservice'])
+        command_table = self.create_command_table([alias_value])
         parser = self.create_parser(command_table)
         alias_cmd = ServiceAliasCommand(
             self.alias_name, alias_value, self.session, command_table, parser)
@@ -254,7 +254,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         shadow_proxy_command = mock.Mock()
         shadow_proxy_command.name = 'some-service'
 
-        command_table = self.create_command_table(['some-other-command'])
+        command_table = self.create_command_table([alias_value])
         parser = self.create_parser(command_table)
 
         alias_cmd = ServiceAliasCommand(
@@ -263,7 +263,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         command_table[self.alias_name] = alias_cmd
 
         alias_cmd([], FakeParsedArgs(command=self.alias_name))
-        command_table['some-other-command'].assert_called_with(
+        command_table[alias_value].assert_called_with(
             [], FakeParsedArgs(command=alias_value))
         # Even though it was provided, it should not be called because
         # the alias value did not match the shadow command name.

--- a/tests/unit/test_argparser.py
+++ b/tests/unit/test_argparser.py
@@ -1,0 +1,43 @@
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from argparse import ArgumentParser
+
+from awscli.testutils import unittest
+from awscli.argparser import CommandAction
+
+
+class TestCommandAction(unittest.TestCase):
+    def setUp(self):
+        self.parser = ArgumentParser()
+
+    def test_choices(self):
+        command_table = {'pre-existing': object()}
+        self.parser.add_argument(
+            'command', action=CommandAction, command_table=command_table)
+        parsed_args = self.parser.parse_args(['pre-existing'])
+        self.assertEqual(parsed_args.command, 'pre-existing')
+
+    def test_choices_added_after(self):
+        command_table = {'pre-existing': object()}
+        self.parser.add_argument(
+            'command', action=CommandAction, command_table=command_table)
+        command_table['after'] = object()
+
+        # The pre-existing command should still be able to be parsed
+        parsed_args = self.parser.parse_args(['pre-existing'])
+        self.assertEqual(parsed_args.command, 'pre-existing')
+
+        # The command added after the argument's creation should be
+        # able to be parsed as well.
+        parsed_args = self.parser.parse_args(['after'])
+        self.assertEqual(parsed_args.command, 'after')


### PR DESCRIPTION
Important to note that the tests will not pass until this PR gets merged: https://github.com/boto/botocore/pull/1088

This pull request adds alias support to the CLI (like git aliases). To define an alias, you need an ``~/.aws/cli/alias`` file, which is an INI file that defines aliases and their values. Here is an example of an alias file:
```
[toplevel]
my-alias = ec2 describe-instances
```
With this alias now, a user can type into the CLI:
```
$ aws my-alias
```
which will translate to running (from the same process):
```
$ aws ec2 describe-instances
```

External aliases can also be defined which let users leverage functionality from their shell. So if the alias file had the following definition:
```
[toplevel]
ls = !ls
```
So if a user types the following into the CLI:
```
$ aws ls
```
it will translate to running (in a subprocess):
```
$ ls
```

Past these examples, here are some important features/limitations that should be noted:

* The ``~/.aws/cli/alias`` file only has support for the ``[toplevel]`` section. Any other sections, will be ignored.
* Aliases defined under the ``[toplevel]`` section will only be applied at the service command level.
* Aliases can defined using multiple lines for readability:
  ```
  [toplevel]
  my-alias = 
     ec2 describe-regions \
        --query Regions
  ls =
     f() {
        ls .
     }; f
  ```
* Global and operation-level parameters can be provided inside of the alias. However ``--debug`` and ``--profile`` are not supported as their value gets set higher up the CLI stack and affect many of the other global parameters. In the case that those parameters are provided, the CLI will throw an error.
* Arguments entered past the alias will be appended to the expanded alias value.
* For subcommand aliases (i.e. not prefixed with ``!``), they must reference a service command and that service command must exist.
* Aliases are undocumented. So if you type ``help`` after a subcommand alias it will proxy to the command it it references.

It is also important to that this PR does not add support for:
* Auto-completeing aliases
* Commands for setting and getting aliases

Those should come in subsequent pull requests.

cc @jamesls @JordonPhillips @stealthycoin 