### PR TITLE
Defer resolution of binary_stdin

### DIFF
--- a/.changes/next-release/bugfix-s3-86692.json
+++ b/.changes/next-release/bugfix-s3-86692.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Fixes a bug where calling the CLI from a context that has no stdin resulted in every command failing instead of only commands that required stdin."
+}

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -46,7 +46,7 @@ from awscli.customizations.s3.utils import DirectoryCreatorSubscriber
 from awscli.customizations.s3.utils import DeleteSourceFileSubscriber
 from awscli.customizations.s3.utils import DeleteSourceObjectSubscriber
 from awscli.customizations.s3.utils import DeleteCopySourceObjectSubscriber
-from awscli.compat import binary_stdin
+from awscli.compat import get_binary_stdin
 
 
 LOGGER = logging.getLogger(__name__)
@@ -471,6 +471,7 @@ class UploadStreamRequestSubmitter(UploadRequestSubmitter):
             subscribers.append(ProvideSizeSubscriber(int(expected_size)))
 
     def _get_filein(self, fileinfo):
+        binary_stdin = get_binary_stdin()
         return NonSeekableStream(binary_stdin)
 
     def _format_local_path(self, path):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -18,6 +18,12 @@ from awscli.testutils import capture_input, set_invalid_utime
 from awscli.compat import six
 
 
+class BufferedBytesIO(six.BytesIO):
+    @property
+    def buffer(self):
+        return self
+
+
 class TestCPCommand(BaseAWSCommandParamsTest):
 
     prefix = 's3 cp '
@@ -484,9 +490,8 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
             'ETag': '"c8afdb36c52cf4727836669019e69222"'
         }]
 
-        binary_stdin = six.BytesIO(b'foo\n')
-        location = "awscli.customizations.s3.s3handler.binary_stdin"
-        with mock.patch(location, binary_stdin):
+        binary_stdin = BufferedBytesIO(b'foo\n')
+        with mock.patch('sys.stdin', binary_stdin):
             self.run_cmd(command)
 
         self.assertEqual(len(self.operations_called), 1)
@@ -506,9 +511,8 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
             'ETag': '"c8afdb36c52cf4727836669019e69222"'
         }]
 
-        binary_stdin = six.BytesIO(b'foo\n')
-        location = "awscli.customizations.s3.s3handler.binary_stdin"
-        with mock.patch(location, binary_stdin):
+        binary_stdin = BufferedBytesIO(b'foo\n')
+        with mock.patch('sys.stdin', binary_stdin):
             self.run_cmd(command)
 
         self.assertEqual(len(self.operations_called), 1)
@@ -533,9 +537,8 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
         }]
         self.http_response.status_code = 404
 
-        binary_stdin = six.BytesIO(b'foo\n')
-        location = "awscli.customizations.s3.s3handler.binary_stdin"
-        with mock.patch(location, binary_stdin):
+        binary_stdin = BufferedBytesIO(b'foo\n')
+        with mock.patch('sys.stdin', binary_stdin):
             _, stderr, _ = self.run_cmd(command, expected_rc=1)
 
         error_message = (
@@ -543,6 +546,20 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
             'the PutObject operation: The specified bucket does not exist'
         )
         self.assertIn(error_message, stderr)
+
+    def test_streaming_upload_when_stdin_unavailable(self):
+        command = "s3 cp - s3://bucket/streaming.txt"
+        self.parsed_responses = [{
+            'ETag': '"c8afdb36c52cf4727836669019e69222"'
+        }]
+
+        with mock.patch('sys.stdin', None):
+            _, stderr, _ = self.run_cmd(command, expected_rc=1)
+
+        expected_message = (
+            'stdin is required for this operation, but is not available'
+        )
+        self.assertIn(expected_message, stderr)
 
     def test_streaming_download(self):
         command = "s3 cp s3://bucket/streaming.txt -"


### PR DESCRIPTION
This replaces the static `binary_stdin` in compat.py with a function
to get the binary version of standard input. This function will raise
a more end-user useful error message if stdin isn't available in the
current process. Since the function only gets called when stdin is
needed, users will be able to run the CLI without stdin for all the
commands that don't use it. See #2518 for context on the original
issue.

Resolves #2990
Closes #2991