### PR TITLE
Add IMDS region loader to the session config chain

### DIFF
--- a/awscli/__init__.py
+++ b/awscli/__init__.py
@@ -34,12 +34,6 @@ _awscli_data_path.append(
 os.environ['AWS_DATA_PATH'] = os.pathsep.join(_awscli_data_path)
 
 
-EnvironmentVariables = {
-    'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
-    'output': ('output', 'AWS_DEFAULT_OUTPUT', 'json', None),
-}
-
-
 SCALAR_TYPES = set([
     'string', 'float', 'integer', 'long', 'boolean', 'double',
     'blob', 'timestamp'

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -10,25 +10,29 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import sys
 import signal
 import logging
 
 import botocore.session
 from botocore import __version__ as botocore_version
-from botocore.hooks import HierarchicalEmitter
 from botocore import xform_name
 from botocore.compat import copy_kwargs, OrderedDict
 from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import NoRegionError
 from botocore.history import get_global_history_recorder
+from botocore.configprovider import InstanceVarProvider
+from botocore.configprovider import EnvironmentProvider
+from botocore.configprovider import ScopedConfigProvider
+from botocore.configprovider import ConstantProvider
+from botocore.configprovider import ChainProvider
 
-from awscli import EnvironmentVariables, __version__
+from awscli import __version__
 from awscli.compat import get_stderr_text_writer
 from awscli.formatter import get_formatter
 from awscli.plugin import load_plugins
 from awscli.commands import CLICommand
-from awscli.compat import six
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.argparser import ArgTableArgParser
@@ -46,6 +50,7 @@ from awscli.alias import AliasLoader
 from awscli.alias import AliasCommandInjector
 from awscli.utils import emit_top_level_args_parsed_event
 from awscli.utils import write_exception
+from awscli.utils import IMDSRegionProvider
 
 
 LOG = logging.getLogger('awscli.clidriver')
@@ -62,7 +67,7 @@ def main():
 
 
 def create_clidriver():
-    session = botocore.session.Session(EnvironmentVariables)
+    session = botocore.session.Session()
     _set_user_agent_for_session(session)
     load_plugins(session.full_config.get('plugins', {}),
                  event_hooks=session.get_component('event_emitter'))
@@ -80,14 +85,62 @@ class CLIDriver(object):
 
     def __init__(self, session=None):
         if session is None:
-            self.session = botocore.session.get_session(EnvironmentVariables)
+            self.session = botocore.session.get_session()
             _set_user_agent_for_session(self.session)
         else:
             self.session = session
+        self._update_config_chain()
         self._cli_data = None
         self._command_table = None
         self._argument_table = None
         self.alias_loader = AliasLoader()
+
+    def _update_config_chain(self):
+        config_store = self.session.get_component('config_store')
+        config_store.set_config_provider(
+            'region',
+            self._construct_cli_region_chain()
+        )
+        config_store.set_config_provider(
+            'output',
+            self._construct_cli_output_chain()
+        )
+
+    def _construct_cli_region_chain(self):
+        providers = [
+            InstanceVarProvider(
+                instance_var='region',
+                session=self.session
+            ),
+            EnvironmentProvider(
+                names='AWS_DEFAULT_REGION',
+                env=os.environ,
+            ),
+            ScopedConfigProvider(
+                config_var_name='region',
+                session=self.session,
+            ),
+            IMDSRegionProvider(self.session),
+        ]
+        return ChainProvider(providers=providers)
+
+    def _construct_cli_output_chain(self):
+        providers = [
+            InstanceVarProvider(
+                instance_var='output',
+                session=self.session,
+            ),
+            EnvironmentProvider(
+                names='AWS_DEFAULT_OUTPUT',
+                env=os.environ,
+            ),
+            ScopedConfigProvider(
+                config_var_name='output',
+                session=self.session,
+            ),
+            ConstantProvider(value='json'),
+        ]
+        return ChainProvider(providers=providers)
 
     def _get_cli_data(self):
         # Not crazy about this but the data in here is needed in
@@ -610,18 +663,18 @@ class CLIOperationCaller(object):
         """Invoke an operation and format the response.
 
         :type service_name: str
-        :param service_name: The name of the service.  Note this is the service name,
-            not the endpoint prefix (e.g. ``ses`` not ``email``).
+        :param service_name: The name of the service.  Note this is the
+            service name, not the endpoint prefix (e.g. ``ses`` not ``email``).
 
         :type operation_name: str
         :param operation_name: The operation name of the service.  The casing
-            of the operation name should match the exact casing used by the service,
-            e.g. ``DescribeInstances``, not ``describe-instances`` or
+            of the operation name should match the exact casing used by the
+            service, e.g. ``DescribeInstances``, not ``describe-instances`` or
             ``describe_instances``.
 
         :type parameters: dict
-        :param parameters: The parameters for the operation call.  Again, these values
-            have the same casing used by the service.
+        :param parameters: The parameters for the operation call.  Again,
+            these values have the same casing used by the service.
 
         :type parsed_globals: Namespace
         :param parsed_globals: The parsed globals from the command line.

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -58,7 +58,6 @@ from botocore.awsrequest import AWSResponse
 import awscli.clidriver
 from awscli.plugin import load_plugins
 from awscli.clidriver import CLIDriver
-from awscli import EnvironmentVariables
 
 
 # In python 3, order matters when calling assertEqual to

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -17,10 +17,106 @@ import contextlib
 import os
 import sys
 import subprocess
+import logging
 
 from awscli.compat import six
 from awscli.compat import get_binary_stdout
 from awscli.compat import get_popen_kwargs_for_pager_cmd
+from botocore.utils import IMDSFetcher
+from botocore.configprovider import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+
+class IMDSRegionProvider(BaseProvider):
+    def __init__(self, session, environ=None, fetcher=None):
+        """Initialize IMDSRegionProvider.
+
+        :type session: :class:`botocore.session.Session`
+        :param session: The session is needed to look up configuration for
+            how to contact the instance metadata service. Specifically the
+            whether or not it should use the IMDS region at all, and if so how
+            to configure the timeout and number of attempts to reach the
+            service.
+
+        :type environ: None or dict
+        :param environ: A dictionary of environment variables to use. If
+            ``None`` is the argument then ``os.environ`` will be used by
+            default.
+
+        :type fecther: :class:`botocore.utils.InstanceMetadataRegionFetcher`
+        :param fetcher: The class to actually handle the fetching of the region
+            from the IMDS. If not provided a default one will be created.
+        """
+        self._session = session
+        if environ is None:
+            environ = os.environ
+        self._environ = environ
+        self._fetcher = fetcher
+
+    def provide(self):
+        """Provide the region value from IMDS."""
+        instance_region = self._get_instance_metadata_region()
+        return instance_region
+
+    def _get_instance_metadata_region(self):
+        fetcher = self._get_fetcher()
+        region = fetcher.retrieve_region()
+        return region
+
+    def _get_fetcher(self):
+        if self._fetcher is None:
+            self._fetcher = self._create_fetcher()
+        return self._fetcher
+
+    def _create_fetcher(self):
+        metadata_timeout = self._session.get_config_variable(
+            'metadata_service_timeout')
+        metadata_num_attempts = self._session.get_config_variable(
+            'metadata_service_num_attempts')
+        fetcher = InstanceMetadataRegionFetcher(
+            timeout=metadata_timeout,
+            num_attempts=metadata_num_attempts,
+            env=self._environ,
+            user_agent=self._session.user_agent(),
+        )
+        return fetcher
+
+
+class InstanceMetadataRegionFetcher(IMDSFetcher):
+    _URL_PATH = 'latest/meta-data/placement/availability-zone/'
+
+    def retrieve_region(self):
+        """Get the current region from the instance metadata service.
+
+        :rvalue: str
+        :returns: The region the current instance is running in or None
+            if the instance metadata service cannot be contacted or does not
+            give a valid response.
+
+        :rtype: None or str
+        :returns: Returns the region as a string if it is configured to use
+            IMDS as a region source. Otherwise returns ``None``. It will also
+            return ``None`` if it fails to get the region from IMDS due to
+            exhausting its retries or not being able to connect.
+        """
+        try:
+            region = self._get_region()
+            return region
+        except self._RETRIES_EXCEEDED_ERROR_CLS:
+            logger.debug("Max number of attempts exceeded (%s) when "
+                         "attempting to retrieve data from metadata service.",
+                         self._num_attempts)
+        return None
+
+    def _get_region(self):
+        response = self._get_request(
+            url_path=self._URL_PATH,
+            retry_func=self._default_retry,
+        )
+        availability_zone = response.text
+        region = availability_zone[:-1]
+        return region
 
 
 def split_on_commas(value):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 from collections import MutableMapping
 from collections import Mapping
+from io import BytesIO
 
 
 # CaseInsensitiveDict from requests that must be serializble.
@@ -49,3 +50,13 @@ class CaseInsensitiveDict(MutableMapping):
 
     def __repr__(self):
         return str(dict(self.items()))
+
+
+class RawResponse(BytesIO):
+    # TODO: There's a few objects similar to this in various tests, let's
+    # try and consolidate to this one in a future commit.
+    def stream(self, **kwargs):
+        contents = self.read()
+        while contents:
+            yield contents
+            contents = self.read()

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -1,0 +1,75 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import re
+import functools
+
+from tests import RawResponse
+
+import mock
+
+import botocore
+from botocore.session import Session
+
+from awscli.testutils import unittest
+from awscli.testutils import BaseCLIDriverTest
+from awscli.clidriver import CLIDriver
+
+
+class TestSession(BaseCLIDriverTest):
+    def setUp(self):
+        super(TestSession, self).setUp()
+        urllib3_session_send = 'botocore.httpsession.URLLib3Session.send'
+        self._urllib3_patch = mock.patch(urllib3_session_send)
+        self._send = self._urllib3_patch.start()
+        self._send.side_effect = self.get_response
+        self._responses = []
+
+    def tearDown(self):
+        self._urllib3_patch.stop()
+
+    def get_response(self, request):
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def add_response(self, body, status_code=200):
+        response = botocore.awsrequest.AWSResponse(
+            url='http://169.254.169.254/',
+            status_code=status_code,
+            headers={},
+            raw=RawResponse(body)
+        )
+        self._responses.append(response)
+
+    def assert_correct_region(self, expected_region, request, **kwargs):
+        url = request.url
+        region = re.match(
+            'https://.*?\.(.*?)\.amazonaws\.com', url).groups(1)[0]
+        self.assertEqual(expected_region, region)
+
+    def test_imds_region_is_used_as_fallback(self):
+        # Remove region override from the environment variables.
+        self.environ.pop('AWS_DEFAULT_REGION', 0)
+        # First response should be from the IMDS server for an availibility
+        # zone.
+        self.add_response(b'us-mars-2a')
+        # Once a region is fetched form the IMDS server we need to mock an
+        # XML response from ec2 so that the CLI driver doesn't throw an error
+        # during parsing.
+        self.add_response(
+            b'<?xml version="1.0" ?><foo><bar>text</bar></foo>')
+        assert_correct_region = functools.partial(
+            self.assert_correct_region, 'us-mars-2')
+        self.session.register('before-send.ec2.*', assert_correct_region)
+        self.driver.main(['ec2', 'describe-instances'])


### PR DESCRIPTION
This commit adds a class that can be used to load the default region
which on an ec2 instance will be the region provided by the metadata
service. The CLI injects this loader into the region config loading
chain at the end to be used instead of the default None value used by
botocore's session.

This is a draft depending on the interface and approval of https://github.com/boto/botocore/pull/1591

cc @jamesls @kyleknap @JordonPhillips @dstufft @joguSD 