### PR TITLE
Add option to return zero rc for empty deploy changeset

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -45,6 +45,7 @@ from awscli.argprocess import unpack_argument
 from awscli.alias import AliasLoader
 from awscli.alias import AliasCommandInjector
 from awscli.utils import emit_top_level_args_parsed_event
+from awscli.utils import write_exception
 
 
 LOG = logging.getLogger('awscli.clidriver')
@@ -229,10 +230,7 @@ class CLIDriver(object):
         except Exception as e:
             LOG.debug("Exception caught in main()", exc_info=True)
             LOG.debug("Exiting with rc 255")
-            err = get_stderr_text_writer()
-            err.write("\n")
-            err.write(six.text_type(e))
-            err.write("\n")
+            write_exception(e, outfile=get_stderr_text_writer())
             return 255
 
     def _emit_session_event(self, parsed_args):

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -186,13 +186,17 @@ class DeployCommand(BasicCommand):
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
                notification_arns):
-        result = deployer.create_and_wait_for_changeset(
-                stack_name=stack_name,
-                cfn_template=template_str,
-                parameter_values=parameters,
-                capabilities=capabilities,
-                role_arn=role_arn,
-                notification_arns=notification_arns)
+        try:
+            result = deployer.create_and_wait_for_changeset(
+                    stack_name=stack_name,
+                    cfn_template=template_str,
+                    parameter_values=parameters,
+                    capabilities=capabilities,
+                    role_arn=role_arn,
+                    notification_arns=notification_arns)
+        except exceptions.ChangeEmptyError as ex:
+            sys.stdout.write("%s\n" % ex)
+            return 0
 
         if execute_changeset:
             deployer.execute_changeset(result.changeset_id, stack_name)

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -20,6 +20,8 @@ from awscli.customizations.cloudformation.deployer import Deployer
 from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 
 from awscli.customizations.commands import BasicCommand
+from awscli.compat import get_stdout_text_writer
+from awscli.utils import write_exception
 
 LOG = logging.getLogger(__name__)
 
@@ -223,7 +225,7 @@ class DeployCommand(BasicCommand):
         except exceptions.ChangeEmptyError as ex:
             if fail_on_empty_changeset:
                 raise
-            sys.stdout.write("%s\n" % ex)
+            write_exception(ex, outfile=get_stdout_text_writer())
             return 0
 
         if execute_changeset:

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -150,6 +150,31 @@ class DeployCommand(BasicCommand):
                 'Amazon Simple Notification Service topic Amazon Resource Names'
                 ' (ARNs) that AWS CloudFormation associates with the stack.'
             )
+        },
+        {
+            'name': 'fail-on-empty-changeset',
+            'required': False,
+            'action': 'store_true',
+            'group_name': 'fail-on-empty-changeset',
+            'dest': 'fail_on_empty_changeset',
+            'default': True,
+            'help_text': (
+                'Specify if the CLI should return a non-zero exit code if '
+                'there are no changes to be made to the stack. The default '
+                'behavior is to return a non-zero exit code.'
+            )
+        },
+        {
+            'name': 'no-fail-on-empty-changeset',
+            'required': False,
+            'action': 'store_false',
+            'group_name': 'fail-on-empty-changeset',
+            'dest': 'fail_on_empty_changeset',
+            'default': True,
+            'help_text': (
+                'Causes the CLI to return an exit code of 0 if there are no '
+                'changes to be made to the stack.'
+            )
         }
     ]
 
@@ -181,11 +206,12 @@ class DeployCommand(BasicCommand):
         return self.deploy(deployer, stack_name, template_str,
                            parameters, parsed_args.capabilities,
                            parsed_args.execute_changeset, parsed_args.role_arn,
-                           parsed_args.notification_arns)
+                           parsed_args.notification_arns,
+                           parsed_args.fail_on_empty_changeset)
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
-               notification_arns):
+               notification_arns, fail_on_empty_changeset=True):
         try:
             result = deployer.create_and_wait_for_changeset(
                     stack_name=stack_name,
@@ -195,6 +221,8 @@ class DeployCommand(BasicCommand):
                     role_arn=role_arn,
                     notification_arns=notification_arns)
         except exceptions.ChangeEmptyError as ex:
