### PR TITLE
Add alias to runtime.sagemaker for backwards compatibility

### DIFF
--- a/.changes/next-release/bugfix-sagemakerruntime-86051.json
+++ b/.changes/next-release/bugfix-sagemakerruntime-86051.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "sagemaker-runtime",
+  "description": "Renamed the runtime.sagemaker service to sagemaker-runtime to be more consistent with existing services. The old service name is now aliased to sagemaker-runtime to maintain backwards compatibility."
+}

--- a/awscli/customizations/sagemaker.py
+++ b/awscli/customizations/sagemaker.py
@@ -1,0 +1,28 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.utils import make_hidden_command_alias
+
+
+def register_alias_sagemaker_runtime_command(event_emitter):
+    event_emitter.register(
+        'building-command-table.main',
+        alias_sagemaker_runtime_command
+    )
+
+
+def alias_sagemaker_runtime_command(command_table, **kwargs):
+    make_hidden_command_alias(
+        command_table,
+        existing_name='sagemaker-runtime',
+        alias_name='runtime.sagemaker',
+    )

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -77,6 +77,7 @@ from awscli.customizations.toplevelbool import register_bool_params
 from awscli.customizations.waiters import register_add_waiters
 from awscli.customizations.opsworkscm import register_alias_opsworks_cm
 from awscli.customizations.mturk import register_alias_mturk_command
+from awscli.customizations.sagemaker import register_alias_sagemaker_runtime_command
 from awscli.customizations.servicecatalog import register_servicecatalog_commands
 
 
@@ -155,6 +156,7 @@ def awscli_initialize(event_handlers):
     cloudformation_init(event_handlers)
     register_alias_opsworks_cm(event_handlers)
     register_alias_mturk_command(event_handlers)
+    register_alias_sagemaker_runtime_command(event_handlers)
     register_servicecatalog_commands(event_handlers)
     register_history_mode(event_handlers)
     register_history_commands(event_handlers)

--- a/tests/functional/sagemaker/test_alias.py
+++ b/tests/functional/sagemaker/test_alias.py
@@ -1,0 +1,23 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestAlias(BaseAWSCommandParamsTest):
+    def test_alias(self):
+        # This command was aliased, both should work
+        command_template = '%s invoke-endpoint --endpoint-name foo --body bar f'
+        old_command = command_template % 'runtime.sagemaker'
+        new_command = command_template % 'sagemaker-runtime'
+        self.run_cmd(old_command, expected_rc=0)
+        self.run_cmd(new_command, expected_rc=0)


### PR DESCRIPTION
This depends on: https://github.com/boto/botocore/pull/1334

In the above PR `runtime.sagemaker` is renamed to `sagemaker-runtime` this adds a hidden alias to `runtime.sagemaker` for backwards compatibility.