### PR TITLE
Update Glacier error message

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -304,8 +304,10 @@ class BaseTransferRequestSubmitter(object):
                         'Object is of storage class GLACIER. Unable to '
                         'perform %s operations on GLACIER objects. You must '
                         'restore the object to be able to the perform '
-                        'operation.' %
-                        fileinfo.operation_name
+                        'operation. See aws s3 %s help for additional '
+                        'parameter options to ignore or force these '
+                        'transfers.' %
+                        (fileinfo.operation_name, fileinfo.operation_name)
                     )
                     self._result_queue.put(warning)
                 return True


### PR DESCRIPTION
This updates the glacier warning to guide users to other options they have, such as `--force-glacier-transfer` when encountering glacier class objects in s3 transfers.

Motivation: #2385 

cc @kyleknap @jamesls @dstufft @stealthycoin 