### PR TITLE
Add reference to the universal param docs

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -571,6 +571,9 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         doc.style.dedent()
         doc.style.new_paragraph()
 
+    def doc_options_end(self, help_command, **kwargs):
+        self._add_top_level_args_reference(help_command)
+
 
 class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     DESCRIPTION = (

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -340,6 +340,16 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         doc.style.h2('Description')
         doc.include_doc_string(operation_model.documentation)
         self._add_webapi_crosslink(help_command)
+        self._add_top_level_args_reference(help_command)
+
+    def _add_top_level_args_reference(self, help_command):
+        help_command.doc.writeln('')
+        help_command.doc.write("See ")
+        help_command.doc.style.internal_link(
+            title="'aws help'",
+            page='/reference/index'
+        )
+        help_command.doc.writeln(' for descriptions of universal parameters.')
 
     def _add_webapi_crosslink(self, help_command):
         doc = help_command.doc

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -349,7 +349,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             title="'aws help'",
             page='/reference/index'
         )
-        help_command.doc.writeln(' for descriptions of universal parameters.')
+        help_command.doc.writeln(' for descriptions of global parameters.')
 
     def _add_webapi_crosslink(self, help_command):
         doc = help_command.doc

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -373,6 +373,7 @@ class BasicDocHandler(OperationDocumentEventHandler):
         self.doc.style.h2('Description')
         self.doc.write(help_command.description)
         self.doc.style.new_paragraph()
+        self._add_top_level_args_reference(help_command)
 
     def doc_synopsis_start(self, help_command, **kwargs):
         if not help_command.synopsis:

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -441,3 +441,6 @@ class BasicDocHandler(OperationDocumentEventHandler):
 
     def doc_output(self, help_command, event_name, **kwargs):
         pass
+
+    def doc_options_end(self, help_command, **kwargs):
+        self._add_top_level_args_reference(help_command)

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -295,6 +295,48 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
             '<https://docs.aws.amazon.com/goto/'
             'WebAPI/service-1-2-3/myoperation>`_', rendered)
 
+    def test_includes_global_args_ref_in_man_description(self):
+        help_command = self.create_help_command()
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_description(help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        # The links aren't generated in the "man" mode.
+        self.assertIn(
+            "See 'aws help' for descriptions of global parameters", rendered
+        )
+
+    def test_includes_global_args_ref_in_html_description(self):
+        help_command = self.create_help_command()
+        help_command.doc.target = 'html'
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_description(help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertIn(
+            "See :doc:`'aws help' </reference/index>` for descriptions of "
+            "global parameters", rendered
+        )
+
+    def test_includes_global_args_ref_in_man_options(self):
+        help_command = self.create_help_command()
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_options_end(help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        # The links aren't generated in the "man" mode.
+        self.assertIn(
+            "See 'aws help' for descriptions of global parameters", rendered
+        )
+
+    def test_includes_global_args_ref_in_html_options(self):
+        help_command = self.create_help_command()
+        help_command.doc.target = 'html'
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_options_end(help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertIn(
+            "See :doc:`'aws help' </reference/index>` for descriptions of "
+            "global parameters", rendered
+        )
+
 
 class TestTopicDocumentEventHandlerBase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This adds a reference to the main doc page for the cli which
documents all the universal parameters.

This depends on boto/botocore#1350

Here's what the html docs will look like:

![help](https://user-images.githubusercontent.com/2643092/34419236-8530b45e-ebb7-11e7-8e95-5dbd6a8b31c4.png)

That link will take you [here](http://docs.aws.amazon.com/cli/latest/reference/).

Here's what the help pages will look like:

![screen shot 2017-12-28 at 10 08 41 am](https://user-images.githubusercontent.com/2643092/34419243-8e42b9e8-ebb7-11e7-8120-b131d464a21b.png)
