### PR TITLE
Changed waiter.config.delay from 5 seconds to 10 seconds

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -169,9 +169,8 @@ class Deployer(object):
             raise RuntimeError("Invalid changeset type {0}"
                                .format(changeset_type))
 
-        # Poll every 5 seconds. Optimizing for the case when the stack has only
-        # minimal changes, such the Code for Lambda Function
-        waiter.config.delay = 5
+        # Changing the polling from 5 seconds to 10 seconds as other services can take longer than 10 minutes to create.
+        waiter.config.delay = 10
 
         try:
             waiter.wait(StackName=stack_name)


### PR DESCRIPTION
The documentation below mentions the following with regards to: aws cloudformation wait stack-create-complete [1]
[1] http://docs.aws.amazon.com/cli/latest/reference/cloudformation/wait/stack-create-complete.html

"Wait until stack status is CREATE_COMPLETE. It will poll every 30 seconds until a successful state has been reached. 
This will exit with a return code of 255 after 120 failed checks."

This should be technically be 30 seconds not 5 seconds or 10 seconds because: 
120 calls at 30 seconds intervals will equal 3600 seconds/1 hour until the "Max attempts exceeded" which to confirms with CloudFormations 1 hour* timeout.

I understand that it is a fine line between performance (speed) and consistency, but unfortunately some services like CloudFront take time to build.