### PR TITLE
Add --generate-cli-skeleton output

### DIFF
--- a/.changes/next-release/feature-generatecliskeletonoutput-36925.json
+++ b/.changes/next-release/feature-generatecliskeletonoutput-36925.json
@@ -1,0 +1,5 @@
+{
+  "category": "``--generate-cli-skeleton output``", 
+  "type": "feature", 
+  "description": "Add support for generating sample output for command"
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -666,6 +666,13 @@ class CLIOperationCaller(object):
             service_name, region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl)
+        response = self._make_client_call(
+            client, operation_name, parameters, parsed_globals)
+        self._display_response(operation_name, response, parsed_globals)
+        return 0
+
+    def _make_client_call(self, client, operation_name, parameters,
+                          parsed_globals):
         py_operation_name = xform_name(operation_name)
         if client.can_paginate(py_operation_name) and parsed_globals.paginate:
             paginator = client.get_paginator(py_operation_name)
@@ -673,8 +680,7 @@ class CLIOperationCaller(object):
         else:
             response = getattr(client, xform_name(operation_name))(
                 **parameters)
-        self._display_response(operation_name, response, parsed_globals)
-        return 0
+        return response
 
     def _display_response(self, command_name, response,
                           parsed_globals):

--- a/awscli/customizations/generatecliskeleton.py
+++ b/awscli/customizations/generatecliskeleton.py
@@ -52,7 +52,8 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
             '``output``, it validates the command inputs and returns a '
             'sample output JSON for that command.'
         ),
-        'nargs': '?', 'const': 'input',
+        'nargs': '?',
+        'const': 'input',
         'choices': ['input', 'output'],
     }
 
@@ -70,10 +71,10 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
         if arg_name in args:
             arg_location = args.index(arg_name)
             try:
-                # If the argument immediately preceeding
-                # --generate-cli-skeleton is output, then do not mark
-                # all of the other arguments as not required because
-                # output allows does parameter validation.
+                # If the value of --generate-cli-skeleton is ``output``,
+                # do not force required arguments to be optional as
+                # ``--generate-cli-skeleton output`` validates commands
+                # as well as print out the sample output.
                 if args[arg_location + 1] == 'output':
                     return
             except IndexError:

--- a/awscli/customizations/generatecliskeleton.py
+++ b/awscli/customizations/generatecliskeleton.py
@@ -19,6 +19,7 @@ from botocore.utils import ArgumentGenerator
 
 from awscli.clidriver import CLIOperationCaller
 from awscli.customizations.arguments import OverrideRequiredArgsArgument
+from awscli.utils import json_encoder
 
 
 def register_generate_cli_skeleton(cli):
@@ -101,7 +102,9 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
                     skeleton = argument_generator.generate_skeleton(
                         operation_input_shape)
 
-                sys.stdout.write(json.dumps(skeleton, indent=4))
+                sys.stdout.write(
+                    json.dumps(skeleton, indent=4, default=json_encoder)
+                )
                 sys.stdout.write('\n')
                 return 0
 

--- a/awscli/customizations/generatecliskeleton.py
+++ b/awscli/customizations/generatecliskeleton.py
@@ -91,6 +91,10 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
             if for_output:
                 service_name = operation_model.service_model.service_name
                 operation_name = operation_model.name
+                # TODO: It would be better to abstract this logic into
+                # classes for both the input and output option such that
+                # a similar set of inputs are taken in and output
+                # similar functionality.
                 return StubbedCLIOperationCaller(self._session).invoke(
                     service_name, operation_name, call_parameters,
                     parsed_globals)

