### PR TITLE
Cfn deploy tag support

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -42,6 +42,7 @@ class DeployCommand(BasicCommand):
     MSG_EXECUTE_SUCCESS = "Successfully created/updated stack - {stack_name}\n"
 
     PARAMETER_OVERRIDE_CMD = "parameter-overrides"
+    TAGS_CMD = "tags"
 
     NAME = 'deploy'
     DESCRIPTION = BasicCommand.FROM_FILE("cloudformation",
@@ -217,35 +218,23 @@ class DeployCommand(BasicCommand):
             )
         },
         {
-            'name': 'tags',
+            'name': TAGS_CMD,
             'action': 'store',
             'required': False,
-            'default': [],
             'schema': {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "Key": {
-                            "description": "The tag key.",
-                            "type": "string",
-                            "required": True
-                        },
-                        "Value": {
-                            "description": "The tag value.",
-                            "type": "string",
-                            "required": True
-                        }
-                    }
+                'type': 'array',
+                'items': {
+                    'type': 'string'
                 }
             },
+            'default': [],
             'help_text': (
-                'Key-value pairs to associate with the stack,'
-                ' that is created or updated by the changeset.'
-                ' AWS CloudFormation also propagates these tags'
-                ' to resources in the stack.'
+                'A list of tags to associate with the stack that is created'
+                ' or updated. AWS CloudFormation also propagates these tags'
+                ' to resources in the stack if the resource supports it.'
+                ' Syntax: TagKey1=TagValue1 TagKey2=TagValue2 ...'
             )
-        },
+        }
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
@@ -265,8 +254,13 @@ class DeployCommand(BasicCommand):
             template_str = handle.read()
 
         stack_name = parsed_args.stack_name
-        parameter_overrides = self.parse_parameter_arg(
-                parsed_args.parameter_overrides)
+        parameter_overrides = self.parse_key_value_arg(
+                parsed_args.parameter_overrides,
+                self.PARAMETER_OVERRIDE_CMD)
+
+        tags_dict = self.parse_key_value_arg(parsed_args.tags, self.TAGS_CMD)
+        tags = [{"Key": key, "Value": value}
+                for key, value in tags_dict.items()]
 
         template_dict = yaml_parse(template_str)
 
@@ -298,7 +292,7 @@ class DeployCommand(BasicCommand):
                            parameters, parsed_args.capabilities,
                            parsed_args.execute_changeset, parsed_args.role_arn,
                            parsed_args.notification_arns, s3_uploader,
-                           parsed_args.tags,
+                           tags,
                            parsed_args.fail_on_empty_changeset)
 
     def deploy(self, deployer, stack_name, template_str,
@@ -365,18 +359,30 @@ class DeployCommand(BasicCommand):
 
         return parameter_values
 
-    def parse_parameter_arg(self, parameter_arg):
+    def parse_key_value_arg(self, arg_value, argname):
+        """
+        Converts arguments that are passed as list of "Key=Value" strings
+        into a real dictionary.
+
+        :param arg_value list: Array of strings, where each string is of
+            form Key=Value
+        :param argname string: Name of the argument that contains the value
+        :return dict: Dictionary representing the key/value pairs
+        """
         result = {}
-        for data in parameter_arg:
+        for data in arg_value:
 
             # Split at first '=' from left
             key_value_pair = data.split("=", 1)
 
             if len(key_value_pair) != 2:
-                raise exceptions.InvalidParameterOverrideArgumentError(
-                        argname=self.PARAMETER_OVERRIDE_CMD,
+                raise exceptions.InvalidKeyValuePairArgumentError(
+                        argname=argname,
                         value=key_value_pair)
 
             result[key_value_pair[0]] = key_value_pair[1]
 
         return result
+
+
+

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -215,7 +215,8 @@ class DeployCommand(BasicCommand):
                 'Causes the CLI to return an exit code of 0 if there are no '
                 'changes to be made to the stack.'
             )
-        }
+        },
+        {
             'name': 'tags',
             'action': 'store',
             'required': False,
@@ -302,7 +303,7 @@ class DeployCommand(BasicCommand):
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
-               notification_arns, s3_uploader, tags
+               notification_arns, s3_uploader, tags,
                fail_on_empty_changeset=True):
         try:
             result = deployer.create_and_wait_for_changeset(

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -216,6 +216,35 @@ class DeployCommand(BasicCommand):
                 'changes to be made to the stack.'
             )
         }
