### PR TITLE
Make idempotency tokens not required

### DIFF
--- a/.changes/next-release/enhancement-Arguments-58814.json
+++ b/.changes/next-release/enhancement-Arguments-58814.json
@@ -1,0 +1,5 @@
+{
+  "category": "Arguments",
+  "description": "Idempotency tokens are no longer marked as a required argument.",
+  "type": "enhancement"
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -559,7 +559,8 @@ class ServiceOperation(object):
             cli_arg_name = xform_name(arg_name, '-')
             arg_class = self.ARG_TYPES.get(arg_shape.type_name,
                                            self.DEFAULT_ARG_CLASS)
-            is_required = arg_name in required_arguments
+            is_token = arg_shape.metadata.get('idempotencyToken', False)
+            is_required = arg_name in required_arguments and not is_token
             event_emitter = self._session.get_component('event_emitter')
             arg_object = arg_class(
                 name=cli_arg_name,


### PR DESCRIPTION
We have a customization that autofills idempotency tokens for the user, so the cli argument should not be marked as required even if it is a required field for the operation.