### PR TITLE
added support for using stdin and pipes

### DIFF
--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -272,10 +272,28 @@ def get_pipe(prefix, path):
         PIPE_CACHE[path] = get_file(prefix, path, mode = 'r')
     return PIPE_CACHE[path]
 
+STDIN_CACHE = None
+def get_stdin(prefix, path):
+    """stdin can only be read once, to completion...
+
+    To facilitate this, we follow get_pipe()'s example, and maintain a cache.
+    To support Windows we do not use the "file" /dev/stdin, but rather sys.stdin
+
+    As we're not using get_file(), we need to re-implement exception handling
+    """
+    global STDIN_CACHE
+    try:
+        if STDIN_CACHE is None:
+            STDIN_CACHE = ''.join(sys.stdin.readlines())
+        return STDIN_CACHE
+    except (OSError, IOError):
+        raise ResourceLoadingError('Unable to read standard input: %s' % ( e ))
+
 LOCAL_PREFIX_MAP = {
     'file://': (get_file, {'mode': 'r'}),
     'fileb://': (get_file, {'mode': 'rb'}),
     'pipe://': (get_pipe, {}),
+    'stdin://': (get_stdin, {}),
 }
 
 

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -260,17 +260,22 @@ def get_uri(prefix, uri):
     except Exception as e:
         raise ResourceLoadingError('Unable to retrieve %s: %s' % (uri, e))
 
-STDIN_CACHE = None
-def get_stdin(prefix, path):
-    global STDIN_CACHE
-    if STDIN_CACHE is None:
-        STDIN_CACHE = get_file(prefix, prefix + '/dev/stdin', mode = 'r')
-    return STDIN_CACHE
+PIPE_CACHE = {}
+def get_pipe(prefix, path):
+    """Pipes can only be read once, to completion...
+
+    To facilitate this, we will maintain a cache of pipes that have been read.
+    Expected use includes /dev/stdin
+    """
+    global PIPE_CACHE
+    if path not in PIPE_CACHE:
+        PIPE_CACHE[path] = get_file(prefix, path, mode = 'r')
+    return PIPE_CACHE[path]
 
 LOCAL_PREFIX_MAP = {
     'file://': (get_file, {'mode': 'r'}),
     'fileb://': (get_file, {'mode': 'rb'}),
-    'stdin://': (get_stdin, {}),
+    'pipe://': (get_pipe, {}),
 }
 
 

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -260,10 +260,17 @@ def get_uri(prefix, uri):
     except Exception as e:
         raise ResourceLoadingError('Unable to retrieve %s: %s' % (uri, e))
 
+STDIN_CACHE = None
+def get_stdin(prefix, path):
+    global STDIN_CACHE
+    if STDIN_CACHE is None:
+        STDIN_CACHE = get_file(prefix, prefix + '/dev/stdin', mode = 'r')
+    return STDIN_CACHE
 
 LOCAL_PREFIX_MAP = {
     'file://': (get_file, {'mode': 'r'}),
     'fileb://': (get_file, {'mode': 'rb'}),
+    'stdin://': (get_stdin, {}),
 }
 
 

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -47,6 +47,21 @@ class TestParamFile(unittest.TestCase):
         self.assertEqual(data, b'This is a test')
         self.assertIsInstance(data, six.binary_type)
 
+    def test_pipe_file(self):
+        contents = 'This is a test'
+        filename = self.files.create_file('foo', contents)
+        prefixed_filename = 'pipe://' + filename
+        data = get_paramfile(prefixed_filename)
+        self.assertEqual(data, contents)
+        self.assertIsInstance(data, six.string_types)
+
+        # simulate a second read (where the pipeline will have been depleated)
+        filename = self.files.create_file('foo', '')
+        prefixed_filename = 'pipe://' + filename
+        data = get_paramfile(prefixed_filename)
+        self.assertEqual(data, contents)
+        self.assertIsInstance(data, six.string_types)
+
     @skip_if_windows('Binary content error only occurs '
                      'on non-Windows platforms.')
     def test_cannot_load_text_file(self):


### PR DESCRIPTION
I'd like to use `aws` in a pipeline, as per [this question](https://superuser.com/q/1306071/707676).
It seems that `aws` will read the indicated file twice, using the second dataset for operation - in a pipeline, the second dataset will be empty...

I've implemented something basic that works - use the `stdin://` prefix/schema.