### PR TITLE
 Use the session profile to write when running aws configure 

### DIFF
--- a/.changes/next-release/bugfix-Configure-3035.json
+++ b/.changes/next-release/bugfix-Configure-3035.json
@@ -1,0 +1,5 @@
+{
+  "category": "Configure",
+  "description": "Fix a bug where the configure command would write to the incorrect profile, fixes `#2970 <https://github.com/aws/aws-cli/issues/2970>`__.",
+  "type": "bugfix"
+}

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -112,10 +112,10 @@ class ConfigureCommand(BasicCommand):
         config_filename = os.path.expanduser(
             self._session.get_config_variable('config_file'))
         if new_values:
-            self._write_out_creds_file_values(new_values,
-                                              parsed_globals.profile)
-            if parsed_globals.profile is not None:
-                section = profile_to_section(parsed_globals.profile)
+            profile = self._session.profile
+            self._write_out_creds_file_values(new_values, profile)
+            if profile is not None:
+                section = profile_to_section(profile)
                 new_values['__section__'] = section
             self._config_writer.update_config(new_values, config_filename)
 

--- a/tests/unit/customizations/configure/__init__.py
+++ b/tests/unit/customizations/configure/__init__.py
@@ -17,7 +17,7 @@ class FakeSession(object):
 
     def __init__(self, all_variables, profile_does_not_exist=False,
                  config_file_vars=None, environment_vars=None,
-                 credentials=None):
+                 credentials=None, profile=None):
         self.variables = all_variables
         self.profile_does_not_exist = profile_does_not_exist
         self.config = {}
@@ -28,7 +28,7 @@ class FakeSession(object):
             environment_vars = {}
         self.environment_vars = environment_vars
         self._credentials = credentials
-        self.profile = None
+        self.profile = profile
 
     def get_credentials(self):
         return self._credentials

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -95,9 +95,9 @@ class TestConfigureCommand(unittest.TestCase):
             {'output': 'NEW OUTPUT FORMAT'}, 'myconfigfile')
 
     def test_section_name_can_be_changed_for_profiles(self):
-        # If the user specifies "--profile myname" we need to write
-        # this out to the [profile myname] section.
-        self.global_args.profile = 'myname'
+        # If the user specifies a profile we need to write this out to
+        # the [profile myname] section.
+        self.session.profile = 'myname'
         self.configure(args=[], parsed_globals=self.global_args)
         # Note the __section__ key name.
         self.assert_credentials_file_updated_with(
@@ -115,11 +115,11 @@ class TestConfigureCommand(unittest.TestCase):
         # We should handle this case, and write out a new profile section
         # in the config file.
         session = FakeSession({'config_file': 'myconfigfile'},
-                              profile_does_not_exist=True)
+                              profile_does_not_exist=True,
+                              profile='profile-does-not-exist')
         self.configure = configure.ConfigureCommand(session,
                                                     prompter=self.precanned,
                                                     config_writer=self.writer)
-        self.global_args.profile = 'profile-does-not-exist'
         self.configure(args=[], parsed_globals=self.global_args)
         self.assert_credentials_file_updated_with(
             {'aws_access_key_id': 'new_value',


### PR DESCRIPTION
Previously the command `aws configure` would only use the profile present in the parsed globals to pass to the `ConfigFileWriter`, but sourced the profile from the session everywhere else. This would cause issues when the profile is set via an environment variable as the updated values would be written to the wrong section. This updates the configure command to consistently use the profile on the session and updates the unit test to rely on the session rather than the parsed globals.

Fixes #2970 