### PR TITLE
remove --key  (deprecated) from s3api list-object-versions   doc.

### DIFF
--- a/awscli/examples/s3api/list-object-versions.rst
+++ b/awscli/examples/s3api/list-object-versions.rst
@@ -1,6 +1,6 @@
 The following command retrieves version information for an object in a bucket named ``my-bucket``::
 
-  aws s3api list-object-versions --bucket my-bucket --key index.html
+  aws s3api list-object-versions --bucket my-bucket --prefix index.html
 
 Output::
 


### PR DESCRIPTION
--prefix isn't exactly the same here, but it works, which --key doesn't.