### PR TITLE
Add ONEZONE_IA to s3 transfer commands

### DIFF
--- a/.changes/next-release/enhancement-s3-99343.json
+++ b/.changes/next-release/enhancement-s3-99343.json
@@ -1,0 +1,5 @@
+{
+  "category": "s3", 
+  "type": "enhancement", 
+  "description": "Add ONEZONE_IA option to the --storage-class argument of the s3 transfer commands"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -248,11 +248,12 @@ SSE_C_COPY_SOURCE_KEY = {
 
 
 STORAGE_CLASS = {'name': 'storage-class',
-                 'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA'],
+                 'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA',
+                             'ONEZONE_IA'],
                  'help_text': (
                      "The type of storage to use for the object. "
                      "Valid choices are: STANDARD | REDUCED_REDUNDANCY "
-                     "| STANDARD_IA. "
+                     "| STANDARD_IA | ONEZONE_IA. "
                      "Defaults to 'STANDARD'")}
 
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -98,6 +98,21 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[0][1]['Bucket'], 'bucket')
         self.assertEqual(self.operations_called[0][1]['Expires'], '90')
 
+    def test_upload_onezone_ia(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = ('%s %s s3://bucket/key.txt --storage-class ONEZONE_IA' %
+                   (self.prefix, full_path))
+        self.parsed_responses = \
+            [{'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 1,
+                         self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        args = self.operations_called[0][1]
+        self.assertEqual(args['Key'], 'key.txt')
+        self.assertEqual(args['Bucket'], 'bucket')
+        self.assertEqual(args['StorageClass'], 'ONEZONE_IA')
+
     def test_operations_used_in_download_file(self):
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},


### PR DESCRIPTION
Add the ONEZONE_IA option to the argument --storage-class on the three
s3 transfer commands sync, mv and cp.

fixes #3252 