### PR TITLE
[CLIv2] Autocomplete parser bugfixes

### DIFF
--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -479,10 +479,14 @@ class CLIArgument(BaseCLIArgument):
 
 class ListArgument(CLIArgument):
 
+    @property
+    def nargs(self):
+        return '*'
+
     def add_to_parser(self, parser):
         cli_name = self.cli_name
         parser.add_argument(cli_name,
-                            nargs='*',
+                            nargs=self.nargs,
                             type=self.cli_type,
                             required=self.required)
 

--- a/awscli/autocomplete/parser.py
+++ b/awscli/autocomplete/parser.py
@@ -219,6 +219,12 @@ class CLIParser(object):
 
     def _handle_option(self, current, remaining_parts, current_args,
                        global_args, parsed, state):
+        if current_args is None:
+            # If there are no arguments found for this current scope,
+            # it usually indicates we've encounted a command we don't know.
+            # In this case we don't try to handle this option.
+            parsed.unparsed_items.append(current)
+            return
         # This is a command line option, remove the `--` portion so we
         # just have the option name.
         option_name = current[2:]

--- a/tests/unit/autocomplete/test_parser.py
+++ b/tests/unit/autocomplete/test_parser.py
@@ -381,6 +381,20 @@ class TestCanParseCLICommand(unittest.TestCase):
             unparsed_items=['ec', 'stop-insta']
         )
 
+    def test_can_handle_error_cases_gracefully(self):
+        # The --foo-arg has nargs of None so this is an invalid command.
+        # It would normally generate a parser error.  We should make sure
+        # we handle this gracefully.
+        result = self.cli_parser.parse(
+            'aws ec2 stop-instances --foo-arg a b --')
+        self.assert_parsed_results_equal(
+            result,
+            current_command='stop-instances',
+            lineage=['aws', 'ec2'],
+            last_fragment=None,
+            unparsed_items=['b', '--'],
+        )
+
 
 class TestParseState(unittest.TestCase):
     def test_can_set_initial_state(self):

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -72,3 +72,15 @@ class TestCLIArgument(unittest.TestCase):
         actual_event_name = self.event_emitter.emit.call_args[0][0]
         self.assertEqual(actual_event_name, expected_event_name)
 
+    def test_list_type_has_correct_nargs_value(self):
+        # We don't actually care about the values, we just need a ListArgument
+        # type.
+        arg = arguments.ListArgument(
+            argument_model=self.argument_model,
+            event_emitter=self.event_emitter,
+            is_required=True,
+            name='test-nargs',
+            operation_model=None,
+            serialized_name='TestNargs'
+        )
+        self.assertEqual(arg.nargs, '*')


### PR DESCRIPTION
This fixes two bugs:

1. The `nargs` property on a `ListArgument` was returning `None`, resulting in the indexer using the wrong nargs value for list types.  This resulted in the parser not parsing list args correctly even though the command was valid.
2. When the above condition happened we'd raise a `TypeError` because `current_args` is `None` because it wasn't able to find a suitable scope associated with the current value.  For example `--instance-ids i-123 i-124` would only consume one value, so it'd assume `i-124` was a command it didn't know about, which sets `current_args` to 0.