### PR TITLE
Adds support for S3 HTTPS urls

### DIFF
--- a/.changes/next-release/enhancement-cloudformation-88566.json
+++ b/.changes/next-release/enhancement-cloudformation-88566.json
@@ -1,0 +1,5 @@
+{
+  "category": "cloudformation",
+  "description": "Added support for S3 HTTPS urls.",
+  "type": "enhancement"
+}

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -328,7 +328,7 @@ class CloudFormationStackResource(Resource):
 
         template_path = resource_dict.get(self.PROPERTY_NAME, None)
 
-        if template_path is None or is_s3_url(template_path):
+        if template_path is None or is_s3_url(template_path) or template_path.startswith("https://s3.amazonaws.com/"):
             # Nothing to do
             return
 

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -60,28 +60,47 @@ def parse_s3_url(url,
                  object_key_property="Key",
                  version_property=None):
 
-    if isinstance(url, six.string_types) \
-            and url.startswith("s3://"):
+    if isinstance(url, six.string_types):
+        if url.startswith("s3://"):
+            # Python < 2.7.10 don't parse query parameters from URI with custom
+            # scheme such as s3://blah/blah. As a workaround, remove scheme
+            # altogether to trigger the parser "s3://foo/bar?v=1" =>"//foo/bar?v=1"
+            parsed = urlparse.urlparse(url[3:])
+            query = urlparse.parse_qs(parsed.query)
 
-        # Python < 2.7.10 don't parse query parameters from URI with custom
-        # scheme such as s3://blah/blah. As a workaround, remove scheme
-        # altogether to trigger the parser "s3://foo/bar?v=1" =>"//foo/bar?v=1"
-        parsed = urlparse.urlparse(url[3:])
-        query = urlparse.parse_qs(parsed.query)
+            if parsed.netloc and parsed.path:
+                result = dict()
+                result[bucket_name_property] = parsed.netloc
+                result[object_key_property] = parsed.path.lstrip('/')
 
-        if parsed.netloc and parsed.path:
-            result = dict()
-            result[bucket_name_property] = parsed.netloc
-            result[object_key_property] = parsed.path.lstrip('/')
+                # If there is a query string that has a single versionId field,
+                # set the object version and return
+                if version_property is not None \
+                        and 'versionId' in query \
+                        and len(query['versionId']) == 1:
+                    result[version_property] = query['versionId'][0]
 
-            # If there is a query string that has a single versionId field,
-            # set the object version and return
-            if version_property is not None \
-                    and 'versionId' in query \
-                    and len(query['versionId']) == 1:
-                result[version_property] = query['versionId'][0]
+                return result
 
