### PR TITLE
Adding set subscription attributes examples

### DIFF
--- a/awscli/examples/sns/set-subscription-attributes.rst
+++ b/awscli/examples/sns/set-subscription-attributes.rst
@@ -1,0 +1,31 @@
+**To set subscription attributes**
+
+This example sets the RawMessageDelivery attribute to an SQS subscription.
+
+Command::
+
+  aws sns set-subscription-attributes --subscription-arn arn:aws:sns:us-east-1:012345678912:mytopic:f248de18-2cf6-578c-8592-b6f1eaa877dc --attribute-name RawMessageDelivery --attribute-value true
+  
+Output::
+
+  None.
+
+This example sets a FilterPolicy attribute to an SQS subscription.
+
+Command::
+
+  aws sns set-subscription-attributes --subscription-arn arn:aws:sns:us-east-1:012345678912:mytopic:f248de18-2cf6-578c-8592-b6f1eaa877dc --attribute-name FilterPolicy --attribute-value "{ \"anyMandatoryKey\": [\"any\", \"of\", \"these\"] }"
+
+Output::
+
+  None.
+
+This example removes the FilterPolicy attribute from an SQS subscription.
+
+Command::
+
+  aws sns set-subscription-attributes --subscription-arn arn:aws:sns:us-east-1:012345678912:mytopic:f248de18-2cf6-578c-8592-b6f1eaa877dc --attribute-name FilterPolicy --attribute-value "{}"
+
+Output::
+
+  None.


### PR DESCRIPTION
Adding some examples for set subscription attributes. There is an example to change an attribute value for RawMessageDelivery, another to add a FilterPolicy and a last one to remove the FilterPolicy.