### PR TITLE
Handle race conditions in s3 sync a little better

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -207,18 +207,17 @@ class FileGenerator(object):
                         for x in self.list_files(file_path, dir_op):
                             yield x
                     else:
-                        stats = self._safely_get_file_stats(path, file_name=name)
+                        stats = self._safely_get_file_stats(file_path)
                         if stats:
                             yield stats
 
-    def _safely_get_file_stats(self, path, file_name=None):
-        file_path = path if file_name is None else os.path.join(path, file_name)
+    def _safely_get_file_stats(self, file_path):
         try:
             size, last_update = get_file_stat(file_path)
         except OSError:
             self.triggers_warning(file_path)
         else:
-            last_update = self._validate_update_time(last_update, path)
+            last_update = self._validate_update_time(last_update, file_path)
             return file_path, {'Size': size, 'LastModified': last_update}
 
     def _validate_update_time(self, update_time, path):


### PR DESCRIPTION
The LBYL approach with `should_ignore_file` checking if `triggers_warning`
is `True` is susceptible to rare race conditions in which a file is
deleted after `should_ignore_file` calls `triggers_warning` but before
`get_file_stat` calls `os.stat`. When that happens, an `OSError` is raised.
This doesn't affect most people, but when you are using `s3 sync` on a
large directory that is constantly shifting (for example, a logging
directory being managed by logrotate, or a directory with a ton of tmp
files that come and go) this has a much higher chance of happening.

While my solution here does not address every possible error case, it
does address a few. I'm not sure how I can create a robust blanket
solution, but a little improvement is better than none at all, right?

Fixes #1841