### PR TITLE
Update CLI for service id event aliasing

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -245,7 +245,7 @@ def _is_complex_shape(model):
 
 class ParamShorthand(object):
 
-    def _uses_old_list_case(self, service_name, operation_name, argument_name):
+    def _uses_old_list_case(self, service_id, operation_name, argument_name):
         """
         Determines whether a given operation for a service needs to use the
         deprecated shorthand parsing case for lists of structures that only have
@@ -260,14 +260,14 @@ class ParamShorthand(object):
                 'rebuild-workspaces': ['rebuild-workspace-requests'],
                 'terminate-workspaces': ['terminate-workspace-requests']
             },
-            'elb': {
+            'elastic-load-balancing': {
                 'remove-tags': ['tags'],
                 'describe-instance-health': ['instances'],
                 'deregister-instances-from-load-balancer': ['instances'],
                 'register-instances-with-load-balancer': ['instances']
             }
         }
-        cases = cases.get(service_name, {}).get(operation_name, [])
+        cases = cases.get(service_id, {}).get(operation_name, [])
         return argument_name in cases
 
 
@@ -308,18 +308,18 @@ class ParamShorthandParser(ParamShorthand):
         if not self._should_parse_as_shorthand(cli_argument, value):
             return
         else:
-            service_name, operation_name = \
+            service_id, operation_name = \
                 find_service_and_method_in_event_name(event_name)
             return self._parse_as_shorthand(
-                cli_argument, value, service_name, operation_name)
+                cli_argument, value, service_id, operation_name)
 
-    def _parse_as_shorthand(self, cli_argument, value, service_name,
+    def _parse_as_shorthand(self, cli_argument, value, service_id,
                             operation_name):
         try:
             LOG.debug("Parsing param %s as shorthand",
                         cli_argument.cli_name)
             handled_value = self._handle_special_cases(
-                cli_argument, value, service_name, operation_name)
+                cli_argument, value, service_id, operation_name)
             if handled_value is not None:
                 return handled_value
             if isinstance(value, list):
@@ -344,7 +344,7 @@ class ParamShorthandParser(ParamShorthand):
             raise ParamError(cli_argument.cli_name, str(e))
         return parsed
 
-    def _handle_special_cases(self, cli_argument, value, service_name,
+    def _handle_special_cases(self, cli_argument, value, service_id,
                               operation_name):
         # We need to handle a few special cases that the previous
         # parser handled in order to stay backwards compatible.
@@ -352,7 +352,7 @@ class ParamShorthandParser(ParamShorthand):
         if model.type_name == 'list' and \
            model.member.type_name == 'structure' and \
            len(model.member.members) == 1 and \
-           self._uses_old_list_case(service_name, operation_name, cli_argument.name):
+           self._uses_old_list_case(service_id, operation_name, cli_argument.name):
             # First special case is handling a list of structures
             # of a single element such as:
             #
@@ -411,7 +411,7 @@ class ParamShorthandDocGen(ParamShorthand):
             return _is_complex_shape(argument_model)
         return False
 
-    def generate_shorthand_example(self, cli_argument, service_name,
+    def generate_shorthand_example(self, cli_argument, service_id,
                                    operation_name):
         """Generate documentation for a CLI argument.
 
