### PR TITLE
Add config override by env var for s3transfer

### DIFF
--- a/awscli/customizations/s3/transferconfig.py
+++ b/awscli/customizations/s3/transferconfig.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
+
 from s3transfer.manager import TransferConfig
 
 from awscli.customizations.s3.utils import human_readable_to_bytes
@@ -56,10 +58,20 @@ class RuntimeConfig(object):
         runtime_config = DEFAULTS.copy()
         if kwargs:
             runtime_config.update(kwargs)
+        environment_config = self._config_from_environment()
+        runtime_config.update(**environment_config)
         self._convert_human_readable_sizes(runtime_config)
         self._convert_human_readable_rates(runtime_config)
         self._validate_config(runtime_config)
         return runtime_config
+
+    def _config_from_environment(self):
+        environment_config = {}
+        for name in DEFAULTS.keys():
+            value = os.environ.get('AWS_S3_' + name.upper(), None)
+            if value is not None:
+                environment_config[name] = value
+        return environment_config
 
     def _convert_human_readable_sizes(self, runtime_config):
         for attr in self.HUMAN_READABLE_SIZES:

--- a/tests/unit/customizations/s3/test_transferconfig.py
+++ b/tests/unit/customizations/s3/test_transferconfig.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
+import mock
+import os
 
 from awscli.customizations.s3 import transferconfig
 from awscli.compat import six
@@ -43,6 +45,21 @@ class TestTransferConfig(unittest.TestCase):
         # And defaults were used for values not specified.
         self.assertEqual(runtime_config['max_queue_size'],
                          int(transferconfig.DEFAULTS['max_queue_size']))
+
+    @mock.patch('os.environ', {
+        'AWS_S3_MULTIPART_THRESHOLD': '10',
+        'AWS_S3_MULTIPART_CHUNKSIZE': '11',
+        'AWS_S3_MAX_CONCURRENT_REQUESTS': '12',
+        'AWS_S3_MAX_QUEUE_SIZE': '13',
+        'AWS_S3_MAX_BANDWIDTH': '10MB/s'})
+    def test_environmental_varlue_provides(self):
+        runtime_config = self.build_config_with()
+
+        self.assertEqual(runtime_config['multipart_threshold'], 10)
+        self.assertEqual(runtime_config['multipart_chunksize'], 11)
+        self.assertEqual(runtime_config['max_concurrent_requests'], 12)
+        self.assertEqual(runtime_config['max_queue_size'], 13)
+        self.assertEqual(runtime_config['max_bandwidth'], 10485760)
 
     def test_validates_integer_types(self):
         with self.assertRaises(transferconfig.InvalidConfigError):


### PR DESCRIPTION
For s3transfer, profile configuration overrided by environ varialble.
This change enable to set config variable dynamically, instead of profile. 

In my case, I wish to use calculated value for max_bandwidth, vary on traffic status, transfer object size.

```
AWS_S3_MULTIPART_THRESHOLD
AWS_S3_MULTIPART_CHUNKSIZE
AWS_S3_MAX_CONCURRENT_REQUESTS
AWS_S3_MAX_QUEUE_SIZE
AWS_S3_MAX_BANDWIDTH
```

eg.
`AWS_S3_MAX_BANDWIDTH=30MB/s aws s3 sync ... ....`