### PR TITLE
[Feature] CloudFormation Package Creates an MD5 Hash of Directory Contents for Artifact Name

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -21,6 +21,7 @@ from awscli.compat import six
 
 from awscli.compat import urlparse
 from contextlib import contextmanager
+from awscli.customizations.cloudformation import utils
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.yamlhelper import yaml_dump, \
     yaml_parse
@@ -146,7 +147,7 @@ def upload_local_artifacts(resource_id, resource_dict, property_name,
 
 def zip_and_upload(local_path, uploader):
     with zip_folder(local_path) as zipfile:
-            return uploader.upload_with_dedup(zipfile)
+            return uploader.upload(local_path, zipfile)
 
 
 @contextmanager
@@ -160,7 +161,7 @@ def zip_folder(folder_path):
     """
 
     filename = os.path.join(
-        tempfile.gettempdir(), "data-" + uuid.uuid4().hex)
+        tempfile.gettempdir(), utils.hash_dir(folder_path))
 
     zipfile_name = make_zip(filename, folder_path)
     try:

--- a/awscli/customizations/cloudformation/s3uploader.py
+++ b/awscli/customizations/cloudformation/s3uploader.py
@@ -23,6 +23,7 @@ from s3transfer.manager import TransferManager
 from s3transfer.subscribers import BaseSubscriber
 
 from awscli.customizations.cloudformation import exceptions
+from awscli.customizations.cloudformation import utils
 
 LOG = logging.getLogger(__name__)
 
@@ -142,25 +143,7 @@ class S3Uploader(object):
             self.bucket_name, obj_path)
 
     def file_checksum(self, file_name):
-
-        with open(file_name, "rb") as file_handle:
-            md5 = hashlib.md5()
-            # Read file in chunks of 4096 bytes
-            block_size = 4096
-
-            # Save current cursor position and reset cursor to start of file
-            curpos = file_handle.tell()
-            file_handle.seek(0)
-
-            buf = file_handle.read(block_size)
-            while len(buf) > 0:
-                md5.update(buf)
-                buf = file_handle.read(block_size)
-
-            # Restore file cursor's position
-            file_handle.seek(curpos)
-
-            return md5.hexdigest()
+        return utils.hash_file(file_name)
 
     def to_path_style_s3_url(self, key, version=None):
         """

--- a/awscli/customizations/cloudformation/utils.py
+++ b/awscli/customizations/cloudformation/utils.py
@@ -1,0 +1,51 @@
+import hashlib
+import os
+
+
+def hash_file(filepath):
+    """Create MD5 hash filename and contents"""
+    md5 = hashlib.md5()
+
+    # Hash filename
+    filename = os.path.basename(filepath)
+    md5.update(filename)
+
+    # md5 file 4096 bytes at a time
+    with open(filepath, "rb") as f:
+        curpos = f.tell()
+        f.seek(0)
+        while True:
+            buff = f.read(4096)
+            if len(buff) == 0:
+                break
+            md5.update(buff)
+        f.seek(curpos)
+    return md5.hexdigest()
+
+
+def hash_dir(base_dirpath):
+    """Create MD5 hash of dirname and contents"""
+    if not os.path.isdir(base_dirpath):
+        raise AttributeError(
+            "dirpath: {0} is not a directory".format(base_dirpath))
+    md5 = hashlib.md5()
+
+    # hash name of directory
+    dirname = os.path.basename(base_dirpath)
+    md5.update(dirname)
+
+    # hash directory contents
+    for root, dirs, files in os.walk(base_dirpath):
+        # hash all nested directories
+        for nested_dir in sorted(dirs):
+            dirpath = os.path.join(root, nested_dir)
+            dirhash = hash_dir(dirpath)
+            md5.update(dirhash)
+
+        # hash all files in the root directory
+        for nested_file in sorted(files):
+            filepath = os.path.join(root, nested_file)
+            filehash = hash_file(filepath)
+            md5.update(filehash)
+
+    return md5.hexdigest()

--- a/awscli/customizations/cloudformation/utils.py
+++ b/awscli/customizations/cloudformation/utils.py
@@ -8,7 +8,7 @@ def hash_file(filepath):
 
     # Hash filename
     filename = os.path.basename(filepath)
-    md5.update(filename)
+    md5.update(filename.encode('UTF-8'))
 
     # md5 file 4096 bytes at a time
     with open(filepath, "rb") as f:
@@ -32,7 +32,7 @@ def hash_dir(base_dirpath):
 
     # hash name of directory
     dirname = os.path.basename(base_dirpath)
-    md5.update(dirname)
+    md5.update(dirname.encode('UTF-8'))
 
     # hash directory contents
     for root, dirs, files in os.walk(base_dirpath):
@@ -40,12 +40,12 @@ def hash_dir(base_dirpath):
         for nested_dir in sorted(dirs):
             dirpath = os.path.join(root, nested_dir)
             dirhash = hash_dir(dirpath)
-            md5.update(dirhash)
+            md5.update(dirhash.encode('UTF-8'))
 
         # hash all files in the root directory
         for nested_file in sorted(files):
             filepath = os.path.join(root, nested_file)
             filehash = hash_file(filepath)
-            md5.update(filehash)
+            md5.update(filehash.encode('UTF-8'))
 
     return md5.hexdigest()

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -341,17 +341,18 @@ class TestArtifactExporter(unittest.TestCase):
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-
-    @patch("awscli.customizations.cloudformation.artifact_exporter.make_zip")
-    def test_zip_folder(self, make_zip_mock):
-        zip_file_name = "name.zip"
-        make_zip_mock.return_value = zip_file_name
+    @patch("awscli.customizations.cloudformation.artifact_exporter.utils")
+    def test_zip_folder(self, utils):
+        zip_file_name = "name"
+        utils.hash_dir = Mock()
+        utils.hash_dir.return_value = zip_file_name
 
         with self.make_temp_dir() as dirname:
-            with zip_folder(dirname) as actual_zip_file_name:
-                self.assertEqual(actual_zip_file_name, zip_file_name)
+            with zip_folder(dirname) as actual_zip_folder:
+                actual_zip_file_name = os.path.basename(actual_zip_folder)
+                self.assertEqual(actual_zip_file_name, zip_file_name + '.zip')
 
-        make_zip_mock.assert_called_once_with(mock.ANY, dirname)
+        utils.hash_dir.assert_called_once_with(dirname)
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource(self, upload_local_artifacts_mock):

--- a/tests/unit/customizations/cloudformation/test_s3uploader.py
+++ b/tests/unit/customizations/cloudformation/test_s3uploader.py
@@ -245,7 +245,7 @@ class TestS3Uploader(unittest.TestCase):
         data = ''.join(random.choice(string.ascii_uppercase)
                        for _ in range(num_chars)).encode('utf-8')
         md5 = hashlib.md5()
-        md5.update(filename)
+        md5.update(filename.encode('UTF-8'))
         md5.update(data)
         expected_checksum = md5.hexdigest()
 

--- a/tests/unit/customizations/cloudformation/test_s3uploader.py
+++ b/tests/unit/customizations/cloudformation/test_s3uploader.py
@@ -240,16 +240,18 @@ class TestS3Uploader(unittest.TestCase):
             uploader.file_exists(key)
 
     def test_file_checksum(self):
+        filename = 'tempfile'
         num_chars = 4096*5
         data = ''.join(random.choice(string.ascii_uppercase)
                        for _ in range(num_chars)).encode('utf-8')
         md5 = hashlib.md5()
+        md5.update(filename)
         md5.update(data)
         expected_checksum = md5.hexdigest()
 
         tempdir = tempfile.mkdtemp()
         try:
-            filename = os.path.join(tempdir, 'tempfile')
+            filename = os.path.join(tempdir, filename)
             with open(filename, 'wb') as f:
                 f.write(data)
 

--- a/tests/unit/customizations/cloudformation/test_utils.py
+++ b/tests/unit/customizations/cloudformation/test_utils.py
@@ -1,0 +1,93 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0e
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+import random
+import shutil
+import string
+import tempfile
+import unittest
+
+from awscli.customizations.cloudformation import utils
+
+
+def random_string(n=10):
+    return ''.join(random.choice(string.ascii_letters) for _ in range(n))
+
+
+def new_temp_file(tempdir):
+    filepath = os.path.join(tempdir, random_string())
+    with open(filepath, "wb") as f:
+        f.write(random_string(100))
+    return filepath
+
+
+def with_temp_dir(f):
+    def test_wrapper(self, *args, **kwargs):
+        tempdir = tempfile.mkdtemp()
+        f(self, tempdir, *args, **kwargs)
+        shutil.rmtree(tempdir)
+    return test_wrapper
+
+
+class TestUtils(unittest.TestCase):
+    @with_temp_dir
+    def test_hash_file(self, tempdir):
+        filepath = new_temp_file(tempdir)
+        first_hash = utils.hash_file(filepath)
+        second_hash = utils.hash_file(filepath)
+        self.assertEquals(first_hash, second_hash)
+
+    @with_temp_dir
+    def test_hash_file_returns_different(self, tempdir):
+        filepath1 = new_temp_file(tempdir)
+        filepath2 = new_temp_file(tempdir)
+        first_hash = utils.hash_file(filepath1)
+        second_hash = utils.hash_file(filepath2)
+        self.assertNotEquals(first_hash, second_hash)
+
+    @with_temp_dir
+    def test_hash_dir(self, tempdir):
+        for _ in range(random.randint(1, 10)):
+            new_temp_file(tempdir)
+        first_hash = utils.hash_dir(tempdir)
+        second_hash = utils.hash_dir(tempdir)
+        self.assertEquals(first_hash, second_hash)
+
+    @with_temp_dir
+    @with_temp_dir
+    def test_hash_dir_different(self, tempdir1, tempdir2):
+        for _ in range(random.randint(1, 10)):
+            new_temp_file(tempdir1)
+        for _ in range(random.randint(1, 10)):
+            new_temp_file(tempdir2)
+        first_hash = utils.hash_dir(tempdir1)
+        second_hash = utils.hash_dir(tempdir2)
+        self.assertNotEquals(first_hash, second_hash)
+
+    @with_temp_dir
+    def test_hash_dir_with_nested_dir(self, tempdir):
+        for _ in range(random.randint(1, 10)):
+            new_temp_file(tempdir)
+        first_hash = utils.hash_dir(tempdir)
+        nested_dir = os.path.join(tempdir, random_string())
+        os.mkdir(nested_dir)
+        for _ in range(random.randint(1, 10)):
+            new_temp_file(nested_dir)
+        second_hash = utils.hash_dir(tempdir)
+        self.assertNotEqual(first_hash, second_hash)
+
+    @with_temp_dir
+    def test_hash_dir_not_dir(self, tempdir):
+        filepath = new_temp_file(tempdir)
+        self.assertRaises(AttributeError, lambda: utils.hash_dir(filepath))

--- a/tests/unit/customizations/cloudformation/test_utils.py
+++ b/tests/unit/customizations/cloudformation/test_utils.py
@@ -28,7 +28,7 @@ def random_string(n=10):
 def new_temp_file(tempdir):
     filepath = os.path.join(tempdir, random_string())
     with open(filepath, "wb") as f:
-        f.write(random_string(100))
+        f.write(random_string(100).encode('UTF-8'))
     return filepath
 
 


### PR DESCRIPTION
This pull request is in response to ticket #2582. `aws cloudformation package` now creates and MD5 hash of the content of a directory to be used as the artifact name before uploading to S3. This will allow faster CF updates as it won't think that every directory uploaded as been changed.

It takes into account file contents and file/directory names.