### PR TITLE
Add top level parameters for passing images to rekognition

### DIFF
--- a/.changes/next-release/enhancement-rekognition-66230.json
+++ b/.changes/next-release/enhancement-rekognition-66230.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "rekognition",
+  "description": "Added top level parameters to rekognition to make it possible\nto supply images to the operations that require bytes."
+}

--- a/.changes/next-release/enhancement-rekognition-66230.json
+++ b/.changes/next-release/enhancement-rekognition-66230.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "rekognition",
-  "description": "Added top level parameters to rekognition to make it possible\nto supply images to the operations that require bytes."
+  "description": "Added top level parameters to rekognition to make it possible to supply images to the operations that require bytes."
 }

--- a/awscli/customizations/rekognition.py
+++ b/awscli/customizations/rekognition.py
@@ -1,0 +1,80 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.arguments import CustomArgument
+
+
+IMAGE_FILE_DOCSTRING = ('<p>The path to the image file you are uploading. '
+                        'Example: fileb://image.png</p>')
+IMAGE_DOCSTRING_ADDENDUM = ('<p>To specify a local file use <code>--%s</code> '
+                            'instead.</p>')
+
+
+class ParameterReplacement(object):
+    def __init__(self, source_param, target_param):
+        self.source_param = source_param
+        self.target_param = target_param
+
+
+FILE_PARAMETER_UPDATES = {
+    'compare-faces': [
+        ParameterReplacement('source-image', 'SourceImage'),
+        ParameterReplacement('target-image', 'TargetImage')
+    ],
+    'detect-faces': [ParameterReplacement('image', 'Image')],
+    'detect-labels': [ParameterReplacement('image', 'Image')],
+    'detect-moderation-labels': [ParameterReplacement('image', 'Image')],
+    'detect-text': [ParameterReplacement('image', 'Image')],
+    'index-faces': [ParameterReplacement('image', 'Image')],
+    'recognize-celebrities': [ParameterReplacement('image', 'Image')],
+    'search-faces-by-image': [ParameterReplacement('image', 'Image')],
+}
+
+
+def register_rekognition_detect_labels(cli):
+    for operation, params_to_update in FILE_PARAMETER_UPDATES.items():
+        cli.register('building-argument-table.rekognition.%s' % operation,
+                     ImageArgUpdater(params_to_update))
+
+
+class ImageArgUpdater(object):
+    def __init__(self, params_to_update):
+        self._params_to_update = params_to_update
+
+    def __call__(self, session, argument_table, **kwargs):
+        for param_to_update in self._params_to_update:
+            self._update_param(param_to_update, argument_table)
+
+    def _update_param(self, param_replacement, argument_table):
+        param = param_replacement.source_param
+        new_param = '%s-file' % param
+        argument_table[new_param] = ImageArgument(
+            new_param, param_replacement.target_param,
+            help_text=IMAGE_FILE_DOCSTRING, cli_type_name='blob')
+        argument_table[param].required = False
+        doc_addendum = IMAGE_DOCSTRING_ADDENDUM % new_param
+        argument_table[param].documentation += doc_addendum
+
+
+class ImageArgument(CustomArgument):
+    def __init__(self, name, parameter_to_overwrite, **kwargs):
+        super(ImageArgument, self).__init__(name, **kwargs)
+        self._parameter_to_overwrite = parameter_to_overwrite
+
+    def add_to_params(self, parameters, value):
+        if value is None:
+            return
+        image_file_param = {'Bytes': value}
+        if parameters.get(self._parameter_to_overwrite):
+            parameters[self._parameter_to_overwrite].update(image_file_param)
+        else:
+            parameters[self._parameter_to_overwrite] = image_file_param

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -65,6 +65,7 @@ from awscli.customizations.preview import register_preview_commands
 from awscli.customizations.putmetricdata import register_put_metric_data
 from awscli.customizations.rds import register_rds_modify_split
 from awscli.customizations.rds import register_add_generate_db_auth_token
+from awscli.customizations.rekognition import register_rekognition_detect_labels
 from awscli.customizations.removals import register_removals
 from awscli.customizations.route53 import register_create_hosted_zone_doc_fix
 from awscli.customizations.s3.s3 import s3_plugin_initialize
@@ -115,6 +116,7 @@ def awscli_initialize(event_handlers):
     register_removals(event_handlers)
     register_preview_commands(event_handlers)
     register_rds_modify_split(event_handlers)
+    register_rekognition_detect_labels(event_handlers)
     register_add_generate_db_auth_token(event_handlers)
     register_put_metric_data(event_handlers)
     register_ses_send_email(event_handlers)