@@ -427,7 +427,7 @@ class ParamShorthandDocGen(ParamShorthand):
 
         """
         docstring = self._handle_special_cases(
-            cli_argument, service_name, operation_name)
+            cli_argument, service_id, operation_name)
         if docstring is self._DONT_DOC:
             return None
         elif docstring:
@@ -445,13 +445,13 @@ class ParamShorthandDocGen(ParamShorthand):
         except TooComplexError:
             return ''
 
-    def _handle_special_cases(self, cli_argument, service_name, operation_name):
+    def _handle_special_cases(self, cli_argument, service_id, operation_name):
         model = cli_argument.argument_model
         if model.type_name == 'list' and \
                 model.member.type_name == 'structure' and \
                 len(model.member.members) == 1 and \
                 self._uses_old_list_case(
-                    service_name, operation_name, cli_argument.name):
+                    service_id, operation_name, cli_argument.name):
             member_name = list(model.member.members)[0]
             return '%s %s1 %s2 %s3' % (cli_argument.cli_name, member_name,
                                        member_name, member_name)

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -420,7 +420,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         doc.write('}')
 
     def doc_option_example(self, arg_name, help_command, event_name, **kwargs):
-        service_name, operation_name = \
+        service_id, operation_name = \
             find_service_and_method_in_event_name(event_name)
         doc = help_command.doc
         cli_argument = help_command.arg_table[arg_name]
@@ -433,7 +433,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         docgen = ParamShorthandDocGen()
         if docgen.supports_shorthand(cli_argument.argument_model):
             example_shorthand_syntax = docgen.generate_shorthand_example(
-                cli_argument, service_name, operation_name)
+                cli_argument, service_id, operation_name)
             if example_shorthand_syntax is None:
                 # If the shorthand syntax returns a value of None,
                 # this indicates to us that there is no example

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -62,11 +62,10 @@ def main():
 
 
 def create_clidriver():
-    emitter = HierarchicalEmitter()
-    session = botocore.session.Session(EnvironmentVariables, emitter)
+    session = botocore.session.Session(EnvironmentVariables)
     _set_user_agent_for_session(session)
     load_plugins(session.full_config.get('plugins', {}),
-                 event_hooks=emitter)
+                 event_hooks=session.get_component('event_emitter'))
     driver = CLIDriver(session=session)
     return driver
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -16,7 +16,7 @@ import logging
 
 import botocore.session
 from botocore import __version__ as botocore_version
-from botocore.hooks import AliasedEventEmitter
+from botocore.hooks import HierarchicalEmitter
 from botocore import xform_name
 from botocore.compat import copy_kwargs, OrderedDict
 from botocore.exceptions import NoCredentialsError
@@ -62,7 +62,7 @@ def main():
 
 
 def create_clidriver():
-    emitter = AliasedEventEmitter()
+    emitter = HierarchicalEmitter()
     session = botocore.session.Session(EnvironmentVariables, emitter)
     _set_user_agent_for_session(session)
     load_plugins(session.full_config.get('plugins', {}),

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 # refers to an actual URI of some sort and we don't want to actually
 # download the content (i.e TemplateURL in cloudformation).
 PARAMFILE_DISABLED = set([
-    'apigateway.put-integration.uri',
-    'appstream2.create-stack.redirect-url',
-    'appstream2.update-stack.redirect-url',
+    'api-gateway.put-integration.uri',
+    'appstream.create-stack.redirect-url',
+    'appstream.update-stack.redirect-url',
     'cloudformation.create-stack.template-url',
     'cloudformation.update-stack.template-url',
     'cloudformation.create-stack-set.template-url',
@@ -72,26 +72,26 @@ PARAMFILE_DISABLED = set([
 
     'iam.create-open-id-connect-provider.url',
 
-    'machinelearning.predict.predict-endpoint',
+    'machine-learning.predict.predict-endpoint',
 
-    'api.mediatailor.put-playback-configuration.ad-decision-server-url',
-    'api.mediatailor.put-playback-configuration.slate-ad-url',
-    'api.mediatailor.put-playback-configuration.video-content-source-url',
+    'mediatailor.put-playback-configuration.ad-decision-server-url',
+    'mediatailor.put-playback-configuration.slate-ad-url',
+    'mediatailor.put-playback-configuration.video-content-source-url',
 
     'rds.copy-db-cluster-snapshot.pre-signed-url',
     'rds.create-db-cluster.pre-signed-url',
     'rds.copy-db-snapshot.pre-signed-url',
     'rds.create-db-instance-read-replica.pre-signed-url',
 
-    'serverlessrepo.create-application.home-page-url',
-    'serverlessrepo.create-application.license-url',
-    'serverlessrepo.create-application.readme-url',
-    'serverlessrepo.create-application.source-code-url',
-    'serverlessrepo.create-application.template-url',
-    'serverlessrepo.create-application-version.source-code-url',
-    'serverlessrepo.create-application-version.template-url',
-    'serverlessrepo.update-application.home-page-url',
-    'serverlessrepo.update-application.readme-url',
+    'serverlessapplicationrepository.create-application.home-page-url',
+    'serverlessapplicationrepository.create-application.license-url',
+    'serverlessapplicationrepository.create-application.readme-url',
+    'serverlessapplicationrepository.create-application.source-code-url',
+    'serverlessapplicationrepository.create-application.template-url',
+    'serverlessapplicationrepository.create-application-version.source-code-url',
+    'serverlessapplicationrepository.create-application-version.template-url',
+    'serverlessapplicationrepository.update-application.home-page-url',
+    'serverlessapplicationrepository.update-application.readme-url',
 
     'sqs.add-permission.queue-url',
     'sqs.change-message-visibility.queue-url',
@@ -121,7 +121,7 @@ PARAMFILE_DISABLED = set([
     'iot.create-job.document-source',
     'translate.translate-text.text',
 
-    'workdocs.create-notification-subscription.notification-endpoint',
+    'workdocs.create-notification-subscription.notification-endpoint'
 ])
 
 

--- a/awscli/plugin.py
+++ b/awscli/plugin.py
@@ -13,7 +13,6 @@
 import logging
 
 from botocore.hooks import HierarchicalEmitter
-from botocore.hooks import AliasedEventEmitter
 
 log = logging.getLogger('awscli.plugin')
 
@@ -44,7 +43,7 @@ def load_plugins(plugin_mapping, event_hooks=None, include_builtins=True):
         plugin_mapping.update(BUILTIN_PLUGINS)
     modules = _import_plugins(plugin_mapping)
     if event_hooks is None:
-        event_hooks = AliasedEventEmitter()
+        event_hooks = HierarchicalEmitter()
     for name, plugin in zip(plugin_mapping.keys(), modules):
         log.debug("Initializing plugin %s: %s", name, plugin)
         plugin.awscli_initialize(event_hooks)

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -47,7 +47,6 @@ except ImportError as e:
     # different story.
     mock = None
 from awscli.compat import six
-from botocore.hooks import HierarchicalEmitter
 from botocore.session import Session
 from botocore.exceptions import ClientError
 from botocore.exceptions import WaiterError

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -116,7 +116,7 @@ def _find_quote_char_in_part(part):
 
 def find_service_and_method_in_event_name(event_name):
     """
