### PR TITLE
Fix ec2 pagination bug

### DIFF
--- a/.changes/next-release/bugfix-ec2-77933.json
+++ b/.changes/next-release/bugfix-ec2-77933.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fixed a bug causing some ec2 commands to fail with an invalid parameter combination error when arguments were supplied via --cli-input-json. Resolves `#2452 <https://github.com/aws/aws-cli/issues/2452>`__",
+  "category": "ec2",
+  "type": "bugfix"
+}

--- a/awscli/customizations/cliinputjson.py
+++ b/awscli/customizations/cliinputjson.py
@@ -50,7 +50,7 @@ class CliInputJSONArgument(OverrideRequiredArgsArgument):
 
     def _register_argument_action(self):
         self._session.register(
-            'calling-command', self.add_to_call_parameters)
+            'calling-command.*', self.add_to_call_parameters)
         super(CliInputJSONArgument, self)._register_argument_action()
 
     def add_to_call_parameters(self, call_parameters, parsed_args,

--- a/tests/functional/ec2/test_describe_volumes.py
+++ b/tests/functional/ec2/test_describe_volumes.py
@@ -10,12 +10,24 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import json
+import shutil
+
 from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import FileCreator
 
 
 class TestDescribeVolumes(BaseAWSCommandParamsTest):
 
     prefix = 'ec2 describe-volumes'
+
+    def setUp(self):
+        super(TestDescribeVolumes, self).setUp()
+        self.file_creator = FileCreator()
+
+    def tearDown(self):
+        super(TestDescribeVolumes, self).tearDown()
+        shutil.rmtree(self.file_creator.rootdir)
 
     def test_max_results_set_by_default(self):
         command = self.prefix
@@ -38,4 +50,12 @@ class TestDescribeVolumes(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(command, params)
 
         command = self.prefix + ' --page-size 5'
+        self.assert_params_for_cmd(command, params)
+
+    def test_max_results_with_cli_input_json(self):
+        params = {'VolumeIds': ['vol-12345']}
+        file_path = self.file_creator.create_file(
+            'params.json', json.dumps(params))
+
+        command = self.prefix + ' --cli-input-json file://%s' % file_path
         self.assert_params_for_cmd(command, params)

--- a/tests/unit/customizations/test_cliinputjson.py
+++ b/tests/unit/customizations/test_cliinputjson.py
@@ -40,7 +40,7 @@ class TestCliInputJSONArgument(unittest.TestCase):
 
     def test_register_argument_action(self):
         register_args = self.session.register.call_args_list
-        self.assertEqual(register_args[0][0][0], 'calling-command')
+        self.assertEqual(register_args[0][0][0], 'calling-command.*')
         self.assertEqual(register_args[0][0][1],
                          self.argument.add_to_call_parameters)
 


### PR DESCRIPTION
Resolves #2452

Fixes a bug where cli json input would get processed after ec2
auto pagination injection.

This was due to a subtle behavior of the event system. A handler
registered at the top level without any delimiters will always
be called *after* any events registered that do have delimiters
regarless of when or how they were registered.

The handler for --cli-input-json was registered against
'calling-command', and the handler for the ec2 pagination injection
was registered against 'calling-command.ec2.operation-name'. So then
even though the ec2 pagination injection was using register_last, it
was being called first.

The solution is to use 'calling-command.*' instead for the event
that --cli-input-json is registered against. This puts it in the same
pool as the other delimited handlers. This had the potential to break
other handlers depending on the existing ordering, but there were
very few registered to that event. Running the tests revealed no
issues, however.

There are four places where the event is used:

* In the [code for cli input json](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/cliinputjson.py#L53)
* In the [cloudsearch domain customization](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/cloudsearchdomain.py#L22)
* In the [ec2 pagination customization](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/ec2/paginate.py#L37)
* In the [code for generate cli skeleton](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/generatecliskeleton.py#L66)

Two of those are the instances under question. Neither of the others
is dependent on `--cli-input-json`.

cc @kyleknap @jamesls @stealthycoin @dstufft