### PR TITLE
Fix broken feedback link

### DIFF
--- a/doc/source/_templates/feedback.html
+++ b/doc/source/_templates/feedback.html
@@ -1,5 +1,5 @@
 <div class="left-bar-other">
   <h3>Feedback</h3>
-  <p class="feedback">Did you find this page useful? Do you have a suggestion? <a href="https://portal.aws.amazon.com/gp/aws/html-forms-controller/documentation/aws_doc_feedback_04?service_name=AWS%20Command%20Line%20Interface&guide_name=Reference&api_version={{ version }}&file_name={{ pagename }}">Give us feedback</a> or
+  <p class="feedback">Did you find this page useful? Do you have a suggestion? <a href="https://docs.aws.amazon.com/forms/aws-doc-feedback?hidden_service_name=AWS%20Command%20Line%20Interface&hidden_guide_name=Reference&hidden_api_version={{ version }}&hidden_file_name={{ pagename }}">Give us feedback</a> or
   send us a <a href="https://github.com/aws/aws-cli">pull request</a> on GitHub.</p>
 </div>


### PR DESCRIPTION
I rebuilt the docs and takes me to the correct page:
https://docs-feedback.aws.amazon.com/feedback.jsp?hidden_service_name=AWS%20Command%20Line%20Interface&hidden_guide_name=Reference&hidden_api_version=1.11.&hidden_file_name=index
