### PR TITLE
Remove help name mapping

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -30,7 +30,6 @@ class CLIDocumentEventHandler(object):
     def __init__(self, help_command):
         self.help_command = help_command
         self.register(help_command.session, help_command.event_class)
-        self.help_command.doc.translation_map = self.build_translation_map()
         self._arg_groups = self._build_arg_table_groups(help_command)
         self._documented_arg_groups = []
 
@@ -40,9 +39,6 @@ class CLIDocumentEventHandler(object):
             if arg.group_name is not None:
                 arg_groups.setdefault(arg.group_name, []).append(arg)
         return arg_groups
-
-    def build_translation_map(self):
-        return dict()
 
     def _get_argument_type_name(self, shape, default):
         if is_json_value_header(shape):
@@ -249,13 +245,6 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
 class ServiceDocumentEventHandler(CLIDocumentEventHandler):
 
-    def build_translation_map(self):
-        d = {}
-        service_model = self.help_command.obj
-        for operation_name in service_model.operation_names:
-            d[operation_name] = xform_name(operation_name, '-')
-        return d
-
     # A service document has no synopsis.
     def doc_synopsis_start(self, help_command, **kwargs):
         pass
@@ -308,31 +297,6 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
 class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
     AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'
-
-    def build_translation_map(self):
-        operation_model = self.help_command.obj
-        d = {}
-        for cli_name, cli_argument in self.help_command.arg_table.items():
-            if cli_argument.argument_model is not None:
-                argument_name = cli_argument.argument_model.name
-                if argument_name in d:
-                    previous_mapping = d[argument_name]
-                    # If the argument name is a boolean argument, we want the
-                    # the translation to default to the one that does not start
-                    # with --no-. So we check if the cli parameter currently
-                    # being used starts with no- and if stripping off the no-
-                    # results in the new proposed cli argument name. If it
-                    # does, we assume we have the postive form of the argument
-                    # which is the name we want to use in doc translations.
-                    if cli_argument.cli_type_name == 'boolean' and \
-                            previous_mapping.startswith('no-') and \
-                            cli_name == previous_mapping[3:]:
-                        d[argument_name] = cli_name
-                else:
-                    d[argument_name] = cli_name
-        for operation_name in operation_model.service_model.operation_names:
-            d[operation_name] = xform_name(operation_name, '-')
-        return d
 
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc
@@ -587,7 +551,6 @@ class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     def __init__(self, help_command):
         self.help_command = help_command
         self.register(help_command.session, help_command.event_class)
-        self.help_command.doc.translation_map = self.build_translation_map()
         self._topic_tag_db = TopicTagDB()
         self._topic_tag_db.load_json_index()
 

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -366,9 +366,6 @@ class BasicDocHandler(OperationDocumentEventHandler):
         super(BasicDocHandler, self).__init__(help_command)
         self.doc = help_command.doc
 
-    def build_translation_map(self):
-        return {}
-
     def doc_description(self, help_command, **kwargs):
         self.doc.style.h2('Description')
         self.doc.write(help_command.description)

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -14,7 +14,6 @@ import json
 
 import mock
 from botocore.model import ShapeResolver, StructureShape, StringShape
-from botocore.model import DenormalizedStructureBuilder
 from botocore.docs.bcdoc.restdoc import ReSTDocument
 
 from awscli.testutils import unittest, FileCreator
@@ -105,42 +104,6 @@ class TestRecursiveShapes(unittest.TestCase):
         self.operation_handler.doc_option_example(
             'arg-name', self.help_command, 'process-cli-arg.foo.bar')
         self.assert_proper_indentation()
-
-
-class TestTranslationMap(unittest.TestCase):
-    def setUp(self):
-        self.arg_table = {}
-        self.help_command = mock.Mock()
-        self.help_command.event_class = 'custom'
-        self.help_command.arg_table = self.arg_table
-        self.operation_model = mock.Mock()
-        self.operation_model.service_model.operation_names = []
-        self.help_command.obj = self.operation_model
-        self.operation_handler = OperationDocumentEventHandler(
-            self.help_command)
-
-    def assert_rendered_docs_contain(self, expected):
-        writes = [args[0][0] for args in
-                  self.help_command.doc.write.call_args_list]
-        writes = '\n'.join(writes)
-        self.assertIn(expected, writes)
-
-    def test_boolean_arg_groups(self):
-        builder = DenormalizedStructureBuilder()
-        input_model = builder.with_members({
-            'Flag': {'type': 'boolean'}
-        }).build_model()
-        argument_model = input_model.members['Flag']
-        argument_model.name = 'Flag'
-        self.arg_table['flag'] = mock.Mock(
-            cli_type_name='boolean', argument_model=argument_model)
-        self.arg_table['no-flag'] = mock.Mock(
-            cli_type_name='boolean', argument_model=argument_model)
-        # The --no-flag should not be used in the translation.
-        self.assertEqual(
-            self.operation_handler.build_translation_map(),
-            {'Flag': 'flag'}
-        )
 
 
 class TestCLIDocumentEventHandler(unittest.TestCase):


### PR DESCRIPTION
Remove documentation mapping between the `APIFormat` and the `cli-format`.