### PR TITLE
Add history show command

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -50,12 +50,13 @@ from awscli.utils import emit_top_level_args_parsed_event
 LOG = logging.getLogger('awscli.clidriver')
 LOG_FORMAT = (
     '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
+HISTORY_RECORDER = get_global_history_recorder()
 
 
 def main():
     driver = create_clidriver()
     rc = driver.main()
-    get_global_history_recorder().record('CLI_RC', rc, 'CLI')
+    HISTORY_RECORDER.record('CLI_RC', rc, 'CLI')
     return rc
 
 
@@ -200,10 +201,9 @@ class CLIDriver(object):
             # command table.  This is why it's in the try/except clause.
             self._handle_top_level_args(parsed_args)
             self._emit_session_event(parsed_args)
-            history_recorder = get_global_history_recorder()
-            history_recorder.record(
+            HISTORY_RECORDER.record(
                 'CLI_VERSION', self.session.user_agent(), 'CLI')
-            history_recorder.record('CLI_ARGUMENTS', args, 'CLI')
+            HISTORY_RECORDER.record('CLI_ARGUMENTS', args, 'CLI')
             return command_table[parsed_args.command](remaining, parsed_args)
         except UnknownArgumentError as e:
             sys.stderr.write("usage: %s\n" % USAGE)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -21,6 +21,7 @@ from botocore import xform_name
 from botocore.compat import copy_kwargs, OrderedDict
 from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import NoRegionError
+from botocore.history import get_global_history_recorder
 
 from awscli import EnvironmentVariables, __version__
 from awscli.compat import get_stderr_text_writer
@@ -53,7 +54,9 @@ LOG_FORMAT = (
 
 def main():
     driver = create_clidriver()
-    return driver.main()
+    rc = driver.main()
+    get_global_history_recorder().record('CLI_RC', rc, 'CLI')
+    return rc
 
 
 def create_clidriver():
@@ -196,7 +199,11 @@ class CLIDriver(object):
             # general exception handling logic as calling into the
             # command table.  This is why it's in the try/except clause.
             self._handle_top_level_args(parsed_args)
-            self._emit_session_event()
+            self._emit_session_event(parsed_args)
+            history_recorder = get_global_history_recorder()
+            history_recorder.record(
+                'CLI_VERSION', self.session.user_agent(), 'CLI')
+            history_recorder.record('CLI_ARGUMENTS', args, 'CLI')
             return command_table[parsed_args.command](remaining, parsed_args)
         except UnknownArgumentError as e:
             sys.stderr.write("usage: %s\n" % USAGE)
@@ -228,13 +235,15 @@ class CLIDriver(object):
             err.write("\n")
             return 255
 
-    def _emit_session_event(self):
+    def _emit_session_event(self, parsed_args):
         # This event is guaranteed to run after the session has been
         # initialized and a profile has been set.  This was previously
         # problematic because if something in CLIDriver caused the
         # session components to be reset (such as session.profile = foo)
         # then all the prior registered components would be removed.
-        self.session.emit('session-initialized', session=self.session)
+        self.session.emit(
+            'session-initialized', session=self.session,
+            parsed_args=parsed_args)
 
     def _show_error(self, msg):
         LOG.debug(msg, exc_info=True)

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -278,7 +278,7 @@ def _windows_shell_quote(s):
     return new_s
 
 
-def get_popen_pager_cmd_with_kwargs(pager_cmd=None):
+def get_popen_kwargs_for_pager_cmd(pager_cmd=None):
     """Returns the default pager to use dependent on platform
 
     :rtype: str
@@ -296,4 +296,5 @@ def get_popen_pager_cmd_with_kwargs(pager_cmd=None):
         popen_kwargs = {'shell': True}
     else:
         pager_cmd = shlex.split(pager_cmd)
-    return pager_cmd, popen_kwargs
+    popen_kwargs['args'] = pager_cmd
+    return popen_kwargs

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
+import shlex
 import os
 import platform
 import zipfile
@@ -274,14 +275,26 @@ def _windows_shell_quote(s):
     return new_s
 
 
-def get_default_platform_pager():
+def is_windows():
+    return platform.system() == 'Windows'
+
+
+def get_popen_pager_cmd_with_kwargs(pager_cmd=None):
     """Returns the default pager to use dependent on platform
 
     :rtype: str
     :returns: A string represent the paging command to run based on the
         platform being used.
     """
-    if platform.system() == 'Windows':
-        return 'more'
+    popen_kwargs = {}
+    if pager_cmd is None:
+        pager_cmd = 'less -R'
+        if is_windows():
+            pager_cmd = 'more'
+    # Similar to what we do with the help command, we need to specify
+    # shell as True to make it work in the pager for Windows
+    if is_windows():
+        popen_kwargs = {'shell': True}
     else:
-        return 'less -R'
+        pager_cmd = shlex.split(pager_cmd)
+    return pager_cmd, popen_kwargs

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -276,7 +276,7 @@ def _windows_shell_quote(s):
 
 
 def is_windows():
-    return platform.system() == 'Windows'
+    return os.name == 'nt'
 
 
 def get_popen_pager_cmd_with_kwargs(pager_cmd=None):

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -47,6 +47,9 @@ except ImportError:
     sqlite3 = None
 
 
+is_windows = sys.platform == 'win32'
+
+
 class NonTranslatedStdout(object):
     """ This context manager sets the line-end translation mode for stdout.
 
@@ -275,10 +278,6 @@ def _windows_shell_quote(s):
     return new_s
 
 
-def is_windows():
-    return os.name == 'nt'
-
-
 def get_popen_pager_cmd_with_kwargs(pager_cmd=None):
     """Returns the default pager to use dependent on platform
 
@@ -289,11 +288,11 @@ def get_popen_pager_cmd_with_kwargs(pager_cmd=None):
     popen_kwargs = {}
     if pager_cmd is None:
         pager_cmd = 'less -R'
-        if is_windows():
+        if is_windows:
             pager_cmd = 'more'
     # Similar to what we do with the help command, we need to specify
     # shell as True to make it work in the pager for Windows
-    if is_windows():
+    if is_windows:
         popen_kwargs = {'shell': True}
     else:
         pager_cmd = shlex.split(pager_cmd)

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import sys
 import os
+import platform
 import zipfile
 
 from botocore.compat import six
@@ -25,6 +26,7 @@ PY3 = six.PY3
 queue = six.moves.queue
 shlex_quote = six.moves.shlex_quote
 StringIO = six.StringIO
+BytesIO = six.BytesIO
 urlopen = six.moves.urllib.request.urlopen
 binary_type = six.binary_type
 
@@ -81,6 +83,9 @@ if six.PY3:
 
     binary_stdin = sys.stdin.buffer
 
+    def get_binary_stdout():
+        return sys.stdout.buffer
+
     def _get_text_writer(stream, errors):
         return stream
 
@@ -124,6 +129,9 @@ else:
     raw_input = raw_input
 
     binary_stdin = sys.stdin
+    
+    def get_binary_stdout():
+        return sys.stdout
 
     def _get_text_writer(stream, errors):
         # In python3, all the sys.stdout/sys.stderr streams are in text
@@ -264,3 +272,16 @@ def _windows_shell_quote(s):
         # quoted.
         return '"%s"' % new_s
     return new_s
+
+
+def get_default_platform_pager():
+    """Returns the default pager to use dependent on platform
+
+    :rtype: str
+    :returns: A string represent the paging command to run based on the
+        platform being used.
+    """
+    if platform.system() == 'Windows':
+        return 'more'
+    else:
+        return 'less -R'

--- a/awscli/customizations/history/__init__.py
+++ b/awscli/customizations/history/__init__.py
@@ -10,12 +10,17 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import logging
+
 from botocore.history import get_global_history_recorder
 
 from awscli.compat import sqlite3
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.history.db import DatabaseHistoryHandler
 from awscli.customizations.history.show import ShowCommand
+
+
+LOG = logging.getLogger(__name__)
 
 
 def register_history_mode(event_handlers):
@@ -30,6 +35,7 @@ def register_history_commands(event_handlers):
 
 def attach_history_handler(session, parsed_args, **kwargs):
     if _should_enable_cli_history(session, parsed_args):
+        LOG.debug('Enabling CLI history')
         history_recorder = get_global_history_recorder()
         history_recorder.add_handler(DatabaseHistoryHandler())
         history_recorder.enable()
@@ -39,6 +45,8 @@ def _should_enable_cli_history(session, parsed_args):
     if parsed_args.command == 'history':
         return False
     elif sqlite3 is None:
+        LOG.debug(
+            'sqlite3 is not available. Skipping check to enable CLI history.')
         return False
     else:
         scoped_config = session.get_scoped_config()

--- a/awscli/customizations/history/__init__.py
+++ b/awscli/customizations/history/__init__.py
@@ -28,6 +28,7 @@ from awscli.customizations.history.show import ShowCommand
 
 
 LOG = logging.getLogger(__name__)
+HISTORY_RECORDER = get_global_history_recorder()
 
 
 def register_history_mode(event_handlers):
@@ -54,9 +55,8 @@ def attach_history_handler(session, parsed_args, **kwargs):
         record_builder = RecordBuilder()
         db_handler = DatabaseHistoryHandler(writer, record_builder)
 
-        history_recorder = get_global_history_recorder()
-        history_recorder.add_handler(db_handler)
-        history_recorder.enable()
+        HISTORY_RECORDER.add_handler(db_handler)
+        HISTORY_RECORDER.enable()
 
 
 def _should_enable_cli_history(session, parsed_args):

--- a/awscli/customizations/history/constants.py
+++ b/awscli/customizations/history/constants.py
@@ -1,0 +1,18 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+
+
+HISTORY_FILENAME_ENV_VAR = 'AWS_CLI_HISTORY_FILE'
+DEFAULT_HISTORY_FILENAME = os.path.expanduser(
+    os.path.join('~', '.aws', 'cli', 'history', 'history.db'))

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -29,7 +29,7 @@ LOG = logging.getLogger(__name__)
 
 HISTORY_FILENAME_ENV_VAR = 'AWS_CLI_HISTORY_FILE'
 DEFAULT_HISTORY_FILENAME = os.path.expanduser(
-    os.path.join('~', '.aws', 'history', 'history.db'))
+    os.path.join('~', '.aws', 'cli', 'history', 'history.db'))
 
 
 def get_history_db_filename():

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -25,6 +25,7 @@ from awscli.compat import binary_type
 
 
 LOG = logging.getLogger(__name__)
+HISTORY_LOCATION_ENV_VAR = 'AWS_CLI_HISTORY_FILE'
 
 
 class DatabaseConnection(object):
@@ -244,7 +245,9 @@ class RecordBuilder(object):
 class DatabaseHistoryHandler(BaseHistoryHandler):
     def __init__(self, writer=None, record_builder=None):
         if writer is None:
-            writer = DatabaseRecordWriter()
+            connection = DatabaseConnection(
+                os.environ.get(HISTORY_LOCATION_ENV_VAR, None))
+            writer = DatabaseRecordWriter(connection)
         self._writer = writer
         if record_builder is None:
             record_builder = RecordBuilder()

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -24,7 +24,7 @@ import colorama
 from awscli.compat import six
 from awscli.compat import is_windows
 from awscli.compat import get_binary_stdout
-from awscli.compat import get_popen_pager_cmd_with_kwargs
+from awscli.compat import get_popen_kwargs_for_pager_cmd
 from awscli.utils import is_a_tty
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.history.db import get_history_db_filename
@@ -345,8 +345,8 @@ class OutputStreamFactory(object):
 
     @contextlib.contextmanager
     def _get_pager_stream(self):
-        pager_cmd, kwargs = self._get_process_pager_with_kwargs()
-        process = self._popen(pager_cmd, **kwargs)
+        popen_kwargs = self._get_process_pager_kwargs()
+        process = self._popen(**popen_kwargs)
         yield process.stdin
         process.stdin.close()
         process.wait()
@@ -355,11 +355,11 @@ class OutputStreamFactory(object):
     def _get_stdout_stream(self):
         yield get_binary_stdout()
 
-    def _get_process_pager_with_kwargs(self):
-        pager_cmd, kwargs = get_popen_pager_cmd_with_kwargs(
+    def _get_process_pager_kwargs(self):
+        kwargs = get_popen_kwargs_for_pager_cmd(
             os.environ.get('PAGER'))
         kwargs['stdin'] = subprocess.PIPE
-        return pager_cmd, kwargs
+        return kwargs
 
 
 class ShowCommand(BasicCommand):

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -10,14 +10,45 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import contextlib
+import datetime
+import json
+import os
+import shlex
+import subprocess
 import sys
+import xml.parsers.expat
+import xml.dom.minidom
 
+import colorama
+
+from awscli.compat import six
+from awscli.compat import get_binary_stdout
+from awscli.compat import get_default_platform_pager
+from awscli.utils import is_a_tty
 from awscli.customizations.commands import BasicCommand
+from awscli.customizations.history.db import HISTORY_LOCATION_ENV_VAR
 from awscli.customizations.history.db import DatabaseRecordReader
+from awscli.customizations.history.db import DatabaseConnection
 
 
 class Formatter(object):
     def __init__(self, output=None, include=None, exclude=None):
+        """Formats and outputs CLI history events
+
+        :type output: File-like obj
+        :param output: The stream to write the formatted event to. By default
+            sys.stdout is used.
+
+        :type include: list
+        :param include: A filter specifying which event to only be displayed.
+            This parameter is mutually exclusive with exclude.
+
+        :type exclude: list
+        :param exclude: A filter specifying which events to exclude from being
+            displayed. This parameter is mutually exclusive with include.
+
+        """
         self._output = output
         if self._output is None:
             self._output = sys.stdout
@@ -28,6 +59,11 @@ class Formatter(object):
         self._exclude = exclude
 
     def display(self, event_record):
+        """Displays a formatted version of the event record
+
+        :type event_record: dict
+        :param event_record: The event record to format and display.
+        """
         if self._should_display(event_record):
             getattr(self, '_display_' + event_record['event_type'].lower(),
                     self._display_noop)(event_record)
@@ -51,93 +87,267 @@ class Formatter(object):
 
 
 class DetailedFormatter(Formatter):
-    _CLI_VERSION_FORMAT = (
-        'The version of the AWS CLI was: {version}\n\n'
-    )
+    _CLI_COMMAND_TITLE = 'AWS CLI command entered'
+    _CLI_VERSION_DESC = 'with AWS CLI version'
+    _CLI_ARGUMENTS_DESC = 'with arguments'
 
-    _CLI_ARGUMENTS_FORMAT = (
-        'the arguments entered were: {arguments}\n\n'
-    )
+    _API_CALL_TITLE = 'API call made'
+    _API_CALL_SERVICE_DESC = 'to service'
+    _API_CALL_OPERATION_DESC = 'using operation'
+    _API_CALL_PARAMS_DESC = 'with parameters'
 
-    _API_CALL_FORMAT = (
-        'service: {service}\n\n'
-        'operation: {operation}\n\n'
-        'with parameters:\n{params}\n\n'
-    )
-    _HTTP_REQUEST_FORMAT = (
-        'the method used for the http request was: {method}\n\n'
-        'the headers of the http request was:\n{headers}\n\n'
-        'the body of the http request was:\n{body}\n\n'
-    )
-    _HTTP_RESPONSE_FORMAT = (
-        'the status code of the http response was: {status_code}\n\n'
-        'the headers of the http response was:\n{headers}\n\n'
-        'the body of the http response was:\n{body}\n\n'
-    )
-    _PARSED_RESPONSE_FORMAT = (
-        'the parsed response was:\n{parsed}\n\n'
-    )
-    _CLI_RC_FORMAT = (
-        'the return code of this command was: {rc}\n\n'
-    )
+    _HTTP_REQUEST_TITLE = 'HTTP request sent'
+    _ENDPOINT_URL_DESC = 'to URL'
+    _HTTP_METHOD_DESC = 'with method'
+    _HTTP_HEADERS_DESC = 'with headers'
+    _HTTP_BODY_DESC = 'with body'
+
+    _HTTP_RESPONSE_TITLE = 'HTTP response received'
+    _HTTP_STATUS_CODE_DESC = 'with status code'
+
+    _PARSED_RESPONSE_TITLE = 'HTTP response parsed'
+    _PARSED_RESPONSE_DESC = 'parsed to'
+
+    _CLI_RC_TITLE = 'AWS CLI command exited'
+    _CLI_RC_DESC = 'with return code'
+
+    _TITLE_COLOR = colorama.Style.BRIGHT + colorama.Fore.WHITE
+    _DESCRIPTION_COLOR = colorama.Fore.CYAN
+    _DESCRIPTION_VALUE_COLOR = colorama.Style.NORMAL
+
+    def __init__(self, output=None, include=None, exclude=None, colorize=True):
+        super(DetailedFormatter, self).__init__(output, include, exclude)
+        self._request_id_to_api_num = {}
+        self._num_api_calls = 0
+        self._colorize = colorize
+        if self._colorize:
+            colorama.init(autoreset=True, strip=False)
 
     def _display_cli_version(self, event_record):
-        self._output.write(
-            self._CLI_VERSION_FORMAT.format(version=event_record['payload'])
+        self._write_formatted_title(self._CLI_COMMAND_TITLE, event_record)
+        self._write_formatted_description_with_value(
+            self._CLI_VERSION_DESC, event_record['payload']
         )
 
     def _display_cli_arguments(self, event_record):
-        self._output.write(
-            self._CLI_ARGUMENTS_FORMAT.format(
-                arguments=event_record['payload'])
+        self._write_formatted_description_with_value(
+            self._CLI_ARGUMENTS_DESC, event_record['payload']
         )
 
     def _display_api_call(self, event_record):
+        self._write_formatted_title(self._API_CALL_TITLE, event_record)
         payload = event_record['payload']
-        self._output.write(
-            self._API_CALL_FORMAT.format(
-                service=payload['service'],
-                operation=payload['operation'],
-                params=payload['params']
-            )
+        self._write_formatted_description_with_value(
+            self._API_CALL_SERVICE_DESC, payload['service']
+        )
+        self._write_formatted_description_with_value(
+            self._API_CALL_OPERATION_DESC, payload['operation']
+        )
+        self._write_formatted_description_with_value(
+            self._API_CALL_PARAMS_DESC,
+            self._format_dictionary(payload['params'])
         )
 
     def _display_http_request(self, event_record):
+        self._write_formatted_title(self._HTTP_REQUEST_TITLE, event_record)
         payload = event_record['payload']
-        self._output.write(
-            self._HTTP_REQUEST_FORMAT.format(
-                method=payload['method'],
-                headers=payload['headers'],
-                body=payload['body']
-            )
+        self._write_formatted_description_with_value(
+            self._ENDPOINT_URL_DESC, payload['url']
+        )
+        self._write_formatted_description_with_value(
+            self._HTTP_METHOD_DESC, payload['method']
+        )
+        self._write_formatted_description_with_value(
+            self._HTTP_HEADERS_DESC,
+            self._format_dictionary(payload['headers'])
+        )
+        self._write_formatted_description_with_value(
+            self._HTTP_BODY_DESC,
+            self._format_body(payload['body'], payload.get('streaming', False))
         )
 
     def _display_http_response(self, event_record):
+        self._write_formatted_title(self._HTTP_RESPONSE_TITLE, event_record)
         payload = event_record['payload']
-        self._output.write(
-            self._HTTP_RESPONSE_FORMAT.format(
-                status_code=payload['status_code'],
-                headers=payload['headers'],
-                body=payload['body']
-            )
+        self._write_formatted_description_with_value(
+            self._HTTP_STATUS_CODE_DESC,
+            self._format_dictionary(payload['status_code'])
+        )
+        self._write_formatted_description_with_value(
+            self._HTTP_HEADERS_DESC,
+            self._format_dictionary(payload['headers'])
+        )
+        self._write_formatted_description_with_value(
+            self._HTTP_BODY_DESC,
+            self._format_body(payload['body'], payload.get('streaming', False))
         )
 
     def _display_parsed_response(self, event_record):
-        payload = event_record['payload']
-        self._output.write(
-            self._PARSED_RESPONSE_FORMAT.format(parsed=payload))
+        self._write_formatted_title(self._PARSED_RESPONSE_TITLE, event_record)
+        self._write_formatted_description_with_value(
+            self._PARSED_RESPONSE_DESC,
+            self._format_dictionary(event_record['payload'])
+        )
 
     def _display_cli_rc(self, event_record):
-        self._output.write(
-            self._CLI_RC_FORMAT.format(rc=event_record['payload']))
+        self._write_formatted_title(self._CLI_RC_TITLE, event_record)
+        self._write_formatted_description_with_value(
+            self._CLI_RC_DESC, event_record['payload']
+        )
+
+    def _write_formatted_title(self, title, event_record):
+        self._write_output(self._format_section_title(title, event_record))
+
+    def _write_formatted_description_with_value(self, desc, value):
+        self._write_output(
+            self._format_description_with_value(desc, value))
+
+    def _write_output(self, content):
+        if isinstance(content, six.text_type):
+            content = content.encode('utf-8')
+        self._output.write(content)
+
+    def _format_section_title(self, title, event_record):
+        formatted_title = ''
+        api_num = self._get_api_num(event_record)
+        if api_num is not None:
+            formatted_title += '[%s] ' % api_num
+        formatted_title += title + ' at: '
+        formatted_title = self._color_title(formatted_title)
+
+        formatted_timestamp = self._color_description_value(
+            self._format_timestamp(event_record['timestamp']))
+
+        return '\n' + formatted_title + formatted_timestamp + '\n'
+
+    def _format_timestamp(self, event_timestamp):
+        return datetime.datetime.fromtimestamp(
+            event_timestamp/1000.0).strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+
+    def _get_api_num(self, event_record):
+        request_id = event_record['request_id']
+        if request_id:
+            if request_id not in self._request_id_to_api_num:
+                self._request_id_to_api_num[
+                    request_id] = self._num_api_calls
+                self._num_api_calls += 1
+            return self._request_id_to_api_num[request_id]
+
+    def _format_description_with_value(self, desc, value,
+                                       description_color=_DESCRIPTION_COLOR):
+        formatted_str = self._color_description(desc + ': ', description_color)
+        formatted_str += self._color_description_value(str(value))
+        formatted_str += '\n'
+        return formatted_str
+
+    def _color_title(self, text):
+        return self._color_if_configured(text, self._TITLE_COLOR)
+
+    def _color_description(self, text, color=_DESCRIPTION_COLOR):
+        return self._color_if_configured(text, color)
+
+    def _color_description_value(self, text):
+        return self._color_if_configured(text, self._DESCRIPTION_VALUE_COLOR)
+
+    def _color_if_configured(self, text, color):
+        if self._colorize:
+            return color + text + colorama.Style.RESET_ALL
+        return text
+
+    def _format_dictionary(self, obj):
+        return json.dumps(obj=obj, sort_keys=True, indent=4)
+
+    def _format_body(self, body, is_streaming):
+        if not body:
+            return 'There is no associated body'
+        elif is_streaming:
+            return 'The body is a stream and will not be displayed'
+        elif self._is_xml(body):
+            return self._format_xml(body)
+        elif self._is_json_structure(body):
+            return self._format_json_structure_string(body)
+        else:
+            return body
+
+    def _is_xml(self, body):
+        try:
+            xml.dom.minidom.parseString(body)
+        except xml.parsers.expat.ExpatError:
+            return False
+        return True
+
+    def _format_xml(self, body):
+        stripped_body = self._strip_whitespace(body)
+        xml_dom = xml.dom.minidom.parseString(stripped_body)
+        return xml_dom.toprettyxml(indent=' '*4, newl='\n')
+
+    def _strip_whitespace(self, xml_string):
+        xml_dom = xml.dom.minidom.parseString(xml_string)
+        return ''.join(
+            [line.strip() for line in xml_dom.toxml().splitlines()]
+        )
+
+    def _is_json_structure(self, body):
+        if body.startswith('{'):
+            try:
+                json.loads(body)
+                return True
+            except json.decoder.JSONDecodeError:
+                return False
+        return False
+
+    def _format_json_structure_string(self, body):
+        obj = json.loads(body)
+        return self._format_dictionary(obj)
+
+
+class OutputStreamFactory(object):
+    def __init__(self, popen=None):
+        self._popen = popen
+        if popen is None:
+            self._popen = subprocess.Popen
+
+    def get_output_stream(self, stream_type):
+        """Get an output stream to write to
+
+        The value is wrapped in a context manager so make sure to use
+        a with statement.
+
+        :type stream_type: string
+        :param stream_type: The name of the stream to get. Valid values
+             consist of pager and stdout.
+        """
+        stream_getter = getattr(self, '_get_' + stream_type + '_stream', None)
+        if stream_getter is None:
+            raise ValueError(
+                'Stream type of %s is not supported' % stream_type)
+        return stream_getter()
+
+    @contextlib.contextmanager
+    def _get_pager_stream(self):
+        pager_cmd = self._get_pager_cmd()
+        process = self._popen(pager_cmd, stdin=subprocess.PIPE)
+        yield process.stdin
+        process.stdin.close()
+        process.wait()
+
+    @contextlib.contextmanager
+    def _get_stdout_stream(self):
+        yield get_binary_stdout()
+
+    def _get_pager_cmd(self):
+        pager = get_default_platform_pager()
+        if 'PAGER' in os.environ:
+            pager = os.environ['PAGER']
+        return shlex.split(pager)
 
 
 class ShowCommand(BasicCommand):
     NAME = 'show'
     DESCRIPTION = (
-        'shows the various events related to running a specific cli command. '
-        'if this command is ran without any positional arguments, it will '
-        'display the events for the last cli command ran.'
+        'Shows the various events related to running a specific CLI command. '
+        'If this command is ran without any positional arguments, it will '
+        'display the events for the last CLI command ran.'
     )
     FORMATTERS = {
         'detailed': DetailedFormatter
@@ -146,17 +356,17 @@ class ShowCommand(BasicCommand):
         {'name': 'command_id', 'nargs': '?', 'default': 'latest',
          'positional_arg': True,
          'help_text': (
-             'the id of the cli command to show. if this argument is '
-             'omitted it will show the last the cli command ran.')},
+             'The ID of the CLI command to show. If this positional argument '
+             'is omitted, it will show the last the CLI command ran.')},
         {'name': 'include', 'nargs': '+',
          'help_text': (
-             'specifies which events to **only** include when showing the '
-             'cli command.  this argument is mutually exclusive with '
+             'Specifies which events to **only** include when showing the '
+             'CLI command. This argument is mutually exclusive with '
              '``--exclude``.')},
         {'name': 'exclude', 'nargs': '+',
          'help_text': (
              'Specifies which events to exclude when showing the '
-             'CLI command.  This argument is mutually exclusive with '
+             'CLI command. This argument is mutually exclusive with '
              '``--include``.')},
         {'name': 'format', 'choices': FORMATTERS.keys(),
          'default': 'detailed', 'help_text': (
@@ -164,18 +374,23 @@ class ShowCommand(BasicCommand):
             'the specified CLI command.')}
     ]
 
-    def __init__(self, session, db_reader=None):
+    def __init__(self, session, db_reader=None, output_stream_factory=None):
         super(ShowCommand, self).__init__(session)
         self._db_reader = db_reader
         if db_reader is None:
-            self._db_reader = DatabaseRecordReader()
+            connection = DatabaseConnection(
+                os.environ.get(HISTORY_LOCATION_ENV_VAR, None))
+            self._db_reader = DatabaseRecordReader(connection)
+        self._output_stream_factory = output_stream_factory
+        if output_stream_factory is None:
+            self._output_stream_factory = OutputStreamFactory()
 
     def _run_main(self, parsed_args, parsed_globals):
         self._validate_args(parsed_args)
-        formatter = self.FORMATTERS[parsed_args.format](
-            include=parsed_args.include, exclude=parsed_args.exclude)
-        for record in self._get_record_iterator(parsed_args):
-            formatter.display(record)
+        with self._get_output_stream() as output_stream:
+            formatter = self._get_formatter(parsed_args, output_stream)
+            for record in self._get_record_iterator(parsed_args):
+                formatter.display(record)
         return 0
 
     def _validate_args(self, parsed_args):
@@ -183,8 +398,27 @@ class ShowCommand(BasicCommand):
             raise ValueError(
                 'Either --exclude or --include can be provided but not both')
 
+    def _get_formatter(self, parsed_args, output_stream):
+        format_type = parsed_args.format
+        formatter_kwargs = {
+            'include': parsed_args.include,
+            'exclude': parsed_args.exclude,
+            'output': output_stream
+        }
+        if format_type == 'detailed':
+            formatter_kwargs['colorize'] = self._should_use_color()
+        return self.FORMATTERS[format_type](**formatter_kwargs)
+
+    def _should_use_color(self):
+        return is_a_tty()
+
+    def _get_output_stream(self):
+        if is_a_tty():
+            return self._output_stream_factory.get_output_stream('pager')
+        return self._output_stream_factory.get_output_stream('stdout')
+
     def _get_record_iterator(self, parsed_args):
         if parsed_args.command_id == 'latest':
-            return self._db_reader.yield_latest_records()
+            return self._db_reader.iter_latest_records()
         else:
-            return self._db_reader.yield_records(parsed_args.command_id)
+            return self._db_reader.iter_records(parsed_args.command_id)

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -1,0 +1,190 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.history.db import DatabaseRecordReader
+
+
+class Formatter(object):
+    def __init__(self, output=None, include=None, exclude=None):
+        self._output = output
+        if self._output is None:
+            self._output = sys.stdout
+        if include and exclude:
+            raise ValueError(
+                'Either input or exclude can be provided but not both')
+        self._include = include
+        self._exclude = exclude
+
+    def display(self, event_record):
+        if self._should_display(event_record):
+            getattr(self, '_display_' + event_record['event_type'].lower(),
+                    self._display_noop)(event_record)
+
+    def _should_display(self, event_record):
+        if self._include:
+            if event_record['event_type'] in self._include:
+                return True
+            else:
+                return False
+        elif self._exclude:
+            if event_record['event_type'] in self._exclude:
+                return False
+            else:
+                return True
+        else:
+            return True
+
+    def _display_noop(self, event_record):
+        pass
+
+
+class DetailedFormatter(Formatter):
+    _CLI_VERSION_FORMAT = (
+        'The version of the AWS CLI was: {version}\n\n'
+    )
+
+    _CLI_ARGUMENTS_FORMAT = (
+        'the arguments entered were: {arguments}\n\n'
+    )
+
+    _API_CALL_FORMAT = (
+        'service: {service}\n\n'
+        'operation: {operation}\n\n'
+        'with parameters:\n{params}\n\n'
+    )
+    _HTTP_REQUEST_FORMAT = (
+        'the method used for the http request was: {method}\n\n'
+        'the headers of the http request was:\n{headers}\n\n'
+        'the body of the http request was:\n{body}\n\n'
+    )
+    _HTTP_RESPONSE_FORMAT = (
+        'the status code of the http response was: {status_code}\n\n'
+        'the headers of the http response was:\n{headers}\n\n'
+        'the body of the http response was:\n{body}\n\n'
+    )
+    _PARSED_RESPONSE_FORMAT = (
+        'the parsed response was:\n{parsed}\n\n'
+    )
+    _CLI_RC_FORMAT = (
+        'the return code of this command was: {rc}\n\n'
+    )
+
+    def _display_cli_version(self, event_record):
+        self._output.write(
+            self._CLI_VERSION_FORMAT.format(version=event_record['payload'])
+        )
+
+    def _display_cli_arguments(self, event_record):
+        self._output.write(
+            self._CLI_ARGUMENTS_FORMAT.format(
+                arguments=event_record['payload'])
+        )
+
+    def _display_api_call(self, event_record):
+        payload = event_record['payload']
+        self._output.write(
+            self._API_CALL_FORMAT.format(
+                service=payload['service'],
+                operation=payload['operation'],
+                params=payload['params']
+            )
+        )
+
+    def _display_http_request(self, event_record):
+        payload = event_record['payload']
+        self._output.write(
+            self._HTTP_REQUEST_FORMAT.format(
+                method=payload['method'],
+                headers=payload['headers'],
+                body=payload['body']
+            )
+        )
+
+    def _display_http_response(self, event_record):
+        payload = event_record['payload']
+        self._output.write(
+            self._HTTP_RESPONSE_FORMAT.format(
+                status_code=payload['status_code'],
+                headers=payload['headers'],
+                body=payload['body']
+            )
+        )
+
+    def _display_parsed_response(self, event_record):
+        payload = event_record['payload']
+        self._output.write(
+            self._PARSED_RESPONSE_FORMAT.format(parsed=payload))
+
+    def _display_cli_rc(self, event_record):
+        self._output.write(
+            self._CLI_RC_FORMAT.format(rc=event_record['payload']))
+
+
+class ShowCommand(BasicCommand):
+    NAME = 'show'
+    DESCRIPTION = (
+        'shows the various events related to running a specific cli command. '
+        'if this command is ran without any positional arguments, it will '
+        'display the events for the last cli command ran.'
+    )
+    FORMATTERS = {
+        'detailed': DetailedFormatter
+    }
+    ARG_TABLE = [
+        {'name': 'command_id', 'nargs': '?', 'default': 'latest',
+         'positional_arg': True,
+         'help_text': (
+             'the id of the cli command to show. if this argument is '
+             'omitted it will show the last the cli command ran.')},
+        {'name': 'include', 'nargs': '+',
+         'help_text': (
+             'specifies which events to **only** include when showing the '
+             'cli command.  this argument is mutually exclusive with '
+             '``--exclude``.')},
+        {'name': 'exclude', 'nargs': '+',
+         'help_text': (
+             'Specifies which events to exclude when showing the '
+             'CLI command.  This argument is mutually exclusive with '
+             '``--include``.')},
+        {'name': 'format', 'choices': FORMATTERS.keys(),
+         'default': 'detailed', 'help_text': (
+            'Specifies which format to use in showing the events for '
+            'the specified CLI command.')}
+    ]
+
+    def __init__(self, session, db_reader=None):
+        super(ShowCommand, self).__init__(session)
+        self._db_reader = db_reader
+        if db_reader is None:
+            self._db_reader = DatabaseRecordReader()
+
+    def _run_main(self, parsed_args, parsed_globals):
+        self._validate_args(parsed_args)
+        formatter = self.FORMATTERS[parsed_args.format](
+            include=parsed_args.include, exclude=parsed_args.exclude)
+        for record in self._get_record_iterator(parsed_args):
+            formatter.display(record)
+        return 0
+
+    def _validate_args(self, parsed_args):
+        if parsed_args.exclude and parsed_args.include:
+            raise ValueError(
+                'Either --exclude or --include can be provided but not both')
+
+    def _get_record_iterator(self, parsed_args):
+        if parsed_args.command_id == 'latest':
+            return self._db_reader.yield_latest_records()
+        else:
+            return self._db_reader.yield_records(parsed_args.command_id)

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -343,19 +343,22 @@ class OutputStreamFactory(object):
         :param stream_type: The name of the stream to get. Valid values
              consist of pager and stdout.
         """
-        stream_getter = getattr(self, '_get_' + stream_type + '_stream', None)
-        if stream_getter is None:
+        if stream_type == 'pager':
+            return self._get_pager_stream()
+        elif stream_type == 'stdout':
+            return self._get_stdout_stream()
+        else:
             raise ValueError(
                 'Stream type of %s is not supported' % stream_type)
-        return stream_getter()
 
     @contextlib.contextmanager
     def _get_pager_stream(self):
         popen_kwargs = self._get_process_pager_kwargs()
-        process = self._popen(**popen_kwargs)
-        yield process.stdin
-        process.stdin.close()
-        process.wait()
+        try:
+            process = self._popen(**popen_kwargs)
+            yield process.stdin
+        finally:
+            process.communicate()
 
     @contextlib.contextmanager
     def _get_stdout_stream(self):

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -27,7 +27,7 @@ from awscli.compat import get_binary_stdout
 from awscli.compat import get_popen_pager_cmd_with_kwargs
 from awscli.utils import is_a_tty
 from awscli.customizations.commands import BasicCommand
-from awscli.customizations.history.db import HISTORY_LOCATION_ENV_VAR
+from awscli.customizations.history.db import get_history_db_filename
 from awscli.customizations.history.db import DatabaseRecordReader
 from awscli.customizations.history.db import DatabaseConnection
 
@@ -402,8 +402,7 @@ class ShowCommand(BasicCommand):
         super(ShowCommand, self).__init__(session)
         self._db_reader = db_reader
         if db_reader is None:
-            connection = DatabaseConnection(
-                os.environ.get(HISTORY_LOCATION_ENV_VAR, None))
+            connection = DatabaseConnection(get_history_db_filename())
             self._db_reader = DatabaseRecordReader(connection)
         self._output_stream_factory = output_stream_factory
         if output_stream_factory is None:

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -68,19 +68,13 @@ class Formatter(object):
             self._display(event_record)
 
     def _display(self, event_record):
-        raise NotImplementedError('display()')
+        raise NotImplementedError('_display()')
 
     def _should_display(self, event_record):
         if self._include:
-            if event_record['event_type'] in self._include:
-                return True
-            else:
-                return False
+            return event_record['event_type'] in self._include
         elif self._exclude:
-            if event_record['event_type'] in self._exclude:
-                return False
-            else:
-                return True
+            return event_record['event_type'] not in self._exclude
         else:
             return True
 

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -111,7 +111,7 @@ class DetailedFormatter(Formatter):
     _CLI_RC_TITLE = 'AWS CLI command exited'
     _CLI_RC_DESC = 'with return code'
 
-    _TITLE_COLOR = colorama.Style.BRIGHT + colorama.Fore.WHITE
+    _TITLE_COLOR = colorama.Style.BRIGHT
     _DESCRIPTION_COLOR = colorama.Fore.CYAN
     _DESCRIPTION_VALUE_COLOR = colorama.Style.NORMAL
 

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -449,7 +449,7 @@ class ShowCommand(BasicCommand):
             return True
         elif parsed_globals.color == 'off':
             return False
-        return is_a_tty() and not is_windows()
+        return is_a_tty() and not is_windows
 
     def _get_output_stream(self):
         if is_a_tty():

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -391,7 +391,21 @@ class ShowCommand(BasicCommand):
         {'name': 'format', 'choices': FORMATTERS.keys(),
          'default': 'detailed', 'help_text': (
             'Specifies which format to use in showing the events for '
-            'the specified CLI command.')}
+            'the specified CLI command. The following formats are '
+            'supported:\n\n'
+            '<ul>'
+            '<li> detailed - This the default format. It prints out a '
+            'detailed overview of the CLI command ran. It displays all '
+            'of the key events in the command lifecycle where each '
+            'important event has a title and its important values '
+            'underneath. The events are ordered by timestamp and events of '
+            'the same API call are associated together with the '
+            '[``api_id``] notation where events that share the same '
+            '``api_id`` belong to the lifecycle of the same API call.'
+            '</li>'
+            '</ul>'
+            )
+         }
     ]
 
     def __init__(self, session, db_reader=None, output_stream_factory=None):

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -39,6 +39,8 @@ from awscli.customizations.configservice.rename_cmd import \
     register_rename_config
 from awscli.customizations.configservice.subscribe import register_subscribe
 from awscli.customizations.configure.configure import register_configure_cmd
