### PR TITLE
Interpret rds presigned urls literally

### DIFF
--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -52,6 +52,9 @@ PARAMFILE_DISABLED = set([
 
     'machinelearning.predict.predict-endpoint',
 
+    'rds.copy-db-snapshot.pre-signed-url',
+    'rds.create-db-instance-read-replica.pre-signed-url',
+
     'sqs.add-permission.queue-url',
     'sqs.change-message-visibility.queue-url',
     'sqs.change-message-visibility-batch.queue-url',


### PR DESCRIPTION
This adds the rds presigned url params to the blacklist so that they
don't use the customization which will make that http request and
submit the result.

cc @kyleknap @jamesls @dstufft @stealthycoin