### PR TITLE
Ensure python-dateutil version is Python 2.6 compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ docutils>=0.10
 -e git://github.com/boto/botocore.git@develop#egg=botocore
 -e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
 -e git://github.com/boto/jmespath.git@develop#egg=jmespath
-nose==1.3.0
+nose==1.3.7
 colorama>=0.2.5,<=0.3.7
 mock==1.3.0
 rsa>=3.1.2,<=3.5.0

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -34,6 +34,7 @@ PACKAGE_VERSION = {
     'ordereddict': '1.1',
     'simplejson': '3.3.0',
     'argparse': '1.2.1',
+    'python-dateutil': '2.6.1',
 }
 INSTALL_ARGS = '--allow-all-external --no-use-wheel'
 
@@ -174,7 +175,7 @@ def main():
     print("Bundle dir at: %s" % scratch_dir)
     download_package_tarballs(
         package_dir,
-        packages=['virtualenv', 'ordereddict', 'simplejson', 'argparse'])
+        packages=['virtualenv', 'ordereddict', 'simplejson', 'argparse', 'python-dateutil'])
     download_cli_deps(package_dir)
     add_cli_sdist(package_dir)
     create_bootstrap_script(scratch_dir)


### PR DESCRIPTION
This force downloads `python-dateutil` v2.6.1 to ensure that we have a Python 2.6 compatible version of the package.

This ensures that no matter what version of Python is used to create the bundled installer v2.6.1 of `python-dateutil` will be present in the packages folder. Depending on the Python version used a more recent version of `python-dateutil` may additionally be present. 