+from awscli.customizations.history import register_history_mode
+from awscli.customizations.history import register_history_commands
 from awscli.customizations.ec2.addcount import register_count_events
 from awscli.customizations.ec2.bundleinstance import register_bundleinstance
 from awscli.customizations.ec2.decryptpassword import ec2_add_priv_launch_key
@@ -154,3 +156,5 @@ def awscli_initialize(event_handlers):
     register_alias_opsworks_cm(event_handlers)
     register_alias_mturk_command(event_handlers)
     register_servicecatalog_commands(event_handlers)
+    register_history_mode(event_handlers)
+    register_history_commands(event_handlers)

--- a/awscli/table.py
+++ b/awscli/table.py
@@ -10,12 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
 import sys
 import struct
 import unicodedata
 
 import colorama
+
+from awscli.utils import is_a_tty
 from awscli.compat import six
 
 
@@ -45,13 +46,6 @@ def determine_terminal_width(default_width=80):
         return default_width
     else:
         return width
-
-
-def is_a_tty():
-    try:
-        return os.isatty(sys.stdout.fileno())
-    except Exception:
-        return False
 
 
 def center_text(text, length=80, left_edge='|', right_edge='|',

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -14,6 +14,8 @@ import csv
 import signal
 import datetime
 import contextlib
+import os
+import sys
 
 from awscli.compat import six
 
@@ -146,3 +148,10 @@ def ignore_ctrl_c():
 def emit_top_level_args_parsed_event(session, args):
     session.emit(
         'top-level-args-parsed', parsed_args=args, session=session)
+
+
+def is_a_tty():
+    try:
+        return os.isatty(sys.stdout.fileno())
+    except Exception as e:
+        return False

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -16,6 +16,7 @@ import re
 
 from awscli.compat import queue
 from awscli.customizations.history.db import DatabaseConnection
+from awscli.customizations.history.db import RecordBuilder
 from awscli.customizations.history.db import DatabaseRecordWriter
 from awscli.customizations.history.db import DatabaseRecordReader
 from awscli.customizations.history.db import DatabaseHistoryHandler
@@ -308,7 +309,9 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
     def setUp(self):
         self.db = DatabaseConnection(':memory:')
         self.writer = DatabaseRecordWriter(connection=self.db)
-        self.handler = DatabaseHistoryHandler(writer=self.writer)
+        self.record_builder = RecordBuilder()
+        self.handler = DatabaseHistoryHandler(
+            writer=self.writer, record_builder=self.record_builder)
 
     def _get_last_record(self):
         record = self.db.execute('SELECT * FROM records').fetchone()

--- a/tests/functional/history/test_show.py
+++ b/tests/functional/history/test_show.py
@@ -1,0 +1,114 @@
+# Copyright 2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import botocore
+from botocore.history import HistoryRecorder
+
+from awscli.testutils import mock, create_clidriver, FileCreator
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestShowCommand(BaseAWSCommandParamsTest):
+    def setUp(self):
+        history_recorder = HistoryRecorder()
+        self.history_recorder_patch = mock.patch(
+            'botocore.history.HISTORY_RECORDER', history_recorder)
+        self.history_recorder_patch.start()
+        super(TestShowCommand, self).setUp()
+        self.files = FileCreator()
+        config_contents = (
+            '[default]\n'
+            'cli_history = enabled'
+        )
+        self.environ['AWS_CONFIG_FILE'] = self.files.create_file(
+            'config', config_contents)
+        self.environ['AWS_HISTORY_PATH'] = self.files.rootdir
+        self.driver = create_clidriver()
+
+    def tearDown(self):
+        self.history_recorder_patch.stop()
+        super(TestShowCommand, self).tearDown()
+        self.files.remove_all()
+
+    def test_show_latest(self):
+        self.parsed_responses = [
+            {
+                "Regions": [
+                    {
+                        "Endpoint": "ec2.ap-south-1.amazonaws.com",
+                        "RegionName": "ap-south-1"
+                    },
+                ]
+            }
+        ]
+        self.run_cmd('ec2 describe-regions', expected_rc=0)
+        stdout, stderr, rc = self.run_cmd('history show', expected_rc=0)
+        # Test that the CLI specific events are present such as arguments
+        # entered and version
+        self.assertIn('ec2', stdout)
+        self.assertIn('version', stdout)
+
+    def test_show_nothing_when_no_history(self):
+        self.environ['AWS_CONFIG_FILE'] = ''
+        self.driver = create_clidriver()
+        self.parsed_responses = [
+            {
+                "Regions": [
+                    {
+                        "Endpoint": "ec2.ap-south-1.amazonaws.com",
+                        "RegionName": "ap-south-1"
+                    },
+                ]
+            }
+        ]
+        self.run_cmd('ec2 describe-regions', expected_rc=0)
+        stdout, stderr, rc = self.run_cmd('history show', expected_rc=0)
+        # The history show should not display anything as no history should
+        # have been collected
+        self.assertEqual('', stdout)
+
+    def test_show_with_include(self):
+        self.parsed_responses = [
+            {
+                "Regions": [
+                    {
+                        "Endpoint": "ec2.ap-south-1.amazonaws.com",
+                        "RegionName": "ap-south-1"
+                    },
+                ]
+            }
+        ]
+        self.run_cmd('ec2 describe-regions', expected_rc=0)
+        stdout, stderr, rc = self.run_cmd(
+            'history show --include CLI_ARGUMENTS', expected_rc=0)
+        self.assertIn('ec2', stdout)
+        # Make sure the CLI version was not included because of the filter.
+        self.assertNotIn('version', stdout)
+
+    def test_show_with_exclude(self):
+        self.parsed_responses = [
+            {
+                "Regions": [
+                    {
+                        "Endpoint": "ec2.ap-south-1.amazonaws.com",
+                        "RegionName": "ap-south-1"
+                    },
+                ]
+            }
+        ]
+        self.run_cmd('ec2 describe-regions', expected_rc=0)
+        stdout, stderr, rc = self.run_cmd(
+            'history show --exclude CLI_ARGUMENTS', expected_rc=0)
+        # Make sure the API call was not included because of the filter,
+        # but all other events such as the version are included.
+        self.assertNotIn('ec2', stdout)
+        self.assertIn('version', stdout)

--- a/tests/functional/history/test_show.py
+++ b/tests/functional/history/test_show.py
@@ -10,19 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import botocore
 from botocore.history import HistoryRecorder
 
 from awscli.testutils import mock, create_clidriver, FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.compat import BytesIO
 
 
 class TestShowCommand(BaseAWSCommandParamsTest):
     def setUp(self):
-        history_recorder = HistoryRecorder()
-        self.history_recorder_patch = mock.patch(
-            'botocore.history.HISTORY_RECORDER', history_recorder)
-        self.history_recorder_patch.start()
+        self._make_clean_history_recorder()
         super(TestShowCommand, self).setUp()
         self.files = FileCreator()
         config_contents = (
@@ -31,13 +28,35 @@ class TestShowCommand(BaseAWSCommandParamsTest):
         )
         self.environ['AWS_CONFIG_FILE'] = self.files.create_file(
             'config', config_contents)
-        self.environ['AWS_HISTORY_PATH'] = self.files.rootdir
+        self.environ['AWS_CLI_HISTORY_FILE'] = self.files.create_file(
+            'history.db', '')
         self.driver = create_clidriver()
+        # The run_cmd patches stdout with a StringIO object (similar to what
+        # nose does). Therefore it will run into issues when
+        # get_binary_stdout is called because it returns sys.stdout.buffer
+        # for Py3 and StringIO does not have a buffer
+        self.binary_stdout_patch = mock.patch(
+            'awscli.customizations.history.show.get_binary_stdout')
+        mock_get_binary_stdout = self.binary_stdout_patch.start()
+        self.binary_stdout = BytesIO()
+        mock_get_binary_stdout.return_value = self.binary_stdout
+
+    def _make_clean_history_recorder(self):
+        # This is to ensure that for each new test run the CLI is using
+        # a brand new HistoryRecorder as this is global so previous test
+        # runs could have injected handlers onto it as all of the tests
+        # are ran in the same process.
+        history_recorder = HistoryRecorder()
+        patch_get_history_recorder = mock.patch(
+            'botocore.history.get_global_history_recorder', history_recorder)
+        get_history_recorder_mock = patch_get_history_recorder.start()
+        get_history_recorder_mock.return_value = history_recorder
+        self.addCleanup(patch_get_history_recorder.stop)
 
     def tearDown(self):
-        self.history_recorder_patch.stop()
         super(TestShowCommand, self).tearDown()
         self.files.remove_all()
+        self.binary_stdout_patch.stop()
 
     def test_show_latest(self):
         self.parsed_responses = [
@@ -51,11 +70,15 @@ class TestShowCommand(BaseAWSCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        stdout, stderr, rc = self.run_cmd('history show', expected_rc=0)
+        self.run_cmd('history show', expected_rc=0)
         # Test that the CLI specific events are present such as arguments
         # entered and version
-        self.assertIn('ec2', stdout)
-        self.assertIn('version', stdout)
+        #
+        # The show command writes the history out as binary to the attached
+        # stream so we want to determine if the values are in the binary
+        # stdout stream
+        self.assertIn(b'describe-regions', self.binary_stdout.getvalue())
+        self.assertIn(b'version', self.binary_stdout.getvalue())
 
     def test_show_nothing_when_no_history(self):
         self.environ['AWS_CONFIG_FILE'] = ''
@@ -71,10 +94,10 @@ class TestShowCommand(BaseAWSCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        stdout, stderr, rc = self.run_cmd('history show', expected_rc=0)
+        self.run_cmd('history show', expected_rc=0)
         # The history show should not display anything as no history should
         # have been collected
-        self.assertEqual('', stdout)
+        self.assertEqual(b'', self.binary_stdout.getvalue())
 
     def test_show_with_include(self):
         self.parsed_responses = [
@@ -88,11 +111,14 @@ class TestShowCommand(BaseAWSCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        stdout, stderr, rc = self.run_cmd(
-            'history show --include CLI_ARGUMENTS', expected_rc=0)
-        self.assertIn('ec2', stdout)
+        self.run_cmd('history show --include CLI_ARGUMENTS', expected_rc=0)
         # Make sure the CLI version was not included because of the filter.
-        self.assertNotIn('version', stdout)
+        #
+        # The show command writes the history out as binary to the attached
+        # stream so we want to determine if the values are in the binary
+        # stdout stream
+        self.assertIn(b'describe-regions', self.binary_stdout.getvalue())
+        self.assertNotIn(b'version', self.binary_stdout.getvalue())
 
     def test_show_with_exclude(self):
         self.parsed_responses = [
@@ -106,9 +132,12 @@ class TestShowCommand(BaseAWSCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        stdout, stderr, rc = self.run_cmd(
-            'history show --exclude CLI_ARGUMENTS', expected_rc=0)
+        self.run_cmd('history show --exclude CLI_ARGUMENTS', expected_rc=0)
         # Make sure the API call was not included because of the filter,
         # but all other events such as the version are included.
-        self.assertNotIn('ec2', stdout)
-        self.assertIn('version', stdout)
+        #
+        # The show command writes the history out as binary to the attached
+        # stream so we want to determine if the values are in the binary
+        # stdout stream
+        self.assertNotIn(b'describe-regions', self.binary_stdout.getvalue())
+        self.assertIn(b'version', self.binary_stdout.getvalue())

--- a/tests/integration/customizations/history/test_show.py
+++ b/tests/integration/customizations/history/test_show.py
@@ -28,7 +28,8 @@ class TestShow(unittest.TestCase):
         )
         self.environ['AWS_DEFAULT_PROFILE'] = 'default'
         self.environ['AWS_DEFAULT_REGION'] = 'us-west-2'
-        self.environ['AWS_HISTORY_PATH'] = self.files.rootdir
+        self.environ['AWS_CLI_HISTORY_FILE'] = os.path.join(
+            self.files.rootdir, 'history.db')
 
     def tearDown(self):
         self.files.remove_all()

--- a/tests/integration/customizations/history/test_show.py
+++ b/tests/integration/customizations/history/test_show.py
@@ -1,0 +1,90 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import re
+
+from awscli.testutils import aws, unittest, FileCreator
+
+
+class TestShow(unittest.TestCase):
+    def setUp(self):
+        self.files = FileCreator()
+        self.environ = os.environ.copy()
+        self.environ['AWS_CONFIG_FILE'] = self.files.create_file(
+            'config', (
+                '[default]\n'
+                'cli_history = enabled'
+            )
+        )
+        self.environ['AWS_DEFAULT_PROFILE'] = 'default'
+        self.environ['AWS_DEFAULT_REGION'] = 'us-west-2'
+        self.environ['AWS_HISTORY_PATH'] = self.files.rootdir
+
+    def tearDown(self):
+        self.files.remove_all()
+
+    def remove_color(self, output):
+        return re.compile(r'\x1b[^m]*m').sub('', output)
+
+    def assert_contains_in_order(self, lines, contents):
+        current_pos = 0
+        prev_line = None
+        for line in lines:
+            self.assertIn(line, contents)
+            new_pos = contents.find(line)
+            if new_pos < current_pos:
+                self.fail('Line: "%s" should have came after line: "%s"' % (
+                    line, prev_line))
+            prev_line = line
+            current_pos = new_pos
+
+    def test_show(self):
+        # Make a call that does not require credentials just in case the
+        # user was using the config file to provide credentials.
+        cmd = 'sts assume-role-with-saml '
+        cmd += '--role-arn  arn:aws:iam::...:invalid '
+        cmd += '--principal-arn  arn:aws:iam::...:invalid  '
+        cmd += '--saml-assertion fake-assertion'
+        aws(cmd, env_vars=self.environ)
+        # Now run the show command and make sure the general output is all
+        # there.
+        result = aws('history show', env_vars=self.environ)
+        uncolored_content = self.remove_color(result.stdout)
+
+        self.assert_contains_in_order(
+            [
+                'AWS CLI command entered',
+                'with AWS CLI version: aws-cli/',
+                "with arguments: ['sts', 'assume-role-with-saml',",
+                '[0] API call made',
+                'to service: sts',
+                'using operation: AssumeRoleWithSAML',
+                'with parameters: {',
+                '    "PrincipalArn": "arn:aws:iam::...:invalid",',
+                '    "RoleArn": "arn:aws:iam::...:invalid",',
+                '    "SAMLAssertion": "fake-assertion"',
+                '[0] HTTP request sent',
+                'to URL: https://sts.amazonaws.com/',
+                'with method: POST',
+                'with body: Action=AssumeRoleWithSAML&Version=2011-06-15',
+                '[0] HTTP response received',
+                'with status code: 400',
+                'with body: <?xml version="1.0" ?>',
+                '[0] HTTP response parsed',
+                'parsed to: {',
+                '    "Error": {',
+                'AWS CLI command exited',
+                'with return code: 255'
+            ],
+            uncolored_content
+        )

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -19,7 +19,6 @@ import datetime
 import mock
 
 from awscli.compat import queue
-from awscli.customizations.history.db import get_history_db_filename
 from awscli.customizations.history.db import DatabaseConnection
 from awscli.customizations.history.db import DatabaseHistoryHandler
 from awscli.customizations.history.db import DatabaseRecordWriter
@@ -41,20 +40,6 @@ class TestGetHistoryDBFilename(unittest.TestCase):
 
     def tearDown(self):
         self.files.remove_all()
-
-    def test_get_history_db_filename_env_var(self):
-        db_filename = os.path.join(self.files.rootdir, 'name.db')
-        with mock.patch('os.environ', {'AWS_CLI_HISTORY_FILE': db_filename}):
-            self.assertEqual(get_history_db_filename(), db_filename)
-
-    def test_get_history_db_filename_create_directory_if_no_exists(self):
-        directory_to_create = os.path.join(self.files.rootdir, 'create-dir')
-        db_filename = os.path.join(directory_to_create, 'name.db')
-        with mock.patch('os.environ', {'AWS_CLI_HISTORY_FILE': db_filename}):
-            self.assertEqual(get_history_db_filename(), db_filename)
-            # Is should create any missing parent directories of the
-            # file as well.
-            self.assertTrue(os.path.exists(directory_to_create))
 
 
 class TestDatabaseConnection(unittest.TestCase):
@@ -94,7 +79,8 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_emit_does_write_cli_rc_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
-        handler = DatabaseHistoryHandler(writer)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
         handler.emit('CLI_RC', 0, 'CLI')
         call = writer.write_record.call_args[0][0]
         self.assertEqual(call, {
@@ -109,7 +95,8 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_emit_does_write_cli_version_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
-        handler = DatabaseHistoryHandler(writer)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
         handler.emit('CLI_VERSION', 'Version Info', 'CLI')
         call = writer.write_record.call_args[0][0]
         self.assertEqual(call, {
@@ -124,7 +111,8 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_emit_does_write_api_call_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
-        handler = DatabaseHistoryHandler(writer)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'foo': 'bar'}
         handler.emit('API_CALL', payload, 'BOTOCORE')
         call = writer.write_record.call_args[0][0]
@@ -141,7 +129,8 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_emit_does_write_http_request_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
-        handler = DatabaseHistoryHandler(writer)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'body': b'data'}
         # In order for an http_request to have a request_id it must have been
         # preceeded by an api_call record.
@@ -161,7 +150,8 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_emit_does_write_http_response_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
-        handler = DatabaseHistoryHandler(writer)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'body': b'data'}
         # In order for an http_response to have a request_id it must have been
         # preceeded by an api_call record.
@@ -181,7 +171,8 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_emit_does_write_parsed_response_record(self):
         writer = mock.Mock(DatabaseRecordWriter)
-        handler = DatabaseHistoryHandler(writer)
+        record_builder = RecordBuilder()
+        handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'metadata': {'data': 'foobar'}}
         # In order for an http_response to have a request_id it must have been
         # preceeded by an api_call record.

--- a/tests/unit/customizations/history/test_history.py
+++ b/tests/unit/customizations/history/test_history.py
@@ -32,8 +32,9 @@ class TestAttachHistoryHander(unittest.TestCase):
         self.files.remove_all()
 
     @mock.patch('awscli.customizations.history.sqlite3')
-    @mock.patch('awscli.customizations.history.get_global_history_recorder')
-    def test_attach_history_handler(self, mock_get_recorder, mock_sqlite3):
+    @mock.patch('awscli.customizations.history.HISTORY_RECORDER',
+                spec=HistoryRecorder)
+    def test_attach_history_handler(self, mock_recorder, mock_sqlite3):
         mock_session = mock.Mock(Session)
         mock_session.get_scoped_config.return_value = {
             'cli_history': 'enabled'
@@ -42,18 +43,16 @@ class TestAttachHistoryHander(unittest.TestCase):
         parsed_args = argparse.Namespace()
         parsed_args.command = 's3'
 
-        mock_recorder = mock.Mock(HistoryRecorder)
-        mock_get_recorder.return_value = mock_recorder
-
         attach_history_handler(session=mock_session, parsed_args=parsed_args)
         self.assertEqual(mock_recorder.add_handler.call_count, 1)
         self.assertIsInstance(
             mock_recorder.add_handler.call_args[0][0], DatabaseHistoryHandler)
 
     @mock.patch('awscli.customizations.history.sqlite3')
-    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    @mock.patch('awscli.customizations.history.HISTORY_RECORDER',
+                spec=HistoryRecorder)
     def test_no_attach_history_handler_when_history_not_configured(
-            self, mock_get_recorder, mock_sqlite3):
+            self, mock_recorder, mock_sqlite3):
         mock_session = mock.Mock(Session)
         mock_session.get_scoped_config.return_value = {}
 
@@ -61,12 +60,13 @@ class TestAttachHistoryHander(unittest.TestCase):
         parsed_args.command = 's3'
 
         attach_history_handler(session=mock_session, parsed_args=parsed_args)
-        self.assertFalse(mock_get_recorder.called)
+        self.assertFalse(mock_recorder.add_handler.called)
 
     @mock.patch('awscli.customizations.history.sqlite3')
-    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    @mock.patch('awscli.customizations.history.HISTORY_RECORDER',
+                spec=HistoryRecorder)
     def test_no_attach_history_handler_when_command_is_history(
-            self, mock_get_recorder, mock_sqlite3):
+            self, mock_recorder, mock_sqlite3):
         mock_session = mock.Mock(Session)
         mock_session.get_scoped_config.return_value = {
             'cli_history': 'enabled'
@@ -76,12 +76,13 @@ class TestAttachHistoryHander(unittest.TestCase):
         parsed_args.command = 'history'
 
         attach_history_handler(session=mock_session, parsed_args=parsed_args)
-        self.assertFalse(mock_get_recorder.called)
+        self.assertFalse(mock_recorder.add_handler.called)
 
     @mock.patch('awscli.customizations.history.sqlite3', None)
-    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    @mock.patch('awscli.customizations.history.HISTORY_RECORDER',
+                spec=HistoryRecorder)
     def test_no_attach_history_handler_when_no_sqlite3(
-            self, mock_get_recorder):
+            self, mock_recorder):
         mock_session = mock.Mock(Session)
         mock_session.get_scoped_config.return_value = {
             'cli_history': 'enabled'
@@ -95,11 +96,12 @@ class TestAttachHistoryHander(unittest.TestCase):
                 session=mock_session, parsed_args=parsed_args)
             self.assertIn(
                 'enabled but sqlite3 is unavailable', mock_stderr.getvalue())
-        self.assertFalse(mock_get_recorder.called)
+        self.assertFalse(mock_recorder.add_handler.called)
 
     @mock.patch('awscli.customizations.history.sqlite3')
-    @mock.patch('awscli.customizations.history.get_global_history_recorder')
-    def test_create_directory_no_exists(self, mock_get_recorder, mock_sqlite3):
+    @mock.patch('awscli.customizations.history.HISTORY_RECORDER',
+                spec=HistoryRecorder)
+    def test_create_directory_no_exists(self, mock_recorder, mock_sqlite3):
         mock_session = mock.Mock(Session)
         mock_session.get_scoped_config.return_value = {
             'cli_history': 'enabled'
@@ -107,9 +109,6 @@ class TestAttachHistoryHander(unittest.TestCase):
 
         parsed_args = argparse.Namespace()
         parsed_args.command = 's3'
-
-        mock_recorder = mock.Mock(HistoryRecorder)
-        mock_get_recorder.return_value = mock_recorder
 
         directory_to_create = os.path.join(self.files.rootdir, 'create-dir')
         db_filename = os.path.join(directory_to_create, 'name.db')

--- a/tests/unit/customizations/history/test_history.py
+++ b/tests/unit/customizations/history/test_history.py
@@ -11,11 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import argparse
+import os
 
 from botocore.session import Session
 from botocore.history import HistoryRecorder
 
-from awscli.testutils import unittest, mock
+from awscli.testutils import unittest, mock, FileCreator
 from awscli.customizations.history import attach_history_handler
 from awscli.customizations.history import add_history_commands
 from awscli.customizations.history import HistoryCommand
@@ -23,6 +24,12 @@ from awscli.customizations.history.db import DatabaseHistoryHandler
 
 
 class TestAttachHistoryHander(unittest.TestCase):
+    def setUp(self):
+        self.files = FileCreator()
+
+    def tearDown(self):
+        self.files.remove_all()
+
     @mock.patch('awscli.customizations.history.sqlite3')
     @mock.patch('awscli.customizations.history.get_global_history_recorder')
     def test_attach_history_handler(self, mock_get_recorder, mock_sqlite3):
@@ -84,6 +91,30 @@ class TestAttachHistoryHander(unittest.TestCase):
 
         attach_history_handler(session=mock_session, parsed_args=parsed_args)
         self.assertFalse(mock_get_recorder.called)
+
+    @mock.patch('awscli.customizations.history.sqlite3')
+    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    def test_create_directory_no_exists(self, mock_get_recorder, mock_sqlite3):
+        mock_session = mock.Mock(Session)
+        mock_session.get_scoped_config.return_value = {
+            'cli_history': 'enabled'
+        }
+
+        parsed_args = argparse.Namespace()
+        parsed_args.command = 's3'
+
+        mock_recorder = mock.Mock(HistoryRecorder)
+        mock_get_recorder.return_value = mock_recorder
+
+        directory_to_create = os.path.join(self.files.rootdir, 'create-dir')
+        db_filename = os.path.join(directory_to_create, 'name.db')
+        with mock.patch('os.environ', {'AWS_CLI_HISTORY_FILE': db_filename}):
+            attach_history_handler(
+                session=mock_session, parsed_args=parsed_args)
+            self.assertEqual(mock_recorder.add_handler.call_count, 1)
+            # Is should create any missing parent directories of the
+            # file as well.
+            self.assertTrue(os.path.exists(directory_to_create))
 
 
 class TestAddHistoryCommand(unittest.TestCase):

--- a/tests/unit/customizations/history/test_history.py
+++ b/tests/unit/customizations/history/test_history.py
@@ -17,6 +17,7 @@ from botocore.session import Session
 from botocore.history import HistoryRecorder
 
 from awscli.testutils import unittest, mock, FileCreator
+from awscli.compat import StringIO
 from awscli.customizations.history import attach_history_handler
 from awscli.customizations.history import add_history_commands
 from awscli.customizations.history import HistoryCommand
@@ -89,7 +90,11 @@ class TestAttachHistoryHander(unittest.TestCase):
         parsed_args = argparse.Namespace()
         parsed_args.command = 's3'
 
-        attach_history_handler(session=mock_session, parsed_args=parsed_args)
+        with mock.patch('sys.stderr', StringIO()) as mock_stderr:
+            attach_history_handler(
+                session=mock_session, parsed_args=parsed_args)
+            self.assertIn(
+                'enabled but sqlite3 is unavailable', mock_stderr.getvalue())
         self.assertFalse(mock_get_recorder.called)
 
     @mock.patch('awscli.customizations.history.sqlite3')

--- a/tests/unit/customizations/history/test_history.py
+++ b/tests/unit/customizations/history/test_history.py
@@ -1,0 +1,107 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import argparse
+
+from botocore.session import Session
+from botocore.history import HistoryRecorder
+
+from awscli.testutils import unittest, mock
+from awscli.customizations.history import attach_history_handler
+from awscli.customizations.history import add_history_commands
+from awscli.customizations.history import HistoryCommand
+from awscli.customizations.history.db import DatabaseHistoryHandler
+
+
+class TestAttachHistoryHander(unittest.TestCase):
+    @mock.patch('awscli.customizations.history.sqlite3')
+    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    def test_attach_history_handler(self, mock_get_recorder, mock_sqlite3):
+        mock_session = mock.Mock(Session)
+        mock_session.get_scoped_config.return_value = {
+            'cli_history': 'enabled'
+        }
+
+        parsed_args = argparse.Namespace()
+        parsed_args.command = 's3'
+
+        mock_recorder = mock.Mock(HistoryRecorder)
+        mock_get_recorder.return_value = mock_recorder
+
+        attach_history_handler(session=mock_session, parsed_args=parsed_args)
+        self.assertEqual(mock_recorder.add_handler.call_count, 1)
+        self.assertIsInstance(
+            mock_recorder.add_handler.call_args[0][0], DatabaseHistoryHandler)
+
+    @mock.patch('awscli.customizations.history.sqlite3')
+    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    def test_no_attach_history_handler_when_history_not_configured(
+            self, mock_get_recorder, mock_sqlite3):
+        mock_session = mock.Mock(Session)
+        mock_session.get_scoped_config.return_value = {}
+
+        parsed_args = argparse.Namespace()
+        parsed_args.command = 's3'
+
+        attach_history_handler(session=mock_session, parsed_args=parsed_args)
+        self.assertFalse(mock_get_recorder.called)
+
+    @mock.patch('awscli.customizations.history.sqlite3')
+    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    def test_no_attach_history_handler_when_command_is_history(
+            self, mock_get_recorder, mock_sqlite3):
+        mock_session = mock.Mock(Session)
+        mock_session.get_scoped_config.return_value = {
+            'cli_history': 'enabled'
+        }
+
+        parsed_args = argparse.Namespace()
+        parsed_args.command = 'history'
+
+        attach_history_handler(session=mock_session, parsed_args=parsed_args)
+        self.assertFalse(mock_get_recorder.called)
+
+    @mock.patch('awscli.customizations.history.sqlite3', None)
+    @mock.patch('awscli.customizations.history.get_global_history_recorder')
+    def test_no_attach_history_handler_when_no_sqlite3(
+            self, mock_get_recorder):
+        mock_session = mock.Mock(Session)
+        mock_session.get_scoped_config.return_value = {
+            'cli_history': 'enabled'
+        }
+
+        parsed_args = argparse.Namespace()
+        parsed_args.command = 's3'
+
+        attach_history_handler(session=mock_session, parsed_args=parsed_args)
+        self.assertFalse(mock_get_recorder.called)
+
+
+class TestAddHistoryCommand(unittest.TestCase):
+    def test_add_history_command(self):
+        command_table = {}
+        mock_session = mock.Mock(Session)
+        add_history_commands(
+            command_table=command_table, session=mock_session)
+        self.assertIn('history', command_table)
+        self.assertIsInstance(command_table['history'], HistoryCommand)
+
+
+class TestHistoryCommand(unittest.TestCase):
+    def test_requires_subcommand(self):
+        mock_session = mock.Mock(Session)
+        history_command = HistoryCommand(mock_session)
+        parsed_args = argparse.Namespace()
+        parsed_args.subcommand = None
+        parsed_globals = argparse.Namespace()
+        with self.assertRaises(ValueError):
+            history_command._run_main(parsed_args, parsed_globals)

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -11,12 +11,18 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import argparse
+import subprocess
+import xml.dom.minidom
 
 from botocore.session import Session
 
+from awscli.compat import ensure_text_type
+from awscli.compat import BytesIO
 from awscli.testutils import unittest, mock
 from awscli.customizations.history.show import ShowCommand
 from awscli.customizations.history.show import Formatter
+from awscli.customizations.history.show import DetailedFormatter
+from awscli.customizations.history.show import OutputStreamFactory
 from awscli.customizations.history.db import DatabaseRecordReader
 
 
@@ -90,41 +96,519 @@ class TestFormatter(unittest.TestCase):
             Formatter(include=['one_event'], exclude=['other_event'])
 
 
-class DetailedFormatter(unittest.TestCase):
+class TestDetailedFormatter(unittest.TestCase):
+    def setUp(self):
+        self.output = BytesIO()
+        self.formatter = DetailedFormatter(self.output, colorize=False)
+
+    def get_pretty_xml(self, xml_str):
+        xml_dom = xml.dom.minidom.parseString(xml_str)
+        return xml_dom.toprettyxml(indent=' '*4, newl='\n')
+
     def test_display_cli_version(self):
-        pass
+        event = {
+            'event_type': 'CLI_VERSION',
+            'id': 'my-id',
+            'payload': 'aws-cli/1.11.188',
+            'timestamp': 0,
+            'request_id': None
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('AWS CLI command entered', collected_output)
+        self.assertIn(
+            'with AWS CLI version: aws-cli/1.11.188', collected_output)
+
+    def test_can_use_color(self):
+        self.formatter = DetailedFormatter(self.output, colorize=True)
+        event = {
+            'event_type': 'CLI_VERSION',
+            'id': 'my-id',
+            'payload': 'aws-cli/1.11.188',
+            'timestamp': 0,
+            'request_id': None
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('\x1b[37mAWS CLI command entered', collected_output)
+        self.assertIn('\x1b[36mwith AWS CLI version:', collected_output)
 
     def test_display_cli_arguments(self):
-        pass
+        event = {
+            'event_type': 'CLI_ARGUMENTS',
+            'id': 'my-id',
+            'payload': ['ec2', 'describe-regions'],
+            'timestamp': 0,
+            'request_id': None
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            "with arguments: ['ec2', 'describe-regions']", collected_output)
 
     def test_display_api_call(self):
-        pass
+        event = {
+            'event_type': 'API_CALL',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'service': 'ec2',
+                'operation': 'DescribeRegions',
+                'params': {}
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('[0] API call made', collected_output)
+        self.assertIn(
+            ('to service: ec2\n'
+             'using operation: DescribeRegions\n'
+             'with parameters: {}\n'),
+            collected_output
+        )
+
+    def test_two_different_api_calls_have_different_numbers(self):
+        event = {
+            'event_type': 'API_CALL',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'service': 'ec2',
+                'operation': 'DescribeRegions',
+                'params': {}
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('[0] API call made', collected_output)
+
+        other_event = {
+            'event_type': 'API_CALL',
+            'id': 'my-id',
+            'request_id': 'other-id',
+            'payload': {
+                'service': 'ec2',
+                'operation': 'DescribeRegions',
+                'params': {}
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(other_event)
+        new_output = ensure_text_type(self.output.getvalue())[
+            len(collected_output):]
+        self.assertIn('[1] API call made', new_output)
 
     def test_display_http_request(self):
-        pass
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': 'This is my body'
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('[0] HTTP request sent', collected_output)
+        self.assertIn(
+            ('to URL: https://myservice.us-west-2.amazonaws.com\n'
+             'with method: GET\n'
+             'with headers: {}\n'
+             'with body: This is my body\n'),
+            collected_output
+        )
+
+    def test_display_http_request_with_streamming_body(self):
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': 'This should not be printed out',
+                'streaming': True
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: The body is a stream and will not be displayed',
+            collected_output
+        )
+
+    def test_display_http_request_with_no_payload(self):
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': None
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: There is no associated body', collected_output)
+
+    def test_display_http_request_with_empty_string_payload(self):
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': ''
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: There is no associated body', collected_output)
+
+    def test_display_http_request_with_xml_payload(self):
+        xml_body = '<?xml version="1.0" ?><foo><bar>text</bar></foo>'
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': xml_body
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: ' + self.get_pretty_xml(xml_body),
+            collected_output
+        )
+
+    def test_display_http_request_with_xml_payload_and_whitespace(self):
+        xml_body = '<?xml version="1.0" ?><foo><bar>text</bar></foo>'
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': self.get_pretty_xml(xml_body)
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        # The XML should not be prettified more than once if the body
+        # of the request was already prettied.
+        self.assertIn(
+            'with body: ' + self.get_pretty_xml(xml_body),
+            collected_output
+        )
+
+    def test_display_http_request_with_json_struct_payload(self):
+        event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': '{"foo": "bar"}'
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            ('with body: {\n'
+             '    "foo": "bar"\n'
+             '}'),
+            collected_output
+        )
+
+    def test_shares_api_number_across_events_of_same_api_call(self):
+        api_event = {
+            'event_type': 'API_CALL',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'service': 'ec2',
+                'operation': 'DescribeRegions',
+                'params': {}
+            },
+            'timestamp': 0,
+        }
+        http_event = {
+            'event_type': 'HTTP_REQUEST',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'method': 'GET',
+                'url': 'https://myservice.us-west-2.amazonaws.com',
+                'headers': {},
+                'body': 'This is my body'
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(api_event)
+        self.formatter.display(http_event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('[0] API call made', collected_output)
+        self.assertIn('[0] HTTP request sent', collected_output)
 
     def test_display_http_response(self):
-        pass
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': 'This is my body'
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('[0] HTTP response received', collected_output)
+        self.assertIn(
+            ('with status code: 200\n'
+             'with headers: {}\n'
+             'with body: This is my body\n'),
+            collected_output
+        )
+
+    def test_display_http_response_with_streamming_body(self):
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': 'This should not be printed out',
+                'streaming': True
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: The body is a stream and will not be displayed',
+            collected_output
+        )
+
+    def test_display_http_response_with_no_payload(self):
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': None
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: There is no associated body', collected_output)
+
+    def test_display_http_response_with_empty_string_payload(self):
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': ''
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: There is no associated body', collected_output)
+
+    def test_display_http_response_with_xml_payload(self):
+        xml_body = '<?xml version="1.0" ?><foo><bar>text</bar></foo>'
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': xml_body
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            'with body: ' + self.get_pretty_xml(xml_body),
+            collected_output
+        )
+
+    def test_display_http_response_with_xml_payload_and_whitespace(self):
+        xml_body = '<?xml version="1.0" ?><foo><bar>text</bar></foo>'
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': self.get_pretty_xml(xml_body)
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        # The XML should not be prettified more than once if the body
+        # of the response was already prettied.
+        self.assertIn(
+            'with body: ' + self.get_pretty_xml(xml_body),
+            collected_output
+        )
+
+    def test_display_http_response_with_json_struct_payload(self):
+        event = {
+            'event_type': 'HTTP_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {
+                'status_code': 200,
+                'headers': {},
+                'body': '{"foo": "bar"}'
+            },
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn(
+            ('with body: {\n'
+             '    "foo": "bar"\n'
+             '}'),
+            collected_output
+        )
 
     def test_display_parsed_response(self):
-        pass
+        event = {
+            'event_type': 'PARSED_RESPONSE',
+            'id': 'my-id',
+            'request_id': 'some-id',
+            'payload': {},
+            'timestamp': 0,
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('[0] HTTP response parsed', collected_output)
+        self.assertIn('parsed to: {}', collected_output)
 
     def test_display_cli_rc(self):
-        pass
+        event = {
+            'event_type': 'CLI_RC',
+            'id': 'my-id',
+            'payload': 0,
+            'timestamp': 0,
+            'request_id': None
+        }
+        self.formatter.display(event)
+        collected_output = ensure_text_type(self.output.getvalue())
+        self.assertIn('AWS CLI command exited', collected_output)
+        self.assertIn('with return code: 0', collected_output)
+
+
+class TestOutputStreamFactory(unittest.TestCase):
+    def setUp(self):
+        self.popen = mock.Mock(subprocess.Popen)
+        self.stream_factory = OutputStreamFactory(self.popen)
+
+    def test_unknown_option(self):
+        with self.assertRaises(ValueError):
+            self.stream_factory.get_output_stream('unknown')
+
+    @mock.patch(
+        'awscli.customizations.history.show.get_default_platform_pager')
+    def test_platform_specific_pager(self, mock_get_pager):
+        mock_get_pager.return_value = 'mypager --option'
+        with mock.patch('os.environ', {}):
+            with self.stream_factory.get_output_stream('pager'):
+                self.assertEqual(
+                    self.popen.call_args_list,
+                    [mock.call(['mypager', '--option'], stdin=subprocess.PIPE)]
+                )
+
+    def test_env_configured_pager(self):
+        environ = {'PAGER': 'mypager --option'}
+        with mock.patch('os.environ', environ):
+            with self.stream_factory.get_output_stream('pager'):
+                self.assertEqual(
+                    self.popen.call_args_list,
+                    [mock.call(['mypager', '--option'], stdin=subprocess.PIPE)]
+                )
+
+    def test_exit_of_context_manager_for_pager(self):
+        with self.stream_factory.get_output_stream('pager'):
+            pass
+        returned_process = self.popen.return_value
+        self.assertTrue(returned_process.stdin.close.called)
+        self.assertTrue(returned_process.wait.called)
+
+    @mock.patch('awscli.customizations.history.show.get_binary_stdout')
+    def test_stdout(self, mock_binary_out):
+        with self.stream_factory.get_output_stream('stdout'):
+            self.assertTrue(mock_binary_out.called)
 
 
 class TestShowCommand(unittest.TestCase):
     def setUp(self):
         self.session = mock.Mock(Session)
 
-        self.db_reader = mock.Mock(DatabaseRecordReader)
-        self.db_reader.yield_latest_records.return_value = []
-        self.db_reader.yield_records.return_value = []
+        self.output_stream_factory = mock.Mock(OutputStreamFactory)
 
-        self.show_cmd = ShowCommand(self.session, self.db_reader)
+        # MagicMock is needed because it can handle context managers.
+        # Normal Mock will throw AttributeErrors
+        output_stream_context = mock.MagicMock()
+        self.output_stream = mock.Mock()
+        output_stream_context.__enter__.return_value = self.output_stream
+
+        self.output_stream_factory.get_output_stream.return_value = \
+            output_stream_context
+
+        self.db_reader = mock.Mock(DatabaseRecordReader)
+        self.db_reader.iter_latest_records.return_value = []
+        self.db_reader.iter_records.return_value = []
+
+        self.show_cmd = ShowCommand(
+            self.session, self.db_reader, self.output_stream_factory)
 
         self.formatter = mock.Mock(Formatter)
-        self.show_cmd.FORMATTERS['mock'] = self.formatter
+        self.add_formatter('mock', self.formatter)
 
         self.parsed_args = argparse.Namespace()
         self.parsed_globals = argparse.Namespace()
@@ -132,25 +616,33 @@ class TestShowCommand(unittest.TestCase):
         self.parsed_args.include = None
         self.parsed_args.exclude = None
 
+    def add_formatter(self, formatter_name, formatter):
+        # We do not want to be adding to the dictionary directly because
+        # the dictionary is scoped to the class as well so even a formatter
+        # to an instance of the class will add it to the class as well.
+        formatters = self.show_cmd.FORMATTERS.copy()
+        formatters[formatter_name] = formatter
+        self.show_cmd.FORMATTERS = formatters
+
     def test_show_latest(self):
         self.parsed_args.command_id = 'latest'
         self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
-        self.assertTrue(self.db_reader.yield_latest_records.called)
+        self.assertTrue(self.db_reader.iter_latest_records.called)
 
     def test_show_specific_id(self):
         self.parsed_args.command_id = 'some-specific-id'
         self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
         self.assertEqual(
-            self.db_reader.yield_records.call_args,
+            self.db_reader.iter_records.call_args,
             mock.call('some-specific-id')
         )
 
-    def test_uses_view(self):
+    def test_uses_format(self):
         formatter = mock.Mock(Formatter)
-        self.show_cmd.FORMATTERS['myformatter'] = formatter
+        self.add_formatter('myformatter', formatter)
 
         return_record = {'id': 'myid', 'event_type': 'CLI_RC', 'payload': 0}
-        self.db_reader.yield_latest_records.return_value = [return_record]
+        self.db_reader.iter_latest_records.return_value = [return_record]
 
         self.parsed_args.format = 'myformatter'
         self.parsed_args.command_id = 'latest'
@@ -170,7 +662,9 @@ class TestShowCommand(unittest.TestCase):
 
         self.assertEqual(
             self.formatter.call_args,
-            mock.call(include=['API_CALL'], exclude=None)
+            mock.call(
+                include=['API_CALL'], exclude=None,
+                output=self.output_stream)
         )
 
     def test_uses_exclude(self):
@@ -181,7 +675,9 @@ class TestShowCommand(unittest.TestCase):
 
         self.assertEqual(
             self.formatter.call_args,
-            mock.call(include=None, exclude=['CLI_RC'])
+            mock.call(
+                include=None, exclude=['CLI_RC'],
+                output=self.output_stream)
         )
 
     def test_raises_error_when_both_include_and_exclude(self):
@@ -189,3 +685,41 @@ class TestShowCommand(unittest.TestCase):
         self.parsed_args.exclude = ['CLI_RC']
         with self.assertRaises(ValueError):
             self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+
+    @mock.patch('awscli.customizations.history.show.is_a_tty')
+    def test_detailed_formatter_is_a_tty(self, mock_is_a_tty):
+        mock_is_a_tty.return_value = True
+        self.formatter = mock.Mock(DetailedFormatter)
+        self.add_formatter('detailed', self.formatter)
+        self.parsed_args.format = 'detailed'
+        self.parsed_args.command_id = 'latest'
+
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+        self.output_stream_factory.get_output_stream.assert_called_with(
+            'pager')
+        self.assertEqual(
+            self.formatter.call_args,
+            mock.call(
+                include=None, exclude=None,
+                output=self.output_stream, colorize=True
+            )
+        )
+
+    @mock.patch('awscli.customizations.history.show.is_a_tty')
+    def test_detailed_formatter_not_a_tty(self, mock_is_a_tty):
+        mock_is_a_tty.return_value = False
+        self.formatter = mock.Mock(DetailedFormatter)
+        self.add_formatter('detailed', self.formatter)
+        self.parsed_args.format = 'detailed'
+        self.parsed_args.command_id = 'latest'
+
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+        self.output_stream_factory.get_output_stream.assert_called_with(
+            'stdout')
+        self.assertEqual(
+            self.formatter.call_args,
+            mock.call(
+                include=None, exclude=None,
+                output=self.output_stream, colorize=False
+            )
+        )

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -130,7 +130,7 @@ class TestDetailedFormatter(unittest.TestCase):
         }
         self.formatter.display(event)
         collected_output = ensure_text_type(self.output.getvalue())
-        self.assertIn('\x1b[37mAWS CLI command entered', collected_output)
+        self.assertIn('\x1b[1mAWS CLI command entered', collected_output)
         self.assertIn('\x1b[36mwith AWS CLI version:', collected_output)
 
     def test_display_cli_arguments(self):

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -603,8 +603,7 @@ class TestOutputStreamFactory(unittest.TestCase):
         with self.stream_factory.get_output_stream('pager'):
             pass
         returned_process = self.popen.return_value
-        self.assertTrue(returned_process.stdin.close.called)
-        self.assertTrue(returned_process.wait.called)
+        self.assertTrue(returned_process.communicate.called)
 
     @mock.patch('awscli.customizations.history.show.get_binary_stdout')
     def test_stdout(self, mock_binary_out):

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -550,44 +550,53 @@ class TestOutputStreamFactory(unittest.TestCase):
             self.stream_factory.get_output_stream('unknown')
 
     @mock.patch(
-        'awscli.customizations.history.show.get_popen_pager_cmd_with_kwargs')
+        'awscli.customizations.history.show.get_popen_kwargs_for_pager_cmd')
     def test_pager(self, mock_get_popen_pager):
-        mock_get_popen_pager.return_value = (
-            ['mypager', '--option'], {})
-        with mock.patch('os.environ', {}):
-            with self.stream_factory.get_output_stream('pager'):
-                mock_get_popen_pager.assert_called_with(None)
-                self.assertEqual(
-                    self.popen.call_args_list,
-                    [mock.call(['mypager', '--option'], stdin=subprocess.PIPE)]
-                )
-
-    @mock.patch(
-        'awscli.customizations.history.show.get_popen_pager_cmd_with_kwargs')
-    def test_env_configured_pager(self, mock_get_popen_pager):
-        environ = {'PAGER': 'mypager --option'}
-        mock_get_popen_pager.return_value = (
-            ['mypager', '--option'], {})
-        with mock.patch('os.environ', environ):
-            with self.stream_factory.get_output_stream('pager'):
-                mock_get_popen_pager.assert_called_with('mypager --option')
-                self.assertEqual(
-                    self.popen.call_args_list,
-                    [mock.call(['mypager', '--option'], stdin=subprocess.PIPE)]
-                )
-
-    @mock.patch(
-        'awscli.customizations.history.show.get_popen_pager_cmd_with_kwargs')
-    def test_pager_using_shell(self, mock_get_popen_pager):
-        mock_get_popen_pager.return_value = (
-            'mypager --option', {'shell': True})
+        mock_get_popen_pager.return_value = {
+                'args': ['mypager', '--option']
+        }
         with mock.patch('os.environ', {}):
             with self.stream_factory.get_output_stream('pager'):
                 mock_get_popen_pager.assert_called_with(None)
                 self.assertEqual(
                     self.popen.call_args_list,
                     [mock.call(
-                        'mypager --option', stdin=subprocess.PIPE, shell=True)]
+                        args=['mypager', '--option'],
+                        stdin=subprocess.PIPE)]
+                )
+
+    @mock.patch(
+        'awscli.customizations.history.show.get_popen_kwargs_for_pager_cmd')
+    def test_env_configured_pager(self, mock_get_popen_pager):
+        environ = {'PAGER': 'mypager --option'}
+        mock_get_popen_pager.return_value = {
+            'args': ['mypager', '--option']
+        }
+        with mock.patch('os.environ', environ):
+            with self.stream_factory.get_output_stream('pager'):
+                mock_get_popen_pager.assert_called_with('mypager --option')
+                self.assertEqual(
+                    self.popen.call_args_list,
+                    [mock.call(
+                        args=['mypager', '--option'],
+                        stdin=subprocess.PIPE)]
+                )
+
+    @mock.patch(
+        'awscli.customizations.history.show.get_popen_kwargs_for_pager_cmd')
+    def test_pager_using_shell(self, mock_get_popen_pager):
+        mock_get_popen_pager.return_value = {
+            'args': 'mypager --option', 'shell': True
+        }
+        with mock.patch('os.environ', {}):
+            with self.stream_factory.get_output_stream('pager'):
+                mock_get_popen_pager.assert_called_with(None)
+                self.assertEqual(
+                    self.popen.call_args_list,
+                    [mock.call(
+                        args='mypager --option',
+                        stdin=subprocess.PIPE,
+                        shell=True)]
                 )
 
     def test_exit_of_context_manager_for_pager(self):

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -1,0 +1,191 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import argparse
+
+from botocore.session import Session
+
+from awscli.testutils import unittest, mock
+from awscli.customizations.history.show import ShowCommand
+from awscli.customizations.history.show import Formatter
+from awscli.customizations.history.db import DatabaseRecordReader
+
+
+class RecordingFormatter(Formatter):
+    def __init__(self, output=None, include=None, exclude=None):
+        super(RecordingFormatter, self).__init__(
+            output=output, include=include, exclude=exclude)
+        self.history = []
+
+    def _display_my_event(self, event_record):
+        self.history.append(('my_event', event_record))
+
+    def _display_my_other_event(self, event_record):
+        self.history.append(('my_other_event', event_record))
+
+
+class TestFormatter(unittest.TestCase):
+    def test_display_known_event_type(self):
+        formatter = RecordingFormatter()
+        event_record = {'event_type': 'my_event'}
+        other_event_record = {'event_type': 'my_other_event'}
+        formatter.display(event_record)
+        formatter.display(other_event_record)
+        self.assertEqual(
+            formatter.history,
+            [
+                ('my_event', event_record),
+                ('my_other_event', other_event_record)
+            ]
+        )
+
+    def test_display_known_event_type_case_insensitive(self):
+        formatter = RecordingFormatter()
+        event_record = {'event_type': 'MY_EVENT'}
+        formatter.display(event_record)
+        self.assertEqual(formatter.history, [('my_event', event_record)])
+
+    def test_display_unknown_event_type(self):
+        formatter = RecordingFormatter()
+        event_record = {'event_type': 'unknown'}
+        formatter.display(event_record)
+        self.assertEqual(formatter.history, [])
+
+    def test_include_specified_event_type(self):
+        formatter = RecordingFormatter(include=['my_event'])
+        event_record = {'event_type': 'my_event'}
+        formatter.display(event_record)
+        self.assertEqual(formatter.history, [('my_event', event_record)])
+
+    def test_include_on_unspecified_event_type(self):
+        formatter = RecordingFormatter(include=['my_event'])
+        other_event_record = {'event_type': 'my_other_event'}
+        formatter.display(other_event_record)
+        self.assertEqual(formatter.history, [])
+
+    def test_exclude_on_specified_event_type(self):
+        formatter = RecordingFormatter(exclude=['my_event'])
+        event_record = {'event_type': 'my_event'}
+        formatter.display(event_record)
+        self.assertEqual(formatter.history, [])
+
+    def test_exclude_on_unspecified_event_type(self):
+        formatter = RecordingFormatter(exclude=['my_event'])
+        other_event_record = {'event_type': 'my_other_event'}
+        formatter.display(other_event_record)
+        self.assertEqual(
+            formatter.history, [('my_other_event', other_event_record)])
+
+    def test_raises_error_when_both_include_and_exclude(self):
+        with self.assertRaises(ValueError):
+            Formatter(include=['one_event'], exclude=['other_event'])
+
+
+class DetailedFormatter(unittest.TestCase):
+    def test_display_cli_version(self):
+        pass
+
+    def test_display_cli_arguments(self):
+        pass
+
+    def test_display_api_call(self):
+        pass
+
+    def test_display_http_request(self):
+        pass
+
+    def test_display_http_response(self):
+        pass
+
+    def test_display_parsed_response(self):
+        pass
+
+    def test_display_cli_rc(self):
+        pass
+
+
+class TestShowCommand(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock(Session)
+
+        self.db_reader = mock.Mock(DatabaseRecordReader)
+        self.db_reader.yield_latest_records.return_value = []
+        self.db_reader.yield_records.return_value = []
+
+        self.show_cmd = ShowCommand(self.session, self.db_reader)
+
+        self.formatter = mock.Mock(Formatter)
+        self.show_cmd.FORMATTERS['mock'] = self.formatter
+
+        self.parsed_args = argparse.Namespace()
+        self.parsed_globals = argparse.Namespace()
+        self.parsed_args.format = 'mock'
+        self.parsed_args.include = None
+        self.parsed_args.exclude = None
+
+    def test_show_latest(self):
+        self.parsed_args.command_id = 'latest'
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+        self.assertTrue(self.db_reader.yield_latest_records.called)
+
+    def test_show_specific_id(self):
+        self.parsed_args.command_id = 'some-specific-id'
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+        self.assertEqual(
+            self.db_reader.yield_records.call_args,
+            mock.call('some-specific-id')
+        )
+
+    def test_uses_view(self):
+        formatter = mock.Mock(Formatter)
+        self.show_cmd.FORMATTERS['myformatter'] = formatter
+
+        return_record = {'id': 'myid', 'event_type': 'CLI_RC', 'payload': 0}
+        self.db_reader.yield_latest_records.return_value = [return_record]
+
+        self.parsed_args.format = 'myformatter'
+        self.parsed_args.command_id = 'latest'
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+
+        self.assertTrue(formatter.called)
+        self.assertEqual(
+            formatter.return_value.display.call_args_list,
+            [mock.call(return_record)]
+        )
+
+    def test_uses_include(self):
+        self.parsed_args.command_id = 'latest'
+        self.parsed_args.include = ['API_CALL']
+        self.parsed_args.exclude = None
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+
+        self.assertEqual(
+            self.formatter.call_args,
+            mock.call(include=['API_CALL'], exclude=None)
+        )
+
+    def test_uses_exclude(self):
+        self.parsed_args.command_id = 'latest'
+        self.parsed_args.include = None
+        self.parsed_args.exclude = ['CLI_RC']
+        self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
+
+        self.assertEqual(
+            self.formatter.call_args,
+            mock.call(include=None, exclude=['CLI_RC'])
+        )
+
+    def test_raises_error_when_both_include_and_exclude(self):
+        self.parsed_args.include = ['API_CALL']
+        self.parsed_args.exclude = ['CLI_RC']
+        with self.assertRaises(ValueError):
+            self.show_cmd._run_main(self.parsed_args, self.parsed_globals)

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -706,11 +706,10 @@ class TestShowCommand(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
 
-    @mock.patch('awscli.customizations.history.show.is_windows')
+    @mock.patch('awscli.customizations.history.show.is_windows', False)
     @mock.patch('awscli.customizations.history.show.is_a_tty')
-    def test_detailed_formatter_is_a_tty(self, mock_is_a_tty, mock_is_windows):
+    def test_detailed_formatter_is_a_tty(self, mock_is_a_tty):
         mock_is_a_tty.return_value = True
-        mock_is_windows.return_value = False
         self.formatter = mock.Mock(DetailedFormatter)
         self.add_formatter('detailed', self.formatter)
         self.parsed_args.format = 'detailed'
@@ -727,12 +726,10 @@ class TestShowCommand(unittest.TestCase):
             )
         )
 
-    @mock.patch('awscli.customizations.history.show.is_windows')
+    @mock.patch('awscli.customizations.history.show.is_windows', False)
     @mock.patch('awscli.customizations.history.show.is_a_tty')
-    def test_detailed_formatter_not_a_tty(self, mock_is_a_tty,
-                                          mock_is_windows):
+    def test_detailed_formatter_not_a_tty(self, mock_is_a_tty):
         mock_is_a_tty.return_value = False
-        mock_is_windows.return_value = False
         self.formatter = mock.Mock(DetailedFormatter)
         self.add_formatter('detailed', self.formatter)
         self.parsed_args.format = 'detailed'
@@ -749,9 +746,8 @@ class TestShowCommand(unittest.TestCase):
             )
         )
 
-    @mock.patch('awscli.customizations.history.show.is_windows')
-    def test_detailed_formatter_no_color_for_windows(self, mock_is_windows):
-        mock_is_windows.return_value = True
+    @mock.patch('awscli.customizations.history.show.is_windows', True)
+    def test_detailed_formatter_no_color_for_windows(self):
         self.formatter = mock.Mock(DetailedFormatter)
         self.add_formatter('detailed', self.formatter)
         self.parsed_args.format = 'detailed'
@@ -766,9 +762,9 @@ class TestShowCommand(unittest.TestCase):
             )
         )
 
-    @mock.patch('awscli.customizations.history.show.is_windows')
+    @mock.patch('awscli.customizations.history.show.is_windows', True)
     @mock.patch('awscli.customizations.history.show.is_a_tty')
-    def test_force_color(self, mock_is_a_tty, mock_is_windows):
+    def test_force_color(self, mock_is_a_tty):
         self.formatter = mock.Mock(DetailedFormatter)
         self.add_formatter('detailed', self.formatter)
         self.parsed_args.format = 'detailed'
@@ -778,7 +774,6 @@ class TestShowCommand(unittest.TestCase):
         # Even with settings that would typically turn off color, it
         # should be turned on because it was explicitly turned on
         mock_is_a_tty.return_value = False
-        mock_is_windows.return_value = True
 
         self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
         self.assertEqual(
@@ -789,9 +784,9 @@ class TestShowCommand(unittest.TestCase):
             )
         )
 
-    @mock.patch('awscli.customizations.history.show.is_windows')
+    @mock.patch('awscli.customizations.history.show.is_windows', False)
     @mock.patch('awscli.customizations.history.show.is_a_tty')
-    def test_disable_color(self, mock_is_a_tty, mock_is_windows):
+    def test_disable_color(self, mock_is_a_tty):
         self.formatter = mock.Mock(DetailedFormatter)
         self.add_formatter('detailed', self.formatter)
         self.parsed_args.format = 'detailed'
@@ -801,7 +796,6 @@ class TestShowCommand(unittest.TestCase):
         # Even with settings that would typically enable color, it
         # should be turned off because it was explicitly turned off
         mock_is_a_tty.return_value = True
-        mock_is_windows.return_value = False
 
         self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
         self.assertEqual(

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -15,7 +15,6 @@ from botocore.compat import six
 
 from awscli.compat import ensure_text_type
 from awscli.compat import compat_shell_quote
-from awscli.compat import is_windows
 from awscli.compat import get_popen_pager_cmd_with_kwargs
 from awscli.testutils import mock, unittest
 
@@ -87,36 +86,26 @@ class ShellQuoteTestCase(object):
         assert_equal(compat_shell_quote(s, platform), expected)
 
 
-class TestIsWindows(unittest.TestCase):
-    @mock.patch('os.name', 'nt')
-    def test_is_windows(self):
-        self.assertTrue(is_windows())
-
-    @mock.patch('os.name', 'posix')
-    def test_is_non_windows(self):
-        self.assertFalse(is_windows())
-
-
 class TestGetPopenPagerCmd(unittest.TestCase):
-    @mock.patch('os.name', 'nt')
+    @mock.patch('awscli.compat.is_windows', True)
     def test_windows(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
         self.assertEqual('more', popen_cmd)
         self.assertEqual({'shell': True}, kwargs)
 
-    @mock.patch('os.name', 'nt')
+    @mock.patch('awscli.compat.is_windows', True)
     def test_windows_with_specific_pager(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('less -R')
         self.assertEqual('less -R', popen_cmd)
         self.assertEqual({'shell': True}, kwargs)
 
-    @mock.patch('os.name', 'posix')
+    @mock.patch('awscli.compat.is_windows', False)
     def test_non_windows(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
         self.assertEqual(['less', '-R'], popen_cmd)
         self.assertEqual({}, kwargs)
 
-    @mock.patch('os.name', 'posix')
+    @mock.patch('awscli.compat.is_windows', False)
     def test_non_windows_specific_pager(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('more')
         self.assertEqual(['more'], popen_cmd)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -15,7 +15,8 @@ from botocore.compat import six
 
 from awscli.compat import ensure_text_type
 from awscli.compat import compat_shell_quote
-from awscli.testutils import unittest
+from awscli.compat import get_default_platform_pager
+from awscli.testutils import mock, unittest
 
 
 class TestEnsureText(unittest.TestCase):
@@ -83,3 +84,15 @@ def test_comat_shell_quote_unix():
 class ShellQuoteTestCase(object):
     def run(self, s, expected, platform=None):
         assert_equal(compat_shell_quote(s, platform), expected)
+
+
+class TestGetDefaultPlatformPager(unittest.TestCase):
+    @mock.patch('platform.system')
+    def test_windows(self, mock_system):
+        mock_system.return_value = 'Windows'
+        self.assertEqual(get_default_platform_pager(), 'more')
+
+    @mock.patch('platform.system')
+    def test_non_windows(self, mock_system):
+        mock_system.return_value = 'Darwin'
+        self.assertEqual(get_default_platform_pager(), 'less -R')

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -15,7 +15,7 @@ from botocore.compat import six
 
 from awscli.compat import ensure_text_type
 from awscli.compat import compat_shell_quote
-from awscli.compat import get_popen_pager_cmd_with_kwargs
+from awscli.compat import get_popen_kwargs_for_pager_cmd
 from awscli.testutils import mock, unittest
 
 
@@ -89,24 +89,20 @@ class ShellQuoteTestCase(object):
 class TestGetPopenPagerCmd(unittest.TestCase):
     @mock.patch('awscli.compat.is_windows', True)
     def test_windows(self):
-        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
-        self.assertEqual('more', popen_cmd)
-        self.assertEqual({'shell': True}, kwargs)
+        kwargs = get_popen_kwargs_for_pager_cmd()
+        self.assertEqual({'args': 'more', 'shell': True}, kwargs)
 
     @mock.patch('awscli.compat.is_windows', True)
     def test_windows_with_specific_pager(self):
-        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('less -R')
-        self.assertEqual('less -R', popen_cmd)
-        self.assertEqual({'shell': True}, kwargs)
+        kwargs = get_popen_kwargs_for_pager_cmd('less -R')
+        self.assertEqual({'args': 'less -R', 'shell': True}, kwargs)
 
     @mock.patch('awscli.compat.is_windows', False)
     def test_non_windows(self):
-        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
-        self.assertEqual(['less', '-R'], popen_cmd)
-        self.assertEqual({}, kwargs)
+        kwargs = get_popen_kwargs_for_pager_cmd()
+        self.assertEqual({'args': ['less', '-R']}, kwargs)
 
     @mock.patch('awscli.compat.is_windows', False)
     def test_non_windows_specific_pager(self):
-        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('more')
-        self.assertEqual(['more'], popen_cmd)
-        self.assertEqual({}, kwargs)
+        kwargs = get_popen_kwargs_for_pager_cmd('more')
+        self.assertEqual({'args': ['more']}, kwargs)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -88,42 +88,36 @@ class ShellQuoteTestCase(object):
 
 
 class TestIsWindows(unittest.TestCase):
-    @mock.patch('platform.system')
-    def test_is_windows(self, mock_system):
-        mock_system.return_value = 'Windows'
+    @mock.patch('os.name', 'nt')
+    def test_is_windows(self):
         self.assertTrue(is_windows())
 
-    @mock.patch('platform.system')
-    def test_is_non_windows(self, mock_system):
-        mock_system.return_value = 'Darwin'
+    @mock.patch('os.name', 'posix')
+    def test_is_non_windows(self):
         self.assertFalse(is_windows())
 
 
 class TestGetPopenPagerCmd(unittest.TestCase):
-    @mock.patch('platform.system')
-    def test_windows(self, mock_system):
-        mock_system.return_value = 'Windows'
+    @mock.patch('os.name', 'nt')
+    def test_windows(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
         self.assertEqual('more', popen_cmd)
         self.assertEqual({'shell': True}, kwargs)
 
-    @mock.patch('platform.system')
-    def test_windows_with_specific_pager(self, mock_system):
-        mock_system.return_value = 'Windows'
+    @mock.patch('os.name', 'nt')
+    def test_windows_with_specific_pager(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('less -R')
         self.assertEqual('less -R', popen_cmd)
         self.assertEqual({'shell': True}, kwargs)
 
-    @mock.patch('platform.system')
-    def test_non_windows(self, mock_system):
-        mock_system.return_value = 'Darwin'
+    @mock.patch('os.name', 'posix')
+    def test_non_windows(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
         self.assertEqual(['less', '-R'], popen_cmd)
         self.assertEqual({}, kwargs)
 
-    @mock.patch('platform.system')
-    def test_non_windows_specific_pager(self, mock_system):
-        mock_system.return_value = 'Darwin'
+    @mock.patch('os.name', 'posix')
+    def test_non_windows_specific_pager(self):
         popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('more')
         self.assertEqual(['more'], popen_cmd)
         self.assertEqual({}, kwargs)

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -15,7 +15,8 @@ from botocore.compat import six
 
 from awscli.compat import ensure_text_type
 from awscli.compat import compat_shell_quote
-from awscli.compat import get_default_platform_pager
+from awscli.compat import is_windows
+from awscli.compat import get_popen_pager_cmd_with_kwargs
 from awscli.testutils import mock, unittest
 
 
@@ -86,13 +87,43 @@ class ShellQuoteTestCase(object):
         assert_equal(compat_shell_quote(s, platform), expected)
 
 
-class TestGetDefaultPlatformPager(unittest.TestCase):
+class TestIsWindows(unittest.TestCase):
+    @mock.patch('platform.system')
+    def test_is_windows(self, mock_system):
+        mock_system.return_value = 'Windows'
+        self.assertTrue(is_windows())
+
+    @mock.patch('platform.system')
+    def test_is_non_windows(self, mock_system):
+        mock_system.return_value = 'Darwin'
+        self.assertFalse(is_windows())
+
+
+class TestGetPopenPagerCmd(unittest.TestCase):
     @mock.patch('platform.system')
     def test_windows(self, mock_system):
         mock_system.return_value = 'Windows'
-        self.assertEqual(get_default_platform_pager(), 'more')
+        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
+        self.assertEqual('more', popen_cmd)
+        self.assertEqual({'shell': True}, kwargs)
+
+    @mock.patch('platform.system')
+    def test_windows_with_specific_pager(self, mock_system):
+        mock_system.return_value = 'Windows'
+        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('less -R')
+        self.assertEqual('less -R', popen_cmd)
+        self.assertEqual({'shell': True}, kwargs)
 
     @mock.patch('platform.system')
     def test_non_windows(self, mock_system):
         mock_system.return_value = 'Darwin'
-        self.assertEqual(get_default_platform_pager(), 'less -R')
+        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs()
+        self.assertEqual(['less', '-R'], popen_cmd)
+        self.assertEqual({}, kwargs)
+
+    @mock.patch('platform.system')
+    def test_non_windows_specific_pager(self, mock_system):
+        mock_system.return_value = 'Darwin'
+        popen_cmd, kwargs = get_popen_pager_cmd_with_kwargs('more')
+        self.assertEqual(['more'], popen_cmd)
+        self.assertEqual({}, kwargs)


### PR DESCRIPTION
This is based on John's PR: https://github.com/aws/aws-cli/pull/2968 and relies on the botocore PR as well: https://github.com/boto/botocore/pull/1315.

To start using the `history show` command. First run:
```
$ aws configure set cli_history enabled
```

Then run a command:
```
$ aws ec2 describe-regions
```

and then run:
```
$ aws history show
```
And you should get an output like this summarizing the entire command for you (providing no args displays the last comand ran). Here is sample output from my terminal:
<img width="1148" alt="screen shot 2017-11-19 at 9 48 55 pm" src="https://user-images.githubusercontent.com/4605355/33004072-98b85476-cd73-11e7-9b0c-a2d29d633682.png">

Let me know what you all think.