### PR TITLE
Add database abstraction for history recorder

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -37,6 +37,12 @@ except ImportError:
     ZIP_COMPRESSION_MODE = zipfile.ZIP_STORED
 
 
+try:
+    import sqlite3
+except ImportError:
+    sqlite3 = None
+
+
 class NonTranslatedStdout(object):
     """ This context manager sets the line-end translation mode for stdout.
 

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -26,6 +26,7 @@ queue = six.moves.queue
 shlex_quote = six.moves.shlex_quote
 StringIO = six.StringIO
 urlopen = six.moves.urllib.request.urlopen
+binary_type = six.binary_type
 
 # Most, but not all, python installations will have zlib. This is required to
 # compress any files we send via a push. If we can't compress, we can still

--- a/awscli/customizations/history/__init__.py
+++ b/awscli/customizations/history/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -88,8 +88,6 @@ class DatabaseConnection(object):
 
 
 class PayloadSerializer(json.JSONEncoder):
-    _DEFAULT_TYPES = set(['str', 'int', 'list', 'dict', 'float'])
-
     def _process_CaseInsensitiveDict(self, obj, type_name):
         return dict(obj)
 
@@ -120,8 +118,6 @@ class PayloadSerializer(json.JSONEncoder):
 
     def default(self, obj):
         type_name = type(obj).__name__
-        if type_name in self._DEFAULT_TYPES:
-            return obj
         return getattr(
             self, '_process_%s' % type_name, self._unknown
         )(obj, type_name)

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -22,6 +22,7 @@ from collections import MutableMapping
 from botocore.history import BaseHistoryHandler
 
 from awscli.compat import sqlite3
+from awscli.compat import ensure_text_type
 
 
 LOG = logging.getLogger('awscli.history.db')
@@ -211,7 +212,7 @@ class RecordBuilder(object):
         # The payload body key here is in bytes in python 3 and needs to be
         # decoded.
         if event_type in self._BYTES_BODY_PAYLOADS:
-            payload['body'] = payload['body'].decode('utf-8')
+            payload['body'] = ensure_text_type(payload['body'])
         return payload
 
     def build_record(self, event_type, payload, source):

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -1,0 +1,223 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import uuid
+import time
+import json
+import base64
+import threading
+
+from botocore.history import BaseHistoryHandler
+
+from awscli.compat import sqlite3
+from awscli.compat import ensure_text_type
+
+
+class DatabaseConnection(object):
+    _CREATE_TABLE = """
+    CREATE TABLE IF NOT EXISTS records (
+      id TEXT,
+      request_id TEXT,
+      source TEXT,
+      event_type TEXT,
+      timestamp INTEGER,
+      payload TEXT
+    )"""
+    _ENABLE_WAL = """PRAGMA journal_mode=WAL"""
+    _DATABASE_NAME = 'history.db'
+    _DEFAULT_DATABASE_FILENAME = os.path.expanduser(
+        os.path.join('~', '.aws', 'cli', 'history', _DATABASE_NAME))
+
+    def __init__(self, db_filename=None):
+        if db_filename:
+            self._db_filename = db_filename
+        elif os.environ.get('AWS_HISTORY_PATH'):
+            self._db_filename = os.path.join(
+                os.environ.get('AWS_HISTORY_PATH'), self._DATABASE_NAME)
+        else:
+            self._db_filename = self._DEFAULT_DATABASE_FILENAME
+
+        if not os.path.isdir(os.path.dirname(self._db_filename)):
+            os.makedirs(os.path.dirname(self._db_filename))
+        self._connection = sqlite3.connect(
+            self._db_filename, check_same_thread=False)
+        self._ensure_database_setup()
+
+    def _ensure_database_setup(self):
+        self._create_record_table()
+        self._try_to_enable_wal()
+
+    def _create_record_table(self):
+        cursor = self._connection.cursor()
+        cursor.execute(self._CREATE_TABLE)
+        self._connection.commit()
+
+    def _try_to_enable_wal(self):
+        try:
+            cursor = self._connection.cursor()
+            cursor.execute(self._ENABLE_WAL)
+            self._connection.commit()
+        except sqlite3.Error:
+            # This is just a performance enhancement so it is optional. Not all
+            # systems will have a sqlite compiled with the WAL enabled.
+            pass
+
+    def cursor(self):
+        return self._connection.cursor()
+
+    def commit(self):
+        self._connection.commit()
+
+    @property
+    def row_factory(self):
+        return self._connection.row_factory
+
+    @row_factory.setter
+    def row_factory(self, row_factory):
+        self._connection.row_factory = row_factory
+
+
+class PayloadSerializer(json.JSONEncoder):
+    DEFAULT_TYPES = set(['str', 'int', 'list', 'dict', 'float'])
+
+    def _process_CaseInsensitiveDict(self, obj, type_name):
+        return dict(obj)
+
+    def _process_bytes(self, obj, type_name):
+        encoded = base64.b64encode(obj)
+        return ensure_text_type(encoded)
+
+    def _process_timestamp(self, obj, type_name):
+        return obj.isoformat()
+
+    def _unknown(self, obj, type_name):
+        return type_name
+
+    def default(self, obj):
+        type_name = type(obj).__name__
+        if type_name in self.DEFAULT_TYPES:
+            return obj
+        return getattr(
+            self, '_process_%s' % type_name, self._unknown
+        )(obj, type_name)
+
+
+class DatabaseRecordWriter(object):
+    _WRITE_RECORD = """
+    INSERT INTO records(id, request_id, source, event_type, timestamp, payload)
+    VALUES (?,?,?,?,?,?)"""
+    _REQUEST_LIFECYCLE_EVENTS = set(
+        ['API_CALL', 'HTTP_REQUEST', 'HTTP_RESPONSE', 'PARSED_RESPONSE'])
+    _START_OF_REQUEST_LIFECYCLE_EVENT = 'API_CALL'
+
+    def __init__(self, connection=None):
+        if connection is None:
+            connection = DatabaseConnection()
+        self._connection = connection
+        self._request_ids = {}
+        self._identifier = None
+
+    def write_record(self, record):
+        cursor = self._connection.cursor()
+        db_record = self._create_db_record(record)
+        cursor.execute(self._WRITE_RECORD, db_record)
+        self._connection.commit()
+
+    def _get_request_id(self, event_type):
+        if event_type == self._START_OF_REQUEST_LIFECYCLE_EVENT:
+            self._start_http_lifecycle()
+        if event_type in self._REQUEST_LIFECYCLE_EVENTS:
+            thread_id = threading.current_thread().ident
+            request_id = self._request_ids.get(thread_id, '')
+        else:
+            request_id = ''
+        return request_id
+
+    def _start_http_lifecycle(self):
+        thread_id = threading.current_thread().ident
+        new_identifier = str(uuid.uuid4())
+        self._request_ids[thread_id] = new_identifier
+
+    def _get_identifier(self):
+        if self._identifier is None:
+            self._identifier = str(uuid.uuid4())
+        return self._identifier
+
+    def _create_db_record(self, record):
+        uid = self._get_identifier()
+        event_type = record['event_type']
+        request_id = self._get_request_id(event_type)
+        json_serialized_payload = json.dumps(record['payload'],
+                                             cls=PayloadSerializer)
+        db_record = (
+            uid,
+            request_id,
+            record['source'],
+            event_type,
+            record['timestamp'],
+            json_serialized_payload
+        )
+        return db_record
+
+
+class DatabaseRecordReader(object):
+    _ORDERING = 'ORDER BY timestamp'
+    _GET_LAST_ID_RECORDS = """
+    SELECT * FROM records
+    WHERE id =
+    (SELECT id FROM records WHERE timestamp =
+    (SELECT max(timestamp) FROM records)) %s;""" % _ORDERING
+    _GET_RECORDS_BY_ID = 'SELECT * from records where id = ? %s' % _ORDERING
+
+    def __init__(self, connection=None):
+        if connection is None:
+            connection = DatabaseConnection()
+        self._connection = connection
+        self._connection.row_factory = self._row_factory
+
+    def _row_factory(self, cursor, row):
+        d = {}
+        for idx, col in enumerate(cursor.description):
+            val = row[idx]
+            if col[0] == 'payload':
+                val = json.loads(val)
+            d[col[0]] = val
+        return d
+
+    def yield_latest_records(self):
+        cursor = self._connection.cursor()
+        cursor.execute(self._GET_LAST_ID_RECORDS)
+        for row in cursor:
+            yield row
+
+    def yield_records(self, record_id):
+        cursor = self._connection.cursor()
+        cursor.execute(self._GET_RECORDS_BY_ID, [record_id])
+        for row in cursor:
+            yield row
+
+
+class DatabaseHistoryHandler(BaseHistoryHandler):
+    def __init__(self, writer=None):
+        if writer is None:
+            writer = DatabaseRecordWriter()
+        self._writer = writer
+
+    def emit(self, event_type, payload, source):
+        record = {
+            'event_type': event_type,
+            'payload': payload,
+            'source': source,
+            'timestamp': int(time.time() * 1000)
+        }
+        self._writer.write_record(record)

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -203,10 +203,12 @@ class RecordBuilder(object):
         return None
 
     def _format_payload(self, event_type, payload):
-        # The payload body key here is in bytes in python 3 and needs to be
-        # decoded.
+        # If the payload has a body key it can be in bytes, so it needs to be
+        # converted to utf-8 if possible so it can be serialized as JSON later.
         if event_type in self._BYTES_BODY_PAYLOADS:
-            payload['body'] = ensure_text_type(payload['body'])
+            body = payload.get('body')
+            if body is not None:
+                payload['body'] = ensure_text_type(body)
         return payload
 
     def _get_identifier(self):

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -58,13 +58,13 @@ class DatabaseConnection(object):
         self._try_to_enable_wal()
 
     def _create_record_table(self):
-        cursor = self._connection.cursor()
+        cursor = self.cursor()
         cursor.execute(self._CREATE_TABLE)
         self._connection.commit()
 
     def _try_to_enable_wal(self):
         try:
-            cursor = self._connection.cursor()
+            cursor = self.cursor()
             cursor.execute(self._ENABLE_WAL)
             self._connection.commit()
         except sqlite3.Error:

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -38,7 +38,6 @@ class DatabaseConnection(object):
           payload TEXT
         )"""
     _ENABLE_WAL = 'PRAGMA journal_mode=WAL'
