### PR TITLE
Append a newline to config files if needed

### DIFF
--- a/.changes/next-release/bugfix-Configuration-17224.json
+++ b/.changes/next-release/bugfix-Configuration-17224.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Configuration",
+  "description": "Fixes `#2996 <https://github.com/aws/aws-cli/issues/2996>`__. Fixed a bug where config file updates would sometimes append new sections to the previous section without adding a newline."
+}

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -76,8 +76,22 @@ class ConfigFileWriter(object):
                                os.O_WRONLY | os.O_CREAT, 0o600), 'w'):
             pass
 
+    def _check_file_needs_newline(self, filename):
+        # check if the last byte is a newline
+        with open(filename, 'rb') as f:
+            # check if the file is empty
+            f.seek(0, os.SEEK_END)
+            if not f.tell():
+                return False
+            f.seek(-1, os.SEEK_END)
+            last = f.read()
+            return last != b'\n'
+
     def _write_new_section(self, section_name, new_values, config_filename):
+        needs_newline = self._check_file_needs_newline(config_filename)
         with open(config_filename, 'a') as f:
+            if needs_newline:
+                f.write('\n')
             f.write('[%s]\n' % section_name)
             contents = []
             self._insert_new_values(line_number=0,

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -356,3 +356,16 @@ class TestConfigFileWriter(unittest.TestCase):
             '[preview]\n'
             'cloudfront = true\n'
         )
+
+    def test_appends_newline_on_new_section(self):
+        original = (
+            '[preview]\n'
+            'cloudfront = true'
+        )
+        self.assert_update_config(
+            original, {'region': 'us-west-2', '__section__': 'new-section'},
+            '[preview]\n'
+            'cloudfront = true\n'
+            '[new-section]\n'
+            'region = us-west-2\n'
+        )


### PR DESCRIPTION
Fixes #2996

This will check if the config file ends in a newline, if not it appends one before writing a new section to avoid writing an invalid config file. This pretty much only happens on windows.