### PR TITLE
Raise minimum required s3transfer version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = ['botocore==1.8.4',
             'colorama>=0.2.5,<=0.3.7',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
-            's3transfer>=0.1.9,<0.2.0',
+            's3transfer>=0.1.12,<0.2.0',
             'PyYAML>=3.10,<=3.12']
 
 


### PR DESCRIPTION
#2997 depended on boto/s3transfer#101 according to its description, but that PR was only released in 0.1.12:
https://github.com/boto/s3transfer/commit/31b344bc3c151b4f09cc80fe8adce3db63b10782
![image](https://user-images.githubusercontent.com/199071/33403849-ce52e862-d516-11e7-8070-2aee6783969c.png)

I'm raising the minimum required version for s3transfer to make sure noone else runs into this issue when upgrading `aws-cli` doesn't automatically pull in the right `s3transfer` version:
```
[localhost] local: aws s3 cp [...] s3://[...]

__init__() got an unexpected keyword argument 'max_bandwidth'
```