### PR TITLE
[CLIv2] Add model based completer

### DIFF
--- a/awscli/autocomplete/completer.py
+++ b/awscli/autocomplete/completer.py
@@ -1,0 +1,102 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+class AutoCompleter(object):
+    """Main auto-completer object for the AWS CLI."""
+    def __init__(self, parser, completers):
+        self._parser = parser
+        self._completers = completers
+
+    def autocomplete(self, command_line, index=None):
+        parsed = self._parser.parse(command_line, index)
+        for completer in self._completers:
+            result = completer.complete(parsed)
+            if result is not None:
+                return result
+
+
+class BaseCompleter(object):
+    def complete(self, parsed):
+        """Attempt to autocomplete parsed on parsed result.
+
+        Subclasses should implement this method.
+
+        :param parsed: A ParsedResult from the auto complete CLI parser.
+        :return: This method should return one of two values:
+
+            * ``None`` - If the completer doesn't understand how to
+              complete the command, it should return ``None``.  This
+              signals to the ``AutoCompleter`` that it should move on
+              to the next completer.
+            * ``List[str]`` - If the completer is able to offer
+              auto-completions it should return a list of strings that
+              are valid suggestions for completing the command.  This
+              indicates to the ``AutoCompleter`` to immediately return
+              and to stop consulting other completers for results.
+        """
+        raise NotImplementedError("complete")
+
+
+class ModelIndexCompleter(BaseCompleter):
+
+    def __init__(self, index):
+        self._index = index
+
+    def complete(self, parsed):
+        if parsed.unparsed_items or parsed.last_fragment is None:
+            # If there's ever any unparsed items, then the parser
+            # encountered something it didn't understand.  We won't
+            # attempt to auto-complete anything here.
+            return
+        last_fragment = parsed.last_fragment
+        if last_fragment.startswith('--'):
+            # We could technically offer completion of options
+            # if the last fragment is an empty string, but to avoid
+            # dumping too much information back to the user, we only
+            # offer completions for options if the value starts with
+            # '--'.
+            return self._complete_options(parsed)
+        else:
+            return self._complete_command(parsed)
+
+    def _complete_command(self, parsed):
+        lineage = parsed.lineage + [parsed.current_command]
+        result = [name for name in self._index.command_names(lineage)
+                  if name.startswith(parsed.last_fragment)]
+        return result
+
+    def _complete_options(self, parsed):
+        # '--endpoint' -> 'endpoint'
+        fragment = parsed.last_fragment[2:]
+        arg_names = self._index.arg_names(
+            lineage=parsed.lineage, command_name=parsed.current_command)
+        results = [
+            '--%s' % arg_name for arg_name in arg_names
+            if arg_name.startswith(fragment)]
+        # Global params apply to any scope, so if we're not
+        # in the global scope, we need to add completions for
+        # global params
+        self._inject_global_params_if_needed(parsed, results, fragment)
+        return results
+
+    def _inject_global_params_if_needed(self, parsed, results, fragment):
+        is_in_global_scope = (
+            parsed.lineage == [] and
+            parsed.current_command == 'aws'
+        )
+        if not is_in_global_scope:
+            global_params = self._index.arg_names(
+                lineage=[], command_name='aws')
+            global_param_completions = [
+                '--%s' % arg_name for arg_name in global_params
+                if arg_name.startswith(fragment)]
+            results.extend(global_param_completions)

--- a/awscli/autocomplete/completer.py
+++ b/awscli/autocomplete/completer.py
@@ -11,17 +11,35 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 class AutoCompleter(object):
-    """Main auto-completer object for the AWS CLI."""
+    """Main auto-completer object for the AWS CLI.
+
+    This object delegates to concrete completers that can perform
+    completions for specific cases (e.g model-based completions,
+    server-side completions, etc).
+    """
     def __init__(self, parser, completers):
