### PR TITLE
cloudformation deploy - exit nonzero when no stack change

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -186,13 +186,17 @@ class DeployCommand(BasicCommand):
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
                notification_arns):
-        result = deployer.create_and_wait_for_changeset(
-                stack_name=stack_name,
-                cfn_template=template_str,
-                parameter_values=parameters,
-                capabilities=capabilities,
-                role_arn=role_arn,
-                notification_arns=notification_arns)
+        try:
+            result = deployer.create_and_wait_for_changeset(
+                    stack_name=stack_name,
+                    cfn_template=template_str,
+                    parameter_values=parameters,
+                    capabilities=capabilities,
+                    role_arn=role_arn,
+                    notification_arns=notification_arns)
+        except exceptions.ChangeEmptyError as ex:
+            sys.stdout.write("%s\n" % ex)
+            return 0
 
         if execute_changeset:
             deployer.execute_changeset(result.changeset_id, stack_name)

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -127,6 +127,29 @@ class DeployCommand(BasicCommand):
                 ' executing the change set. After you view the change set,'
                 ' execute it to implement your changes.'
             )
+        },
+        {
+            'name': 'role-arn',
+            'required': False,
+            'help_text': (
+                'The Amazon Resource Name (ARN) of an AWS Identity and Access '
+                'Management (IAM) role that AWS CloudFormation assumes when '
+                'executing the change set.'
+            )
+        },
+        {
+            'name': 'notification-arns',
+            'required': False,
+            'schema': {
+                'type': 'array',
+                'items': {
+                    'type': 'string'
+                }
+            },
+            'help_text': (
+                'Amazon Simple Notification Service topic Amazon Resource Names'
+                ' (ARNs) that AWS CloudFormation associates with the stack.'
+            )
         }
     ]
 
