### PR TITLE
Bundle in dateutil's setup_requires

### DIFF
--- a/.changes/next-release/bugfix-bundledinstaller-82739.json
+++ b/.changes/next-release/bugfix-bundledinstaller-82739.json
@@ -1,0 +1,5 @@
+{
+  "category": "bundled-installer", 
+  "type": "bugfix", 
+  "description": "Fixes a bug in the bundled installer caused by a dependency using `setup_requires`. pip doesn't manage these setup time dependencies, so we have to manually handle them. This fixes the issue where running the bundled installer on a machine without internet access would fail since we were not bundling all the transitive dependencies."
+}

--- a/scripts/install
+++ b/scripts/install
@@ -95,6 +95,16 @@ def pip_install_packages(install_dir):
     cli_tarball = cli_tarball[0]
     pip_script = os.path.join(install_dir, bin_path(), 'pip')
 
+    # Some packages declare `setup_requires`, which is a list of dependencies
+    # to be used at setup time. These need to be installed before anything
+    # else, and pip doesn't manage them.
+    setup_requires_dir = os.path.join(PACKAGES_DIR, 'setup')
+    with cd(setup_requires_dir):
+        for package in os.listdir(setup_requires_dir):
+            run('%s install --no-index --find-links file://%s %s' % (
+                pip_script, setup_requires_dir, package
+            ))
+
     with cd(PACKAGES_DIR):
         run('%s install --no-index --find-links file://%s %s' % (
             pip_script, PACKAGES_DIR, cli_tarball))

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -35,6 +35,7 @@ PACKAGE_VERSION = {
     'simplejson': '3.3.0',
     'argparse': '1.2.1',
     'python-dateutil': '2.6.1',
+    'setuptools-scm': '2.0.0',
 }
 INSTALL_ARGS = '--allow-all-external --no-use-wheel'
 
@@ -72,6 +73,7 @@ def create_scratch_dir():
     # Then we need to create a dir where all the packages
     # will come from.
     os.mkdir(os.path.join(dirname, 'packages'))
+    os.mkdir(os.path.join(dirname, 'packages', 'setup'))
     return dirname
 
 
@@ -176,6 +178,17 @@ def main():
     download_package_tarballs(
         package_dir,
         packages=['virtualenv', 'ordereddict', 'simplejson', 'argparse', 'python-dateutil'])
+
+    # Some packages require setup time dependencies, and so we will need to
+    # manually install them. We isolate them to a particular directory so we
+    # can run the install before the things they're dependent on. We have to do
+    # this because pip won't actually find them since it doesn't handle build
+    # dependencies.
+    setup_dir = os.path.join(package_dir, 'setup')
+    download_package_tarballs(
+        setup_dir,
+        packages=['setuptools-scm']
+    )
     download_cli_deps(package_dir)
     add_cli_sdist(package_dir)
     create_bootstrap_script(scratch_dir)


### PR DESCRIPTION
dateutil added a `setup_requires`, which is a setup time dependency. pip
doesn't manage these, so we have to make sure that they're installed
ourselves. This bundles in the existing `setup_requires` packages and
makes sure that they're installed before anything else.