### PR TITLE
Adding example for deleting two Docker images from ECR

### DIFF
--- a/awscli/examples/ecr/batch-delete-image.rst
+++ b/awscli/examples/ecr/batch-delete-image.rst
@@ -18,3 +18,26 @@ Output::
           }
       ]
   }
+
+This example deletes multiple images by the ``SHA256`` hash in a repository called
+``ubuntu`` in the default registry for an account.
+
+Command::
+
+  aws ecr batch-delete-image --repository-name ubuntu imageDigest=sha256:71b0c3f03a0ea8dc79f2853a6f4a66d632257e781d263f6951c2aa8c4f1a3078 imageDigest=sha256:c598f629ab6255397795fda45947161b05ce5a94eae592762436cac3f71f7812
+
+Output::
+
+  {
+      "failures": [],
+      "imageIds": [
+          {
+              "imageTag": "b70634b",
+              "imageDigest": "sha256:c598f629ab6255397795fda45947161b05ce5a94eae592762436cac3f71f7812"
+          },
+          {
+              "imageTag": "9ab868e",
+              "imageDigest": "sha256:71b0c3f03a0ea8dc79f2853a6f4a66d632257e781d263f6951c2aa8c4f1a3078"
+          }
+      ]
+  }


### PR DESCRIPTION
Howdy,

This PR covers providing an example of deleting two or more Docker images from ECR.