### PR TITLE
Fixed yaml parsing error for !GetAtt

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -35,7 +35,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
         # ShortHand notation for !GetAtt accepts Resource.Attribute format
         # while the standard notation is to use an array
         # [Resource, Attribute]. Convert shorthand to standard format
-        value = node.value.split(".")
+        value = node.value.split(".", 1)
 
     elif isinstance(node, ScalarNode):
         # Value of this node is scalar

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -27,6 +27,7 @@ class TestYaml(unittest.TestCase):
         Key2: !GetAtt Another.Arn
         Key3: !FooBar [!Baz YetAnother, "hello"]
         Key4: !SomeTag {"a": "1"}
+        Key5: !GetAtt OneMore.Outputs.Arn
     """
 
     parsed_yaml_dict = {
@@ -47,6 +48,9 @@ class TestYaml(unittest.TestCase):
                 "Fn::SomeTag": {
                     "a": "1"
                 }
+            },
+            "Key5": {
+                "Fn::GetAtt": ["OneMore", "Outputs.Arn"]
             }
         }
     }


### PR DESCRIPTION
When parsing `!GetAtt`, attributes should not be split on periods.

## Example:

### Original:
`!GetAtt MyStack.Outputs.Arn`

### Parses to:
`{ "Fn::GetAtt": [ "MyStack", "Outputs", "Arn" ] }`

### Should be:
`{ "Fn::GetAtt": [ "MyStack", "Outputs.Arn" ] }`