### PR TITLE
Fixing a TypeError when running from context of library

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -371,8 +371,9 @@ class BucketLister(object):
             contents = page.get('Contents', [])
             for content in contents:
                 source_path = bucket + '/' + content['Key']
-                content['LastModified'] = self._date_parser(
-                    content['LastModified'])
+                last_modified = content['LastModified']
+                if type(last_modified) is not datetime:
+                    content['LastModified'] = self._date_parser(last_modified)
                 yield source_path, content
 
 

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -249,6 +249,27 @@ class TestBucketList(unittest.TestCase):
              ('foo/c', individual_response_elements[2])])
         for individual_response in individual_response_elements:
             self.assertEqual(individual_response['LastModified'], now)
+            
+    def test_list_objects_from_library_context(self):
+        self.client.get_paginator.return_value.paginate = self.fake_paginate
+        dt = datetime.datetime(2014, 2, 27, hour=4, minute=20, second=38)
+        individual_response_elements = [
+            {'LastModified': dt, 'Key': 'a', 'Size': 1},
+            {'LastModified': dt, 'Key': 'b', 'Size': 2},
+            {'LastModified': dt, 'Key': 'c', 'Size': 3}
+        ]
+        self.responses = [
+            {'Contents': individual_response_elements[0:2]},
+            {'Contents': [individual_response_elements[2]]}
+        ]
+        lister = BucketLister(self.client, self.date_parser)
+        objects = list(lister.list_objects(bucket='foo'))
+        self.assertEqual(objects,
+            [('foo/a', individual_response_elements[0]),
+             ('foo/b', individual_response_elements[1]),
+             ('foo/c', individual_response_elements[2])])
+        for individual_response in individual_response_elements:
+            self.assertEqual(individual_response['LastModified'], dt)
 
     def test_list_objects_passes_in_extra_args(self):
         self.client.get_paginator.return_value.paginate.return_value = [


### PR DESCRIPTION
When running the S3 Sync from the context of a library, a TypeError occurs here because the BucketLister erroneously assumes the LastModified value is a string. Boto3's default behavior is for LastModified to be a datetime, and only in the case where one is running the aws cli from the context of a command line application is it a string.