### PR TITLE
Add --request-payer to transfer commands

### DIFF
--- a/.changes/next-release/enhancement-s3-9777.json
+++ b/.changes/next-release/enhancement-s3-9777.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "enhancement", 
+  "description": "Expose ``--request-payer`` to ``cp``, ``sync``, ``mv`, and ``rm`` commands."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,3 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
-# virtualenv
-.venv

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
+# virtualenv
+.venv

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -31,7 +31,7 @@ def is_special_file(path):
     """
     This function checks to see if a special file.  It checks if the
     file is a character special device, block special device, FIFO, or
-    socket. 
+    socket.
     """
     mode = os.stat(path).st_mode
     # Character special device.
@@ -318,8 +318,9 @@ class FileGenerator(object):
             yield self._list_single_object(s3_path)
         else:
             lister = BucketLister(self._client)
+            request_payer = self.request_parameters.get('RequestPayer')
             for key in lister.list_objects(bucket=bucket, prefix=prefix,
-                                           page_size=self.page_size):
+                                           page_size=self.page_size, request_payer=request_payer):
                 source_path, response_data = key
                 if response_data['Size'] == 0 and source_path.endswith('/'):
                     if self.operation_name == 'delete':

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -318,9 +318,10 @@ class FileGenerator(object):
             yield self._list_single_object(s3_path)
         else:
             lister = BucketLister(self._client)
-            request_payer = self.request_parameters.get('RequestPayer')
+            extra_args = self.request_parameters.get('ListObjects', {})
             for key in lister.list_objects(bucket=bucket, prefix=prefix,
-                                           page_size=self.page_size, request_payer=request_payer):
+                                           page_size=self.page_size,
+                                           extra_args=extra_args):
                 source_path, response_data = key
                 if response_data['Size'] == 0 and source_path.endswith('/'):
                     if self.operation_name == 'delete':

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -498,7 +498,7 @@ class DownloadStreamRequestSubmitter(DownloadRequestSubmitter):
 
 
 class DeleteRequestSubmitter(BaseTransferRequestSubmitter):
-    REQUEST_MAPPER_METHOD = None
+    REQUEST_MAPPER_METHOD = RequestParamsMapper.map_delete_params
     RESULT_SUBSCRIBER_CLASS = DeleteResultSubscriber
 
     def can_submit(self, fileinfo):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -498,7 +498,7 @@ class DownloadStreamRequestSubmitter(DownloadRequestSubmitter):
 
 
 class DeleteRequestSubmitter(BaseTransferRequestSubmitter):
-    REQUEST_MAPPER_METHOD = RequestParamsMapper.map_delete_params
+    REQUEST_MAPPER_METHOD = RequestParamsMapper.map_delete_object_params
     RESULT_SUBSCRIBER_CLASS = DeleteResultSubscriber
 
     def can_submit(self, fileinfo):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -725,7 +725,7 @@ class CpCommand(S3TransferCommand):
             "or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
+                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE, REQUEST_PAYER]
 
 
 class MvCommand(S3TransferCommand):
@@ -744,7 +744,7 @@ class RmCommand(S3TransferCommand):
     USAGE = "<S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 1, 'positional_arg': True,
                   'synopsis': USAGE}, DRYRUN, QUIET, RECURSIVE, INCLUDE,
-                 EXCLUDE, ONLY_SHOW_ERRORS, PAGE_SIZE]
+                 EXCLUDE, ONLY_SHOW_ERRORS, PAGE_SIZE, REQUEST_PAYER]
 
 
 class SyncCommand(S3TransferCommand):
@@ -757,7 +757,7 @@ class SyncCommand(S3TransferCommand):
             "<LocalPath> or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA, METADATA_DIRECTIVE]
+                [METADATA, METADATA_DIRECTIVE, REQUEST_PAYER]
 
 
 class MbCommand(S3Command):
@@ -985,10 +985,17 @@ class CommandArchitecture(object):
             'result_queue': result_queue,
         }
 
-        fgen_request_parameters = {}
+        fgen_request_parameters = {
+            'RequestPayer': self.parameters.get('request_payer'),
+        }
         fgen_head_object_params = {}
         fgen_request_parameters['HeadObject'] = fgen_head_object_params
         fgen_kwargs['request_parameters'] = fgen_request_parameters