+            'name': 'tags',
+            'action': 'store',
+            'required': False,
+            'default': [],
+            'schema': {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "Key": {
+                            "description": "The tag key.",
+                            "type": "string",
+                            "required": True
+                        },
+                        "Value": {
+                            "description": "The tag value.",
+                            "type": "string",
+                            "required": True
+                        }
+                    }
+                }
+            },
+            'help_text': (
+                'Key-value pairs to associate with the stack,'
+                ' that is created or updated by the changeset.'
+                ' AWS CloudFormation also propagates these tags'
+                ' to resources in the stack.'
+            )
+        },
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
@@ -267,22 +296,25 @@ class DeployCommand(BasicCommand):
         return self.deploy(deployer, stack_name, template_str,
                            parameters, parsed_args.capabilities,
                            parsed_args.execute_changeset, parsed_args.role_arn,
-                           parsed_args.notification_arns,
-                           s3_uploader,
+                           parsed_args.notification_arns, s3_uploader,
+                           parsed_args.tags,
                            parsed_args.fail_on_empty_changeset)
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
-               notification_arns, s3_uploader, fail_on_empty_changeset=True):
+               notification_arns, s3_uploader, tags
+               fail_on_empty_changeset=True):
         try:
             result = deployer.create_and_wait_for_changeset(
-                    stack_name=stack_name,
-                    cfn_template=template_str,
-                    parameter_values=parameters,
-                    capabilities=capabilities,
-                    role_arn=role_arn,
-                    notification_arns=notification_arns,
-                    s3_uploader=s3_uploader)
+                stack_name=stack_name,
+                cfn_template=template_str,
+                parameter_values=parameters,
+                capabilities=capabilities,
+                role_arn=role_arn,
+                notification_arns=notification_arns,
+                s3_uploader=s3_uploader,
+                tags=tags
+            )
         except exceptions.ChangeEmptyError as ex:
             if fail_on_empty_changeset:
                 raise

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -73,7 +73,7 @@ class Deployer(object):
 
     def create_changeset(self, stack_name, cfn_template,
                          parameter_values, capabilities, role_arn,
-                         notification_arns, s3_uploader):
+                         notification_arns, s3_uploader, tags):
         """
         Call Cloudformation to create a changeset and wait for it to complete
 
@@ -81,6 +81,7 @@ class Deployer(object):
         :param cfn_template: CloudFormation template string
         :param parameter_values: Template parameters object
         :param capabilities: Array of capabilities passed to CloudFormation
+        :param tags: Array of tags passed to CloudFormation
         :return:
         """
 
@@ -216,12 +217,11 @@ class Deployer(object):
 
     def create_and_wait_for_changeset(self, stack_name, cfn_template,
                                       parameter_values, capabilities, role_arn,
-                                      notification_arns, s3_uploader):
+                                      notification_arns, s3_uploader, tags):
 
         result = self.create_changeset(
                 stack_name, cfn_template, parameter_values, capabilities,
-                role_arn, notification_arns, s3_uploader)
-
+                role_arn, notification_arns, s3_uploader, tags)
         self.wait_for_changeset(result.changeset_id, stack_name)
 
         return result

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -116,6 +116,7 @@ class Deployer(object):
             'Parameters': parameter_values,
             'Capabilities': capabilities,
             'Description': description,
+            'Tags': tags,
         }
 
         # If an S3 uploader is available, use TemplateURL to deploy rather than

--- a/awscli/customizations/cloudformation/exceptions.py
+++ b/awscli/customizations/cloudformation/exceptions.py
@@ -34,9 +34,9 @@ class ExportFailedError(CloudFormationCommandError):
            "{ex}")
 
 
-class InvalidParameterOverrideArgumentError(CloudFormationCommandError):
+class InvalidKeyValuePairArgumentError(CloudFormationCommandError):
     fmt = ("{value} value passed to --{argname} must be of format "
-           "ParameterKey=ParameterValue")
+           "Key=Value")
 
 
 class DeployFailedError(CloudFormationCommandError):

--- a/awscli/examples/cloudformation/deploy.rst
+++ b/awscli/examples/cloudformation/deploy.rst
@@ -2,5 +2,5 @@ Following command deploys template named ``template.json`` to a stack named
 ``my-new-stack``::
 
 
