### PR TITLE
Feature/use s3 uploader for cf package with include transforms

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -452,12 +452,16 @@ class Template(object):
         here we iterate through the template dict and export params with a 
         handler defined in GLOBAL_EXPORT_DICT
         """
-        for key, val in iter(template_dict.items()):
+        for key, val in template_dict.items():
             if key in GLOBAL_EXPORT_DICT:
                 template_dict[key] = GLOBAL_EXPORT_DICT[key](val, self.uploader)
-            elif type(val) is dict:
+            elif isinstance(val, dict):
                 self.export_global_artifacts(val)
-        return self.template_dict
+            elif isinstance(val, list):
+                for item in val:
+                    if isinstance(item, dict):
+                        self.export_global_artifacts(item)
+        return template_dict
 
 
     def export(self):

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -452,7 +452,7 @@ class Template(object):
         here we iterate through the template dict and export params with a 
         handler defined in GLOBAL_EXPORT_DICT
         """
-        for key, val in template_dict.iteritems():
+        for key, val in iter(template_dict.items()):
             if key in GLOBAL_EXPORT_DICT:
                 template_dict[key] = GLOBAL_EXPORT_DICT[key](val, self.uploader)
             elif type(val) is dict:

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -8,7 +8,7 @@ Use this command to quickly upload local artifacts that might be required by
 your template. After you package your template's artifacts, run the deploy
 command to ``deploy`` the returned template.
 
-This command can upload local artifacts specified by following properties of a resource:
+This command can upload local artifacts referenced in the following places:
 
 
     - ``BodyS3Location`` property for the ``AWS::ApiGateway::RestApi`` resource
@@ -16,6 +16,7 @@ This command can upload local artifacts specified by following properties of a r
     - ``CodeUri`` property for the ``AWS::Serverless::Function`` resource
     - ``DefinitionS3Location`` property for the ``AWS::AppSync::GraphQLSchema`` resource
     - ``DefinitionUri`` property for the ``AWS::Serverless::Api`` resource
+    - ``Location`` parameter for the ``AWS::Include`` transform
     - ``SourceBundle`` property for the ``AWS::ElasticBeanstalk::ApplicationVersion`` resource
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -818,9 +818,10 @@ class TestArtifactExporter(unittest.TestCase):
                 exported_template = template_exporter.export_global_artifacts(template_exporter.template_dict)
 
                 first_call_args, kwargs = include_transform_export_handler_mock.call_args_list[0]
-                self.assertEquals(first_call_args[0], {"Name": "AWS::Include", "Parameters": {"Location": "foo.yaml"}})
                 second_call_args, kwargs = include_transform_export_handler_mock.call_args_list[1]
