### PR TITLE
Use UTF-8 encoding when guessing a MIME type of text/html for S3 uploads.

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -335,7 +335,10 @@ def guess_content_type(filename):
     If the type cannot be guessed, a value of None is returned.
     """
     try:
-        return mimetypes.guess_type(filename)[0]
+        guessed_type = mimetypes.guess_type(filename)[0]
+        if guessed_type == 'text/html':
+            return 'text/html; charset=utf-8'
+        return guessed_type
     # This catches a bug in the mimetype libary where some MIME types
     # specifically on windows machines cause a UnicodeDecodeError
     # because the MIME type in the Windows registery has an encoding

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -131,6 +131,9 @@ class TestGuessContentType(unittest.TestCase):
     def test_guess_content_type(self):
         self.assertEqual(guess_content_type('foo.txt'), 'text/plain')
 
+    def test_guess_content_type_with_html_charset(self):
+        self.assertEqual(guess_content_type('foo.html'), 'text/html; charset=utf-8')
+
     def test_guess_content_type_with_no_valid_matches(self):
         self.assertEqual(guess_content_type('no-extension'), None)
 


### PR DESCRIPTION
This PR addresses what I suspect is the most common cause of #1346, which is that `aws s3` guesses the MIME type of `.html` files as `text/html`, without any encoding specification.

This change simply alters any "guessed" `text/html` MIME type to be guessed as `text/html; charset=utf-8` instead. It's a bit of a stop-gap measure to address #1346, but given that the issue is now almost 2 years old, I thought this PR might be worth making in any case.

In terms of relevant statistics to justify this PR, [this somewhat dubious report](https://w3techs.com/technologies/details/en-utf8/all/all) suggests that:

> **UTF-8 is used by 88.5%** of all the websites whose character encoding we know.

My gut feeling also tells me that UTF-8 is a more sensible guess for encoding in 2017, rather than omitting the encoding from the `text/html` MIME type which, in the HTTP specification, means `ISO-8859-1`.