### PR TITLE
Fix get-lifecycle-policy-preview example command

### DIFF
--- a/awscli/examples/ecr/get-lifecycle-policy-preview.rst
+++ b/awscli/examples/ecr/get-lifecycle-policy-preview.rst
@@ -5,7 +5,7 @@ This example retrieves the result of a lifecycle policy preview for a repository
 
 Command::
 
-  aws ecr get-lifecycle-policy --repository-name "project-a/amazon-ecs-sample"
+  aws ecr get-lifecycle-policy-preview --repository-name "project-a/amazon-ecs-sample"
 
 Output::
 


### PR DESCRIPTION
Just a minor correction for the get-lifecycle-policy-preview example. It was using the get-lifecycle-policy command.