### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/.changes/1.10.0.json
+++ b/.changes/1.10.0.json
@@ -26,7 +26,7 @@
   }, 
   {
     "category": "``aws cloudformation``", 
-    "description": "adds suport for ContinueUpdateRollback", 
+    "description": "adds support for ContinueUpdateRollback", 
     "type": "feature"
   }
 ]

--- a/.changes/1.10.7.json
+++ b/.changes/1.10.7.json
@@ -6,7 +6,7 @@
   }, 
   {
     "category": "``aws route53``", 
-    "description": "Add suport for SNI health checks", 
+    "description": "Add support for SNI health checks", 
     "type": "feature"
   }
 ]

--- a/.changes/1.11.171.json
+++ b/.changes/1.11.171.json
@@ -37,6 +37,6 @@
   {
     "category": "cloudwatch", 
     "description": "Extract ``--storage-resolution`` in put-metric-data as a top level argument.", 
-    "type": "enchancement"
+    "type": "enhancement"
   }
 ]

--- a/.changes/1.2.10.json
+++ b/.changes/1.2.10.json
@@ -1,7 +1,7 @@
 [
   {
     "category": "``aws autoscaling``", 
-    "description": "Add support for creating launch configuration or Auto Scaling groups using an Amazon EC2 instance, for attaching Amazon EC2 isntances to an existing Auto Scaling group, and for describing the limits on the Auto Scaling resources in the ``aws autoscaling`` command", 
+    "description": "Add support for creating launch configuration or Auto Scaling groups using an Amazon EC2 instance, for attaching Amazon EC2 instances to an existing Auto Scaling group, and for describing the limits on the Auto Scaling resources in the ``aws autoscaling`` command", 
     "type": "feature"
   }, 
   {

--- a/.changes/1.4.3.json
+++ b/.changes/1.4.3.json
@@ -21,7 +21,7 @@
   }, 
   {
     "category": "``aws kinesis``", 
-    "description": "Add suport for tagging.", 
+    "description": "Add support for tagging.", 
     "type": "feature"
   }, 
   {

--- a/.changes/1.9.11.json
+++ b/.changes/1.9.11.json
@@ -16,7 +16,7 @@
   }, 
   {
     "category": "Timeouts", 
-    "description": "Added additonal options for configuring socket timeouts.", 
+    "description": "Added additional options for configuring socket timeouts.", 
     "type": "feature"
   }
 ]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1358,7 +1358,7 @@ CHANGELOG
 * api-change:``es``: Update es command to latest version
 * api-change:``waf``: Update waf command to latest version
 * enhancement:s3: Add a no-progress flag to s3 transfer commands. Resolves `#519 <https://github.com/aws/aws-cli/issues/519>`__.
-* enchancement:cloudwatch: Extract ``--storage-resolution`` in put-metric-data as a top level argument.
+* enhancement:cloudwatch: Extract ``--storage-resolution`` in put-metric-data as a top level argument.
 
 
 1.11.170
@@ -3227,7 +3227,7 @@ CHANGELOG
 ======
 
 * bug:``aws configure set``: Fix issue when adding entries to an empty profile section (`issue 1806 <https://github.com/aws/aws-cli/pull/1806>`__)
-* feature:``aws route53``: Add suport for SNI health checks
+* feature:``aws route53``: Add support for SNI health checks
 
 
 1.10.6
@@ -3280,7 +3280,7 @@ CHANGELOG
 * feature:``aws cloudfront create-distribution``: Adds support for --origin-domain-name and --default-root-object
 * feature:``aws cloudfront update-distribution``: Adds support for --default-root-object
 * feature:``aws iot``: adds support for topic rules
-* feature:``aws cloudformation``: adds suport for ContinueUpdateRollback
+* feature:``aws cloudformation``: adds support for ContinueUpdateRollback
 
 
 1.9.21
@@ -3356,7 +3356,7 @@ CHANGELOG
 * feature:``aws rds``: Added support for specifying port number.
 * feature:``aws ds``: Added support for Microsoft ActiveDirctory.
 * feature:``aws route53``: Added support for TrafficFlow, a new management and modeling layer for Route53.
-* feature:Timeouts: Added additonal options for configuring socket timeouts.
+* feature:Timeouts: Added additional options for configuring socket timeouts.
 
 
 1.9.10
@@ -4133,7 +4133,7 @@ CHANGELOG
 * feature:``aws cognito-sync``: Update ``aws cognito-sync`` command to latest version.
 * feature:``aws opsworks``: Update ``aws opsworks`` command to latest version.
 * feature:``aws elasticbeanstalk``: Add support for bundling logs.
-* feature:``aws kinesis``: Add suport for tagging.
+* feature:``aws kinesis``: Add support for tagging.
 * feature:Page Size: Add a ``--page-size`` option, that controls page size when perfoming an operation that uses pagination. (`issue 889 <https://github.com/aws/aws-cli/pull/889>`__)
 * bugfix:``aws s3``: Added support for ignoring and warning about files that do not exist, user does not have read permissions, or are special files (i.e. sockets, FIFOs, character special devices, and block special devices) (`issue 881 <https://github.com/aws/aws-cli/pull/881>`__)
 * feature:Parameter Shorthand: Added support for ``structure(list-scalar, scalar)`` parameter shorthand. (`issue 882 <https://github.com/aws/aws-cli/pull/882>`__)
@@ -4442,7 +4442,7 @@ CHANGELOG
 1.2.10
 ======
 