-    _DEFAULT_DATABASE_NAME = 'history.db'
 
     def __init__(self, db_filename):
         self._connection = sqlite3.connect(
@@ -79,7 +78,7 @@ class PayloadSerializer(json.JSONEncoder):
     def _encode_datetime(self, obj):
         return obj.isoformat()
 
-    def _try_encode(self, obj):
+    def _try_decode_bytes(self, obj):
         try:
             obj = obj.decode('utf-8')
         except UnicodeDecodeError:
@@ -88,7 +87,7 @@ class PayloadSerializer(json.JSONEncoder):
 
     def _remove_non_unicode_stings(self, obj):
         if isinstance(obj, str):
-            obj = self._try_encode(obj)
+            obj = self._try_decode_bytes(obj)
         elif isinstance(obj, dict):
             obj = dict((k, self._remove_non_unicode_stings(v)) for k, v
                        in obj.items())
@@ -122,10 +121,10 @@ class PayloadSerializer(json.JSONEncoder):
         elif isinstance(obj, binary_type):
             # In PY3 the bytes type differs from the str type so the default
             # method will be called when a bytes object is encountered.
-            # We call the same _try_encode method that either decodes it to a
-            # utf-8 string and continues serialization, or removes the value
-            # if it is not valid utf-8 string.
-            return self._try_encode(obj)
+            # We call the same _try_decode_bytes method that either decodes it
+            # to a utf-8 string and continues serialization, or removes the
+            # value if it is not valid utf-8 string.
+            return self._try_decode_bytes(obj)
         else:
             return repr(obj)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,51 @@
+from collections import MutableMapping
+from collections import Mapping
+
+
+# CaseInsensitiveDict from requests that must be serializble.
+class CaseInsensitiveDict(MutableMapping):
+    def __init__(self, data=None, **kwargs):
+        self._store = dict()
+        if data is None:
+            data = {}
+        self.update(data, **kwargs)
+
+    def __setitem__(self, key, value):
+        # Use the lowercased key for lookups, but store the actual
+        # key alongside the value.
+        self._store[key.lower()] = (key, value)
+
+    def __getitem__(self, key):
+        return self._store[key.lower()][1]
+
+    def __delitem__(self, key):
+        del self._store[key.lower()]
+
+    def __iter__(self):
+        return (casedkey for casedkey, mappedvalue in self._store.values())
+
+    def __len__(self):
+        return len(self._store)
+
+    def lower_items(self):
+        """Like iteritems(), but with all lowercase keys."""
+        return (
+            (lowerkey, keyval[1])
+            for (lowerkey, keyval)
+            in self._store.items()
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, Mapping):
+            other = CaseInsensitiveDict(other)
+        else:
+            return NotImplemented
+        # Compare insensitively
+        return dict(self.lower_items()) == dict(other.lower_items())
+
+    # Copy is required
+    def copy(self):
+        return CaseInsensitiveDict(self._store.values())
+
+    def __repr__(self):
+        return str(dict(self.items()))

--- a/tests/functional/history/__init__.py
+++ b/tests/functional/history/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -182,7 +182,7 @@ class TestDatabaseRecordWriter(BaseDatabaseTest):
             'source': 'TEST',
             'event_type': 'foo',
             'payload': '',
-            'timestamp': 12334
+            'timestamp': 1234
         }
         records_to_write = 40
         for _ in range(records_to_write):
