### PR TITLE
Don't package Serverless API DefinitionUri property if not present

### DIFF
--- a/.changes/next-release/bugfix-cloudformation-74058.json
+++ b/.changes/next-release/bugfix-cloudformation-74058.json
@@ -1,0 +1,5 @@
+{
+  "category": "cloudformation", 
+  "type": "bugfix", 
+  "description": "Fixes awslabs/serverless-application-model`#93 <https://github.com/aws/aws-cli/issues/93>`__"
+}

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -283,7 +283,9 @@ class ServerlessFunctionResource(Resource):
 
 class ServerlessApiResource(Resource):
     PROPERTY_NAME = "DefinitionUri"
-
+    # Don't package the directory if DefinitionUri is omitted.
+    # Necessary to support DefinitionBody
+    PACKAGE_NULL_PROPERTY = False
 
 class LambdaFunctionResource(ResourceWithS3UrlDict):
     PROPERTY_NAME = "Code"


### PR DESCRIPTION
Similar to https://github.com/aws/aws-cli/issues/2317