### PR TITLE
[CLIv2] Support only 2.7.9 and up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ This package provides a unified command line interface to Amazon Web Services.
 
 The aws-cli package works on Python versions:
 
-* 2.7.x and greater
+* 2.7.9 and greater
 * 3.5.x and greater
 * 3.6.x and greater
 * 3.7.x and greater


### PR DESCRIPTION
Python 2.7.9 represented a significant change for python networking. There's an entire laundry list of features that were added with regards to ssl, many of which are important to us. For example, SNI was added as part of this release and is required to use some servies. The lack of SNI also means that we have to use deprecated endpoint urls for SQS. This is just one example of a feature we would want, for more details on what changed see [here](https://www.python.org/downloads/release/python-279/).