+            if fail_on_empty_changeset:
+                raise
             sys.stdout.write("%s\n" % ex)
             return 0
 

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -144,7 +144,7 @@ class Deployer(object):
             reason = resp["StatusReason"]
 
             if status == "FAILED" and \
-               "No updates are to be performed" in reason:
+               "The submitted information didn't contain changes." in reason:
                     raise exceptions.ChangeEmptyError(stack_name=stack_name)
 
             raise RuntimeError("Failed to create the changeset: {0} "

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -187,3 +187,9 @@ class OutputStreamFactory(object):
         kwargs = get_popen_kwargs_for_pager_cmd(pager_cmd)
         kwargs['stdin'] = subprocess.PIPE
         return kwargs
+
+
+def write_exception(ex, outfile):
+    outfile.write("\n")
+    outfile.write(six.text_type(ex))
+    outfile.write("\n")

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import shutil
+import codecs
+
+from awscli.testutils import unittest
+from awscli.utils import write_exception
+
+
+class TestWriteException(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.outfile = os.path.join(self.tempdir, 'stdout')
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def test_write_exception(self):
+        error_message = "Some error message."
+        ex = Exception(error_message)
+        with codecs.open(self.outfile, 'w+', encoding='utf-8') as outfile:
+            write_exception(ex, outfile)
+            outfile.seek(0)
+
+            expected_output = (
+                "\n%s\n" % error_message
+            )
+            self.assertEqual(outfile.read(), expected_output)
+

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -56,7 +56,8 @@ class TestDeployCommand(unittest.TestCase):
                                     execute_changeset=True,
                                     capabilities=None,
                                     role_arn=None,
-                                    notification_arns=[])
+                                    notification_arns=[],
+                                    fail_on_empty_changeset=True)
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
         self.deploy_command = DeployCommand(self.session)
@@ -109,7 +110,7 @@ class TestDeployCommand(unittest.TestCase):
                         None,
                         not self.parsed_args.no_execute_changeset,
                         None,
-                        [])
+                        [], True)
 
                 self.deploy_command.parse_parameter_arg.assert_called_once_with(
                         self.parsed_args.parameter_overrides)
@@ -223,6 +224,41 @@ class TestDeployCommand(unittest.TestCase):
                                        role_arn,
                                        notification_arns)
 
+    def test_deploy_raises_exception_on_empty_changeset(self):
+        stack_name = "stack_name"
+        parameters = ["a", "b"]
+        template = "cloudformation template"
+        capabilities = ["foo", "bar"]
+        execute_changeset = True
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+
+        empty_changeset = exceptions.ChangeEmptyError(stack_name=stack_name)
+        changeset_func = self.deployer.create_and_wait_for_changeset
+        changeset_func.side_effect = empty_changeset
+        with self.assertRaises(exceptions.ChangeEmptyError):
+            self.deploy_command.deploy(
+                self.deployer, stack_name, template, parameters, capabilities,
+                execute_changeset, role_arn, notification_arns
+            )
+
+    def test_deploy_does_not_raise_exception_on_empty_changeset(self):
+        stack_name = "stack_name"
+        parameters = ["a", "b"]
+        template = "cloudformation template"
+        capabilities = ["foo", "bar"]
+        execute_changeset = True
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+
+        empty_changeset = exceptions.ChangeEmptyError(stack_name=stack_name)
+        changeset_func = self.deployer.create_and_wait_for_changeset
+        changeset_func.side_effect = empty_changeset
+        self.deploy_command.deploy(
+            self.deployer, stack_name, template, parameters, capabilities,
+            execute_changeset, role_arn, notification_arns,
+            fail_on_empty_changeset=False
+        )
 
     def test_parse_parameter_arg_success(self):
         """

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -243,7 +243,7 @@ class TestDeployer(unittest.TestCase):
 
         response = {
             "Status": "FAILED",
-            "StatusReason": "No updates are to be performed"
+            "StatusReason": "The submitted information didn't contain changes."
         }
 
         waiter_error = botocore.exceptions.WaiterError(name="name",


### PR DESCRIPTION
Closes #2606

This adds a flag to allow users to have deploy return a zero rc in
the event that their deploy changeset is empty. This is something
we would want to look at changing the default for on a major version
bump.