### PR TITLE
UTF-8 is default file encoding to read

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -88,7 +88,9 @@ if six.PY3:
         encoding.
 
         """
-        if 'b' not in mode:
+        if 'b' in mode:
+            encoding = None
+        elif encoding is None:
             encoding = locale.getpreferredencoding()
         return open(filename, mode, encoding=encoding)
 
@@ -145,7 +147,9 @@ else:
 
     def compat_open(filename, mode='r', encoding=None):
         # See docstring for compat_open in the PY3 section above.
-        if 'b' not in mode:
+        if 'b' in mode:
+            encoding = None
+        elif encoding is None:
             encoding = locale.getpreferredencoding()
         return io.open(filename, mode, encoding=encoding)
 

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -116,8 +116,14 @@ def get_paramfile(path):
 def get_file(prefix, path, mode):
     file_path = os.path.expandvars(os.path.expanduser(path[len(prefix):]))
     try:
-        with compat_open(file_path, mode) as f:
-            return f.read()
+        try:
+            # almost utf-8
+            with compat_open(file_path, mode, 'utf-8') as f:
+                return f.read()
+        except UnicodeDecodeError:
+            # system default encoding
+            with compat_open(file_path, mode) as f:
+                return f.read()
     except UnicodeDecodeError:
         raise ResourceLoadingError(
             'Unable to load paramfile (%s), text contents could '

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -70,15 +70,14 @@ class TestParamFile(unittest.TestCase):
         self.assertEqual(data, u'\u95a2\u6238\u3066\u3059\u3068')
         self.assertIsInstance(data, six.string_types)
 
-    @unittest.skipIf(locale.getpreferredencoding() != 'cp932',
-            'encoding fallback test with cp932 system')
     def test_get_file_fallback_platformdefault_in_cp932(self):
-        contents = b'\x8a\xd6\x8c\xcb\x82\xc4\x82\xb7\x82\xc6'
-        filename = self.files.create_file('foo', contents, mode='wb')
-        data = get_file('', filename, 'r')
-        self.assertEqual(data, u'\u95a2\u6238\u3066\u3059\u3068')
-        self.assertIsInstance(data, six.string_types)
-
+        with mock.patch('locale.getpreferredencoding') as mock_getpreferredencoding:
+            mock_getpreferredencoding.return_value = 'cp932'
+            contents = b'\x8a\xd6\x8c\xcb\x82\xc4\x82\xb7\x82\xc6'
+            filename = self.files.create_file('foo', contents, mode='wb')
+            data = get_file('', filename, 'r')
+            self.assertEqual(data, u'\u95a2\u6238\u3066\u3059\u3068')
+            self.assertIsInstance(data, six.string_types)
 
 class TestHTTPBasedResourceLoading(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -67,7 +67,7 @@ class TestParamFile(unittest.TestCase):
         contents = b'\xe9\x96\xa2\xe6\x88\xb8\xe3\x81\xa6\xe3\x81\x99\xe3\x81\xa8'
         filename = self.files.create_file('foo', contents, mode='wb')
         data = get_file('', filename, 'r')
-        self.assertEqual(data, u'関戸てすと')
+        self.assertEqual(data, u'\u95a2\u6238\u3066\u3059\u3068')
         self.assertIsInstance(data, six.string_types)
 
     @unittest.skipIf(locale.getpreferredencoding() != 'cp932',
@@ -76,7 +76,7 @@ class TestParamFile(unittest.TestCase):
         contents = b'\x8a\xd6\x8c\xcb\x82\xc4\x82\xb7\x82\xc6'
         filename = self.files.create_file('foo', contents, mode='wb')
         data = get_file('', filename, 'r')
-        self.assertEqual(data, u'関戸てすと')
+        self.assertEqual(data, u'\u95a2\u6238\u3066\u3059\u3068')
         self.assertIsInstance(data, six.string_types)
 
 


### PR DESCRIPTION
## My Environment

* Windows 7 Pro, Japanese (CP932)
* git bash 2.13.0
* AWS CLI via pip (aws-cli/1.11.109 Python/3.6.1 Windows/7 botocore/1.5.72)

## Problem

`aws cloudformation create-stack --template-body 'file://template.yml' --debug` raises an error.
template.yml is UTF-8 encoding.

```
Traceback (most recent call last):
  File "...\python36\lib\site-packages\awscli\paramfile.py", line 120, in get_file
    return f.read()
UnicodeDecodeError: 'cp932' codec can't decode byte 0x83 in position 68: illegal multibyte sequence
```

`get_file` calls `compat_open`, and `compat_open` opens file with platform dependent encoding, 'cp932' in Japanese environment, although the file is UTF-8 encoding.

```
$ python -i
Python 3.6.1 (v3.6.1:69c0db5, Mar 21 2017, 18:41:36) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import locale
>>> locale.getpreferredencoding()
'cp932'
```

## How to fix

1. UTF-8 is default file encoding to read in `get_file`
2. Try to read the file with platform default encoding again if the file cannot read with UTF-8 encoding
3. Clear encoding parameter in `compat_open` because `open` doesn't receive "encoding" parameter in binary mode