### PR TITLE
Adding models now supports unicode models.

### DIFF
--- a/awscli/customizations/configure/addmodel.py
+++ b/awscli/customizations/configure/addmodel.py
@@ -114,7 +114,7 @@ class AddModelCommand(BasicCommand):
             os.makedirs(model_directory)
 
         # Write the model to the specified location
-        with open(model_location, 'w') as f:
-            f.write(parsed_args.service_model)
+        with open(model_location, 'wb') as f:
+            f.write(parsed_args.service_model.encode('utf-8'))
 
         return 0


### PR DESCRIPTION
Adding models in py2 with unicode characters in them didn't work.

cc @jamesls @JordonPhillips @dstufft @kyleknap 