### PR TITLE
don't set UsePreviousValue if parameters doesn't exist (fixes #2599)

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -88,7 +88,6 @@ class Deployer(object):
         # Each changeset will get a unique name based on time
         changeset_name = self.changeset_prefix + str(int(time.time()))
 
-        changeset_type = "UPDATE"
         if not self.has_stack(stack_name):
             changeset_type = "CREATE"
             # When creating a new stack, UsePreviousValue=True is invalid.
@@ -96,6 +95,15 @@ class Deployer(object):
             # or set a Default value in template to successfully create a stack.
             parameter_values = [x for x in parameter_values
                                 if not x.get("UsePreviousValue", False)]
+        else:
+            changeset_type = "UPDATE"
+            # UsePreviousValue not valid if parameter is new
+            summary = self._client.get_template_summary(StackName=stack_name)
+            existing_parameters = [parameter['ParameterKey'] for parameter in \
+                                   summary['Parameters']]
+            parameter_values = [x for x in parameter_values
+                                if not (x.get("UsePreviousValue", False) and \
+                                x["ParameterKey"] not in existing_parameters)]
 
         kwargs = {
             'ChangeSetName': changeset_name,

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -135,10 +135,18 @@ class TestDeployer(unittest.TestCase):
 
         # Case 2: Stack exists. We are updating it
         self.deployer.has_stack.return_value = True
+        self.stub_client.add_response("get_template_summary",
+            {"Parameters": [{"ParameterKey": parameter["ParameterKey"]}
+                for parameter in parameters]},
+            {"StackName": stack_name})
         expected_params["ChangeSetType"] = "UPDATE"
         expected_params["Parameters"] = parameters
         self.stub_client.add_response("create_change_set", response,
                                       expected_params)
+        # template has new parameter but should not be included in
+        # expected_params as no previous value
+        parameters = list(parameters) + \
+            [{"ParameterKey": "New", "UsePreviousValue": True}]
         with self.stub_client:
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,


### PR DESCRIPTION
fixes #2599