### PR TITLE
Remove inaccurate comment from zsh auto complete file

### DIFF
--- a/bin/aws_zsh_completer.sh
+++ b/bin/aws_zsh_completer.sh
@@ -12,9 +12,6 @@
 # https://github.com/zsh-users/zsh/commit/edab1d3dbe61da7efe5f1ac0e40444b2ec9b9570
 #
 # zsh relases prior to that version do not export the required env variables!
-#
-# It is planned to write a proper zsh auto completion soon. Please talk
-# to Frank Becker <fb@alien8.de>.
 
 autoload -Uz bashcompinit
 bashcompinit -i


### PR DESCRIPTION
When I was using zsh + aws-cli it was a quick way to add auto
complete to zsh via the bash emulation. At the time I intended
to write native zsh auto completion.

However, I never found the time to do it and lost the motivation.
Thus, removing the comment.

Signed-off-by: Frank Becker <fb@alien8.de>