### PR TITLE
[CLIv2] Add subcommand/arg_table properties to clidriver

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -89,6 +89,14 @@ class CLIDriver(object):
         self._argument_table = None
         self.alias_loader = AliasLoader()
 
+    @property
+    def subcommand_table(self):
+        return self._get_command_table()
+
+    @property
+    def arg_table(self):
+        return self._get_argument_table()
+
     def _get_cli_data(self):
         # Not crazy about this but the data in here is needed in
         # several places (e.g. MainArgParser, ProviderHelp) so
@@ -321,6 +329,16 @@ class ServiceCommand(CLICommand):
     def lineage(self, value):
         self._lineage = value
 
+    @property
+    def subcommand_table(self):
+        return self._get_command_table()
+
+    @property
+    def arg_table(self):
+        # No service level arguments so we just return an empty
+        # dictionary.
+        return {}
+
     def _get_command_table(self):
         if self._command_table is None:
             self._command_table = self._create_command_table()
@@ -454,6 +472,12 @@ class ServiceOperation(object):
     def lineage_names(self):
         # Represents the lineage of a command in terms of command ``name``
         return [cmd.name for cmd in self.lineage]
+
+    @property
+    def subcommand_table(self):
+        # There's no subcommands for an operation so we return an
+        # empty dictionary.
+        return {}
 
     @property
     def arg_table(self):

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -20,6 +20,7 @@ import sys
 import mock
 import nose
 from awscli.compat import six
+from botocore import xform_name
 from botocore.awsrequest import AWSResponse
 from botocore.exceptions import NoCredentialsError
 from botocore.compat import OrderedDict
@@ -318,6 +319,15 @@ class TestCliDriver(unittest.TestCase):
         stderr.flush()
         self.assertEqual(rc, 255)
         self.assertEqual(stderr_b.getvalue().strip(), u"☃".encode("UTF-8"))
+
+    def test_can_access_subcommand_table(self):
+        table = self.driver.subcommand_table
+        self.assertEqual(list(table), self.session.get_available_services())
+
+    def test_can_access_argument_table(self):
+        arg_table = self.driver.arg_table
+        expected = list(GET_DATA['cli']['options'])
+        self.assertEqual(list(arg_table), expected)
 
 
 class TestCliDriverHooks(unittest.TestCase):
@@ -840,6 +850,17 @@ class TestServiceCommand(unittest.TestCase):
         self.session = FakeSession()
         self.cmd = ServiceCommand(self.name, self.session)
 
+    def test_can_access_subcommand_table(self):
+        table = self.cmd.subcommand_table
+        expected = [
+            xform_name(op, '-') for op in
+            self.session.get_service_model(self.name).operation_names
+        ]
+        self.assertEqual(set(table), set(expected))
+
+    def test_can_access_arg_table(self):
+        self.assertEqual(self.cmd.arg_table, {})
+
     def test_name(self):
         self.assertEqual(self.cmd.name, self.name)
         self.cmd.name = 'bar'
@@ -876,11 +897,20 @@ class TestServiceCommand(unittest.TestCase):
 
 class TestServiceOperation(unittest.TestCase):
     def setUp(self):
-        self.name = 'foo'
-        operation = mock.Mock(spec=botocore.model.OperationModel)
-        operation.deprecated = False
+        self.name = 'list-objects'
+        self.session = FakeSession()
+        operation = self.session.get_service_model(
+            's3').operation_model('ListObjects')
         self.mock_operation = operation
-        self.cmd = ServiceOperation(self.name, None, None, operation, None)
+        self.cmd = ServiceOperation(self.name, None, None, operation,
+                                    self.session)
+
+    def test_can_access_subcommand_table(self):
+        self.assertEqual(self.cmd.subcommand_table, {})
+
+    def test_can_access_arg_table(self):
+        self.assertEqual(set(self.cmd.arg_table),
+                         set(['bucket', 'marker', 'max-keys']))
 
     def test_name(self):
         self.assertEqual(self.cmd.name, self.name)
@@ -894,7 +924,7 @@ class TestServiceOperation(unittest.TestCase):
         self.assertEqual(self.cmd.lineage, [cmd])
 
     def test_lineage_names(self):
