### PR TITLE
Fix cloudformation unit tests

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -166,7 +166,7 @@ def zip_folder(folder_path):
     try:
         yield zipfile_name
     finally:
-        if zipfile_name:
+        if os.path.exists(zipfile_name):
             os.remove(zipfile_name)
 
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -632,7 +632,7 @@ class TestArtifactExporter(unittest.TestCase):
 
         dirname = test_file_creator.rootdir
 
-        expected_files = {'index.js'}
+        expected_files = set(['index.js'])
 
         random_name = ''.join(random.choice(string.ascii_letters) for _ in range(10))
         outfile = os.path.join(tempfile.gettempdir(), random_name)

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -342,13 +342,12 @@ class TestArtifactExporter(unittest.TestCase):
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.make_zip")
     def test_zip_folder(self, make_zip_mock):
-        my_zip_file_name = "some name"
+        zip_file_name = "name.zip"
+        make_zip_mock.return_value = zip_file_name
 
-        make_zip_mock.return_value = my_zip_file_name
         with self.make_temp_dir() as dirname:
-
-            generator = zip_folder(dirname)
-            self.assertEquals(generator.__enter__(), my_zip_file_name)
+            with zip_folder(dirname) as actual_zip_file_name:
+                self.assertEqual(actual_zip_file_name, zip_file_name)
 
         make_zip_mock.assert_called_once_with(mock.ANY, dirname)
 


### PR DESCRIPTION
There were two issues in the cloudformation tests:

1. Set literals were being used, which is incompatible with 2.6
2. Existence of zip folders was not being validated before deleting, but that wasn't being raised in the tests since we were only calling __enter__ on the generator.

cc @kyleknap @jamesls @stealthycoin