### PR TITLE
Expose max_bandwidth configuration for s3 commands

### DIFF
--- a/.changes/next-release/feature-maxbandwidth-2947.json
+++ b/.changes/next-release/feature-maxbandwidth-2947.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``max_bandwidth``",
+  "description": "Add the ability to set maximum bandwidth consumption for ``s3`` commands. (`issue 1090 <https://github.com/aws/aws-cli/issues/1090>`__)"
+}

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -28,6 +28,8 @@ command set:
   transfers of individual files.
 * ``multipart_chunksize`` - When using multipart transfers, this is the chunk
   size that the CLI uses for multipart transfers of individual files.
+* ``max_bandwidth`` - The maximum bandwidth that will be consumed for uploading
+  and downloading data to and from Amazon S3.
 
 
 These are the configuration values that can be set for both ``aws s3``
@@ -60,6 +62,7 @@ configuration::
       max_queue_size = 10000
       multipart_threshold = 64MB
       multipart_chunksize = 16MB
+      max_bandwidth = 50MB/s
       use_accelerate_endpoint = true
       addressing_style = path
 
@@ -75,6 +78,7 @@ could instead run these commands::
     $ aws configure set default.s3.max_queue_size 10000
     $ aws configure set default.s3.multipart_threshold 64MB
     $ aws configure set default.s3.multipart_chunksize 16MB
+    $ aws configure set default.s3.max_bandwidth 50MB/s
     $ aws configure set default.s3.use_accelerate_endpoint true
     $ aws configure set default.s3.addressing_style path
 
@@ -162,6 +166,33 @@ the chunk size (also referred to as the part size) should be.  This
 value can specified using the same semantics as ``multipart_threshold``,
 that is either as the number of bytes as an integer, or using a size
 suffix.
+
+
+max_bandwidth
+-------------
+
+**Default** - None
+
+This controls the maximum bandwidth that the S3 commands will
+utilize when streaming content data to and from S3. Thus, this value only
+applies for uploads and downloads. It does not apply to copies nor deletes
+because those data transfers take place server side. The value is
+in terms of **bytes** per second. The value can be specified as:
+
+* An integer. For example, ``1048576`` would set the maximum bandwidth usage
+  to 1 megabyte per second.
+* A rate suffix. You can specify rate suffixes using: ``KB/s``, ``MB/s``,
+  ``GB/s``, etc. For example: ``300KB/s``, ``10MB/s``.
+
+In general, it is recommended to first use ``max_concurrent_requests`` to lower
+transfers to the desired bandwidth consumption. The ``max_bandwidth`` setting
+should then be used to further limit bandwidth consumption if setting
+``max_concurrent_requests`` is unable to lower bandwidth consumption to the
+desired rate. This is recommended because ``max_concurrent_requests`` controls
+how many threads are currently running. So if a high ``max_concurrent_requests``
+value is set and a low ``max_bandwidth`` value is set, it may result in
+threads having to wait unneccessarily which can lead to excess resource
+consumption and connection timeouts.
 
 
 use_accelerate_endpoint

--- a/tests/unit/customizations/s3/test_transferconfig.py
+++ b/tests/unit/customizations/s3/test_transferconfig.py
@@ -70,6 +70,18 @@ class TestTransferConfig(unittest.TestCase):
             multipart_threshold=long_value)
         self.assertEqual(runtime_config['multipart_threshold'], long_value)
 
+    def test_converts_max_bandwidth_as_string(self):
+        runtime_config = self.build_config_with(max_bandwidth='1MB/s')
+        self.assertEqual(runtime_config['max_bandwidth'], 1024 * 1024)
+
+    def test_validates_max_bandwidth_no_seconds(self):
+        with self.assertRaises(transferconfig.InvalidConfigError):
+            self.build_config_with(max_bandwidth='1MB')
+
+    def test_validates_max_bandwidth_in_bits_per_second(self):
+        with self.assertRaises(transferconfig.InvalidConfigError):
+            self.build_config_with(max_bandwidth='1Mb/s')
+
 
 class TestConvertToS3TransferConfig(unittest.TestCase):
     def test_convert(self):
@@ -78,6 +90,7 @@ class TestConvertToS3TransferConfig(unittest.TestCase):
             'multipart_chunksize': 2,
             'max_concurrent_requests': 3,
             'max_queue_size': 4,
+            'max_bandwidth': 1024 * 1024,
             'addressing_style': 'path',
             'use_accelerate_endpoint': True,
             # This is a TransferConfig only option, it should
@@ -90,4 +103,5 @@ class TestConvertToS3TransferConfig(unittest.TestCase):
         self.assertEqual(result.multipart_chunksize, 2)
         self.assertEqual(result.max_request_concurrency, 3)
         self.assertEqual(result.max_request_queue_size, 4)
+        self.assertEqual(result.max_bandwidth, 1024 * 1024)
         self.assertNotEqual(result.max_in_memory_upload_chunks, 1000)


### PR DESCRIPTION
Relies on this PR: https://github.com/boto/s3transfer/pull/101 so tests won't pass until after that gets merged.

You can configure `max_bandwidth` in the config file by doing the following:
```
[default]
s3 = 
    max_bandwidth = 1MB/s
```
The value is in terms of bytes per second so you can use the usual suffixes but you must include the per seconds part. It applies to specifically to the speed of streaming content to and from S3 through uploads and downloads.