### PR TITLE
Fix issue #2806: Support for section names that contain spaces

### DIFF
--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -115,8 +115,12 @@ class ConfigureCommand(BasicCommand):
             self._write_out_creds_file_values(new_values,
                                               parsed_globals.profile)
             if parsed_globals.profile is not None:
-                new_values['__section__'] = (
-                    'profile \'%s\'' % parsed_globals.profile)
+                if ' ' in parsed_globals.profile:
+                    new_values['__section__'] = (
+                        'profile \'%s\'' % parsed_globals.profile)
+                else:
+                    new_values['__section__'] = (
+                        'profile %s' % parsed_globals.profile)
             self._config_writer.update_config(new_values, config_filename)
 
     def _write_out_creds_file_values(self, new_values, profile_name):

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -116,7 +116,7 @@ class ConfigureCommand(BasicCommand):
                                               parsed_globals.profile)
             if parsed_globals.profile is not None:
                 new_values['__section__'] = (
-                    'profile %s' % parsed_globals.profile)
+                    'profile \'%s\'' % parsed_globals.profile)
             self._config_writer.update_config(new_values, config_filename)
 
     def _write_out_creds_file_values(self, new_values, profile_name):

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
+import shlex
 import re
 
 from . import SectionNotFoundError
@@ -52,6 +53,10 @@ class ConfigFileWriter(object):
 
         """
         section_name = new_values.pop('__section__', 'default')
+        parts = shlex.split(section_name)
+        head, rest = parts[0], ' '.join(parts[1:])
+        if ' ' in rest:
+            section_name = "{} '{}'".format(head, rest)
         if not os.path.isfile(config_filename):
             self._create_file(config_filename)
             self._write_new_section(section_name, new_values, config_filename)

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import shlex
 import re
 
 from . import SectionNotFoundError
@@ -53,10 +52,6 @@ class ConfigFileWriter(object):
 
         """
         section_name = new_values.pop('__section__', 'default')
-        parts = section_name.split(' ')
-        head, rest = parts[0], ' '.join(parts[1:])
-        if ' ' in rest:
-            section_name = "{0} \"{1}\"".format(head, rest)
         if not os.path.isfile(config_filename):
             self._create_file(config_filename)
             self._write_new_section(section_name, new_values, config_filename)

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -56,7 +56,7 @@ class ConfigFileWriter(object):
         parts = shlex.split(section_name)
         head, rest = parts[0], ' '.join(parts[1:])
         if ' ' in rest:
-            section_name = "{} '{}'".format(head, rest)
+            section_name = "{0} '{1}'".format(head, rest)
         if not os.path.isfile(config_filename):
             self._create_file(config_filename)
             self._write_new_section(section_name, new_values, config_filename)

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -53,7 +53,7 @@ class ConfigFileWriter(object):
 
         """
         section_name = new_values.pop('__section__', 'default')
-        parts = shlex.split(section_name)
+        parts = section_name.split(' ')
         head, rest = parts[0], ' '.join(parts[1:])
         if ' ' in rest:
             section_name = "{0} '{1}'".format(head, rest)

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -56,7 +56,7 @@ class ConfigFileWriter(object):
         parts = section_name.split(' ')
         head, rest = parts[0], ' '.join(parts[1:])
         if ' ' in rest:
-            section_name = "{0} '{1}'".format(head, rest)
+            section_name = "{0} \"{1}\"".format(head, rest)
         if not os.path.isfile(config_filename):
             self._create_file(config_filename)
             self._write_new_section(section_name, new_values, config_filename)


### PR DESCRIPTION
Fixes issue #2806 

## Testing
```
(aws-cli) ubuntu@ubuntu-xenial:~/workspace/aws-cli/aws-cli$ cat ~/.aws/config
cat: /home/ubuntu/.aws/config: No such file or directory
(aws-cli) ubuntu@ubuntu-xenial:~/workspace/aws-cli/aws-cli$ aws configure --profile 'Foo Bar'
AWS Access Key ID [None]: foo
AWS Secret Access Key [None]: bar
Default region name [None]: us-west-1
Default output format [None]: json
(aws-cli) ubuntu@ubuntu-xenial:~/workspace/aws-cli/aws-cli$ aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names group_name --profile 'Foo Bar'

An error occurred (InvalidClientTokenId) when calling the DescribeAutoScalingGroups operation: The security token included in the request is invalid.
(aws-cli) ubuntu@ubuntu-xenial:~/workspace/aws-cli/aws-cli$ cat ~/.aws/config
[profile 'Foo Bar']
output = json
region = us-west-1
(aws-cli) ubuntu@ubuntu-xenial:~/workspace/aws-cli/aws-cli$
```

This indicates that the section has been successfully fetched from the profile.