### PR TITLE
Metadata option for cloudformation package command

### DIFF
--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -109,6 +109,17 @@ class PackageCommand(BasicCommand):
                 ' Specify this flag to upload artifacts even if they '
                 ' match existing artifacts in the S3 bucket.'
             )
+        },
+        {
+            "name": "metadata",
+            "cli_type_name": "map",
+            "schema": {
+                "type": "map",
+                "key": {"type": "string"},
+                "value": {"type": "string"}
+            },
+            "help_text": "A map of metadata to attach to *ALL* the artifacts that"
+            " are referenced in your template."
         }
     ]
 
@@ -132,6 +143,8 @@ class PackageCommand(BasicCommand):
                                       parsed_args.s3_prefix,
                                       parsed_args.kms_key_id,
                                       parsed_args.force_upload)
+        # attach the given metadata to the artifacts to be uploaded
+        self.s3_uploader.artifact_metadata = parsed_args.metadata
 
         output_file = parsed_args.output_template_file
         use_json = parsed_args.use_json

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -44,6 +44,19 @@ class S3Uploader(object):
     does not already use versioning, this class will turn on versioning.
     """
 
+    @property
+    def artifact_metadata(self):
+        """
+        Metadata to attach to the object(s) uploaded by the uploader.
+        """
+        return self._artifact_metadata
+
+    @artifact_metadata.setter
+    def artifact_metadata(self, val):
+        if val is not None and type(val) is not dict:
+            raise TypeError("Artifact metadata should be in dict type")
+        self._artifact_metadata = val
+
     def __init__(self, s3_client,
                  bucket_name,
                  region,
@@ -61,6 +74,8 @@ class S3Uploader(object):
         self.transfer_manager = transfer_manager
         if not transfer_manager:
             self.transfer_manager = TransferManager(self.s3)
+
+        self._artifact_metadata = None
 
     def upload(self, file_name, remote_path):
         """
@@ -90,6 +105,9 @@ class S3Uploader(object):
             if self.kms_key_id:
                 additional_args["ServerSideEncryption"] = "aws:kms"
                 additional_args["SSEKMSKeyId"] = self.kms_key_id
+
+            if self.artifact_metadata:
+                additional_args["Metadata"] = self.artifact_metadata
 
             print_progress_callback = \
                 ProgressPercentage(file_name, remote_path)

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -53,7 +53,8 @@ class TestPackageCommand(unittest.TestCase):
                                     kms_key_id="kmskeyid",
                                     output_template_file="./oputput",
                                     use_json=False,
-                                    force_upload=False)
+                                    force_upload=False,
+                                    metadata=None)
         self.parsed_globals = FakeArgs(region="us-east-1", endpoint_url=None,
                                        verify_ssl=None)
         self.package_command = PackageCommand(self.session)


### PR DESCRIPTION
Re: https://github.com/aws/aws-cli/issues/3417

This adds the functionality to attach metadata to **ALL** the artifacts
referenced in the input CloudFormation template when they are uploaded
to S3.