### PR TITLE
Reduce `cloudformation deploy` command polling delay

### DIFF
--- a/.changes/next-release/enhancement-Cloudformation-90843.json
+++ b/.changes/next-release/enhancement-Cloudformation-90843.json
@@ -1,0 +1,5 @@
+{
+  "category": "Cloudformation",
+  "type": "enhancement",
+  "description": "Reduce polling delay for `cloudformation deploy`."
+}

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -124,8 +124,8 @@ class Deployer(object):
 
         # Wait for changeset to be created
         waiter = self._client.get_waiter("change_set_create_complete")
-        # Poll every 10 seconds. Changeset creation should be fast
-        waiter.config.delay = 10
+        # Poll every 5 seconds. Changeset creation should be fast
+        waiter.config.delay = 5
         try:
             waiter.wait(ChangeSetName=changeset_id, StackName=stack_name)
         except botocore.exceptions.WaiterError as ex:
@@ -168,6 +168,10 @@ class Deployer(object):
         else:
             raise RuntimeError("Invalid changeset type {0}"
                                .format(changeset_type))
+
+        # Poll every 5 seconds. Optimizing for the case when the stack has only
+        # minimal changes, such the Code for Lambda Function
+        waiter.config.delay = 5
 
         try:
             waiter.wait(StackName=stack_name)


### PR DESCRIPTION
Customers have asked for a faster deployment time.
See awslabs/serverless-application-model#125. This fix should
at least make the command complete as soon as cloudformation completes.