### PR TITLE
Support cache for SharedCredentialFile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
+# venv
+venv/

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -21,7 +21,7 @@ from awscli.argprocess import uri_param
 from awscli.customizations import datapipeline
 from awscli.customizations.addexamples import add_examples
 from awscli.customizations.argrename import register_arg_renames
-from awscli.customizations.assumerole import register_assume_role_provider
+from awscli.customizations.sessiontokenservice import register_session_token_provider
 from awscli.customizations.awslambda import register_lambda_create_function
 from awscli.customizations.cliinputjson import register_cli_input_json
 from awscli.customizations.cloudformation import initialize as cloudformation_init
@@ -130,7 +130,7 @@ def awscli_initialize(event_handlers):
     register_cloudsearchdomain(event_handlers)
     register_s3_endpoint(event_handlers)
     register_generate_cli_skeleton(event_handlers)
-    register_assume_role_provider(event_handlers)
+    register_session_token_provider(event_handlers)
     register_add_waiters(event_handlers)
     codedeploy_init(event_handlers)
     register_subscribe(event_handlers)

--- a/tests/unit/customizations/test_sessiontokenservice.py
+++ b/tests/unit/customizations/test_sessiontokenservice.py
@@ -16,24 +16,36 @@ from botocore.hooks import HierarchicalEmitter
 from botocore.exceptions import ProfileNotFound
 
 from awscli.testutils import unittest
-from awscli.customizations import assumerole
+from awscli.customizations import sessiontokenservice
+
+
+import sys
 
 
 class TestAssumeRolePlugin(unittest.TestCase):
     def test_assume_role_provider_injected(self):
         session = mock.Mock()
-        assumerole.inject_assume_role_provider_cache(
+
+        credential_provider = mock.Mock()
+        session.get_component.return_value = credential_provider
+        providers = [mock.Mock(), mock.Mock()]
+
+        credential_provider.get_provider.side_effect = providers
+
+        sessiontokenservice.inject_session_token_provider_cache(
             session, event_name='building-command-table.foo')
+
         session.get_component.assert_called_with('credential_provider')
-        credential_provider = session.get_component.return_value
-        get_provider = credential_provider.get_provider
-        get_provider.assert_called_with('assume-role')
-        self.assertIsInstance(get_provider.return_value.cache,
-                              assumerole.JSONFileCache)
+
+        credential_provider.get_provider.assert_any_call('assume-role')
+        credential_provider.get_provider.assert_any_call('shared-credentials-file')
+
+        for provider in providers:
+            self.assertIsInstance(provider.cache, sessiontokenservice.JSONFileCache)
 
     def test_assume_role_provider_registration(self):
         event_handlers = HierarchicalEmitter()
-        assumerole.register_assume_role_provider(event_handlers)
+        sessiontokenservice.register_session_token_provider(event_handlers)
         session = mock.Mock()
         event_handlers.emit('session-initialized', session=session)
         # Just verifying that anything on the session was called ensures
@@ -46,7 +58,7 @@ class TestAssumeRolePlugin(unittest.TestCase):
         session.get_component.side_effect = ProfileNotFound(
             profile='unknown')
 
-        assumerole.inject_assume_role_provider_cache(
+        sessiontokenservice.inject_session_token_provider_cache(
             session, event_name='building-command-table.foo')
 
         credential_provider = session.get_component.return_value


### PR DESCRIPTION
Implementation to support cache for when MFA is used for shared credential files. See https://github.com/aws/aws-sdk/issues/529
Depends on https://github.com/boto/botocore/pull/1399