-* feature:``aws autoscaling``: Add support for creating launch configuration or Auto Scaling groups using an Amazon EC2 instance, for attaching Amazon EC2 isntances to an existing Auto Scaling group, and for describing the limits on the Auto Scaling resources in the ``aws autoscaling`` command
+* feature:``aws autoscaling``: Add support for creating launch configuration or Auto Scaling groups using an Amazon EC2 instance, for attaching Amazon EC2 instances to an existing Auto Scaling group, and for describing the limits on the Auto Scaling resources in the ``aws autoscaling`` command
 * feature:Documentation: Update documentation in the ``aws support`` command
 * bugfix:``aws ec2``: Allow the ``--protocol`` customization for ``CreateNetworkAclEntry`` to also work for ``ReplaceNetworkAclEntry`` (`issue 559 <https://github.com/aws/aws-cli/issues/559>`__)
 * bugfix:``aws s3``: Remove one second delay when tasks are finished running for several ``aws s3`` subcommands (`issue 551 <https://github.com/aws/aws-cli/pull/551>`__)

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -153,7 +153,7 @@ class ServiceAliasCommand(BaseAliasCommand):
         :type parser: awscli.argparser.MainArgParser
         :param parser: The parser to parse commands provided at the top level
             of a CLI command which includes service commands and global
-            parameters. This is used to parse the service commmand and any
+            parameters. This is used to parse the service command and any
             global parameters from the alias's value.
 
         :type shadow_proxy_command: CLICommand
@@ -180,7 +180,7 @@ class ServiceAliasCommand(BaseAliasCommand):
         LOG.debug(
             'Alias %r passing on arguments: %r to %r command',
             self._alias_name, remaining, parsed_alias_args.command)
-        # Pass the update remaing args and global args to the service command
+        # Pass the update remaining args and global args to the service command
         # the alias proxied to.
         command = self._command_table[parsed_alias_args.command]
         if self._shadow_proxy_command:

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -338,7 +338,7 @@ class ParamShorthandParser(ParamShorthand):
             raise ParamError(cli_argument.cli_name, str(e))
         except (ParamError, ParamUnknownKeyError) as e:
             # The shorthand parse methods don't have the cli_name,
-            # so any ParamError won't have this value.  To accomodate
+            # so any ParamError won't have this value.  To accommodate
             # this, ParamErrors are caught and reraised with the cli_name
             # injected.
             raise ParamError(cli_argument.cli_name, str(e))

--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -234,7 +234,7 @@ class CustomArgument(BaseCLIArgument):
         self.argument_model = argument_model
 
         # If the top level element is a list then set nargs to
-        # accept multiple values seperated by a space.
+        # accept multiple values separated by a space.
         if self.argument_model is not None and \
                 self.argument_model.type_name == 'list':
             self._nargs = '+'

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -74,7 +74,7 @@ ARGUMENT_RENAMES = {
 }
 
 # Same format as ARGUMENT_RENAMES, but instead of renaming the arguments,
