### PR TITLE
Hardcode the command name as `aws`

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -113,13 +113,14 @@ class MainArgParser(CLIArgParser):
     Formatter = argparse.RawTextHelpFormatter
 
     def __init__(self, command_table, version_string,
-                 description, argument_table):
+                 description, argument_table, prog=None):
         super(MainArgParser, self).__init__(
             formatter_class=self.Formatter,
             add_help=False,
             conflict_handler='resolve',
             description=description,
-            usage=USAGE)
+            usage=USAGE,
+            prog=prog)
         self._build(command_table, version_string, argument_table)
 
     def _create_choice_help(self, choices):

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -172,7 +172,8 @@ class CLIDriver(object):
         parser = MainArgParser(
             command_table, self.session.user_agent(),
             cli_data.get('description', None),
-            self._get_argument_table())
+            self._get_argument_table(),
+            prog="aws")
         return parser
 
     def main(self, args=None):


### PR DESCRIPTION
This presents errors from being shown as ``__main__.py`` when using ``python -m awscli``.