### PR TITLE
[#3638] eks update-kubeconfig --alias for context name

### DIFF
--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -229,17 +229,17 @@ class KubeconfigAppender(object):
         config.content[key] = array
         return config
 
-    def _make_context(self, cluster, user):
-        """ Generate a context to associate cluster and user."""
+    def _make_context(self, cluster, user, alias=None):
+        """ Generate a context to associate cluster and user with a given alias."""
         return OrderedDict([
             ("context", OrderedDict([
                 ("cluster", cluster["name"]),
                 ("user", user["name"])
             ])),
-            ("name", user["name"])
+            ("name", alias or user["name"])
         ])
 
-    def insert_cluster_user_pair(self, config, cluster, user):
+    def insert_cluster_user_pair(self, config, cluster, user, alias=None):
         """
         Insert the passed cluster entry and user entry,
         then make a context to associate them
@@ -255,10 +255,13 @@ class KubeconfigAppender(object):
         :param user: the user entry
         :type user: OrderedDict
 
+        :param alias: the alias for the context; defaults top user entry name
+        :type context: str
+
         :return: The generated context
         :rtype: OrderedDict
         """
-        context = self._make_context(cluster, user)
+        context = self._make_context(cluster, user, alias=alias)
         self.insert_entry(config, "clusters", cluster)
         self.insert_entry(config, "users", user)
         self.insert_entry(config, "contexts", context)

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -118,6 +118,12 @@ class UpdateKubeconfigCommand(BasicCommand):
             'help_text': ("Print more detailed output "
                           "when writing to the kubeconfig file, "
                           "including the appended entries.")
+        },
+        {
+            'name': 'alias',
+            'help_text': ("Alias for the cluster context name. "
+                          "Defaults to match cluster ARN."),
+            'required': False
         }
     ]
 
@@ -152,7 +158,8 @@ class UpdateKubeconfigCommand(BasicCommand):
         appender = KubeconfigAppender()
         new_context_dict = appender.insert_cluster_user_pair(config,
                                                              new_cluster_dict,
-                                                             new_user_dict)
+                                                             new_user_dict,
+                                                             parsed_args.alias)
 
         if parsed_args.dry_run:
             uni_print(config.dump_content())

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -274,3 +274,23 @@ class TestKubeconfigAppender(unittest.TestCase):
         ])
         context = self._appender._make_context(cluster, user)
         self.assertDictEqual(context, context_correct)
+
+    def test_make_context_alias(self):
+        cluster = OrderedDict([
+            ("name", "clustername"),
+            ("cluster", OrderedDict())
+        ])
+        user = OrderedDict([
+            ("name", "username"),
+            ("user", OrderedDict())
+        ])
+        context_correct = OrderedDict([
+            ("context", OrderedDict([
+                ("cluster", "clustername"),
+                ("user", "username")
+            ])),
+            ("name", "alias")
+        ])
+        alias = "alias"
+        context = self._appender._make_context(cluster, user, alias=alias)
+        self.assertDictEqual(context, context_correct)


### PR DESCRIPTION
This PR closes #3638 by adding a --alias command line flag to eks update-kubeconfig. If present, the generated kubeconfig will use the alias in place of the ARN for the context name. The cluster name and the user profile name stay unchanged.