### PR TITLE
Fix datapipeline CLI args for multi-value params

### DIFF
--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -306,7 +306,10 @@ class ParameterValuesInlineArgument(CustomArgument):
                 key = argument_components[0]
                 value = argument_components[1]
                 if key in parameter_object:
-                    parameter_object[key] = [parameter_object[key], value]
+                    if isinstance(parameter_object[key], list):
+                        parameter_object[key].append(value)
+                    else:
+                        parameter_object[key] = [parameter_object[key], value]
                 else:
                     parameter_object[key] = value
             except IndexError:

--- a/tests/unit/customizations/datapipeline/test_arg_parse.py
+++ b/tests/unit/customizations/datapipeline/test_arg_parse.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from awscli.testutils import unittest
+
+from awscli.customizations.datapipeline import ParameterValuesInlineArgument
+
+
+class TestParameterValuesInlineArgument(unittest.TestCase):
+
+    def test_over_2_values_with_same_key(self):
+        parameters = {}
+        argument = ParameterValuesInlineArgument('parameter-values')
+        argument.add_to_params(
+            parameters,
+            [
+                'param1=value1',
+                'param1=value2',
+                'param1=value3',
+            ]
+        )
+        self.assertEqual(
+            parameters['parameterValues'],
+            [
+                {
+                    "id": "param1",
+                    "stringValue": "value1"
+                },
+                {
+                    "id": "param1",
+                    "stringValue": "value2"
+                },
+                {
+                    "id": "param1",
+                    "stringValue": "value3"
+                }
+            ]
+        )


### PR DESCRIPTION
Previously adding 1 or 2 values with the same key/id would work, but not 3. Test included, but made a new file as I couldn't find an existing file that looked appropriate.

I couldn't get tox working with Python 2.6 locally (problem with installing PyYAML), and this test failed in every other version `test_iso (tests.functional.test_timeformat.TestCLITimestampParser) ... FAIL` but hopefully OK.