### PR TITLE
[CLIv2] Add indexing for model based completer

### DIFF
--- a/awscli/autocomplete/__init__.py
+++ b/awscli/autocomplete/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/awscli/autocomplete/generator.py
+++ b/awscli/autocomplete/generator.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Generates auto completion index."""
+from awscli.autocomplete import indexer
+
+
+def create_model_indexer(filename):
+    index = indexer.ModelIndexer(
+        indexer.DatabaseConnection(filename)
+    )
+    return index
+
+
+class IndexGenerator(object):
+    """Generates auto completion index.
+
+    This will generate an auto completion index for all the low level
+    indexer used by the CLI.  This object primarily delegates to other
+    objects that do the actual heavy lifting of generating auto completion
+    indices.
+
+    """
+    def __init__(self, model_indexer):
+        self._model_indexer = model_indexer
+
+    def generate_index(self, clidriver):
+        self._model_indexer.generate_index(clidriver)

--- a/awscli/autocomplete/indexer.py
+++ b/awscli/autocomplete/indexer.py
@@ -1,0 +1,118 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+import sqlite3
+
+
+LOG = logging.getLogger(__name__)
+
+
+class ModelIndexer(object):
+    def __init__(self, db_connection):
+        self._db_connection = db_connection
+
+    def generate_index(self, clidriver):
+        parent = 'aws'
+        self._db_connection.execute(
+            'INSERT OR REPLACE INTO command_table (command)'
+            'VALUES (:command)',
+            command=parent
+        )
+        command_table = clidriver.subcommand_table
+        self._generate_arg_index(command=parent, parent='',
+                                 arg_table=clidriver.arg_table)
+        self._generate_command_index(command_table, parent=parent)
+
+    def _generate_arg_index(self, command, parent, arg_table):
+        for name, value in arg_table.items():
+            self._db_connection.execute(
+                'INSERT INTO param_table '
+                '(argname, type_name, command, parent, nargs)'
+                ' VALUES (:argname, :type_name, :command, :parent, :nargs)',
+                argname=name, type_name=value.cli_type_name,
+                command=command, parent=parent,
+                nargs=value.nargs,
+            )
+
+    def _generate_command_index(self, command_table, parent):
+        for name, command in command_table.items():
+            self._db_connection.execute(
+                'INSERT INTO command_table (command, parent) '
+                'VALUES (:command, :parent)',
+                command=name, parent=parent,
+            )
+            self._generate_arg_index(command=name, parent=parent,
+                                     arg_table=command.arg_table)
+            self._generate_command_index(command.subcommand_table,
+                                         parent='%s.%s' % (parent, name))
+
+
+# This is similar to DBConnection in awscli.customization.history.
+# I'd like to reuse code, but we also have the contraint that we don't
+# want to import anything outside of awscli.autocomplete to ensure
+# our startup time is as minimal as possible.
+class DatabaseConnection(object):
+    _CREATE_CMD_TABLE = """\
+        CREATE TABLE IF NOT EXISTS command_table (
+          command TEXT,
+          parent TEXT REFERENCES command_table,
+          PRIMARY KEY (command, parent)
+        );
+    """
+    _CREATE_PARAM_TABLE = """\
+        CREATE TABLE IF NOT EXISTS param_table (
+          argname TEXT,
+          type_name TEXT,
+          command TEXT,
+          parent TEXT,
+          nargs TEXT,
+          FOREIGN KEY (command, parent) REFERENCES
+            command_table(command, parent)
+        );
+    """
+    _ENABLE_WAL = 'PRAGMA journal_mode=WAL'
+
+    def __init__(self, db_filename):
+        self._db_conn = None
+        self._db_filename = db_filename
+
+    @property
+    def _connection(self):
+        if self._db_conn is None:
+            self._db_conn = sqlite3.connect(
+                self._db_filename, check_same_thread=False,
+                isolation_level=None)
+            self._ensure_database_setup()
+        return self._db_conn
+
+    def close(self):
+        self._connection.close()
+
+    def execute(self, query, **kwargs):
+        return self._connection.execute(query, kwargs)
+
+    def _ensure_database_setup(self):
+        self._create_table()
+        self._try_to_enable_wal()
+
+    def _create_table(self):
+        self.execute(self._CREATE_CMD_TABLE)
+        self.execute(self._CREATE_PARAM_TABLE)
+
+    def _try_to_enable_wal(self):
+        try:
+            self.execute(self._ENABLE_WAL)
+        except sqlite3.Error:
+            # This is just a performance enhancement so it is optional. Not all
+            # systems will have a sqlite compiled with the WAL enabled.
+            LOG.debug('Failed to enable sqlite WAL.')

--- a/awscli/autocomplete/model.py
+++ b/awscli/autocomplete/model.py
@@ -1,0 +1,107 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Model based auto-completer.
+
+This provides autocompletion based on information found
+in the `service-2.json` files.
+
+"""
+from collections import namedtuple
+from awscli.autocomplete import indexer
+
+
+CLIArgument = namedtuple('CLIArgument', ['argname', 'type_name',
+                                         'command', 'parent', 'nargs'])
+
+
+class ModelIndex(object):
+    """Retrieve command/param names through querying an index.
+
+    This class provides methods for retrieving valid command
+    and parameter names given some context.  It's used by
+    the model based autocompleter.
+
+    """
+    def __init__(self, db_filename):
+        self._db_filename = db_filename
+        self._db_connection = None
+
+    def _get_db_connection(self):
+        if self._db_connection is None:
+            self._db_connection = indexer.DatabaseConnection(
+                self._db_filename)
+        return self._db_connection
+
+    def command_names(self, lineage):
+        """Return command names given a lineage.
+
+        This ``lineage`` is the same concept used in the
+        AWS CLI command classes, except that it explicitly
+        uses ``aws`` as the first parent.  This is the list of
+        parent commands for a given CLI command.  For example,
+        ``aws ec2 <here>`` has a lineage of ``['ec2']``.  The
+        command ``aws ec2 wait instance-running`` has a lineage
+        of ``['ec2', 'wait', 'instance-running']``.
+
+        :return: A list of available commands.
+        """
+        db = self._get_db_connection()
+        parent = '.'.join(lineage)
+        results = db.execute(
+            'select command from command_table '
+            'where parent = :parent',
+            parent=parent,
+        )
+        return [row[0] for row in results]
+
+    def arg_names(self, lineage, command_name):
+        """Return arg names for a given lineage.
+
+        The return values do not have the `--` added, e.g
+        we'll return ``region``, not ``-region``.
+
+        If you want the arg names for ``aws ec2 describe-instances``,
+        you would provide
+        ``lineage=['aws', 'ec2'], command_name='describe-instances'``.
+
+        """
+        db = self._get_db_connection()
+        parent = '.'.join(lineage)
+        results = db.execute(
+            'select argname from param_table '
+            'where parent = :parent and '
+            'command = :command',
+            parent=parent,
+            command=command_name,
+        )
+        return [row[0] for row in results]
+
+    def get_argument_data(self, lineage, command_name, arg_name):
+        """Return all metadata for a single argument.
+
+        :return: A CLIArgument object.
+
+        """
+        db = self._get_db_connection()
+        parent = '.'.join(lineage)
+        results = list(db.execute(
+            'select * from param_table '
+            'where parent = :parent and '
+            'command = :command and '
+            'argname = :argname',
+            parent=parent,
+            command=command_name,
+            argname=arg_name,
+        ))
+        if len(results) == 1:
+            return CLIArgument(*results[0])

