### PR TITLE
possible solution for #2518

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -72,7 +72,10 @@ if six.PY3:
 
     raw_input = input
 
-    binary_stdin = sys.stdin.buffer
+    if sys.stdin:
+        binary_stdin = sys.stdin.buffer
+    else:
+        binary_stdin = None
 
     def get_stdout_text_writer():
         return sys.stdout


### PR DESCRIPTION
Details have been included in the issue #2518

This is to stop running `aws` from failing if no stdin is set when running from Python3. This is not an issue for Python2.

Thoughts?