### PR TITLE
aws cloudformation package: follow symlinks when packging

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -183,7 +183,7 @@ def make_zip(filename, source_root):
     with open(zipfile_name, 'wb') as f:
         zip_file = zipfile.ZipFile(f, 'w', zipfile.ZIP_DEFLATED)
         with contextlib.closing(zip_file) as zf:
-            for root, dirs, files in os.walk(source_root):
+            for root, dirs, files in os.walk(source_root, followlinks=True):
                 for filename in files:
                     full_path = os.path.join(root, filename)
                     relative_path = os.path.relpath(


### PR DESCRIPTION
When we run `aws cloudformation package` and have specified a directory
in our Uri the make_zip function will zip the files using `os.walk`.
However by default `os.walk` will not follow symlinks unless the flag
`followlinks` is set to True.

Relates to #2900