### PR TITLE
Clarify environment credential source documentation

### DIFF
--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -209,7 +209,9 @@ in the AWS CLI config file:
   the initial ``assume-role`` call. This parameter cannot be provided
   alongside ``source_profile``. Valid values are:
 
-  * ``Environment`` to pull source credentials from environment variables.
+  * ``Environment`` to pull source credentials from environment variables. Note
+    this credential source does not work alongside the ``AWS_PROFILE``
+    environment variable.
   * ``Ec2InstanceMetadata`` to use the EC2 instance role as source credentials.
   * ``EcsContainer`` to use the ECS container credentials as the source
     credentials.


### PR DESCRIPTION
Adding a specific call out to note that you can't combine `credential_source = Environment` and setting the profile via `AWS_PROFILE` as this results in the environment credentials being preferred and we never attempt to assume role.

See: https://github.com/boto/botocore/issues/1401