### PR TITLE
Condition function doesn't support "Fn::" prefix

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -26,7 +26,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     # Get the actual tag name excluding the first exclamation
     tag = node.tag[1:]
 
-    # Some intrinsic functions doesn't support prefix "Fn::"
+    # Some intrinsic functions doesn't support prefix "Fn::"
     prefix = "Fn::"
     if tag in ["Ref", "Condition"]:
         prefix = ""

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -26,7 +26,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     # Get the actual tag name excluding the first exclamation
     tag = node.tag[1:]
 
-    # All CloudFormation intrinsics have prefix Fn:: except Ref
+    # Some intrinsic functions doesn't support prefix "Fn::"
     prefix = "Fn::"
     if tag in ["Ref", "Condition"]:
         prefix = ""

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -28,7 +28,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
 
     # All CloudFormation intrinsics have prefix Fn:: except Ref
     prefix = "Fn::"
-    if tag == "Ref":
+    if tag in ["Ref", "Condition"]:
         prefix = ""
 
     cfntag = prefix + tag

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -28,6 +28,7 @@ class TestYaml(unittest.TestCase):
         Key3: !FooBar [!Baz YetAnother, "hello"]
         Key4: !SomeTag {"a": "1"}
         Key5: !GetAtt OneMore.Outputs.Arn
+        Key6: !Condition OtherCondition
     """
 
     parsed_yaml_dict = {
@@ -51,6 +52,9 @@ class TestYaml(unittest.TestCase):
             },
             "Key5": {
                 "Fn::GetAtt": ["OneMore", "Outputs.Arn"]
+            },
+            "Key6": {
+                "Condition": "OtherCondition"
             }
         }
     }


### PR DESCRIPTION
# Summary

Fix the AWS CLI cloudformation package command

# Details

When we use CLI tools to package a template it adds the function prefix *Fn::*. If we try to create a stack using the *package* cloudformation template it will thrown an error:

```
Template validation error: Template Error: Encountered unsupported function: Fn::Condition Supported functions are: [Fn::Base64, Fn::GetAtt, Fn::GetAZs, Fn::ImportValue, Fn::Join, Fn::Split, Fn::FindInMap, Fn::Select, Ref, Fn::Equals, Fn::If, Fn::Not, Condition, Fn::And, Fn::Or, Fn::Contains, Fn::EachMemberEquals, Fn::EachMemberIn, Fn::ValueOf, Fn::ValueOfAll, Fn::RefAll, Fn::Sub]
```

# References: 
 * [AWS Condition Documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html)