### PR TITLE
Add --include-email/--no-include-email to get-login command

### DIFF
--- a/.changes/next-release/enhancement-ecr-62148.json
+++ b/.changes/next-release/enhancement-ecr-62148.json
@@ -1,0 +1,5 @@
+{
+  "category": "``ecr``", 
+  "type": "enhancement", 
+  "description": "Add ``--include-email/--no-include-email`` to the ``get-login`` command."
+}

--- a/awscli/customizations/ecr.py
+++ b/awscli/customizations/ecr.py
@@ -38,7 +38,31 @@ class ECRLogin(BasicCommand):
                          'Amazon ECR registries that you want to log in to.',
             'required': False,
             'nargs': '+'
-        }
+        },
+        {
+            'name': 'include-email',
+            'action': 'store_true',
+            'group_name': 'include-email',
+            'dest': 'include_email',
+            'default': True,
+            'required': False,
+            'help_text': (
+                "Specify if the '-e' flag should be included in the "
+                "'docker login' command.  The '-e' option has been deprecated "
+                "and is removed in docker version 17.06 and later.  You must "
+                "specify --no-include-email If you're using docker version "
+                "17.06 or later.  The default behavior is to include the "
+                "'-e' flag."),
+        },
+        {
+            'name': 'no-include-email',
+            'help_text': 'Include email arg',
+            'action': 'store_false',
+            'default': True,
+            'group_name': 'include-email',
+            'dest': 'include_email',
+            'required': False,
+        },
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
@@ -52,6 +76,10 @@ class ECRLogin(BasicCommand):
         for auth in result['authorizationData']:
             auth_token = b64decode(auth['authorizationToken']).decode()
             username, password = auth_token.split(':')
-            sys.stdout.write('docker login -u %s -p %s -e none %s\n'
-                             % (username, password, auth['proxyEndpoint']))
+            command = ['docker', 'login', '-u', username, '-p', password]
+            if parsed_args.include_email:
+                command.extend(['-e', 'none'])
+            command.append(auth['proxyEndpoint'])
+            sys.stdout.write(' '.join(command))
+            sys.stdout.write('\n')
         return 0

--- a/tests/functional/ecr/test_get_login.py
+++ b/tests/functional/ecr/test_get_login.py
@@ -15,7 +15,8 @@ from awscli.testutils import BaseAWSCommandParamsTest
 
 
 class TestGetLoginCommand(BaseAWSCommandParamsTest):
-    def test_prints_get_login_command(self):
+    def setUp(self):
+        super(TestGetLoginCommand, self).setUp()
         self.parsed_responses = [
             {
                 'authorizationData': [
@@ -27,11 +28,21 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
                 ]
             },
         ]
-        stdout, _, rc = self.run_cmd("ecr get-login")
+
+    def test_prints_get_login_command(self):
+        stdout = self.run_cmd("ecr get-login")[0]
         self.assertIn(
             'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io', stdout)
         self.assertEquals(1, len(self.operations_called))
         self.assertNotIn('registryIds', self.operations_called[0][1])
+
+    def test_prints_login_command_with_no_email(self):
+        stdout = self.run_cmd("ecr get-login --no-include-email")[0]
+        self.assertNotIn('-e none', stdout)
+
+    def test_prints_login_with_email_flag(self):
+        stdout = self.run_cmd("ecr get-login --include-email")[0]
+        self.assertIn('-e none', stdout)
 
     def test_prints_multiple_get_login_commands(self):
         self.parsed_responses = [
@@ -50,7 +61,7 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
                 ]
             },
         ]
-        stdout, _, rc = self.run_cmd("ecr get-login --registry-ids 1234 5678")
+        stdout = self.run_cmd("ecr get-login --registry-ids 1234 5678")[0]
         self.assertIn(
             'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io\n',
             stdout)


### PR DESCRIPTION
This is to help ease the transition to later versions of docker
where the '-e' option is no longer required and has actually
been removed.  The defaults aren't changing here so there's
no breaking change.

Closes https://github.com/aws/aws-cli/issues/1926

cc @kyleknap @JordonPhillips @stealthycoin @dstufft 