### PR TITLE
Add configure mfa command

### DIFF
--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ProfileNotFound
 from awscli.compat import compat_input
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.configure.addmodel import AddModelCommand
+from awscli.customizations.configure.mfa import ConfigureMfaCommand
 from awscli.customizations.configure.set import ConfigureSetCommand
 from awscli.customizations.configure.get import ConfigureGetCommand
 from awscli.customizations.configure.list import ConfigureListCommand
@@ -73,7 +74,8 @@ class ConfigureCommand(BasicCommand):
         {'name': 'list', 'command_class': ConfigureListCommand},
         {'name': 'get', 'command_class': ConfigureGetCommand},
         {'name': 'set', 'command_class': ConfigureSetCommand},
-        {'name': 'add-model', 'command_class': AddModelCommand}
+        {'name': 'add-model', 'command_class': AddModelCommand},
+        {'name': 'mfa', 'command_class': ConfigureMfaCommand},
     ]
 
     # If you want to add new values to prompt, update this list here.

--- a/awscli/customizations/configure/mfa.py
+++ b/awscli/customizations/configure/mfa.py
@@ -1,0 +1,189 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+
+from botocore.credentials import Credentials
+
+from awscli.arguments import create_argument_model_from_schema
+from awscli.compat import compat_input
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.configure.writer import ConfigFileWriter
+
+
+CONFIG_KEY_MFA_SERIAL_NUMBER = 'aws_mfa_serial_number'
+CONFIG_KEY_ACCESS_KEY_ID = 'aws_access_key_id'
+CONFIG_KEY_SECRET_ACCESS_KEY = 'aws_secret_access_key'
+CONFIG_KEY_SESSION_TOKEN = 'aws_session_token'
+CONFIG_KEY_ACCESS_KEY_ID_SAVED = '%s_saved' % CONFIG_KEY_ACCESS_KEY_ID
+CONFIG_KEY_SECRET_ACCESS_KEY_SAVED = '%s_saved' % CONFIG_KEY_SECRET_ACCESS_KEY
+
+
+def get_saved_credentials(session):
+    """
+    Return saved credentials (ie. non-temporary ones) if they are present, else
+    default to credentials already set in the given session.
+
+    :type session: botocore.session.Session
+    :rtype: botocore.credentials.Credentials
+    """
+    config = session.get_scoped_config()
+    access_key = config.get(CONFIG_KEY_ACCESS_KEY_ID_SAVED)
+    secret_key = config.get(CONFIG_KEY_SECRET_ACCESS_KEY_SAVED)
+
+    if access_key is None or secret_key is None:
+        return session.get_credentials()
+
+    return Credentials(
+        access_key=access_key, secret_key=secret_key, token=None)
+
+
+class ConfigureMfaCommand(BasicCommand):
+    NAME = 'mfa'
+    DESCRIPTION = BasicCommand.FROM_FILE('configure', 'mfa',
+                                         '_description.rst')
+    SYNOPSIS = 'aws configure mfa ' \
+               '[--duration-seconds seconds] ' \
+               '[--serial-number mfa_serial_number] ' \
+               '[--token mfa_token] ' \
+               '[--profile profile-name]'
+    EXAMPLES = BasicCommand.FROM_FILE('configure', 'mfa', '_examples.rst')
+    ARG_TABLE = [
+        {'name': 'duration-seconds',
+         'help_text': 'Duration in seconds for session validity.',
+         'default': 43200,
+         'argument_model': create_argument_model_from_schema({
+             'type': 'integer'}),
+         'action': 'store',
+         'required': False,
+         'cli_type_name': 'string', 'positional_arg': False},
+        {'name': 'serial-number',
+         'help_text': 'The serial number of the MFA device to use when '
+                      'requesting temporary credentials.',
+         'action': 'store',
+         'required': False,
+         'cli_type_name': 'string', 'positional_arg': False},
+        {'name': 'token',
+         'help_text': 'The MFA token to use when requesting temporary '
+                      'credentials.',
+         'action': 'store',
+         'required': False,
+         'cli_type_name': 'string', 'positional_arg': False},
+    ]
+
+    def __init__(self, session, config_writer=None):
+        super(ConfigureMfaCommand, self).__init__(session)
+        if config_writer is None:
+            config_writer = ConfigFileWriter()
+        self._config_writer = config_writer
+
+    def refresh_temporary_credentials(
+            self, duration=43200, mfa_serial_number=None, mfa_token=None):
+        saved_credentials = get_saved_credentials(session=self._session)
+        self._session.set_credentials(
+            access_key=saved_credentials.access_key,
+            secret_key=saved_credentials.secret_key,
+            token=None)
+
+        if mfa_serial_number is None:
+            mfa_serial_number = self.get_mfa_serial_number()
+
+        if mfa_token is None:
+            mfa_token = compat_input("MFA token: ")
+
+        if not mfa_token:
+            raise ValueError('MFA token required.')
+        elif len(mfa_token) < 6:
+            raise ValueError('MFA token is required to be at least 6 long.')
+
+        client = self._session.create_client('sts')
+        response = client.get_session_token(
+            DurationSeconds=duration,
+            SerialNumber=mfa_serial_number,
+            TokenCode=mfa_token).get('Credentials')
+
+        access_key_id = response.get('AccessKeyId')
+        secret_access_key = response.get('SecretAccessKey')
+        session_token = response.get('SessionToken')
+
+        from awscli.customizations.configure.set import ConfigureSetCommand
+        set_command = ConfigureSetCommand(self._session, self._config_writer)
+
+        # set saved values only if they never existed
+        if saved_credentials.access_key is not None \
+                and saved_credentials.secret_key is not None:
+            set_command(
+                args=[CONFIG_KEY_ACCESS_KEY_ID_SAVED, saved_credentials.access_key],
+                parsed_globals=None)
+            set_command(
+                args=[CONFIG_KEY_SECRET_ACCESS_KEY_SAVED, saved_credentials.secret_key],
+                parsed_globals=None)
+
+        set_command(
+            args=[CONFIG_KEY_ACCESS_KEY_ID, access_key_id],
+            parsed_globals=None)
+        set_command(
+            args=[CONFIG_KEY_SECRET_ACCESS_KEY, secret_access_key],
+            parsed_globals=None)
+        set_command(
+            args=[CONFIG_KEY_SESSION_TOKEN, session_token],
+            parsed_globals=None)
+
+    def get_mfa_serial_number(self):
+        from awscli.customizations.configure.set import ConfigureSetCommand
+        config = self._session.get_scoped_config()
+        mfa_serial_number = config.get(CONFIG_KEY_MFA_SERIAL_NUMBER)
+        if mfa_serial_number is None:
+            mfa_serial_number = self.select_mfa_device()
+            set_command = ConfigureSetCommand(
+                self._session, self._config_writer)
+            set_command(
+                args=[CONFIG_KEY_MFA_SERIAL_NUMBER, mfa_serial_number],
+                parsed_globals=None)
+        return mfa_serial_number
+
+    def select_mfa_device(self):
+        client = self._session.create_client('iam')
+        mfa_devices = [
+            device['SerialNumber']
+            for device in client.list_mfa_devices()['MFADevices']
+        ]
+
+        mfa_device_count = len(mfa_devices)
+        if mfa_device_count == 0:
+            raise Exception('No MFA device configured. '
+                            'Refer to http://docs.aws.amazon.com/IAM/latest/'
+                            'UserGuide/id_credentials_mfa_enable_virtual.html '
+                            'for information on how to add one.')
+        elif mfa_device_count == 1:
+            # if there is only one device configured, use it
+            return mfa_devices.pop()
+
+        for i in range(len(mfa_devices)):
+            sys.stdout.write('[%d] %s\n' % (i, mfa_devices[i]))
+
+        response = compat_input("Select MFA Device [0]: ")
+        if not response:
+            response = 0
+
+        try:
+            return mfa_devices.pop(int(response))
+        except (ValueError, IndexError):
+            raise Exception(
+                'Invalid Choice. Please select a number from the list.')
+
+    def _run_main(self, parsed_args, parsed_globals):
+        self.refresh_temporary_credentials(
+            duration=parsed_args.duration_seconds,
+            mfa_serial_number=parsed_args.serial_number,
+            mfa_token=parsed_args.token
+        )

