### PR TITLE
Don't upload and set GraphQL Schema Definition

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -319,6 +319,9 @@ class ServerlessApiResource(Resource):
 
 class GraphQLSchemaResource(Resource):
     PROPERTY_NAME = "DefinitionS3Location"
+    # Don't package the directory if DefinitionS3Location is omitted.
+    # Necessary to support Definition
+    PACKAGE_NULL_PROPERTY = False
 
 
 class LambdaFunctionResource(ResourceWithS3UrlDict):


### PR DESCRIPTION
If Definition is provided in-line, don't upload it and modify the
template. Previously, it would be uploaded, DefinitionS3Location would
be set, but Definition would also remain, leaving conflicting
properties.