--- a/tests/functional/test_generatecliskeleton.py
+++ b/tests/functional/test_generatecliskeleton.py
@@ -1,0 +1,86 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import json
+
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestGenerateCliSkeletonOutput(BaseAWSCommandParamsTest):
+    def test_generate_cli_skeleton_output(self):
+        cmdline = 'ec2 describe-regions --generate-cli-skeleton output'
+        stdout, _, _ = self.run_cmd(cmdline)
+        # The format of the response should be a json blob with the
+        # following structure:
+        # {
+        #     "Regions": [
+        #         {
+        #             "RegionName": "RegionName",
+        #             "Endpoint": "Endpoint"
+        #         }
+        #     ]
+        # }
+        #
+        # We assert only components of the response in case members
+        # are added in the future that would break an exactly equals
+        # assertion
+        skeleton_output = json.loads(stdout)
+        self.assertIn('Regions', skeleton_output)
+        self.assertEqual(
+            skeleton_output['Regions'][0]['RegionName'], 'RegionName')
+        self.assertEqual(
+            skeleton_output['Regions'][0]['Endpoint'], 'Endpoint')
+
+    def test_can_pass_in_input_parameters(self):
+        cmdline = 'ec2 describe-regions --generate-cli-skeleton output '
+        cmdline += ' --region-names us-east-1'
+        stdout, _, _ = self.assert_params_for_cmd(
+            cmdline, {'RegionNames': ['us-east-1']})
+
+        # Make sure the output has the proper mocked response as well.
+        skeleton_output = json.loads(stdout)
+        self.assertIn('Regions', skeleton_output)
+        self.assertEqual(
+            skeleton_output['Regions'][0]['RegionName'], 'RegionName')
+        self.assertEqual(
+            skeleton_output['Regions'][0]['Endpoint'], 'Endpoint')
+
+    def test_when_no_output_shape(self):
+        cmdline = 'ec2 attach-internet-gateway '
+        cmdline += '--internet-gateway-id igw-c0a643a9 --vpc-id vpc-a01106 '
+        cmdline += '--generate-cli-skeleton output'
+        stdout, _, _ = self.assert_params_for_cmd(
+            cmdline,
+            {'InternetGatewayId': 'igw-c0a643a9', 'VpcId': 'vpc-a01106'})
+        # There should be no output as the command has no output shape
+        self.assertEqual('', stdout)
+
+    def test_respects_formatting(self):
+        cmdline = 'ec2 describe-regions --generate-cli-skeleton output '
+        cmdline += ' --query Regions[].RegionName --output text'
+        stdout, _, _ = self.run_cmd(cmdline)
+        self.assertEqual(stdout, 'RegionName\n')
+
+    def test_validates_at_command_line_level(self):
+        cmdline = 'ec2 create-vpc --generate-cli-skeleton output'
+        stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        self.assertIn('--cidr-block is required', stderr)
+        self.assertEqual('', stdout)
+
+    def test_validates_at_client_level(self):
+        cmdline = 'ec2 describe-instances --generate-cli-skeleton output '
+        # Note: The for --filters instead of Value the key should be Values
+        # which should throw a validation error.
+        cmdline += '--filters Name=instance-id,Value=foo'
+        stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=255)
+        self.assertIn('Unknown parameter in Filters[0]', stderr)
+        self.assertEqual('', stdout)

--- a/tests/functional/test_generatecliskeleton.py
+++ b/tests/functional/test_generatecliskeleton.py
@@ -64,6 +64,16 @@ class TestGenerateCliSkeletonOutput(BaseAWSCommandParamsTest):
         # There should be no output as the command has no output shape
         self.assertEqual('', stdout)
 
+    def test_can_handle_timestamps(self):
+        cmdline = 's3api list-buckets --generate-cli-skeleton output'
+        stdout, _, _ = self.run_cmd(cmdline)
+        skeleton_output = json.loads(stdout)
+        # The CreationDate has the type of timestamp
+        self.assertEqual(
+            skeleton_output['Buckets'][0]['CreationDate'],
+            '1970-01-01T00:00:00'
+        )
+
     def test_respects_formatting(self):
         cmdline = 'ec2 describe-regions --generate-cli-skeleton output '
         cmdline += ' --query Regions[].RegionName --output text'

--- a/tests/functional/test_generatecliskeleton.py
+++ b/tests/functional/test_generatecliskeleton.py
@@ -89,7 +89,8 @@ class TestGenerateCliSkeletonOutput(BaseAWSCommandParamsTest):
     def test_validates_at_command_line_level(self):
         cmdline = 'ec2 create-vpc --generate-cli-skeleton output'
         stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
-        self.assertIn('--cidr-block is required', stderr)
+        self.assertIn('required', stderr)
+        self.assertIn('--cidr-block', stderr)
         self.assertEqual('', stdout)
 
     def test_validates_at_client_level(self):

--- a/tests/functional/test_generatecliskeleton.py
+++ b/tests/functional/test_generatecliskeleton.py
@@ -74,6 +74,12 @@ class TestGenerateCliSkeletonOutput(BaseAWSCommandParamsTest):
             '1970-01-01T00:00:00'
         )
 