@@ -157,15 +180,19 @@ class DeployCommand(BasicCommand):
         deployer = Deployer(cloudformation_client)
         return self.deploy(deployer, stack_name, template_str,
                            parameters, parsed_args.capabilities,
-                           parsed_args.execute_changeset)
+                           parsed_args.execute_changeset, parsed_args.role_arn,
+                           parsed_args.notification_arns)
 
     def deploy(self, deployer, stack_name, template_str,
-               parameters, capabilities, execute_changeset):
+               parameters, capabilities, execute_changeset, role_arn,
+               notification_arns):
         result = deployer.create_and_wait_for_changeset(
                 stack_name=stack_name,
                 cfn_template=template_str,
                 parameter_values=parameters,
-                capabilities=capabilities)
+                capabilities=capabilities,
+                role_arn=role_arn,
+                notification_arns=notification_arns)
 
         if execute_changeset:
             deployer.execute_changeset(result.changeset_id, stack_name)

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -70,7 +70,8 @@ class Deployer(object):
                 raise e
 
     def create_changeset(self, stack_name, cfn_template,
-                         parameter_values, capabilities):
+                         parameter_values, capabilities, role_arn,
+                         notification_arns):
         """
         Call Cloudformation to create a changeset and wait for it to complete
 
@@ -96,16 +97,22 @@ class Deployer(object):
             parameter_values = [x for x in parameter_values
                                 if not x.get("UsePreviousValue", False)]
 
+        kwargs = dict(
+            ChangeSetName=changeset_name,
+            StackName=stack_name,
+            TemplateBody=cfn_template,
+            ChangeSetType=changeset_type,
+            Parameters=parameter_values,
+            Capabilities=capabilities,
+            Description=description,
+        )
+        # don't set these arguments if not specified to use existing values
+        if role_arn is not None:
+            kwargs['RoleARN'] = role_arn
+        if notification_arns is not None:
+            kwargs['NotificationARNs'] = notification_arns
         try:
-            resp = self._client.create_change_set(
-                    ChangeSetName=changeset_name,
-                    StackName=stack_name,
-                    TemplateBody=cfn_template,
-                    ChangeSetType=changeset_type,
-                    Parameters=parameter_values,
-                    Capabilities=capabilities,
-                    Description=description
-            )
+            resp = self._client.create_change_set(**kwargs)
             return ChangeSetResult(resp["Id"], changeset_type)
         except Exception as ex:
             LOG.debug("Unable to create changeset", exc_info=ex)
@@ -177,10 +184,12 @@ class Deployer(object):
             raise exceptions.DeployFailedError(stack_name=stack_name)
 
     def create_and_wait_for_changeset(self, stack_name, cfn_template,
-                                      parameter_values, capabilities):
+                                      parameter_values, capabilities, role_arn,
+                                      notification_arns):
 
         result = self.create_changeset(
-                stack_name, cfn_template, parameter_values, capabilities)
+                stack_name, cfn_template, parameter_values, capabilities,
+                role_arn, notification_arns)
 
         self.wait_for_changeset(result.changeset_id, stack_name)
 

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -143,7 +143,7 @@ class Deployer(object):
             reason = resp["StatusReason"]
 
             if status == "FAILED" and \
-               "No updates are to be performed" in reason:
+               "The submitted information didn't contain changes." in reason:
                     raise exceptions.ChangeEmptyError(stack_name=stack_name)
 
             raise RuntimeError("Failed to create the changeset: {0} "

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -54,7 +54,9 @@ class TestDeployCommand(unittest.TestCase):
                                                          "Key2=Value2"],
                                     no_execute_changeset=False,
                                     execute_changeset=True,
-                                    capabilities=None)
+                                    capabilities=None,
+                                    role_arn=None,
+                                    notification_arns=[])
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
         self.deploy_command = DeployCommand(self.session)
@@ -105,7 +107,9 @@ class TestDeployCommand(unittest.TestCase):
                         mock.ANY,
                         fake_parameters,
                         None,
-                        not self.parsed_args.no_execute_changeset)
+                        not self.parsed_args.no_execute_changeset,
+                        None,
+                        [])
 
                 self.deploy_command.parse_parameter_arg.assert_called_once_with(
                         self.parsed_args.parameter_overrides)
@@ -134,6 +138,9 @@ class TestDeployCommand(unittest.TestCase):
         capabilities = ["foo", "bar"]
         execute_changeset = True
         changeset_type = "CREATE"
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+
 
         # Set the mock to return this fake changeset_id
         self.deployer.create_and_wait_for_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -143,14 +150,18 @@ class TestDeployCommand(unittest.TestCase):
                                    template,
                                    parameters,
                                    capabilities,
-                                   execute_changeset)
+                                   execute_changeset,
+                                   role_arn,
+                                   notification_arns)
         self.assertEqual(rc, 0)
 
 
         self.deployer.create_and_wait_for_changeset.assert_called_once_with(stack_name=stack_name,
                                                      cfn_template=template,
                                                      parameter_values=parameters,
-                                                     capabilities=capabilities)
+                                                     capabilities=capabilities,
+                                                     role_arn=role_arn,
+                                                     notification_arns=notification_arns)
 
         # since execute_changeset is set to True, deploy() will execute changeset
         self.deployer.execute_changeset.assert_called_once_with(changeset_id, stack_name)
@@ -164,6 +175,8 @@ class TestDeployCommand(unittest.TestCase):
         template = "cloudformation template"
         capabilities = ["foo", "bar"]
         execute_changeset = False
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
 
 
         self.deployer.create_and_wait_for_changeset.return_value = ChangeSetResult(changeset_id, "CREATE")
@@ -172,13 +185,17 @@ class TestDeployCommand(unittest.TestCase):
                                             template,
                                             parameters,
                                             capabilities,
-                                            execute_changeset)
+                                            execute_changeset,
+                                            role_arn,
+                                            notification_arns)
         self.assertEqual(rc, 0)
 
         self.deployer.create_and_wait_for_changeset.assert_called_once_with(stack_name=stack_name,
                                                      cfn_template=template,
                                                      parameter_values=parameters,
-                                                     capabilities=capabilities)
+                                                     capabilities=capabilities,
+                                                     role_arn=role_arn,
+                                                     notification_arns=notification_arns)
 
         # since execute_changeset is set to True, deploy() will execute changeset
         self.deployer.execute_changeset.assert_not_called()
@@ -191,6 +208,9 @@ class TestDeployCommand(unittest.TestCase):
         template = "cloudformation template"
         capabilities = ["foo", "bar"]
         execute_changeset = True
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+
 
         self.deployer.wait_for_execute.side_effect = RuntimeError("Some error")
         with self.assertRaises(RuntimeError):
@@ -199,7 +219,9 @@ class TestDeployCommand(unittest.TestCase):
                                        template,
                                        parameters,
                                        capabilities,
-                                       execute_changeset)
+                                       execute_changeset,
+                                       role_arn,
+                                       notification_arns)
 
 
     def test_parse_parameter_arg_success(self):

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -243,7 +243,7 @@ class TestDeployer(unittest.TestCase):
 
         response = {
             "Status": "FAILED",
-            "StatusReason": "No updates are to be performed"
+            "StatusReason": "The submitted information didn't contain changes."
         }
 
         waiter_error = botocore.exceptions.WaiterError(name="name",

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -101,6 +101,8 @@ class TestDeployer(unittest.TestCase):
             {"ParameterKey": "Key3", "UsePreviousValue": False},
         ]
         capabilities = ["capabilities"]
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
 
         # Case 1: Stack DOES NOT exist
         self.deployer.has_stack = Mock()
@@ -113,7 +115,9 @@ class TestDeployer(unittest.TestCase):
             "ChangeSetType": "CREATE",
             "Parameters": filtered_parameters,
             "Capabilities": capabilities,
-            "Description": botocore.stub.ANY
+            "Description": botocore.stub.ANY,
+            "RoleARN": role_arn,
+            "NotificationARNs": notification_arns
         }
 
         response = {
@@ -124,7 +128,8 @@ class TestDeployer(unittest.TestCase):
                                       expected_params)
         with self.stub_client:
             result = self.deployer.create_changeset(
-                    stack_name, template, parameters, capabilities)
+                    stack_name, template, parameters, capabilities, role_arn,
+                    notification_arns)
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("CREATE", result.changeset_type)
 
@@ -136,7 +141,8 @@ class TestDeployer(unittest.TestCase):
                                       expected_params)
         with self.stub_client:
             result = self.deployer.create_changeset(
-                    stack_name, template, parameters, capabilities)
+                    stack_name, template, parameters, capabilities, role_arn,
+                    notification_arns)
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("UPDATE", result.changeset_type)
 
@@ -146,6 +152,8 @@ class TestDeployer(unittest.TestCase):
         parameters = [{"ParameterKey": "Key1", "ParameterValue": "Value",
                        "UsePreviousValue": True}]
         capabilities = ["capabilities"]
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
 
         self.deployer.has_stack = Mock()
         self.deployer.has_stack.return_value = False
@@ -154,7 +162,8 @@ class TestDeployer(unittest.TestCase):
                 'create_change_set', "Somethign is wrong", "Service is bad")
         with self.stub_client:
             with self.assertRaises(botocore.exceptions.ClientError):
-                self.deployer.create_changeset(stack_name, template, parameters, capabilities)
+                self.deployer.create_changeset(stack_name, template, parameters,
+                capabilities, role_arn, notification_arns)
 
     def test_execute_changeset(self):
         stack_name = "stack_name"
@@ -187,6 +196,8 @@ class TestDeployer(unittest.TestCase):
         capabilities = ["capabilities"]
         changeset_id = "changeset id"
         changeset_type = "changeset type"
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
 
         self.deployer.create_changeset = Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -194,7 +205,8 @@ class TestDeployer(unittest.TestCase):
         self.deployer.wait_for_changeset = Mock()
 
         result = self.deployer.create_and_wait_for_changeset(
-                stack_name, template, parameters, capabilities)
+                stack_name, template, parameters, capabilities, role_arn,
+                notification_arns)
         self.assertEquals(result.changeset_id, changeset_id)
         self.assertEquals(result.changeset_type, changeset_type)
 
@@ -206,6 +218,8 @@ class TestDeployer(unittest.TestCase):
         capabilities = ["capabilities"]
         changeset_id = "changeset id"
         changeset_type = "changeset type"
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
 
         self.deployer.create_changeset = Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -215,7 +229,8 @@ class TestDeployer(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             result = self.deployer.create_and_wait_for_changeset(
-                    stack_name, template, parameters, capabilities)
+                    stack_name, template, parameters, capabilities, role_arn,
+                    notification_arns)
 
     def test_wait_for_changeset_no_changes(self):
         stack_name = "stack_name"


### PR DESCRIPTION
Seems like a better default and works better with scripted deploy.  But perhaps shouldn't change the default behaviour?