### PR TITLE
correct `aws s3 rm exclude` filter example

### DIFF
--- a/awscli/examples/s3/rm.rst
+++ b/awscli/examples/s3/rm.rst
@@ -31,7 +31,7 @@ The following ``rm`` command recursively deletes all objects under a specified b
 parameter ``--recursive`` while excluding all objects under a particular prefix by using an ``--exclude`` parameter.  In
 this example, the bucket ``mybucket`` has the objects ``test1.txt`` and ``another/test.txt``::
 
-    aws s3 rm s3://mybucket/ --recursive --exclude "mybucket/another/*"
+    aws s3 rm s3://mybucket/ --recursive --exclude "another/*"
 
 Output::
 


### PR DESCRIPTION
The initial example, which includes "bucket" in the --exclude pattern did not work. 
"bucket" (or the root bucket" is automatically added.