-    aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides Key1=Value1 Key2=Value2
+    aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides Key1=Value1 Key2=Value2 --tags  Key=key1,Value=value1,Key=key2,Value=Value2
 

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -13,7 +13,7 @@
 import mock
 import tempfile
 import six
-from mock import patch, Mock, MagicMock
+from mock import patch, Mock, MagicMock, call
 import collections
 
 from awscli.testutils import unittest
@@ -62,7 +62,7 @@ class TestDeployCommand(unittest.TestCase):
                                     s3_prefix="some prefix",
                                     kms_key_id="some kms key id",
                                     force_upload=True,
-                                    tags=[{"Key": "key1", "Value": "val1"}])
+                                    tags=["tagkey1=tagvalue1"])
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
         self.deploy_command = DeployCommand(self.session)
@@ -78,6 +78,8 @@ class TestDeployCommand(unittest.TestCase):
         Tests that deploy method is invoked when command is run
         """
         fake_parameter_overrides = []
+        fake_tags_dict = {"tagkey1": "tagvalue1"}
+        fake_tags = [{"Key": "tagkey1", "Value": "tagvalue1"}]
         fake_parameters = "some return value"
         template_str = "some template"
 
@@ -95,8 +97,9 @@ class TestDeployCommand(unittest.TestCase):
 
                 self.deploy_command.deploy = MagicMock()
                 self.deploy_command.deploy.return_value = 0
-                self.deploy_command.parse_parameter_arg = MagicMock(
-                        return_value=fake_parameter_overrides)
+                self.deploy_command.parse_key_value_arg = Mock()
+                self.deploy_command.parse_key_value_arg.side_effect = [
+                    fake_parameter_overrides, fake_tags_dict]
                 self.deploy_command.merge_parameters = MagicMock(
                         return_value=fake_parameters)
 
@@ -117,11 +120,21 @@ class TestDeployCommand(unittest.TestCase):
                     None,
                     [],
                     None,
-                    mock.ANY,
+                    fake_tags,
                     True
                 )
-                self.deploy_command.parse_parameter_arg.assert_called_once_with(
-                        self.parsed_args.parameter_overrides)
+
+                print self.deploy_command.parse_key_value_arg.call_args_list
+                self.deploy_command.parse_key_value_arg.assert_has_calls([
+                    call(
+                        self.parsed_args.parameter_overrides,
+                         "parameter-overrides"
+                    ),
+                    call(
+                        self.parsed_args.tags,
+                        "tags"
+                    )
+                ])
 
                 self.deploy_command.merge_parameters.assert_called_once_with(
                         fake_template, fake_parameter_overrides)
@@ -194,7 +207,7 @@ class TestDeployCommand(unittest.TestCase):
                 None,
                 [],
                 s3UploaderObject,
-                [{'Key': 'key1', 'Value': 'val1'}],
+                [{"Key": "tagkey1", "Value": "tagvalue1"}],
                 True
             )
 
@@ -354,30 +367,32 @@ class TestDeployCommand(unittest.TestCase):
             fail_on_empty_changeset=False
         )
 
-    def test_parse_parameter_arg_success(self):
+    def test_parse_key_value_arg_success(self):
         """
         Tests that we can parse parameter arguments provided in proper format
         Expected format: ["Key=Value", "Key=Value"]
         :return:
         """
+        argname = "parameter-overrides"
         data = ["Key1=Value1", 'Key2=[1,2,3]', 'Key3={"a":"val", "b": 2}']
         output = {"Key1": "Value1", "Key2": '[1,2,3]', "Key3": '{"a":"val", "b": 2}'}
 
-        result = self.deploy_command.parse_parameter_arg(data)
+        result = self.deploy_command.parse_key_value_arg(data, argname)
         self.assertEqual(result, output)
 
         # Empty input should return empty output
-        result = self.deploy_command.parse_parameter_arg([])
+        result = self.deploy_command.parse_key_value_arg([], argname)
         self.assertEqual(result, {})
 
-    def test_parse_parameter_arg_invalid_input(self):
+    def test_parse_key_value_arg_invalid_input(self):
         # non-list input
-        with self.assertRaises(exceptions.InvalidParameterOverrideArgumentError):
-            self.deploy_command.parse_parameter_arg("hello=world")
+        argname = "parameter-overrides"
+        with self.assertRaises(exceptions.InvalidKeyValuePairArgumentError):
+            self.deploy_command.parse_key_value_arg("hello=world", argname)
 
         # missing equal to sign
-        with self.assertRaises(exceptions.InvalidParameterOverrideArgumentError):
-            self.deploy_command.parse_parameter_arg(["hello world"])
+        with self.assertRaises(exceptions.InvalidKeyValuePairArgumentError):
+            self.deploy_command.parse_key_value_arg(["hello world"], argname)
 
     def test_merge_parameters_success(self):
         """

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -124,7 +124,6 @@ class TestDeployCommand(unittest.TestCase):
                     True
                 )
 
