### PR TITLE
Keep modification time when zipping single file to avoid new checksum

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -210,6 +210,7 @@ def copy_to_temp_dir(filepath):
     tmp_dir = tempfile.mkdtemp()
     dst = os.path.join(tmp_dir, os.path.basename(filepath))
     shutil.copyfile(filepath, dst)
+    shutil.copystat(filepath, dst)
     return tmp_dir
 
 


### PR DESCRIPTION
The `cloudformation package` command will upload a zip, e.g. for source of a lambda function. When referencing a directory, the files stays in-place when being zipped. However, when referencing a single file, a temporary directory is created and the file is copied there before the directory is zipped.

Before, the file stats were not copied, leading to new modification times every time `cloudformation package` were run referencing a single file.

This change also copies the file stats, ensuring the zip file gets the same checksum and filename as previous runs, and avoids an necessary upload and change set of the CFN stack, unless the source file gets a new modification time or changes content.

Partly solves #3131. However, the source file still needs to have the same modification time as previous to avoid a new checksum. In a CI-environment the file will probably get a different modification time for every checkout. This can be mitigated by forcing a modification timestamp on the source file, e.g. by `touch -t '200001010000' file.py` before running `cloudformation package`.

I'm a bit unsure about the tests I've added. Don't like adding `time.sleep()`, but not sure how to test this otherwise.