### PR TITLE
Add --preserve-symlinks option for "deploy push" command

### DIFF
--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -95,6 +95,24 @@ class Push(BasicCommand):
             )
         },
         {
+            'name': 'preserve-symlinks',
+            'action': 'store_true',
+            'default': False,
+            'group_name': 'preserve-symlinks',
+            'help_text': (
+                'Optional. Set the --preserve-symlinks flag to preserve symlinks '
+                'when building your deployment archive; otherwise, set the '
+                '--no-preserve-symlinks flag (the default) to resolve symlinks '
+                'to their contents and include contents directly in the archive.'
+            )
+        },
+        {
+            'name': 'no-preserve-symlinks',
+            'action': 'store_true',
+            'default': False,
+            'group_name': 'preserve-symlinks'
+        },
+        {
             'name': 'description',
             'synopsis': '--description <description>',
             'help_text': (
@@ -128,6 +146,12 @@ class Push(BasicCommand):
                 'You cannot specify both --ignore-hidden-files and '
                 '--no-ignore-hidden-files.'
             )
+        if parsed_args.preserve_symlinks \
+                and parsed_args.no_preserve_symlinks:
+            raise RuntimeError(
+                'You cannot specify both --preserve-symlinks and '
+                '--no-preserve-symlinks.'
+            )
         if not parsed_args.description:
             parsed_args.description = (
                 'Uploaded by AWS CLI {0} UTC'.format(
@@ -138,7 +162,8 @@ class Push(BasicCommand):
     def _push(self, params):
         with self._compress(
                 params.source,
-                params.ignore_hidden_files
+                params.ignore_hidden_files,
+                params.preserve_symlinks
         ) as bundle:
             try:
                 upload_response = self._upload_to_s3(params, bundle)
@@ -180,7 +205,7 @@ class Push(BasicCommand):
         )
 
     @contextlib.contextmanager
-    def _compress(self, source, ignore_hidden_files=False):
+    def _compress(self, source, ignore_hidden_files=False, preserve_symlinks=False):
         source_path = os.path.abspath(source)
         appspec_path = os.path.sep.join([source_path, 'appspec.yml'])
         with tempfile.TemporaryFile('w+b') as tf:
@@ -199,7 +224,16 @@ class Push(BasicCommand):
                         arcname = filename[len(source_path) + 1:]
                         if filename == appspec_path:
                             contains_appspec = True
-                        zf.write(filename, arcname, ZIP_COMPRESSION_MODE)
+                        if preserve_symlinks and os.path.islink(filename):
+                            # Adapted from https://gist.github.com/kgn/610907
+                            # http://www.mail-archive.com/python-list@python.org/msg34223.html
+                            zip_info = zipfile.ZipInfo(arcname)
+                            zip_info.create_system = 3
+                            # long type of hex val of '0xA1ED0000L', say, symlink attr magic...
+                            zip_info.external_attr = 2716663808L
+                            zf.writestr(zip_info, os.readlink(filename))
+                        else:
+                            zf.write(filename, arcname, ZIP_COMPRESSION_MODE)
                 if not contains_appspec:
                     raise RuntimeError(
                         '{0} was not found'.format(appspec_path)

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -44,6 +44,8 @@ class TestPush(unittest.TestCase):
         self.args.s3_location = self.s3_location
         self.args.ignore_hidden_files = False
         self.args.no_ignore_hidden_files = False
+        self.args.preserve_symlinks = False
+        self.args.no_preserve_symlinks = False
         self.args.description = self.description
         self.args.source = self.source
 
@@ -138,6 +140,12 @@ class TestPush(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.push._validate_args(self.args)
 
+    def test_validate_args_throws_on_preserve_and_no_preserve_symlinks(self):
+        self.args.preserve_symlinks = True
+        self.args.no_preserve_symlinks = True
+        with self.assertRaises(RuntimeError):
+            self.push._validate_args(self.args)
+
     def test_validate_args_default_description(self):
         self.args.description = None
         self.push._validate_args(self.args)
@@ -210,7 +218,8 @@ class TestPush(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             with self.push._compress(
                     self.args.source,
-                    self.args.ignore_hidden_files):
+                    self.args.ignore_hidden_files,
+                    self.args.preserve_symlinks):
                 pass
 
     @patch('zipfile.ZipFile')
@@ -226,7 +235,8 @@ class TestPush(unittest.TestCase):
         zf.return_value = self.zipfile_mock
         with self.push._compress(
                 self.args.source,
-                self.args.ignore_hidden_files):
+                self.args.ignore_hidden_files,
+                self.args.preserve_symlinks):
             zf.assert_called_with(ANY, 'w', allowZip64=True)
             zf().write.assert_called_with(
                 '/tmp/appspec.yml',


### PR DESCRIPTION
By default, symlinks are materialized into their targets when they are zipped for deploy. Some applications, e.g. PHP's Doctrine ORM vendor/bin scripts, rely on symlinks to be preserved to work, and are thus broken by the default deploy behavior if your PHP project's deployment archive includes its vendor directory (which it should).

This commit adds an option (default off for BC reasons) to preserve symlinks when creating the deployment archive. Used --ignore-hidden-files as a template for parameter implementation.

Tests have been updated with the extra argument, including asserting that you can't specify to both preserve and not preserve symlinks simultaneously. However, while I've confirmed that behavior works as expected in the scenario for which I needed this functionality, there isn't an automated test to that effect, partially because I'm not sure how that test would fare across all environments.

References:
https://gist.github.com/kgn/610907
http://www.mail-archive.com/python-list@python.org/msg34223.html