### PR TITLE
Taking over #2778 - aws cloudformation deploy large template support

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -18,6 +18,8 @@ import botocore
 import collections
 
 from awscli.customizations.cloudformation import exceptions
+from awscli.customizations.cloudformation.artifact_exporter import mktempfile, parse_s3_url
+
 from datetime import datetime
 
 LOG = logging.getLogger(__name__)
@@ -71,7 +73,7 @@ class Deployer(object):
 
     def create_changeset(self, stack_name, cfn_template,
                          parameter_values, capabilities, role_arn,
-                         notification_arns):
+                         notification_arns, s3_uploader):
         """
         Call Cloudformation to create a changeset and wait for it to complete
 
@@ -106,6 +108,19 @@ class Deployer(object):
             'Capabilities': capabilities,
             'Description': description,
         }
+
+        # If an S3 uploader is available, use TemplateURL to deploy rather than
+        # TemplateBody. This is required for large templates.
+        if s3_uploader:
+            with mktempfile() as temporary_file:
+                temporary_file.write(kwargs.pop('TemplateBody'))
+                temporary_file.flush()
+                url = s3_uploader.upload_with_dedup(
+                        temporary_file.name, "template")
+                # TemplateUrl property requires S3 URL to be in path-style format
+                parts = parse_s3_url(url, version_property="Version")
+                kwargs['TemplateURL'] = s3_uploader.to_path_style_s3_url(parts["Key"], parts.get("Version", None))
+
         # don't set these arguments if not specified to use existing values
         if role_arn is not None:
             kwargs['RoleARN'] = role_arn
@@ -126,7 +141,7 @@ class Deployer(object):
         :param stack_name:   Stack name
         :return: Latest status of the create-change-set operation
         """
-        sys.stdout.write("Waiting for changeset to be created..\n")
+        sys.stdout.write("\nWaiting for changeset to be created..\n")
         sys.stdout.flush()
 
         # Wait for changeset to be created
@@ -193,11 +208,11 @@ class Deployer(object):
 
     def create_and_wait_for_changeset(self, stack_name, cfn_template,
                                       parameter_values, capabilities, role_arn,
-                                      notification_arns):
+                                      notification_arns, s3_uploader):
 
         result = self.create_changeset(
                 stack_name, cfn_template, parameter_values, capabilities,
-                role_arn, notification_arns)
+                role_arn, notification_arns, s3_uploader)
 
         self.wait_for_changeset(result.changeset_id, stack_name)
 

--- a/awscli/customizations/cloudformation/exceptions.py
+++ b/awscli/customizations/cloudformation/exceptions.py
@@ -46,3 +46,10 @@ class DeployFailedError(CloudFormationCommandError):
          "to fetch the list of events leading up to the failure"
          "\n"
          "aws cloudformation describe-stack-events --stack-name {stack_name}")
+
+class DeployBucketRequiredError(CloudFormationCommandError):
+    fmt = \
+        ("Templates with a size greater than 51,200 bytes must be deployed "
+         "via an S3 Bucket. Please add the --s3-bucket parameter to your "
+         "command. The local template will be copied to that S3 bucket and "
+         "then deployed.")

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -57,7 +57,7 @@ class TestDeployCommand(unittest.TestCase):
                                     capabilities=None,
                                     role_arn=None,
                                     notification_arns=[],
-                                    fail_on_empty_changeset=True
+                                    fail_on_empty_changeset=True,
                                     s3_bucket=None)
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
@@ -112,8 +112,8 @@ class TestDeployCommand(unittest.TestCase):
                         not self.parsed_args.no_execute_changeset,
                         None,
                         [], 
-                        True
-                        mock.ANY)
+                        mock.ANY,
+                        True)
 
                 self.deploy_command.parse_parameter_arg.assert_called_once_with(
                         self.parsed_args.parameter_overrides)
@@ -269,8 +269,8 @@ class TestDeployCommand(unittest.TestCase):
         with self.assertRaises(exceptions.ChangeEmptyError):
             self.deploy_command.deploy(
                 self.deployer, stack_name, template, parameters, capabilities,
-                execute_changeset, role_arn, notification_arns
-            )
+                execute_changeset, role_arn, notification_arns,
+                s3_uploader=None)
 
     def test_deploy_does_not_raise_exception_on_empty_changeset(self):
         stack_name = "stack_name"
@@ -287,6 +287,7 @@ class TestDeployCommand(unittest.TestCase):
         self.deploy_command.deploy(
             self.deployer, stack_name, template, parameters, capabilities,
             execute_changeset, role_arn, notification_arns,
+            s3_uploader=None,
             fail_on_empty_changeset=False
         )
 

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -103,6 +103,7 @@ class TestDeployer(unittest.TestCase):
         capabilities = ["capabilities"]
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+        s3_uploader = None
 
         # Case 1: Stack DOES NOT exist
         self.deployer.has_stack = Mock()
