### PR TITLE
ecr default --no-include-email to get-login command

### DIFF
--- a/awscli/customizations/ecr.py
+++ b/awscli/customizations/ecr.py
@@ -44,7 +44,7 @@ class ECRLogin(BasicCommand):
             'action': 'store_true',
             'group_name': 'include-email',
             'dest': 'include_email',
-            'default': True,
+            'default': False,
             'required': False,
             'help_text': (
                 "Specify if the '-e' flag should be included in the "

--- a/awscli/examples/ecr/get-login.rst
+++ b/awscli/examples/ecr/get-login.rst
@@ -9,7 +9,7 @@ Command::
 
 Output::
 
-  docker login -u AWS -p <password> -e none https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com
+  docker login -u AWS -p <password> https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com
 
 **To log in to another account's registry**
 
@@ -22,5 +22,5 @@ Command::
 
 Output::
 
-  docker login -u <username> -p <token-1> -e none <endpoint-1>
-  docker login -u <username> -p <token-2> -e none <endpoint-2>
+  docker login -u <username> -p <token-1> <endpoint-1>
+  docker login -u <username> -p <token-2> <endpoint-2>

--- a/tests/functional/ecr/test_get_login.py
+++ b/tests/functional/ecr/test_get_login.py
@@ -32,7 +32,7 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
     def test_prints_get_login_command(self):
         stdout = self.run_cmd("ecr get-login")[0]
         self.assertIn(
-            'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io', stdout)
+            'docker login -u foo -p bar 1235.ecr.us-east-1.io', stdout)
         self.assertEquals(1, len(self.operations_called))
         self.assertNotIn('registryIds', self.operations_called[0][1])
 
@@ -63,10 +63,10 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
         ]
         stdout = self.run_cmd("ecr get-login --registry-ids 1234 5678")[0]
         self.assertIn(
-            'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io\n',
+            'docker login -u foo -p bar 1235.ecr.us-east-1.io\n',
             stdout)
         self.assertIn(
-            'docker login -u abc -p 123 -e none 4567.ecr.us-east-1.io\n',
+            'docker login -u abc -p 123 4567.ecr.us-east-1.io\n',
             stdout)
         self.assertEquals(1, len(self.operations_called))
         self.assertEquals([u'1234', u'5678'],


### PR DESCRIPTION
#2753 #2743 #2732 #2718 #2691 
flag -e/--email are deprecated since docker 1.11 and removed in docker 17.06.0-ce
https://docs.docker.com/release-notes/docker-ce/#17060-ce-2017-06-28