### PR TITLE
Some editing and formatting (mostly literals).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,17 @@ The aws-cli package works on Python versions:
 Installation
 ------------
 
-The easiest way to install aws-cli is to use `pip`_::
+The easiest way to install aws-cli is to use `pip`_ in a ``virtualenv``::
 
     $ pip install awscli
 
-or, if you are not installing in a ``virtualenv``::
+or, if you are not installing in a ``virtualenv``, to install globally::
 
     $ sudo pip install awscli
+
+or for your user::
+
+    $ pip install --user awscli
 
 If you have the aws-cli installed and want to upgrade to the latest version
 you can run::
@@ -90,13 +94,13 @@ For tcsh::
 
 You should add this to your startup scripts to enable it for future sessions.
 
-For zsh please refer to bin/aws_zsh_completer.sh.  Source that file, e.g.
-from your `~/.zshrc`, and make sure you run `compinit` before::
+For zsh please refer to ``bin/aws_zsh_completer.sh``.  Source that file, e.g.
+from your ``~/.zshrc``, and make sure you run ``compinit`` before::
 
     $ source bin/aws_zsh_completer.sh
 
-For now the bash compatibility auto completion (bashcompinit) is used.
-For further details please refer to the top of bin/aws_zsh_completer.sh.
+For now the bash compatibility auto completion (``bashcompinit``) is used.
+For further details please refer to the top of ``bin/aws_zsh_completer.sh``.
 
 ---------------
 Getting Started
@@ -255,7 +259,7 @@ from the CLI as well by running ``aws help config-vars``.
 Accessing Services With Global Endpoints
 ----------------------------------------
 
-Some services, such as AWS Identity and Access Management (IAM)
+Some services, such as *AWS Identity and Access Management* (IAM)
 have a single, global endpoint rather than different endpoints for
 each region.
 
@@ -266,7 +270,7 @@ Therefore, the following::
 
     $ aws iam list-users
 
-Will automatically use the global endpoint for the IAM service
+will automatically use the global endpoint for the IAM service
 regardless of the value of the ``AWS_DEFAULT_REGION`` environment
 variable or the ``region`` variable specified in your profile.
 
@@ -296,7 +300,7 @@ entering the value directly on the command line.
 Let's use the ``authorize-security-group-ingress`` command shown above.
 Rather than provide the value of the ``--ip-permissions`` parameter directly
 in the command, you could first store the values in a file.  Let's call
-the file ip_perms.json::
+the file ``ip_perms.json``::
 
     {"FromPort":22,
      "ToPort":22,
@@ -310,7 +314,7 @@ Then, we could make the same call as above like this::
 
 The ``file://`` prefix on the parameter value signals that the parameter value
 is actually a reference to a file that contains the actual parameter value.
-aws-cli will open the file, read the value and pass use that value as the
+aws-cli will open the file, read the value and use that value as the
 parameter value.
 
 This is also useful when the parameter is really referring to file-based
@@ -372,7 +376,7 @@ CLI Dev Version
 ---------------
 
 If you are just interested in using the latest released version of the AWS CLI,
-please see the "Installation" section above.  This section is for anyone that
+please see the Installation_ section above.  This section is for anyone who
 wants to install the development version of the CLI.  You normally would not
 need to do this unless:
 
@@ -384,7 +388,7 @@ need to do this unless:
 The latest changes to the CLI are in the ``develop`` branch on github.  This is
 the default branch when you clone the git repository.
 
-Additionally, there are several other packages that are developed in tandem
+Additionally, there are several other packages that are developed in lockstep
 with the CLI.  This includes:
 
 * `botocore <https://github.com/boto/botocore>`__


### PR DESCRIPTION
Global installation isn't necessary if not using a venv.
"tandem" is for two things, not multiple.
Headings create implicit anchors, so you can link to them
(Installation_).
Delete stray word ("pass").