### PR TITLE
[#3619] eks update-kubeconfig set env from --profile/AWS_PROFILE env

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -333,4 +333,10 @@ class EKSClient(object):
                 self._role_arn
             ])
 
+        if self._session.profile:
+            generated_user["user"]["exec"]["env"] = [OrderedDict([
+                ("name", "AWS_PROFILE"),
+                ("value", self._session.profile)
+            ])]
+
         return generated_user

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -195,6 +195,7 @@ class TestEKSClient(unittest.TestCase):
 
         self._session = mock.Mock(spec=botocore.session.Session)
         self._session.create_client.return_value = self._mock_client
+        self._session.profile = None
 
         self._client = EKSClient(self._session, "ExampleCluster", None)
 
@@ -257,6 +258,21 @@ class TestEKSClient(unittest.TestCase):
                                            describe_cluster_deleting_response()
         self.assertRaises(EKSClusterError,
                           self._client._get_cluster_description)
+        self._mock_client.describe_cluster.assert_called_once_with(
+            name="ExampleCluster"
+        )
+        self._session.create_client.assert_called_once_with("eks")
+
+    def test_profile(self):
+        self._session.profile = "profile"
+        self._correct_user_entry["user"]["exec"]["env"] = [
+            OrderedDict([
+                ("name", "AWS_PROFILE"),
+                ("value", "profile")
+            ])
+        ]
+        self.assertEqual(self._client.get_user_entry(),
+                         self._correct_user_entry)
         self._mock_client.describe_cluster.assert_called_once_with(
             name="ExampleCluster"
         )


### PR DESCRIPTION
This PR closes #3619 by reading the value of profile from the session. It is set either by --profile CLI flag or the AWS_PROFILE environment variable. If present, it adds a env to the kubeconfig dictionary for the user's exec.

Current questions:
* Should there be a flag that either turns on this feature, or disables it at the command line?
* Do we only want this to be set if the user actually set --profile at the command line, but not if it's coming from AWS_PROFILE? (In such case, this can be rewritten to read from parsed_globals.profile instead).
* Should this be done in a more general way by allowing the user to set arbitrary environment variables, instead of special casing for profile?>