### PR TITLE
Remove "\" char from "$\Latest" value option

### DIFF
--- a/awscli/examples/ssm/update-document.rst
+++ b/awscli/examples/ssm/update-document.rst
@@ -4,7 +4,7 @@ This creates a new version of a document. The document must be in JSON format. N
 
 Command::
 
-  aws ssm update-document --name "RunShellScript" --content "file://RunShellScript.json" --document-version "\$LATEST"
+  aws ssm update-document --name "RunShellScript" --content "file://RunShellScript.json" --document-version "$LATEST"
   
 Output::
 


### PR DESCRIPTION
The "\" character in --version "\$LATEST"causes the command to fail and should be removed. Error message in CLI when --version is omitted confirms this.