### PR TITLE
Fix typo in describe-create-account-status example output

### DIFF
--- a/awscli/examples/organizations/describe-create-account-status.rst
+++ b/awscli/examples/organizations/describe-create-account-status.rst
@@ -9,7 +9,7 @@ Command::
 Output::
 
   {
-    "CreateAccountStatusRequest": {
+    "CreateAccountStatus": {
       "State": "SUCCEEDED",
       "AccountId": "555555555555",
       "AccountName": "Beta account",


### PR DESCRIPTION
Having just run one, I can see this is incorrect :)