### PR TITLE
Remove unnecessary HeadObject for single object rm

### DIFF
--- a/.changes/next-release/bugfix-s3rm-54186.json
+++ b/.changes/next-release/bugfix-s3rm-54186.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3 rm``", 
+  "type": "bugfix", 
+  "description": "Remove unnecessary HeadObject call for non-recursive ``s3 rm``. This caused errors when a remote S3 object was encrypted with SSE-C as HeadObject call requires the SSE-C key but DeleteObject does not (`#2494 <https://github.com/aws/aws-cli/issues/2494>`__)"
+}

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -151,8 +151,8 @@ class FileGenerator(object):
 
     def _inject_extra_information(self, file_stat_kwargs, extra_information):
         src_type = file_stat_kwargs['src_type']
-        file_stat_kwargs['size'] = extra_information['Size']
-        file_stat_kwargs['last_update'] = extra_information['LastModified']
+        file_stat_kwargs['size'] = extra_information.get('Size')
+        file_stat_kwargs['last_update'] = extra_information.get('LastModified')
 
         # S3 objects require the response data retrieved from HeadObject
         # and ListObject
@@ -340,6 +340,12 @@ class FileGenerator(object):
         # a ListObjects operation (which causes concern for anyone setting
         # IAM policies with the smallest set of permissions needed) and
         # instead use a HeadObject request.
+        if self.operation_name == 'delete':
+            # If the operation is just a single remote delete, there is
+            # no need to run HeadObject on the S3 object as none of the
+            # information gained from HeadObject is required to delete the
+            # object.
+            return s3_path, {}
         bucket, key = find_bucket_key(s3_path)
         try:
             params = {'Bucket': bucket, 'Key': key}

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -151,8 +151,8 @@ class FileGenerator(object):
 
     def _inject_extra_information(self, file_stat_kwargs, extra_information):
         src_type = file_stat_kwargs['src_type']
-        file_stat_kwargs['size'] = extra_information.get('Size')
-        file_stat_kwargs['last_update'] = extra_information.get('LastModified')
+        file_stat_kwargs['size'] = extra_information['Size']
+        file_stat_kwargs['last_update'] = extra_information['LastModified']
 
         # S3 objects require the response data retrieved from HeadObject
         # and ListObject
@@ -345,7 +345,7 @@ class FileGenerator(object):
             # no need to run HeadObject on the S3 object as none of the
             # information gained from HeadObject is required to delete the
             # object.
-            return s3_path, {}
+            return s3_path, {'Size': None, 'LastModified': None}
         bucket, key = find_bucket_key(s3_path)
         try:
             params = {'Bucket': bucket, 'Key': key}

--- a/tests/functional/s3/test_rm_command.py
+++ b/tests/functional/s3/test_rm_command.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+
+
+class TestRmCommand(BaseAWSCommandParamsTest):
+
+    prefix = 's3 rm'
+
+    def setUp(self):
+        super(TestRmCommand, self).setUp()
+        self.files = FileCreator()
+
+    def tearDown(self):
+        super(TestRmCommand, self).tearDown()
+        self.files.remove_all()
+
+    def test_operations_used_in_upload(self):
+        cmdline = '%s s3://bucket/key.txt' % self.prefix
+        self.run_cmd(cmdline, expected_rc=0)
+        # The only operation we should have called is DeleteObject.
+        self.assertEqual(
+            len(self.operations_called), 1, self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'DeleteObject')

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -2037,6 +2037,20 @@ class TestSSECRelatedParams(BaseS3IntegrationTest):
         self.download_and_assert_sse_c_object_integrity(
             self.bucket, key, self.encrypt_key, contents)
 
+    def test_can_delete_single_sse_c_object(self):
+        key = 'foo.txt'
+        contents = 'contents'
+        self.put_object(
+            self.bucket, key, contents,
+            extra_args={
+                'SSECustomerKey': self.encrypt_key,
+                'SSECustomerAlgorithm': 'AES256'
+            }
+        )
+        p = aws('s3 rm s3://%s/%s' % (self.bucket, key))
+        self.assert_no_errors(p)
+        self.assertFalse(self.key_exists(self.bucket, key))
+
     def test_sse_c_upload_and_download_large_file(self):
         key = 'foo.txt'
         contents = 'a' * (10 * (1024 * 1024))

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -534,6 +534,25 @@ class S3FileGeneratorTest(BaseAWSCommandParamsTest):
         with self.assertRaisesRegexp(ClientError, '404.*text1.txt'):
             list(files)
 
+    def test_s3_single_file_delete(self):
+        input_s3_file = {'src': {'path': self.file1, 'type': 's3'},
+                         'dest': {'path': '', 'type': 'local'},
+                         'dir_op': False, 'use_src_name': True}
+        self.client = mock.Mock()
+        file_gen = FileGenerator(self.client, 'delete')
+        result_list = list(file_gen.call(input_s3_file))
+        self.assertEqual(len(result_list), 1)
+        compare_files(
+            self,
+            result_list[0],
+            FileStat(src=self.file1, dest='text1.txt',
+                     compare_key='text1.txt',
+                     size=None, last_update=None,
+                     src_type='s3', dest_type='local',
+                     operation_name='delete')
+        )
+        self.client.head_object.assert_not_called()
+
     def test_s3_directory(self):
         """
         Generates s3 files under a common prefix. Also it ensures that


### PR DESCRIPTION
This causes issues where the object is encrypted with SSE-C as you will get errors since HeadObject requires SSE-C key be provided.

Fixes https://github.com/aws/aws-cli/issues/2494