### PR TITLE
Resolve #519 by adding --hide-progress

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -563,6 +563,12 @@ class OnlyShowErrorsResultPrinter(ResultPrinter):
         pass
 
 
+class HideProgressResultPrinter(ResultPrinter):
+    """A result printer that only lists files transferred upon completion"""
+    def _print_progress(self, **kwargs):
+        pass
+
+
 class ResultProcessor(threading.Thread):
     def __init__(self, result_queue, result_handlers=None):
         """Thread to process results from result queue

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -33,6 +33,7 @@ from awscli.customizations.s3.results import DryRunResult
 from awscli.customizations.s3.results import ResultRecorder
 from awscli.customizations.s3.results import ResultPrinter
 from awscli.customizations.s3.results import OnlyShowErrorsResultPrinter
+from awscli.customizations.s3.results import HideProgressResultPrinter
 from awscli.customizations.s3.results import ResultProcessor
 from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.utils import RequestParamsMapper
@@ -110,6 +111,8 @@ class S3TransferHandlerFactory(object):
             result_printer = OnlyShowErrorsResultPrinter(result_recorder)
         elif self._cli_params.get('is_stream'):
             result_printer = OnlyShowErrorsResultPrinter(result_recorder)
+        elif self._cli_params.get('hide_progress'):
+            result_printer = HideProgressResultPrinter(result_recorder)
         else:
             result_printer = ResultPrinter(result_recorder)
         result_processor_handlers.append(result_printer)

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -368,6 +368,11 @@ ONLY_SHOW_ERRORS = {'name': 'only-show-errors', 'action': 'store_true',
                         'Only errors and warnings are displayed. All other '
                         'output is suppressed.')}
 
+HIDE_PROGRESS = {'name': 'hide-progress', 'action': 'store_true',
+                 'help_text': (
+                     'Suppress transfer progress messages, but still list '
+                     'files transferred.')}
+
 
 EXPECTED_SIZE = {'name': 'expected-size',
                  'help_text': (
@@ -424,7 +429,7 @@ TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  SSE_C_COPY_SOURCE_KEY, STORAGE_CLASS, GRANTS,
                  WEBSITE_REDIRECT, CONTENT_TYPE, CACHE_CONTROL,
                  CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE,
-                 EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS,
+                 EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS, HIDE_PROGRESS,
                  PAGE_SIZE, IGNORE_GLACIER_WARNINGS, FORCE_GLACIER_TRANSFER]
 
 
@@ -735,7 +740,7 @@ class RmCommand(S3TransferCommand):
     USAGE = "<S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 1, 'positional_arg': True,
                   'synopsis': USAGE}, DRYRUN, QUIET, RECURSIVE, INCLUDE,
-                 EXCLUDE, ONLY_SHOW_ERRORS, PAGE_SIZE]
+                 EXCLUDE, ONLY_SHOW_ERRORS, HIDE_PROGRESS, PAGE_SIZE]
 
 
 class SyncCommand(S3TransferCommand):


### PR DESCRIPTION
This hides transfer progress messages, but unlike --only-show-errors, the results of the transfer (list of filenames) is still displayed.  This makes the output more suitable for logging.