-                self.assertEquals(second_call_args[0], {"Name": "AWS::OtherTransform"})
+                call_args = [first_call_args[0], second_call_args[0]]
+                self.assertTrue({"Name": "AWS::Include", "Parameters": {"Location": "foo.yaml"}} in call_args)
+                self.assertTrue({"Name": "AWS::OtherTransform"} in call_args)
                 self.assertEquals(include_transform_export_handler_mock.call_count, 2)
                 #new s3 url is added to include location
                 self.assertEquals(exported_template["Resources"]["Resource1"]["Properties"]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -7,7 +7,7 @@ import random
 import zipfile
 
 from nose.tools import assert_true, assert_false, assert_equal
-from contextlib import contextmanager,closing
+from contextlib import contextmanager, closing, nested
 from mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
 from awscli.testutils import unittest, FileCreator
@@ -19,7 +19,7 @@ from awscli.customizations.cloudformation.artifact_exporter \
     ServerlessFunctionResource, GraphQLSchemaResource, \
     LambdaFunctionResource, ApiGatewayRestApiResource, \
     ElasticBeanstalkApplicationVersion, CloudFormationStackResource, \
-    copy_to_temp_dir
+    copy_to_temp_dir, include_transform_export_handler, GLOBAL_EXPORT_DICT
 
 
 def test_is_s3_url():
@@ -769,6 +769,88 @@ class TestArtifactExporter(unittest.TestCase):
             resource_type2_class.assert_called_once_with(self.s3_uploader_mock)
             resource_type2_instance.export.assert_called_once_with(
                 "Resource2", mock.ANY, template_dir)
+
+    @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
+    def test_template_global_export(self, yaml_parse_mock):
+        parent_dir = os.path.sep
+        template_dir = os.path.join(parent_dir, 'foo', 'bar')
+        template_path = os.path.join(template_dir, 'path')
+        template_str = self.example_yaml_template()
+
+        resource_type1_class = Mock()
+        resource_type1_instance = Mock()
+        resource_type1_class.return_value = resource_type1_instance
+        resource_type2_class = Mock()
+        resource_type2_instance = Mock()
+        resource_type2_class.return_value = resource_type2_instance
+
+        resources_to_export = {
+            "resource_type1": resource_type1_class,
+            "resource_type2": resource_type2_class
+        }
+        properties1 = {"foo": "bar", "Fn::Transform": {"Name": "AWS::Include", "Parameters": {"Location": "foo.yaml"}}}
+        properties2 = {"foo": "bar", "Fn::Transform": {"Name": "AWS::OtherTransform"}}
+        template_dict = {
+            "Resources": {
+                "Resource1": {
+                    "Type": "resource_type1",
+                    "Properties": properties1
+                },
+                "Resource2": {
+                    "Type": "resource_type2",
+                    "Properties": properties2
+                }
+            }
+        }
+        open_mock = mock.mock_open()
+        include_transform_export_handler_mock = Mock()
+        include_transform_export_handler_mock.return_value = {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}}
+        yaml_parse_mock.return_value = template_dict
+
+        with nested(
+            patch("awscli.customizations.cloudformation.artifact_exporter.open",
+                open_mock(read_data=template_str)),
+            patch.dict(GLOBAL_EXPORT_DICT, {"Fn::Transform": include_transform_export_handler_mock})) as (open_mock):
+
+            dict_patch = patch.dict(GLOBAL_EXPORT_DICT)
+            template_exporter = Template(
+                template_path, parent_dir, self.s3_uploader_mock,
+                resources_to_export)
+
+            exported_template = template_exporter.export_global_artifacts(template_exporter.template_dict)
+
+            first_call_args, kwargs = include_transform_export_handler_mock.call_args_list[0]
+            self.assertEquals(first_call_args[0], {"Name": "AWS::Include", "Parameters": {"Location": "foo.yaml"}})
+            second_call_args, kwargs = include_transform_export_handler_mock.call_args_list[1]
+            self.assertEquals(second_call_args[0], {"Name": "AWS::OtherTransform"})
+            self.assertEquals(include_transform_export_handler_mock.call_count, 2)
+            #new s3 url is added to include location
+            self.assertEquals(exported_template["Resources"]["Resource1"]["Properties"]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
+
+    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    def test_include_transform_export_handler(self, is_local_file_mock):
+        #exports transform
+        self.s3_uploader_mock.upload_with_dedup.return_value = "s3://foo"
+        is_local_file_mock.return_value = True
+        handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": "foo.yaml"}}, self.s3_uploader_mock)
+        self.s3_uploader_mock.upload_with_dedup.assert_called_once_with("foo.yaml")
+        self.assertEquals(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
+
+    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    def test_include_transform_export_handler_non_local_file(self, is_local_file_mock):
+        #returns unchanged template dict if transform not a local file
+        is_local_file_mock.return_value = False
+        handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": "http://foo.yaml"}}, self.s3_uploader_mock)
+        self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+        self.assertEquals(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": "http://foo.yaml"}})
+    
+    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    def test_include_transform_export_handler_non_include_transform(self, is_local_file_mock):
+        #ignores transform that is not aws::include
+        handler_output = include_transform_export_handler({"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}}, self.s3_uploader_mock)
+        self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+        self.assertEquals(handler_output, {"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}})
+
 
     def test_template_export_path_be_folder(self):
 


### PR DESCRIPTION
I recently opened a PR which added exports for include transform of inline swagger AWS::Serverless::Api resource. I've reconsidered and decided to add an implementation that will upload AWS::Include from anywhere in a cloud formation template for cloudformation package command. I have seen several discussions where users have asked for this feature, we would like to manage templates for various resources in isolation and also potentially reuse them in different stacks, this feature will help a lot towards this end. 

A few notes, I originally considered doing this on yaml parse or dump to avoid a pass through the entire template dictionary, however since JSON is also supported this would have been clunky, since it would be difficult to reuse parse hooks across pyyaml and json. It was impossible to add this without bypassing the existing "resource" export pattern since these can appear anywhere in the document, adding a handler that matched some key seemed reasonable to me, and I don't think we have to worry about cyclic references for yaml_parse return val. Lastly my python is not very strong and I've never used this unit testing framework, open to any suggestions you have

If this PR is approved I will reject and close the other one