### PR TITLE
Typo in glacier warning message

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -306,7 +306,7 @@ class BaseTransferRequestSubmitter(object):
                         's3://'+fileinfo.src,
                         'Object is of storage class GLACIER. Unable to '
                         'perform %s operations on GLACIER objects. You must '
-                        'restore the object to be able to the perform '
+                        'restore the object to be able to perform the '
                         'operation. See aws s3 %s help for additional '
                         'parameter options to ignore or force these '
                         'transfers.' %


### PR DESCRIPTION
The warning message currently is: `You must restore the object to be able to the perform operation.` 

It should instead read: `You must restore the object to be able to perform the operation.`