### PR TITLE
Remove mapping of exception from os.stat

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -207,11 +207,7 @@ def get_file_stat(path):
     This is a helper function that given a local path return the size of
     the file in bytes and time of last modification.
     """
-    try:
-        stats = os.stat(path)
-    except IOError as e:
-        raise ValueError('Could not retrieve file stat of "%s": %s' % (
-            path, e))
+    stats = os.stat(path)
 
     try:
         update_time = datetime.fromtimestamp(stats.st_mtime, tzlocal())

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -176,7 +176,9 @@ class TestSyncCommand(BaseAWSCommandParamsTest):
         # get their stats.
         def side_effect(_):
             os.remove(full_path)
-            raise OSError()
+            # PEP 3151: Python 3.3+ translate this into a FileNotFoundError.
+            # This matches the behaviour of os.stat across Python versions.
+            raise OSError(2, "file not found", "foo.txt")
         with patch(
                 'awscli.customizations.s3.filegenerator.get_file_stat',
                 side_effect=side_effect

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -264,11 +264,6 @@ class TestGetFileStat(unittest.TestCase):
             self.assertEqual(size, 3)
             self.assertEqual(time.mktime(update_time.timetuple()), epoch_now)
 
-    def test_error_message(self):
-        with mock.patch('os.stat', mock.Mock(side_effect=IOError('msg'))):
-            with self.assertRaisesRegexp(ValueError, 'myfilename\.txt'):
-                get_file_stat('myfilename.txt')
-
     def assert_handles_fromtimestamp_error(self, error):
         patch_attribute = 'awscli.customizations.s3.utils.datetime'
         with mock.patch(patch_attribute) as datetime_mock:


### PR DESCRIPTION
This mapping has no effect on Python 2.x, because os.stat raises an
OSError if the file is not found, not an IOError. Python 3.3+ raise a
FileNotFoundError, so the mapping provides no additional context.

It does however throw off the handling of this error later, so this
change fixes #2960.

To make sure the error handling works correctly, throw the correct
exception depending on the python version running the test.

This is an alternative to #3026.