### PR TITLE
Alias old names changed by xform_name() changes

### DIFF
--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -86,6 +86,22 @@ HIDDEN_ALIASES = {
     'storagegateway.describe-cached-iscsi-volumes.volume-arns': 'volume-ar-ns',
     'storagegateway.describe-stored-iscsi-volumes.volume-arns': 'volume-ar-ns',
     'route53domains.view-billing.start-time': 'start',
+    # These come from the xform_name() changes that no longer separates words
+    # by numbers.
+    'deploy.create-deployment-group.ec2-tag-set': 'ec-2-tag-set',
+    'deploy.list-application-revisions.s3-bucket': 's-3-bucket',
+    'deploy.list-application-revisions.s3-key-prefix': 's-3-key-prefix',
+    'deploy.update-deployment-group.ec2-tag-set': 'ec-2-tag-set',
+    'iam.enable-mfa-device.authentication-code1': 'authentication-code-1',
+    'iam.enable-mfa-device.authentication-code2': 'authentication-code-2',
+    'iam.resync-mfa-device.authentication-code1': 'authentication-code-1',
+    'iam.resync-mfa-device.authentication-code2': 'authentication-code-2',
+    'importexport.get-shipping-label.street1': 'street-1',
+    'importexport.get-shipping-label.street2': 'street-2',
+    'importexport.get-shipping-label.street3': 'street-3',
+    'lambda.publish-version.code-sha256': 'code-sha-256',
+    'lightsail.import-key-pair.public-key-base64': 'public-key-base-64',
+    'opsworks.register-volume.ec2-volume-id': 'ec-2-volume-id',
 }
 
 


### PR DESCRIPTION
We changed how xform_name() separates words by numbers
and as a result, some of the top level params in the CLI
changed.  To preserve backwards compatibility, I've added
aliases for every affected param.

See boto/botocore#1492 for more info.

Here's the diff I got:

