### PR TITLE
Add lock to DatabaseRecordWriter

### DIFF
--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -140,16 +140,15 @@ class DatabaseRecordWriter(object):
 
     def __init__(self, connection):
         self._connection = connection
+        self._lock = threading.Lock()
 
     def close(self):
         self._connection.close()
 
     def write_record(self, record):
-        # This method is not threadsafe by itself, it is only threadsafe when
-        # used inside a handler bound to the HistoryRecorder in botocore which
-        # is protected by a lock.
         db_record = self._create_db_record(record)
-        self._connection.execute(self._WRITE_RECORD, db_record)
+        with self._lock:
+            self._connection.execute(self._WRITE_RECORD, db_record)
 
     def _create_db_record(self, record):
         event_type = record['event_type']


### PR DESCRIPTION
This will allow the removal of the lock from the global history recorder as the DB writer is the only component currently that is definitely not thread safe and needs a lock. The reader may technically be not thread safe as well but it is only ever used by a single thread.

Related botocore PR that removes the lock: https://github.com/boto/botocore/pull/1447

Either this should get merged first or both roughly at the same time.