### PR TITLE
cloudformation deploy: Use parameter default value only on stack creation

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -197,11 +197,6 @@ class DeployCommand(BasicCommand):
 
         for key, value in template_dict["Parameters"].items():
 
-            if key not in parameter_overrides and "Default" in value:
-                # Parameters that have default value and not overridden, should not be
-                # passed to CloudFormation
-                continue
-
             obj = {
                 "ParameterKey": key
             }

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -90,6 +90,11 @@ class Deployer(object):
         changeset_type = "UPDATE"
         if not self.has_stack(stack_name):
             changeset_type = "CREATE"
+            # When creating a new stack, UsePreviousValue=True is invalid.
+            # For such parameters, users should either override with new value,
+            # or set a Default value in template to successfully create a stack.
+            parameter_values = [x for x in parameter_values
+                                if not x.get("UsePreviousValue", False)]
 
         try:
             resp = self._client.create_change_set(

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -260,7 +260,9 @@ class TestDeployCommand(unittest.TestCase):
             {"ParameterKey": "Key2", "UsePreviousValue": True},
             {"ParameterKey": "Key4", "UsePreviousValue": True},
 
-            # Parameter with default value is NOT sent to CloudFormation
+            # Parameter with default value but NOT overridden.
+            # Use previous value, but this gets removed later when we are creating stack for first time
+            {"ParameterKey": "KeyWithDefaultValue", "UsePreviousValue": True},
         ]
 
         self.assertItemsEqual(


### PR DESCRIPTION
There are four state combinations:
YES Override + YES Stack: Use overriden value
YES Override + NO Stack: Use overriden value

NO Override + YES Stack: Set UsePreviousValue to True
  ^^ This commit fixes this case. Earlier we were letting CloudFormation pickup default value from template

NO Override + NO Stack: Skip parameter to force CloudFormation to use template default value. UsePreviousValue=True will fail here because stack does not have any previous state.