### PR TITLE
Output format changes for aws-cloudformation-package command

### DIFF
--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -15,6 +15,8 @@ import os
 import logging
 import sys
 
+import json
+
 from botocore.client import Config
 
 from awscli.customizations.cloudformation.s3uploader import S3Uploader
@@ -91,6 +93,15 @@ class PackageCommand(BasicCommand):
         },
 
         {
+            "name": "use-yaml",
+            "action": "store_true",
+            "help_text": (
+                "Indicates whether to use YAML as the format for the output AWS"
+                " CloudFormation template. JSON is used by default."
+            )
+        },
+
+        {
             "name": "force-upload",
             "action": "store_true",
             "help_text": (
@@ -123,7 +134,8 @@ class PackageCommand(BasicCommand):
                                       parsed_args.force_upload)
 
         output_file = parsed_args.output_template_file
-        exported_str = self._export(template_path)
+        use_yaml = parsed_args.use_yaml
+        exported_str = self._export(template_path, use_yaml)
 
         sys.stdout.write("\n")
         self.write_output(output_file, exported_str)
@@ -137,10 +149,15 @@ class PackageCommand(BasicCommand):
         sys.stdout.flush()
         return 0
 
-    def _export(self, template_path):
+    def _export(self, template_path, use_yaml):
         template = Template(template_path, os.getcwd(), self.s3_uploader)
         exported_template = template.export()
-        exported_str = yaml_dump(exported_template)
+        
+        if use_yaml:
+            exported_str = yaml_dump(exported_template)
+        else:
+            exported_str = json.dumps(exported_template, indent=4, ensure_ascii=False)
+
         return exported_str
 
     def write_output(self, output_file_name, data):

--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -93,11 +93,11 @@ class PackageCommand(BasicCommand):
         },
 
         {
-            "name": "use-yaml",
+            "name": "use-json",
             "action": "store_true",
             "help_text": (
-                "Indicates whether to use YAML as the format for the output AWS"
-                " CloudFormation template. JSON is used by default."
+                "Indicates whether to use JSON as the format for the output AWS"
+                " CloudFormation template. YAML is used by default."
             )
         },
 
@@ -134,8 +134,8 @@ class PackageCommand(BasicCommand):
                                       parsed_args.force_upload)
 
         output_file = parsed_args.output_template_file
-        use_yaml = parsed_args.use_yaml
-        exported_str = self._export(template_path, use_yaml)
+        use_json = parsed_args.use_json
+        exported_str = self._export(template_path, use_json)
 
         sys.stdout.write("\n")
         self.write_output(output_file, exported_str)
@@ -149,14 +149,14 @@ class PackageCommand(BasicCommand):
         sys.stdout.flush()
         return 0
 
-    def _export(self, template_path, use_yaml):
+    def _export(self, template_path, use_json):
         template = Template(template_path, os.getcwd(), self.s3_uploader)
         exported_template = template.export()
-        
-        if use_yaml:
-            exported_str = yaml_dump(exported_template)
-        else:
+
+        if use_json:
             exported_str = json.dumps(exported_template, indent=4, ensure_ascii=False)
+        else:
+            exported_str = yaml_dump(exported_template)
 
         return exported_str
 

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -53,12 +53,18 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     return {cfntag: value}
 
 
+def str_representer(dumper, node):
+    return ScalarNode(tag='tag:yaml.org,2002:str', value=node, style='\'')
+    
+
 def yaml_dump(dict_to_dump):
     """
     Dumps the dictionary as a YAML document
     :param dict_to_dump:
     :return:
     """
+    yaml.SafeDumper.add_representer(str, str_representer)
+
     return yaml.safe_dump(dict_to_dump, default_flow_style=False)
 
 

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -53,18 +53,12 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     return {cfntag: value}
 
 
-def str_representer(dumper, node):
-    return ScalarNode(tag='tag:yaml.org,2002:str', value=node, style='\'')
-    
-
 def yaml_dump(dict_to_dump):
     """
     Dumps the dictionary as a YAML document
     :param dict_to_dump:
     :return:
     """
-    yaml.SafeDumper.add_representer(str, str_representer)
-
     return yaml.safe_dump(dict_to_dump, default_flow_style=False)
 
 

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -52,7 +52,7 @@ class TestPackageCommand(unittest.TestCase):
                                     s3_prefix="s3prefix",
                                     kms_key_id="kmskeyid",
                                     output_template_file="./oputput",
-                                    use_yaml=False,
+                                    use_json=False,
                                     force_upload=False)
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
@@ -61,7 +61,6 @@ class TestPackageCommand(unittest.TestCase):
 
     @patch("awscli.customizations.cloudformation.package.yaml_dump")
     def test_main(self, mock_yaml_dump):
-        exported_template = {}
         exported_template_str = "hello"
 
         self.package_command.write_output = Mock()
@@ -70,16 +69,22 @@ class TestPackageCommand(unittest.TestCase):
 
         # Create a temporary file and make this my template
         with tempfile.NamedTemporaryFile() as handle:
-            filename = handle.name
-            use_yaml = self.parsed_args.use_yaml
-            self.parsed_args.template_file = filename
+            for use_json in (False, True):
+                filename = handle.name
+                self.parsed_args.template_file = filename
+                self.parsed_args.use_json=use_json
 
-            rc = self.package_command._run_main(self.parsed_args, self.parsed_globals)
-            self.assertEquals(rc, 0)
+                rc = self.package_command._run_main(self.parsed_args, self.parsed_globals)
+                self.assertEquals(rc, 0)
 
-            self.package_command._export.assert_called_once_with(filename, use_yaml)
-            self.package_command.write_output.assert_called_once_with(
-                    self.parsed_args.output_template_file, mock.ANY)
+                self.package_command._export.assert_called_once_with(filename, use_json)
+                self.package_command.write_output.assert_called_once_with(
+                        self.parsed_args.output_template_file, mock.ANY)
+
+                self.package_command._export.reset_mock()
+                self.package_command.write_output.reset_mock()
+
+
 
     def test_main_error(self):
 

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -71,12 +71,13 @@ class TestPackageCommand(unittest.TestCase):
         # Create a temporary file and make this my template
         with tempfile.NamedTemporaryFile() as handle:
             filename = handle.name
+            use_yaml = self.parsed_args.use_yaml
             self.parsed_args.template_file = filename
 
             rc = self.package_command._run_main(self.parsed_args, self.parsed_globals)
             self.assertEquals(rc, 0)
 
-            self.package_command._export.assert_called_once_with(filename)
+            self.package_command._export.assert_called_once_with(filename, use_yaml)
             self.package_command.write_output.assert_called_once_with(
                     self.parsed_args.output_template_file, mock.ANY)
 

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -52,6 +52,7 @@ class TestPackageCommand(unittest.TestCase):
                                     s3_prefix="s3prefix",
                                     kms_key_id="kmskeyid",
                                     output_template_file="./oputput",
+                                    use_yaml=False,
                                     force_upload=False)
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)


### PR DESCRIPTION
Use JSON as default format for output of "aws cloudformation package" command, added an flag for YAML.