@@ -203,12 +203,12 @@ class TestDatabaseRecordReader(BaseDatabaseTest):
 
     def test_yields_nothing_if_no_matching_record_id(self):
         reader = DatabaseRecordReader(self.connection)
-        records = [record for record in reader.yield_records('fake_id')]
+        records = [record for record in reader.iter_records('fake_id')]
         self.assertEqual(len(records), 0)
 
     def test_yields_nothing_no_recent_records(self):
         reader = DatabaseRecordReader(self.connection)
-        records = [record for record in reader.yield_latest_records()]
+        records = [record for record in reader.iter_latest_records()]
         self.assertEqual(len(records), 0)
 
     def test_can_read_record(self):
@@ -257,7 +257,7 @@ class TestDatabaseRecordReader(BaseDatabaseTest):
         # This should select only the three records from writer_a since we
         # are explicitly looking for the records that match the id of the
         # foo event record.
-        records = [record for record in reader.yield_records(identifier)]
+        records = [record for record in reader.iter_records(identifier)]
         self.assertEqual(len(records), 3)
         for record in records:
             record_id = record['id']
@@ -295,5 +295,5 @@ class TestDatabaseRecordReader(BaseDatabaseTest):
         # foo and bar records only.
         reader = DatabaseRecordReader(self.connection)
         records = set([record['event_type'] for record
-                       in reader.yield_latest_records()])
+                       in reader.iter_latest_records()])
         self.assertEqual(set(['foo', 'bar']), records)

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -1,0 +1,199 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import tempfile
+import shutil
+import json
+import os
+
+from awscli.customizations.history.db import DatabaseConnection
+from awscli.customizations.history.db import DatabaseRecordWriter
+from awscli.customizations.history.db import DatabaseRecordReader
+from awscli.testutils import unittest
+from awscli.compat import sqlite3
+
+
+class BaseDatabaseTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.db_filename = os.path.join(self.tempdir, 'history.db')
+        self.connection = DatabaseConnection(db_filename=self.db_filename)
+        self.connection.row_factory = sqlite3.Row
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def _get_cursor(self):
+        return self.connection.cursor()
+
+
+@unittest.skipIf(sqlite3 is None,
+                 "sqlite3 not supported in this python")
+class TestDatabaseRecordWriter(BaseDatabaseTest):
+    def test_does_create_database(self):
+        self.assertTrue(os.path.isfile(self.db_filename))
+
+    def test_does_create_table(self):
+        cursor = self._get_cursor()
+        cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE "
+                       "type='table' AND name='records';")
+        result = cursor.fetchone()
+        self.assertEqual(result[0], 1)
+
+    def test_can_write_record(self):
+        writer = DatabaseRecordWriter(connection=self.connection)
+        known_record_fields = {
+            'source': 'TEST',
+            'event_type': 'foo',
+            'payload': {"foo": "bar"},
+            'timestamp': 1234
+        }
+        writer.write_record(known_record_fields)
+
+        cursor = self._get_cursor()
+        cursor.execute("SELECT COUNT(*) FROM records;")
+        num_records = cursor.fetchone()
+        self.assertEqual(num_records[0], 1)
+
+        cursor.execute("SELECT * FROM records;")
+        record = dict(cursor.fetchone())
+        for col_name, row_value in known_record_fields.items():
+            # Normally our reader would take care of parsing the JSON from
+            # the payload.
+            if col_name == 'payload':
+                record[col_name] = json.loads(record[col_name])
+            self.assertEqual(record[col_name], row_value)
+
+        self.assertIn('id', record.keys())
+        self.assertIn('request_id', record.keys())
+
+    def test_can_write_many_records(self):
+        writer = DatabaseRecordWriter(connection=self.connection)
+        known_record_fields = {
+            'source': 'TEST',
+            'event_type': 'foo',
+            'payload': '',
+            'timestamp': 12334
+        }
+        records_to_write = 40
+        for _ in range(records_to_write):
+            writer.write_record(known_record_fields)
+
+        cursor = self._get_cursor()
+        cursor.execute("SELECT COUNT(*) FROM records;")
+        num_records = cursor.fetchone()
+        self.assertEqual(num_records[0], records_to_write)
+
+
+@unittest.skipIf(sqlite3 is None,
+                 "sqlite3 not supported in this python")
+class TestDatabaseRecordReader(BaseDatabaseTest):
+    def _write_sequence_of_records(self, writer, records):
+        for record in records:
+            writer.write_record(record)
+
+    def test_yields_nothing_if_no_matching_record_id(self):
+        reader = DatabaseRecordReader(self.connection)
+        records = [record for record in reader.yield_records('fake_id')]
+        self.assertEqual(len(records), 0)
+
+    def test_yields_nothing_no_recent_records(self):
+        reader = DatabaseRecordReader(self.connection)
+        records = [record for record in reader.yield_latest_records()]
+        self.assertEqual(len(records), 0)
+
+    def test_can_read_record(self):
+        writer_a = DatabaseRecordWriter(self.connection)
+        writer_b = DatabaseRecordWriter(self.connection)
+        self._write_sequence_of_records(writer_a, [
+            {
+                'source': 'TEST',
+                'event_type': 'foo',
+                'payload': '',
+                'timestamp': 3
+            },
+            {
+                'source': 'TEST',
+                'event_type': 'bar',
+                'payload': '',
+                'timestamp': 1
+            },
+            {
+                'source': 'TEST',
+                'event_type': 'baz',
+                'payload': '',
+                'timestamp': 4
+            }
+        ])
+        self._write_sequence_of_records(writer_b, [
+            {
+                'source': 'TEST',
+                'event_type': 'qux',
+                'payload': '',
+                'timestamp': 2
+            },
+            {
+                'source': 'TEST',
+                'event_type': 'zip',
+                'payload': '',
+                'timestamp': 6
+            }
+        ])
+        reader = DatabaseRecordReader(self.connection)
+        cursor = self._get_cursor()
+        cursor.execute(
+            'select id from records where event_type = "foo" limit 1')
+        identifier = cursor.fetchone()['id']
+
+        # This should select only the three records from writer_a since we
+        # are explicitly looking for the records that match the id of the
+        # foo event record.
+        records = [record for record in reader.yield_records(identifier)]
+        self.assertEqual(len(records), 3)
+        for record in records:
+            record_id = record['id']
+            self.assertEqual(record_id, identifier)
+
+    def test_can_read_most_recent_records(self):
+        writer_a = DatabaseRecordWriter(self.connection)
+        writer_b = DatabaseRecordWriter(self.connection)
+        self._write_sequence_of_records(writer_a, [
+            {
+                'source': 'TEST',
+                'event_type': 'foo',
+                'payload': '',
+                'timestamp': 3
+            },
+            {
+                'source': 'TEST',
+                'event_type': 'bar',
+                'payload': '',
+                'timestamp': 1
+            }
+        ])
+        self._write_sequence_of_records(writer_b, [
+            {
+                'source': 'TEST',
+                'event_type': 'baz',
+                'payload': '',
+                'timestamp': 2
+            }
+        ])
+
+        # Since the foo and bar events were written by the writer_a they all
+        # share an id. foo was written at time 3 which makes it the most
+        # recent, so when we call get_latest_records we should get the
+        # foo and bar records only.
+        reader = DatabaseRecordReader(self.connection)
+        records = set([record['event_type'] for record
+                       in reader.yield_latest_records()])
+        self.assertEqual(set(['foo', 'bar']), records)

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -52,13 +52,8 @@ class ThreadedRecordWriter(object):
 
 class BaseDatabaseTest(unittest.TestCase):
     def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.db_filename = os.path.join(self.tempdir, 'history.db')
