### PR TITLE
Delegate jsonfilecache to botocore

### DIFF
--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -1,10 +1,11 @@
 import os
-import json
 import logging
 
 from botocore.exceptions import ProfileNotFound
+from botocore.credentials import JSONFileCache
 
 LOG = logging.getLogger(__name__)
+CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
 
 
 def register_assume_role_provider(event_handlers):
@@ -37,52 +38,4 @@ def inject_assume_role_provider_cache(session, **kwargs):
                   "JSONFileCache for assume-role.")
         return
     provider = cred_chain.get_provider('assume-role')
-    provider.cache = JSONFileCache()
-
-
-class JSONFileCache(object):
-    """JSON file cache.
-
-    This provides a dict like interface that stores JSON serializable
-    objects.
-
-    The objects are serialized to JSON and stored in a file.  These
-    values can be retrieved at a later time.
-
-    """
-
-    CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
-
-    def __init__(self, working_dir=CACHE_DIR):
-        self._working_dir = working_dir
-
-    def __contains__(self, cache_key):
-        actual_key = self._convert_cache_key(cache_key)
-        return os.path.isfile(actual_key)
-
-    def __getitem__(self, cache_key):
-        """Retrieve value from a cache key."""
-        actual_key = self._convert_cache_key(cache_key)
-        try:
-            with open(actual_key) as f:
-                return json.load(f)
-        except (OSError, ValueError, IOError):
-            raise KeyError(cache_key)
-
-    def __setitem__(self, cache_key, value):
-        full_key = self._convert_cache_key(cache_key)
-        try:
-            file_content = json.dumps(value)
-        except (TypeError, ValueError):
-            raise ValueError("Value cannot be cached, must be "
-                             "JSON serializable: %s" % value)
-        if not os.path.isdir(self._working_dir):
-            os.makedirs(self._working_dir)
-        with os.fdopen(os.open(full_key,
-                               os.O_WRONLY | os.O_CREAT, 0o600), 'w') as f:
-            f.truncate()
-            f.write(file_content)
-
-    def _convert_cache_key(self, cache_key):
-        full_path = os.path.join(self._working_dir, cache_key + '.json')
-        return full_path
+    provider.cache = JSONFileCache(CACHE_DIR)

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -10,19 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import shutil
-import tempfile
-import os
-import platform
-from datetime import datetime, timedelta
-
 import mock
-from botocore.hooks import HierarchicalEmitter
-from botocore.exceptions import PartialCredentialsError
-from botocore.exceptions import ProfileNotFound
-from dateutil.tz import tzlocal
 
-from awscli.testutils import unittest, skip_if_windows
+from botocore.hooks import HierarchicalEmitter
+from botocore.exceptions import ProfileNotFound
+
+from awscli.testutils import unittest
 from awscli.customizations import assumerole
 
 
@@ -58,64 +51,3 @@ class TestAssumeRolePlugin(unittest.TestCase):
 
         credential_provider = session.get_component.return_value
         self.assertFalse(credential_provider.get_provider.called)
-
-
-class TestJSONCache(unittest.TestCase):
-    def setUp(self):
-        self.tempdir = tempfile.mkdtemp()
-        self.cache = assumerole.JSONFileCache(self.tempdir)
-
-    def tearDown(self):
-        shutil.rmtree(self.tempdir)
-
-    def test_supports_contains_check(self):
-        # By default the cache is empty because we're
-        # using a new temp dir everytime.
-        self.assertTrue('mykey' not in self.cache)
-
-    def test_add_key_and_contains_check(self):
-        self.cache['mykey'] = {'foo': 'bar'}
-        self.assertTrue('mykey' in self.cache)
-
-    def test_added_key_can_be_retrieved(self):
-        self.cache['mykey'] = {'foo': 'bar'}
-        self.assertEqual(self.cache['mykey'], {'foo': 'bar'})
-
-    def test_only_accepts_json_serializable_data(self):
-        with self.assertRaises(ValueError):
-            # set()'s cannot be serialized to a JSOn string.
-            self.cache['mykey'] = set()
-
-    def test_can_override_existing_values(self):
-        self.cache['mykey'] = {'foo': 'bar'}
-        self.cache['mykey'] = {'baz': 'newvalue'}
-        self.assertEqual(self.cache['mykey'], {'baz': 'newvalue'})
-
-    def test_can_add_multiple_keys(self):
-        self.cache['mykey'] = {'foo': 'bar'}
-        self.cache['mykey2'] = {'baz': 'qux'}
-        self.assertEqual(self.cache['mykey'], {'foo': 'bar'})
-        self.assertEqual(self.cache['mykey2'], {'baz': 'qux'})
-
-    def test_working_dir_does_not_exist(self):
-        working_dir = os.path.join(self.tempdir, 'foo')
-        cache = assumerole.JSONFileCache(working_dir)
-        cache['foo'] = {'bar': 'baz'}
-        self.assertEqual(cache['foo'], {'bar': 'baz'})
-
-    def test_key_error_raised_when_cache_key_does_not_exist(self):
-        with self.assertRaises(KeyError):
-            self.cache['foo']
-
-    def test_file_is_truncated_before_writing(self):
-        self.cache['mykey'] = {
-            'really long key in the cache': 'really long value in cache'}
-        # Now overwrite it with a smaller value.
-        self.cache['mykey'] = {'a': 'b'}
-        self.assertEqual(self.cache['mykey'], {'a': 'b'})
-
-    @skip_if_windows('File permissions tests not supported on Windows.')
-    def test_permissions_for_file_restricted(self):
-        self.cache['mykey'] = {'foo': 'bar'}
-        filename = os.path.join(self.tempdir, 'mykey.json')
-        self.assertEqual(os.stat(filename).st_mode & 0xFFF, 0o600)


### PR DESCRIPTION
This removes the cli version of jsonfilecache in favor of the version
now in botocore so we don't have to duplicate work.