### PR TITLE
Add template name defaults for SAM commands

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -50,14 +50,6 @@ class DeployCommand(BasicCommand):
 
     ARG_TABLE = [
         {
-            'name': 'template-file',
-            'required': True,
-            'help_text': (
-                'The path where your AWS CloudFormation'
-                ' template is located.'
-            )
-        },
-        {
             'name': 'stack-name',
             'action': 'store',
             'required': True,
@@ -65,6 +57,15 @@ class DeployCommand(BasicCommand):
                 'The name of the AWS CloudFormation stack you\'re deploying to.'
                 ' If you specify an existing stack, the command updates the'
                 ' stack. If you specify a new stack, the command creates it.'
+            )
+        },
+        {
+            'name': 'template-file',
+            'required': False,
+            'default': 'packaged-template.yaml',
+            'help_text': (
+                'The path where your AWS CloudFormation template is located.'
+                ' Defaults to packaged-template.yaml.'
             )
         },
         {

--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -47,20 +47,21 @@ class PackageCommand(BasicCommand):
 
     ARG_TABLE = [
         {
-            'name': 'template-file',
-            'required': True,
-            'help_text': (
-                'The path where your AWS CloudFormation'
-                ' template is located.'
-            )
-        },
-
-        {
             'name': 's3-bucket',
             'required': True,
             'help_text': (
                 'The name of the S3 bucket where this command uploads'
                 ' the artifacts that are referenced in your template.'
+            )
+        },
+
+        {
+            'name': 'template-file',
+            'required': False,
+            'default': 'template.yaml',
+            'help_text': (
+                'The path where your AWS CloudFormation template is located.'
+                ' Defaults to template.yaml.'
             )
         },
 


### PR DESCRIPTION
SAM strives to make deployment of serverless applications to AWS as
easy as possible. To make it even easier as it is right now, this commit
adds defaults for the template file names the `cloudformation package`
and `cloudformation deploy` commands take.

The default values for the template names are taken from the
[SAM Howto][1]. If there are better fitting values I'm of course
open to adjusting them.

Together with #3040 this commit would allow running
`cloudformation package` without the need to provide any arguments.

[1]: https://github.com/awslabs/serverless-application-model/blob/master/HOWTO.md