### PR TITLE
Paramfile handler object

### DIFF
--- a/.changes/next-release/enhancement-Argumentprocessing-46505.json
+++ b/.changes/next-release/enhancement-Argumentprocessing-46505.json
@@ -1,0 +1,5 @@
+{
+  "category": "Argument processing",
+  "type": "enhancement",
+  "description": "Added cli_follow_urlparam option in the config file which can be set to false to disable the automatic following of string parameters prefixed with http:// or https://. closes #2507 #3076 #2577. Further discussion #3398."
+}

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -18,8 +18,6 @@ from awscli.compat import six
 from botocore.compat import OrderedDict, json
 
 from awscli import SCALAR_TYPES, COMPLEX_TYPES
-from awscli.paramfile import get_paramfile, ResourceLoadingError
-from awscli.paramfile import PARAMFILE_DISABLED
 from awscli import shorthand
 from awscli.utils import find_service_and_method_in_event_name
 from botocore.utils import is_json_value_header
@@ -86,27 +84,6 @@ def unpack_argument(session, service_name, operation_name, cli_argument, value):
         value = value_override
 
     return value
-
-
-def uri_param(event_name, param, value, **kwargs):
-    """Handler that supports param values from URIs.
-    """
-    cli_argument = param
-    qualified_param_name = '.'.join(event_name.split('.')[1:])
-    if qualified_param_name in PARAMFILE_DISABLED or \
-            getattr(cli_argument, 'no_paramfile', None):
-        return
-    else:
-        return _check_for_uri_param(cli_argument, value)
-
-
-def _check_for_uri_param(param, value):
-    if isinstance(value, list) and len(value) == 1:
-        value = value[0]
-    try:
-        return get_paramfile(value)
-    except ResourceLoadingError as e:
-        raise ParamError(param.cli_name, six.text_type(e))
 
 
 def detect_shape_structure(param):

--- a/awscli/customizations/cliinputjson.py
+++ b/awscli/customizations/cliinputjson.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-from awscli.paramfile import get_paramfile
+from awscli.paramfile import get_paramfile, LOCAL_PREFIX_MAP
 from awscli.argprocess import ParamError
 from awscli.customizations.arguments import OverrideRequiredArgsArgument
 
@@ -60,7 +60,7 @@ class CliInputJSONArgument(OverrideRequiredArgsArgument):
         input_json = getattr(parsed_args, 'cli_input_json', None)
         if input_json is not None:
             # Retrieve the JSON from the file if needed.
-            retrieved_json = get_paramfile(input_json)
+            retrieved_json = get_paramfile(input_json, LOCAL_PREFIX_MAP)
             # Nothing was retrieved from the file. So assume the argument
             # is already a JSON string.
             if retrieved_json is None:

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -17,7 +17,7 @@ registered with the event system.
 
 """
 from awscli.argprocess import ParamShorthandParser
-from awscli.argprocess import uri_param
+from awscli.paramfile import register_uri_param_handler
 from awscli.customizations import datapipeline
 from awscli.customizations.addexamples import add_examples
 from awscli.customizations.argrename import register_arg_renames
@@ -83,7 +83,7 @@ from awscli.customizations.s3events import register_event_stream_arg
 
 
 def awscli_initialize(event_handlers):
-    event_handlers.register('load-cli-arg', uri_param)
+    event_handlers.register('session-initialized', register_uri_param_handler)
     param_shorthand = ParamShorthandParser()
     event_handlers.register('process-cli-arg', param_shorthand)
     # The s3 error mesage needs to registered before the

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -12,11 +12,13 @@
 # language governing permissions and limitations under the License.
 import logging
 import os
+import copy
 
 from botocore.vendored import requests
 from awscli.compat import six
 
 from awscli.compat import compat_open
+from awscli.argprocess import ParamError
 
 
 logger = logging.getLogger(__name__)
@@ -121,7 +123,45 @@ class ResourceLoadingError(Exception):
     pass
 
 
-def get_paramfile(path):
+def register_uri_param_handler(session, **kwargs):
+    prefix_map = copy.deepcopy(LOCAL_PREFIX_MAP)
+    fetch_url = session.get_scoped_config().get(
+        'cli_follow_urlparam', 'true') == 'true'
+
+    if fetch_url:
+        prefix_map.update(REMOTE_PREFIX_MAP)
+
+    handler = URIArgumentHandler(prefix_map)
+    session.register('load-cli-arg', handler)
+
+
+class URIArgumentHandler(object):
+    def __init__(self, prefixes=None):
+        if prefixes is None:
+            prefixes = copy.deepcopy(LOCAL_PREFIX_MAP)
+            prefixes.update(REMOTE_PREFIX_MAP)
+        self._prefixes = prefixes
+
+    def __call__(self, event_name, param, value, **kwargs):
+        """Handler that supports param values from URIs."""
+        cli_argument = param
+        qualified_param_name = '.'.join(event_name.split('.')[1:])
+        if qualified_param_name in PARAMFILE_DISABLED or \
+                getattr(cli_argument, 'no_paramfile', None):
+            return
+        else:
+            return self._check_for_uri_param(cli_argument, value)
+
+    def _check_for_uri_param(self, param, value):
+        if isinstance(value, list) and len(value) == 1:
+            value = value[0]
+        try:
+            return get_paramfile(value, self._prefixes)
+        except ResourceLoadingError as e:
+            raise ParamError(param.cli_name, six.text_type(e))
+
+
+def get_paramfile(path, cases):
     """Load parameter based on a resource URI.
 
     It is possible to pass parameters to operations by referring
