### PR TITLE
aws cloudformation deploy large template support

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -15,8 +15,11 @@ import os
 import sys
 import logging
 
+from botocore.client import Config
+
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.deployer import Deployer
+from awscli.customizations.cloudformation.s3uploader import S3Uploader
 from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 
 from awscli.customizations.commands import BasicCommand
@@ -59,6 +62,40 @@ class DeployCommand(BasicCommand):
                 'The name of the AWS CloudFormation stack you\'re deploying to.'
                 ' If you specify an existing stack, the command updates the'
                 ' stack. If you specify a new stack, the command creates it.'
+            )
+        },
+        {
+            'name': 's3-bucket',
+            'required': False,
+            'help_text': (
+                'The name of the S3 bucket where this command uploads'
+                ' your template if required.'
+            )
+        },
+        {
+            "name": "force-upload",
+            "action": "store_true",
+            "help_text": (
+                'Indicates whether to override existing files in the S3 bucket.'
+                ' Specify this flag to upload artifacts even if they '
+                ' match existing artifacts in the S3 bucket.'
+            )
+        },
+        {
+            'name': 's3-prefix',
+            'help_text': (
+                'A prefix name that the command adds to the'
+                ' artifacts\' name when it uploads them to the S3 bucket.'
+                ' The prefix name is a path name (folder name) for'
+                ' the S3 bucket.'
+            )
+        },
+
+        {
+            'name': 'kms-key-id',
+            'help_text': (
+                'The ID of an AWS KMS key that the command uses'
+                ' to encrypt artifacts that are at rest in the S3 bucket.'
             )
         },
         {
@@ -177,22 +214,41 @@ class DeployCommand(BasicCommand):
 
         parameters = self.merge_parameters(template_dict, parameter_overrides)
 
+        bucket = parsed_args.s3_bucket
+        if bucket:
+            s3_client = self._session.create_client(
+                "s3",
+                config=Config(signature_version='s3v4'),
+                region_name=parsed_globals.region,
+                verify=parsed_globals.verify_ssl)
+
+            s3_uploader = S3Uploader(s3_client,
+                                      bucket,
+                                      parsed_globals.region,
+                                      parsed_args.s3_prefix,
+                                      parsed_args.kms_key_id,
+                                      parsed_args.force_upload)
+        else:
+            s3_uploader = None
+
         deployer = Deployer(cloudformation_client)
         return self.deploy(deployer, stack_name, template_str,
                            parameters, parsed_args.capabilities,
                            parsed_args.execute_changeset, parsed_args.role_arn,
-                           parsed_args.notification_arns)
+                           parsed_args.notification_arns, s3_uploader)
+
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
-               notification_arns):
+               notification_arns, s3_uploader):
         result = deployer.create_and_wait_for_changeset(
                 stack_name=stack_name,
                 cfn_template=template_str,
                 parameter_values=parameters,
                 capabilities=capabilities,
                 role_arn=role_arn,
-                notification_arns=notification_arns)
+                notification_arns=notification_arns,
+                s3_uploader=s3_uploader)
 
         if execute_changeset:
             deployer.execute_changeset(result.changeset_id, stack_name)


### PR DESCRIPTION
Currently the AWS SAM extensions for aws-cli only support CloudFormation templates smaller than 51200 bytes (this is a published limitation of CloudFormation). 

In order to support larger templates, we can first upload these templates to S3, then create the changeset for the deployment of the templates. This adds options to `aws cloudformation deploy` to facilitate the deployment of large templates (460,800 bytes).

This fixes #2461 by allowing `--s3-bucket` to be passed in `aws cloudformation deploy` along with `--template-file`. If the template is larger than 51200 bytes, the template is uploaded to the S3 bucket and the CloudFormation ChangeSet is created referencing the S3 URL. We use the included s3uploader of awscli/customizations/cloudformation the same way as it is used in SAM packaging. 

This also fixes issue number 151 in awslabs/serverless-application-model. 

@sanathkr has commented on both those issues, so might be a good resource for discussion on this pull request. 