### PR TITLE
Fix issue with opsworks register on some machines

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -61,7 +61,7 @@ def ensure_text_type(s):
     if isinstance(s, six.text_type):
         return s
     if isinstance(s, six.binary_type):
-        return s.decode('utf-8', 'strict')
+        return s.decode('utf-8')
     raise ValueError("Expected str, unicode or bytes, received %s." % type(s))
 
 if six.PY3:

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -57,6 +57,12 @@ class NonTranslatedStdout(object):
             import msvcrt
             msvcrt.setmode(sys.stdout.fileno(), self.previous_mode)
 
+def ensure_text_type(s, encoding='utf-8', errors='strict'):
+    if isinstance(s, six.text_type):
+        return s
+    if isinstance(s, six.binary_type):
+        return s.decode(encoding, errors)
+    raise ValueError("Expected str or unicode, received %s." % type(s))
 
 if six.PY3:
     import locale

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -57,12 +57,12 @@ class NonTranslatedStdout(object):
             import msvcrt
             msvcrt.setmode(sys.stdout.fileno(), self.previous_mode)
 
-def ensure_text_type(s, encoding='utf-8', errors='strict'):
+def ensure_text_type(s):
     if isinstance(s, six.text_type):
         return s
     if isinstance(s, six.binary_type):
-        return s.decode(encoding, errors)
-    raise ValueError("Expected str or unicode, received %s." % type(s))
+        return s.decode('utf-8', 'strict')
+    raise ValueError("Expected str, unicode or bytes, received %s." % type(s))
 
 if six.PY3:
     import locale

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -24,7 +24,7 @@ import textwrap
 
 from botocore.exceptions import ClientError
 
-from awscli.compat import shlex_quote, urlopen
+from awscli.compat import shlex_quote, urlopen, ensure_text_type
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import create_client_from_parsed_globals
 
@@ -278,7 +278,8 @@ class OpsWorksRegister(BasicCommand):
 
         if args.infrastructure_class == 'ec2' and args.local:
             # make sure the regions match
-            region = json.loads(urlopen(IDENTITY_URL).read())['region']
+            region = json.loads(
+                ensure_text_type(urlopen(IDENTITY_URL).read()))['region']
             if region != self._stack['Region']:
                 raise ValueError(
                     "The stack's and the instance's region must match.")

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -736,20 +736,18 @@ class TestOpsWorksRegisterEc2(TestOpsWorksBase):
 
     @mock.patch.object(opsworks, "urlopen")
     def test_validate_same_region_bytes(self, mock_urlopen):
-        """Same as the above test, on some OSes urlopen.read returns a bytes"""
+        """Check that register can handle bytes returned by urlopen.read"""
 
         self.register._stack = {"Region": "mars-east-1"}
 
         mock_urlopen.return_value.read.return_value = \
             b'{"region": "mars-east-1"}'
-        self.register.validate_arguments(
-            self._build_args(hostname=None, local=True))
-
-        with self.assertRaises(ValueError):
-            mock_urlopen.return_value.read.return_value = \
-                b'{"region": "mars-west-1"}'
+        try:
             self.register.validate_arguments(
                 self._build_args(hostname=None, local=True))
+        except Exception:
+            self.fail(
+                'Register should work with bytes response from urlopen.read.')
 
     def test_retrieve_stack_ec2(self):
         """Should retrieve an EC2 stack and the matching instance."""

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -745,9 +745,10 @@ class TestOpsWorksRegisterEc2(TestOpsWorksBase):
         try:
             self.register.validate_arguments(
                 self._build_args(hostname=None, local=True))
-        except Exception:
+        except Exception as e:
             self.fail(
-                'Register should work with bytes response from urlopen.read.')
+                'Register should work with bytes response from urlopen.read. '
+                'Got exception: %s' % e)
 
     def test_retrieve_stack_ec2(self):
         """Should retrieve an EC2 stack and the matching instance."""

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -734,6 +734,23 @@ class TestOpsWorksRegisterEc2(TestOpsWorksBase):
             self.register.validate_arguments(
                 self._build_args(hostname=None, local=True))
 
+    @mock.patch.object(opsworks, "urlopen")
+    def test_validate_same_region_bytes(self, mock_urlopen):
+        """Same as the above test, on some OSes urlopen.read returns a bytes"""
+
+        self.register._stack = {"Region": "mars-east-1"}
+
+        mock_urlopen.return_value.read.return_value = \
+            b'{"region": "mars-east-1"}'
+        self.register.validate_arguments(
+            self._build_args(hostname=None, local=True))
+
+        with self.assertRaises(ValueError):
+            mock_urlopen.return_value.read.return_value = \
+                b'{"region": "mars-west-1"}'
+            self.register.validate_arguments(
+                self._build_args(hostname=None, local=True))
+
     def test_retrieve_stack_ec2(self):
         """Should retrieve an EC2 stack and the matching instance."""
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from awscli.compat import ensure_text_type
+from botocore.compat import six
+
+from awscli.testutils import unittest
+
+
+class TestEnsureText(unittest.TestCase):
+    def test_string(self):
+        value = 'foo'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, 'foo')
+
+    def test_binary(self):
+        value = b'bar'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, 'bar')
+
+    def test_unicode(self):
+        value = u'baz'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, 'baz')
+
+    def test_non_ascii(self):
+        value = b'\xe2\x9c\x93'
+        response = ensure_text_type(value)
+        self.assertIsInstance(response, six.text_type)
+        self.assertEqual(response, u'\u2713')
+
+    def test_non_string_or_bytes_raises_error(self):
+        value = 500
+        with self.assertRaises(ValueError):
+            ensure_text_type(value)


### PR DESCRIPTION
Ensures the response from urlopen.read is a text type before passing it to json.loads.
Fixes #2247 #2309

cc @JordonPhillips @kyleknap @jamesls 