### PR TITLE
Revert "Use --no-download for creating bundled installer"

### DIFF
--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -94,7 +94,7 @@ def download_cli_deps(scratch_dir):
     # Step one create a virtualenv.
     venv_dir = tempfile.mkdtemp()
     try:
-        run('virtualenv --no-download  %s' % venv_dir)
+        run('virtualenv %s' % venv_dir)
         pip = os.path.join(venv_dir, 'bin', 'pip')
         assert os.path.isfile(pip)
         awscli_dir = os.path.dirname(


### PR DESCRIPTION
Reverts aws/aws-cli#3277