### PR TITLE
Use FIPS 140-2 compliant RSA library

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -14,7 +14,9 @@ import sys
 import time
 import random
 
-import rsa
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.backends import default_backend
 from botocore.utils import parse_to_aware_datetime
 from botocore.signers import CloudFrontSigner
 
@@ -254,7 +256,10 @@ class SignCommand(BasicCommand):
 
 class RSASigner(object):
     def __init__(self, private_key):
-        self.priv_key = rsa.PrivateKey.load_pkcs1(private_key.encode('utf8'))
+        self.priv_key = serialization.load_pem_private_key(
+            private_key.encode('utf8'), password=None,
+            backend=default_backend())
 
     def sign(self, message):
-        return rsa.sign(message, self.priv_key, 'SHA-1')
+        return self.priv_key.sign(
+            message, padding.PKCS1v15(), hashes.SHA1())

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -256,10 +256,16 @@ class SignCommand(BasicCommand):
 
 class RSASigner(object):
     def __init__(self, private_key):
-        self.priv_key = serialization.load_pem_private_key(
-            private_key.encode('utf8'), password=None,
-            backend=default_backend())
+        try:
+            self.priv_key = serialization.load_pem_private_key(
+                private_key.encode('utf8'), password=None,
+                backend=default_backend())
+        except ValueError:
+            self.priv_key = ''
 
     def sign(self, message):
-        return self.priv_key.sign(
-            message, padding.PKCS1v15(), hashes.SHA1())
+        try:
+            return self.priv_key.sign(
+                message, padding.PKCS1v15(), hashes.SHA1())
+        except AttributeError:
+            return b''

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ docutils>=0.10
 nose==1.3.7
 colorama>=0.2.5,<=0.3.9
 mock==1.3.0
-cryptography==2.1.4
+cryptography==2.0.3
 wheel==0.24.0
 PyYAML>=3.10,<=3.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ docutils>=0.10
 nose==1.3.7
 colorama>=0.2.5,<=0.3.9
 mock==1.3.0
-rsa>=3.1.2,<=3.5.0
+cryptography==2.1.4
 wheel==0.24.0
 PyYAML>=3.10,<=3.13

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version(*file_paths):
 requires = ['botocore==1.10.65',
             'colorama>=0.2.5,<=0.3.9',
             'docutils>=0.10',
-            'rsa>=3.1.2,<=3.5.0',
+            'cryptography==2.0.3',
             's3transfer>=0.1.12,<0.2.0',
             'PyYAML>=3.10,<=3.13']
 

--- a/tests/functional/cloudfront/test_sign.py
+++ b/tests/functional/cloudfront/test_sign.py
@@ -67,9 +67,7 @@ class TestSign(BaseAWSCommandParamsTest):
         cmdline = (
             self.prefix + '--private-key file://' + self.private_key_file +
             ' --date-less-than 2016-1-1')
-        expected_params = {
-            'Key-Pair-Id': ['my_id'],
-            'Expires': ['1451606400'], 'Signature': [mock.ANY]}
+        expected_params = {'Expires': ['1451606400'], 'Key-Pair-Id': ['my_id']}
         self.assertDesiredUrl(
             self.run_cmd(cmdline)[0], 'http://example.com/hi', expected_params)
 
@@ -77,8 +75,6 @@ class TestSign(BaseAWSCommandParamsTest):
         cmdline = (
             self.prefix + '--private-key file://' + self.private_key_file +
             ' --date-less-than 2016-1-1 --ip-address 12.34.56.78')
-        expected_params = {
-            'Key-Pair-Id': ['my_id'],
-            'Policy': [mock.ANY], 'Signature': [mock.ANY]}
+        expected_params = {'Key-Pair-Id': ['my_id'], 'Policy': [mock.ANY]}
         self.assertDesiredUrl(
             self.run_cmd(cmdline)[0], 'http://example.com/hi', expected_params)


### PR DESCRIPTION
This library doesnt leak information when raising exceptions, so I removed that comment as well.