-            return result
+        elif url.startswith("https://s3.amazonaws.com/"):
+            parsed = urlparse.urlparse(url)
+            query = urlparse.parse_qs(parsed.query)
+
+            folders = parsed.path.lstrip('/').split('/')
+
+            if len(folders) >= 2:
+                result = dict()
+                result[bucket_name_property] = folders[0]
+                result[object_key_property] = '/'.join(folders[1:])
+
+                # If there is a query string that has a single versionId field,
+                # set the object version and return
+                if version_property is not None \
+                        and 'versionId' in query \
+                        and len(query['versionId']) == 1:
+                    result[version_property] = query['versionId'][0]
+
+                return result
 
     raise ValueError("URL given to the parse method is not a valid S3 url "
                      "{0}".format(url))

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -82,7 +82,7 @@ def parse_s3_url(url,
 
                 return result
 
-        elif url.startswith("https://s3.amazonaws.com/"):
+        elif url.startswith("https://s3."):
             parsed = urlparse.urlparse(url)
             query = urlparse.parse_qs(parsed.query)
 

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -91,16 +91,19 @@ def parse_s3_url(url,
             if len(folders) >= 2:
                 result = dict()
                 result[bucket_name_property] = folders[0]
-                result[object_key_property] = '/'.join(folders[1:])
 
-                # If there is a query string that has a single versionId field,
-                # set the object version and return
-                if version_property is not None \
-                        and 'versionId' in query \
-                        and len(query['versionId']) == 1:
-                    result[version_property] = query['versionId'][0]
+                object_key = '/'.join(folders[1:])
+                if object_key:
+                    result[object_key_property] = object_key
 
-                return result
+                    # If there is a query string that has a single versionId field,
+                    # set the object version and return
+                    if version_property is not None \
+                            and 'versionId' in query \
+                            and len(query['versionId']) == 1:
+                        result[version_property] = query['versionId'][0]
+
+                    return result
 
     raise ValueError("URL given to the parse method is not a valid S3 url "
                      "{0}".format(url))

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -60,50 +60,28 @@ def parse_s3_url(url,
                  object_key_property="Key",
                  version_property=None):
 
-    if isinstance(url, six.string_types):
-        if url.startswith("s3://"):
-            # Python < 2.7.10 don't parse query parameters from URI with custom
-            # scheme such as s3://blah/blah. As a workaround, remove scheme
-            # altogether to trigger the parser "s3://foo/bar?v=1" =>"//foo/bar?v=1"
-            parsed = urlparse.urlparse(url[3:])
-            query = urlparse.parse_qs(parsed.query)
+    if isinstance(url, six.string_types) \
+            and url.startswith("s3://"):
 
-            if parsed.netloc and parsed.path:
-                result = dict()
-                result[bucket_name_property] = parsed.netloc
-                result[object_key_property] = parsed.path.lstrip('/')
+        # Python < 2.7.10 don't parse query parameters from URI with custom
+        # scheme such as s3://blah/blah. As a workaround, remove scheme
+        # altogether to trigger the parser "s3://foo/bar?v=1" =>"//foo/bar?v=1"
+        parsed = urlparse.urlparse(url[3:])
+        query = urlparse.parse_qs(parsed.query)
 
-                # If there is a query string that has a single versionId field,
-                # set the object version and return
-                if version_property is not None \
-                        and 'versionId' in query \
-                        and len(query['versionId']) == 1:
-                    result[version_property] = query['versionId'][0]
+        if parsed.netloc and parsed.path:
+            result = dict()
+            result[bucket_name_property] = parsed.netloc
+            result[object_key_property] = parsed.path.lstrip('/')
 
-                return result
+            # If there is a query string that has a single versionId field,
+            # set the object version and return
+            if version_property is not None \
+                    and 'versionId' in query \
+                    and len(query['versionId']) == 1:
+                result[version_property] = query['versionId'][0]
 
-        elif url.startswith("https://s3."):
-            parsed = urlparse.urlparse(url)
-            query = urlparse.parse_qs(parsed.query)
-
-            folders = parsed.path.lstrip('/').split('/')
-
-            if len(folders) >= 2:
-                result = dict()
-                result[bucket_name_property] = folders[0]
-
-                object_key = '/'.join(folders[1:])
-                if object_key:
-                    result[object_key_property] = object_key
-
-                    # If there is a query string that has a single versionId field,
-                    # set the object version and return
-                    if version_property is not None \
-                            and 'versionId' in query \
-                            and len(query['versionId']) == 1:
-                        result[version_property] = query['versionId'][0]
-
-                    return result
+            return result
 
     raise ValueError("URL given to the parse method is not a valid S3 url "
                      "{0}".format(url))

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -550,6 +550,18 @@ class TestArtifactExporter(unittest.TestCase):
         self.assertEquals(resource_dict[property_name], s3_url)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
+    def test_export_cloudformation_stack_no_upload_path_is_httpsurl(self):
+        stack_resource = CloudFormationStackResource(self.s3_uploader_mock)
+        resource_id = "id"
+        property_name = stack_resource.PROPERTY_NAME
+        s3_url = "https://s3.amazonaws.com/hello/world"
+        resource_dict = {property_name: s3_url}
+
+        # Case 1: Path is already S3 url
+        stack_resource.export(resource_id, resource_dict, "dir")
+        self.assertEquals(resource_dict[property_name], s3_url)
+        self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+
     def test_export_cloudformation_stack_no_upload_path_is_empty(self):
         stack_resource = CloudFormationStackResource(self.s3_uploader_mock)
         resource_id = "id"

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -29,14 +29,6 @@ def test_is_s3_url():
         "s3://foo/bar/baz?versionId=abc",
         "s3://www.amazon.com/foo/bar",
         "s3://my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
-
-        "https://s3.amazonaws.com/foo/bar",
-        "https://s3.amazonaws.com/foo/bar/baz/cat/dog",
-        "https://s3.amazonaws.com/foo/bar?versionId=abc",
-        "https://s3.amazonaws.com/foo/bar/baz?versionId=abc&versionId=123",
-        "https://s3.amazonaws.com/foo/bar/baz?versionId=abc",
-        "https://s3.amazonaws.com/www.amazon.com/foo/bar",
-        "https://s3.amazonaws.com/my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
     ]
 
     invalid = [
@@ -44,10 +36,6 @@ def test_is_s3_url():
         # For purposes of exporter, we need S3 URLs to point to an object
         # and not a bucket
         "s3://foo",
-        "https://s3.amazonaws.com/foo",
-        "https://s3.amazonaws.com/foo/",
-        "https://s3.us-west-2.amazonaws.com/",
-
 
         # two versionIds is invalid
         "https://s3-eu-west-1.amazonaws.com/bucket/key",
@@ -64,19 +52,10 @@ def _assert_is_valid_s3_url(url):
     assert_true(is_s3_url(url), "{0} should be valid".format(url))
 
 def _assert_is_invalid_s3_url(url):
-    assert_false(is_s3_url(url), "{0} should be invalid".format(url))
+    assert_false(is_s3_url(url), "{0} should be valid".format(url))
 
-def test_all_resources_export_s3():
+def test_all_resources_export():
     uploaded_s3_url = "s3://foo/bar?versionId=baz"
-
-    _helper_all_resources_export(uploaded_s3_url)
-
-def test_all_resources_export_https():
-    uploaded_s3_url = "https://s3.amazonaws.com/foo/bar?versionId=baz"
-
-    _helper_all_resources_export(uploaded_s3_url)
-
-def _helper_all_resources_export(uploaded_s3_url):
 
     setup = [
         {
@@ -180,60 +159,6 @@ class TestArtifactExporter(unittest.TestCase):
             # For purposes of exporter, we need S3 URLs to point to an object
             # and not a bucket
             "s3://foo",
-            "https://s3.amazonaws.com/foo",
-            "https://s3.amazonaws.com/foo/",
-            "https://s3.us-west-2.amazonaws.com/",
-
-
-            # two versionIds is invalid
-            "https://s3-eu-west-1.amazonaws.com/bucket/key",
-            "https://www.amazon.com"
-        ]
-
-        for config in valid:
-            result = parse_s3_url(config["url"],
-                                  bucket_name_property="Bucket",
-                                  object_key_property="Key",
-                                  version_property="VersionId")
-
-            self.assertEquals(result, config["result"])
-
-        for url in invalid:
-            with self.assertRaises(ValueError):
-                parse_s3_url(url)
-
-    def test_parse_https_s3_url(self):
-
-        valid = [
-            {
-                "url": "https://s3.amazonaws.com/foo/bar",
-                "result": {"Bucket": "foo", "Key": "bar"}
-            },
-            {
-                "url": "https://s3.amazonaws.com/foo/bar/cat/dog",
-                "result": {"Bucket": "foo", "Key": "bar/cat/dog"}
-            },
-            {
-                "url": "https://s3.amazonaws.com/foo/bar/baz?versionId=abc&param1=val1&param2=val2",
-                "result": {"Bucket": "foo", "Key": "bar/baz", "VersionId": "abc"}
-            },
-            {
-                # VersionId is not returned if there are more than one versionId
-                # keys in query parameter
-                "url": "https://s3.amazonaws.com/foo/bar/baz?versionId=abc&versionId=123",
-                "result": {"Bucket": "foo", "Key": "bar/baz"}
-            }
-        ]
-
-        invalid = [
-
-            # For purposes of exporter, we need S3 URLs to point to an object
-            # and not a bucket
-            "s3://foo",
-            "https://s3.amazonaws.com/foo",
-            "https://s3.amazonaws.com/foo/",
-            "https://s3.us-west-2.amazonaws.com/",
-
 
             # two versionIds is invalid
             "https://s3-eu-west-1.amazonaws.com/bucket/key",

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -29,6 +29,14 @@ def test_is_s3_url():
         "s3://foo/bar/baz?versionId=abc",
         "s3://www.amazon.com/foo/bar",
         "s3://my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
+
+        "https://s3.amazonaws.com/foo/bar",
+        "https://s3.amazonaws.com/foo/bar/baz/cat/dog",
+        "https://s3.amazonaws.com/foo/bar?versionId=abc",
+        "https://s3.amazonaws.com/foo/bar/baz?versionId=abc&versionId=123",
+        "https://s3.amazonaws.com/foo/bar/baz?versionId=abc",
+        "https://s3.amazonaws.com/www.amazon.com/foo/bar",
+        "https://s3.amazonaws.com/my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
     ]
 
     invalid = [
@@ -36,6 +44,10 @@ def test_is_s3_url():
         # For purposes of exporter, we need S3 URLs to point to an object
         # and not a bucket
         "s3://foo",
+        "https://s3.amazonaws.com/foo",
+        "https://s3.amazonaws.com/foo/",
+        "https://s3.us-west-2.amazonaws.com/",
+
 
         # two versionIds is invalid
         "https://s3-eu-west-1.amazonaws.com/bucket/key",
@@ -52,10 +64,19 @@ def _assert_is_valid_s3_url(url):
     assert_true(is_s3_url(url), "{0} should be valid".format(url))
 
 def _assert_is_invalid_s3_url(url):
-    assert_false(is_s3_url(url), "{0} should be valid".format(url))
+    assert_false(is_s3_url(url), "{0} should be invalid".format(url))
 
-def test_all_resources_export():
+def test_all_resources_export_s3():
     uploaded_s3_url = "s3://foo/bar?versionId=baz"
+
+    _helper_all_resources_export(uploaded_s3_url)
+
+def test_all_resources_export_https():
+    uploaded_s3_url = "https://s3.amazonaws.com/foo/bar?versionId=baz"
+
+    _helper_all_resources_export(uploaded_s3_url)
+
+def _helper_all_resources_export(uploaded_s3_url):
 
     setup = [
         {
@@ -159,6 +180,60 @@ class TestArtifactExporter(unittest.TestCase):
             # For purposes of exporter, we need S3 URLs to point to an object
             # and not a bucket
             "s3://foo",
+            "https://s3.amazonaws.com/foo",
+            "https://s3.amazonaws.com/foo/",
+            "https://s3.us-west-2.amazonaws.com/",
+
+
+            # two versionIds is invalid
+            "https://s3-eu-west-1.amazonaws.com/bucket/key",
+            "https://www.amazon.com"
+        ]
+
+        for config in valid:
+            result = parse_s3_url(config["url"],
+                                  bucket_name_property="Bucket",
+                                  object_key_property="Key",
+                                  version_property="VersionId")
+
+            self.assertEquals(result, config["result"])
+
+        for url in invalid:
+            with self.assertRaises(ValueError):
+                parse_s3_url(url)
+
+    def test_parse_https_s3_url(self):
+
+        valid = [
+            {
+                "url": "https://s3.amazonaws.com/foo/bar",
+                "result": {"Bucket": "foo", "Key": "bar"}
+            },
+            {
+                "url": "https://s3.amazonaws.com/foo/bar/cat/dog",
+                "result": {"Bucket": "foo", "Key": "bar/cat/dog"}
+            },
+            {
+                "url": "https://s3.amazonaws.com/foo/bar/baz?versionId=abc&param1=val1&param2=val2",
+                "result": {"Bucket": "foo", "Key": "bar/baz", "VersionId": "abc"}
+            },
+            {
+                # VersionId is not returned if there are more than one versionId
+                # keys in query parameter
+                "url": "https://s3.amazonaws.com/foo/bar/baz?versionId=abc&versionId=123",
+                "result": {"Bucket": "foo", "Key": "bar/baz"}
+            }
+        ]
+
+        invalid = [
+
+            # For purposes of exporter, we need S3 URLs to point to an object
+            # and not a bucket
+            "s3://foo",
+            "https://s3.amazonaws.com/foo",
+            "https://s3.amazonaws.com/foo/",
+            "https://s3.us-west-2.amazonaws.com/",
+
 
             # two versionIds is invalid
             "https://s3-eu-west-1.amazonaws.com/bucket/key",


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/2564

This adds logic for supporting https://s3.amazonaws.com as a supported s3 URL.