### PR TITLE
Fix --query statement in command example

### DIFF
--- a/awscli/examples/ssm/get-parameters.rst
+++ b/awscli/examples/ssm/get-parameters.rst
@@ -23,7 +23,7 @@ To list the name and value of multiple parameters the --query argument can be us
 
 Command::
   
-  aws ssm get-parameters --names key1 key2 --query "Parameters[*].{Name:Value,Value:Value}"
+  aws ssm get-parameters --names key1 key2 --query "Parameters[*].{Name:Name,Value:Value}"
 
 Output::
   


### PR DESCRIPTION
Without this change the example outputs the parameter _value_
for both the Name and Value keys, which is not expected.