### PR TITLE
[Doc]Fix class of SecurityGroups value

### DIFF
--- a/awscli/examples/ec2/run-instances.rst
+++ b/awscli/examples/ec2/run-instances.rst
@@ -39,10 +39,7 @@ Output::
               "PrivateDnsName": null,
               "KeyName": "MyKeyPair",
               "SecurityGroups": [
-                  {
-                      "GroupName": "MySecurityGroup",
-                      "GroupId": "sg-903004f8"
-                  }
+                  "sg-903004f8"
               ],
               "ClientToken": null,
               "InstanceType": "c3.large",
@@ -103,10 +100,7 @@ Output::
               "PrivateDnsName": "ip-10-0-1-114.ec2.internal",
               "KeyName": "MyKeyPair",
               "SecurityGroups": [
-                  {
-                      "GroupName": "MySecurityGroup",
-                      "GroupId": "sg-903004f8"
-                  }
+                  "GroupId": "sg-903004f8"
               ],
               "ClientToken": null,
               "SubnetId": "subnet-6e7f829e",
@@ -291,4 +285,4 @@ You can launch an instance and specify tags for the instance, volumes, or both. 
 
 Command::
 
-  aws ec2 run-instances --image-id ami-abc12345 --count 1 --instance-type t2.micro --key-name MyKeyPair --subnet-id subnet-6e7f829e --tag-specifications 'ResourceType=instance,Tags=[{Key=webserver,Value=production}]' 'ResourceType=volume,Tags=[{Key=cost-center,Value=cc123}]' 
+  aws ec2 run-instances --image-id ami-abc12345 --count 1 --instance-type t2.micro --key-name MyKeyPair --subnet-id subnet-6e7f829e --tag-specifications 'ResourceType=instance,Tags=[{Key=webserver,Value=production}]' 'ResourceType=volume,Tags=[{Key=cost-center,Value=cc123}]'


### PR DESCRIPTION
I encounted error when I execute ec2 run-instances sample.
So I think this is wrong of example.

### procedure
test.json
```
...
            "SecurityGroups": [
                {
                    "GroupName": "MySecurityGroup",
                    "GroupId": "sg-903004f8"
                }
            ],
...
```

`$ aws ec2 run-instances --cli-input-json file://test.json`

return 
```
Invalid type for parameter SecurityGroups[0], value: {'GroupId': 'MySecurityGroup', 'GroupName': 'sg-903004f8'}, type: <class 'dict'>, valid types: <class 'str'>
```
