### PR TITLE
S3 commands ensure error RC takes precedence

### DIFF
--- a/.changes/next-release/bugfix-S3-3229.json
+++ b/.changes/next-release/bugfix-S3-3229.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "S3",
+  "description": "S3 commands that encountered both an error and warning will now return the RC for error instead of warning."
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1082,7 +1082,7 @@ class CommandArchitecture(object):
         rc = 0
         if files[0].num_tasks_failed > 0:
             rc = 1
-        if files[0].num_tasks_warned > 0:
+        elif files[0].num_tasks_warned > 0:
             rc = 2
         return rc
 


### PR DESCRIPTION
If an S3 command encounters an error and a warning it will use the warning RC masking that the error happened. This adds a test for this case and ensures we use the correct RC.