-# an alias is created to the original arugment and marked as undocumented.
+# an alias is created to the original argument and marked as undocumented.
 # This is useful when you need to change the name of an argument but you
 # still need to support the old argument.
 HIDDEN_ALIASES = {

--- a/awscli/customizations/configure/addmodel.py
+++ b/awscli/customizations/configure/addmodel.py
@@ -60,7 +60,7 @@ def get_model_location(session, service_definition, service_name=None):
         and the service definition.
 
     :returns: The path to where are model should be placed based on
-        the service defintion and the current services in botocore.
+        the service definition and the current services in botocore.
     """
     # Add the ServiceModel abstraction over the service json definition to
     # make it easier to work with.

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-"""This module has customizations to unify paging paramters.
+"""This module has customizations to unify paging parameters.
 
 For any operation that can be paginated, we will:
 

--- a/awscli/customizations/s3/fileformat.py
+++ b/awscli/customizations/s3/fileformat.py
@@ -65,7 +65,7 @@ class FileFormat(object):
         the editted path.
         Formatting Rules:
             1) If a destination file is taking on a source name, it must end
-               with the apporpriate operating system seperator
+               with the appropriate operating system separator
 
         General Options:
             1) If the operation is on a directory, the destination file will
@@ -73,11 +73,11 @@ class FileFormat(object):
             2) If the path of the destination exists and is a directory it
                will always use the name of the source file.
             3) If the destination path ends with the appropriate operating
-               system seperator but is not an existing directory, the
+               system separator but is not an existing directory, the
                appropriate directories will be made and the file will use the
                source's name.
             4) If the destination path does not end with the appropriate
-               operating system seperator and is not an existing directory, the
+               operating system separator and is not an existing directory, the
                appropriate directories will be created and the file name will
                be of the one provided.
         """

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -234,7 +234,7 @@ class FileGenerator(object):
 
     def normalize_sort(self, names, os_sep, character):
         """
-        The purpose of this function is to ensure that the same path seperator
+        The purpose of this function is to ensure that the same path separator
         is used when sorting.  In windows, the path operator is a backslash as
         opposed to a forward slash which can lead to differences in sorting
         between s3 and a windows machine.

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -286,7 +286,7 @@ class ResultRecorder(BaseResultHandler):
         # gets created that the timestamp on the progress result is less
         # than the timestamp of when the result processor actually
         # processes that initial queued result. So this will avoid
-        # negative progress being displayed or zero divison occuring.
+        # negative progress being displayed or zero division occurring.
         if result.timestamp > self.start_time:
             self.bytes_transfer_speed = self.bytes_transferred / (
                 result.timestamp - self.start_time)

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -22,7 +22,7 @@ from awscli.customizations.s3.syncstrategy.register import \
 def awscli_initialize(cli):
     """
     This function is require to use the plugin.  It calls the functions
-    required to add all neccessary commands and parameters to the CLI.
+    required to add all necessary commands and parameters to the CLI.
     This function is necessary to install the plugin using a configuration
     file
     """
@@ -33,7 +33,7 @@ def awscli_initialize(cli):
 def s3_plugin_initialize(event_handlers):
     """
     This is a wrapper to make the plugin built-in to the cli as opposed
-    to specifiying it in the configuration file.
+    to specifying it in the configuration file.
     """
     awscli_initialize(event_handlers)
 

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -277,7 +277,7 @@ class BaseTransferRequestSubmitter(object):
         for warning_handler in self._get_warning_handlers():
             if warning_handler(fileinfo):
                 # On the first warning handler that returns a signal to skip
-                # immediately propogate this signal and no longer check
+                # immediately propagate this signal and no longer check
                 # the other warning handlers as no matter what the file will
                 # be skipped.
                 return True
@@ -532,7 +532,7 @@ class LocalDeleteRequestSubmitter(BaseTransferRequestSubmitter):
         # the burden of this functionality should live in the CLI.
 
         # The main downsides in doing this is that delete and the result
-        # creation happens in the main thread as opposed to a seperate thread
+        # creation happens in the main thread as opposed to a separate thread
         # in s3transfer. However, this is not too big of a downside because
         # deleting a local file only happens for sync --delete downloads and
         # is very fast compared to all of the other types of transfers.

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -635,7 +635,7 @@ class WebsiteCommand(S3Command):
         # bucketname
         #
         # We also strip off the trailing slash if a user
-        # accidently appends a slash.
+        # accidentally appends a slash.
         if path.startswith('s3://'):
             path = path[5:]
         if path.endswith('/'):

--- a/awscli/customizations/s3/syncstrategy/base.py
+++ b/awscli/customizations/s3/syncstrategy/base.py
@@ -94,7 +94,7 @@ class BaseSync(object):
 
         :type src_file: ``FileStat`` object
         :param src_file: A representation of the opertaion that is to be
-            performed on a specfic file existing in the source.  Note if
+            performed on a specific file existing in the source.  Note if
             the file does not exist at the source, ``src_file`` is None.
 
         :type dest_file: ``FileStat`` object

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -115,7 +115,7 @@ class AppendFilter(argparse.Action):
     --exclude and the value will be the rule to apply.  This will
     format all of the rules inputted into the command line
     in a way compatible with the Filter class.  Note that rules that
-    appear later in the command line take preferance over rulers that
+    appear later in the command line take preference over rulers that
     appear earlier.
     """
     def __call__(self, parser, namespace, values, option_string=None):
@@ -292,9 +292,9 @@ def guess_content_type(filename):
     """
     try:
         return mimetypes.guess_type(filename)[0]
-    # This catches a bug in the mimetype libary where some MIME types
+    # This catches a bug in the mimetype library where some MIME types
     # specifically on windows machines cause a UnicodeDecodeError
-    # because the MIME type in the Windows registery has an encoding
+    # because the MIME type in the Windows registry has an encoding
     # that cannot be properly encoded using the default system encoding.
     # https://bugs.python.org/issue9291
     #
@@ -417,7 +417,7 @@ class RequestParamsMapper(object):
         >>> print(request_params)
         {'StorageClass': 'GLACIER', 'ServerSideEncryption': 'AES256'}
 
-    Note that existing parameters in ``request_params`` will be overriden if
+    Note that existing parameters in ``request_params`` will be overridden if
     a parameter in ``cli_params`` maps to the existing parameter.
     """
     @classmethod
@@ -606,7 +606,7 @@ class OnDoneFilteredSubscriber(BaseSubscriber):
             future.result()
         except Exception as e:
             future_exception = e
-        # If the result propogates an error, call the on_failure
+        # If the result propagates an error, call the on_failure
         # method instead.
         if future_exception:
             self._on_failure(future, future_exception)

--- a/awscli/examples/acm/list-tags-for-certificate.rst
+++ b/awscli/examples/acm/list-tags-for-certificate.rst
@@ -4,7 +4,7 @@ The following ``list-tags-for-certificate`` command lists the tags applied to a 
 
   aws acm list-tags-for-certificate --certificate-arn arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012
 
-The preceding command produces ouput similar to the following::
+The preceding command produces output similar to the following::
 
   {
     "Tags": [

--- a/awscli/examples/apigateway/get-export.rst
+++ b/awscli/examples/apigateway/get-export.rst
@@ -4,7 +4,7 @@ Command::
 
   aws apigateway get-export --rest-api-id a1b2c3d4e5 --stage-name dev --export-type swagger /path/to/filename.json
 
-**To get the JSON Swagger template + API Gateway Extentions for a stage**
+**To get the JSON Swagger template + API Gateway Extensions for a stage**
 
 Command::
 

--- a/awscli/examples/configure/set/_description.rst
+++ b/awscli/examples/configure/set/_description.rst
@@ -13,6 +13,6 @@ configuration value already exists in the config file, it will updated with the
 new configuration value.
 
 Setting a value for the ``aws_access_key_id``, ``aws_secret_access_key``, or
-the ``aws_session_token`` will result in the value being writen to the
+the ``aws_session_token`` will result in the value being written to the
 shared credentials file (``~/.aws/credentials``).  All other values will
 be written to the config file (default location is ``~/.aws/config``).

--- a/awscli/examples/directconnect/allocate-hosted-connection.rst
+++ b/awscli/examples/directconnect/allocate-hosted-connection.rst
@@ -4,7 +4,7 @@ The following example creates a hosted connection on the specified interconnect.
 
 Command::
 
-  aws directconnect allocate-hosted-conection --bandwidth 500Mbps --connection-name mydcinterconnect --owner-account 123456789012 --connection-id dxcon-fgktov66 --vlan 101
+  aws directconnect allocate-hosted-connection --bandwidth 500Mbps --connection-name mydcinterconnect --owner-account 123456789012 --connection-id dxcon-fgktov66 --vlan 101
 
 Output::
 

--- a/awscli/examples/ec2/get-console-output.rst
+++ b/awscli/examples/ec2/get-console-output.rst
@@ -1,6 +1,6 @@
 **To get the console output**
 
-This example gets the console ouput for the specified Linux instance.
+This example gets the console output for the specified Linux instance.
 
 Command::
 

--- a/awscli/examples/opsworks/describe-commands.rst
+++ b/awscli/examples/opsworks/describe-commands.rst
@@ -1,6 +1,6 @@
 **To describe commands**
 
-The following ``describe-commands`` commmand describes the commands in a specified instance. ::
+The following ``describe-commands`` command describes the commands in a specified instance. ::
 
   aws opsworks --region us-east-1 describe-commands --instance-id 8c2673b9-3fe5-420d-9cfa-78d875ee7687
 

--- a/awscli/examples/opsworks/describe-deployments.rst
+++ b/awscli/examples/opsworks/describe-deployments.rst
@@ -1,6 +1,6 @@
 **To describe deployments**
 
-The following ``describe-deployments`` commmand describes the deployments in a specified stack. ::
+The following ``describe-deployments`` command describes the deployments in a specified stack. ::
 
   aws opsworks --region us-east-1 describe-deployments --stack-id 38ee91e2-abdc-4208-a107-0b7168b3cc7a
 

--- a/awscli/examples/opsworks/describe-elastic-ips.rst
+++ b/awscli/examples/opsworks/describe-elastic-ips.rst
@@ -1,6 +1,6 @@
 **To describe Elastic IP instances**
 
-The following ``describe-elastic-ips`` commmand describes the Elastic IP addresses in a specified instance. ::
+The following ``describe-elastic-ips`` command describes the Elastic IP addresses in a specified instance. ::
 
   aws opsworks --region us-east-1 describe-elastic-ips --instance-id b62f3e04-e9eb-436c-a91f-d9e9a396b7b0
 

--- a/awscli/examples/opsworks/describe-instances.rst
+++ b/awscli/examples/opsworks/describe-instances.rst
@@ -1,6 +1,6 @@
 **To describe instances**
 
-The following ``describe-instances`` commmand describes the instances in a specified stack::
+The following ``describe-instances`` command describes the instances in a specified stack::
 
   aws opsworks --region us-east-1 describe-instances --stack-id 8c428b08-a1a1-46ce-a5f8-feddc43771b8
 

--- a/awscli/examples/opsworks/describe-layers.rst
+++ b/awscli/examples/opsworks/describe-layers.rst
@@ -1,6 +1,6 @@
 **To describe a stack's layers**
 
-The following ``describe-layers`` commmand describes the layers in a specified stack::
+The following ``describe-layers`` command describes the layers in a specified stack::
 
   aws opsworks --region us-east-1 describe-layers --stack-id 38ee91e2-abdc-4208-a107-0b7168b3cc7a
 

--- a/awscli/examples/opsworks/register.rst
+++ b/awscli/examples/opsworks/register.rst
@@ -22,7 +22,7 @@ such as a default private SSH key. If that fails, ``register`` queries for the p
 
   aws opsworks register --infrastructure-class=ec2 --stack-id 935450cc-61e0-4b03-a3e0-160ac817d2bb i-12345678
 
-The following example registers an EC2 instance with the specifed stack from a separate workstation.
+The following example registers an EC2 instance with the specified stack from a separate workstation.
 It uses the ``--ssh-username`` and ``--ssh-private-key`` arguments to explicitly
 specify the SSH username and private key file that the command uses to log into the instance.
 ``ec2-user`` is the standard username for Amazon Linux instances. Use ``ubuntu`` for Ubuntu instances. ::

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -76,7 +76,7 @@ class ShorthandParseError(Exception):
             num_spaces = self.index - last_newline - 1
         if '\n' in self.value[self.index:]:
             # If there's newline in the remaining, divide value
-            # into consumed and remainig
+            # into consumed and remaininig
             # foo==bar,\n
             #     ^
             # bar=baz

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -191,7 +191,7 @@ should then be used to further limit bandwidth consumption if setting
 desired rate. This is recommended because ``max_concurrent_requests`` controls
 how many threads are currently running. So if a high ``max_concurrent_requests``
 value is set and a low ``max_bandwidth`` value is set, it may result in
-threads having to wait unneccessarily which can lead to excess resource
+threads having to wait unnecessarily which can lead to excess resource
 consumption and connection timeouts.
 
 

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -185,7 +185,7 @@ class TopicTagDB(object):
             if tag in self.VALID_TAGS:
                 # Get the value of the tag.
                 values = field_body.childNodes[0].firstChild.nodeValue
-                # Seperate values into a list by splitting at commas
+                # Separate values into a list by splitting at commas
                 tag_values = values.split(',')
                 # Strip the white space around each of these values.
                 for i in range(len(tag_values)):

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -413,7 +413,7 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_can_emit_http_request_record(self):
         # HTTP_REQUEST records have have their entire body field as a binary
-        # blob, howver it will all be utf-8 valid since the binary fields
+        # blob, however it will all be utf-8 valid since the binary fields
         # from the api call will have been b64 encoded.
         payload = {
             'url': ('https://lambda.us-west-2.amazonaws.com/2015-03-31/'

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -48,19 +48,19 @@ class TestSyncCommand(BaseS3TransferCommandTest):
         # Return code will be 2 for invalid parameter ``--recursive``
         self.run_cmd(cmdline, expected_rc=2)
 
-    def test_sync_from_non_existant_directory(self):
-        non_existant_directory = os.path.join(self.files.rootdir, 'fakedir')
-        cmdline = '%s %s s3://bucket/' % (self.prefix, non_existant_directory)
+    def test_sync_from_non_existent_directory(self):
+        non_existent_directory = os.path.join(self.files.rootdir, 'fakedir')
+        cmdline = '%s %s s3://bucket/' % (self.prefix, non_existent_directory)
         self.parsed_responses = [
             {"CommonPrefixes": [], "Contents": []}
         ]
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=255)
         self.assertIn('does not exist', stderr)
 
-    def test_sync_to_non_existant_directory(self):
+    def test_sync_to_non_existent_directory(self):
         key = 'foo.txt'
-        non_existant_directory = os.path.join(self.files.rootdir, 'fakedir')
-        cmdline = '%s s3://bucket/ %s' % (self.prefix, non_existant_directory)
+        non_existent_directory = os.path.join(self.files.rootdir, 'fakedir')
+        cmdline = '%s s3://bucket/ %s' % (self.prefix, non_existent_directory)
         self.parsed_responses = [
             {"CommonPrefixes": [], "Contents": [
                 {"Key": key, "Size": 3,
@@ -71,7 +71,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
         self.run_cmd(cmdline, expected_rc=0)
         # Make sure the file now exists.
         self.assertTrue(
-            os.path.exists(os.path.join(non_existant_directory, key)))
+            os.path.exists(os.path.join(non_existent_directory, key)))
 
     def test_glacier_sync_with_force_glacier(self):
         self.parsed_responses = [

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -71,7 +71,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
     def test_streaming_output_arg_with_error_response(self):
         # Checking that the StreamingOutputArg handles the
         # case where it's passed an error body.  Previously
-        # it would propogate a KeyError so we want to ensure
+        # it would propagate a KeyError so we want to ensure
         # this case is handled.
         self.parsed_response = {
             'Error': {

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -44,7 +44,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
-    def test_subcommand_alias_with_additonal_params(self):
+    def test_subcommand_alias_with_additional_params(self):
         self.add_alias(
             'my-alias', 'ec2 describe-regions --region-names us-east-1')
         cmdline = 'my-alias'
@@ -56,7 +56,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         )
         self.assertEqual(self.operations_called[0][0].name, 'DescribeRegions')
 
-    def test_subcommand_alias_then_additonal_params(self):
+    def test_subcommand_alias_then_additional_params(self):
         self.add_alias('my-alias', 'ec2')
         cmdline = 'my-alias describe-regions --region-names us-east-1'
         self.assert_params_for_cmd(cmdline, {'RegionNames': ['us-east-1']})
@@ -203,7 +203,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         self.run_cmd('mkdir')
         self.assertTrue(os.path.isdir(directory_to_make))
 
-    def test_external_alias_then_additonal_args(self):
+    def test_external_alias_then_additional_args(self):
         # The external alias is tested by using mkdir; a command that
         # is universal for the various OS's we support
         directory_to_make = os.path.join(self.files.rootdir, 'newdir')

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1299,7 +1299,7 @@ class TestOutput(BaseS3IntegrationTest):
         self.assertEqual(p.rc, 1)
         self.assertIn('upload failed', p.stderr)
 
-    def test_error_ouput_quiet(self):
+    def test_error_output_quiet(self):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
@@ -1309,7 +1309,7 @@ class TestOutput(BaseS3IntegrationTest):
         self.assertEqual(p.rc, 1)
         self.assertEqual('', p.stderr)
 
-    def test_error_ouput_only_show_errors(self):
+    def test_error_output_only_show_errors(self):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
@@ -1731,7 +1731,7 @@ class TestStreams(BaseS3IntegrationTest):
     def test_multipart_upload(self):
         """
         This tests the ability to multipart upload streams from stdin.
-        The data has some unicode in it to avoid having to do a seperate
+        The data has some unicode in it to avoid having to do a separate
         multipart upload test just for unicode.
         """
         bucket_name = _SHARED_BUCKET
@@ -1777,7 +1777,7 @@ class TestStreams(BaseS3IntegrationTest):
     def test_multipart_download(self):
         """
         This tests the ability to multipart download streams to stdout.
-        The data has some unicode in it to avoid having to do a seperate
+        The data has some unicode in it to avoid having to do a separate
         multipart download test just for unicode.
         """
         bucket_name = _SHARED_BUCKET

--- a/tests/integration/customizations/test_cliinputjson.py
+++ b/tests/integration/customizations/test_cliinputjson.py
@@ -24,7 +24,7 @@ from awscli.testutils import unittest, aws
 class TestIntegCliInputJson(unittest.TestCase):
     """This tests to see if a service properly uses the generated input JSON.
 
-    The s3 service was chosen becuase its operations do not take a lot of time.
+    The s3 service was chosen because its operations do not take a lot of time.
     These tests are essentially smoke tests. They are testing that the
     ``--cli-input-json`` works. It is by no means exhaustive.
     """

--- a/tests/integration/customizations/test_generatecliskeleton.py
+++ b/tests/integration/customizations/test_generatecliskeleton.py
@@ -58,7 +58,7 @@ class TestIntegGenerateCliSkeleton(unittest.TestCase):
     operations that do not have many input options for the sake of readablity
     and maintenance. These are essentially smoke tests. It is not trying to
     test the different types of input shapes that can be generated in the
-    skeleton. It is only testing wheter the skeleton generator argument works
+    skeleton. It is only testing whether the skeleton generator argument works
     for various services.
     """
     def test_generate_cli_skeleton_s3api(self):

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -415,14 +415,14 @@ class TestDeployCommand(unittest.TestCase):
         }
 
         expected_result = [
-            # Overriden values
+            # Overridden values
             {"ParameterKey": "Key1", "ParameterValue": "Value1"},
             {"ParameterKey": "Key3", "ParameterValue": "Value3"},
 
             # Parameter contains default value, but overridden with new value
             {"ParameterKey": "KeyWithDefaultValueButOverridden", "ParameterValue": "Value4"},
 
-            # non-overriden values
+            # non-overridden values
             {"ParameterKey": "Key2", "UsePreviousValue": True},
             {"ParameterKey": "Key4", "UsePreviousValue": True},
 

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -251,7 +251,7 @@ class TestDeployer(unittest.TestCase):
         self.deployer.has_stack.return_value = False
 
         self.stub_client.add_client_error(
-                'create_change_set', "Somethign is wrong", "Service is bad")
+                'create_change_set', "Something is wrong", "Service is bad")
         with self.stub_client:
             with self.assertRaises(botocore.exceptions.ClientError):
                 self.deployer.create_changeset(stack_name, template, parameters,
@@ -275,7 +275,7 @@ class TestDeployer(unittest.TestCase):
         changeset_id = "changeset_id"
 
         self.stub_client.add_client_error(
-                'execute_change_set', "Somethign is wrong", "Service is bad")
+                'execute_change_set', "Something is wrong", "Service is bad")
         with self.stub_client:
             with self.assertRaises(botocore.exceptions.ClientError):
                 self.deployer.execute_changeset(changeset_id, stack_name)

--- a/tests/unit/customizations/datapipeline/test_translator.py
+++ b/tests/unit/customizations/datapipeline/test_translator.py
@@ -19,7 +19,7 @@ from botocore.compat import OrderedDict, json
 from awscli.customizations.datapipeline import translator
 
 
-# Thoughout these tests, 'df' refers to the condensed JSON definition format
+# Throughout these tests, 'df' refers to the condensed JSON definition format
 # that the user provides and API refers to the format expected by the API.
 
 class TestTranslatePipelineDefinitions(unittest.TestCase):

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -146,7 +146,7 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'body': b'data'}
         # In order for an http_request to have a request_id it must have been
-        # preceeded by an api_call record.
+        # preceded by an api_call record.
         handler.emit('API_CALL', '', 'BOTOCORE')
         handler.emit('HTTP_REQUEST', payload, 'BOTOCORE')
         call = writer.write_record.call_args[0][0]
@@ -167,7 +167,7 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'body': b'data'}
         # In order for an http_response to have a request_id it must have been
-        # preceeded by an api_call record.
+        # preceded by an api_call record.
         handler.emit('API_CALL', '', 'BOTOCORE')
         handler.emit('HTTP_RESPONSE', payload, 'BOTOCORE')
         call = writer.write_record.call_args[0][0]
@@ -188,7 +188,7 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
         handler = DatabaseHistoryHandler(writer, record_builder)
         payload = {'metadata': {'data': 'foobar'}}
         # In order for an http_response to have a request_id it must have been
-        # preceeded by an api_call record.
+        # preceded by an api_call record.
         handler.emit('API_CALL', '', 'BOTOCORE')
         handler.emit('PARSED_RESPONSE', payload, 'BOTOCORE')
         call = writer.write_record.call_args[0][0]

--- a/tests/unit/customizations/history/test_list.py
+++ b/tests/unit/customizations/history/test_list.py
@@ -99,7 +99,7 @@ class TestTextFormatter(unittest.TestCase):
         self.assertEqual(expected_output, actual_output)
 
     def test_can_truncate_args(self):
-        # Truncate the argument if it won't fit in the space alotted to the
+        # Truncate the argument if it won't fit in the space allotted to the
         # arguments field.
         self._format_records([
             {

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -1532,7 +1532,7 @@ class TestNoProgressResultPrinter(BaseResultPrinterTest):
         self.result_printer(progress_result)
         self.assertEqual(self.out_file.getvalue(), '')
 
-    def test_does_print_sucess_result(self):
+    def test_does_print_success_result(self):
         transfer_type = 'upload'
         src = 'file'
         dest = 's3://mybucket/mykey'
@@ -1599,7 +1599,7 @@ class TestOnlyShowErrorsResultPrinter(BaseResultPrinterTest):
         self.result_printer(progress_result)
         self.assertEqual(self.out_file.getvalue(), '')
 
-    def test_does_not_print_sucess_result(self):
+    def test_does_not_print_success_result(self):
         transfer_type = 'upload'
         src = 'file'
         dest = 's3://mybucket/mykey'

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -329,7 +329,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                                       {'region': 'us-east-1',
                                        'endpoint_url': None,
                                        'verify_ssl': None})
-        # Check that the default sync strategy is overwritted if a plugin
+        # Check that the default sync strategy is overwrite if a plugin
         # returns its sync strategy.
         mock_strategy = Mock()
         mock_strategy.sync_type = 'file_at_src_and_dest'

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -632,18 +632,18 @@ class TestDirectoryCreatorSubscriber(BaseTestWithFileCreator):
         # The directory should still exist
         self.assertTrue(os.path.exists(self.directory_to_create))
 
-    def test_on_queued_failure_propogates_create_directory_error(self):
+    def test_on_queued_failure_propagates_create_directory_error(self):
         # If makedirs() raises an OSError of exception, we should
-        # propogate the exception with a better worded CreateDirectoryError.
+        # propagate the exception with a better worded CreateDirectoryError.
         with mock.patch('os.makedirs') as makedirs_patch:
             makedirs_patch.side_effect = OSError()
             with self.assertRaises(CreateDirectoryError):
                 self.subscriber.on_queued(self.future)
         self.assertFalse(os.path.exists(self.directory_to_create))
 
-    def test_on_queued_failure_propogates_clear_error_message(self):
+    def test_on_queued_failure_propagates_clear_error_message(self):
         # If makedirs() raises an OSError of exception, we should
-        # propogate the exception.
+        # propagate the exception.
         with mock.patch('os.makedirs') as makedirs_patch:
             os_error = OSError()
             os_error.errno = errno.EEXIST

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -92,7 +92,7 @@ class TestBasicCommand(unittest.TestCase):
         sub_help_command = subcommand.create_help_command()
         # Note that the name of this Subcommand was never changed even
         # though it was put into the table as ``basic``. If no name
-        # is overriden it uses the name ``commandname``.
+        # is overridden it uses the name ``commandname``.
         self.assertEqual(sub_help_command.event_class, 'mock.commandname')
 
 

--- a/tests/unit/customizations/test_flatten.py
+++ b/tests/unit/customizations/test_flatten.py
@@ -212,6 +212,6 @@ class TestFlattenCommands(unittest.TestCase):
         self.assertEqual(False, argument_table['foo'].required)
         self.assertEqual(True, argument_table['bar'].required)
 
-        # Make sure docs can be overriden and get the defaults
+        # Make sure docs can be overridden and get the defaults
         self.assertEqual('Original docs', argument_table['foo'].documentation)
         self.assertEqual('Some help text', argument_table['bar'].documentation)

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -125,7 +125,7 @@ class TestFormattersHandleClosedPipes(unittest.TestCase):
         fake_closed_stream.flush.side_effect = IOError
         formatter = JSONFormatter(args)
         formatter('command_name', response, stream=fake_closed_stream)
-        # We should not have let the IOError propogate, but
+        # We should not have let the IOError propagate, but
         # we still should have called the flush() on the
         # stream.
         fake_closed_stream.flush.assert_called_with()

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -250,7 +250,7 @@ class FakeSession(object):
 class FakeCommand(BasicCommand):
     def _run_main(self, args, parsed_globals):
         # We just return success. If this code is reached, it means that
-        # all the logic in the __call__ method has sucessfully been run.
+        # all the logic in the __call__ method has successfully been run.
         # We subclass it here because the default implementation raises
         # an exception and we don't want that behavior.
         return 0
@@ -664,7 +664,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
 
         self.driver.session.register('calling-command', override_with_rc)
         rc = self.driver.main('ec2 describe-instances'.split())
-        # Check that the overriden rc is as expected.
+        # Check that the overridden rc is as expected.
         self.assertEqual(rc, 20)
 
     def test_override_calling_command_error(self):

--- a/tests/unit/test_topictags.py
+++ b/tests/unit/test_topictags.py
@@ -393,7 +393,7 @@ class TestTopicTagDBQuery(TestTopicTagDB):
                               {'foo': ['topic-name-1'],
                                'bar': ['topic-name-1', 'topic-name-2']})
 
-    def topic_query_with_non_existant_tag(self):
+    def topic_query_with_non_existent_tag(self):
         tag_dict = {
             'topic-name-1': {
                 'category': ['foo']

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -101,7 +101,7 @@ class TestIgnoreCtrlC(unittest.TestCase):
             # Should have the noop signal handler installed.
             self.assertEqual(signal.getsignal(signal.SIGINT), signal.SIG_IGN)
             # And if we actually try to sigint ourselves, an exception
-            # should not propogate.
+            # should not propagate.
             os.kill(os.getpid(), signal.SIGINT)
 
 


### PR DESCRIPTION
This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell).

```
$ misspell .
.changes/1.11.171.json:40:13: "enchancement" is a misspelling of "enhancement"
.changes/1.2.10.json:4:144: "isntances" is a misspelling of "instances"
.changes/1.10.0.json:29:25: "suport" is a misspelling of "support"
.changes/1.10.7.json:9:24: "suport" is a misspelling of "support"
.changes/1.4.3.json:24:24: "suport" is a misspelling of "support"
.changes/1.9.11.json:19:26: "additonal" is a misspelling of "additional"
awscli/alias.py:156:58: "commmand" is a misspelling of "command"
awscli/alias.py:183:26: "remaing" is a misspelling of "remaining"
awscli/argprocess.py:341:59: "accomodate" is a misspelling of "accommodate"
awscli/arguments.py:237:33: "seperated" is a misspelling of "separated"
awscli/customizations/argrename.py:77:38: "arugment" is a misspelling of "argument"
CHANGELOG.rst:1361:2: "enchancement" is a misspelling of "enhancement"
CHANGELOG.rst:3230:31: "suport" is a misspelling of "support"
CHANGELOG.rst:3283:39: "suport" is a misspelling of "support"
CHANGELOG.rst:3359:26: "additonal" is a misspelling of "additional"
CHANGELOG.rst:4136:31: "suport" is a misspelling of "support"
CHANGELOG.rst:4445:155: "isntances" is a misspelling of "instances"
awscli/customizations/configure/addmodel.py:63:20: "defintion" is a misspelling of "definition"
awscli/customizations/paginate.py:13:50: "paramters" is a misspelling of "parameters"
awscli/customizations/s3/fileformat.py:68:24: "apporpriate" is a misspelling of "appropriate"
awscli/customizations/s3/fileformat.py:68:53: "seperator" is a misspelling of "separator"
awscli/customizations/s3/fileformat.py:76:22: "seperator" is a misspelling of "separator"
awscli/customizations/s3/fileformat.py:80:32: "seperator" is a misspelling of "separator"
awscli/customizations/s3/filegenerator.py:237:69: "seperator" is a misspelling of "separator"
awscli/customizations/s3/s3.py:25:24: "neccessary" is a misspelling of "necessary"
awscli/customizations/s3/s3.py:36:7: "specifiying" is a misspelling of "specifying"
awscli/customizations/s3/results.py:289:52: "divison" is a misspelling of "division"
awscli/customizations/s3/results.py:289:60: "occuring" is a misspelling of "occurring"
awscli/customizations/s3/s3handler.py:280:30: "propogate" is a misspelling of "propagate"
awscli/customizations/s3/s3handler.py:535:62: "seperate" is a misspelling of "separate"
awscli/customizations/s3/syncstrategy/base.py:97:27: "specfic" is a misspelling of "specific"
awscli/customizations/s3/subcommands.py:638:10: "accidently" is a misspelling of "accidentally"
awscli/customizations/s3/utils.py:118:42: "preferance" is a misspelling of "preference"
awscli/customizations/s3/utils.py:295:41: "libary" is a misspelling of "library"
awscli/customizations/s3/utils.py:297:43: "registery" is a misspelling of "registry"
awscli/customizations/s3/utils.py:420:64: "overriden" is a misspelling of "overridden"
awscli/customizations/s3/utils.py:609:24: "propogates" is a misspelling of "propagates"
awscli/examples/acm/list-tags-for-certificate.rst:7:31: "ouput" is a misspelling of "output"
awscli/examples/apigateway/get-export.rst:7:49: "Extentions" is a misspelling of "Extensions"
awscli/examples/configure/set/_description.rst:16:57: "writen" is a misspelling of "written"
awscli/examples/directconnect/allocate-hosted-connection.rst:7:36: "conection" is a misspelling of "connection"
awscli/examples/ec2/get-console-output.rst:3:30: "ouput" is a misspelling of "output"
awscli/examples/opsworks/describe-commands.rst:3:36: "commmand" is a misspelling of "command"
awscli/examples/opsworks/describe-deployments.rst:3:39: "commmand" is a misspelling of "command"
awscli/examples/opsworks/describe-elastic-ips.rst:3:39: "commmand" is a misspelling of "command"
awscli/examples/opsworks/describe-instances.rst:3:37: "commmand" is a misspelling of "command"
awscli/examples/opsworks/describe-layers.rst:3:34: "commmand" is a misspelling of "command"
awscli/examples/opsworks/register.rst:25:57: "specifed" is a misspelling of "specified"
awscli/shorthand.py:79:32: "remainig" is a misspelling of "remaining"
awscli/topics/s3-config.rst:194:23: "unneccessarily" is a misspelling of "unnecessarily"
awscli/topictags.py:188:18: "Seperate" is a misspelling of "Separate"
tests/functional/history/test_db.py:416:16: "howver" is a misspelling of "however"
tests/functional/s3api/test_get_object.py:74:19: "propogate" is a misspelling of "propagate"
tests/functional/s3/test_sync_command.py:51:27: "existant" is a misspelling of "existent"
tests/functional/s3/test_sync_command.py:52:12: "existant" is a misspelling of "existent"
tests/functional/s3/test_sync_command.py:53:59: "existant" is a misspelling of "existent"
tests/functional/s3/test_sync_command.py:60:25: "existant" is a misspelling of "existent"
tests/functional/s3/test_sync_command.py:62:12: "existant" is a misspelling of "existent"
tests/functional/s3/test_sync_command.py:63:59: "existant" is a misspelling of "existent"
tests/functional/s3/test_sync_command.py:74:44: "existant" is a misspelling of "existent"
tests/functional/test_alias.py:47:35: "additonal" is a misspelling of "additional"
tests/functional/test_alias.py:59:35: "additonal" is a misspelling of "additional"
tests/functional/test_alias.py:206:33: "additonal" is a misspelling of "additional"
tests/integration/customizations/test_cliinputjson.py:27:30: "becuase" is a misspelling of "because"
tests/integration/customizations/test_generatecliskeleton.py:61:33: "wheter" is a misspelling of "whether"
tests/integration/customizations/s3/test_plugin.py:1302:19: "ouput" is a misspelling of "output"
tests/integration/customizations/s3/test_plugin.py:1312:19: "ouput" is a misspelling of "output"
tests/integration/customizations/s3/test_plugin.py:1734:64: "seperate" is a misspelling of "separate"
tests/integration/customizations/s3/test_plugin.py:1780:64: "seperate" is a misspelling of "separate"
tests/unit/customizations/cloudformation/test_deploy.py:418:14: "Overriden" is a misspelling of "Overridden"
tests/unit/customizations/cloudformation/test_deploy.py:425:18: "overriden" is a misspelling of "overridden"
tests/unit/customizations/cloudformation/test_deployer.py:254:38: "Somethign" is a misspelling of "Something"
tests/unit/customizations/cloudformation/test_deployer.py:278:39: "Somethign" is a misspelling of "Something"
tests/unit/customizations/datapipeline/test_translator.py:22:2: "Thoughout" is a misspelling of "Throughout"
tests/unit/customizations/history/test_db.py:149:10: "preceeded" is a misspelling of "preceded"
tests/unit/customizations/history/test_db.py:170:10: "preceeded" is a misspelling of "preceded"
tests/unit/customizations/history/test_db.py:191:10: "preceeded" is a misspelling of "preceded"
tests/unit/customizations/history/test_list.py:102:61: "alotted" is a misspelling of "allotted"
tests/unit/customizations/s3/test_results.py:1535:24: "sucess" is a misspelling of "success"
tests/unit/customizations/s3/test_results.py:1602:28: "sucess" is a misspelling of "success"
tests/unit/customizations/s3/test_subcommands.py:332:50: "overwritted" is a misspelling of "overwrite"
tests/unit/customizations/s3/test_utils.py:635:31: "propogates" is a misspelling of "propagates"
tests/unit/customizations/s3/test_utils.py:637:10: "propogate" is a misspelling of "propagate"
tests/unit/customizations/s3/test_utils.py:644:31: "propogates" is a misspelling of "propagates"
tests/unit/customizations/s3/test_utils.py:646:10: "propogate" is a misspelling of "propagate"
tests/unit/customizations/test_commands.py:95:13: "overriden" is a misspelling of "overridden"
tests/unit/customizations/test_flatten.py:215:32: "overriden" is a misspelling of "overridden"
tests/unit/output/test_json_output.py:128:45: "propogate" is a misspelling of "propagate"
tests/unit/test_clidriver.py:253:51: "sucessfully" is a misspelling of "successfully"
tests/unit/test_clidriver.py:667:25: "overriden" is a misspelling of "overridden"
tests/unit/test_utils.py:104:25: "propogate" is a misspelling of "propagate"
tests/unit/test_topictags.py:396:29: "existant" is a misspelling of "existent"
```