### PR TITLE
Alias mturk command

### DIFF
--- a/awscli/customizations/mturk.py
+++ b/awscli/customizations/mturk.py
@@ -1,0 +1,29 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.utils import alias_command
+
+
+def register_alias_mturk_command(event_emitter):
+    event_emitter.register(
+        'building-command-table.mturk',
+        alias_mturk_command
+    )
+
+
+def alias_mturk_command(command_table, **kwargs):
+    alias_command(
+        command_table,
+        existing_name='list-hits-for-qualification-type',
+        new_name='list-hi-ts-for-qualification-type',
+        hide_current=False
+    )

--- a/awscli/customizations/mturk.py
+++ b/awscli/customizations/mturk.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.customizations.utils import alias_command
+from awscli.customizations.utils import make_hidden_command_alias
 
 
 def register_alias_mturk_command(event_emitter):
@@ -21,9 +21,8 @@ def register_alias_mturk_command(event_emitter):
 
 
 def alias_mturk_command(command_table, **kwargs):
-    alias_command(
+    make_hidden_command_alias(
         command_table,
         existing_name='list-hits-for-qualification-type',
-        new_name='list-hi-ts-for-qualification-type',
-        hide_current=False
+        alias_name='list-hi-ts-for-qualification-type',
     )

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -80,7 +80,7 @@ def alias_command(command_table, existing_name, new_name, hide_current=True):
 
     :type hide_current: bool
     :param hide_current: Whether to hide the current command name or the new
-        command name. If True, the current name is hidden. If False, the ne
+        command name. If True, the current name is hidden. If False, the new
         name is hidden.
     """
     current = command_table[existing_name]

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -66,11 +66,30 @@ def rename_command(command_table, existing_name, new_name):
     del command_table[existing_name]
 
 
-def alias_command(command_table, existing_name, new_name):
-    """Moves an argument to a new name, keeping the old as a hidden alias."""
+def alias_command(command_table, existing_name, new_name, hide_current=True):
+    """Moves an argument to a new name, keeping the old as a hidden alias.
+
+    :type command_table: dict
+    :param command_table: The full command table for the CLI or a service.
+
+    :type existing_name: str
+    :param existing_name: The current name of the command.
+
+    :type new_name: str
+    :param new_name: The new name for the command.
+
+    :type hide_current: bool
+    :param hide_current: Whether to hide the current command name or the new
+        command name. If True, the current name is hidden. If False, the ne
+        name is hidden.
+    """
     current = command_table[existing_name]
-    _copy_argument(command_table, existing_name, new_name)
-    current._UNDOCUMENTED = True
+    new = _copy_argument(command_table, existing_name, new_name)
+
+    if hide_current:
+        current._UNDOCUMENTED = True
+    else:
+        new._UNDOCUMENTED = True
 
 
 def validate_mutually_exclusive_handler(*groups):

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -66,7 +66,7 @@ def rename_command(command_table, existing_name, new_name):
     del command_table[existing_name]
 
 
-def alias_command(command_table, existing_name, new_name, hide_current=True):
+def alias_command(command_table, existing_name, new_name):
     """Moves an argument to a new name, keeping the old as a hidden alias.
 
     :type command_table: dict
@@ -77,19 +77,33 @@ def alias_command(command_table, existing_name, new_name, hide_current=True):
 
     :type new_name: str
     :param new_name: The new name for the command.
-
-    :type hide_current: bool
-    :param hide_current: Whether to hide the current command name or the new
-        command name. If True, the current name is hidden. If False, the new
-        name is hidden.
     """
     current = command_table[existing_name]
-    new = _copy_argument(command_table, existing_name, new_name)
+    _copy_argument(command_table, existing_name, new_name)
+    current._UNDOCUMENTED = True
 
-    if hide_current:
-        current._UNDOCUMENTED = True
-    else:
-        new._UNDOCUMENTED = True
+
+def make_hidden_command_alias(command_table, existing_name, alias_name):
+    """Create a hidden alias for an exiting command.
+
+    This will copy an existing command object in a command table and add a new
+    entry to the command table with a different name. The new command will
+    be undocumented.
+
+    This is needed if you want to change an existing command, but you still
+    need the old name to work for backwards compatibility reasons.
+
+    :type command_table: dict
+    :param command_table: The full command table for the CLI or a service.
+
+    :type existing_name: str
+    :param existing_name: The current name of the command.
+
+    :type alias_name: str
+    :param alias_name: The new name for the command.
+    """
+    new = _copy_argument(command_table, existing_name, alias_name)
+    new._UNDOCUMENTED = True
 
 
 def validate_mutually_exclusive_handler(*groups):

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -73,6 +73,7 @@ from awscli.customizations.streamingoutputarg import add_streaming_output_arg
 from awscli.customizations.toplevelbool import register_bool_params
 from awscli.customizations.waiters import register_add_waiters
 from awscli.customizations.opsworkscm import register_alias_opsworks_cm
+from awscli.customizations.mturk import register_alias_mturk_command
 
 
 def awscli_initialize(event_handlers):
@@ -148,3 +149,4 @@ def awscli_initialize(event_handlers):
     register_ec2_page_size_injector(event_handlers)
     cloudformation_init(event_handlers)
     register_alias_opsworks_cm(event_handlers)
+    register_alias_mturk_command(event_handlers)

--- a/tests/functional/mturk/test_alias.py
+++ b/tests/functional/mturk/test_alias.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestAlias(BaseAWSCommandParamsTest):
+    def test_alias(self):
+        # This command was aliased, both should work
+        command_tempalte = 'mturk %s --qualification-type-id foo'
+        old_command = command_tempalte % 'list-hi-ts-for-qualification-type'
+        new_command = command_tempalte % 'list-hits-for-qualification-type'
+        self.run_cmd(old_command, expected_rc=0)
+        self.run_cmd(new_command, expected_rc=0)

--- a/tests/functional/mturk/test_alias.py
+++ b/tests/functional/mturk/test_alias.py
@@ -16,8 +16,8 @@ from awscli.testutils import BaseAWSCommandParamsTest
 class TestAlias(BaseAWSCommandParamsTest):
     def test_alias(self):
         # This command was aliased, both should work
-        command_tempalte = 'mturk %s --qualification-type-id foo'
-        old_command = command_tempalte % 'list-hi-ts-for-qualification-type'
-        new_command = command_tempalte % 'list-hits-for-qualification-type'
+        command_template = 'mturk %s --qualification-type-id foo'
+        old_command = command_template % 'list-hi-ts-for-qualification-type'
+        new_command = command_template % 'list-hits-for-qualification-type'
         self.run_cmd(old_command, expected_rc=0)
         self.run_cmd(new_command, expected_rc=0)

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -49,19 +49,20 @@ class TestCommandTableAlias(BaseAWSHelpOutputTest):
         def handler(command_table, **kwargs):
             utils.alias_command(command_table, old_name, new_name)
 
-        self._assert_commands_exist(old_name, new_name, handler)
+        self._assert_command_exists(old_name, handler)
+        self._assert_command_exists(new_name, handler)
 
         # Verify that the new name is documented
         self.driver.main(['help'])
         self.assert_contains(new_name)
         self.assert_not_contains(old_name)
 
-    def test_hide_new_command_name(self):
+    def test_make_hidden_alias(self):
         old_name = 'ec2'
         new_name = 'nopossiblewaythisisalreadythere'
 
         def handler(command_table, **kwargs):
-            utils.alias_command(command_table, old_name, new_name, False)
+            utils.make_hidden_command_alias(command_table, old_name, new_name)
 
         self._assert_command_exists(old_name, handler)
         self._assert_command_exists(new_name, handler)

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -63,29 +63,22 @@ class TestCommandTableAlias(BaseAWSHelpOutputTest):
         def handler(command_table, **kwargs):
             utils.alias_command(command_table, old_name, new_name, False)
 
-        self._assert_commands_exist(old_name, new_name, handler)
+        self._assert_command_exists(old_name, handler)
+        self._assert_command_exists(new_name, handler)
 
         # Verify that the new isn't documented
         self.driver.main(['help'])
         self.assert_not_contains(new_name)
         self.assert_contains(old_name)
 
-    def _assert_commands_exist(self, old_name, new_name, handler):
+    def _assert_command_exists(self, command_name, handler):
         # Verify that we can alias a top level command.
         self.session.register('building-command-table.main', handler)
-        self.driver.main([new_name, 'help'])
-        self.assert_contains(new_name)
+        self.driver.main([command_name, 'help'])
+        self.assert_contains(command_name)
 
         # We can also see subcommands help as well.
-        self.driver.main([new_name, 'run-instances', 'help'])
-        self.assert_contains('run-instances')
-
-        # Verify that the old is still available
-        self.session.register('building-command-table.main', handler)
-        self.driver.main([old_name, 'help'])
-        self.assert_contains(old_name)
-
-        self.driver.main([new_name, 'run-instances', 'help'])
+        self.driver.main([command_name, 'run-instances', 'help'])
         self.assert_contains('run-instances')
 
 

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -43,23 +43,49 @@ class TestCommandTableRenames(BaseAWSHelpOutputTest):
 class TestCommandTableAlias(BaseAWSHelpOutputTest):
 
     def test_alias_command_table(self):
-        handler = lambda command_table, **kwargs: utils.alias_command(
-            command_table, 'ec2', 'foo')
+        old_name = 'ec2'
+        new_name = 'nopossiblewaythisisalreadythere'
+
+        def handler(command_table, **kwargs):
+            utils.alias_command(command_table, old_name, new_name)
+
+        self._assert_commands_exist(old_name, new_name, handler)
+
+        # Verify that the new name is documented
+        self.driver.main(['help'])
+        self.assert_contains(new_name)
+        self.assert_not_contains(old_name)
+
+    def test_hide_new_command_name(self):
+        old_name = 'ec2'
+        new_name = 'nopossiblewaythisisalreadythere'
+
+        def handler(command_table, **kwargs):
+            utils.alias_command(command_table, old_name, new_name, False)
+
+        self._assert_commands_exist(old_name, new_name, handler)
+
+        # Verify that the new isn't documented
+        self.driver.main(['help'])
+        self.assert_not_contains(new_name)
+        self.assert_contains(old_name)
+
+    def _assert_commands_exist(self, old_name, new_name, handler):
         # Verify that we can alias a top level command.
         self.session.register('building-command-table.main', handler)
-        self.driver.main(['foo', 'help'])
-        self.assert_contains('foo')
+        self.driver.main([new_name, 'help'])
+        self.assert_contains(new_name)
 
         # We can also see subcommands help as well.
-        self.driver.main(['foo', 'run-instances', 'help'])
+        self.driver.main([new_name, 'run-instances', 'help'])
         self.assert_contains('run-instances')
 
         # Verify that the old is still available
         self.session.register('building-command-table.main', handler)
-        self.driver.main(['ec2', 'help'])
-        self.assert_contains('ec2')
+        self.driver.main([old_name, 'help'])
+        self.assert_contains(old_name)
 
-        self.driver.main(['ec2', 'run-instances', 'help'])
+        self.driver.main([new_name, 'run-instances', 'help'])
         self.assert_contains('run-instances')
 
 


### PR DESCRIPTION
A command was renamed at the botocore level, this is providing a
hidden alias to continue supporting the old spelling.

This requires boto/botocore#1172