-                print self.deploy_command.parse_key_value_arg.call_args_list
                 self.deploy_command.parse_key_value_arg.assert_has_calls([
                     call(
                         self.parsed_args.parameter_overrides,

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -61,7 +61,8 @@ class TestDeployCommand(unittest.TestCase):
                                     s3_bucket=None,
                                     s3_prefix="some prefix",
                                     kms_key_id="some kms key id",
-                                    force_upload=True)
+                                    force_upload=True,
+                                    tags=[{"Key": "key1", "Value": "val1"}])
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
         self.deploy_command = DeployCommand(self.session)
@@ -114,9 +115,12 @@ class TestDeployCommand(unittest.TestCase):
                         None,
                         not self.parsed_args.no_execute_changeset,
                         None,
-                        [], 
+                        [],
                         None,
+                        mock.Any,
                         True)
+                        [],
+                        mock.ANY)
 
                 self.deploy_command.parse_parameter_arg.assert_called_once_with(
                         self.parsed_args.parameter_overrides)
@@ -158,7 +162,7 @@ class TestDeployCommand(unittest.TestCase):
     @patch('awscli.customizations.cloudformation.deploy.os.path.getsize')
     @patch('awscli.customizations.cloudformation.deploy.DeployCommand.deploy')
     @patch('awscli.customizations.cloudformation.deploy.S3Uploader')