--- a/tests/functional/rekognition/test_image_parameters.py
+++ b/tests/functional/rekognition/test_image_parameters.py
@@ -1,0 +1,211 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import FileCreator
+
+
+class BaseRekognitionTest(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(BaseRekognitionTest, self).setUp()
+        self.files = FileCreator()
+        self.temp_file = self.files.create_file(
+            'foo', 'mycontents')
+        with open(self.temp_file, 'rb') as f:
+            self.temp_file_bytes = f.read()
+
+    def tearDown(self):
+        super(BaseRekognitionTest, self).tearDown()
+        self.files.remove_all()
+
+
+class TestCompareFaces(BaseRekognitionTest):
+
+    prefix = 'rekognition compare-faces'
+
+    def test_image_file_does_populate_bytes_param(self):
+        second_temp_file = self.files.create_file('bar', 'othercontents')
+        second_file_bytes = open(second_temp_file, 'rb').read()
+
+        cmdline = self.prefix
+        cmdline += ' --source-image-file fileb://%s' % self.temp_file
+        cmdline += ' --target-image-file fileb://%s' % second_temp_file
+        result = {
+            'SourceImage': {'Bytes': self.temp_file_bytes},
+            'TargetImage': {'Bytes': second_file_bytes},
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --source-image Bytes=foo'
+        cmdline += ' --target-image Bytes=bar'
+        result = {
+            'SourceImage': {'Bytes': 'foo'},
+            'TargetImage': {'Bytes': 'bar'},
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestDetectFaces(BaseRekognitionTest):
+
+    prefix = 'rekognition detect-faces'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestDetectLabels(BaseRekognitionTest):
+
+    prefix = 'rekognition detect-labels'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestDetectModerationLabels(BaseRekognitionTest):
+
+    prefix = 'rekognition detect-moderation-labels'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestDetectText(BaseRekognitionTest):
+
+    prefix = 'rekognition detect-text'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestIndexFaces(BaseRekognitionTest):
+
+    prefix = 'rekognition index-faces'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --collection-id foobar'
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'CollectionId': 'foobar',
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --collection-id foobar'
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'CollectionId': 'foobar',
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestRecognizeCelebrities(BaseRekognitionTest):
+
+    prefix = 'rekognition recognize-celebrities'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+
+class TestSearchFacesByImage(BaseRekognitionTest):
+
+    prefix = 'rekognition search-faces-by-image'
+
+    def test_image_file_does_populate_bytes_param(self):
+        cmdline = self.prefix
+        cmdline += ' --collection-id foobar'
+        cmdline += ' --image-file fileb://%s' % self.temp_file
+        result = {
+            'CollectionId': 'foobar',
+            'Image': {'Bytes': self.temp_file_bytes}
+        }
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_image_bytes_still_works(self):
+        cmdline = self.prefix
+        cmdline += ' --collection-id foobar'
+        cmdline += ' --image Bytes=foobar'
+        result = {
+            'CollectionId': 'foobar',
+            'Image': {'Bytes': 'foobar'}
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/rekognition/test_image_parameters.py
+++ b/tests/functional/rekognition/test_image_parameters.py
@@ -37,8 +37,8 @@ class TestCompareFaces(BaseRekognitionTest):
         second_file_bytes = open(second_temp_file, 'rb').read()
 
         cmdline = self.prefix
-        cmdline += ' --source-image-file fileb://%s' % self.temp_file
-        cmdline += ' --target-image-file fileb://%s' % second_temp_file
+        cmdline += ' --source-image-bytes fileb://%s' % self.temp_file
+        cmdline += ' --target-image-bytes fileb://%s' % second_temp_file
         result = {
             'SourceImage': {'Bytes': self.temp_file_bytes},
             'TargetImage': {'Bytes': second_file_bytes},
@@ -62,7 +62,7 @@ class TestDetectFaces(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'Image': {'Bytes': self.temp_file_bytes}
         }
@@ -83,7 +83,7 @@ class TestDetectLabels(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'Image': {'Bytes': self.temp_file_bytes}
         }
@@ -104,7 +104,7 @@ class TestDetectModerationLabels(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'Image': {'Bytes': self.temp_file_bytes}
         }
@@ -125,7 +125,7 @@ class TestDetectText(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'Image': {'Bytes': self.temp_file_bytes}
         }
@@ -147,7 +147,7 @@ class TestIndexFaces(BaseRekognitionTest):
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
         cmdline += ' --collection-id foobar'
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'CollectionId': 'foobar',
             'Image': {'Bytes': self.temp_file_bytes}
@@ -171,7 +171,7 @@ class TestRecognizeCelebrities(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'Image': {'Bytes': self.temp_file_bytes}
         }
@@ -193,7 +193,7 @@ class TestSearchFacesByImage(BaseRekognitionTest):
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
         cmdline += ' --collection-id foobar'
-        cmdline += ' --image-file fileb://%s' % self.temp_file
+        cmdline += ' --image-bytes fileb://%s' % self.temp_file
         result = {
             'CollectionId': 'foobar',
             'Image': {'Bytes': self.temp_file_bytes}


### PR DESCRIPTION
Raw bytes cannot be passed to nested parameters. Rekognition has many
operations that accept an image as a nested parameter, as essentially a
tagged union between the raw local file, or an S3 location. In the CLI
the S3 location specification works, and the raw image bytes option does
not. This commit adds a new top level parameter that overwrites the
nested image bytes option, which allows for the use of the `fileb://`
prefix to load a file.

For example the detect-labels operation would look like this:

    aws rekognition detect-labels --image-file fileb://image.png

The new top level --image-file parameter fill in the Bytes value of the
existing --image parameter.