### PR TITLE
Add no progress result printer to s3 transfer

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -554,6 +554,12 @@ class ResultPrinter(BaseResultHandler):
             uni_print(self._adjust_statement_padding(''), self._out_file)
 
 
+class NoProgressResultPrinter(ResultPrinter):
+    """A result printer that doesn't print progress"""
+    def _print_progress(self, **kwargs):
+        pass
+
+
 class OnlyShowErrorsResultPrinter(ResultPrinter):
     """A result printer that only prints out errors"""
     def _print_progress(self, **kwargs):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -111,7 +111,7 @@ class S3TransferHandlerFactory(object):
             result_printer = OnlyShowErrorsResultPrinter(result_recorder)
         elif self._cli_params.get('is_stream'):
             result_printer = OnlyShowErrorsResultPrinter(result_recorder)
-        elif self._cli_params.get('no_progress'):
+        elif not self._cli_params.get('progress'):
             result_printer = NoProgressResultPrinter(result_recorder)
         else:
             result_printer = ResultPrinter(result_recorder)

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -33,6 +33,7 @@ from awscli.customizations.s3.results import DryRunResult
 from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import ResultPrinter
 from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
+from awscli.customizations.s3.results import NoProgressResultPrinter
 from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.utils import RequestParamsMapper
@@ -110,6 +111,8 @@ class S3TransferHandlerFactory(object):
             result_printer = OnlyShowErrorsResultPrinter(result_recorder)
         elif self._cli_params.get('is_stream'):
             result_printer = OnlyShowErrorsResultPrinter(result_recorder)
+        elif self._cli_params.get('no_progress'):
+            result_printer = NoProgressResultPrinter(result_recorder)
         else:
             result_printer = ResultPrinter(result_recorder)
         result_processor_handlers.append(result_printer)

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -369,9 +369,13 @@ ONLY_SHOW_ERRORS = {'name': 'only-show-errors', 'action': 'store_true',
                         'output is suppressed.')}
 
 
-NO_PROGRESS = {'name': 'no-progress', 'action': 'store_true',
-                    'help_text': (
-                        'File transfer progress is not displayed.')}
+NO_PROGRESS = {'name': 'no-progress',
+               'action': 'store_false',
+               'dest': 'progress',
+               'help_text': (
+                   'File transfer progress is not displayed. This flag '
+                   'is only applied when the quiet and only-show-errors '
+                   'flags are not provided.')}
 
 
 EXPECTED_SIZE = {'name': 'expected-size',

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -369,6 +369,11 @@ ONLY_SHOW_ERRORS = {'name': 'only-show-errors', 'action': 'store_true',
                         'output is suppressed.')}
 
 
+NO_PROGRESS = {'name': 'no-progress', 'action': 'store_true',
+                    'help_text': (
+                        'File transfer progress is not displayed.')}
+
+
 EXPECTED_SIZE = {'name': 'expected-size',
                  'help_text': (
                      'This argument specifies the expected size of a stream '
@@ -424,7 +429,7 @@ TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  SSE_C_COPY_SOURCE_KEY, STORAGE_CLASS, GRANTS,
                  WEBSITE_REDIRECT, CONTENT_TYPE, CACHE_CONTROL,
                  CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE,
-                 EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS,
+                 EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS, NO_PROGRESS,
                  PAGE_SIZE, IGNORE_GLACIER_WARNINGS, FORCE_GLACIER_TRANSFER]
 
 

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1255,6 +1255,17 @@ class TestOutput(BaseS3IntegrationTest):
         # Check that nothing was printed to stdout.
         self.assertEqual('', p.stdout)
 
+    def test_normal_output_no_progress(self):
+        bucket_name = _SHARED_BUCKET
+        foo_txt = self.files.create_file('foo.txt', 'foo contents')
+
+        # Copy file into bucket.
+        p = aws('s3 cp %s s3://%s/ --no-progress' % (foo_txt, bucket_name))
+        self.assertEqual(p.rc, 0)
+        # Ensure success message was printed
+        self.assertIn('upload', p.stdout)
+        self.assertIn('s3://%s/foo.txt' % bucket_name, p.stdout)
+
     def test_error_output(self):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1265,6 +1265,8 @@ class TestOutput(BaseS3IntegrationTest):
         # Ensure success message was printed
         self.assertIn('upload', p.stdout)
         self.assertIn('s3://%s/foo.txt' % bucket_name, p.stdout)
+        self.assertNotIn('Completed ', p.stdout)
+        self.assertNotIn('calculating', p.stdout)
 
     def test_error_output(self):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')


### PR DESCRIPTION
This seemed relatively easy to implement and a lot of people have been asking for it.
This is basically a copy paste of the `OnlyShowErrorsResultPrinter` except that it still prints success messages. Just like the `--only-show-errors` flag you can now also pass `--no-progress` to omit the progress rendering. Not sure if I hit all the tests we need for this.

Implements: https://github.com/aws/aws-cli/issues/519