### PR TITLE
Handle default profile in configure get and have more useful errors

### DIFF
--- a/.changes/next-release/bugfix-configure-87594.json
+++ b/.changes/next-release/bugfix-configure-87594.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "configure",
+  "description": "Properly use the default profile in ``configure get``"
+}

--- a/awscli/customizations/configure/get.py
+++ b/awscli/customizations/configure/get.py
@@ -76,6 +76,8 @@ class ConfigureGetCommand(BasicCommand):
             remaining = parts[2:]
         else:
             profile_name = self._session.get_config_variable('profile')
+            if profile_name is None:
+                profile_name = 'default'
             config_name = parts[0]
             remaining = parts[1:]
 

--- a/awscli/customizations/configure/get.py
+++ b/awscli/customizations/configure/get.py
@@ -21,7 +21,7 @@ class ConfigureGetCommand(BasicCommand):
     NAME = 'get'
     DESCRIPTION = BasicCommand.FROM_FILE('configure', 'get',
                                          '_description.rst')
-    SYNOPSIS = ('aws configure get varname [--profile profile-name]')
+    SYNOPSIS = 'aws configure get varname [--profile profile-name]'
     EXAMPLES = BasicCommand.FROM_FILE('configure', 'get', '_examples.rst')
     ARG_TABLE = [
         {'name': 'varname',
@@ -36,7 +36,7 @@ class ConfigureGetCommand(BasicCommand):
 
     def _run_main(self, args, parsed_globals):
         varname = args.varname
-        value = None
+
         if '.' not in varname:
             # get_scoped_config() returns the config variables in the config
             # file (not the logical_var names), which is what we want.
@@ -44,6 +44,7 @@ class ConfigureGetCommand(BasicCommand):
             value = config.get(varname)
         else:
             value = self._get_dotted_config_value(varname)
+
         if value is not None:
             self._stream.write(value)
             self._stream.write('\n')
@@ -54,7 +55,9 @@ class ConfigureGetCommand(BasicCommand):
     def _get_dotted_config_value(self, varname):
         parts = varname.split('.')
         num_dots = varname.count('.')
-        # Logic to deal with predefined sections like [preview], [plugin] and etc.
+
+        # Logic to deal with predefined sections like [preview], [plugin] and
+        # etc.
         if num_dots == 1 and parts[0] in PREDEFINED_SECTION_NAMES:
             full_config = self._session.full_config
             section, config_name = varname.split('.')
@@ -64,13 +67,16 @@ class ConfigureGetCommand(BasicCommand):
                 value = full_config['profiles'].get(
                     section, {}).get(config_name)
             return value
+
         if parts[0] == 'profile':
             profile_name = parts[1]
             config_name = parts[2]
             remaining = parts[3:]
-        # Check if varname starts with 'default' profile (e.g. default.emr-dev.emr.instance_profile)
-        # If not, go further to check if varname starts with a known profile name
-        elif parts[0] == 'default' or (parts[0] in self._session.full_config['profiles']):
+        # Check if varname starts with 'default' profile (e.g.
+        # default.emr-dev.emr.instance_profile) If not, go further to check
+        # if varname starts with a known profile name
+        elif parts[0] == 'default' or (
+                parts[0] in self._session.full_config['profiles']):
             profile_name = parts[0]
             config_name = parts[1]
             remaining = parts[2:]

--- a/tests/unit/customizations/configure/test_get.py
+++ b/tests/unit/customizations/configure/test_get.py
@@ -102,3 +102,14 @@ class TestConfigureGetCommand(unittest.TestCase):
                    parsed_globals=None)
         rendered = stream.getvalue()
         self.assertEqual(rendered.strip(), '')
+
+    def test_get_nested_attribute_from_implicit_default(self):
+        session = FakeSession({})
+        session.full_config = {
+            'profiles': {'default': {'s3': {'signature_version': 's3v4'}}}}
+        stream = six.StringIO()
+        config_get = ConfigureGetCommand(session, stream)
+        config_get(args=['s3.signature_version'],
+                   parsed_globals=None)
+        rendered = stream.getvalue()
+        self.assertEqual(rendered.strip(), 's3v4')

--- a/tests/unit/customizations/configure/test_get.py
+++ b/tests/unit/customizations/configure/test_get.py
@@ -20,11 +20,16 @@ from . import FakeSession
 
 class TestConfigureGetCommand(unittest.TestCase):
 
+    def create_command(self, session):
+        stdout = six.StringIO()
+        stderr = six.StringIO()
+        command = ConfigureGetCommand(session, stdout, stderr)
+        return stdout, stderr, command
+
     def test_configure_get_command(self):
         session = FakeSession({})
         session.config['region'] = 'us-west-2'
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['region'], parsed_globals=None)
         rendered = stream.getvalue()
         self.assertEqual(rendered.strip(), 'us-west-2')