-    def test_s3_uploader_is_configured_properly(self, s3UploaderMock, 
+    def test_s3_uploader_is_configured_properly(self, s3UploaderMock,
         deploy_method_mock, mock_getsize, mock_yaml_parse, mock_isfile):
         """
         Tests that large templates are detected prior to deployment
@@ -190,12 +194,12 @@ class TestDeployCommand(unittest.TestCase):
                     None,
                     not self.parsed_args.no_execute_changeset,
                     None,
-                    [], 
+                    [],
                     s3UploaderObject,
                     True)
 
-            s3UploaderMock.assert_called_once_with(mock.ANY, 
-                    bucket_name, 
+            s3UploaderMock.assert_called_once_with(mock.ANY,
+                    bucket_name,
                     mock.ANY,
                     self.parsed_args.s3_prefix,
                     self.parsed_args.kms_key_id,
@@ -216,6 +220,7 @@ class TestDeployCommand(unittest.TestCase):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
+        tags = [{"Key":"key1", "Value": "val1"}]
 
         # Set the mock to return this fake changeset_id
         self.deployer.create_and_wait_for_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -228,7 +233,8 @@ class TestDeployCommand(unittest.TestCase):
                                    execute_changeset,
                                    role_arn,
                                    notification_arns,
-                                   s3_uploader)
+                                   s3_uploader,
+                                   tags)
         self.assertEqual(rc, 0)
 
 
@@ -238,7 +244,8 @@ class TestDeployCommand(unittest.TestCase):
                                                      capabilities=capabilities,
                                                      role_arn=role_arn,
                                                      notification_arns=notification_arns,
-                                                     s3_uploader=s3_uploader)
+                                                     s3_uploader=s3_uploader,
+                                                     tags=tags)
 
         # since execute_changeset is set to True, deploy() will execute changeset
         self.deployer.execute_changeset.assert_called_once_with(changeset_id, stack_name)
@@ -255,6 +262,7 @@ class TestDeployCommand(unittest.TestCase):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
+        tags = [{"Key":"key1", "Value": "val1"}]
 
 
         self.deployer.create_and_wait_for_changeset.return_value = ChangeSetResult(changeset_id, "CREATE")
@@ -266,7 +274,8 @@ class TestDeployCommand(unittest.TestCase):
                                             execute_changeset,
                                             role_arn,
                                             notification_arns,
-                                            s3_uploader)
+                                            s3_uploader,
+                                            tags)
         self.assertEqual(rc, 0)
 
         self.deployer.create_and_wait_for_changeset.assert_called_once_with(stack_name=stack_name,
@@ -275,7 +284,8 @@ class TestDeployCommand(unittest.TestCase):
                                                      capabilities=capabilities,
                                                      role_arn=role_arn,
                                                      notification_arns=notification_arns,
-                                                     s3_uploader=s3_uploader)
+                                                     s3_uploader=s3_uploader,
+                                                     tags=tags)
 
         # since execute_changeset is set to True, deploy() will execute changeset
         self.deployer.execute_changeset.assert_not_called()
@@ -291,6 +301,7 @@ class TestDeployCommand(unittest.TestCase):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
+        tags = [{"Key":"key1", "Value": "val1"}]
 
         self.deployer.wait_for_execute.side_effect = RuntimeError("Some error")
         with self.assertRaises(RuntimeError):
@@ -302,7 +313,8 @@ class TestDeployCommand(unittest.TestCase):
                                        execute_changeset,
                                        role_arn,
                                        notification_arns,
-                                       s3_uploader)
+                                       s3_uploader,
+                                       tags)
 
     def test_deploy_raises_exception_on_empty_changeset(self):
         stack_name = "stack_name"

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -108,20 +108,18 @@ class TestDeployCommand(unittest.TestCase):
                 open_mock.assert_called_once_with(file_path, "r")
 
                 self.deploy_command.deploy.assert_called_once_with(
-                        mock.ANY,
-                        self.parsed_args.stack_name,
-                        mock.ANY,
-                        fake_parameters,
-                        None,
-                        not self.parsed_args.no_execute_changeset,
-                        None,
-                        [],
-                        None,
-                        mock.Any,
-                        True)
-                        [],
-                        mock.ANY)
-
+                    mock.ANY,
+                    'some_stack_name',
+                    mock.ANY,
+                    fake_parameters,
+                    None,
+                    not self.parsed_args.no_execute_changeset,
+                    None,
+                    [],
+                    None,
+                    mock.ANY,
+                    True
+                )
                 self.deploy_command.parse_parameter_arg.assert_called_once_with(
                         self.parsed_args.parameter_overrides)
 
@@ -187,16 +185,18 @@ class TestDeployCommand(unittest.TestCase):
                             parsed_globals=self.parsed_globals)
 
             self.deploy_command.deploy.assert_called_once_with(
-                    mock.ANY,
-                    self.parsed_args.stack_name,
-                    mock.ANY,
-                    mock.ANY,
-                    None,
-                    not self.parsed_args.no_execute_changeset,
-                    None,
-                    [],
-                    s3UploaderObject,
-                    True)
+                mock.ANY,
+                self.parsed_args.stack_name,
+                mock.ANY,
+                mock.ANY,
+                None,
+                not self.parsed_args.no_execute_changeset,
+                None,
+                [],
+                s3UploaderObject,
+                [{'Key': 'key1', 'Value': 'val1'}],
+                True
+            )
 
             s3UploaderMock.assert_called_once_with(mock.ANY,
                     bucket_name,
@@ -324,6 +324,7 @@ class TestDeployCommand(unittest.TestCase):
         execute_changeset = True
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+        tags = []
 
         empty_changeset = exceptions.ChangeEmptyError(stack_name=stack_name)
         changeset_func = self.deployer.create_and_wait_for_changeset
@@ -332,7 +333,7 @@ class TestDeployCommand(unittest.TestCase):
             self.deploy_command.deploy(
                 self.deployer, stack_name, template, parameters, capabilities,
                 execute_changeset, role_arn, notification_arns,
-                s3_uploader=None)
+                None, tags)
 
     def test_deploy_does_not_raise_exception_on_empty_changeset(self):
         stack_name = "stack_name"
@@ -349,7 +350,7 @@ class TestDeployCommand(unittest.TestCase):
         self.deploy_command.deploy(
             self.deployer, stack_name, template, parameters, capabilities,
             execute_changeset, role_arn, notification_arns,
-            s3_uploader=None,
+            s3_uploader=None, tags=[],
             fail_on_empty_changeset=False
         )
 

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -217,8 +217,16 @@ class TestDeployer(unittest.TestCase):
 
         # Case 2: Stack exists. We are updating it
         self.deployer.has_stack.return_value = True
+        self.stub_client.add_response("get_template_summary",
+            {"Parameters": [{"ParameterKey": parameter["ParameterKey"]}
+                for parameter in parameters]},
+            {"StackName": stack_name})
         expected_params["ChangeSetType"] = "UPDATE"
         expected_params["Parameters"] = parameters
+        # template has new parameter but should not be included in
+        # expected_params as no previous value
+        parameters = list(parameters) + \
+            [{"ParameterKey": "New", "UsePreviousValue": True}]
         self.stub_client.add_response("create_change_set", response,
                                       expected_params)
         with self.stub_client:

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -198,6 +198,7 @@ class TestDeployer(unittest.TestCase):
             "Capabilities": capabilities,
             "Description": botocore.stub.ANY,
             "RoleARN": role_arn,
+            "Tags": [],
             "NotificationARNs": notification_arns
         }
 
@@ -209,8 +210,8 @@ class TestDeployer(unittest.TestCase):
                                       expected_params)
         with self.stub_client:
             result = self.deployer.create_changeset(
-                    stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns, s3_uploader)
+                stack_name, template, parameters, capabilities, role_arn,
+                notification_arns, s3_uploader, [])
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("CREATE", result.changeset_type)
 
@@ -223,7 +224,7 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns, s3_uploader)
+                    notification_arns, s3_uploader, [])
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("UPDATE", result.changeset_type)
 

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -105,6 +105,8 @@ class TestDeployer(unittest.TestCase):
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
 
+        tags = [{"Key":"key1", "Value": "val1"}]
+
         # Case 1: Stack DOES NOT exist
         self.deployer.has_stack = Mock()
         self.deployer.has_stack.return_value = False
@@ -118,7 +120,8 @@ class TestDeployer(unittest.TestCase):
             "Capabilities": capabilities,
             "Description": botocore.stub.ANY,
             "RoleARN": role_arn,
-            "NotificationARNs": notification_arns
+            "NotificationARNs": notification_arns,
+            "Tags": tags
         }
 
         response = {
@@ -130,7 +133,7 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns, s3_uploader)
+                    notification_arns, s3_uploader, tags)
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("CREATE", result.changeset_type)
 
@@ -151,7 +154,7 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns, s3_uploader)
+                    notification_arns, s3_uploader, tags)
             self.assertEquals(response["Id"], result.changeset_id)
             self.assertEquals("UPDATE", result.changeset_type)
 
@@ -233,6 +236,7 @@ class TestDeployer(unittest.TestCase):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
+        tags = [{"Key":"key1", "Value": "val1"}]
 
         self.deployer.has_stack = Mock()
         self.deployer.has_stack.return_value = False
@@ -242,7 +246,7 @@ class TestDeployer(unittest.TestCase):
         with self.stub_client:
             with self.assertRaises(botocore.exceptions.ClientError):
                 self.deployer.create_changeset(stack_name, template, parameters,
-                capabilities, role_arn, notification_arns, None)
+                                               capabilities, role_arn, notification_arns, None, tags)
 
     def test_execute_changeset(self):
         stack_name = "stack_name"
@@ -278,6 +282,7 @@ class TestDeployer(unittest.TestCase):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
+        tags = [{"Key":"key1", "Value": "val1"}]
 
         self.deployer.create_changeset = Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -286,7 +291,7 @@ class TestDeployer(unittest.TestCase):
 
         result = self.deployer.create_and_wait_for_changeset(
                 stack_name, template, parameters, capabilities, role_arn,
-                notification_arns, s3_uploader)
+                notification_arns, s3_uploader, tags)
         self.assertEquals(result.changeset_id, changeset_id)
         self.assertEquals(result.changeset_type, changeset_type)
 
@@ -301,6 +306,7 @@ class TestDeployer(unittest.TestCase):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
         s3_uploader = None
+        tags = [{"Key":"key1", "Value": "val1"}]
 
         self.deployer.create_changeset = Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
@@ -311,7 +317,7 @@ class TestDeployer(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             result = self.deployer.create_and_wait_for_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
-                    notification_arns, s3_uploader)
+                    notification_arns, s3_uploader, tags)
 
     def test_wait_for_changeset_no_changes(self):
         stack_name = "stack_name"


### PR DESCRIPTION
Taking over #2620 and #3105. This PR modifies the tags parameter to be specified in `mykey=myvalue` format instead of the `{Key="mykey", Value="myvalue"}` format. This keeps the tags parameter format consistent with --parameter-overrides