### PR TITLE
Also catch ValueError when handling deleted files

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -214,7 +214,7 @@ class FileGenerator(object):
     def _safely_get_file_stats(self, file_path):
         try:
             size, last_update = get_file_stat(file_path)
-        except OSError:
+        except (OSError, ValueError):
             self.triggers_warning(file_path)
         else:
             last_update = self._validate_update_time(last_update, file_path)

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -176,7 +176,7 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         # get their stats.
         def side_effect(_):
             os.remove(full_path)
-            raise OSError()
+            raise ValueError()
         with patch(
                 'awscli.customizations.s3.filegenerator.get_file_stat',
                 side_effect=side_effect

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -166,7 +166,37 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
 
         self.assertFalse(os.path.exists(full_path))
 
-    def test_sync_skips_over_files_deleted_between_listing_and_transfer(self):
+    # When a file has been deleted after listing,
+    # awscli.customizations.s3.utils.get_file_stat may raise either some kind
+    # of OSError, or a ValueError, depending on the environment. In both cases,
+    # the behaviour should be the same: skip the file and emit a warning.
+    #
+    # This test covers the case where a ValueError is emitted.
+    def test_sync_skips_over_files_deleted_between_listing_and_transfer_valueerror(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = '%s %s s3://bucket/' % (
+            self.prefix, self.files.rootdir)
+
+        # FileGenerator.list_files should skip over files that cause an
+        # IOError to be raised because they are missing when we try to
+        # get their stats. This IOError is translated to a ValueError in
+        # awscli.customizations.s3.utils.get_file_stat.
+        def side_effect(_):
+            os.remove(full_path)
+            raise ValueError()
+        with patch(
+                'awscli.customizations.s3.filegenerator.get_file_stat',
+                side_effect=side_effect
+                ):
+            self.run_cmd(cmdline, expected_rc=2)
+
+        # We should not call PutObject because the file was deleted
+        # before we could transfer it
+        self.assertEqual(len(self.operations_called), 1, self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjects')
+
+    # This test covers the case where an OSError is emitted.
+    def test_sync_skips_over_files_deleted_between_listing_and_transfer_oserror(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
         cmdline = '%s %s s3://bucket/' % (
             self.prefix, self.files.rootdir)
@@ -176,7 +206,7 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         # get their stats.
         def side_effect(_):
             os.remove(full_path)
-            raise ValueError()
+            raise OSError()
         with patch(
                 'awscli.customizations.s3.filegenerator.get_file_stat',
                 side_effect=side_effect


### PR DESCRIPTION
This try/except tries to handle failed stat calls due to files not being
there. However, before it can do so, get_file_stat has already
transformed any IOError into a ValueError. This is presumably necessary
for Python versions < 3.3 where there is no distinct FileNotFoundError,
so we can't just delete that mapping.

Fixes #2960.