-        self.assertEqual(self.cmd.lineage_names, ['foo'])
+        self.assertEqual(self.cmd.lineage_names, ['list-objects'])
 
     def test_deprecated_operation(self):
         self.mock_operation.deprecated = True

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -269,39 +269,34 @@ class FakeCommandVerify(FakeCommand):
 class TestCliDriver(unittest.TestCase):
     def setUp(self):
         self.session = FakeSession()
+        self.driver = CLIDriver(session=self.session)
 
     def test_session_can_be_passed_in(self):
-        driver = CLIDriver(session=self.session)
-        self.assertEqual(driver.session, self.session)
+        self.assertEqual(self.driver.session, self.session)
 
     def test_paginate_rc(self):
-        driver = CLIDriver(session=self.session)
-        rc = driver.main('s3 list-objects --bucket foo'.split())
+        rc = self.driver.main('s3 list-objects --bucket foo'.split())
         self.assertEqual(rc, 0)
 
     def test_no_profile(self):
-        driver = CLIDriver(session=self.session)
-        driver.main('s3 list-objects --bucket foo'.split())
-        self.assertEqual(driver.session.profile, None)
+        self.driver.main('s3 list-objects --bucket foo'.split())
+        self.assertEqual(self.driver.session.profile, None)
 
     def test_profile(self):
-        driver = CLIDriver(session=self.session)
-        driver.main('s3 list-objects --bucket foo --profile foo'.split())
-        self.assertEqual(driver.session.profile, 'foo')
+        self.driver.main('s3 list-objects --bucket foo --profile foo'.split())
+        self.assertEqual(self.driver.session.profile, 'foo')
 
     def test_error_logger(self):
-        driver = CLIDriver(session=self.session)
-        driver.main('s3 list-objects --bucket foo --profile foo'.split())
+        self.driver.main('s3 list-objects --bucket foo --profile foo'.split())
         expected = {'log_level': logging.ERROR, 'logger_name': 'awscli'}
-        self.assertEqual(driver.session.stream_logger_args[1], expected)
+        self.assertEqual(self.driver.session.stream_logger_args[1], expected)
 
     def test_ctrl_c_is_handled(self):
-        driver = CLIDriver(session=self.session)
         fake_client = mock.Mock()
         fake_client.list_objects.side_effect = KeyboardInterrupt
         fake_client.can_paginate.return_value = False
-        driver.session.create_client = mock.Mock(return_value=fake_client)
-        rc = driver.main('s3 list-objects --bucket foo'.split())
+        self.driver.session.create_client = mock.Mock(return_value=fake_client)
+        rc = self.driver.main('s3 list-objects --bucket foo'.split())
         self.assertEqual(rc, 130)
 
     def test_error_unicode(self):
@@ -313,14 +308,13 @@ class TestCliDriver(unittest.TestCase):
         else:
             stderr = stderr_b = six.StringIO()
             stderr.encoding = "UTF-8"
-        driver = CLIDriver(session=self.session)
         fake_client = mock.Mock()
         fake_client.list_objects.side_effect = Exception(u"☃")
         fake_client.can_paginate.return_value = False
-        driver.session.create_client = mock.Mock(return_value=fake_client)
+        self.driver.session.create_client = mock.Mock(return_value=fake_client)
         with mock.patch("sys.stderr", stderr):
             with mock.patch("locale.getpreferredencoding", lambda: "UTF-8"):
-                rc = driver.main('s3 list-objects --bucket foo'.split())
+                rc = self.driver.main('s3 list-objects --bucket foo'.split())
         stderr.flush()
         self.assertEqual(rc, 255)
         self.assertEqual(stderr_b.getvalue().strip(), u"☃".encode("UTF-8"))


### PR DESCRIPTION
This provides a consistent interface across built in commands and custom
commands for accessing both the subcommand and argument tables.  The
custom command class already exposed these properties so I just added
them to the builtin command objects.  This allows us to traverse command
structures without having to use the help commands.  The help may be
changing so we want to avoid coupling autocompletion to the help command
interface.
