### PR TITLE
Update skeleton test

### DIFF
--- a/tests/integration/customizations/test_generatecliskeleton.py
+++ b/tests/integration/customizations/test_generatecliskeleton.py
@@ -66,8 +66,13 @@ class TestIntegGenerateCliSkeleton(unittest.TestCase):
         self.assertEqual(p.rc, 0)
         self.assertEqual(
             json.loads(p.stdout),
-            {'Bucket': '','Key': '', 'MFA': '', 'VersionId': '',
-             'RequestPayer': ''}
+            {
+                'Bucket': '',
+                'Key': '',
+                'MFA': '',
+                'VersionId': '',
+                'RequestPayer': 'requester',
+            }
         )
 
     def test_generate_cli_skeleton_sqs(self):


### PR DESCRIPTION
Updates the generate skeleton test for S3 to asert that the enum
`requester` is put into place rather than an empty string.