### PR TITLE
removed tag-value filter from examples

### DIFF
--- a/awscli/examples/ec2/describe-images.rst
+++ b/awscli/examples/ec2/describe-images.rst
@@ -50,11 +50,11 @@ Command::
 
 **To describe tagged AMIs**
 
-This example describes all AMIs that have the tag ``Custom=Linux1`` or ``Custom=Ubuntu1``. The output is filtered to display only the AMI IDs.
+This example describes all AMIs that have the tag ``Custom=Linux1``. The output is filtered to display only the AMI IDs.
 
 Command::
 
-  aws ec2 describe-images --filters Name=tag-key,Values=Custom Name=tag-value,Values=Linux1,Ubuntu1 --query 'Images[*].{ID:ImageId}'
+  aws ec2 describe-images --filters "Name=tag:Custom,Values=Linux1" --query 'Images[*].{ID:ImageId}'
 
 Output::
 

--- a/awscli/examples/ec2/describe-security-groups.rst
+++ b/awscli/examples/ec2/describe-security-groups.rst
@@ -128,7 +128,7 @@ This example describes all security groups that include ``test`` in the security
 
 Command::
 
-  aws ec2 describe-security-groups --filters Name=group-name,Values='*test*' Name=tag-key,Values=Test Name=tag-value,Values=To-delete --query 'SecurityGroups[*].{Name:GroupName,ID:GroupId}'
+  aws ec2 describe-security-groups --filters Name=group-name,Values=*test* Name=tag:Test,Values=To-delete --query 'SecurityGroups[*].{Name:GroupName,ID:GroupId}'
   
 Output::
 

--- a/awscli/examples/ec2/describe-snapshots.rst
+++ b/awscli/examples/ec2/describe-snapshots.rst
@@ -54,7 +54,7 @@ This example command describes all snapshots that have the tag ``Group=Prod``. T
 
 Command::
 
-  aws ec2 describe-snapshots --filters Name=tag-key,Values="Group" Name=tag-value,Values="Prod" --query 'Snapshots[*].{ID:SnapshotId,Time:StartTime}'
+  aws ec2 describe-snapshots --filters Name=tag:Group,Values=Prod --query 'Snapshots[*].{ID:SnapshotId,Time:StartTime}'
 
 Output::
 

--- a/awscli/examples/ec2/describe-volumes.rst
+++ b/awscli/examples/ec2/describe-volumes.rst
@@ -113,7 +113,7 @@ This example command describes all volumes that have the tag key ``Name`` and a 
 
 Command::
 
-  aws ec2 describe-volumes --filters Name=tag-key,Values="Name" Name=tag-value,Values="Test*" --query 'Volumes[*].{ID:VolumeId,Tag:Tags}'
+  aws ec2 describe-volumes --filters Name=tag:Name,Values=Test* --query 'Volumes[*].{ID:VolumeId,Tag:Tags}'
 
 Output::
 

--- a/awscli/examples/ec2/describe-vpc-peering-connections.rst
+++ b/awscli/examples/ec2/describe-vpc-peering-connections.rst
@@ -72,11 +72,11 @@ Command::
   aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance
 
 
-This example describes all of your VPC peering connections that have the tag Name=Finance or Name=Accounts.
+This example describes all of your VPC peering connections that have the tag Owner=Finance.
 
 Command::
 
-  aws ec2 describe-vpc-peering-connections --filters Name=tag-key,Values=Name Name=tag-value,Values=Finance,Accounts
+  aws ec2 describe-vpc-peering-connections --filters Name=tag:Owner,Values=Finance
 
 
 This example describes all of the VPC peering connections you requested for the specified VPC, vpc-1a2b3c4d.


### PR DESCRIPTION
Removed "tag-value" filter from example commands. Users should instead use the "tag:key=value" filter to filter on assigned tags. The "tag-values" filter will be removed from the list of supported filters soon.