```
--- /tmp/develop-cli-names.txt	2018-06-25 17:26:56.000000000 -0700
+++ /tmp/xform-cli-names.txt	2018-06-25 17:26:43.000000000 -0700
@@ -6360,8 +6360,8 @@
 deploy:create-deployment-group:deployment-config-name
 deploy:create-deployment-group:deployment-group-name
 deploy:create-deployment-group:deployment-style
-deploy:create-deployment-group:ec-2-tag-set
 deploy:create-deployment-group:ec2-tag-filters
+deploy:create-deployment-group:ec2-tag-set
 deploy:create-deployment-group:generate-cli-skeleton
 deploy:create-deployment-group:load-balancer-info
 deploy:create-deployment-group:on-premises-instance-tag-filters
@@ -6436,8 +6436,8 @@
 deploy:list-application-revisions:generate-cli-skeleton
 deploy:list-application-revisions:max-items
 deploy:list-application-revisions:next-token
-deploy:list-application-revisions:s-3-bucket
-deploy:list-application-revisions:s-3-key-prefix
+deploy:list-application-revisions:s3-bucket
+deploy:list-application-revisions:s3-key-prefix
 deploy:list-application-revisions:sort-by
 deploy:list-application-revisions:sort-order
 deploy:list-application-revisions:starting-token
@@ -6551,8 +6551,8 @@
 deploy:update-deployment-group:current-deployment-group-name
 deploy:update-deployment-group:deployment-config-name
 deploy:update-deployment-group:deployment-style
-deploy:update-deployment-group:ec-2-tag-set
 deploy:update-deployment-group:ec2-tag-filters
+deploy:update-deployment-group:ec2-tag-set
 deploy:update-deployment-group:generate-cli-skeleton
 deploy:update-deployment-group:load-balancer-info
 deploy:update-deployment-group:new-deployment-group-name
@@ -14703,8 +14703,8 @@
 iam:detach-user-policy:policy-arn
 iam:detach-user-policy:user-name
 iam:operation:enable-mfa-device
-iam:enable-mfa-device:authentication-code-1
-iam:enable-mfa-device:authentication-code-2
+iam:enable-mfa-device:authentication-code1
+iam:enable-mfa-device:authentication-code2
 iam:enable-mfa-device:cli-input-json
 iam:enable-mfa-device:generate-cli-skeleton
 iam:enable-mfa-device:serial-number
@@ -15045,8 +15045,8 @@
 iam:reset-service-specific-credential:service-specific-credential-id
 iam:reset-service-specific-credential:user-name
 iam:operation:resync-mfa-device
-iam:resync-mfa-device:authentication-code-1
-iam:resync-mfa-device:authentication-code-2
+iam:resync-mfa-device:authentication-code1
+iam:resync-mfa-device:authentication-code2
 iam:resync-mfa-device:cli-input-json
 iam:resync-mfa-device:generate-cli-skeleton
 iam:resync-mfa-device:serial-number
@@ -15227,9 +15227,9 @@
 importexport:get-shipping-label:phone-number
 importexport:get-shipping-label:postal-code
 importexport:get-shipping-label:state-or-province
-importexport:get-shipping-label:street-1
-importexport:get-shipping-label:street-2
-importexport:get-shipping-label:street-3
+importexport:get-shipping-label:street1
+importexport:get-shipping-label:street2
+importexport:get-shipping-label:street3
 importexport:operation:get-status
 importexport:get-status:api-version
 importexport:get-status:cli-input-json
@@ -17198,7 +17198,7 @@
 lambda:list-versions-by-function:max-items
 lambda:operation:publish-version
 lambda:publish-version:cli-input-json
-lambda:publish-version:code-sha-256
+lambda:publish-version:code-sha256
 lambda:publish-version:description
 lambda:publish-version:function-name
 lambda:publish-version:generate-cli-skeleton
@@ -17863,7 +17863,7 @@
 lightsail:import-key-pair:cli-input-json
 lightsail:import-key-pair:generate-cli-skeleton
 lightsail:import-key-pair:key-pair-name
-lightsail:import-key-pair:public-key-base-64
+lightsail:import-key-pair:public-key-base64
 lightsail:operation:is-vpc-peered
 lightsail:is-vpc-peered:cli-input-json
 lightsail:is-vpc-peered:generate-cli-skeleton
@@ -20361,7 +20361,7 @@
 opsworks:register-rds-db-instance:stack-id
 opsworks:operation:register-volume
 opsworks:register-volume:cli-input-json
-opsworks:register-volume:ec-2-volume-id
+opsworks:register-volume:ec2-volume-id
 opsworks:register-volume:generate-cli-skeleton
 opsworks:register-volume:stack-id
 opsworks:operation:set-load-based-auto-scaling

```

using this script:

```python
import awscli.clidriver


def main():
    driver = awscli.clidriver.create_clidriver()
    help_command = driver.create_help_command()
    for command_name, command_obj in sorted(help_command.command_table.items()):
        sub_help = command_obj.create_help_command()
        if hasattr(sub_help, 'command_table'):
            for sub_name, sub_command in sorted(sub_help.command_table.items()):
                print(f"{command_name}:operation:{sub_name}")
                op_help = sub_command.create_help_command()
                arg_table = op_help.arg_table
                for arg_name in sorted(arg_table):
                    print(f"{command_name}:{sub_name}:{arg_name}")
                leaf_help = sub_command.create_help_command()
                if hasattr(leaf_help, 'command_table'):
                    leaf_command_table = leaf_help.command_table
                    for leaf_name, leaf_command in sorted(leaf_command_table.items()):
                        print(f"{command_name}:leaf:{leaf_name}")
                        # We're making the assumption that there's nothing
                        # lower than 4 levels of nesting, but to ensure
                        # we don't miss anything we'll add an assertion
                        # to flag any cases we miss.
                        assert not leaf_command.create_help_command().command_table


main()

```