-    Grabs the service name and the operation name from an event name.
+    Grabs the service id and the operation name from an event name.
     This is making the assumption that the event name is in the form
     event.service.operation.
     """

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -271,7 +271,7 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_list_structure_scalars(self):
         p = self.get_param_model(
             'elb.RegisterInstancesWithLoadBalancer.Instances')
-        event_name = ('process-cli-arg.elb'
+        event_name = ('process-cli-arg.elastic-load-balancing'
                       '.register-instances-with-load-balancer')
         # Because this is a list type param, we'll use nargs
         # with argparse which means the value will be presented
@@ -532,11 +532,12 @@ class TestDocGen(BaseArgProcessTest):
         self.shorthand_documenter = ParamShorthandDocGen()
         self.service_name = 'foo'
         self.operation_name = 'bar'
+        self.service_id = 'baz'
 
     def get_generated_example_for(self, argument):
         # Returns a string containing the generated documentation.
         return self.shorthand_documenter.generate_shorthand_example(
-            argument, self.service_name, self.operation_name)
+            argument, self.service_id, self.operation_name)
 
     def assert_generated_example_is(self, argument, expected_docs):
         generated_docs = self.get_generated_example_for(argument)
@@ -556,6 +557,7 @@ class TestDocGen(BaseArgProcessTest):
 
     def test_gen_list_scalar_docs(self):
         self.service_name = 'elb'
+        self.service_id = 'elastic-load-balancing'
         self.operation_name = 'register-instances-with-load-balancer'
         argument = self.get_param_model(
             'elb.RegisterInstancesWithLoadBalancer.Instances')


### PR DESCRIPTION
This fixes issues that sprung up as a result botocore switching to
using service id in events.

Related to boto/botocore#1524 , the tests won't pass without it.