### PR TITLE
Add tagging functionality during S3 upload

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -346,6 +346,26 @@ METADATA_DIRECTIVE = {
 }
 
 
+TAGGING = {'name': 'tagging',
+           'help_text': (
+               'The tag-set for the object destination object this '
+               'value must be used in conjunction with the TaggingDirective. '
+               'The tag-set must be encoded as URL Query parameters')
+}
+
+
+TAGGING_DIRECTIVE = {
+    'name': 'tagging-directive', 'choices': ['COPY', 'REPLACE'],
+    'help_text': (
+        'Specifies whether the tagging is copied from the source object '
+        'or replaced with tag-set provided when copying S3 objects. Valid '
+        'values are ``COPY`` and ``REPLACE``. If this parameter is not '
+        'specified, ``COPY`` will be used by default. If ``REPLACE`` is used, '
+        'the copied object will only have the metadata values that were '
+        'specified by the CLI command.')
+}
+
+
 INDEX_DOCUMENT = {'name': 'index-document',
                   'help_text': (
                       'A suffix that is appended to a request that is for '
@@ -716,7 +736,8 @@ class CpCommand(S3TransferCommand):
             "or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
+                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE,
+                 TAGGING, TAGGING_DIRECTIVE]
 
 
 class MvCommand(S3TransferCommand):
@@ -727,7 +748,8 @@ class MvCommand(S3TransferCommand):
             "or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS +\
-                [METADATA, METADATA_DIRECTIVE, RECURSIVE]
+                [METADATA, METADATA_DIRECTIVE, RECURSIVE, TAGGING,
+                 TAGGING_DIRECTIVE]
 
 class RmCommand(S3TransferCommand):
     NAME = 'rm'
@@ -748,7 +770,7 @@ class SyncCommand(S3TransferCommand):
             "<LocalPath> or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA, METADATA_DIRECTIVE]
+                [METADATA, METADATA_DIRECTIVE, TAGGING, TAGGING_DIRECTIVE]
 
 
 class MbCommand(S3Command):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -422,6 +422,7 @@ class RequestParamsMapper(object):
         """Map CLI params to PutObject request params"""
         cls._set_general_object_params(request_params, cli_params)
         cls._set_metadata_params(request_params, cli_params)
+        cls._set_tagging_param(request_params, cli_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
 
@@ -437,6 +438,9 @@ class RequestParamsMapper(object):
         cls._set_metadata_directive_param(request_params, cli_params)
         cls._set_metadata_params(request_params, cli_params)
         cls._auto_populate_metadata_directive(request_params)
+        cls._set_tagging_directive_param(request_params, cli_params)
+        cls._set_tagging_param(request_params, cli_params)
+        cls._auto_populate_tagging_directive(request_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_and_copy_source_request_params(
             request_params, cli_params)
@@ -453,6 +457,7 @@ class RequestParamsMapper(object):
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
         cls._set_metadata_params(request_params, cli_params)
+        cls._set_tagging_param(request_params, cli_params)
 
     @classmethod
     def map_upload_part_params(cls, request_params, cli_params):
@@ -527,6 +532,22 @@ class RequestParamsMapper(object):
         if cli_params.get('metadata_directive'):
             request_params['MetadataDirective'] = cli_params[
                 'metadata_directive']
+
+    @classmethod
+    def _set_tagging_param(cls, request_params, cli_params):
+        if cli_params.get('tagging'):
+            request_params['Tagging'] = cli_params['tagging']
+
+    @classmethod
+    def _auto_populate_tagging_directive(cls, request_params):
+        if request_params.get('Tagging') and \
+                not request_params.get('TaggingDirective'):
+            request_params['TaggingDirective'] = 'COPY'
+
+    @classmethod
+    def _set_tagging_directive_param(cls, request_params, cli_params):
+        if cli_params.get('tagging_directive'):
+            request_params['TaggingDirective'] = cli_params['tagging_directive']
 
     @classmethod
     def _set_sse_request_params(cls, request_params, cli_params):

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -84,5 +84,34 @@ class TestMvCommand(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
+    def test_tagging_directive_copy(self):
+        self.parsed_responses = [
+            {"ContentLength": "100", "LastModified": "00:00:00Z"},
+            {'ETag': '"foo-1"'},
+            {'ETag': '"foo-2"'}
+        ]
+        cmdline = ('%s s3://bucket/key.txt s3://bucket/key2.txt'
+                   ' --tagging-directive REPLACE' % self.prefix)
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 3,
+                         self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'CopyObject')
+        self.assertEqual(self.operations_called[2][0].name, 'DeleteObject')
+        self.assertEqual(self.operations_called[1][1]['TaggingDirective'],
+                         'REPLACE')
+
+    def test_no_tagging_directive_for_non_copy(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket --tagging-directive REPLACE' % \
+            (self.prefix, full_path)
+        self.parsed_responses = \
+            [{'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 1,
+                         self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        self.assertNotIn('TaggingDirective', self.operations_called[0][1])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add the ability to set tags on S3 uploads, moves, copies, similar to the existing metadata parameter.