### PR TITLE
Fix cloudformation tests on Windows

### DIFF
--- a/awscli/customizations/cloudformation/s3uploader.py
+++ b/awscli/customizations/cloudformation/s3uploader.py
@@ -12,14 +12,16 @@
 # language governing permissions and limitations under the License.
 
 import hashlib
-import botocore
 import logging
 import threading
 import os
 import sys
 
+import botocore
+import botocore.exceptions
 from s3transfer.manager import TransferManager
 from s3transfer.subscribers import BaseSubscriber
+
 from awscli.customizations.cloudformation import exceptions
 
 LOG = logging.getLogger(__name__)
@@ -98,7 +100,6 @@ class S3Uploader(object):
         """
         Makes and returns name of the S3 object based on the file's MD5 sum
 
-        :param uploader: Instance of S3Uploader
         :param file_name: file to upload
         :param extension: String of file extension to append to the object
         :return: S3 URL of the uploaded object

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -551,12 +551,11 @@ class TestArtifactExporter(unittest.TestCase):
                 stack_resource.export(resource_id, resource_dict, "dir")
                 self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-
     @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
     def test_template_export(self, yaml_parse_mock):
-        template_path = "foo/bar/path"
-        parent_dir = "/"
-        template_dir = "/foo/bar"
+        parent_dir = os.path.sep
+        template_dir = os.path.join(parent_dir, 'foo', 'bar')
+        template_path = os.path.join(template_dir, 'path')
         template_str = self.example_yaml_template()
 
         resource_type1_class = Mock()
@@ -592,13 +591,14 @@ class TestArtifactExporter(unittest.TestCase):
         open_mock = mock.mock_open()
         yaml_parse_mock.return_value = template_dict
 
-
         # Patch the file open method to return template string
         with patch(
                 "awscli.customizations.cloudformation.artifact_exporter.open",
                 open_mock(read_data=template_str)) as open_mock:
 
-            template_exporter = Template(template_path, parent_dir, self.s3_uploader_mock, resources_to_export)
+            template_exporter = Template(
+                template_path, parent_dir, self.s3_uploader_mock,
+                resources_to_export)
             exported_template = template_exporter.export()
             self.assertEquals(exported_template, template_dict)
 
@@ -608,9 +608,11 @@ class TestArtifactExporter(unittest.TestCase):
             self.assertEquals(1, yaml_parse_mock.call_count)
 
             resource_type1_class.assert_called_once_with(self.s3_uploader_mock)
-            resource_type1_instance.export.assert_called_once_with("Resource1", mock.ANY, template_dir)
+            resource_type1_instance.export.assert_called_once_with(
+                "Resource1", mock.ANY, template_dir)
             resource_type2_class.assert_called_once_with(self.s3_uploader_mock)
-            resource_type2_instance.export.assert_called_once_with("Resource2", mock.ANY, template_dir)
+            resource_type2_instance.export.assert_called_once_with(
+                "Resource2", mock.ANY, template_dir)
 
     def test_template_export_path_be_folder(self):
 

--- a/tests/unit/customizations/cloudformation/test_s3uploader.py
+++ b/tests/unit/customizations/cloudformation/test_s3uploader.py
@@ -13,17 +13,19 @@
 import mock
 import random
 import string
-import botocore
 import tempfile
 import hashlib
+from mock import patch, Mock
 
+import botocore
+import botocore.session
+import botocore.exceptions
 from botocore.stub import Stubber
-from mock import patch, Mock, MagicMock
+from s3transfer import S3Transfer
+
 from awscli.testutils import unittest
 from awscli.customizations.cloudformation.s3uploader import S3Uploader
 from awscli.customizations.cloudformation import exceptions
-from awscli.customizations.cloudformation.s3uploader import ProgressPercentage
-from s3transfer import S3Transfer
 
 
 class TestS3Uploader(unittest.TestCase):
@@ -37,7 +39,9 @@ class TestS3Uploader(unittest.TestCase):
         self.bucket_name = "bucketname"
         self.prefix = None
 
-        self.s3uploader = S3Uploader(self.s3client, self.bucket_name, self.prefix, None, False, self.transfer_manager_mock)
+        self.s3uploader = S3Uploader(
+            self.s3client, self.bucket_name, self.prefix, None, False,
+            self.transfer_manager_mock)
 
     @patch("awscli.customizations.cloudformation.s3uploader.ProgressPercentage")
     def test_upload_successful(self, progress_percentage_mock):
@@ -45,10 +49,11 @@ class TestS3Uploader(unittest.TestCase):
         remote_path = "remotepath"
         prefix = "SomePrefix"
         remote_path_with_prefix = "{0}/{1}".format(prefix, remote_path)
-        s3uploader = S3Uploader(self.s3client, self.bucket_name, prefix, None, False, self.transfer_manager_mock)
-        expected_upload_url = "s3://{0}/{1}/{2}".format(self.bucket_name,
-                                                    prefix,
-                                                    remote_path)
+        s3uploader = S3Uploader(
+            self.s3client, self.bucket_name, prefix, None, False,
+            self.transfer_manager_mock)
+        expected_upload_url = "s3://{0}/{1}/{2}".format(
+            self.bucket_name, prefix, remote_path)
 
         # Setup mock to fake that file does not exist
         s3uploader.file_exists = Mock()
@@ -87,8 +92,9 @@ class TestS3Uploader(unittest.TestCase):
                                                     remote_path)
 
         # Set ForceUpload = True
-        self.s3uploader = S3Uploader(self.s3client, self.bucket_name, self.prefix,
-                                     None, True, self.transfer_manager_mock)
+        self.s3uploader = S3Uploader(
+            self.s3client, self.bucket_name, self.prefix,
+            None, True, self.transfer_manager_mock)
 
         # Pretend file already exists
         self.s3uploader.file_exists = Mock()
@@ -116,8 +122,9 @@ class TestS3Uploader(unittest.TestCase):
         expected_upload_url = "s3://{0}/{1}".format(self.bucket_name,
                                                     remote_path)
         # Set KMS Key Id
-        self.s3uploader = S3Uploader(self.s3client, self.bucket_name, self.prefix,
-                                     kms_key_id, False, self.transfer_manager_mock)
+        self.s3uploader = S3Uploader(
+            self.s3client, self.bucket_name, self.prefix,
+            kms_key_id, False, self.transfer_manager_mock)
 
         # Setup mock to fake that file does not exist
         self.s3uploader.file_exists = Mock()
@@ -152,7 +159,6 @@ class TestS3Uploader(unittest.TestCase):
         with self.assertRaises(exceptions.NoSuchBucketError):
             self.s3uploader.upload(file_name, remote_path)
 
-
     @patch("awscli.customizations.cloudformation.s3uploader.ProgressPercentage")
     def test_upload_successful_exceptions(self, progress_percentage_mock):
         file_name = "filename"
@@ -175,7 +181,6 @@ class TestS3Uploader(unittest.TestCase):
         with self.assertRaises(FloatingPointError):
             self.s3uploader.upload(file_name, remote_path)
 
-
     def test_upload_with_dedup(self):
 
         checksum = "some md5 checksum"
@@ -191,7 +196,6 @@ class TestS3Uploader(unittest.TestCase):
 
         remotepath = "{0}.{1}".format(checksum, extension)
         self.s3uploader.upload.assert_called_once_with(filename, remotepath)
-
 
     def test_file_exists(self):
         key = "some/path"
@@ -218,7 +222,8 @@ class TestS3Uploader(unittest.TestCase):
             self.assertTrue(self.s3uploader.file_exists(key))
 
         # Let's pretend file does not exist
-        self.s3client_stub.add_client_error('head_object', "ClientError", "some error")
+        self.s3client_stub.add_client_error(
+            'head_object', "ClientError", "some error")
         with self.s3client_stub:
             self.assertFalse(self.s3uploader.file_exists(key))
 
@@ -231,10 +236,10 @@ class TestS3Uploader(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             uploader.file_exists(key)
 
-
     def test_file_checksum(self):
         num_chars = 4096*5
-        data = ''.join(random.choice(string.ascii_uppercase) for _ in range(num_chars)).encode('utf-8')
+        data = ''.join(random.choice(string.ascii_uppercase)
+                       for _ in range(num_chars)).encode('utf-8')
         md5 = hashlib.md5()
         md5.update(data)
         expected_checksum = md5.hexdigest()

--- a/tests/unit/customizations/cloudformation/test_s3uploader.py
+++ b/tests/unit/customizations/cloudformation/test_s3uploader.py
@@ -10,11 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import mock
 import random
 import string
 import tempfile
 import hashlib
+import shutil
 from mock import patch, Mock
 
 import botocore
@@ -244,13 +246,16 @@ class TestS3Uploader(unittest.TestCase):
         md5.update(data)
         expected_checksum = md5.hexdigest()
 
-        with tempfile.NamedTemporaryFile() as handle:
-            handle.write(data)
-            handle.flush()
+        tempdir = tempfile.mkdtemp()
+        try:
+            filename = os.path.join(tempdir, 'tempfile')
+            with open(filename, 'wb') as f:
+                f.write(data)
 
-            filename = handle.name
             actual_checksum = self.s3uploader.file_checksum(filename)
             self.assertEqual(expected_checksum, actual_checksum)
+        finally:
+            shutil.rmtree(tempdir)
 
     def test_make_url(self):
         path = "Hello/how/are/you"


### PR DESCRIPTION
There were a few issues with the cloudformation tests on windows.
Namely, not using `os.path` to generate paths and improper use of
a `NamedTemporaryFile`.

cc @kyleknap @jamesls @stealthycoin