--- a/tests/functional/autocomplete/__init__.py
+++ b/tests/functional/autocomplete/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/autocomplete/test_generator.py
+++ b/tests/functional/autocomplete/test_generator.py
@@ -1,0 +1,48 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, create_clidriver, temporary_file
+from awscli.autocomplete import generator, model
+
+
+class TestCanGenerateEntireIndex(unittest.TestCase):
+    def test_can_generate_entire_index(self):
+        # The point of this test is to make sure generating the index
+        # doesn't break in some obvious way.  The specifics of index
+        # generation are tested in tests/unit/autocomplete.  Here we just
+        # generate the entire index and perform basic sanity checks.  It's
+        # just a functional smoke test.
+        driver = create_clidriver()
+        with temporary_file('w') as f:
+            index_generator = generator.IndexGenerator(
+                generator.create_model_indexer(f.name))
+            index_generator.generate_index(driver)
+
+            # Basic sanity checks.  Index generation for the entire CLI
+            # takes a while so all the sanity checks are combined in a single
+            # test method.
+            model_index = model.ModelIndex(f.name)
+            commands = model_index.command_names(lineage=['aws'])
+            self.assertIn('ec2', commands)
+            self.assertIn('s3', commands)
+            self.assertIn('s3api', commands)
+            global_args = model_index.arg_names(lineage=[], command_name='aws')
+            self.assertIn('region', global_args)
+            self.assertIn('endpoint-url', global_args)
+
+            single_arg = model_index.get_argument_data(
+                lineage=[], command_name='aws',
+                arg_name='output')
+            self.assertEqual(single_arg.argname, 'output')
+            self.assertEqual(single_arg.command, 'aws')
+            self.assertEqual(single_arg.parent, '')
+            self.assertIsNone(single_arg.nargs)

