### PR TITLE
Ensure the full pattern type is logged

### DIFF
--- a/awscli/customizations/s3/filters.py
+++ b/awscli/customizations/s3/filters.py
@@ -149,5 +149,5 @@ class Filter(object):
                         file_path, path_pattern)
         else:
             LOG.debug("%s did not match %s filter: %s",
-                        file_path, pattern_type[2:], path_pattern)
+                        file_path, pattern_type, path_pattern)
         return file_status


### PR DESCRIPTION
When the _match_pattern function falls through the if blocks to the final else statement, it ends up logging something like:

> /users/jeremyw/dev/path/to/file.html did not match clude filter: s3://bucket/path/to/file.html

_Note the "clude" part of the log message._

This was caused by slicing the `pattern_type` string which I suspect used to be prefixed with something that needed to be removed.
  