### PR TITLE
Awscli docs mappings

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -314,9 +314,6 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         operation_model = self.help_command.obj
         d = {}
         for cli_name, cli_argument in self.help_command.arg_table.items():
-            # print(cli_name,
-            #       type(cli_argument),
-            #       cli_argument.)
             # Some arguments map directly to basic shapes which results in the
             # translation mapping containing parameter names that map directly
             # to basic types. For example dry-run/no-dry-run maps to 'Boolean'
@@ -325,24 +322,11 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             # of basic types in the raw documentation with parameter names
             # we need to skip any mappings that map a parameter name
             # directly to a base scalar type.
-#            if cli_argument.cli_type_name in SCALAR_TYPES:
-#                continue
+            if cli_argument.cli_type_name in SCALAR_TYPES:
+                continue
             if cli_argument.argument_model is not None:
                 argument_name = cli_argument.argument_model.name
-                if argument_name in d:
-                    previous_mapping = d[argument_name]
-                    # If the argument name is a boolean argument, we want the
-                    # the translation to default to the one that does not start
-                    # with --no-. So we check if the cli parameter currently
-                    # being used starts with no- and if stripping off the no-
-                    # results in the new proposed cli argument name. If it
-                    # does, we assume we have the postive form of the argument
-                    # which is the name we want to use in doc translations.
-                    if cli_argument.cli_type_name == 'boolean' and \
-                            previous_mapping.startswith('no-') and \
-                            cli_name == previous_mapping[3:]:
-                        d[argument_name] = cli_name
-                else:
+                if argument_name not in d:
                     d[argument_name] = cli_name
         for operation_name in operation_model.service_model.operation_names:
             d[operation_name] = xform_name(operation_name, '-')

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import json
 import logging
 import os
 from botocore import xform_name
@@ -313,6 +314,19 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         operation_model = self.help_command.obj
         d = {}
         for cli_name, cli_argument in self.help_command.arg_table.items():
+            # print(cli_name,
+            #       type(cli_argument),
+            #       cli_argument.)
+            # Some arguments map directly to basic shapes which results in the
+            # translation mapping containing parameter names that map directly
+            # to basic types. For example dry-run/no-dry-run maps to 'Boolean'
+            # rather than an intermediate type that can be safely
+            # search/replaced. Since we do not want to replace all occurrences
+            # of basic types in the raw documentation with parameter names
+            # we need to skip any mappings that map a parameter name
+            # directly to a base scalar type.
+#            if cli_argument.cli_type_name in SCALAR_TYPES:
+#                continue
             if cli_argument.argument_model is not None:
                 argument_name = cli_argument.argument_model.name
                 if argument_name in d:

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -404,6 +404,15 @@ class TestEC2AuthorizeSecurityGroupNotRendered(BaseAWSHelpOutputTest):
         self.assert_not_contains('--source-security-group-owner-id')
 
 
+class TestEC2DescribeImages(BaseAWSHelpOutputTest):
+    def test_basic_types_not_replaced(self):
+        self.driver.main(['ec2', 'describe-images', 'help'])
+        # Ensure that boolean was not replaced with dry-run
+        self.assert_not_contains('is-public - A dry-run that indicates')
+        self.assert_not_contains('ena-support - A dry-run that indicates')
+        self.assert_not_contains('block-device-mapping.delete-on-termination '
+                                 '- A dry-run value')
+
 class TestKMSCreateGrant(BaseAWSHelpOutputTest):
     def test_proper_casing(self):
         self.driver.main(['kms', 'create-grant', 'help'])

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -101,7 +101,7 @@ class TestTranslationMap(unittest.TestCase):
         writes = '\n'.join(writes)
         self.assertIn(expected, writes)
 
-    def test_boolean_arg_groups(self):
+    def test_no_scalar_types(self):
         builder = DenormalizedStructureBuilder()
         input_model = builder.with_members({
             'Flag': {'type': 'boolean'}
@@ -112,11 +112,24 @@ class TestTranslationMap(unittest.TestCase):
             cli_type_name='boolean', argument_model=argument_model)
         self.arg_table['no-flag'] = mock.Mock(
             cli_type_name='boolean', argument_model=argument_model)
-        # The --no-flag should not be used in the translation.
-        self.assertEqual(
-            self.operation_handler.build_translation_map(),
-            {'Flag': 'flag'}
-        )
+        self.assertEqual({}, self.operation_handler.build_translation_map())
+
+    def test_translation_map_normal_remapping(self):
+        builder = DenormalizedStructureBuilder()
+        input_model = builder.with_members({
+            'ItemHolder': {
+                'type': 'structure',
+                'members': {
+                    'TheItem': {'type': 'string'}
+                }
+            }
+        }).build_model()
+        argument_model = input_model.members['ItemHolder']
+        argument_model.name = 'ItemHolder'
+        self.arg_table['item-holder'] = mock.Mock(
+            cli_type_name='structure', argument_model=argument_model)
+        self.assertEqual({'ItemHolder': 'item-holder'},
+                         self.operation_handler.build_translation_map())
 
 
 class TestCLIDocumentEventHandler(unittest.TestCase):


### PR DESCRIPTION
Prevent the doc generator from remapping basic scalar types to argument names. For example
`Boolean -> dry-run`  

cc @dstufft @jamesls @JordonPhillips @kyleknap 