### PR TITLE
Don't call `describe_stacks` in `aws cloudformation deploy`

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -43,21 +43,18 @@ class Deployer(object):
         :return: True if stack exists. False otherwise
         """
         try:
-            resp = self._client.describe_stacks(StackName=stack_name)
-            if len(resp["Stacks"]) != 1:
-                return False
+            resp = self._client.describe_stack_resources(StackName=stack_name)
 
-            # When you run CreateChangeSet on a a stack that does not exist,
-            # CloudFormation will create a stack and set it's status
-            # REVIEW_IN_PROGRESS. However this stack is cannot be manipulated
-            # by "update" commands. Under this circumstances, we treat like
-            # this stack does not exist and call CreateChangeSet will
+            # When you run CreateChangeSet on a stack that does not exist,
+            # CloudFormation will create an empty stack and set its status to
+            # REVIEW_IN_PROGRESS. However this stack cannot be manipulated by
+            # "update" commands. Under these circumstances, we treat it like
+            # this stack does not exist and call CreateChangeSet with the
             # ChangeSetType set to CREATE and not UPDATE.
-            stack = resp["Stacks"][0]
-            return stack["StackStatus"] != "REVIEW_IN_PROGRESS"
+            return len(resp["StackResources"]) != 0
 
         except botocore.exceptions.ClientError as e:
-            # If a stack does not exist, describe_stacks will throw an
+            # If a stack does not exist, describe_stack_resources will throw an
             # exception. Unfortunately we don't have a better way than parsing
             # the exception msg to understand the nature of this exception.
             msg = str(e)

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -26,12 +26,12 @@ class TestDeployer(unittest.TestCase):
         }
 
         response = {
-            "Stacks": [
-                make_stack_obj(stack_name)
+            "StackResources": [
+                make_stack_resources_obj(stack_name)
             ]
         }
 
-        self.stub_client.add_response('describe_stacks', response,
+        self.stub_client.add_response('describe_stack_resources', response,
                                       expected_params)
 
         with self.stub_client:
@@ -44,18 +44,8 @@ class TestDeployer(unittest.TestCase):
             "StackName": stack_name
         }
 
-        # Response contains NO stack
-        no_stack_response = {
-            "Stacks": []
-        }
-        self.stub_client.add_response('describe_stacks', no_stack_response,
-                                      expected_params)
-        with self.stub_client:
-            response = self.deployer.has_stack(stack_name)
-            self.assertFalse(response)
-
         # Response is a ClientError with a message that the stack does not exist
-        self.stub_client.add_client_error('describe_stacks', "ClientError",
+        self.stub_client.add_client_error('describe_stack_resources', "ClientError",
                                           "Stack with id {0} does not exist"
                                           .format(stack_name))
         with self.stub_client:
@@ -68,11 +58,11 @@ class TestDeployer(unittest.TestCase):
             "StackName": stack_name
         }
 
-        # Response contains NO stack
+        # Response contains NO stack resources
         review_in_progress_response = {
-            "Stacks": [make_stack_obj(stack_name, "REVIEW_IN_PROGRESS")]
+            "StackResources": []
         }
-        self.stub_client.add_response('describe_stacks',
+        self.stub_client.add_response('describe_stack_resources',
                                       review_in_progress_response,
                                       expected_params)
         with self.stub_client:
@@ -80,7 +70,7 @@ class TestDeployer(unittest.TestCase):
             self.assertFalse(response)
 
     def test_has_stack_exception(self):
-        self.stub_client.add_client_error('describe_stacks', "ValidationError",
+        self.stub_client.add_client_error('describe_stack_resources', "ValidationError",
                                           "Service is bad")
         with self.stub_client:
             with self.assertRaises(botocore.exceptions.ClientError):
@@ -446,10 +436,13 @@ class TestDeployer(unittest.TestCase):
                 "stack_create_complete")
 
 
-def make_stack_obj(stack_name, status="CREATE_COMPLETE"):
+def make_stack_resources_obj(stack_name, status="CREATE_COMPLETE"):
     return {
         "StackId": stack_name,
         "StackName": stack_name,
-        "CreationTime": "2013-08-23T01:02:15.422Z",
-        "StackStatus": status
+        "LogicalResourceId": "Test",
+        "PhysicalResourceId": "a9984e36-262c-49a7-9b57-f7f1c45ce890",
+        "ResourceType": "Custom::Test",
+        "Timestamp": "2013-08-23T01:02:15.422Z",
+        "ResourceStatus": status
     }


### PR DESCRIPTION
We're running into the following throttling errors when trying to call `aws cloudformation deploy` multiple times both sequentially across multiple deployment machines and in parallel on a single machine.

```
Waiting for changeset to be created..
An error occurred (Throttling) when calling the DescribeStacks operation (reached max retries: 4): Rate exceeded
Command exited with non-zero status 255
```

We've opened support case 4890801861 in regards to this issue where it was determined that the `aws cloudformation deploy` command is actually calling the cloudformation `describe_stacks` command under the hood to determine if a stack exists or not.

Since we have so many CloudFormation stacks the `describe_stacks` API can be slow and ineffecient so this pull request replaces those calls with ones to `describe_stack_resources` instead. It retains the same behavior for determining if the deploy should be performed with either a `create` or an `update` command for the following scenarios:

* If the stack does not exist then `create` is used
* If the stack exists in `REVIEW_IN_PROGRESS` state then `create` is used
* Otherwise if the stack already exists then `update` is used

Here are a couple links I found where this issue was previously reported.

* https://aws.uservoice.com/forums/598381-aws-command-line-interface/suggestions/33168517--aws-cloudformation-deploy-wait-describe-stack
* https://github.com/aws/aws-cli/issues/2948