@@ -32,8 +37,7 @@ class TestConfigureGetCommand(unittest.TestCase):
     def test_configure_get_command_no_exist(self):
         no_vars_defined = {}
         session = FakeSession(no_vars_defined)
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         rc = config_get(args=['region'], parsed_globals=None)
         rendered = stream.getvalue()
         # If a config value does not exist, we don't print any output.
@@ -44,8 +48,7 @@ class TestConfigureGetCommand(unittest.TestCase):
     def test_dotted_get(self):
         session = FakeSession({})
         session.full_config = {'preview': {'emr': 'true'}}
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['preview.emr'], parsed_globals=None)
         rendered = stream.getvalue()
         self.assertEqual(rendered.strip(), 'true')
@@ -55,16 +58,16 @@ class TestConfigureGetCommand(unittest.TestCase):
         session.full_config = {'profiles': {'emr-dev': {
             'emr': {'instance_profile': 'my_ip'}}}}
         session.config = {'emr': {'instance_profile': 'my_ip'}}
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['emr-dev.emr.instance_profile'], parsed_globals=None)
         rendered = stream.getvalue()
         self.assertEqual(rendered.strip(), 'my_ip')
 
     def test_get_from_profile(self):
         session = FakeSession({})
-        session.full_config = {'profiles': {'testing': {'aws_access_key_id': 'access_key'}}}
-        stream = six.StringIO()
+        session.full_config = {
+            'profiles': {'testing': {'aws_access_key_id': 'access_key'}}}
+        stream, error_stream, config_get = self.create_command(session)
         config_get = ConfigureGetCommand(session, stream)
         config_get(args=['profile.testing.aws_access_key_id'],
                    parsed_globals=None)
@@ -75,8 +78,7 @@ class TestConfigureGetCommand(unittest.TestCase):
         session = FakeSession({})
         session.full_config = {
             'profiles': {'testing': {'s3': {'signature_version': 's3v4'}}}}
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['profile.testing.s3.signature_version'],
                    parsed_globals=None)
         rendered = stream.getvalue()
@@ -86,8 +88,7 @@ class TestConfigureGetCommand(unittest.TestCase):
         session = FakeSession({})
         session.full_config = {
             'profiles': {'default': {'s3': {'signature_version': 's3v4'}}}}
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['default.s3.signature_version'],
                    parsed_globals=None)
         rendered = stream.getvalue()
@@ -96,8 +97,7 @@ class TestConfigureGetCommand(unittest.TestCase):
     def test_get_nested_attribute_from_default_does_not_exist(self):
         session = FakeSession({})
         session.full_config = {'profiles': {}}
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['default.s3.signature_version'],
                    parsed_globals=None)
         rendered = stream.getvalue()
@@ -107,9 +107,36 @@ class TestConfigureGetCommand(unittest.TestCase):
         session = FakeSession({})
         session.full_config = {
             'profiles': {'default': {'s3': {'signature_version': 's3v4'}}}}
-        stream = six.StringIO()
-        config_get = ConfigureGetCommand(session, stream)
+        stream, error_stream, config_get = self.create_command(session)
         config_get(args=['s3.signature_version'],
                    parsed_globals=None)
         rendered = stream.getvalue()
         self.assertEqual(rendered.strip(), 's3v4')
+
+    def test_get_section_returns_error(self):
+        session = FakeSession({})
+        session.full_config = {
+            'profiles': {'default': {'s3': {'signature_version': 's3v4'}}}}
+        session.config = {'s3': {'signature_version': 's3v4'}}
+        stream, error_stream, config_get = self.create_command(session)
+        rc = config_get(args=['s3'], parsed_globals=None)
+        self.assertEqual(rc, 1)
+
+        error_message = error_stream.getvalue()
+        expected_message = (
+            'varname (s3) must reference a value, not a section or '
+            'sub-section.')
+        self.assertEqual(error_message, expected_message)
+        self.assertEqual(stream.getvalue(), '')
+
+    def test_get_non_string_returns_error(self):
+        # This should never happen, but we handle this case so we should
+        # test it.
+        session = FakeSession({})
+        session.full_config = {
+            'profiles': {'default': {'foo': object()}}}
+        stream, error_stream, config_get = self.create_command(session)
+        rc = config_get(args=['foo'], parsed_globals=None)
+        self.assertEqual(rc, 1)
+        self.assertEqual(stream.getvalue(), '')
+        self.assertEqual(error_stream.getvalue(), '')


### PR DESCRIPTION
Fixes #2536 

Basically, `configure get` didn't properly handle the default profile if you did something like `aws configure get s3.signature_version`. In addition to that, it gave an opaque error message if you tried to get an entire subsection.

While we could potentially support getting subsections, we would need to print them off in the same way that they are written to the config file, which could be tricky. For now we should at least have a better error message.