### PR TITLE
 copy permission bits when single file defined in CodeUri

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -209,7 +209,7 @@ def mktempfile():
 def copy_to_temp_dir(filepath):
     tmp_dir = tempfile.mkdtemp()
     dst = os.path.join(tmp_dir, os.path.basename(filepath))
-    shutil.copyfile(filepath, dst)
+    shutil.copy(filepath, dst)
     return tmp_dir
 
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -804,7 +804,7 @@ class TestArtifactExporter(unittest.TestCase):
                 os.remove(zipfile_name)
             test_file_creator.remove_all()
 
-    @patch("shutil.copyfile")
+    @patch("shutil.copy")
     @patch("tempfile.mkdtemp")
     def test_copy_to_temp_dir(self, mkdtemp_mock, copyfile_mock):
         temp_dir = "/tmp/foo/"


### PR DESCRIPTION
`CodeUri:` is set to a file (eg. golang compiled file), the file permissions are not copied across when packaged using `aws cloudformation package`  and `aws cloudformation deploy`. The packaged file has these permission `-rw-r--r--`.  I get the following error when test the lambda function. 
`{ "errorMessage": "fork/exec /var/task/main: permission denied", "errorType": "PathError" }`

`shutil.copyfile` doesn't copy the file permission bits, however `shutil.copy` copies the permission bits. The original file permission is `rwxr-xr-x`.