### PR TITLE
Add filtering to history show command

### DIFF
--- a/awscli/customizations/history/filters.py
+++ b/awscli/customizations/history/filters.py
@@ -1,0 +1,18 @@
+import re
+
+
+class RegexFilter(object):
+    def __init__(self, pattern, replacement):
+        self._pattern = pattern
+        self._replacement = replacement
+        self._regex = None
+
+    def filter_text(self, text):
+        regex = self._get_regex()
+        filtered_text = regex.subn(self._replacement, text)
+        return filtered_text[0]
+
+    def _get_regex(self):
+        if self._regex is None:
+            self._regex = re.compile(self._pattern)
+        return self._regex

--- a/tests/unit/customizations/history/test_filters.py
+++ b/tests/unit/customizations/history/test_filters.py
@@ -1,0 +1,34 @@
+from awscli.testutils import unittest
+from awscli.customizations.history.filters import RegexFilter
+
+
+class TestRegexFilter(unittest.TestCase):
+    def assert_filter(self, pattern, replacement, input_text,
+                      expected_result):
+        regex_filter = RegexFilter(pattern, replacement)
+        result = regex_filter.filter_text(input_text)
+        self.assertEqual(result, expected_result)
+
+    def test_can_filter_out_content(self):
+        self.assert_filter(
+            pattern='foo',
+            replacement='bar',
+            input_text='Content with foo.',
+            expected_result='Content with bar.',
+        )
+
+    def test_can_filter_with_backreferences(self):
+        self.assert_filter(
+            pattern='Key=(....).*',
+            replacement=r'Key=\1...',
+            input_text='Key=foobar',
+            expected_result='Key=foob...',
+        )
+
+    def test_does_not_filter_if_no_match(self):
+        self.assert_filter(
+            pattern='Key=(....).*',
+            replacement=r'Key=\1...',
+            input_text='Blah=foobar',
+            expected_result='Blah=foobar',
+        )

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -219,6 +219,30 @@ class TestDetailedFormatter(unittest.TestCase):
             ]
         )
 
+    def test_display_http_request_filter_signature(self):
+        self.assert_output(
+            for_event={
+                'event_type': 'HTTP_REQUEST',
+                'id': 'my-id',
+                'request_id': 'some-id',
+                'payload': {
+                    'method': 'GET',
+                    'url': 'https://myservice.us-west-2.amazonaws.com',
+                    'headers': {
+                        'Authorization': (
+                            'Signature=d7fa4de082b598a0ac08b756db438c630a6'
+                            'cc79c4f3d1636cf69fac0e7c1abcd'
+                        )
+                    },
+                    'body': 'This is my body'
+                },
+                'timestamp': 86400000,
+            },
+            contains=[
+                '"Authorization": "Signature=d7fa..."'
+            ]
+        )
+
     def test_display_http_request_with_streaming_body(self):
         self.assert_output(
             for_event={


### PR DESCRIPTION
Filters out the hash after Signature=<hash here>. Introduces a filter
abstraction that can be added to a particular Formatter section to
filter any content emitted by it.