### PR TITLE
adds capability to resolve anchors and aliases in yaml in `aws cloudformation package`

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -54,6 +54,17 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     return {cfntag: value}
 
 
+def _resolve_aliases(dict_to_resolve):
+    """
+    Resolves all anchors in a yaml template
+    :param dict_to_resolve
+    :return:
+    """
+    yaml.SafeDumper.ignore_aliases = lambda *args: True
+    return yaml.safe_load(
+        yaml.safe_dump(dict_to_resolve, default_flow_style=False))
+
+
 def yaml_dump(dict_to_dump):
     """
     Dumps the dictionary as a YAML document
@@ -73,4 +84,4 @@ def yaml_parse(yamlstr):
     except ValueError:
         yaml.SafeLoader.add_multi_constructor(
             "!", intrinsics_multi_constructor)
-        return yaml.safe_load(yamlstr)
+        return _resolve_aliases(yaml.safe_load(yamlstr))

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -30,6 +30,30 @@ class TestYaml(unittest.TestCase):
         Key5: !GetAtt OneMore.Outputs.Arn
         Key6: !Condition OtherCondition
     """
+    
+    yaml_with_aliases = """
+    Resource:
+        Foobar: &Foobar
+            Qux: Quux
+            Overridable: unknown
+        Baz:
+            <<: *Foobar
+            Overridable: True
+    """
+    
+    
+    parsed_yaml_with_aliases = {
+      "Resource": {
+        "Foobar": {
+          "Qux": "Quux", 
+          "Overridable": "unknown"
+        }, 
+        "Baz": {
+          "Qux": "Quux", 
+          "Overridable": True
+        }
+      }
+    }
 
     parsed_yaml_dict = {
         "Resource": {
@@ -68,6 +92,10 @@ class TestYaml(unittest.TestCase):
         output_again = yaml_parse(formatted_str)
         self.assertEquals(output, output_again)
 
+    def test_yaml_aliases_resolution(self):
+        output = yaml_parse(self.yaml_with_aliases)
+        self.assertEquals(self.parsed_yaml_with_aliases, output)
+        
     def test_yaml_getatt(self):
         # This is an invalid syntax for !GetAtt. But make sure the code does not crash when we encouter this syntax
         # Let CloudFormation interpret this value at runtime


### PR DESCRIPTION
*Issue #, if available:*

No issue number specifically, but this has been mentioned before in several cases and a feature folks have wanted natively in CloudFormation but we aren't going to get anytime soon.

*Description of changes:*

This simply enhances the yaml parser used to resolve anchors and aliases to a non-referential structure. This lets you do a little bit DRYing up your templates without any external tooling. This should be fully backwards compatible and you only need to use it if you want to.

Important to note, this is doing _nothing_ that nearly all other yaml libs can't do. Take the below template for example and plug it in to http://yaml-online-parser.appspot.com and you'll get perfectly valid json outputs with no additional logic. Of course, you would still need `aws cloudformation package` to populate the `CodeUri` but that is a different process.

Also note, the usage of the Metadata section is inconsequential. It's just an easy place to put stuff without impacting the template. You could just as well anchor to the first instance of properties on your actual resource instance.

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Transform: 'AWS::Serverless-2016-10-31'
Description: A starter AWS Lambda function.

Metadata:
  Templates:
    Resources:
      Properties: &Props
        Handler: lambda_function.lambda_handler
        Runtime: python3.6
        CodeUri: .
        Description: A starter AWS Lambda function.
        MemorySize: 128
        Timeout: 3

Resources:
  helloworldpython3:
    Type: 'AWS::Serverless::Function'
    Properties:
      <<: *Props

  helloworldnode:
    Type: 'AWS::Serverless::Function'
    Properties:
      <<: *Props
      Runtime: nodejs8.10
```

Example output from `aws cloudformation package` in this case would be

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Description: A starter AWS Lambda function.
Metadata:
  Templates:
    Resources:
      Properties:
        CodeUri: .
        Description: A starter AWS Lambda function.
        Handler: lambda_function.lambda_handler
        MemorySize: 128
        Runtime: python3.6
        Timeout: 3
Resources:
  helloworldnode:
    Properties:
      CodeUri: s3://serverless-deployments-us-east-1-123456789101/ec854419bcd553ab2fa06d17aa10f7c9
      Description: A starter AWS Lambda function.
      Handler: lambda_function.lambda_handler
      MemorySize: 128
      Runtime: nodejs8.10
      Timeout: 3
    Type: AWS::Serverless::Function
  helloworldpython3:
    Properties:
      CodeUri: s3://serverless-deployments-us-east-1-123456789101/ec854419bcd553ab2fa06d17aa10f7c9
      Description: A starter AWS Lambda function.
      Handler: lambda_function.lambda_handler
      MemorySize: 128
      Runtime: python3.6
      Timeout: 3
    Type: AWS::Serverless::Function
Transform: AWS::Serverless-2016-10-31
```