--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -13,6 +13,9 @@
 import os
 
 from awscli.customizations.commands import BasicCommand
+from awscli.customizations.configure.mfa import \
+    CONFIG_KEY_MFA_SERIAL_NUMBER, CONFIG_KEY_ACCESS_KEY_ID_SAVED, \
+    CONFIG_KEY_SECRET_ACCESS_KEY_SAVED
 from awscli.customizations.configure.writer import ConfigFileWriter
 
 from . import PREDEFINED_SECTION_NAMES, profile_to_section
@@ -38,7 +41,10 @@ class ConfigureSetCommand(BasicCommand):
     # Any variables specified in this list will be written to
     # the ~/.aws/credentials file instead of ~/.aws/config.
     _WRITE_TO_CREDS_FILE = ['aws_access_key_id', 'aws_secret_access_key',
-                            'aws_session_token']
+                            'aws_session_token',
+                            CONFIG_KEY_MFA_SERIAL_NUMBER,
+                            CONFIG_KEY_ACCESS_KEY_ID_SAVED,
+                            CONFIG_KEY_SECRET_ACCESS_KEY_SAVED]
 
     def __init__(self, session, config_writer=None):
         super(ConfigureSetCommand, self).__init__(session)

--- a/awscli/examples/configure/mfa/_description.rst
+++ b/awscli/examples/configure/mfa/_description.rst
@@ -1,0 +1,9 @@
+Configure temporary session credentials
+
+The ``aws configure mfa`` command can be used to configure the MFA device to use (first time configuration), generate new or refresh existing temporary session credentials.
+
+This command expects initial configuration for the cli to have been successfully completed (see ``aws configure help`` for more information).
+
+On initial configuration, if one is not passed in via ``--serial-number``, the user will be asked to select from a list of existing MFA devices (if more than one exists).
+
+On successful generation of new temporary credentials, the original credential values are preserved in corresponding configuration names suffixed by ``_saved`` within the shared credentials file (``~/.aws/credentials``).

