### PR TITLE
Removed typo in --kerebos-attributes parameter

### DIFF
--- a/awscli/examples/emr/create-cluster-synopsis.rst
+++ b/awscli/examples/emr/create-cluster-synopsis.rst
@@ -22,4 +22,4 @@
      [--custom-ami-id <value>]
      [--ebs-root-volume-size <value>]
      [--repo-upgrade-on-boot <value>]
-     [--kerberos--attributes <value>]
+     [--kerberos-attributes <value>]


### PR DESCRIPTION
I noticed there were two dashes in the kerebos-attributes parameter instead of one. All other examples of this parameter show only one dash and no other AWS CLI options that I have seen use multiple dashes to separate words like this so I assume this was a typo.

Running `aws emr create-cluster --kerberos--attributes` also yields `Unknown options: --kerberos--attributes` while `aws emr create-cluster --kerberos-attributes` recognizes the argument.

Thanks