### PR TITLE
Remove '-e' deprecated parameter from 'docker login' command generated by 'aws ecr get-login' command.

### DIFF
--- a/awscli/customizations/ecr.py
+++ b/awscli/customizations/ecr.py
@@ -52,6 +52,6 @@ class ECRLogin(BasicCommand):
         for auth in result['authorizationData']:
             auth_token = b64decode(auth['authorizationToken']).decode()
             username, password = auth_token.split(':')
-            sys.stdout.write('docker login -u %s -p %s -e none %s\n'
+            sys.stdout.write('docker login -u %s -p %s %s\n'
                              % (username, password, auth['proxyEndpoint']))
         return 0

--- a/awscli/examples/ecr/get-login.rst
+++ b/awscli/examples/ecr/get-login.rst
@@ -9,7 +9,7 @@ Command::
 
 Output::
 
-  docker login -u AWS -p <password> -e none https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com
+  docker login -u AWS -p <password> https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com
 
 **To log in to another account's registry**
 
@@ -22,5 +22,5 @@ Command::
 
 Output::
 
-  docker login -u <username> -p <token-1> -e none <endpoint-1>
-  docker login -u <username> -p <token-2> -e none <endpoint-2>
+  docker login -u <username> -p <token-1> <endpoint-1>
+  docker login -u <username> -p <token-2> <endpoint-2>

--- a/tests/functional/ecr/test_get_login.py
+++ b/tests/functional/ecr/test_get_login.py
@@ -29,7 +29,7 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
         ]
         stdout, _, rc = self.run_cmd("ecr get-login")
         self.assertIn(
-            'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io', stdout)
+            'docker login -u foo -p bar 1235.ecr.us-east-1.io', stdout)
         self.assertEquals(1, len(self.operations_called))
         self.assertNotIn('registryIds', self.operations_called[0][1])
 
@@ -52,10 +52,10 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
         ]
         stdout, _, rc = self.run_cmd("ecr get-login --registry-ids 1234 5678")
         self.assertIn(
-            'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io\n',
+            'docker login -u foo -p bar 1235.ecr.us-east-1.io\n',
             stdout)
         self.assertIn(
-            'docker login -u abc -p 123 -e none 4567.ecr.us-east-1.io\n',
+            'docker login -u abc -p 123 4567.ecr.us-east-1.io\n',
             stdout)
         self.assertEquals(1, len(self.operations_called))
         self.assertEquals([u'1234', u'5678'],


### PR DESCRIPTION
Hey, all!

Every time I run `eval $(aws ecr get-login)` I get a following warning message: 
```
Warning: '-e' is deprecated, it will be removed soon. See usage.
```
This PR helps to remove this warning (somebody needed to do it).

I use Docker version 1.11.2. `-e` parameter was removed almost a year ago by this PR: https://github.com/docker/docker/pull/20565

Thank you,
Alex L.