-        self.connection = DatabaseConnection(db_filename=self.db_filename)
+        self.connection = DatabaseConnection(':memory:')
         self.connection.row_factory = sqlite3.Row
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
 
     def _get_cursor(self):
         return self.connection.cursor()
@@ -143,9 +138,6 @@ class TestMultithreadedDatabaseWriter(BaseThreadedDatabaseWriter):
 @unittest.skipIf(sqlite3 is None,
                  "sqlite3 not supported in this python")
 class TestDatabaseRecordWriter(BaseDatabaseTest):
-    def test_does_create_database(self):
-        self.assertTrue(os.path.isfile(self.db_filename))
-
     def test_does_create_table(self):
         cursor = self._get_cursor()
         cursor.execute("SELECT COUNT(*) FROM sqlite_master WHERE "
@@ -178,8 +170,8 @@ class TestDatabaseRecordWriter(BaseDatabaseTest):
                 record[col_name] = json.loads(record[col_name])
                 self.assertEqual(record[col_name], row_value)
 
-        self.assertIn('id', record.keys())
-        self.assertIn('request_id', record.keys())
+        self.assertTrue('id' in record.keys())
+        self.assertTrue('request_id' in record.keys())
 
     def test_can_write_many_records(self):
         writer = DatabaseRecordWriter(connection=self.connection)

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -97,21 +97,25 @@ class TestMultithreadedDatabaseWriter(BaseThreadedDatabaseWriter):
         for i in range(thread_count):
             self._write_records(i, [
                 {
+                    'command_id': 'command',
                     'event_type': 'API_CALL',
                     'payload': i,
                     'source': 'TEST',
                     'timestamp': 1234
                 }, {
+                    'command_id': 'command',
                     'event_type': 'HTTP_REQUEST',
                     'payload': i,
                     'source': 'TEST',
                     'timestamp': 1234
                 }, {
+                    'command_id': 'command',
                     'event_type': 'HTTP_RESPONSE',
                     'payload': i,
                     'source': 'TEST',
                     'timestamp': 1234
                 }, {
+                    'command_id': 'command',
                     'event_type': 'PARSED_RESPONSE',
                     'payload': i,
                     'source': 'TEST',
@@ -152,6 +156,7 @@ class TestDatabaseRecordWriter(BaseDatabaseTest):
     def test_can_write_record(self):
         writer = DatabaseRecordWriter(connection=self.connection)
         known_record_fields = {
+            'command_id': 'command',
             'source': 'TEST',
             'event_type': 'foo',
             'payload': {"foo": "bar"},
@@ -179,6 +184,7 @@ class TestDatabaseRecordWriter(BaseDatabaseTest):
     def test_can_write_many_records(self):
         writer = DatabaseRecordWriter(connection=self.connection)
         known_record_fields = {
+            'command_id': 'command',
             'source': 'TEST',
             'event_type': 'foo',
             'payload': '',
@@ -212,36 +218,40 @@ class TestDatabaseRecordReader(BaseDatabaseTest):
         self.assertEqual(len(records), 0)
 
     def test_can_read_record(self):
-        writer_a = DatabaseRecordWriter(self.connection)
-        writer_b = DatabaseRecordWriter(self.connection)
-        self._write_sequence_of_records(writer_a, [
+        writer = DatabaseRecordWriter(self.connection)
+        self._write_sequence_of_records(writer, [
             {
+                'command_id': 'command a',
                 'source': 'TEST',
                 'event_type': 'foo',
                 'payload': '',
                 'timestamp': 3
             },
             {
+                'command_id': 'command a',
                 'source': 'TEST',
                 'event_type': 'bar',
                 'payload': '',
                 'timestamp': 1
             },
             {
+                'command_id': 'command a',
                 'source': 'TEST',
                 'event_type': 'baz',
                 'payload': '',
                 'timestamp': 4
             }
         ])
-        self._write_sequence_of_records(writer_b, [
+        self._write_sequence_of_records(writer, [
             {
+                'command_id': 'command b',
                 'source': 'TEST',
                 'event_type': 'qux',
                 'payload': '',
                 'timestamp': 2
             },
             {
+                'command_id': 'command b',
                 'source': 'TEST',
                 'event_type': 'zip',
                 'payload': '',
@@ -264,24 +274,26 @@ class TestDatabaseRecordReader(BaseDatabaseTest):
             self.assertEqual(record_id, identifier)
 
     def test_can_read_most_recent_records(self):
-        writer_a = DatabaseRecordWriter(self.connection)
-        writer_b = DatabaseRecordWriter(self.connection)
-        self._write_sequence_of_records(writer_a, [
+        writer = DatabaseRecordWriter(self.connection)
+        self._write_sequence_of_records(writer, [
             {
+                'command_id': 'command a',
                 'source': 'TEST',
                 'event_type': 'foo',
                 'payload': '',
                 'timestamp': 3
             },
             {
+                'command_id': 'command a',
                 'source': 'TEST',
                 'event_type': 'bar',
                 'payload': '',
                 'timestamp': 1
             }
         ])
-        self._write_sequence_of_records(writer_b, [
+        self._write_sequence_of_records(writer, [
             {
+                'command_id': 'command b',
                 'source': 'TEST',
                 'event_type': 'baz',
                 'payload': '',

--- a/tests/unit/customizations/history/__init__.py
+++ b/tests/unit/customizations/history/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -630,7 +630,7 @@ class TestRecordBuilder(unittest.TestCase):
         self.assertTrue('command_id' in record)
         self.assertTrue('timestamp' in record)
 
-    def test_can_process_http_request_with_noone_body(self):
+    def test_can_process_http_request_with_none_body(self):
         try:
             self.builder.build_record('HTTP_REQUEST', {'body': None}, '')
         except ValueError:

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -607,7 +607,7 @@ class TestPayloadSerialzier(unittest.TestCase):
         self.assertEqual(encoded, reloaded)
 
 
-class TestRequestTracker(unittest.TestCase):
+class TestRequestBuilder(unittest.TestCase):
     UUID_PATTERN = re.compile(
         '^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$',
         re.I
@@ -616,6 +616,20 @@ class TestRequestTracker(unittest.TestCase):
     def _get_request_id_for_event_type(self, builder, event_type):
         record = builder.build_record(event_type, {'body': b''}, '')
         return record.get('request_id')
+
+    def test_can_process_http_request_with_no_body(self):
+        builder = RecordBuilder()
+        try:
+            builder.build_record('HTTP_REQUEST', {}, '')
+        except ValueError:
+            self.fail("Should not raise value error")
+
+    def test_can_process_http_response_with_no_body(self):
+        builder = RecordBuilder()
+        try:
+            builder.build_record('HTTP_RESPONSE', {}, '')
+        except ValueError:
+            self.fail("Should not raise value error")
 
     def test_can_get_request_id_from_api_call(self):
         builder = RecordBuilder()

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -1,0 +1,561 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import re
+import json
+import threading
+import queue
+
+import mock
+
+from awscli.customizations.history.db import DatabaseHistoryHandler
+from awscli.customizations.history.db import DatabaseRecordWriter
+from awscli.customizations.history.db import DatabaseRecordReader
+from awscli.testutils import unittest
+
+
+class FakeDatabaseConnection(object):
+    def __init__(self):
+        self.mock_cursor = mock.Mock()
+        self.commits = 0
+
+    def cursor(self):
+        return self.mock_cursor
+
+    def commit(self):
+        self.commits += 1
+
+
+class TestDatabaseHistoryHandler(unittest.TestCase):
+    def test_history_creates_record_for_writer(self):
+        writer = mock.Mock(DatabaseRecordWriter)
+        handler = DatabaseHistoryHandler(writer)
+        handler.emit('CLI_RC', 0, 'CLI')
+        self.assertEqual(
+            writer.write_record.call_args_list,
+            [
+                mock.call({
+                    'event_type': 'CLI_RC',
+                    'payload': 0,
+                    'source': 'CLI',
+                    'timestamp': mock.ANY
+                })
+            ]
+        )
+        # Also make sure the timestamp is of the correct type
+        self.assertIsInstance(
+            writer.write_record.call_args[0][0]['timestamp'], int)
+
+
+class BaseDatabaseRecordTester(unittest.TestCase):
+    def assert_contains_lines_in_order(self, lines, contents):
+        for line in lines:
+            self.assertIn(line, contents)
+            beginning = contents.find(line)
+            contents = contents[(beginning + len(line)):]
+
+
+class BaseDatabaseRecordWriterTester(BaseDatabaseRecordTester):
+    UUID_PATTERN = re.compile(
+        '^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$',
+        re.I
+    )
+
+    def setUp(self):
+        self.fake_connection = FakeDatabaseConnection()
+        self.writer = DatabaseRecordWriter(connection=self.fake_connection)
+
+    def _write_record(self, record):
+        self.writer.write_record(record)
+        write_call = self.fake_connection.mock_cursor.execute.call_args[0]
+        insert_stmt, written_record = write_call
+        return insert_stmt, written_record
+
+    def assert_insert_statement_structure_correct(self, stmt):
+        # Make sure the columns are in the expected order.
+        self.assert_contains_lines_in_order(['insert into records',
+                                            '(',
+                                             'id',
+                                             'request_id',
+                                             'source',
+                                             'event_type',
+                                             'timestamp',
+                                             'payload',
+                                             ')',
+                                             'values'], stmt.lower())
+
+
+class TestDatabaseRecordWriter(BaseDatabaseRecordWriterTester):
+    def setUp(self):
+        super(TestDatabaseRecordWriter, self).setUp()
+
+    def test_can_write_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'FOO',
+            'payload': 'bar',
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+
+        # Now that we have verified the order of the fields in the insert
+        # statement we can verify that the record values are in the correct
+        # order in the tuple.
+        # The written records first two fields are an id and the request_id
+        # which are generated uuid4s. The rest of the fields should be the
+        # ones from the above record in the order:
+        # (source, event_type, timestamp, payload)
+        self.assertEqual(written_record[2:], ('TEST', 'FOO', 1234, '"bar"'))
+
+        # The id will always be present and will be a uuid4 and the request_id
+        # will either be blank or a valid uuid4. In this case since the
+        # event_type TEST is not a known http lifecycle event it will not have
+        # a request_id.
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+        self.assertEqual(request_id, '')
+
+    def test_commit_count_matches_write_count(self):
+        records_to_write = 10
+        for _ in range(records_to_write):
+            self._write_record({
+                'event_type': 'foo',
+                'payload': '',
+                'source': 'TEST',
+                'timestamp': 1234
+            })
+        self.assertEqual(self.fake_connection.commits, records_to_write)
+
+    def test_can_write_cli_version_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'CLI_VERSION',
+            'payload': ('aws-cli/1.11.184 Python/3.6.2 Darwin/15.6.0 '
+                        'botocore/1.7.42'),
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'CLI_VERSION', 1234,
+             '"aws-cli/1.11.184 Python/3.6.2 Darwin/15.6.0 botocore/1.7.42"')
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+        self.assertEqual(request_id, '')
+
+    def test_can_write_cli_arguments_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'CLI_ARGUMENTS',
+            'payload': ['s3', 'ls'],
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'CLI_ARGUMENTS', 1234, '["s3", "ls"]')
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+        self.assertEqual(request_id, '')
+
+    def test_can_write_api_call_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'API_CALL',
+            'payload': {
+                'service': 's3',
+                'operation': 'ListBuckets',
+                'params': {},
+            },
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'API_CALL', 1234, json.dumps({
+                'service': 's3',
+                'operation': 'ListBuckets',
+                'params': {},
+            }))
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+        self.assertTrue(self.UUID_PATTERN.match(request_id))
+
+    def test_can_write_http_request_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'HTTP_REQUEST',
+            'payload': {
+                'method': 'GET',
+                'headers': {},
+                'body': '...',
+            },
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'HTTP_REQUEST', 1234, json.dumps({
+                'method': 'GET',
+                'headers': {},
+                'body': '...',
+            }))
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+
+    def test_can_write_http_response_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'HTTP_RESPONSE',
+            'payload': {
+                'streaming': False,
+                'headers': {},
+                'body': '...',
+                'status_code': 200,
+                'request_id': '1234abcd'
+            },
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'HTTP_RESPONSE', 1234, json.dumps({
+                'streaming': False,
+                'headers': {},
+                'body': '...',
+                'status_code': 200,
+                'request_id': '1234abcd'
+            }))
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+
+    def test_can_write_parsed_response_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'PARSED_RESPONSE',
+            'payload': {},
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'PARSED_RESPONSE', 1234, '{}')
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+
+    def test_can_write_cli_rc_record(self):
+        insert_stmt, written_record = self._write_record({
+            'event_type': 'CLI_RC',
+            'payload': 0,
+            'source': 'TEST',
+            'timestamp': 1234
+        })
+
+        self.assert_insert_statement_structure_correct(insert_stmt)
+        self.assertEqual(
+            written_record[2:],
+            ('TEST', 'CLI_RC', 1234, '0')
+        )
+        identifier, request_id = written_record[:2]
+        self.assertTrue(self.UUID_PATTERN.match(identifier))
+        self.assertEqual(request_id, '')
+
+
+class TestIdentifierLifecycles(BaseDatabaseRecordWriterTester):
+    def _write_sequence_of_records(self, records):
+        written_records = [
+            written_record for _, written_record in
+            [self._write_record(record) for record in records]]
+        return written_records
+
+    def test_multiple_http_lifecycle_writes_have_same_request_id(self):
+        written_records = self._write_sequence_of_records([
+                {
+                    'event_type': 'API_CALL',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'HTTP_REQUEST',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'HTTP_RESPONSE',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'PARSED_RESPONSE',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                }
+        ])
+        # Exctract just the request_ids from the written records which is
+        # the second field.
+        written_record_request_ids = [record[1] for record in written_records]
+
+        # All request_ids should match since this is one request lifecycle
+        unique_request_ids = set(written_record_request_ids)
+        self.assertEqual(len(unique_request_ids), 1)
+
+    def test_request_id_reset_on_api_call(self):
+        written_records = self._write_sequence_of_records([
+                {
+                    'event_type': 'API_CALL',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'PARSED_RESPONSE',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'API_CALL',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'PARSED_RESPONSE',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'API_CALL',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'PARSED_RESPONSE',
+                    'payload': '',
+                    'source': 'TEST',
+                    'timestamp': 1234
+                }
+        ])
+        written_record_request_ids = [record[1] for record in written_records]
+
+        # There should be three distinct requet_ids since there are three
+        # distinct calls that end with a parsed response.
+        unique_request_ids = set(written_record_request_ids)
+        self.assertEqual(len(unique_request_ids), 3)
+
+        # Check that the request ids match the correct events.
+        first_request_ids = written_record_request_ids[:2]
+        unique_first_request_ids = set(first_request_ids)
+        self.assertEqual(len(unique_first_request_ids), 1)
+
+        second_request_ids = written_record_request_ids[2:4]
+        unique_second_request_ids = set(second_request_ids)
+        self.assertEqual(len(unique_second_request_ids), 1)
+
+        third_request_ids = written_record_request_ids[4:]
+        unique_third_request_ids = set(third_request_ids)
+        self.assertEqual(len(unique_third_request_ids), 1)
+
+    def test_identifier_is_always_the_same(self):
+        # Three http lifecycles are written here, the overall identifier for
+        # the records should remain the same regardless.
+        written_records = self._write_sequence_of_records([
+                {
+                    'event_type': 'api_call',
+                    'payload': '',
+                    'source': 'test',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'parsed_response',
+                    'payload': '',
+                    'source': 'test',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'api_call',
+                    'payload': '',
+                    'source': 'test',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'parsed_response',
+                    'payload': '',
+                    'source': 'test',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'api_call',
+                    'payload': '',
+                    'source': 'test',
+                    'timestamp': 1234
+                },
+                {
+                    'event_type': 'parsed_response',
+                    'payload': '',
+                    'source': 'test',
+                    'timestamp': 1234
+                }
+        ])
+        # The record id is the first field in the record.
+        written_record_ids = [record[0] for record in written_records]
+        # Even though the request lifecycle was reset multpile times the
+        # overall id should be the same.
+        unique_ids = set(written_record_ids)
+        self.assertEqual(len(unique_ids), 1)
+
+
+class ThreadedRecordWriter(object):
+    def __init__(self, writer, fake_connection):
+        self._read_q = queue.Queue()
+        self._write_q = queue.Queue()
+        self._thread = threading.Thread(
+            target=self._threaded_record_writer,
+            args=(writer, fake_connection))
+        self._thread.start()
+
+    def _threaded_record_writer(self, writer, fake_connection):
+        while True:
+            record = self._read_q.get()
+            if record is False:
+                return
+            writer.write_record(record)
+            write_call = fake_connection.mock_cursor.execute.call_args[0]
+            _, written_record = write_call
+            self._write_q.put_nowait(written_record)
+
+    def read_n_records(self, n):
+        records = [self._write_q.get() for _ in range(n)]
+        return records
+
+    def write_record(self, record):
+        self._read_q.put_nowait(record)
+
+    def close(self):
+        self._read_q.put_nowait(False)
+        self._thread.join()
+
+
+class TestMultithreadRequestId(TestIdentifierLifecycles):
+    def setUp(self):
+        super(TestMultithreadRequestId, self).setUp()
+        self.thread_a = ThreadedRecordWriter(
+            self.writer, self.fake_connection)
+        self.thread_b = ThreadedRecordWriter(
+            self.writer, self.fake_connection)
+
+    def tearDown(self):
+        self.thread_a.close()
+        self.thread_b.close()
+
+    def test_each_thread_has_separate_request_id(self):
+        self.thread_a.write_record({
+            'event_type': 'API_CALL',
+            'payload': '',
+            'source': 'TEST_a',
+            'timestamp': 1234
+        })
+        self.thread_a.write_record({
+            'event_type': 'HTTP_REQUEST',
+            'payload': '',
+            'source': 'TEST_a',
+            'timestamp': 1234
+        })
+
+        self.thread_b.write_record({
+            'event_type': 'API_CALL',
+            'payload': '',
+            'source': 'TEST_b',
+            'timestamp': 1234
+        })
+        self.thread_b.write_record({
+            'event_type': 'HTTP_REQUEST',
+            'payload': '',
+            'source': 'TEST_b',
+            'timestamp': 1234
+        })
+
+        a_records = self.thread_a.read_n_records(2)
+        b_records = self.thread_b.read_n_records(2)
+
+        # Each thread should have its own set of request_ids so the request
+        # ids in each set of records should match, but should not match the
+        # request_ids from the other thread.
+        a_request_ids = [record[1] for record in a_records]
+        self.assertEqual(len(a_request_ids), 2)
+        self.assertEqual(a_request_ids[0], a_request_ids[1])
+        thread_a_request_id = a_request_ids[0]
+
+        b_request_ids = [record[1] for record in b_records]
+        self.assertEqual(len(b_request_ids), 2)
+        self.assertEqual(b_request_ids[0], b_request_ids[1])
+        thread_b_request_id = b_request_ids[0]
+
+        self.assertNotEqual(thread_a_request_id, thread_b_request_id)
+
+        # Since the request_id is reset by the API_CALL record being written
+        # and thread b has now written an API_CALL record the request id has
+        # been reset once. To ensure this doesnt bleed over to other threads
+        # we will write another record in thread a and ensure that it's
+        # request_id matches the previous ones from thread a rather than then
+        # thread b request_id
+        self.thread_a.write_record({
+            'event_type': 'HTTP_RESPONSE',
+            'payload': '',
+            'source': 'TEST_a',
+            'timestamp': 1234
+        })
+        self.thread_b.write_record({
+            'event_type': 'HTTP_RESPONSE',
+            'payload': '',
+            'source': 'TEST_b',
+            'timestamp': 1234
+        })
+        a_record = self.thread_a.read_n_records(1)[0]
+        b_record = self.thread_b.read_n_records(1)[0]
+        self.assertEqual(a_record[1], thread_a_request_id)
+        self.assertEqual(b_record[1], thread_b_request_id)
+
+
+class TestDatabaseRecordReader(BaseDatabaseRecordTester):
+    def setUp(self):
+        self.fake_connection = FakeDatabaseConnection()
+        self.reader = DatabaseRecordReader(self.fake_connection)
+
+    def test_row_factory_set(self):
+        self.assertEqual(self.fake_connection.row_factory,
+                         self.reader._row_factory)
+
+    def test_yield_latest_records(self):
+        pass
+
+    def test_yield_records(self):
+        pass


### PR DESCRIPTION
Adds database connection and interaction abstractions as well as a
handler that can hook into botocore's HistoryRecorder
 * DatabaseConnection
 * DatabaseRecordReader
 * DatabaseRecordWriter
 * PayloadSerializer
 * DatabaseHistoryHandler

cc @jamesls @kyleknap @dstufft @JordonPhillips @joguSD 