--- a/tests/unit/autocomplete/test_generator.py
+++ b/tests/unit/autocomplete/test_generator.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, mock
+from awscli.autocomplete import generator, indexer
+from awscli.clidriver import CLIDriver
+
+
+class TestGenerateCompletionIndex(unittest.TestCase):
+
+    def test_can_create_model_indexer(self):
+        index = generator.create_model_indexer('/tmp/a/b/c/d')
+        self.assertIsInstance(index, indexer.ModelIndexer)
+
+    def test_use_high_level_generator_for_index_creation(self):
+        model_index = mock.Mock(spec=indexer.ModelIndexer)
+        clidriver = mock.Mock(spec=CLIDriver)
+        index = generator.IndexGenerator(model_index)
+        index.generate_index(clidriver)
+        model_index.generate_index.assert_called_with(clidriver)

--- a/tests/unit/autocomplete/test_indexer.py
+++ b/tests/unit/autocomplete/test_indexer.py
@@ -1,0 +1,180 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, mock
+from awscli.autocomplete import indexer, model
+import tempfile
+
+from botocore.session import Session
+
+
+# Quick note about these tests.  sqlite3 is used as the data store for the
+# index cache.  When testing this we have two options.  We can either invoke
+# various methods from the indexer and the query the generate sqlite DB and
+# make sure the records make sense, or we can invoke various methods from the
+# indexer and then use our ``ModelIndex`` class to query the index.  The
+# ``ModelIndex`` is an abstraction that hides sqlite3 from the clients of the
+# index.  I've decided to test the two together, that is, use our indexer and
+# the ``ModelIndexer`` to ensure we're getting the right data.  This has the
+# downsides that we don't verify anything that we're writing to our sqlite3
+# database.  We could be writing inefficient or completely wrong data to our
+# DB, but as last the ``ModelIndexer`` understands how to query the data, we'll
+# never know.  The reason I think this approach makes sense is that I suspect
+# the schema will change as this feature is developed, and it's more important
+# to ensure that we can read the index we generate compared to verifying the
+# contents of the index.  Once this schema has stabilized we could go in and
+# write tests that work at the sqlite3 layer.
+
+class DummyCommand(object):
+    def __init__(self, command_name, subcommand_table=None, arg_table=None):
+        self.name = command_name
+        if subcommand_table is None:
+            subcommand_table = {}
+        self.subcommand_table = subcommand_table
+        if arg_table is None:
+            arg_table = {}
+        self.arg_table = arg_table
+
+
+class DummyArg(object):
+    def __init__(self, name, cli_type_name='string', nargs=None):
+        self.name = name
+        self.cli_type_name = cli_type_name
+        self.nargs = nargs
+
+
+class TestCanRetrieveCommands(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock(spec=Session)
+        self.aws_command = DummyCommand(
+            # The CLIDriver doesn't actually have a ``name`` property,
+            # but it should probably be 'aws'.
+            command_name=None,
+            arg_table={
+                'region': DummyArg('region'),
+                'endpoint-url': DummyArg('endpoint-url'),
+            },
+            subcommand_table={
+                'ec2': DummyCommand(
+                    command_name='ec2',
+                    subcommand_table={
+                        'describe-instances': DummyCommand(
+                            'describe-instances',
+                            arg_table={
+                                'instance-ids': DummyArg('instance-ids'),
+                                'filters': DummyArg(
+                                    'filters', 'list', nargs='+'),
+                            }
+                        ),
+                        'run-instances': DummyCommand('run-instances'),
+                    }
+                ),
+                's3': DummyCommand(
+                    command_name='s3',
+                    subcommand_table={
+                        'list-objects': DummyCommand('list-objects'),
+                        'put-object': DummyCommand('put-object'),
+                    }
+                )
+            }
+        )
+        # Ideally we just use ':memory:', but that's for
+        # a specific sqlite3 connection so we'd have to
+        # update our interfaces to return/accept a db connection.
+        # I'd prefer not to have db connections as part of the
+        # indexing interface.
+        self.tempfile = tempfile.NamedTemporaryFile('w')
+        self.db_conn = indexer.DatabaseConnection(self.tempfile.name)
+        self.indexer = indexer.ModelIndexer(self.db_conn)
+        self.query = model.ModelIndex(self.tempfile.name)
+
+    def tearDown(self):
+        self.tempfile.close()
+
+    def test_can_retrieve_top_level_commands(self):
+        self.indexer.generate_index(self.aws_command)
+        self.assertEqual(
+            set(self.query.command_names(lineage=['aws'])),
+            set(['ec2', 's3'])
+        )
+
+    def test_can_retrieve_operation_names(self):
+        self.indexer.generate_index(self.aws_command)
+        self.assertEqual(
+            set(self.query.command_names(lineage=['aws', 'ec2'])),
+            set(['describe-instances', 'run-instances']),
+        )
+
+    def test_can_retrieve_global_params(self):
+        self.indexer.generate_index(self.aws_command)
+        self.assertEqual(
+            set(self.query.arg_names(lineage=[], command_name='aws')),
+            set(['region', 'endpoint-url']),
+        )
+
+    def test_can_retrieve_service_params(self):
+        self.indexer.generate_index(self.aws_command)
+        self.assertEqual(
+            set(self.query.arg_names(lineage=['aws.ec2'],
+                                     command_name='describe-instances')),
+            set(['instance-ids', 'filters']),
+        )
+
+    def test_can_retrieve_correct_commands_when_shadowed(self):
+        # Suppose that 's3' had a 'describe-instances' operation.  We
+        # should be able to differentiate between this command and the
+        # one in ec2 via the ``parent`` arg.
+        s3_commands = self.aws_command.subcommand_table['s3'].subcommand_table
+        s3_commands['describe-instances'] = DummyCommand('describe-instances')
+        self.indexer.generate_index(self.aws_command)
+        # The 'ec2' version has several params in its arg table, but this
+        # 's3' version should have no params because we didn't add an arg
+        # table.
+        self.assertEqual(
+            set(self.query.arg_names(lineage=['aws.s3'],
+                                     command_name='describe-instances')),
+            set([]),
+        )
+
+    def test_empty_list_when_no_args(self):
+        # Service commands don't have arguments.
+        self.indexer.generate_index(self.aws_command)
+        self.assertEqual(
+            set(self.query.arg_names(lineage=['aws'],
+                                     command_name='ec2')),
+            set([]),
+        )
+
+    def test_empty_list_on_unknown_service(self):
+        self.indexer.generate_index(self.aws_command)
+        self.assertEqual(
+            set(self.query.command_names(lineage=['aws', 'foobar'])),
+            set([]),
+        )
+
+    def test_can_get_argument_data(self):
+        self.indexer.generate_index(self.aws_command)
+        arg_data = self.query.get_argument_data(
+            lineage=['aws', 'ec2'],
+            command_name='describe-instances',
+            arg_name='filters',
+        )
+        self.assertEqual(
+            arg_data,
+            model.CLIArgument(
+                argname='filters',
+                type_name='list',
+                command='describe-instances',
+                parent='aws.ec2',
+                nargs='+',
+            ),
+        )


### PR DESCRIPTION
This is the start of the rewrite of the CLI autocompleter.  This first PR adds
the data model for handling auto completion based on the service model
definitions.  The big change from the current implementation is that rather
than do this dynmically, we instead generate an index separately, and then we
use the index to drive the auto completion process.

The original approach of traversing the `command_table` during the auto
completion process worked "ok" when the number of services was relatively small
5 years ago, but that approach is too slow given the number of services we now
have.  Also, importing the clidriver imports the majority of the AWS CLI as
well as botocore.  The import times for both of these packages has grown over
the years as we've added more functionality.  This is something we should look
at addressing separately, but regardless, we should try to avoid unnecessary
imports during the auto completion process.  The end goal is that we only
need to import sqlite3 in order to drive our auto completer.

This initial PR isn't enough to replace the existing auto completer.  There's
several other features needed that will be part of subsequence PRs once this
one gets merged into the `v2-autocomplete` branch.  We need an updated CLI
parser that's based on this generated index.  We also need to figure how/when
to plumb in this index generation.  I'm thinking we have an explicit command to
auto generate the index, and we also have some sort of smart detection where we
generate the index generation when we notice there's no index available (the
details still need to be worked out on that).  Another option is to check in
a pre-generated index before we cut CLI releases (in addition to the
auto generation heuristics).

I imagine the schema will need to change as we start adding more functionality
to the auto completer.  I'm looking for initial feedback on the overall
approach.