### PR TITLE
Improve installer error message

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -25,6 +25,10 @@ class BadRCError(Exception):
     pass
 
 
+class MultipleBundlesError(Exception):
+    pass
+
+
 @contextmanager
 def cd(dirname):
     original = os.getcwd()
@@ -91,7 +95,12 @@ def create_working_dir():
 def pip_install_packages(install_dir):
     cli_tarball = [p for p in os.listdir(PACKAGES_DIR)
                    if p.startswith('awscli')]
-    assert len(cli_tarball) == 1
+    if len(cli_tarball) != 1:
+        message = (
+            "Multiple versions of the CLI were found in %s. Please clear "
+            "out this directory before proceeding."
+        )
+        raise MultipleBundlesError(message % PACKAGES_DIR)
     cli_tarball = cli_tarball[0]
     pip_script = os.path.join(install_dir, bin_path(), 'pip')
 


### PR DESCRIPTION
This improves the error message when a user tries to install a new version of the bundled installer when they unzip the new bundle on top of the old. This results in multiple versions of the cli being in their bundle.

Reproduction:

```
$ mkdir /tmp/bundle
$ cd /tmp/bundle
$ aws s3 cp s3://aws-cli/awscli-bundle-1.16.13.zip .
$ unzip awscli-bundle-1.16.13.zip
$ aws s3 cp s3://aws-cli/awscli-bundle-1.16.14.zip .
$ unzip -o awscli-bundle-1.16.14.zip
$ mkdir /tmp/bundle/local
$ mkdir /tmp/bundle/local/bin
$ ./awscli-bundle/install -i /tmp/bundle/local/aws -b /tmp/bundle/local/bin/aws
Traceback (most recent call last):
  File "./awscli-bundle/install", line 153, in <module>
    main()
  File "./awscli-bundle/install", line 142, in main
    pip_install_packages(opts.install_dir)
  File "./awscli-bundle/install", line 94, in pip_install_packages
    assert len(cli_tarball) == 1
AssertionError
```

New Error:

```
$ ./awscli-bundle/install -i /tmp/bundle/local/aws -b /tmp/bundle/local/bin/aws
Traceback (most recent call last):
  File "./awscli-bundle/install", line 162, in <module>
    main()
  File "./awscli-bundle/install", line 151, in main
    pip_install_packages(opts.install_dir)
  File "./awscli-bundle/install", line 103, in pip_install_packages
    raise MultipleBundlesError(message % PACKAGES_DIR)
__main__.MultipleBundlesError: Multiple versions of the CLI were found in /private/tmp/bundle/awscli-bundle/packages. Please clear out this directory or install to a different location.
```