### PR TITLE
[CLIv2] Remove backcompat shim in shorthand parser

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -275,7 +275,7 @@ class ParamShorthandParser(ParamShorthand):
 
     def __init__(self):
         self._parser = shorthand.ShorthandParser()
-        self._visitor = shorthand.BackCompatVisitor()
+        self._visitor = shorthand.ModelVisitor()
 
     def __call__(self, cli_argument, value, event_name, **kwargs):
         """Attempt to parse shorthand syntax for values.

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -384,21 +384,6 @@ class ModelVisitor(object):
             self._visit(value, value_shape, k, v)
 
     def _visit_scalar(self, parent, shape, name, value):
-        pass
-
-
-class BackCompatVisitor(ModelVisitor):
-    def _visit_list(self, parent, shape, name, value):
-        if not isinstance(value, list):
-            # Convert a -> [a] because they specified
-            # "foo=bar", but "bar" should really be ["bar"].
-            if value is not None:
-                parent[name] = [value]
-        else:
-            return super(BackCompatVisitor, self)._visit_list(
-                parent, shape, name, value)
-
-    def _visit_scalar(self, parent, shape, name, value):
         if value is None:
             return
         type_name = shape.type_name

--- a/tests/functional/ec2/test_describe_instances.py
+++ b/tests/functional/ec2/test_describe_instances.py
@@ -54,7 +54,7 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(cmdline, result)
 
     def test_filter_simple(self):
-        args = """ --filters Name=group-name,Values=foobar"""
+        args = """ --filters Name=group-name,Values=[foobar]"""
         cmdline = self.prefix + args
         result = {
             'Filters': [
@@ -76,8 +76,8 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(cmdline, result)
 
     def test_multiple_filters(self):
-        args = (' --filters Name=group-name,Values=foobar '
-                'Name=instance-id,Values=i-12345')
+        args = (' --filters Name=group-name,Values=[foobar] '
+                'Name=instance-id,Values=[i-12345]')
         cmdline = self.prefix + args
         result = {
             'Filters': [
@@ -92,8 +92,8 @@ class TestDescribeInstances(BaseAWSCommandParamsTest):
     def test_multiple_filters_alternate(self):
         cmdlist = 'ec2 describe-instances'.split()
         cmdlist.extend(['--filters',
-                        'Name = group-name, Values= foobar',
-                        'Name=instance-id,Values=i-12345'])
+                        'Name = group-name, Values= [foobar]',
+                        'Name=instance-id,Values=[i-12345]'])
         result = {
             'Filters': [
                 {'Name': 'group-name',

--- a/tests/functional/ec2/test_describe_snapshots.py
+++ b/tests/functional/ec2/test_describe_snapshots.py
@@ -28,7 +28,9 @@ class TestDescribeSnapshots(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(command, params)
 
     def test_max_results_not_set_with_filter(self):
-        command = self.prefix + ' --filters Name=snapshot-id,Values=snap-snap'
+        command = (
+            self.prefix + ' --filters Name=snapshot-id,Values=[snap-snap]'
+        )
         params = {'Filters': [{
             'Name': 'snapshot-id', 'Values': ['snap-snap']
         }]}

--- a/tests/functional/ec2/test_describe_volumes.py
+++ b/tests/functional/ec2/test_describe_volumes.py
@@ -40,7 +40,7 @@ class TestDescribeVolumes(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(command, params)
 
     def test_max_results_not_set_with_filter(self):
-        command = self.prefix + ' --filters Name=volume-id,Values=id-volume'
+        command = self.prefix + ' --filters Name=volume-id,Values=[id-volume]'
         params = {'Filters': [{'Name': 'volume-id', 'Values': ['id-volume']}]}
         self.assert_params_for_cmd(command, params)
 

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -467,24 +467,34 @@ class TestAddSteps(BaseAWSCommandParamsTest):
             expected_result_release=expected_result_release)
 
     def test_empty_step_args(self):
-        cmd = self.prefix + 'Type=Streaming,Args='
-        expected_error_msg = ('\naws: error: The prameter Args cannot '
-                              'be an empty list.\n')
+        cmd = self.prefix + 'Type=Streaming,Args=[]'
+        expected_error_msg = (
+            '\naws: error: The following required parameters are missing '
+            'for StreamingStepConfig: Args.\n'
+        )
         self.assert_error_for_ami_and_release_based_clusters(
             cmd=cmd, expected_error_msg=expected_error_msg,
             expected_result_release=expected_error_msg)
 
-        cmd = self.prefix + 'Type=Pig,Args='
+        expected_error_msg = (
+            '\naws: error: The following required parameters are missing '
+            'for PigStepConfig: Args.\n'
+        )
+        cmd = self.prefix + 'Type=Pig,Args=[]'
         self.assert_error_for_ami_and_release_based_clusters(
             cmd=cmd, expected_error_msg=expected_error_msg,
             expected_result_release=expected_error_msg)
 
-        cmd = self.prefix + 'Type=Hive,Args='
+        expected_error_msg = (
+            '\naws: error: The following required parameters are missing '
+            'for HiveStepConfig: Args.\n'
+        )
+        cmd = self.prefix + 'Type=Hive,Args=[]'
         self.assert_error_for_ami_and_release_based_clusters(
             cmd=cmd, expected_error_msg=expected_error_msg,
             expected_result_release=expected_error_msg)
 
-        cmd = self.prefix + 'Args='
+        cmd = self.prefix + 'Args=[]'
         expected_error_msg = ('\naws: error: The following required parameters'
                               ' are missing for CustomJARStepConfig: Jar.\n')
         self.assert_error_for_ami_and_release_based_clusters(

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -1173,25 +1173,37 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(cmd, result)
 
     def test_empty_step_args(self):
-        cmd = DEFAULT_CMD + '--steps Type=Streaming,Args= '
-        expect_error_msg = ('\naws: error: The prameter Args cannot '
-                            'be an empty list.\n')
+        cmd = DEFAULT_CMD + '--steps Type=Streaming,Args=[]'
+        expected_error_msg = (
+            '\naws: error: The following required parameters are missing '
+            'for StreamingStepConfig: Args.\n'
+        )
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEquals(expected_error_msg, result[1])
 
-        cmd = DEFAULT_CMD + '--steps Type=Pig,Args= '
+        expected_error_msg = (
+            '\naws: error: The following required parameters are missing '
+            'for PigStepConfig: Args.\n'
+        )
+        cmd = DEFAULT_CMD + '--steps Type=Pig,Args=[]'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEquals(expected_error_msg, result[1])
 
-        cmd = DEFAULT_CMD + '--steps Type=Hive,Args= '
+        expected_error_msg = (
+            '\naws: error: The following required parameters are missing '
+            'for HiveStepConfig: Args.\n'
+        )
+        cmd = DEFAULT_CMD + '--steps Type=Hive,Args=[]'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEquals(expected_error_msg, result[1])
 
-        cmd = DEFAULT_CMD + '--steps Args= '
-        expect_error_msg = ('\naws: error: The following required parameters '
-                            'are missing for CustomJARStepConfig: Jar.\n')
+        cmd = DEFAULT_CMD + '--steps Args=[]'
+        expected_error_msg = (
+            '\naws: error: The following required parameters '
+            'are missing for CustomJARStepConfig: Jar.\n'
+        )
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEquals(expected_error_msg, result[1])
 
     def test_missing_applications_for_steps(self):
         cmd = DEFAULT_CMD +\

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -283,34 +283,20 @@ class TestParamShorthand(BaseArgProcessTest):
 
     def test_list_structure_list_scalar(self):
         p = self.get_param_model('ec2.DescribeInstances.Filters')
-        expected = [{"Name": "instance-id", "Values": ["i-1", "i-2"]},
-                    {"Name": "architecture", "Values": ["i386"]}]
+        expected = [{"Name": "instance-id", "Values": ["i-1", "i-2"]}]
         returned = self.parse_shorthand(
-            p, ["Name=instance-id,Values=i-1,i-2",
-                "Name=architecture,Values=i386"])
+            p, ["Name=instance-id,Values=i-1,i-2"])
         self.assertEqual(returned, expected)
 
         # With spaces around the comma.
         returned2 = self.parse_shorthand(
-            p, ["Name=instance-id, Values=i-1,i-2",
-                "Name=architecture, Values=i386"])
+            p, ["Name=instance-id, Values=i-1,i-2"])
         self.assertEqual(returned2, expected)
 
         # Strip off leading/trailing spaces.
         returned3 = self.parse_shorthand(
-            p, ["Name = instance-id, Values = i-1,i-2",
-                "Name = architecture, Values = i386"])
+            p, ["Name = instance-id, Values = i-1,i-2"])
         self.assertEqual(returned3, expected)
-
-    def test_parse_empty_values(self):
-        # A value can be omitted and will default to an empty string.
-        p = self.get_param_model('ec2.DescribeInstances.Filters')
-        expected = [{"Name": "", "Values": ["i-1", "i-2"]},
-                    {"Name": "architecture", "Values": ['']}]
-        returned = self.parse_shorthand(
-            p, ["Name=,Values=i-1,i-2",
-                "Name=architecture,Values="])
-        self.assertEqual(returned, expected)
 
     def test_list_structure_list_scalar_2(self):
         p = self.get_param_model('emr.ModifyInstanceGroups.InstanceGroups')
@@ -491,7 +477,7 @@ class TestParamShorthandCustomArguments(BaseArgProcessTest):
 
         simplified = self.shorthand(cli_argument, [
             "Name=foo,Args=[a,k1=v1,b]",
-            "Name=bar,Args=baz",
+            "Name=bar,Args=[baz]",
             "Name=single_kv,Args=[key=value]",
             "Name=single_v,Args=[value]"
         ], 'process-cli-arg.foo.bar')

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -190,36 +190,6 @@ def _can_parse(data, expected):
 
 
 class TestModelVisitor(unittest.TestCase):
-    def test_promote_to_list_of_ints(self):
-        m = model.DenormalizedStructureBuilder().with_members({
-            'A': {
-                'type': 'list',
-                'member': {'type': 'string'}
-            },
-        }).build_model()
-        b = shorthand.BackCompatVisitor()
-
-        params = {'A': 'foo'}
-        b.visit(params, m)
-        self.assertEqual(params, {'A': ['foo']})
-
-    def test_dont_promote_list_if_none_value(self):
-        m = model.DenormalizedStructureBuilder().with_members({
-            'A': {
-                'type': 'list',
-                'member': {
-                    'type': 'structure',
-                    'members': {
-                        'Single': {'type': 'string'}
-                    },
-                },
-            },
-        }).build_model()
-        b = shorthand.BackCompatVisitor()
-        params = {}
-        b.visit(params, m)
-        self.assertEqual(params, {})
-
     def test_can_convert_scalar_types_from_string(self):
         m = model.DenormalizedStructureBuilder().with_members({
             'A': {'type': 'integer'},
@@ -228,7 +198,7 @@ class TestModelVisitor(unittest.TestCase):
             'D': {'type': 'boolean'},
             'E': {'type': 'boolean'},
         }).build_model()
-        b = shorthand.BackCompatVisitor()
+        b = shorthand.ModelVisitor()
 
         params = {'A': '24', 'B': '24', 'C': '24.12345',
                   'D': 'true', 'E': 'false'}
@@ -242,7 +212,7 @@ class TestModelVisitor(unittest.TestCase):
         m = model.DenormalizedStructureBuilder().with_members({
             'A': {'type': 'boolean'},
         }).build_model()
-        b = shorthand.BackCompatVisitor()
+        b = shorthand.ModelVisitor()
 
         params = {}
         b.visit(params, m)
@@ -257,7 +227,7 @@ class TestModelVisitor(unittest.TestCase):
                 },
             },
         }).build_model()
-        b = shorthand.BackCompatVisitor()
+        b = shorthand.ModelVisitor()
         params = {'A': ['1', '2']}
         b.visit(params, m)
         # We should have converted each list element to an integer


### PR DESCRIPTION
Now foo=bar will parse to {'foo': 'bar'}, which resolves
an inconsistency that you can't tell how a shorthand snippet
is parsed without also knowing the underlying types in the service
model.

There were some changes I had to make in the EMR tests, but that
was primarily related to the expected messages in the error cases.

CLIv2: https://github.com/aws/aws-cli/issues/3587