### PR TITLE
Set region on session if region arg is provided

### DIFF
--- a/.changes/next-release/bugfix-Credentials-63421.json
+++ b/.changes/next-release/bugfix-Credentials-63421.json
@@ -1,0 +1,5 @@
+{
+  "category": "Credentials", 
+  "type": "bugfix", 
+  "description": "Fix issue where incorrect region was being used when using assume role credentials outside of the `aws` partition."
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -251,6 +251,8 @@ class CLIDriver(object):
         emit_top_level_args_parsed_event(self.session, args)
         if args.profile:
             self.session.set_config_variable('profile', args.profile)
+        if args.region:
+            self.session.set_config_variable('region', args.region)
         if args.debug:
             # TODO:
             # Unfortunately, by setting debug mode here, we miss out


### PR DESCRIPTION
This fixes a bug where code that's calling session.create_client()
and not providing an explicit region value.  In this case we fall
back to pulling the region from the session config vars, which will
check env vars, config files, and session instance vars.  By setting
the region as a session instance var, this will ensure that clients
use the same region as specified from the `--region` arg.