@@ -129,7 +130,7 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns)
+                    notification_arns, s3_uploader)
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("CREATE", result.changeset_type)
 
@@ -142,7 +143,76 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns)
+                    notification_arns, s3_uploader)
+            self.assertEquals(response["Id"], result.changeset_id)
+            self.assertEquals("UPDATE", result.changeset_type)
+
+    def test_create_changeset_success_s3_bucket(self):
+        stack_name = "stack_name"
+        template = "template"
+        template_url = "https://s3.amazonaws.com/bucket/file"
+        parameters = [
+            {"ParameterKey": "Key1", "ParameterValue": "Value"},
+            {"ParameterKey": "Key2", "UsePreviousValue": True},
+            {"ParameterKey": "Key3", "UsePreviousValue": False},
+        ]
+        # Parameters that Use Previous Value will be removed on stack creation
+        # to either force CloudFormation to use the Default value, or ask user to specify a parameter
+        filtered_parameters = [
+            {"ParameterKey": "Key1", "ParameterValue": "Value"},
+            {"ParameterKey": "Key3", "UsePreviousValue": False},
+        ]
+        capabilities = ["capabilities"]
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+
+        s3_uploader = Mock()
+        def to_path_style_s3_url(some_string, Version=None):
+            return "https://s3.amazonaws.com/bucket/file"
+        s3_uploader.to_path_style_s3_url = to_path_style_s3_url
+        def upload_with_dedup(filename,extension):
+            return "s3://bucket/file"
+        s3_uploader.upload_with_dedup = upload_with_dedup
+
+        # Case 1: Stack DOES NOT exist
+        self.deployer.has_stack = Mock()
+        self.deployer.has_stack.return_value = False
+
+        expected_params = {
+            "ChangeSetName": botocore.stub.ANY,
+            "StackName": stack_name,
+            "TemplateURL": template_url,
+            "ChangeSetType": "CREATE",
+            "Parameters": filtered_parameters,
+            "Capabilities": capabilities,
+            "Description": botocore.stub.ANY,
+            "RoleARN": role_arn,
+            "NotificationARNs": notification_arns
+        }
+
+        response = {
+            "Id": "changeset ID"
+        }
+
+        self.stub_client.add_response("create_change_set", response,
+                                      expected_params)
+        with self.stub_client:
+            result = self.deployer.create_changeset(
+                    stack_name, template, parameters, capabilities, role_arn,
+                    notification_arns, s3_uploader)
+            self.assertEquals(response["Id"], result.changeset_id)
+            self.assertEquals("CREATE", result.changeset_type)
+
+        # Case 2: Stack exists. We are updating it
+        self.deployer.has_stack.return_value = True
+        expected_params["ChangeSetType"] = "UPDATE"
+        expected_params["Parameters"] = parameters
+        self.stub_client.add_response("create_change_set", response,
+                                      expected_params)
+        with self.stub_client:
+            result = self.deployer.create_changeset(
+                    stack_name, template, parameters, capabilities, role_arn,
+                    notification_arns, s3_uploader)
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("UPDATE", result.changeset_type)
 
@@ -154,6 +224,7 @@ class TestDeployer(unittest.TestCase):
         capabilities = ["capabilities"]
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+        s3_uploader = None
 
         self.deployer.has_stack = Mock()
         self.deployer.has_stack.return_value = False
@@ -163,7 +234,7 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             with self.assertRaises(botocore.exceptions.ClientError):
                 self.deployer.create_changeset(stack_name, template, parameters,
-                capabilities, role_arn, notification_arns)
+                capabilities, role_arn, notification_arns, None)
 
     def test_execute_changeset(self):
         stack_name = "stack_name"
@@ -198,6 +269,7 @@ class TestDeployer(unittest.TestCase):
         changeset_type = "changeset type"
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+        s3_uploader = None
 
         self.deployer.create_changeset = Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -206,7 +278,7 @@ class TestDeployer(unittest.TestCase):
 
         result = self.deployer.create_and_wait_for_changeset(
                 stack_name, template, parameters, capabilities, role_arn,
-                notification_arns)
+                notification_arns, s3_uploader)
         self.assertEquals(result.changeset_id, changeset_id)
         self.assertEquals(result.changeset_type, changeset_type)
 
@@ -220,6 +292,7 @@ class TestDeployer(unittest.TestCase):
         changeset_type = "changeset type"
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+        s3_uploader = None
 
         self.deployer.create_changeset = Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -230,7 +303,7 @@ class TestDeployer(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             result = self.deployer.create_and_wait_for_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns)
+                    notification_arns, s3_uploader)
 
     def test_wait_for_changeset_no_changes(self):
         stack_name = "stack_name"


### PR DESCRIPTION
Pull Request #2778 broke the tests because it had a bad import statement (S3Uploader) in deploy.py. Fixing this and submitting a new PR