+    def test_can_handle_lists_with_strings_that_have_a_min_length(self):
+        cmdline = 'dynamodb list-tables --generate-cli-skeleton output'
+        stdout, _, _ = self.run_cmd(cmdline)
+        skeleton_output = json.loads(stdout)
+        self.assertEqual(skeleton_output['TableNames'], ['TableName'])
+
     def test_respects_formatting(self):
         cmdline = 'ec2 describe-regions --generate-cli-skeleton output '
         cmdline += ' --query Regions[].RegionName --output text'

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -51,9 +51,36 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         self.assertEqual(register_args[0][0][1],
                          self.argument.generate_json_skeleton)
 
+    def test_no_override_required_args_when_output(self):
+        argument_table = {}
+        mock_arg = mock.Mock()
+        mock_arg.required = True
+        argument_table['required-arg'] = mock_arg
+        args = ['--generate-cli-skeleton', 'output']
+        self.argument.override_required_args(argument_table, args)
+        self.assertTrue(argument_table['required-arg'].required)
+
+    def test_override_required_args_when_input(self):
+        argument_table = {}
+        mock_arg = mock.Mock()
+        mock_arg.required = True
+        argument_table['required-arg'] = mock_arg
+        args = ['--generate-cli-skeleton']
+        self.argument.override_required_args(argument_table, args)
+        self.assertFalse(argument_table['required-arg'].required)
+
+    def test_override_required_args_when_output_present_but_not_value(self):
+        argument_table = {}
+        mock_arg = mock.Mock()
+        mock_arg.required = True
+        argument_table['required-arg'] = mock_arg
+        args = ['--generate-cli-skeleton', '--some-other-param', 'output']
+        self.argument.override_required_args(argument_table, args)
+        self.assertFalse(argument_table['required-arg'].required)
+
     def test_generate_json_skeleton(self):
         parsed_args = mock.Mock()
-        parsed_args.generate_cli_skeleton = True
+        parsed_args.generate_cli_skeleton = 'input'
         with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
@@ -66,7 +93,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
 
     def test_no_generate_json_skeleton(self):
         parsed_args = mock.Mock()
-        parsed_args.generate_cli_skeleton = False
+        parsed_args.generate_cli_skeleton = None
         with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
@@ -80,7 +107,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
 
     def test_generate_json_skeleton_no_input_shape(self):
         parsed_args = mock.Mock()
-        parsed_args.generate_cli_skeleton = True
+        parsed_args.generate_cli_skeleton = 'input'
         # Set the input shape to ``None``.
         self.argument = GenerateCliSkeletonArgument(
             self.session, mock.Mock(input_shape=None))

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -121,3 +121,32 @@ class TestGenerateCliSkeleton(unittest.TestCase):
             self.assertEqual('{}\n', mock_stdout.getvalue())
             # Ensure it is the correct return code of zero.
             self.assertEqual(rc, 0)
+
+    def test_generate_json_skeleton_with_timestamp(self):
+        parsed_args = mock.Mock()
+        parsed_args.generate_cli_skeleton = 'input'
+        input_shape = {
+            'A': {
+                'type': 'structure',
+                'members': {
+                    'B': {'type': 'timestamp'},
+                }
+            }
+        }
+        shape = DenormalizedStructureBuilder().with_members(
+            input_shape).build_model()
+        operation_model = mock.Mock(input_shape=shape)
+        argument = GenerateCliSkeletonArgument(
+            self.session, operation_model)
+        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+            rc = argument.generate_json_skeleton(
+                call_parameters=None, parsed_args=parsed_args,
+                parsed_globals=None
+            )
+            self.assertEqual(
+                '{\n'
+                '    "A": {\n'
+                '        "B": "1970-01-01T00:00:00"\n'
+                '    }\n'
+                '}\n', mock_stdout.getvalue())
+            self.assertEqual(rc, 0)


### PR DESCRIPTION
Allows users to run a CLI command without sending a request over the wire. Inputs will be validated and a mocked response will be printed back to the user.

Implementation-wise, I re-used ``CLIOperationCaller`` but stubbed the client with ``ArgumentGenerator`` to get the closest validation and client response back (essentially we are removing the HTTP Request/Response part of the stack).

As to testing, I primarily focused on functional testing. I found that a lot more useful, because the setup required to get unit test working properly (i.e. mocked client and no disk writing for models) it would require a ton of mocking to the point that would be difficult to read/manage the session/client mocks and understand what is being tested. But if you would like to see more unit tests, I can look into adding them.

cc @jamesls @JordonPhillips @stealthycoin 