+        """
+
+        :param parser: A parser.CLIParser instance.
+        :param completers: A list of ``BaseCompleter`` instances.
+
+        """
         self._parser = parser
         self._completers = completers
 
     def autocomplete(self, command_line, index=None):
+        """Attempt to find completion suggestions.
+
+        :param command_line: The currently entered command line as a string.
+        :param index: An optional integer that indicates the location where
+            the cursor is located (0 based index).
+        """
         parsed = self._parser.parse(command_line, index)
         for completer in self._completers:
             result = completer.complete(parsed)
             if result is not None:
                 return result
+        return []
 
 
 class BaseCompleter(object):

--- a/awscli/autocomplete/parser.py
+++ b/awscli/autocomplete/parser.py
@@ -10,6 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+WORD_BOUNDARY = ''
+
+
 class ParsedResult(object):
     def __init__(self, current_command=None,
                  global_params=None, current_params=None,
@@ -155,7 +158,7 @@ class CLIParser(object):
         # e.g. 'aws ec2 describe-instances --instance-ids '
         # Note the space at the end.  In this case we don't have a value
         # to consume so we special case this and short circuit.
-        if remaining_parts == ['']:
+        if remaining_parts == [WORD_BOUNDARY]:
             return ''
         elif not remaining_parts:
             return None
@@ -189,7 +192,7 @@ class CLIParser(object):
             # an empty list being returned.  This is acceptable
             # for auto-completion purposes.
             value = []
-            while remaining_parts and not remaining_parts == ['']:
+            while remaining_parts and not remaining_parts == [WORD_BOUNDARY]:
                 if remaining_parts[0].startswith('--'):
                     break
                 value.append(remaining_parts.pop(0))
@@ -211,7 +214,7 @@ class CLIParser(object):
             # because we can auto-complete a command such as:
             # "aws ec2 stop-<TAB>" but we can't auto-complete
             # a command like: "aws ec2 stop- <TAB>"
-            parts.append('')
+            parts.append(WORD_BOUNDARY)
         return parts
 
     def _handle_option(self, current, remaining_parts, current_args,

--- a/awscli/autocomplete/parser.py
+++ b/awscli/autocomplete/parser.py
@@ -150,6 +150,15 @@ class CLIParser(object):
 
     def _consume_value(self, remaining_parts, option_name,
                        lineage, current_command):
+        # We have a special case where a user is trying to complete
+        # a value for an option, which is the last fragment of the command,
+        # e.g. 'aws ec2 describe-instances --instance-ids '
+        # Note the space at the end.  In this case we don't have a value
+        # to consume so we special case this and short circuit.
+        if remaining_parts == ['']:
+            return ''
+        elif not remaining_parts:
+            return None
         arg_data = self._index.get_argument_data(
             lineage=lineage,
             command_name=current_command,
@@ -180,7 +189,7 @@ class CLIParser(object):
             # an empty list being returned.  This is acceptable
             # for auto-completion purposes.
             value = []
-            while remaining_parts:
+            while remaining_parts and not remaining_parts == ['']:
                 if remaining_parts[0].startswith('--'):
                     break
                 value.append(remaining_parts.pop(0))

--- a/tests/unit/autocomplete/__init__.py
+++ b/tests/unit/autocomplete/__init__.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.autocomplete import model
+
+
+class InMemoryIndex(model.ModelIndex):
+    # An in-memory version of a model index.
+
+    def __init__(self, index):
+        """
+
+        The index param you provide is a dictionary that has top level
+        keys that correspond to the method names here:
+
+
+        ::
+
+            {'command_names': {'dot.lineage': [<values>]},
+             'arg_names': {'dot.lineage': {'command_name': [<values>]}},
+             'get_argument_data': {
+                 'dot.lineage': {
+                     'command-name': {
+                         'arg-name': (argname, type, command, parent, nargs)
+                     }
+                 }
+            }
+
+        """
+        self.index = index
+
+    def command_names(self, lineage):
+        parent = '.'.join(lineage)
+        return self.index['command_names'].get(parent, [])
+
+    def arg_names(self, lineage, command_name):
+        parent = '.'.join(lineage)
+        return self.index['arg_names'].get(parent, {}).get(command_name, [])
+
+    def get_argument_data(self, lineage, command_name, arg_name):
+        parent = '.'.join(lineage)
+        arg_data = self.index['arg_data'].get(parent, {}).get(
+            command_name, {}).get(arg_name)
+        if arg_data is not None:
+            return model.CLIArgument(*arg_data)
+
+

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -15,7 +15,7 @@ from awscli.autocomplete import completer, parser, model
 from awscli.clidriver import CLIDriver
 
 
-class TestAutoCompelter(unittest.TestCase):
+class TestAutoCompleter(unittest.TestCase):
     def setUp(self):
         self.parser = mock.Mock(spec=parser.CLIParser)
         self.parsed_result = parser.ParsedResult()
@@ -55,7 +55,7 @@ class TestAutoCompelter(unittest.TestCase):
 
         auto_complete = completer.AutoCompleter(
             self.parser, completers=[first, second])
-        self.assertIsNone(auto_complete.autocomplete('aws e'))
+        self.assertEqual(auto_complete.autocomplete('aws e'), [])
 
         first.complete.assert_called_with(self.parsed_result)
         second.complete.assert_called_with(self.parsed_result)

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -11,8 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest, mock
-from awscli.autocomplete import completer, parser, model
-from awscli.clidriver import CLIDriver
+from awscli.autocomplete import completer, parser
+
+from tests.unit.autocomplete import InMemoryIndex
 
 
 class TestAutoCompleter(unittest.TestCase):
@@ -63,22 +64,32 @@ class TestAutoCompleter(unittest.TestCase):
 
 class TestModelIndexCompleter(unittest.TestCase):
     def setUp(self):
-        self.index = mock.Mock(spec=model.ModelIndex)
+        self.index = InMemoryIndex({
+            'command_names': {
+                '': ['aws'],
+                'aws': ['ec2', 'ecs', 's3'],
+                'aws.ec2': ['describe-instances'],
+            },
+            'arg_names': {
+                '': {
+                    'aws': ['region', 'endpoint-url'],
+                },
+                'aws.ec2': {
+                    'describe-instances': ['instance-ids', 'reserve'],
+                }
+            },
+        })
+        self.parser = parser.CLIParser(self.index)
+
+
         self.completer = completer.ModelIndexCompleter(self.index)
 
     def test_does_not_complete_if_unparsed_items(self):
-        parsed = parser.ParsedResult(
-            current_command='aws', lineage=[],
-            unparsed_items=['foo'], last_fragment='')
+        parsed = self.parser.parse('aws foo ')
         self.assertIsNone(self.completer.complete(parsed))
 
     def test_does_complete_if_last_fragment_is_none(self):
-        parsed = parser.ParsedResult(
-            lineage=[],
-            unparsed_items=[],
-            current_command='aws',
-            last_fragment=None,
-        )
+        parsed = self.parser.parse('aws')
         self.assertIsNone(self.completer.complete(parsed))
 
     def test_can_prefix_match_services(self):
@@ -86,56 +97,22 @@ class TestModelIndexCompleter(unittest.TestCase):
             current_command='aws', lineage=[],
             last_fragment='e',
         )
-        self.index.command_names.return_value = ['ec2', 'ecs', 's3']
+        parsed = self.parser.parse('aws e')
         self.assertEqual(self.completer.complete(parsed), ['ec2', 'ecs'])
 
     def test_returns_all_results_when_last_fragment_empty(self):
-        parsed = parser.ParsedResult(
-            current_command='aws', lineage=[],
-            last_fragment='',
-        )
-        self.index.command_names.return_value = ['ec2', 'ecs', 's3']
+        parsed = self.parser.parse('aws ')
         self.assertEqual(self.completer.complete(parsed), ['ec2', 'ecs', 's3'])
 
     def test_can_autocomplete_global_param(self):
-        parsed = parser.ParsedResult(
-            lineage=[],
-            unparsed_items=[],
-            current_command=u'aws',
-            last_fragment=u'--re',
-        )
-        self.index.arg_names.return_value = ['region', 'endpoint-url']
+        parsed = self.parser.parse('aws --re')
         self.assertEqual(self.completer.complete(parsed), ['--region'])
 
     def test_can_combine_global_and_command_params(self):
-        parsed = parser.ParsedResult(
-            lineage=['aws', 'ec2'],
-            unparsed_items=[],
-            current_params={},
-            current_command='describe-instances',
-            last_fragment='--r',
-        )
-        self.index.arg_names.side_effect = [
-            ['foo', 'reserve'],
-            ['region', 'endpoint-url'],
-        ]
+        parsed = self.parser.parse('aws ec2 describe-instances --r')
         self.assertEqual(self.completer.complete(parsed),
                          ['--reserve', '--region'])
-        # Because there were multiple calls to arg_names() we'll also
-        # assert the call args and the call orders.
-        self.assertEqual(
-            self.index.arg_names.call_args_list,
-            [mock.call(lineage=['aws', 'ec2'],
-                       command_name='describe-instances'),
-             mock.call(lineage=[], command_name='aws')]
-        )
 
     def test_no_autocompletions_if_nothing_matches(self):
-        parsed = parser.ParsedResult(
-            lineage=[],
-            unparsed_items=[],
-            current_command=u'aws',
-            last_fragment=u'--foo',
-        )
-        self.index.arg_names.return_value = ['region', 'endpoint-url']
+        parsed = self.parser.parse('aws --foo')
         self.assertEqual(self.completer.complete(parsed), [])

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -1,0 +1,141 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, mock
+from awscli.autocomplete import completer, parser, model
+from awscli.clidriver import CLIDriver
+
+
+class TestAutoCompelter(unittest.TestCase):
+    def setUp(self):
+        self.parser = mock.Mock(spec=parser.CLIParser)
+        self.parsed_result = parser.ParsedResult()
+        self.parser.parse.return_value = self.parsed_result
+
+    def test_delegates_to_autocompleters(self):
+        mock_complete = mock.Mock(spec=completer.BaseCompleter)
+        mock_complete.complete.return_value = ['ec2', 'ecs']
+        auto_complete = completer.AutoCompleter(
+            self.parser, completers=[mock_complete])
+
+        results = auto_complete.autocomplete('aws e')
+        self.assertEqual(results, ['ec2', 'ecs'])
+        self.parser.parse.assert_called_with('aws e', None)
+        mock_complete.complete.assert_called_with(self.parsed_result)
+
+    def test_stops_processing_when_list_returned(self):
+        first = mock.Mock(spec=completer.BaseCompleter)
+        second = mock.Mock(spec=completer.BaseCompleter)
+
+        first.complete.return_value = None
+        second.complete.return_value = ['ec2', 'ecs']
+
+        auto_complete = completer.AutoCompleter(
+            self.parser, completers=[first, second])
+        self.assertEqual(auto_complete.autocomplete('aws e'), ['ec2', 'ecs'])
+
+        first.complete.assert_called_with(self.parsed_result)
+        second.complete.assert_called_with(self.parsed_result)
+
+    def test_returns_empty_list_if_no_completers_have_results(self):
+        first = mock.Mock(spec=completer.BaseCompleter)
+        second = mock.Mock(spec=completer.BaseCompleter)
+
+        first.complete.return_value = None
+        second.complete.return_value = None
+
+        auto_complete = completer.AutoCompleter(
+            self.parser, completers=[first, second])
+        self.assertIsNone(auto_complete.autocomplete('aws e'))
+
+        first.complete.assert_called_with(self.parsed_result)
+        second.complete.assert_called_with(self.parsed_result)
+
+
+class TestModelIndexCompleter(unittest.TestCase):
+    def setUp(self):
+        self.index = mock.Mock(spec=model.ModelIndex)
+        self.completer = completer.ModelIndexCompleter(self.index)
+
+    def test_does_not_complete_if_unparsed_items(self):
+        parsed = parser.ParsedResult(
+            current_command='aws', lineage=[],
+            unparsed_items=['foo'], last_fragment='')
+        self.assertIsNone(self.completer.complete(parsed))
+
+    def test_does_complete_if_last_fragment_is_none(self):
+        parsed = parser.ParsedResult(
+            lineage=[],
+            unparsed_items=[],
+            current_command='aws',
+            last_fragment=None,
+        )
+        self.assertIsNone(self.completer.complete(parsed))
+
+    def test_can_prefix_match_services(self):
+        parsed = parser.ParsedResult(
+            current_command='aws', lineage=[],
+            last_fragment='e',
+        )
+        self.index.command_names.return_value = ['ec2', 'ecs', 's3']
+        self.assertEqual(self.completer.complete(parsed), ['ec2', 'ecs'])
+
+    def test_returns_all_results_when_last_fragment_empty(self):
+        parsed = parser.ParsedResult(
+            current_command='aws', lineage=[],
+            last_fragment='',
+        )
+        self.index.command_names.return_value = ['ec2', 'ecs', 's3']
+        self.assertEqual(self.completer.complete(parsed), ['ec2', 'ecs', 's3'])
+
+    def test_can_autocomplete_global_param(self):
+        parsed = parser.ParsedResult(
+            lineage=[],
+            unparsed_items=[],
+            current_command=u'aws',
+            last_fragment=u'--re',
+        )
+        self.index.arg_names.return_value = ['region', 'endpoint-url']
+        self.assertEqual(self.completer.complete(parsed), ['--region'])
+
+    def test_can_combine_global_and_command_params(self):
+        parsed = parser.ParsedResult(
+            lineage=['aws', 'ec2'],
+            unparsed_items=[],
+            current_params={},
+            current_command='describe-instances',
+            last_fragment='--r',
+        )
+        self.index.arg_names.side_effect = [
+            ['foo', 'reserve'],
+            ['region', 'endpoint-url'],
+        ]
+        self.assertEqual(self.completer.complete(parsed),
+                         ['--reserve', '--region'])
+        # Because there were multiple calls to arg_names() we'll also
+        # assert the call args and the call orders.
+        self.assertEqual(
+            self.index.arg_names.call_args_list,
+            [mock.call(lineage=['aws', 'ec2'],
+                       command_name='describe-instances'),
+             mock.call(lineage=[], command_name='aws')]
+        )
+
+    def test_no_autocompletions_if_nothing_matches(self):
+        parsed = parser.ParsedResult(
+            lineage=[],
+            unparsed_items=[],
+            current_command=u'aws',
+            last_fragment=u'--foo',
+        )
+        self.index.arg_names.return_value = ['region', 'endpoint-url']
+        self.assertEqual(self.completer.complete(parsed), [])

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -70,6 +70,23 @@ class TestAutoCompleter(unittest.TestCase):
         first.complete.assert_called_with(self.parsed_result)
         second.complete.assert_called_with(self.parsed_result)
 
+    def test_first_result_wins(self):
+        first = mock.Mock(spec=completer.BaseCompleter)
+        second = mock.Mock(spec=completer.BaseCompleter)
+
+        first.complete.return_value = [CompletionResult('ec2', -1)]
+        second.complete.return_value = [CompletionResult('ecs', -1)]
+
+        auto_complete = completer.AutoCompleter(
+            self.parser, completers=[first, second])
+        self.assertEqual(
+            auto_complete.autocomplete('aws e'),
+            [CompletionResult('ec2', -1)]
+        )
+
+        first.complete.assert_called_with(self.parsed_result)
+        self.assertFalse(second.complete.called)
+
 
 class TestModelIndexCompleter(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/autocomplete/test_parser.py
+++ b/tests/unit/autocomplete/test_parser.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import copy
 from functools import partial
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_is_instance, assert_true
 
 from awscli.testutils import unittest
 from awscli.autocomplete import parser, model
@@ -117,6 +117,39 @@ def _assert_parses_to(command_line, expected):
     p = parser.CLIParser(SAMPLE_MODEL)
     result = p.parse(command_line)
     assert_equal(result, expected)
+
+
+def test_properties_of_unparsed_results():
+    # The parser should never raise an exception.  If it can't
+    # understand something it should still return a ParsedResult
+    # with the parts it doesn't understand addded to the unparsed_items
+    # attribute.  The ParsedResult should always have some basic invariants
+    # we can verify which are called out in the tests below.
+    # This test ensures that at every single slice of the full command_line
+    # we always produce a sensical ParsedResult.
+    command_line = (
+        'aws ec2 stop-instances --instance-ids i-123 i-124 '
+        '--foo-arg value --debug --endpoint-url https://foo'
+    )
+    cli_parser = parser.CLIParser(SAMPLE_MODEL)
+    for i in range(1, len(command_line)):
+        chunk = command_line[:i]
+        yield _assert_parsed_properties, chunk, cli_parser
+
+
+def _assert_parsed_properties(chunk, cli_parser):
+    result = cli_parser.parse(chunk)
+    assert_is_instance(result, parser.ParsedResult)
+    if chunk[-1].isspace():
+        # If there's a space as the last char, then we should have
+        # a last_fragment of an empty string.  This results in
+        # all results being returned from the prefix match in the
+        # auto-completer.
+        assert_equal(result.last_fragment, '')
+    elif result.last_fragment is not None:
+        # The last_fragment, if not None is always the last part
+        # of the command line.
+        assert_true(chunk.endswith(result.last_fragment))
 
 
 class TestCanParseCLICommand(unittest.TestCase):

--- a/tests/unit/autocomplete/test_parser.py
+++ b/tests/unit/autocomplete/test_parser.py
@@ -16,34 +16,12 @@ from nose.tools import assert_equal, assert_is_instance, assert_true
 
 from awscli.testutils import unittest
 from awscli.autocomplete import parser, model
-
-
-
-class FakeModelIndex(model.ModelIndex):
-    # An in-memory version of a model index.
-
-    def __init__(self, index):
-        self.index = index
-
-    def command_names(self, lineage):
-        parent = '.'.join(lineage)
-        return self.index['command_names'].get(parent, [])
-
-    def arg_names(self, lineage, command_name):
-        parent = '.'.join(lineage)
-        return self.index['arg_names'].get(parent, {}).get(command_name, [])
-
-    def get_argument_data(self, lineage, command_name, arg_name):
-        parent = '.'.join(lineage)
-        arg_data = self.index['arg_data'].get(parent, {}).get(
-            command_name, {}).get(arg_name)
-        if arg_data is not None:
-            return model.CLIArgument(*arg_data)
+from tests.unit.autocomplete import InMemoryIndex
 
 
 # This models an 'aws ec2 stop-instances' command
 # along with the 'region', 'endpoint-url', and 'debug' global params.
-SAMPLE_MODEL = FakeModelIndex(
+SAMPLE_MODEL = InMemoryIndex(
     # This format is intended to match the structure you'd get from
     # querying the index db to minimize any parity issues between
     # the tests and the real indexer.


### PR DESCRIPTION
This integrates the model index and the cli parser to create an auto-completer.  This includes:

* A model-based completer that uses the index to auto complete commands and parameters
* A class that's used to delegate to concrete completers so we can support for more types of auto-completers.
* A bug fix for the parser found when testing this model completer.  It was raising an `IndexError` in cases where it tried to consume a value for an argument, and there were cases where `last_fragment` was suppose to be an empty string but was `None` instead.

This should give us feature parity with the existing completer in the CLI.