### PR TITLE
Make configure/set command properly handle spaces in profiles

### DIFF
--- a/.changes/next-release/bugfix-Config-5978.json
+++ b/.changes/next-release/bugfix-Config-5978.json
@@ -1,0 +1,5 @@
+{
+  "category": "Config",
+  "type": "bugfix",
+  "description": "Properly handle spaces in profile names when being written out via the configure command, fixes `#2806 <https://github.com/aws/aws-cli/issues/2806>`__"
+}

--- a/awscli/customizations/configure/__init__.py
+++ b/awscli/customizations/configure/__init__.py
@@ -10,8 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import string
+from botocore.vendored.six.moves import shlex_quote
+
 NOT_SET = '<not set>'
 PREDEFINED_SECTION_NAMES = ('preview', 'plugins')
+_WHITESPACE = ' \t'
 
 
 class ConfigValue(object):
@@ -36,3 +40,10 @@ def mask_value(current_value):
         return 'None'
     else:
         return ('*' * 16) + current_value[-4:]
+
+
+def profile_to_section(profile_name):
+    """Converts a profile name to a section header to be used in the config."""
+    if any(c in _WHITESPACE for c in profile_name):
+        profile_name = shlex_quote(profile_name)
+    return 'profile %s' % profile_name

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -23,7 +23,7 @@ from awscli.customizations.configure.get import ConfigureGetCommand
 from awscli.customizations.configure.list import ConfigureListCommand
 from awscli.customizations.configure.writer import ConfigFileWriter
 
-from . import mask_value
+from . import mask_value, profile_to_section
 
 
 logger = logging.getLogger(__name__)
@@ -115,12 +115,8 @@ class ConfigureCommand(BasicCommand):
             self._write_out_creds_file_values(new_values,
                                               parsed_globals.profile)
             if parsed_globals.profile is not None:
-                if ' ' in parsed_globals.profile:
-                    new_values['__section__'] = (
-                        'profile \'%s\'' % parsed_globals.profile)
-                else:
-                    new_values['__section__'] = (
-                        'profile %s' % parsed_globals.profile)
+                section = profile_to_section(parsed_globals.profile)
+                new_values['__section__'] = section
             self._config_writer.update_config(new_values, config_filename)
 
     def _write_out_creds_file_values(self, new_values, profile_name):

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -115,8 +115,12 @@ class ConfigureCommand(BasicCommand):
             self._write_out_creds_file_values(new_values,
                                               parsed_globals.profile)
             if parsed_globals.profile is not None:
-                new_values['__section__'] = (
-                    'profile %s' % parsed_globals.profile)
+                if ' ' in parsed_globals.profile:
+                    new_values['__section__'] = (
+                        'profile \'%s\'' % parsed_globals.profile)
+                else:
+                    new_values['__section__'] = (
+                        'profile %s' % parsed_globals.profile)
             self._config_writer.update_config(new_values, config_filename)
 
     def _write_out_creds_file_values(self, new_values, profile_name):

--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -15,7 +15,7 @@ import os
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.configure.writer import ConfigFileWriter
 
-from . import PREDEFINED_SECTION_NAMES
+from . import PREDEFINED_SECTION_NAMES, profile_to_section
 
 
 class ConfigureSetCommand(BasicCommand):
@@ -60,7 +60,7 @@ class ConfigureSetCommand(BasicCommand):
             # profile (or leave it as the 'default' section if
             # no profile is set).
             if self._session.profile is not None:
-                section = 'profile %s' % self._session.profile
+                section = profile_to_section(self._session.profile)
         else:
             # First figure out if it's been scoped to a profile.
             parts = varname.split('.')
@@ -71,14 +71,14 @@ class ConfigureSetCommand(BasicCommand):
                     remaining = parts[1:]
                 else:
                     # [profile, profile_name, ...]
-                    section = "profile %s" % parts[1]
+                    section = profile_to_section(parts[1])
                     remaining = parts[2:]
                 varname = remaining[0]
                 if len(remaining) == 2:
                     value = {remaining[1]: value}
             elif parts[0] not in PREDEFINED_SECTION_NAMES:
                 if self._session.profile is not None:
-                    section = 'profile %s' % self._session.profile
+                    section = profile_to_section(self._session.profile)
                 else:
                     profile_name = self._session.get_config_variable('profile')
                     if profile_name is not None:

--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -188,6 +188,30 @@ class TestConfigureCommand(unittest.TestCase):
             '[default]\n'
             'region = us-west-1\n', self.get_config_file_contents())
 
+    def test_set_with_profile_spaces(self):
+        p = aws('configure set region us-west-1 --profile "test with spaces"',
+                env_vars=self.env_vars)
+        self.assert_no_errors(p)
+        self.assertEqual(
+            '[profile \'test with spaces\']\n'
+            'region = us-west-1\n', self.get_config_file_contents())
+
+    def test_set_with_profile_unknown_nested_key(self):
+        p = aws('configure set un.known us-west-1 --profile "space test"',
+                env_vars=self.env_vars)
+        self.assert_no_errors(p)
+        self.assertEqual(
+            '[profile \'space test\']\n'
+            'un =\n    known = us-west-1\n', self.get_config_file_contents())
+
+    def test_set_with_profile_spaces_scoped(self):
+        p = aws('configure set profile."test with spaces".region us-west-1',
+                env_vars=self.env_vars)
+        self.assert_no_errors(p)
+        self.assertEqual(
+            '[profile \'test with spaces\']\n'
+            'region = us-west-1\n', self.get_config_file_contents())
+
     def test_set_with_profile(self):
         p = aws('configure set region us-west-1 --profile testing',
                 env_vars=self.env_vars)

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -14,6 +14,7 @@ import os
 import mock
 
 from awscli.customizations.configure import configure, ConfigValue, NOT_SET
+from awscli.customizations.configure import profile_to_section
 from awscli.testutils import unittest
 from awscli.compat import six
 
@@ -236,6 +237,29 @@ class TestConfigValueMasking(unittest.TestCase):
         self.assertEqual(no_config.value, NOT_SET)
         no_config.mask_value()
         self.assertEqual(no_config.value, NOT_SET)
+
+
+class TestProfileToSection(unittest.TestCase):
+
+    def test_normal_profile(self):
+        profile = 'my-profile'
+        section = profile_to_section(profile)
+        self.assertEqual('profile my-profile', section)
+
+    def test_profile_with_spaces(self):
+        profile = 'my spaced profile'
+        section = profile_to_section(profile)
+        self.assertEqual('profile \'my spaced profile\'', section)
+
+    def test_profile_with_tab(self):
+        profile = 'tab\ts'
+        section = profile_to_section(profile)
+        self.assertEqual('profile \'tab\ts\'', section)
+
+    def test_profile_with_consecutive_spaces(self):
+        profile = '    '
+        section = profile_to_section(profile)
+        self.assertEqual('profile \'    \'', section)
 
 
 class PrecannedPrompter(object):


### PR DESCRIPTION
Fixes #2806
 A big thanks to @gtseres for submitting the fix.

I refactored his fix a little bit to make it a function so we can unit test it and apply it to the `set` command as well.