### PR TITLE
[Feature] Adding support for passing local paths to nested CloudFormation stacks

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -206,9 +206,9 @@ class Resource(object):
 
     PROPERTY_NAME = None
 
-    def __init__(self, uploader, template_params={}):
+    def __init__(self, uploader, template_params=None):
         self.uploader = uploader
-        self.template_params = template_params
+        self.template_params = template_params if template_params else {}
 
     def export(self, resource_id, resource_dict, parent_dir):
         if resource_dict is None:
@@ -356,7 +356,8 @@ class CloudFormationStackResource(Resource):
         stack_params = self.get_params(resource_dict, parent_dir)
 
         exported_template_dict = \
-            Template(template_path, parent_dir, self.uploader, template_params=stack_params).export()
+            Template(template_path, parent_dir, self.uploader,
+                     template_params=stack_params).export()
 
         exported_template_str = yaml_dump(exported_template_dict)
 
@@ -407,7 +408,7 @@ class Template(object):
     """
 
     def __init__(self, template_path, parent_dir, uploader,
-                 resources_to_export=EXPORT_DICT, template_params={}):
+                 resources_to_export=EXPORT_DICT, template_params=None):
         """
         Reads the template and makes it ready for export
         """
@@ -427,7 +428,7 @@ class Template(object):
         self.template_dir = template_dir
         self.resources_to_export = resources_to_export
         self.uploader = uploader
-        self.template_params = template_params
+        self.template_params = template_params if template_params else {}
 
     def export(self):
         """

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -561,7 +561,9 @@ class TestArtifactExporter(unittest.TestCase):
         test_template_params = {
             "Parameter1": "./relative/filepath.txt"
         }
-        stack_resource = CloudFormationStackResource(self.s3_uploader_mock, template_params=test_template_params)
+        stack_resource = CloudFormationStackResource(
+            self.s3_uploader_mock,
+            template_params=test_template_params)
 
         test_resource_dict = {
             "Parameters": {
@@ -570,15 +572,19 @@ class TestArtifactExporter(unittest.TestCase):
                 }
             }
         }
-        returned_params = stack_resource.get_params(test_resource_dict, '/path/to/folder')
+        returned_params = stack_resource.get_params(test_resource_dict,
+                                                    '/path/to/folder')
 
-        self.assertEquals(returned_params["Parameter1Ref"], "/path/to/folder/relative/filepath.txt")
+        self.assertEquals(returned_params["Parameter1Ref"],
+                          "/path/to/folder/relative/filepath.txt")
 
-    def test_export_cloudformation_stack_get_params_relative_path(self):
+    def test_export_cloudformation_stack_get_params_absolute_path(self):
         test_template_params = {
             "Parameter1": "/absolute/filepath.txt"
         }
-        stack_resource = CloudFormationStackResource(self.s3_uploader_mock, template_params=test_template_params)
+        stack_resource = CloudFormationStackResource(
+            self.s3_uploader_mock,
+            template_params=test_template_params)
 
         test_resource_dict = {
             "Parameters": {
@@ -587,9 +593,11 @@ class TestArtifactExporter(unittest.TestCase):
                 }
             }
         }
-        returned_params = stack_resource.get_params(test_resource_dict, '/path/to/folder')
+        returned_params = stack_resource.get_params(test_resource_dict,
+                                                    '/path/to/folder')
 
-        self.assertEquals(returned_params["Parameter1Ref"], "/absolute/filepath.txt")
+        self.assertEquals(returned_params["Parameter1Ref"],
+                          "/absolute/filepath.txt")
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
     def test_template_export(self, yaml_parse_mock):
@@ -705,7 +713,8 @@ class TestArtifactExporter(unittest.TestCase):
             parameter_key: "Parameter1Value"
         }
 
-        test_resource = Resource(self.s3_uploader_mock, template_params=test_template_params)
+        test_resource = Resource(self.s3_uploader_mock,
+                                 template_params=test_template_params)
 
         test_resource.export = Mock()
 
@@ -717,7 +726,8 @@ class TestArtifactExporter(unittest.TestCase):
         test_property_value = {
             "Ref": parameter_key
         }
-        test_resource = Resource(self.s3_uploader_mock, template_params=test_template_params)
+        test_resource = Resource(self.s3_uploader_mock,
+                                 template_params=test_template_params)
 
         returned_property = test_resource.resolve_param_reference(test_property_value)
 


### PR DESCRIPTION
This is a feature I've been using with `aws cloudformation package` for my own work and thought I'd rework the code and add tests for your consideration for a merge.

The idea is to map references in nested stacks to parameters passed in from it's parent stack. The reference is parsed and replaced with the parameter's value (if the value is not dependent on a deploy time parameter) before the `package` command exports the resource's artifact to S3.

---
**Example**:

```yaml
# package.yaml
AWSTemplateFormatVersion: 2010-09-09
Resources:
  ApiStack:
    Type: AWS::CloudFormation::Stack
    Properties:
      TemplateURL: ./api-template.yaml
      Parameters:
        SwaggerDoc: /path/to/swagger.yaml


# api-template.yaml
AWSTemplateFormatVersion: 2010-09-09
Parameters:
  SwaggerDoc:
    Type: String
Resources:
  MyFunction:
    Type: AWS::ApiGateway::RestApi
    Properties:
        BodyS3Location: !Ref SwaggerDoc
```

The command maps the parameter `SwaggerDoc` in `api-template.yaml` to the parameter value passed in from `package.yaml` (`/path/to/swagger.yaml`) before iterating over the resources. When it comes to the `BodyS3Location` property of `MyFunction` it will replace the `!Ref SwaggerDoc` with the value `/path/to/swagger.yaml`, then export that file to S3.

---
This feature also converts any relative paths to absolute paths by merging with the calling template's ***parent*** directory's path.

---
**Example**:

`./swagger.yaml` would become `/absolute/path/to/swagger.yaml`

---

This only affects the the specific properties of resources specified [here](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html). Any properties not specified in the previous link are not affected.


I find this really helps keep things DRY when composing multiple connected local templates.

I'd love y'all's feedback.