+
+        rgen_request_parameters = {
+            'RequestPayer': self.parameters.get('request_payer'),
+        }
+        rgen_kwargs['request_parameters'] = rgen_request_parameters
 
         # SSE-C may be neaded for HeadObject for copies/downloads/deletes
         # If the operation is s3 to s3, the FileGenerator should use the
@@ -1111,6 +1118,8 @@ class CommandParameters(object):
             self.parameters['follow_symlinks'] = True
         if 'source_region' not in parameters:
             self.parameters['source_region'] = None
+        if 'request_payer' not in parameters:
+            self.parameters['request_payer'] = None
         if self.cmd in ['sync', 'mb', 'rb']:
             self.parameters['dir_op'] = True
         if self.cmd == 'mv':

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -434,7 +434,8 @@ TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  WEBSITE_REDIRECT, CONTENT_TYPE, CACHE_CONTROL,
                  CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE,
                  EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS, NO_PROGRESS,
-                 PAGE_SIZE, IGNORE_GLACIER_WARNINGS, FORCE_GLACIER_TRANSFER]
+                 PAGE_SIZE, IGNORE_GLACIER_WARNINGS, FORCE_GLACIER_TRANSFER,
+                 REQUEST_PAYER]
 
 
 def get_client(session, region, endpoint_url, verify, config=None):
@@ -725,7 +726,7 @@ class CpCommand(S3TransferCommand):
             "or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE, REQUEST_PAYER]
+                [METADATA, METADATA_DIRECTIVE, EXPECTED_SIZE, RECURSIVE]
 
 
 class MvCommand(S3TransferCommand):
@@ -743,8 +744,8 @@ class RmCommand(S3TransferCommand):
     DESCRIPTION = "Deletes an S3 object."
     USAGE = "<S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 1, 'positional_arg': True,
-                  'synopsis': USAGE}, DRYRUN, QUIET, RECURSIVE, INCLUDE,
-                 EXCLUDE, ONLY_SHOW_ERRORS, PAGE_SIZE, REQUEST_PAYER]
+                  'synopsis': USAGE}, DRYRUN, QUIET, RECURSIVE, REQUEST_PAYER,
+                 INCLUDE, EXCLUDE, ONLY_SHOW_ERRORS, PAGE_SIZE]
 
 
 class SyncCommand(S3TransferCommand):
@@ -757,7 +758,7 @@ class SyncCommand(S3TransferCommand):
             "<LocalPath> or <S3Uri> <S3Uri>"
     ARG_TABLE = [{'name': 'paths', 'nargs': 2, 'positional_arg': True,
                   'synopsis': USAGE}] + TRANSFER_ARGS + \
-                [METADATA, METADATA_DIRECTIVE, REQUEST_PAYER]
+                [METADATA, METADATA_DIRECTIVE]
 
 
 class MbCommand(S3Command):
@@ -985,33 +986,16 @@ class CommandArchitecture(object):
             'result_queue': result_queue,
         }
 
-        fgen_request_parameters = {
-            'RequestPayer': self.parameters.get('request_payer'),
-        }
-        fgen_head_object_params = {}
-        fgen_request_parameters['HeadObject'] = fgen_head_object_params
+        fgen_request_parameters = \
+            self._get_file_generator_request_parameters_skeleton()
+        self._map_request_payer_params(fgen_request_parameters)
+        self._map_sse_c_params(fgen_request_parameters, paths_type)
         fgen_kwargs['request_parameters'] = fgen_request_parameters
 
-        rgen_request_parameters = {
-            'RequestPayer': self.parameters.get('request_payer'),
-        }
+        rgen_request_parameters =  \
+            self._get_file_generator_request_parameters_skeleton()
+        self._map_request_payer_params(rgen_request_parameters)
         rgen_kwargs['request_parameters'] = rgen_request_parameters
