### PR TITLE
Add newline to config when adding a new section

### DIFF
--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -77,8 +77,14 @@ class ConfigFileWriter(object):
             pass
 
     def _write_new_section(self, section_name, new_values, config_filename):
+        section_header = '[%s]\n' % section_name
+        if os.path.isfile(config_filename) and os.path.getsize(config_filename) > 0:
+             with open(config_filename, 'r') as f:
+                 f.seek(-1, 2)
+                 if f.read(1) != '\n':
+                     section_header = '\n' + section_header
         with open(config_filename, 'a') as f:
-            f.write('[%s]\n' % section_name)
+            f.write(section_header)
             contents = []
             self._insert_new_values(line_number=0,
                                     contents=contents,

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -79,9 +79,9 @@ class ConfigFileWriter(object):
     def _write_new_section(self, section_name, new_values, config_filename):
         section_header = '[%s]\n' % section_name
         if os.path.isfile(config_filename) and os.path.getsize(config_filename) > 0:
-             with open(config_filename, 'r') as f:
+             with open(config_filename, 'rb') as f:
                  f.seek(-1, 2)
-                 if f.read(1) != '\n':
+                 if ord(f.read(1)) != ord('\n'):
                      section_header = '\n' + section_header
         with open(config_filename, 'a') as f:
             f.write(section_header)

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -68,6 +68,12 @@ class TestConfigFileWriter(unittest.TestCase):
             '[default]\nfoo=1\nbar=2',
             {'baz': 'newvalue'}, expected)
 
+    def test_handle_no_newline(self):
+        original = '[default]\nfoo=1\nbar=1'
+        updated = '[default]\nfoo=1\nbar=1\n[foo]\nbar = 1\n'
+        self.assert_update_config(
+            original, {'__section__': 'foo', 'bar': '1'}, updated)
+
     def test_insert_values_in_middle_section(self):
         original_contents = (
             '[a]\n'


### PR DESCRIPTION
I found this issue when I used `aws configure --profile new_profile` and I had an existing hand-written configuration. My `~/.aws/credentials` had no new line at the end:

```
[default]
aws_access_key_id=xxx
aws_secret_access_key=xxxx
```

I then used `aws configure --profile new_profile` and got:

```
[default]
aws_access_key_id=xxx
aws_secret_access_key=xxxx[new_profile]
aws_access_key_id=xxx
aws_secret_access_key=xxxx
```

Any `aws` command failed after this because the configuration file was corrupted.

This PR adds a simple check to add a new line when needed.