### PR TITLE
Add transfer speed reporting to s3 commands

### DIFF
--- a/.changes/next-release/feature-s3-72946.json
+++ b/.changes/next-release/feature-s3-72946.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "feature", 
+  "description": "Display transfer speed for s3 commands"
+}

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from __future__ import division
 import logging
 import sys
 import threading
@@ -277,7 +278,7 @@ class ResultRecorder(BaseResultHandler):
             self._get_ongoing_dict_key(result)] += bytes_transferred
         self.bytes_transferred += bytes_transferred
         if result.timestamp > self.start_time:
-            self.bytes_transfer_speed = 1.0 * self.bytes_transferred / (
+            self.bytes_transfer_speed = self.bytes_transferred / (
                 result.timestamp - self.start_time)
 
     def _update_ongoing_transfer_size_if_unknown(self, result):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -277,6 +277,13 @@ class ResultRecorder(BaseResultHandler):
         self._ongoing_progress[
             self._get_ongoing_dict_key(result)] += bytes_transferred
         self.bytes_transferred += bytes_transferred
+        # Since the start time is captured in the result recorder and
+        # capture timestamps in the subscriber, there is a chance that if
+        # a progress result gets created right after the queued result
+        # gets created that the timestamp on the progress result is less
+        # than the timestamp of when the result processor actually
+        # processes that initial queued result. So this will avoid
+        # negative progress being displayed or zero divison occuring.
         if result.timestamp > self.start_time:
             self.bytes_transfer_speed = self.bytes_transferred / (
                 result.timestamp - self.start_time)

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -136,7 +136,8 @@ class TestUploadResultSubscriber(BaseResultSubscriberTest):
                 src=self.src,
                 dest=self.dest,
                 bytes_transferred=ref_bytes_transferred,
-                total_transfer_size=self.size
+                total_transfer_size=self.size,
+                timestamp=mock.ANY
             )
         )
 
@@ -382,7 +383,8 @@ class ResultRecorderTest(unittest.TestCase):
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
-                total_transfer_size=self.total_transfer_size
+                total_transfer_size=self.total_transfer_size,
+                timestamp=0
             )
         )
 
@@ -399,12 +401,13 @@ class ResultRecorderTest(unittest.TestCase):
 
         bytes_transferred = 1024 * 1024  # 1MB
         num_results = 5
-        for _ in range(num_results):
+        for i in range(num_results):
             self.result_recorder(
                 ProgressResult(
                     transfer_type=self.transfer_type, src=self.src,
                     dest=self.dest, bytes_transferred=bytes_transferred,
-                    total_transfer_size=self.total_transfer_size
+                    total_transfer_size=self.total_transfer_size,
+                    timestamp=i
                 )
             )
 
@@ -426,7 +429,7 @@ class ResultRecorderTest(unittest.TestCase):
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
-                total_transfer_size=None
+                total_transfer_size=None, timestamp=0
             )
         )
         # Because the transfer size is still not known, update the
@@ -449,7 +452,8 @@ class ResultRecorderTest(unittest.TestCase):
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
-                total_transfer_size=self.total_transfer_size
+                total_transfer_size=self.total_transfer_size,
+                timestamp=0
             )
         )
 
@@ -566,7 +570,8 @@ class ResultRecorderTest(unittest.TestCase):
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
-                total_transfer_size=self.total_transfer_size
+                total_transfer_size=self.total_transfer_size,
+                timestamp=0
             )
         )
 
@@ -619,7 +624,8 @@ class ResultRecorderTest(unittest.TestCase):
             ProgressResult(
                 transfer_type=self.transfer_type, src=self.src,
                 dest=self.dest, bytes_transferred=bytes_transferred,
-                total_transfer_size=self.total_transfer_size
+                total_transfer_size=self.total_transfer_size,
+                timestamp=0
             )
         )
         self.result_recorder(
@@ -737,7 +743,7 @@ class BaseResultPrinterTest(unittest.TestCase):
         # the ResultRecorder to determine what to print out on progress.
         return ProgressResult(
             transfer_type=None, src=None, dest=None, bytes_transferred=None,
-            total_transfer_size=None
+            total_transfer_size=None, timestamp=0
         )
 
 
@@ -760,7 +766,8 @@ class TestResultPrinter(BaseResultPrinterTest):
         progress_result = self.get_progress_result()
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r')
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) '
+            'remaining\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
     def test_progress_with_no_expected_transfer_bytes(self):
@@ -790,7 +797,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r')
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
+        )
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
         # Add the second progress update
@@ -799,8 +807,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         # The result should be the combination of the two
         ref_progress_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
-            'Completed 2.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
+            'Completed 2.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
@@ -815,7 +823,7 @@ class TestResultPrinter(BaseResultPrinterTest):
         progress_result = self.get_progress_result()
         self.result_printer(progress_result)
         ref_progress_statement = (
-            'Completed 1.0 MiB/~20.0 MiB with ~3 file(s) '
+            'Completed 1.0 MiB/~20.0 MiB (0 Bytes/s) with ~3 file(s) '
             'remaining (calculating...)\r')
         self.assertEqual(self.out_file.getvalue(), ref_progress_statement)
 