-
-        # SSE-C may be neaded for HeadObject for copies/downloads/deletes
-        # If the operation is s3 to s3, the FileGenerator should use the
-        # copy source key and algorithm. Otherwise, use the regular
-        # SSE-C key and algorithm. Note the reverse FileGenerator does
-        # not need any of these because it is used only for sync operations
-        # which only use ListObjects which does not require HeadObject.
-        RequestParamsMapper.map_head_object_params(
-            fgen_head_object_params, self.parameters)
-        if paths_type == 's3s3':
-            RequestParamsMapper.map_head_object_params(
-                fgen_head_object_params, {
-                    'sse_c': self.parameters.get('sse_c_copy_source'),
-                    'sse_c_key': self.parameters.get('sse_c_copy_source_key')
-                }
-            )
 
         file_generator = FileGenerator(**fgen_kwargs)
         rev_generator = FileGenerator(**rgen_kwargs)
@@ -1093,6 +1077,41 @@ class CommandArchitecture(object):
             rc = 2
         return rc
 
+    def _get_file_generator_request_parameters_skeleton(self):
+        return {
+            'HeadObject': {},
+            'ListObjects': {}
+        }
+
+    def _map_request_payer_params(self, request_parameters):
+        RequestParamsMapper.map_head_object_params(
+            request_parameters['HeadObject'], {
+                'request_payer': self.parameters.get('request_payer')
+            }
+        )
+        RequestParamsMapper.map_list_objects_params(
+            request_parameters['ListObjects'], {
+                'request_payer': self.parameters.get('request_payer')
+            }
+        )
+
+    def _map_sse_c_params(self, request_parameters, paths_type):
+        # SSE-C may be neaded for HeadObject for copies/downloads/deletes
+        # If the operation is s3 to s3, the FileGenerator should use the
+        # copy source key and algorithm. Otherwise, use the regular
+        # SSE-C key and algorithm. Note the reverse FileGenerator does
+        # not need any of these because it is used only for sync operations
+        # which only use ListObjects which does not require HeadObject.
+        RequestParamsMapper.map_head_object_params(
+            request_parameters['HeadObject'], self.parameters)
+        if paths_type == 's3s3':
+            RequestParamsMapper.map_head_object_params(
+                request_parameters['HeadObject'], {
+                    'sse_c': self.parameters.get('sse_c_copy_source'),
+                    'sse_c_key': self.parameters.get('sse_c_copy_source_key')
+                }
+            )
+
 
 class CommandParameters(object):
     """
@@ -1118,8 +1137,6 @@ class CommandParameters(object):
             self.parameters['follow_symlinks'] = True
         if 'source_region' not in parameters:
             self.parameters['source_region'] = None
-        if 'request_payer' not in parameters:
-            self.parameters['request_payer'] = None
         if self.cmd in ['sync', 'mb', 'rb']:
             self.parameters['dir_op'] = True
         if self.cmd == 'mv':

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -357,10 +357,12 @@ class BucketLister(object):
         self._client = client
         self._date_parser = date_parser
 
-    def list_objects(self, bucket, prefix=None, page_size=None):
+    def list_objects(self, bucket, prefix=None, page_size=None, request_payer=None):
         kwargs = {'Bucket': bucket, 'PaginationConfig': {'PageSize': page_size}}
         if prefix is not None:
             kwargs['Prefix'] = prefix
+        if request_payer is not None:
+            kwargs['RequestPayer'] = request_payer
 
         paginator = self._client.get_paginator('list_objects')
         pages = paginator.paginate(**kwargs)
@@ -424,11 +426,13 @@ class RequestParamsMapper(object):
         cls._set_metadata_params(request_params, cli_params)
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
     def map_get_object_params(cls, request_params, cli_params):
         """Map CLI params to GetObject request params"""
         cls._set_sse_c_request_params(request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
     def map_copy_object_params(cls, request_params, cli_params):
@@ -440,11 +444,13 @@ class RequestParamsMapper(object):
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_and_copy_source_request_params(
             request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
     def map_head_object_params(cls, request_params, cli_params):
         """Map CLI params to HeadObject request params"""
         cls._set_sse_c_request_params(request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
     def map_create_multipart_upload_params(cls, request_params, cli_params):
@@ -453,21 +459,33 @@ class RequestParamsMapper(object):
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
         cls._set_metadata_params(request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
     def map_upload_part_params(cls, request_params, cli_params):
         """Map CLI params to UploadPart request params"""
         cls._set_sse_c_request_params(request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
     def map_upload_part_copy_params(cls, request_params, cli_params):
         """Map CLI params to UploadPartCopy request params"""
         cls._set_sse_c_and_copy_source_request_params(
             request_params, cli_params)
+        cls._set_request_payer_param(request_params, cli_params)
+
+    @classmethod
+    def map_delete_params(cls, request_params, cli_params):
+        cls._set_request_payer_param(request_params, cli_params)
+
+    @classmethod
+    def _set_request_payer_param(cls, request_params, cli_params):
+        if cli_params.get('request_payer'):
+            request_params['RequestPayer'] = cli_params['request_payer']
 
     @classmethod
     def _set_general_object_params(cls, request_params, cli_params):
-        # Paramters set in this method should be applicable to the following
+        # Parameters set in this method should be applicable to the following
         # operations involving objects: PutObject, CopyObject, and
         # CreateMultipartUpload.
         general_param_translation = {

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -10,3 +10,22 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+
+
+class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(BaseS3TransferCommandTest, self).setUp()
+        self.files = FileCreator()
+
+    def tearDown(self):
+        super(BaseS3TransferCommandTest, self).tearDown()
+        self.files.remove_all()
+
+    def assert_operations_called(self, expected_operations_with_params):
+        actual_operations_with_params = [
+            (operation_called[0].name, operation_called[1])
+            for operation_called in self.operations_called
+        ]
+        self.assertEqual(
+            actual_operations_with_params, expected_operations_with_params)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -13,9 +13,10 @@
 # language governing permissions and limitations under the License.
 import mock
 
-from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import capture_input, set_invalid_utime
 from awscli.compat import six
+from tests.functional.s3 import BaseS3TransferCommandTest
 
 
 class BufferedBytesIO(six.BytesIO):
@@ -24,18 +25,11 @@ class BufferedBytesIO(six.BytesIO):
         return self
 
 
-class TestCPCommand(BaseAWSCommandParamsTest):
-
+class BaseCPCommandTest(BaseS3TransferCommandTest):
     prefix = 's3 cp '
 
-    def setUp(self):
-        super(TestCPCommand, self).setUp()
-        self.files = FileCreator()
 
-    def tearDown(self):
-        super(TestCPCommand, self).tearDown()
-        self.files.remove_all()
-
+class TestCPCommand(BaseCPCommandTest):
     def test_operations_used_in_upload(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
         cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
@@ -609,3 +603,298 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
             'the HeadObject operation: The specified bucket does not exist'
         )
         self.assertIn(error_message, stderr)
+
+
+class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
+    def test_single_upload(self):
+        full_path = self.files.create_file('myfile', 'mycontent')
+        cmdline = (
+            '%s %s s3://mybucket/mykey --request-payer' % (
+                self.prefix, full_path
+            )
+        )
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('PutObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                    'Body': mock.ANY,
+                })
+            ]
+        )
+
+    def test_multipart_upload(self):
+        full_path = self.files.create_file('myfile', 'a' * 10 * (1024 ** 2))
+        cmdline = (
+            '%s %s s3://mybucket/mykey --request-payer' % (
+                self.prefix, full_path))
+
+        self.parsed_responses = [
+            {'UploadId': 'myid'},      # CreateMultipartUpload
+            {'ETag': '"myetag"'},      # UploadPart
+            {'ETag': '"myetag"'},      # UploadPart
+            {}                         # CompleteMultipartUpload
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('CreateMultipartUpload', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                }),
+                ('UploadPart', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                    'UploadId': 'myid',
+                    'PartNumber': mock.ANY,
+                    'Body': mock.ANY,
+                }),
+                ('UploadPart', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                    'UploadId': 'myid',
+                    'PartNumber': mock.ANY,
+                    'Body': mock.ANY,
+
+                }),
+                ('CompleteMultipartUpload', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                    'UploadId': 'myid',
+                    'MultipartUpload': {'Parts': [
+                        {'ETag': '"myetag"', 'PartNumber': 1},
+                        {'ETag': '"myetag"', 'PartNumber': 2}]
+                    }
+                })
+            ]
+        )
+
+    def test_recursive_upload(self):
+        self.files.create_file('myfile', 'mycontent')
+        cmdline = (
+            '%s %s s3://mybucket/ --request-payer --recursive' % (
+                self.prefix, self.files.rootdir
+            )
+        )
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('PutObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'myfile',
+                    'RequestPayer': 'requester',
+                    'Body': mock.ANY,
+                })
+            ]
+        )
+
+    def test_single_download(self):
+        cmdline = '%s s3://mybucket/mykey %s --request-payer' % (
+            self.prefix, self.files.rootdir)
+
+        self.parsed_responses = [
+            {"ContentLength": 100, "LastModified": "00:00:00Z"},
+            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+        ]
+
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('HeadObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                }),
+                ('GetObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                })
+            ]
+        )
+
+    def test_ranged_download(self):
+        cmdline = '%s s3://mybucket/mykey %s --request-payer' % (
+            self.prefix, self.files.rootdir)
+
+        self.parsed_responses = [
+            {"ContentLength": 10 * (1024 ** 2), "LastModified": "00:00:00Z"},
+            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')}
+        ]
+
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('HeadObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                }),
+                ('GetObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                    'Range': mock.ANY,
+                }),
+                ('GetObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                    'Range': mock.ANY,
+                })
+            ]
+        )
+
+    def test_recursive_download(self):
+        cmdline = '%s s3://mybucket/ %s --request-payer --recursive' % (
+            self.prefix, self.files.rootdir)
+        self.parsed_responses = [
+            {
+                'Contents': [
+                    {'Key': 'mykey',
+                     'LastModified': '00:00:00Z',
+                     'Size': 100},
+                ],
+                'CommonPrefixes': []
+            },
+            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('ListObjects', {
+                    'Bucket': 'mybucket',
+                    'Prefix': '',
+                    'EncodingType': 'url',
+                    'RequestPayer': 'requester',
+                }),
+                ('GetObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester',
+                })
+            ]
+        )
+
+    def test_single_copy(self):
+        cmdline = self.prefix
+        cmdline += ' s3://sourcebucket/sourcekey s3://mybucket/mykey'
+        cmdline += ' --request-payer'
+        self.parsed_responses = [
+            {'ContentLength': 5, 'LastModified': '00:00:00Z'},
+            {}
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('HeadObject', {
+                    'Bucket': 'sourcebucket',
+                    'Key': 'sourcekey',
+                    'RequestPayer': 'requester',
+                }),
+                ('CopyObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'CopySource': 'sourcebucket/sourcekey',
+                    'RequestPayer': 'requester',
+                })
+            ]
+        )
+
+    def test_multipart_copy(self):
+        cmdline = self.prefix
+        cmdline += ' s3://sourcebucket/sourcekey s3://mybucket/mykey'
+        cmdline += ' --request-payer'
+        self.parsed_responses = [
+            {'ContentLength': 10 * (1024 ** 2),
+             'LastModified': '00:00:00Z'},           # HeadObject
+            {'UploadId': 'myid'},                    # CreateMultipartUpload
+            {'CopyPartResult': {'ETag': '"etag"'}},  # UploadPartCopy
+            {'CopyPartResult': {'ETag': '"etag"'}},  # UploadPartCopy
+            {}                                       # CompleteMultipartUpload
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('HeadObject', {
+                    'Bucket': 'sourcebucket',
+                    'Key': 'sourcekey',
+                    'RequestPayer': 'requester',
+                }),
+                ('CreateMultipartUpload', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester'
+                }),
+                ('UploadPartCopy', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'CopySource': 'sourcebucket/sourcekey',
+                    'UploadId': 'myid',
+                    'RequestPayer': 'requester',
+                    'PartNumber': mock.ANY,
+                    'CopySourceRange': mock.ANY,
+
+                }),
+                ('UploadPartCopy', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'CopySource': 'sourcebucket/sourcekey',
+                    'UploadId': 'myid',
+                    'RequestPayer': 'requester',
+                    'PartNumber': mock.ANY,
+                    'CopySourceRange': mock.ANY,
+                }),
+                ('CompleteMultipartUpload', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'UploadId': 'myid',
+                    'RequestPayer': 'requester',
+                    'MultipartUpload': {'Parts': [
+                        {'ETag': '"etag"', 'PartNumber': 1},
+                        {'ETag': '"etag"', 'PartNumber': 2}]
+                    }
+                })
+            ]
+        )
+
+    def test_recursive_copy(self):
+        cmdline = self.prefix
+        cmdline += ' s3://sourcebucket/ s3://mybucket/'
+        cmdline += ' --request-payer'
+        cmdline += ' --recursive'
+        self.parsed_responses = [
+            {
+                'Contents': [
+                    {'Key': 'mykey',
+                     'LastModified': '00:00:00Z',
+                     'Size': 100},
+                ],
+                'CommonPrefixes': []
+            },
+            {},
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('ListObjects', {
+                    'Bucket': 'sourcebucket',
+                    'Prefix': '',
+                    'EncodingType': 'url',
+                    'RequestPayer': 'requester',
+                }),
+                ('CopyObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'CopySource': 'sourcebucket/mykey',
+                    'RequestPayer': 'requester',
+                })
+            ]
+        )

--- a/tests/functional/s3/test_rm_command.py
+++ b/tests/functional/s3/test_rm_command.py
@@ -10,25 +10,62 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+from tests.functional.s3 import BaseS3TransferCommandTest
 
 
-class TestRmCommand(BaseAWSCommandParamsTest):
-
+class TestRmCommand(BaseS3TransferCommandTest):
     prefix = 's3 rm'
 
-    def setUp(self):
-        super(TestRmCommand, self).setUp()
-        self.files = FileCreator()
-
-    def tearDown(self):
-        super(TestRmCommand, self).tearDown()
-        self.files.remove_all()
-
-    def test_operations_used_in_upload(self):
+    def test_operations_used(self):
         cmdline = '%s s3://bucket/key.txt' % self.prefix
         self.run_cmd(cmdline, expected_rc=0)
         # The only operation we should have called is DeleteObject.
         self.assertEqual(
             len(self.operations_called), 1, self.operations_called)
         self.assertEqual(self.operations_called[0][0].name, 'DeleteObject')
+
+    def test_delete_with_request_payer(self):
+        cmdline = '%s s3://mybucket/mykey --request-payer' % self.prefix
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('DeleteObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester'
+                })
+            ]
+
+        )
+
+    def test_recursive_delete_with_requests(self):
+        cmdline = '%s s3://mybucket/ --recursive --request-payer' % self.prefix
+        self.parsed_responses = [
+            {
+                'Contents': [
+                    {'Key': 'mykey',
+                     'LastModified': '00:00:00Z',
+                     'Size': 100},
+                ],
+                'CommonPrefixes': []
+            },
+            {},
+        ]
+
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                ('ListObjects', {
+                    'Bucket': 'mybucket',
+                    'Prefix': '',
+                    'EncodingType': 'url',
+                    'RequestPayer': 'requester'
+                }),
+                ('DeleteObject', {
+                    'Bucket': 'mybucket',
+                    'Key': 'mykey',
+                    'RequestPayer': 'requester'
+                })
+            ]
+
+        )


### PR DESCRIPTION
This builds on this previous PR: https://github.com/aws/aws-cli/pull/3016

Compared to the original PR, there was a lot more lines added. For the most part, the logic from the original PR stayed intact. Just I added a lot of functional tests for this as practically all API requests used in a command will require the request payer header or the command will fail, and so I wanted to be sure that I caught all of the different scenarios (good thing I did too because I found a bug in s3transfer as well related to this). I also tested it locally on a bucket enabled for requester pays using an account that does not own the bucket and it was working well there. For anyone following/reviewing this PR, feel free to try it out locally as well and that will help double check I did not miss anything.

Also, note tests won't pass until this PR gets merged from `s3transfer`: https://github.com/boto/s3transfer/pull/103