### PR TITLE
- Support use of colorama up to 0.3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 
 
 requires = ['botocore==1.7.7',
-            'colorama>=0.2.5,<=0.3.7',
+            'colorama>=0.2.5,<=0.3.8',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
             's3transfer>=0.1.9,<0.2.0',


### PR DESCRIPTION
  + colorama bugfix release 0.3.8 is available and contains no incompatible
    changes. There is no need to restrict use to less or equal 0.3.7