@@ -880,9 +888,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The success statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
-            'upload: file to s3://mybucket/mykey                \n'
-            'Completed 1.0 MiB/20.0 MiB with 2 file(s) remaining\r'
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
+            'upload: file to s3://mybucket/mykey                            \n'
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 2 file(s) remaining\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -904,8 +912,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         ref_success_statement = (
             'upload: file to s3://mybucket/mykey\n'
-            'Completed 1.0 MiB/~4.0 MiB with ~3 file(s) remaining '
-            '(calculating...)\r'
+            'Completed 1.0 MiB/~4.0 MiB (0 Bytes/s) with ~3 file(s) '
+            'remaining (calculating...)\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_success_statement)
 
@@ -927,8 +935,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         ref_success_statement = (
             'upload: file to s3://mybucket/mykey\n'
-            'Completed 1.0 MiB/~1.0 MiB with ~0 file(s) remaining '
-            '(calculating...)\r'
+            'Completed 1.0 MiB/~1.0 MiB (0 Bytes/s) with ~0 file(s) '
+            'remaining (calculating...)\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_success_statement)
 
@@ -1037,8 +1045,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         ref_statement = (
             'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 1.0 MiB/~4.0 MiB with ~3 file(s) remaining '
-            '(calculating...)\r'
+            'Completed 1.0 MiB/~4.0 MiB (0 Bytes/s) with ~3 file(s) '
+            'remaining (calculating...)\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -1068,8 +1076,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         ref_statement = (
             'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 1.0 MiB/~1.0 MiB with ~0 file(s) remaining '
-            '(calculating...)\r'
+            'Completed 1.0 MiB/~1.0 MiB (0 Bytes/s) with ~0 file(s) '
+            'remaining (calculating...)\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_statement)
 
@@ -1111,9 +1119,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The failure statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
-            'upload failed: file to s3://mybucket/mykey my exception\n'
-            'Completed 4.0 MiB/20.0 MiB with 2 file(s) remaining\r'
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
+            'upload failed: file to s3://mybucket/mykey my exception        \n'
+            'Completed 4.0 MiB/20.0 MiB (0 Bytes/s) with 2 file(s) remaining\r'
         )
         self.assertEqual(shared_file.getvalue(), ref_statement)
 
@@ -1232,9 +1240,9 @@ class TestResultPrinter(BaseResultPrinterTest):
         # * The warning statement
         # * And the progress again since the transfer is still ongoing
         ref_statement = (
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
-            'warning: my warning                                \n'
-            'Completed 1.0 MiB/20.0 MiB with 3 file(s) remaining\r'
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
+            'warning: my warning                                            \n'
+            'Completed 1.0 MiB/20.0 MiB (0 Bytes/s) with 3 file(s) remaining\r'
         )
 
         self.assertEqual(shared_file.getvalue(), ref_statement)
@@ -1292,8 +1300,8 @@ class TestResultPrinter(BaseResultPrinterTest):
 
         ref_success_statement = (
             'upload: file to s3://mybucket/mykey\n'
-            'Completed 1.0 MiB/~1.0 MiB with ~0 file(s) remaining '
-            '(calculating...)\r'
+            'Completed 1.0 MiB/~1.0 MiB (0 Bytes/s) with ~0 file(s) '
+            'remaining (calculating...)\r'
         )
         self.assertEqual(self.out_file.getvalue(), ref_success_statement)
 
@@ -1307,10 +1315,10 @@ class TestResultPrinter(BaseResultPrinterTest):
         self.result_printer(FinalTotalSubmissionsResult(1))
         ref_success_statement = (
             'upload: file to s3://mybucket/mykey\n'
-            'Completed 1.0 MiB/~1.0 MiB with ~0 file(s) remaining '
-            '(calculating...)\r'
-            '                                                     '
-            '                \n'
+            'Completed 1.0 MiB/~1.0 MiB (0 Bytes/s) '
+            'with ~0 file(s) remaining (calculating...)\r'
+            '                                             '
+            '                                    \n'
         )
         self.assertEqual(self.out_file.getvalue(), ref_success_statement)
 


### PR DESCRIPTION
This adds transfer speed reporting by default to whenever there is bytes progress to the ``s3`` transfer commands. Here is how it looks:
```
$ aws s3 cp 5GB s3://mybucketfoo
Completed 9.0 MiB/5.0 GiB (6.1 MiB/s) with 1 file(s) remaining
```

Let me know what you think. I am up for suggestions on the output and whether to make it opt in or not. So go ahead and try out the branch.

I did performance tests on the implementation as well and there were no noticeable performance differences.

cc @jamesls @JordonPhillips @stealthycoin 