### PR TITLE
Expand expected assumerole exceptions

### DIFF
--- a/tests/integration/test_assume_role.py
+++ b/tests/integration/test_assume_role.py
@@ -116,7 +116,7 @@ class TestAssumeRoleCredentials(unittest.TestCase):
                 return result['Credentials']
             except ClientError as e:
                 code = e.response.get('Error', {}).get('Code')
-                if code == "InvalidClientTokenId":
+                if code in ["InvalidClientTokenId", "AccessDenied"]:
                     time.sleep(delay)
                 else:
                     raise


### PR DESCRIPTION
This adds 'AccessDenied' to the list of expected assumerole exceptions.
The api will *usually* return 'InvalidClientTokenId', but not always.