### PR TITLE
Allow forward slashes in key names in shorthand

### DIFF
--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -162,8 +162,8 @@ class ShorthandParser(object):
         return {key: values}
 
     def _key(self):
-        # key = 1*(alpha / %x30-39 / %x5f / %x2e / %x23)  ; [a-zA-Z0-9\-_.#]
-        valid_chars = string.ascii_letters + string.digits + '-_.#'
+        # key = 1*(alpha / %x30-39 / %x5f / %x2e / %x23)  ; [a-zA-Z0-9\-_.#/]
+        valid_chars = string.ascii_letters + string.digits + '-_.#/'
         start = self._index
         while not self._at_eof():
             if self._current() not in valid_chars:

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -59,6 +59,9 @@ def test_parse():
     # Pound signs are allowed.
     yield (_can_parse, '#key=value', {'#key': 'value'})
 
+    # Forward slashes are allowed in keys.
+    yield (_can_parse, 'some/thing=value', {'some/thing': 'value'})
+
     # Explicit lists.
     yield (_can_parse, 'foo=[]', {'foo': []})
     yield (_can_parse, 'foo=[a]', {'foo': ['a']})


### PR DESCRIPTION
Forward slashes can appear in key names for example when using the `aws cognito-identity get-id` command's `--logins` parameter.