### PR TITLE
Adding support for skipping automatic property uploads

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -205,6 +205,7 @@ class Resource(object):
     """
 
     PROPERTY_NAME = None
+    PACKAGE_NULL_PROPERTY = True
 
     def __init__(self, uploader):
         self.uploader = uploader
@@ -214,6 +215,9 @@ class Resource(object):
             return
 
         property_value = resource_dict.get(self.PROPERTY_NAME, None)
+
+        if not property_value and not self.PACKAGE_NULL_PROPERTY:
+            return
 
         if isinstance(property_value, dict):
             LOG.debug("Property {0} of {1} resource is not a URL"
@@ -290,6 +294,7 @@ class LambdaFunctionResource(ResourceWithS3UrlDict):
 
 class ApiGatewayRestApiResource(ResourceWithS3UrlDict):
     PROPERTY_NAME = "BodyS3Location"
+    PACKAGE_NULL_PROPERTY = False
     BUCKET_NAME_PROPERTY = "Bucket"
     OBJECT_KEY_PROPERTY = "Key"
     VERSION_PROPERTY = "Version"

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -31,8 +31,9 @@ the local path with the S3 location: ``CodeUri: s3://mybucket/lambdafunction.zip
 
 If you specify a file, the command directly uploads it to the S3 bucket. If you
 specify a folder, the command zips the folder and then uploads the .zip file.
-If you don't specify a path, the command zips and uploads the current working
-directory.
+For most resources, if you don't specify a path, the command zips and uploads the
+current working directory. The exception is ``AWS::ApiGateway::RestApi``;
+if you don't specify a ``BodyS3Location``, this command will not upload an artifact to S3.
 
 Before the command uploads artifacts, it checks if the artifacts are already
 present in the S3 bucket to prevent unnecessary uploads. The command uses MD5

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -106,7 +106,9 @@ def _helper_verify_export_resources(
     upload_local_artifacts_mock.reset_mock()
 
     resource_id = "id"
-    resource_dict = {}
+    resource_dict = {
+        test_class.PROPERTY_NAME: "foo"
+    }
     parent_dir = "dir"
 
     upload_local_artifacts_mock.return_value = uploaded_s3_url
@@ -423,6 +425,26 @@ class TestArtifactExporter(unittest.TestCase):
         upload_local_artifacts_mock.assert_not_called()
         self.assertEquals(resource_dict, {"foo": {"a": "b"}})
 
+    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    def test_resource_has_package_null_property_to_false(self, upload_local_artifacts_mock):
+        # Should not upload anything if PACKAGE_NULL_PROPERTY is set to False
+
+        class MockResource(Resource):
+            PROPERTY_NAME = "foo"
+            PACKAGE_NULL_PROPERTY = False
+
+        resource = MockResource(self.s3_uploader_mock)
+        resource_id = "id"
+        resource_dict = {}
+        parent_dir = "dir"
+        s3_url = "s3://foo/bar"
+
+        upload_local_artifacts_mock.return_value = s3_url
+
+        resource.export(resource_id, resource_dict, parent_dir)
+
+        upload_local_artifacts_mock.assert_not_called()
+        self.assertNotIn(resource.PROPERTY_NAME, resource_dict)
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_export_fails(self, upload_local_artifacts_mock):


### PR DESCRIPTION
This adds the ability to specify that a resource should not have its property automatically uploaded when run through `aws cloudformation package` if the property is not specified in the original template.

It also adds this functionality to `ApiGatewayRestApiResource`.

This is in response to #2320 