### PR TITLE
Update bundled urllib3 versions

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -110,12 +110,12 @@ def pip_install_packages(install_dir):
     setup_requires_dir = os.path.join(PACKAGES_DIR, 'setup')
     with cd(setup_requires_dir):
         for package in os.listdir(setup_requires_dir):
-            run('%s install --no-index --find-links file://%s %s' % (
+            run('%s install --no-cache-dir --no-index --find-links file://%s %s' % (
                 pip_script, setup_requires_dir, package
             ))
 
     with cd(PACKAGES_DIR):
-        run('%s install --no-index --find-links file://%s %s' % (
+        run('%s install --no-cache-dir --no-index --find-links file://%s %s' % (
             pip_script, PACKAGES_DIR, cli_tarball))
 
 

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -36,6 +36,7 @@ PACKAGE_VERSION = {
     'argparse': '1.2.1',
     'python-dateutil': '2.6.1',
     'setuptools-scm': '1.15.7',
+    'urllib3': '1.22',
 }
 INSTALL_ARGS = '--allow-all-external --no-use-wheel'
 
@@ -177,7 +178,11 @@ def main():
     print("Bundle dir at: %s" % scratch_dir)
     download_package_tarballs(
         package_dir,
-        packages=['virtualenv', 'ordereddict', 'simplejson', 'argparse', 'python-dateutil'])
+        packages=[
+            'virtualenv', 'ordereddict', 'simplejson',
+            'argparse', 'python-dateutil', 'urllib3',
+        ]
+    )
 
     # Some packages require setup time dependencies, and so we will need to
     # manually install them. We isolate them to a particular directory so we


### PR DESCRIPTION
`urllib3` dropped support for 2.6 in the latest version. This updates the bundled installer to include a version of `urllib3` that will be compatible with Python 2.6 and 3.3 in addition to the latest version.

This also adds the `--no-cache-dir` to the `pip` commands we use to install packages using the bundled installer, as we shouldn't be relying on it.

I've created a bundled installer locally and tested that 2.6, 2.7, 3.3+ work with it.

Related botocore PR: https://github.com/boto/botocore/pull/1584