@@ -135,6 +175,10 @@ def get_paramfile(path):
     :param path: The resource URI, e.g. file://foo.txt.  This value
         may also be a non resource URI, in which case ``None`` is returned.
 
+    :type cases: dict
+    :param cases: A dictionary of URI prefixes to function mappings
+        that a parameter is checked against.
+
     :return: The loaded value associated with the resource URI.
         If the provided ``path`` is not a resource URI, then a
         value of ``None`` is returned.
@@ -142,7 +186,7 @@ def get_paramfile(path):
     """
     data = None
     if isinstance(path, six.string_types):
-        for prefix, function_spec in PREFIX_MAP.items():
+        for prefix, function_spec in cases.items():
             if path.startswith(prefix):
                 function, kwargs = function_spec
                 data = function(prefix, path, **kwargs)
@@ -177,9 +221,13 @@ def get_uri(prefix, uri):
         raise ResourceLoadingError('Unable to retrieve %s: %s' % (uri, e))
 
 
-PREFIX_MAP = {
+LOCAL_PREFIX_MAP = {
     'file://': (get_file, {'mode': 'r'}),
     'fileb://': (get_file, {'mode': 'rb'}),
+}
+
+
+REMOTE_PREFIX_MAP = {
     'http://': (get_uri, {}),
     'https://': (get_uri, {}),
 }

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -487,7 +487,7 @@ class BaseCLIWireResponseTest(unittest.TestCase):
 
     def patch_send(self, status_code=200, headers={}, content=b''):
         if self.send_is_patched:
-            self.patch_send.stop()
+            self.send_patch.stop()
             self.send_is_patched = False
         send_patch = self.send_patch.start()
         send_patch.return_value = mock.Mock(status_code=status_code,

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -71,6 +71,8 @@ output               --output    output                AWS_DEFAULT_OUTPUT    Def
 -------------------- ----------- --------------------- --------------------- ----------------------------
 cli_timestamp_format N/A         cli_timestamp_format  N/A                   Output format of timestamps
 -------------------- ----------- --------------------- --------------------- ----------------------------
+cli_follow_urlparam  N/A         cli_follow_urlparam   N/A                   Fetch URL url parameters
+-------------------- ----------- --------------------- --------------------- ----------------------------
 ca_bundle            --ca-bundle ca_bundle             AWS_CA_BUNDLE         CA Certificate Bundle
 -------------------- ----------- --------------------- --------------------- ----------------------------
 parameter_validation             parameter_validation                        Toggles parameter validation
@@ -88,10 +90,21 @@ The valid values of the ``output`` configuration variable are:
 * text
 
 ``cli_timestamp_format`` controls the format of timestamps displayed by the AWS CLI.
-The valid values of the ``cli_timestamp_format`` configuration varaible are:
+The valid values of the ``cli_timestamp_format`` configuration variable are:
 
 * none - Display the timestamp exactly as received from the HTTP response.
 * iso8601 - Reformat timestamp using iso8601 in the UTC timezone.
+
+``cli_follow_urlparam`` controls whether or not the CLI will attempt to follow
+URL links in parameters that start with either prefix ``https://`` or
+``http://``.  The valid values of the ``cli_follow_urlparam`` configuration
+variable are:
+
+* true - This is the default value. With this configured the CLI will follow
+  any string parameters that start with ``https://`` or ``http://`` will be
+  fetched, and the downloaded content will be used as the parameter instead.
+* false - The CLI will not treat strings prefixed with ``https://`` or
+  ``http://`` any differently than normal string parameters.
 
 ``parameter_validation`` controls whether parameter validation should occur
 when serializing requests. The default is True. You can disable parameter

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -1,0 +1,203 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+
+from mock import patch, ANY
+
+from awscli.testutils import FileCreator, BaseAWSCommandParamsTest
+from awscli.clidriver import create_clidriver
+
+logger = logging.getLogger(__name__)
+
+
+class FakeResponse(object):
+    def __init__(self, content):
+        self.status_code = 200
+        self.text = content
+
+
+class BaseTestCLIFollowParamURL(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(BaseTestCLIFollowParamURL, self).setUp()
+        self.files = FileCreator()
+        self.prefix = 'lambda get-function --function-name'
+
+    def tearDown(self):
+        super(BaseTestCLIFollowParamURL, self).tearDown()
+        self.files.remove_all()
+
+    def assert_param_expansion_is_correct(self, provided_param, expected_param):
+        cmd = '%s %s' % (self.prefix, provided_param)
+        # We do not care about the return code here. All that is of interest
+        # is what happened to the arguments before they were passed to botocore
+        # which we get from the params={} key. For binary types we will fail in
+        # python 3 with an rc of 255 and get an rc of 0 in python 2 where it
+        # can't tell the difference, so we pass ANY here to ignore the rc.
+        self.assert_params_for_cmd(cmd,
+                                   params={'FunctionName': expected_param},
+                                   expected_rc=ANY)
+
+
+class TestCLIFollowParamURLDefault(BaseTestCLIFollowParamURL):
+    def test_does_not_prefixes_when_none_in_param(self):
+        self.assert_param_expansion_is_correct(
+            provided_param='foobar',
+            expected_param='foobar'
+        )
+
+    @patch('awscli.paramfile.requests.get')
+    def test_does_use_http_prefix(self, mock_get):
+        content = 'http_content'
+        mock_get.return_value = FakeResponse(content=content)
+        param = 'http://foobar.com'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=content
+        )
+        mock_get.assert_called_with(param)
+
+    @patch('awscli.paramfile.requests.get')
+    def test_does_use_https_prefix(self, mock_get):
+        content = 'https_content'
+        mock_get.return_value = FakeResponse(content=content)
+        param = 'https://foobar.com'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=content
+        )
+        mock_get.assert_called_with(param)
+
+    def test_does_use_file_prefix(self):
+        path = self.files.create_file('foobar.txt', 'file content')
+        param = 'file://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param='file content'
+        )
+
+    def test_does_use_fileb_prefix(self):
+        # The command will fail with error code 255 since bytes type does
+        # not work for this parameter, however we still record the raw
+        # parameter that we passed, which is all this test is concerend about.
+        path = self.files.create_file('foobar.txt', b'file content', mode='wb')
+        param = 'fileb://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=b'file content'
+        )
+
+
+class TestCLIFollowParamURLDisabled(BaseTestCLIFollowParamURL):
+    def setUp(self):
+        super(TestCLIFollowParamURLDisabled, self).setUp()
+        self.environ['AWS_CONFIG_FILE'] = self.files.create_file(
+            'config',
+            '[default]\ncli_follow_urlparam = false\n')
+        self.driver = create_clidriver()
+
+    def test_does_not_prefixes_when_none_in_param(self):
+        param = 'foobar'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=param
+        )
+
+    @patch('awscli.paramfile.requests.get')
+    def test_does_not_use_http_prefix(self, mock_get):
+        param = 'http://foobar'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=param
+        )
+        mock_get.assert_not_called()
+
+    @patch('awscli.paramfile.requests.get')
+    def test_does_not_use_https_prefix(self, mock_get):
+        param = 'https://foobar'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=param
+        )
+        mock_get.assert_not_called()
+
+    def test_does_use_file_prefix(self):
+        path = self.files.create_file('foobar.txt', 'file content')
+        param = 'file://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param='file content'
+        )
+
+    def test_does_use_fileb_prefix(self):
+        # The command will fail with error code 255 since bytes type does
+        # not work for this parameter, however we still record the raw
+        # parameter that we passed, which is all this test is concerend about.
+        path = self.files.create_file('foobar.txt', b'file content', mode='wb')
+        param = 'fileb://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=b'file content'
+        )
+
+
+class TestCLIFollowParamURLEnabled(BaseTestCLIFollowParamURL):
+    def setUp(self):
+        super(TestCLIFollowParamURLEnabled, self).setUp()
+        self.environ['AWS_CONFIG_FILE'] = self.files.create_file(
+            'config',
+            '[default]\ncli_follow_urlparam = true\n')
+        self.driver = create_clidriver()
+
+    def test_does_not_prefixes_when_none_in_param(self):
+        self.assert_param_expansion_is_correct('foobar', 'foobar')
+
+    @patch('awscli.paramfile.requests.get')
+    def test_does_use_http_prefix(self, mock_get):
+        content = 'http_content'
+        mock_get.return_value = FakeResponse(content=content)
+        param = 'http://foobar.com'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=content
+        )
+        mock_get.assert_called_with(param)
+
+    @patch('awscli.paramfile.requests.get')
+    def test_does_use_https_prefix(self, mock_get):
+        content = 'https_content'
+        mock_get.return_value = FakeResponse(content=content)
+        param = 'https://foobar.com'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=content
+        )
+        mock_get.assert_called_with(param)
+
+    def test_does_use_file_prefix(self):
+        path = self.files.create_file('foobar.txt', 'file content')
+        param = 'file://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param='file content'
+        )
+
+    def test_does_use_fileb_prefix(self):
+        # The command will fail with error code 255 since bytes type does
+        # not work for this parameter, however we still record the raw
+        # parameter that we passed, which is all this test is concerend about.
+        path = self.files.create_file('foobar.txt', b'file content', mode='wb')
+        param = 'fileb://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=b'file content'
+        )

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -27,7 +27,7 @@ from awscli.argprocess import ParamShorthandParser
 from awscli.argprocess import ParamShorthandDocGen
 from awscli.argprocess import ParamError
 from awscli.argprocess import ParamUnknownKeyError
-from awscli.argprocess import uri_param
+from awscli.paramfile import URIArgumentHandler
 from awscli.arguments import CustomArgument, CLIArgument
 from awscli.arguments import ListArgument, BooleanArgument
 from awscli.arguments import create_argument_model_from_schema
@@ -68,13 +68,19 @@ class BaseArgProcessTest(BaseCLIDriverTest):
 
 
 class TestURIParams(BaseArgProcessTest):
+    def setUp(self):
+        super(TestURIParams, self).setUp()
+        self.uri_param = URIArgumentHandler()
+
     def test_uri_param(self):
         p = self.get_param_model('ec2.DescribeInstances.Filters')
         with temporary_file('r+') as f:
-            json_argument = json.dumps([{"Name": "instance-id", "Values": ["i-1234"]}])
+            json_argument = json.dumps(
+                [{"Name": "instance-id", "Values": ["i-1234"]}]
+            )
             f.write(json_argument)
             f.flush()
-            result = uri_param('event-name', p, 'file://%s' % f.name)
+            result = self.uri_param('event-name', p, 'file://%s' % f.name)
         self.assertEqual(result, json_argument)
 
     def test_uri_param_no_paramfile_false(self):
@@ -84,7 +90,7 @@ class TestURIParams(BaseArgProcessTest):
             json_argument = json.dumps([{"Name": "instance-id", "Values": ["i-1234"]}])
             f.write(json_argument)
             f.flush()
-            result = uri_param('event-name', p, 'file://%s' % f.name)
+            result = self.uri_param('event-name', p, 'file://%s' % f.name)
         self.assertEqual(result, json_argument)
 
     def test_uri_param_no_paramfile_true(self):
@@ -94,7 +100,7 @@ class TestURIParams(BaseArgProcessTest):
             json_argument = json.dumps([{"Name": "instance-id", "Values": ["i-1234"]}])
             f.write(json_argument)
             f.flush()
-            result = uri_param('event-name', p, 'file://%s' % f.name)
+            result = self.uri_param('event-name', p, 'file://%s' % f.name)
         self.assertEqual(result, None)
 
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -32,6 +32,7 @@ from awscli.clidriver import CustomArgument
 from awscli.clidriver import CLICommand
 from awscli.clidriver import ServiceCommand
 from awscli.clidriver import ServiceOperation
+from awscli.paramfile import URIArgumentHandler
 from awscli.customizations.commands import BasicCommand
 from awscli import formatter
 from awscli.argparser import HELP_BLURB
@@ -510,51 +511,60 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         self.assertEqual(len(args_seen), 1)
         self.assertEqual(args_seen[0].unknown_arg, 'foo')
 
-    def test_custom_arg_paramfile(self):
-        with mock.patch('awscli.handlers.uri_param',
-                        return_value=None) as uri_param_mock:
-            driver = create_clidriver()
-            driver.session.register(
-                'building-argument-table', self.inject_new_param)
+    @mock.patch('awscli.paramfile.URIArgumentHandler',
+                spec=URIArgumentHandler)
+    def test_custom_arg_paramfile(self, mock_handler):
+        mock_paramfile = mock.Mock(autospec=True)
+        mock_paramfile.return_value = None
+        mock_handler.return_value = mock_paramfile
 
-            self.patch_make_request()
-            rc = driver.main(
-                'ec2 describe-instances --unknown-arg file:///foo'.split())
+        driver = create_clidriver()
+        driver.session.register(
+            'building-argument-table', self.inject_new_param)
 
-            self.assertEqual(rc, 0)
+        self.patch_make_request()
+        rc = driver.main(
+            'ec2 describe-instances --unknown-arg file:///foo'.split())
 
-            # Make sure uri_param was called
-            uri_param_mock.assert_any_call(
-                event_name='load-cli-arg.ec2.describe-instances.unknown-arg',
-                operation_name='describe-instances',
-                param=mock.ANY,
-                service_name='ec2',
-                value='file:///foo',
-            )
-            # Make sure it was called with our passed-in URI
-            self.assertEqual('file:///foo',
-                             uri_param_mock.call_args_list[-1][1]['value'])
+        self.assertEqual(rc, 0)
 
-    def test_custom_command_paramfile(self):
-        with mock.patch('awscli.handlers.uri_param',
-                        return_value=None) as uri_param_mock:
-            driver = create_clidriver()
-            driver.session.register(
-                'building-command-table', self.inject_command)
+        # Make sure uri_param was called
+        mock_paramfile.assert_any_call(
+            event_name='load-cli-arg.ec2.describe-instances.unknown-arg',
+            operation_name='describe-instances',
+            param=mock.ANY,
+            service_name='ec2',
+            value='file:///foo',
+        )
+        # Make sure it was called with our passed-in URI
+        self.assertEqual(
+            'file:///foo',
+            mock_paramfile.call_args_list[-1][1]['value'])
 
-            self.patch_make_request()
-            rc = driver.main(
-                'ec2 foo --bar file:///foo'.split())
+    @mock.patch('awscli.paramfile.URIArgumentHandler',
+                spec=URIArgumentHandler)
+    def test_custom_command_paramfile(self, mock_handler):
+        mock_paramfile = mock.Mock(autospec=True)
+        mock_paramfile.return_value = None
+        mock_handler.return_value = mock_paramfile
 
-            self.assertEqual(rc, 0)
+        driver = create_clidriver()
+        driver.session.register(
+            'building-command-table', self.inject_command)
 
-            uri_param_mock.assert_any_call(
-                event_name='load-cli-arg.custom.foo.bar',
-                operation_name='foo',
-                param=mock.ANY,
-                service_name='custom',
-                value='file:///foo',
-            )
+        self.patch_make_request()
+        rc = driver.main(
+            'ec2 foo --bar file:///foo'.split())
+
+        self.assertEqual(rc, 0)
+
+        mock_paramfile.assert_any_call(
+            event_name='load-cli-arg.custom.foo.bar',
+            operation_name='foo',
+            param=mock.ANY,
+            service_name='custom',
+            value='file:///foo',
+        )
 
     @unittest.skip
     def test_custom_arg_no_paramfile(self):

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -10,14 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import platform
-
 import mock
 from awscli.compat import six
 from awscli.testutils import unittest, FileCreator
 from awscli.testutils import skip_if_windows
 
 from awscli.paramfile import get_paramfile, ResourceLoadingError
+from awscli.paramfile import URIArgumentHandler
+from awscli.paramfile import LOCAL_PREFIX_MAP, REMOTE_PREFIX_MAP
+from awscli.paramfile import register_uri_param_handler
+from botocore.hooks import HierarchicalEmitter
 
 
 class TestParamFile(unittest.TestCase):
@@ -27,11 +29,14 @@ class TestParamFile(unittest.TestCase):
     def tearDown(self):
         self.files.remove_all()
 
+    def get_paramfile(self, path):
+        return get_paramfile(path, LOCAL_PREFIX_MAP.copy())
+
     def test_text_file(self):
         contents = 'This is a test'
         filename = self.files.create_file('foo', contents)
         prefixed_filename = 'file://' + filename
-        data = get_paramfile(prefixed_filename)
+        data = self.get_paramfile(prefixed_filename)
         self.assertEqual(data, contents)
         self.assertIsInstance(data, six.string_types)
 
@@ -39,7 +44,7 @@ class TestParamFile(unittest.TestCase):
         contents = 'This is a test'
         filename = self.files.create_file('foo', contents)
         prefixed_filename = 'fileb://' + filename
-        data = get_paramfile(prefixed_filename)
+        data = self.get_paramfile(prefixed_filename)
         self.assertEqual(data, b'This is a test')
         self.assertIsInstance(data, six.binary_type)
 
@@ -50,17 +55,17 @@ class TestParamFile(unittest.TestCase):
         filename = self.files.create_file('foo', contents, mode='wb')
         prefixed_filename = 'file://' + filename
         with self.assertRaises(ResourceLoadingError):
-            get_paramfile(prefixed_filename)
+            self.get_paramfile(prefixed_filename)
 
     def test_file_does_not_exist_raises_error(self):
         with self.assertRaises(ResourceLoadingError):
-            get_paramfile('file://file/does/not/existsasdf.txt')
+            self.get_paramfile('file://file/does/not/existsasdf.txt')
 
     def test_no_match_uris_returns_none(self):
-        self.assertIsNone(get_paramfile('foobar://somewhere.bar'))
+        self.assertIsNone(self.get_paramfile('foobar://somewhere.bar'))
 
     def test_non_string_type_returns_none(self):
-        self.assertIsNone(get_paramfile(100))
+        self.assertIsNone(self.get_paramfile(100))
 
 
 class TestHTTPBasedResourceLoading(unittest.TestCase):
@@ -73,24 +78,27 @@ class TestHTTPBasedResourceLoading(unittest.TestCase):
     def tearDown(self):
         self.requests_patch.stop()
 
+    def get_paramfile(self, path):
+        return get_paramfile(path, REMOTE_PREFIX_MAP.copy())
+
     def test_resource_from_http(self):
         self.response.text = 'http contents'
-        loaded = get_paramfile('http://foo.bar.baz')
+        loaded = self.get_paramfile('http://foo.bar.baz')
         self.assertEqual(loaded, 'http contents')
         self.requests_mock.get.assert_called_with('http://foo.bar.baz')
 
     def test_resource_from_https(self):
         self.response.text = 'http contents'
-        loaded = get_paramfile('https://foo.bar.baz')
+        loaded = self.get_paramfile('https://foo.bar.baz')
         self.assertEqual(loaded, 'http contents')
         self.requests_mock.get.assert_called_with('https://foo.bar.baz')
 
     def test_non_200_raises_error(self):
         self.response.status_code = 500
         with self.assertRaisesRegexp(ResourceLoadingError, 'foo\.bar\.baz'):
-            get_paramfile('https://foo.bar.baz')
+            self.get_paramfile('https://foo.bar.baz')
 
     def test_connection_error_raises_error(self):
         self.requests_mock.get.side_effect = Exception("Connection error.")
         with self.assertRaisesRegexp(ResourceLoadingError, 'foo\.bar\.baz'):
-            get_paramfile('https://foo.bar.baz')
+            self.get_paramfile('https://foo.bar.baz')


### PR DESCRIPTION
Add configuration option to opt-out of url parameter fetching

By default the CLI will fetch the content from any string parameter that
starts with https:// or http:// and use the content as the parameter
rather than the URL itself. This adds a configuration option to block
this behavior and these two cases the same as any other string argument.

Specifically the newly added config option is the `cli_follow_urlparam`
option. It can be used to disable this behavior by adding the following
to the config file in `.aws/config`.

```
cli_follow_urlparam = false
```

If the value is set to `true` or if the config key is not present then the
default behavior is preserved.
