### PR TITLE
Fix RDS tests for 2.6

### DIFF
--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -65,4 +65,5 @@ class TestGenerateDBAuthToken(BaseAWSCommandParamsTest):
             '36c6c9a0c5e0e362'
         )
 
-        self.assert_url_equal(stdout.strip('\n'), expected)
+        self.assert_url_equal(
+            'https://' + stdout.strip('\n'), 'https://' + expected)


### PR DESCRIPTION
This injects a scheme into some compared urls as urlsplit will fail
to properly split if the scheme is absent in some versions.

I have successfully run the tests on Windows.