--- a/awscli/examples/configure/mfa/_examples.rst
+++ b/awscli/examples/configure/mfa/_examples.rst
@@ -1,0 +1,21 @@
+Given ``~/.aws/credentials`` file after executing ``aws configure`` file::
+
+    [default]
+    aws_access_key_id = default_access_key
+    aws_secret_access_key = default_secret_key
+
+the following command::
+
+    $ aws configure mfa
+    MFA token: 123456
+
+will produce the following credential file::
+
+    [default]
+    aws_access_key_id = temporary_access_key
+    aws_secret_access_key = temporary_secret_key
+    aws_mfa_serial_number = default_mfa_device_serial_number
+    aws_access_key_id_saved = default_access_key
+    aws_secret_access_key_saved = default_secret_key
+    aws_session_token = temporary_session_token
+


### PR DESCRIPTION
Issue #, if available:
#1985 

Description of changes:
* generate/refresh and persist temporary session credentials
* accept duration/serial/token as parameters
* introduce `aws_access_key_id_saved` and `aws_secret_access_key_saved`
  in credential file as a mechanism to keep non-temporary credentials
  for refreshing temporary ones

Creating this PR so as to start a discussion around this topic. This may touch on requests covered in #1985.

This implementation follows the procedure outlined by the knowledge center article "[How do I use an MFA token to authenticate access to my AWS resources through the AWS CLI?](https://aws.amazon.com/premiumsupport/knowledge-center/authenticate-mfa-cli/)". 

Note that I am unfamiliar with this code base and have made best-effort guesses at a lot of places, so feedback welcome on changes required. I have not written up any test at the moment due to time constraints and would rather do that once I get an okay for the idea.

At the end of the day, if this is merged one can expect end users to do the following to get up and running;
```sh
aws configure
aws configure mfa
```