### PR TITLE
Undocument deprecated operations

### DIFF
--- a/.changes/next-release/enhancement-documentation-54107.json
+++ b/.changes/next-release/enhancement-documentation-54107.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "documentation",
+  "description": "Deprecated operations will no longer appear in help documentation or be suggested in autocompletion results."
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -425,6 +425,8 @@ class ServiceOperation(object):
         self._lineage = [self]
         self._operation_model = operation_model
         self._session = session
+        if operation_model.deprecated:
+            self._UNDOCUMENTED = True
 
     @property
     def name(self):

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -183,6 +183,13 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
         self.driver.main(['elb', 'remove-tags', 'help'])
         self.assert_contains("--tags Key1 Key2 Key3")
 
+    def test_deprecated_operations_not_documented(self):
+        self.driver.main(['s3api', 'help'])
+        self.assert_not_contains('get-bucket-lifecycle\n')
+        self.assert_not_contains('put-bucket-lifecycle\n')
+        self.assert_not_contains('get-bucket-notification\n')
+        self.assert_not_contains('put-bucket-notification\n')
+
 
 class TestRemoveDeprecatedCommands(BaseAWSHelpOutputTest):
     def assert_command_does_not_exist(self, service, command):

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -873,7 +873,10 @@ class TestServiceCommand(unittest.TestCase):
 class TestServiceOperation(unittest.TestCase):
     def setUp(self):
         self.name = 'foo'
-        self.cmd = ServiceOperation(self.name, None, None, None, None)
+        operation = mock.Mock(spec=botocore.model.OperationModel)
+        operation.deprecated = False
+        self.mock_operation = operation
+        self.cmd = ServiceOperation(self.name, None, None, operation, None)
 
     def test_name(self):
         self.assertEqual(self.cmd.name, self.name)
@@ -888,6 +891,12 @@ class TestServiceOperation(unittest.TestCase):
 
     def test_lineage_names(self):
         self.assertEqual(self.cmd.lineage_names, ['foo'])
+
+    def test_deprecated_operation(self):
+        self.mock_operation.deprecated = True
+        cmd = ServiceOperation(self.name, None, None, self.mock_operation,
+                               None)
+        self.assertTrue(getattr(cmd, '_UNDOCUMENTED'))
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_completer.py
+++ b/tests/unit/test_completer.py
@@ -16,6 +16,7 @@ import difflib
 import mock
 
 from botocore.compat import OrderedDict
+from botocore.model import OperationModel
 from awscli.clidriver import (
     CLIDriver, ServiceCommand, ServiceOperation, CLICommand)
 from awscli.arguments import BaseCLIArgument, CustomArgument
@@ -378,7 +379,10 @@ class MockCLIDriverFactory(object):
     def _create_operation_command(self, name, command):
         argument_table = self.create_argument_table(
             command.get('arguments', []))
-        operation = ServiceOperation(name, 'parent', None, {}, None)
+        mock_operation = mock.Mock(spec=OperationModel)
+        mock_operation.deprecated = False
+        operation = ServiceOperation(name, 'parent', None, mock_operation,
+                                     None)
         operation._arg_table = argument_table
         return operation
 


### PR DESCRIPTION
This will undocument deprecated operations removing them from the documentation as well as auto-completion in an effort to make these operations less discoverable. 

These changes depend on https://github.com/boto/botocore/pull/1292 being merged. So the tests might fail initially.