### PR TITLE
update s3api list-buckets example

### DIFF
--- a/awscli/examples/s3api/list-buckets.rst
+++ b/awscli/examples/s3api/list-buckets.rst
@@ -1,7 +1,7 @@
 The following command uses the ``list-buckets`` command to display the names of all your Amazon S3 buckets (across all
 regions)::
 
-  aws s3api list-buckets --query 'Buckets[].Name'
+  aws s3api list-buckets --query "Buckets[].Name"
 
 The query option filters the output of ``list-buckets`` down to only the bucket names.
 


### PR DESCRIPTION
The list-buckets command line example uses single quotes which works on macOS but not on Windows. Using double quotes works on both platforms.