### PR TITLE
Support `--s3-endpoint-url` argument to `cloudformation package`

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -96,6 +96,16 @@ class DeployCommand(BasicCommand):
         },
 
         {
+            'name': 's3-endpoint-url',
+            'help_text': (
+                'URL of storage service where packaged templates and artifacts'
+                ' will be uploaded. Useful for testing and local development'
+                ' or when uploading to a non-AWS storage service that is'
+                ' nonetheless S3-compatible.'
+            )
+        },
+
+        {
             'name': 'kms-key-id',
             'help_text': (
                 'The ID of an AWS KMS key that the command uses'
@@ -276,7 +286,8 @@ class DeployCommand(BasicCommand):
                 "s3",
                 config=Config(signature_version='s3v4'),
                 region_name=parsed_globals.region,
-                verify=parsed_globals.verify_ssl)
+                verify=parsed_globals.verify_ssl,
+                endpoint_url=parsed_args.s3_endpoint_url)
 
             s3_uploader = S3Uploader(s3_client,
                                       bucket,

--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -75,6 +75,16 @@ class PackageCommand(BasicCommand):
         },
 
         {
+            'name': 's3-endpoint-url',
+            'help_text': (
+                'URL of storage service where packaged templates and artifacts'
+                ' will be uploaded. Useful for testing and local development'
+                ' or when uploading to a non-AWS storage service that is'
+                ' nonetheless S3-compatible.'
+            )
+        },
+
+        {
             'name': 'kms-key-id',
             'help_text': (
                 'The ID of an AWS KMS key that the command uses'
@@ -128,7 +138,8 @@ class PackageCommand(BasicCommand):
             "s3",
             config=Config(signature_version='s3v4'),
             region_name=parsed_globals.region,
-            verify=parsed_globals.verify_ssl)
+            verify=parsed_globals.verify_ssl,
+            endpoint_url=parsed_args.s3_endpoint_url)
 
         template_path = parsed_args.template_file
         if not os.path.isfile(template_path):

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -53,8 +53,12 @@ PARAMFILE_DISABLED = set([
     'cloudformation.set-stack-policy.stack-policy-url',
     # aws cloudformation package --template-file
     'custom.package.template-file',
+    # aws cloudformation package --s3-endpoint-url
+    'custom.package.s3-endpoint-url',
     # aws cloudformation deploy --template-file
     'custom.deploy.template-file',
+    # aws cloudformation deploy --s3-endpoint-url
+    'custom.deploy.s3-endpoint-url',
 
     'cloudformation.update-stack.stack-policy-during-update-url',
     # We will want to change the event name to ``s3`` as opposed to

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -60,6 +60,7 @@ class TestDeployCommand(unittest.TestCase):
                                     fail_on_empty_changeset=True,
                                     s3_bucket=None,
                                     s3_prefix="some prefix",
+                                    s3_endpoint_url="http://localhost",
                                     kms_key_id="some kms key id",
                                     force_upload=True,
                                     tags=["tagkey1=tagvalue1"])

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -50,6 +50,7 @@ class TestPackageCommand(unittest.TestCase):
         self.parsed_args = FakeArgs(template_file='./foo',
                                     s3_bucket="s3bucket",
                                     s3_prefix="s3prefix",
+                                    s3_endpoint_url="http://localhost",
                                     kms_key_id="kmskeyid",
                                     output_template_file="./oputput",
                                     use_json=False,


### PR DESCRIPTION
Most other S3 commands accept an `--endpoint-url` argument. `cloudformation package` uses S3 under the hood, so it made sense to me that we could allow users to configure the S3 endpoint.

Additionally, it makes it somewhat easier to use to launch CF stacks for local development/testing. See https://github.com/localstack/localstack/issues/632.