### PR TITLE
Load the GitHub Button over HTTPS

### DIFF
--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -53,7 +53,7 @@
         </ul>
         {%- if theme_github_user and theme_github_repo %}
         <div class="pull-right" id="github-stars">
-          <iframe src="http://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type=watch&count=true&size=small"
+          <iframe src="https://ghbtns.com/github-btn.html?user={{ theme_github_user }}&repo={{ theme_github_repo }}&type=watch&count=true&size=small"
                   allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
         </div>
         {%- endif %}


### PR DESCRIPTION
Browsers will block HTTP requests on a website served via HTTPS
See: https://support.google.com/chrome/?p=unauthenticated