### PR TITLE
[CLIv2] Initial generation of server side completion data

### DIFF
--- a/awscli/data/acm-pca/2017-08-22/completions-1.json
+++ b/awscli/data/acm-pca/2017-08-22/completions-1.json
@@ -1,0 +1,33 @@
+{
+  "version": "1.0",
+  "resources": {
+    "CertificateAuthority": {
+      "operation": "ListCertificateAuthorities",
+      "resourceIdentifier": {
+        "CertificateAuthorityConfiguration": "CertificateAuthorities[].CertificateAuthorityConfiguration"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "CertificateAuthorityArn"
+      ]
+    }
+  },
+  "operations": {
+    "CreateCertificateAuthority": {
+      "CertificateAuthorityConfiguration": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CertificateAuthority",
+            "resourceIdentifier": "CertificateAuthorityConfiguration"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/acm/2015-12-08/completions-1.json
+++ b/awscli/data/acm/2015-12-08/completions-1.json
@@ -1,0 +1,110 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Certificate": {
+      "operation": "ListCertificates",
+      "resourceIdentifier": {
+        "CertificateArn": "CertificateSummaryList[].CertificateArn"
+      }
+    },
+    "TagsForCertificate": {
+      "operation": "ListTagsForCertificate",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "CertificateArn"
+      ]
+    }
+  },
+  "operations": {
+    "AddTagsToCertificate": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "DeleteCertificate": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "ExportCertificate": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "GetCertificate": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "ImportCertificate": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "RemoveTagsFromCertificate": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "ResendValidationEmail": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    },
+    "UpdateCertificateOptions": {
+      "CertificateArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificateArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/alexaforbusiness/2017-11-09/completions-1.json
+++ b/awscli/data/alexaforbusiness/2017-11-09/completions-1.json
@@ -1,0 +1,75 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DeviceEvent": {
+      "operation": "ListDeviceEvents",
+      "resourceIdentifier": {
+        "Timestamp": "DeviceEvents[].Timestamp"
+      },
+      "inputParameters": [
+        "DeviceArn"
+      ]
+    },
+    "Skill": {
+      "operation": "ListSkills",
+      "resourceIdentifier": {
+        "SkillId": "SkillSummaries[].SkillId"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "Arn"
+      ]
+    }
+  },
+  "operations": {
+    "DeleteRoomSkillParameter": {
+      "SkillId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Skill",
+            "resourceIdentifier": "SkillId"
+          }
+        ]
+      }
+    },
+    "GetRoomSkillParameter": {
+      "SkillId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Skill",
+            "resourceIdentifier": "SkillId"
+          }
+        ]
+      }
+    },
+    "PutRoomSkillParameter": {
+      "SkillId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Skill",
+            "resourceIdentifier": "SkillId"
+          }
+        ]
+      }
+    },
+    "ResolveRoom": {
+      "SkillId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Skill",
+            "resourceIdentifier": "SkillId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/apigateway/2015-07-09/completions-1.json
+++ b/awscli/data/apigateway/2015-07-09/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/application-autoscaling/2016-02-06/completions-1.json
+++ b/awscli/data/application-autoscaling/2016-02-06/completions-1.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ScalableTarget": {
+      "operation": "DescribeScalableTargets",
+      "resourceIdentifier": {
+        "ScalableDimension": "ScalableTargets[].ScalableDimension"
+      },
+      "inputParameters": [
+        "ServiceNamespace"
+      ]
+    },
+    "ScalingActivity": {
+      "operation": "DescribeScalingActivities",
+      "resourceIdentifier": {
+        "ActivityId": "ScalingActivities[].ActivityId"
+      },
+      "inputParameters": [
+        "ServiceNamespace"
+      ]
+    },
+    "ScalingPolicy": {
+      "operation": "DescribeScalingPolicies",
+      "resourceIdentifier": {
+        "StepScalingPolicyConfiguration": "ScalingPolicies[].StepScalingPolicyConfiguration"
+      },
+      "inputParameters": [
+        "ServiceNamespace"
+      ]
+    },
+    "ScheduledAction": {
+      "operation": "DescribeScheduledActions",
+      "resourceIdentifier": {
+        "ScheduledActionARN": "ScheduledActions[].ScheduledActionARN"
+      },
+      "inputParameters": [
+        "ServiceNamespace"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/appstream/2016-12-01/completions-1.json
+++ b/awscli/data/appstream/2016-12-01/completions-1.json
@@ -1,0 +1,107 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DirectoryConfig": {
+      "operation": "DescribeDirectoryConfigs",
+      "resourceIdentifier": {
+        "DirectoryName": "DirectoryConfigs[].DirectoryName"
+      }
+    },
+    "Fleet": {
+      "operation": "DescribeFleets",
+      "resourceIdentifier": {
+        "FleetErrors": "Fleets[].FleetErrors"
+      }
+    },
+    "ImageBuilder": {
+      "operation": "DescribeImageBuilders",
+      "resourceIdentifier": {
+        "ImageBuilderErrors": "ImageBuilders[].ImageBuilderErrors"
+      }
+    },
+    "ImagePermission": {
+      "operation": "DescribeImagePermissions",
+      "resourceIdentifier": {
+        "imagePermissions": "SharedImagePermissionsList[].imagePermissions"
+      },
+      "inputParameters": [
+        "Name"
+      ]
+    },
+    "Image": {
+      "operation": "DescribeImages",
+      "resourceIdentifier": {
+        "BaseImageArn": "Images[].BaseImageArn"
+      }
+    },
+    "Session": {
+      "operation": "DescribeSessions",
+      "resourceIdentifier": {
+        "NetworkAccessConfiguration": "Sessions[].NetworkAccessConfiguration"
+      },
+      "inputParameters": [
+        "StackName",
+        "FleetName"
+      ]
+    },
+    "Stack": {
+      "operation": "DescribeStacks",
+      "resourceIdentifier": {
+        "StackErrors": "Stacks[].StackErrors"
+      }
+    },
+    "AssociatedFleet": {
+      "operation": "ListAssociatedFleets",
+      "resourceIdentifier": {
+        "Names": "Names[]"
+      },
+      "inputParameters": [
+        "StackName"
+      ]
+    },
+    "AssociatedStack": {
+      "operation": "ListAssociatedStacks",
+      "resourceIdentifier": {
+        "Names": "Names[]"
+      },
+      "inputParameters": [
+        "FleetName"
+      ]
+    }
+  },
+  "operations": {
+    "CreateDirectoryConfig": {
+      "DirectoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectoryConfig",
+            "resourceIdentifier": "DirectoryName"
+          }
+        ]
+      }
+    },
+    "DeleteDirectoryConfig": {
+      "DirectoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectoryConfig",
+            "resourceIdentifier": "DirectoryName"
+          }
+        ]
+      }
+    },
+    "UpdateDirectoryConfig": {
+      "DirectoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectoryConfig",
+            "resourceIdentifier": "DirectoryName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/appsync/2017-07-25/completions-1.json
+++ b/awscli/data/appsync/2017-07-25/completions-1.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ApiKey": {
+      "operation": "ListApiKeys",
+      "resourceIdentifier": {
+        "expires": "apiKeys[].expires"
+      },
+      "inputParameters": [
+        "apiId"
+      ]
+    },
+    "DataSource": {
+      "operation": "ListDataSources",
+      "resourceIdentifier": {
+        "dataSourceArn": "dataSources[].dataSourceArn"
+      },
+      "inputParameters": [
+        "apiId"
+      ]
+    },
+    "GraphqlApi": {
+      "operation": "ListGraphqlApis",
+      "resourceIdentifier": {
+        "uris": "graphqlApis[].uris"
+      }
+    },
+    "Resolver": {
+      "operation": "ListResolvers",
+      "resourceIdentifier": {
+        "resolverArn": "resolvers[].resolverArn"
+      },
+      "inputParameters": [
+        "apiId",
+        "typeName"
+      ]
+    },
+    "Type": {
+      "operation": "ListTypes",
+      "resourceIdentifier": {
+        "description": "types[].description"
+      },
+      "inputParameters": [
+        "apiId",
+        "format"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/athena/2017-05-18/completions-1.json
+++ b/awscli/data/athena/2017-05-18/completions-1.json
@@ -1,0 +1,96 @@
+{
+  "version": "1.0",
+  "resources": {
+    "NamedQuery": {
+      "operation": "ListNamedQueries",
+      "resourceIdentifier": {
+        "NamedQueryIds": "NamedQueryIds[]"
+      }
+    },
+    "QueryExecution": {
+      "operation": "ListQueryExecutions",
+      "resourceIdentifier": {
+        "QueryExecutionIds": "QueryExecutionIds[]"
+      }
+    }
+  },
+  "operations": {
+    "BatchGetNamedQuery": {
+      "NamedQueryIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NamedQuery",
+            "resourceIdentifier": "NamedQueryIds"
+          }
+        ]
+      }
+    },
+    "BatchGetQueryExecution": {
+      "QueryExecutionIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QueryExecution",
+            "resourceIdentifier": "QueryExecutionIds"
+          }
+        ]
+      }
+    },
+    "DeleteNamedQuery": {
+      "NamedQueryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NamedQuery",
+            "resourceIdentifier": "NamedQueryId"
+          }
+        ]
+      }
+    },
+    "GetNamedQuery": {
+      "NamedQueryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NamedQuery",
+            "resourceIdentifier": "NamedQueryId"
+          }
+        ]
+      }
+    },
+    "GetQueryExecution": {
+      "QueryExecutionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QueryExecution",
+            "resourceIdentifier": "QueryExecutionId"
+          }
+        ]
+      }
+    },
+    "GetQueryResults": {
+      "QueryExecutionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QueryExecution",
+            "resourceIdentifier": "QueryExecutionId"
+          }
+        ]
+      }
+    },
+    "StopQueryExecution": {
+      "QueryExecutionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QueryExecution",
+            "resourceIdentifier": "QueryExecutionId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/autoscaling-plans/2018-01-06/completions-1.json
+++ b/awscli/data/autoscaling-plans/2018-01-06/completions-1.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ScalingPlanResource": {
+      "operation": "DescribeScalingPlanResources",
+      "resourceIdentifier": {
+        "ScalingPlanVersion": "ScalingPlanResources[].ScalingPlanVersion"
+      },
+      "inputParameters": [
+        "ScalingPlanName",
+        "ScalingPlanVersion"
+      ]
+    },
+    "ScalingPlan": {
+      "operation": "DescribeScalingPlans",
+      "resourceIdentifier": {
+        "ScalingPlanName": "ScalingPlans[].ScalingPlanName"
+      }
+    }
+  },
+  "operations": {
+    "CreateScalingPlan": {
+      "ScalingPlanName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ScalingPlan",
+            "resourceIdentifier": "ScalingPlanName"
+          }
+        ]
+      }
+    },
+    "DeleteScalingPlan": {
+      "ScalingPlanName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ScalingPlan",
+            "resourceIdentifier": "ScalingPlanName"
+          }
+        ]
+      }
+    },
+    "UpdateScalingPlan": {
+      "ScalingPlanName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ScalingPlan",
+            "resourceIdentifier": "ScalingPlanName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/autoscaling/2011-01-01/completions-1.json
+++ b/awscli/data/autoscaling/2011-01-01/completions-1.json
@@ -1,0 +1,487 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AdjustmentType": {
+      "operation": "DescribeAdjustmentTypes",
+      "resourceIdentifier": {
+        "AdjustmentType": "AdjustmentTypes[].AdjustmentType"
+      }
+    },
+    "AutoScalingGroup": {
+      "operation": "DescribeAutoScalingGroups",
+      "resourceIdentifier": {
+        "AutoScalingGroupARN": "AutoScalingGroups[].AutoScalingGroupARN"
+      }
+    },
+    "AutoScalingInstance": {
+      "operation": "DescribeAutoScalingInstances",
+      "resourceIdentifier": {
+        "AutoScalingGroupName": "AutoScalingInstances[].AutoScalingGroupName"
+      }
+    },
+    "AutoScalingNotificationType": {
+      "operation": "DescribeAutoScalingNotificationTypes",
+      "resourceIdentifier": {
+        "AutoScalingNotificationTypes": "AutoScalingNotificationTypes[]"
+      }
+    },
+    "LaunchConfiguration": {
+      "operation": "DescribeLaunchConfigurations",
+      "resourceIdentifier": {
+        "LaunchConfigurationARN": "LaunchConfigurations[].LaunchConfigurationARN"
+      }
+    },
+    "LifecycleHookType": {
+      "operation": "DescribeLifecycleHookTypes",
+      "resourceIdentifier": {
+        "LifecycleHookTypes": "LifecycleHookTypes[]"
+      }
+    },
+    "LifecycleHook": {
+      "operation": "DescribeLifecycleHooks",
+      "resourceIdentifier": {
+        "LifecycleHookName": "LifecycleHooks[].LifecycleHookName"
+      },
+      "inputParameters": [
+        "AutoScalingGroupName"
+      ]
+    },
+    "LoadBalancerTargetGroup": {
+      "operation": "DescribeLoadBalancerTargetGroups",
+      "resourceIdentifier": {
+        "LoadBalancerTargetGroupARN": "LoadBalancerTargetGroups[].LoadBalancerTargetGroupARN"
+      },
+      "inputParameters": [
+        "AutoScalingGroupName"
+      ]
+    },
+    "LoadBalancer": {
+      "operation": "DescribeLoadBalancers",
+      "resourceIdentifier": {
+        "LoadBalancerName": "LoadBalancers[].LoadBalancerName"
+      },
+      "inputParameters": [
+        "AutoScalingGroupName"
+      ]
+    },
+    "NotificationConfiguration": {
+      "operation": "DescribeNotificationConfigurations",
+      "resourceIdentifier": {
+        "NotificationType": "NotificationConfigurations[].NotificationType"
+      }
+    },
+    "Policy": {
+      "operation": "DescribePolicies",
+      "resourceIdentifier": {
+        "PolicyName": "ScalingPolicies[].PolicyName"
+      }
+    },
+    "ScalingActivity": {
+      "operation": "DescribeScalingActivities",
+      "resourceIdentifier": {
+        "ActivityId": "Activities[].ActivityId"
+      }
+    },
+    "ScalingProcessType": {
+      "operation": "DescribeScalingProcessTypes",
+      "resourceIdentifier": {
+        "ProcessName": "Processes[].ProcessName"
+      }
+    },
+    "ScheduledAction": {
+      "operation": "DescribeScheduledActions",
+      "resourceIdentifier": {
+        "ScheduledActionARN": "ScheduledUpdateGroupActions[].ScheduledActionARN"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      }
+    },
+    "TerminationPolicyType": {
+      "operation": "DescribeTerminationPolicyTypes",
+      "resourceIdentifier": {
+        "TerminationPolicyTypes": "TerminationPolicyTypes[]"
+      }
+    }
+  },
+  "operations": {
+    "AttachInstances": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "AttachLoadBalancerTargetGroups": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "AttachLoadBalancers": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "BatchDeleteScheduledAction": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "BatchPutScheduledUpdateGroupAction": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "CompleteLifecycleAction": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "CreateAutoScalingGroup": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteAutoScalingGroup": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteLifecycleHook": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteNotificationConfiguration": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DeletePolicy": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "DeleteScheduledAction": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DetachInstances": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DetachLoadBalancerTargetGroups": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DetachLoadBalancers": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "DisableMetricsCollection": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "EnableMetricsCollection": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "EnterStandby": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "ExecutePolicy": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "ExitStandby": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "PutLifecycleHook": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "PutNotificationConfiguration": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      },
+      "NotificationTypes": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NotificationConfiguration",
+            "resourceIdentifier": "NotificationTypes"
+          }
+        ]
+      }
+    },
+    "PutScalingPolicy": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      },
+      "AdjustmentType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AdjustmentType",
+            "resourceIdentifier": "AdjustmentType"
+          }
+        ]
+      }
+    },
+    "PutScheduledUpdateGroupAction": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "RecordLifecycleActionHeartbeat": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "ResumeProcesses": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "SetDesiredCapacity": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "SetInstanceProtection": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "SuspendProcesses": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    },
+    "UpdateAutoScalingGroup": {
+      "AutoScalingGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutoScalingInstance",
+            "resourceIdentifier": "AutoScalingGroupName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/batch/2016-08-10/completions-1.json
+++ b/awscli/data/batch/2016-08-10/completions-1.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ComputeEnvironment": {
+      "operation": "DescribeComputeEnvironments",
+      "resourceIdentifier": {
+        "computeEnvironmentArn": "computeEnvironments[].computeEnvironmentArn"
+      }
+    },
+    "JobDefinition": {
+      "operation": "DescribeJobDefinitions",
+      "resourceIdentifier": {
+        "jobDefinitionArn": "jobDefinitions[].jobDefinitionArn"
+      }
+    },
+    "JobQueue": {
+      "operation": "DescribeJobQueues",
+      "resourceIdentifier": {
+        "jobQueueArn": "jobQueues[].jobQueueArn"
+      }
+    },
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "jobId": "jobSummaryList[].jobId"
+      },
+      "inputParameters": [
+        "jobs"
+      ]
+    }
+  },
+  "operations": {
+    "DeleteComputeEnvironment": {
+      "computeEnvironment": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ComputeEnvironment",
+            "resourceIdentifier": "computeEnvironment"
+          }
+        ]
+      }
+    },
+    "UpdateComputeEnvironment": {
+      "computeEnvironment": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ComputeEnvironment",
+            "resourceIdentifier": "computeEnvironment"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/budgets/2016-10-20/completions-1.json
+++ b/awscli/data/budgets/2016-10-20/completions-1.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Budget": {
+      "operation": "DescribeBudgets",
+      "resourceIdentifier": {
+        "BudgetName": "Budgets[].BudgetName"
+      },
+      "inputParameters": [
+        "AccountId"
+      ]
+    },
+    "NotificationsForBudget": {
+      "operation": "DescribeNotificationsForBudget",
+      "resourceIdentifier": {
+        "NotificationType": "Notifications[].NotificationType"
+      },
+      "inputParameters": [
+        "AccountId",
+        "BudgetName"
+      ]
+    },
+    "SubscribersForNotification": {
+      "operation": "DescribeSubscribersForNotification",
+      "resourceIdentifier": {
+        "SubscriptionType": "Subscribers[].SubscriptionType"
+      },
+      "inputParameters": [
+        "AccountId",
+        "BudgetName",
+        "Notification"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/ce/2017-10-25/completions-1.json
+++ b/awscli/data/ce/2017-10-25/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/cloud9/2017-09-23/completions-1.json
+++ b/awscli/data/cloud9/2017-09-23/completions-1.json
@@ -1,0 +1,78 @@
+{
+  "version": "1.0",
+  "resources": {
+    "EnvironmentMembership": {
+      "operation": "DescribeEnvironmentMemberships",
+      "resourceIdentifier": {
+        "environmentId": "memberships[].environmentId"
+      }
+    },
+    "Environment": {
+      "operation": "ListEnvironments",
+      "resourceIdentifier": {
+        "name": "environments[].name",
+        "environmentIds": "environmentIds[]"
+      },
+      "inputParameters": [
+        "environmentIds"
+      ]
+    }
+  },
+  "operations": {
+    "CreateEnvironmentMembership": {
+      "environmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EnvironmentMembership",
+            "resourceIdentifier": "environmentId"
+          }
+        ]
+      }
+    },
+    "DeleteEnvironment": {
+      "environmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EnvironmentMembership",
+            "resourceIdentifier": "environmentId"
+          }
+        ]
+      }
+    },
+    "DeleteEnvironmentMembership": {
+      "environmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EnvironmentMembership",
+            "resourceIdentifier": "environmentId"
+          }
+        ]
+      }
+    },
+    "UpdateEnvironment": {
+      "environmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EnvironmentMembership",
+            "resourceIdentifier": "environmentId"
+          }
+        ]
+      }
+    },
+    "UpdateEnvironmentMembership": {
+      "environmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EnvironmentMembership",
+            "resourceIdentifier": "environmentId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/clouddirectory/2017-01-11/completions-1.json
+++ b/awscli/data/clouddirectory/2017-01-11/completions-1.json
@@ -1,0 +1,618 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AppliedSchemaArn": {
+      "operation": "ListAppliedSchemaArns",
+      "resourceIdentifier": {
+        "SchemaArns": "SchemaArns[]"
+      },
+      "inputParameters": [
+        "DirectoryArn"
+      ]
+    },
+    "AttachedIndice": {
+      "operation": "ListAttachedIndices",
+      "resourceIdentifier": {
+        "IndexedAttributes": "IndexAttachments[].IndexedAttributes"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "TargetReference"
+      ]
+    },
+    "DevelopmentSchemaArn": {
+      "operation": "ListDevelopmentSchemaArns",
+      "resourceIdentifier": {
+        "SchemaArns": "SchemaArns[]"
+      }
+    },
+    "Directory": {
+      "operation": "ListDirectories",
+      "resourceIdentifier": {
+        "DirectoryArn": "Directories[].DirectoryArn"
+      }
+    },
+    "FacetAttribute": {
+      "operation": "ListFacetAttributes",
+      "resourceIdentifier": {
+        "AttributeReference": "Attributes[].AttributeReference"
+      },
+      "inputParameters": [
+        "SchemaArn",
+        "Name"
+      ]
+    },
+    "FacetName": {
+      "operation": "ListFacetNames",
+      "resourceIdentifier": {
+        "FacetNames": "FacetNames[]"
+      },
+      "inputParameters": [
+        "SchemaArn"
+      ]
+    },
+    "IncomingTypedLink": {
+      "operation": "ListIncomingTypedLinks",
+      "resourceIdentifier": {
+        "TypedLinkFacet": "LinkSpecifiers[].TypedLinkFacet"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "ObjectReference"
+      ]
+    },
+    "Index": {
+      "operation": "ListIndex",
+      "resourceIdentifier": {
+        "IndexedAttributes": "IndexAttachments[].IndexedAttributes"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "IndexReference"
+      ]
+    },
+    "ManagedSchemaArn": {
+      "operation": "ListManagedSchemaArns",
+      "resourceIdentifier": {
+        "SchemaArns": "SchemaArns[]"
+      }
+    },
+    "ObjectAttribute": {
+      "operation": "ListObjectAttributes",
+      "resourceIdentifier": {
+        "Key": "Attributes[].Key"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "ObjectReference"
+      ]
+    },
+    "ObjectParentPath": {
+      "operation": "ListObjectParentPaths",
+      "resourceIdentifier": {
+        "ObjectIdentifiers": "PathToObjectIdentifiersList[].ObjectIdentifiers"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "ObjectReference"
+      ]
+    },
+    "ObjectPolicy": {
+      "operation": "ListObjectPolicies",
+      "resourceIdentifier": {
+        "AttachedPolicyIds": "AttachedPolicyIds[]"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "ObjectReference"
+      ]
+    },
+    "OutgoingTypedLink": {
+      "operation": "ListOutgoingTypedLinks",
+      "resourceIdentifier": {
+        "TypedLinkFacet": "TypedLinkSpecifiers[].TypedLinkFacet"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "ObjectReference"
+      ]
+    },
+    "PolicyAttachment": {
+      "operation": "ListPolicyAttachments",
+      "resourceIdentifier": {
+        "ObjectIdentifiers": "ObjectIdentifiers[]"
+      },
+      "inputParameters": [
+        "DirectoryArn",
+        "PolicyReference"
+      ]
+    },
+    "PublishedSchemaArn": {
+      "operation": "ListPublishedSchemaArns",
+      "resourceIdentifier": {
+        "SchemaArns": "SchemaArns[]"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceArn"
+      ]
+    },
+    "TypedLinkFacetAttribute": {
+      "operation": "ListTypedLinkFacetAttributes",
+      "resourceIdentifier": {
+        "Type": "Attributes[].Type"
+      },
+      "inputParameters": [
+        "SchemaArn",
+        "Name"
+      ]
+    },
+    "TypedLinkFacetName": {
+      "operation": "ListTypedLinkFacetNames",
+      "resourceIdentifier": {
+        "FacetNames": "FacetNames[]"
+      },
+      "inputParameters": [
+        "SchemaArn"
+      ]
+    }
+  },
+  "operations": {
+    "AddFacetToObject": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "ApplySchema": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "AttachObject": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "AttachPolicy": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "AttachToIndex": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "AttachTypedLink": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "BatchRead": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "BatchWrite": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "CreateDirectory": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "CreateFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "CreateIndex": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "CreateObject": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "CreateTypedLinkFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "DeleteDirectory": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "DeleteFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "DeleteObject": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "DeleteSchema": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "DeleteTypedLinkFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "DetachFromIndex": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "DetachObject": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "DetachPolicy": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "DetachTypedLink": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "DisableDirectory": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "EnableDirectory": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "GetAppliedSchemaVersion": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "GetDirectory": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "GetFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "GetLinkAttributes": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "GetObjectAttributes": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "GetObjectInformation": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "GetSchemaAsJson": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "GetTypedLinkFacetInformation": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "LookupPolicy": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "PutSchemaFromJson": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "RemoveFacetFromObject": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "UpdateFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "UpdateLinkAttributes": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "UpdateObjectAttributes": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    },
+    "UpdateSchema": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "UpdateTypedLinkFacet": {
+      "SchemaArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PublishedSchemaArn",
+            "resourceIdentifier": "SchemaArn"
+          }
+        ]
+      }
+    },
+    "UpgradeAppliedSchema": {
+      "DirectoryArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/cloudformation/2010-05-15/completions-1.json
+++ b/awscli/data/cloudformation/2010-05-15/completions-1.json
@@ -1,0 +1,246 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountLimit": {
+      "operation": "DescribeAccountLimits",
+      "resourceIdentifier": {
+        "Name": "AccountLimits[].Name"
+      }
+    },
+    "StackEvent": {
+      "operation": "DescribeStackEvents",
+      "resourceIdentifier": {
+        "StackName": "StackEvents[].StackName"
+      }
+    },
+    "StackResource": {
+      "operation": "ListStackResources",
+      "resourceIdentifier": {
+        "ResourceStatus": "StackResourceSummaries[].ResourceStatus"
+      },
+      "inputParameters": [
+        "StackName"
+      ]
+    },
+    "Stack": {
+      "operation": "ListStacks",
+      "resourceIdentifier": {
+        "StackId": "StackSummaries[].StackId"
+      }
+    },
+    "ChangeSet": {
+      "operation": "ListChangeSets",
+      "resourceIdentifier": {
+        "ChangeSetId": "Summaries[].ChangeSetId"
+      },
+      "inputParameters": [
+        "StackName"
+      ]
+    },
+    "Export": {
+      "operation": "ListExports",
+      "resourceIdentifier": {
+        "ExportingStackId": "Exports[].ExportingStackId"
+      }
+    },
+    "Import": {
+      "operation": "ListImports",
+      "resourceIdentifier": {
+        "Imports": "Imports[]"
+      },
+      "inputParameters": [
+        "ExportName"
+      ]
+    },
+    "StackInstance": {
+      "operation": "ListStackInstances",
+      "resourceIdentifier": {
+        "StackId": "Summaries[].StackId"
+      },
+      "inputParameters": [
+        "StackSetName"
+      ]
+    },
+    "StackSetOperationResult": {
+      "operation": "ListStackSetOperationResults",
+      "resourceIdentifier": {
+        "AccountGateResult": "Summaries[].AccountGateResult"
+      },
+      "inputParameters": [
+        "StackSetName",
+        "OperationId"
+      ]
+    },
+    "StackSetOperation": {
+      "operation": "ListStackSetOperations",
+      "resourceIdentifier": {
+        "OperationId": "Summaries[].OperationId"
+      },
+      "inputParameters": [
+        "StackSetName"
+      ]
+    },
+    "StackSet": {
+      "operation": "ListStackSets",
+      "resourceIdentifier": {
+        "StackSetId": "Summaries[].StackSetId"
+      }
+    }
+  },
+  "operations": {
+    "CancelUpdateStack": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "ContinueUpdateRollback": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "CreateChangeSet": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "CreateStack": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "DeleteChangeSet": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "DeleteStack": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "ExecuteChangeSet": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "GetStackPolicy": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "GetTemplate": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "GetTemplateSummary": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "SetStackPolicy": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "SignalResource": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "UpdateStack": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    },
+    "UpdateTerminationProtection": {
+      "StackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StackEvent",
+            "resourceIdentifier": "StackName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/cloudfront/2018-06-18/completions-1.json
+++ b/awscli/data/cloudfront/2018-06-18/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/cloudhsm/2014-05-30/completions-1.json
+++ b/awscli/data/cloudhsm/2014-05-30/completions-1.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Hsm": {
+      "operation": "ListHsms",
+      "resourceIdentifier": {
+        "Partitions": "Partitions[]",
+        "HsmList": "HsmList[]"
+      }
+    },
+    "AvailableZone": {
+      "operation": "ListAvailableZones",
+      "resourceIdentifier": {
+        "AZList": "AZList[]"
+      }
+    },
+    "Hapg": {
+      "operation": "ListHapgs",
+      "resourceIdentifier": {
+        "HapgList": "HapgList[]"
+      }
+    },
+    "LunaClient": {
+      "operation": "ListLunaClients",
+      "resourceIdentifier": {
+        "ClientList": "ClientList[]"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceArn"
+      ]
+    }
+  },
+  "operations": {
+    "GetConfig": {
+      "HapgList": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Hapg",
+            "resourceIdentifier": "HapgList"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/cloudhsmv2/2017-04-28/completions-1.json
+++ b/awscli/data/cloudhsmv2/2017-04-28/completions-1.json
@@ -1,0 +1,105 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Backup": {
+      "operation": "DescribeBackups",
+      "resourceIdentifier": {
+        "BackupId": "Backups[].BackupId"
+      }
+    },
+    "Cluster": {
+      "operation": "DescribeClusters",
+      "resourceIdentifier": {
+        "ClusterId": "Clusters[].ClusterId"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceId"
+      ]
+    }
+  },
+  "operations": {
+    "CopyBackupToRegion": {
+      "BackupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupId"
+          }
+        ]
+      }
+    },
+    "CreateHsm": {
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      }
+    },
+    "DeleteBackup": {
+      "BackupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupId"
+          }
+        ]
+      }
+    },
+    "DeleteCluster": {
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      }
+    },
+    "DeleteHsm": {
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      }
+    },
+    "InitializeCluster": {
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      }
+    },
+    "RestoreBackup": {
+      "BackupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/cloudsearch/2013-01-01/completions-1.json
+++ b/awscli/data/cloudsearch/2013-01-01/completions-1.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AnalysisScheme": {
+      "operation": "DescribeAnalysisSchemes",
+      "resourceIdentifier": {
+        "Status": "AnalysisSchemes[].Status"
+      },
+      "inputParameters": [
+        "DomainName"
+      ]
+    },
+    "Domain": {
+      "operation": "DescribeDomains",
+      "resourceIdentifier": {
+        "DomainId": "DomainStatusList[].DomainId"
+      }
+    },
+    "Expression": {
+      "operation": "DescribeExpressions",
+      "resourceIdentifier": {
+        "Options": "Expressions[].Options"
+      },
+      "inputParameters": [
+        "DomainName"
+      ]
+    },
+    "IndexField": {
+      "operation": "DescribeIndexFields",
+      "resourceIdentifier": {
+        "Options": "IndexFields[].Options"
+      },
+      "inputParameters": [
+        "DomainName"
+      ]
+    },
+    "Suggester": {
+      "operation": "DescribeSuggesters",
+      "resourceIdentifier": {
+        "Status": "Suggesters[].Status"
+      },
+      "inputParameters": [
+        "DomainName"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/cloudsearchdomain/2013-01-01/completions-1.json
+++ b/awscli/data/cloudsearchdomain/2013-01-01/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/cloudtrail/2013-11-01/completions-1.json
+++ b/awscli/data/cloudtrail/2013-11-01/completions-1.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Trail": {
+      "operation": "DescribeTrails",
+      "resourceIdentifier": {
+        "TrailARN": "trailList[].TrailARN"
+      }
+    },
+    "PublicKey": {
+      "operation": "ListPublicKeys",
+      "resourceIdentifier": {
+        "Value": "PublicKeyList[].Value"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "TagsList": "ResourceTagList[].TagsList"
+      },
+      "inputParameters": [
+        "ResourceIdList"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/cloudwatch/2010-08-01/completions-1.json
+++ b/awscli/data/cloudwatch/2010-08-01/completions-1.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AlarmHistory": {
+      "operation": "DescribeAlarmHistory",
+      "resourceIdentifier": {
+        "HistoryData": "AlarmHistoryItems[].HistoryData"
+      }
+    },
+    "Alarm": {
+      "operation": "DescribeAlarms",
+      "resourceIdentifier": {
+        "AlarmArn": "MetricAlarms[].AlarmArn"
+      }
+    },
+    "AlarmsForMetric": {
+      "operation": "DescribeAlarmsForMetric",
+      "resourceIdentifier": {
+        "AlarmArn": "MetricAlarms[].AlarmArn"
+      },
+      "inputParameters": [
+        "MetricName",
+        "Namespace"
+      ]
+    },
+    "Dashboard": {
+      "operation": "ListDashboards",
+      "resourceIdentifier": {
+        "DashboardArn": "DashboardEntries[].DashboardArn"
+      }
+    },
+    "Metric": {
+      "operation": "ListMetrics",
+      "resourceIdentifier": {
+        "MetricName": "Metrics[].MetricName"
+      }
+    }
+  },
+  "operations": {
+    "GetMetricStatistics": {
+      "MetricName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Metric",
+            "resourceIdentifier": "MetricName"
+          }
+        ]
+      }
+    },
+    "PutMetricAlarm": {
+      "MetricName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Metric",
+            "resourceIdentifier": "MetricName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/codebuild/2016-10-06/completions-1.json
+++ b/awscli/data/codebuild/2016-10-06/completions-1.json
@@ -1,0 +1,56 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Build": {
+      "operation": "ListBuilds",
+      "resourceIdentifier": {
+        "ids": "ids[]"
+      }
+    },
+    "BuildsForProject": {
+      "operation": "ListBuildsForProject",
+      "resourceIdentifier": {
+        "ids": "ids[]"
+      },
+      "inputParameters": [
+        "projectName"
+      ]
+    },
+    "CuratedEnvironmentImage": {
+      "operation": "ListCuratedEnvironmentImages",
+      "resourceIdentifier": {
+        "languages": "platforms[].languages"
+      }
+    },
+    "Project": {
+      "operation": "ListProjects",
+      "resourceIdentifier": {
+        "projects": "projects[]"
+      }
+    }
+  },
+  "operations": {
+    "BatchDeleteBuilds": {
+      "ids": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Build",
+            "resourceIdentifier": "ids"
+          }
+        ]
+      }
+    },
+    "BatchGetBuilds": {
+      "ids": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Build",
+            "resourceIdentifier": "ids"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/codecommit/2015-04-13/completions-1.json
+++ b/awscli/data/codecommit/2015-04-13/completions-1.json
@@ -1,0 +1,315 @@
+{
+  "version": "1.0",
+  "resources": {
+    "PullRequestEvent": {
+      "operation": "DescribePullRequestEvents",
+      "resourceIdentifier": {
+        "pullRequestEventType": "pullRequestEvents[].pullRequestEventType"
+      },
+      "inputParameters": [
+        "pullRequestId"
+      ]
+    },
+    "Branche": {
+      "operation": "ListBranches",
+      "resourceIdentifier": {
+        "branches": "branches[]"
+      },
+      "inputParameters": [
+        "repositoryName"
+      ]
+    },
+    "PullRequest": {
+      "operation": "ListPullRequests",
+      "resourceIdentifier": {
+        "pullRequestIds": "pullRequestIds[]"
+      },
+      "inputParameters": [
+        "repositoryName"
+      ]
+    },
+    "Repository": {
+      "operation": "ListRepositories",
+      "resourceIdentifier": {
+        "repositoryName": "repositories[].repositoryName"
+      }
+    }
+  },
+  "operations": {
+    "BatchGetRepositories": {
+      "repositoryNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryNames"
+          }
+        ]
+      }
+    },
+    "CreateBranch": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "CreateRepository": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "DeleteBranch": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "DeleteFile": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "DeleteRepository": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetBlob": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetBranch": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetCommentsForComparedCommit": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetCommentsForPullRequest": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetCommit": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetDifferences": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetFile": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetFolder": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetMergeConflicts": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetRepository": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "GetRepositoryTriggers": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "MergePullRequestByFastForward": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "PostCommentForComparedCommit": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "PostCommentForPullRequest": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "PutFile": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "PutRepositoryTriggers": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "TestRepositoryTriggers": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "UpdateDefaultBranch": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    },
+    "UpdateRepositoryDescription": {
+      "repositoryName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Repository",
+            "resourceIdentifier": "repositoryName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/codedeploy/2014-10-06/completions-1.json
+++ b/awscli/data/codedeploy/2014-10-06/completions-1.json
@@ -1,0 +1,141 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ApplicationRevision": {
+      "operation": "ListApplicationRevisions",
+      "resourceIdentifier": {
+        "revisionType": "revisions[].revisionType"
+      },
+      "inputParameters": [
+        "applicationName"
+      ]
+    },
+    "Application": {
+      "operation": "ListApplications",
+      "resourceIdentifier": {
+        "applications": "applications[]"
+      }
+    },
+    "DeploymentConfig": {
+      "operation": "ListDeploymentConfigs",
+      "resourceIdentifier": {
+        "deploymentConfigsList": "deploymentConfigsList[]"
+      }
+    },
+    "DeploymentGroup": {
+      "operation": "ListDeploymentGroups",
+      "resourceIdentifier": {
+        "deploymentGroups": "deploymentGroups[]"
+      },
+      "inputParameters": [
+        "applicationName"
+      ]
+    },
+    "DeploymentInstance": {
+      "operation": "ListDeploymentInstances",
+      "resourceIdentifier": {
+        "instancesList": "instancesList[]"
+      },
+      "inputParameters": [
+        "deploymentId"
+      ]
+    },
+    "Deployment": {
+      "operation": "ListDeployments",
+      "resourceIdentifier": {
+        "deployments": "deployments[]"
+      }
+    },
+    "GitHubAccountTokenName": {
+      "operation": "ListGitHubAccountTokenNames",
+      "resourceIdentifier": {
+        "tokenNameList": "tokenNameList[]"
+      }
+    },
+    "OnPremisesInstance": {
+      "operation": "ListOnPremisesInstances",
+      "resourceIdentifier": {
+        "instanceNames": "instanceNames[]"
+      }
+    }
+  },
+  "operations": {
+    "AddTagsToOnPremisesInstances": {
+      "instanceNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OnPremisesInstance",
+            "resourceIdentifier": "instanceNames"
+          }
+        ]
+      }
+    },
+    "BatchGetDeployments": {
+      "deploymentIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Deployment",
+            "resourceIdentifier": "deploymentIds"
+          }
+        ]
+      }
+    },
+    "BatchGetOnPremisesInstances": {
+      "instanceNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OnPremisesInstance",
+            "resourceIdentifier": "instanceNames"
+          }
+        ]
+      }
+    },
+    "DeregisterOnPremisesInstance": {
+      "instanceName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OnPremisesInstance",
+            "resourceIdentifier": "instanceName"
+          }
+        ]
+      }
+    },
+    "GetOnPremisesInstance": {
+      "instanceName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OnPremisesInstance",
+            "resourceIdentifier": "instanceName"
+          }
+        ]
+      }
+    },
+    "RegisterOnPremisesInstance": {
+      "instanceName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OnPremisesInstance",
+            "resourceIdentifier": "instanceName"
+          }
+        ]
+      }
+    },
+    "RemoveTagsFromOnPremisesInstances": {
+      "instanceNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OnPremisesInstance",
+            "resourceIdentifier": "instanceNames"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/codepipeline/2015-07-09/completions-1.json
+++ b/awscli/data/codepipeline/2015-07-09/completions-1.json
@@ -1,0 +1,76 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ActionType": {
+      "operation": "ListActionTypes",
+      "resourceIdentifier": {
+        "settings": "actionTypes[].settings"
+      }
+    },
+    "PipelineExecution": {
+      "operation": "ListPipelineExecutions",
+      "resourceIdentifier": {
+        "pipelineExecutionId": "pipelineExecutionSummaries[].pipelineExecutionId"
+      },
+      "inputParameters": [
+        "pipelineName"
+      ]
+    },
+    "Pipeline": {
+      "operation": "ListPipelines",
+      "resourceIdentifier": {
+        "version": "pipelines[].version"
+      }
+    },
+    "Webhook": {
+      "operation": "ListWebhooks",
+      "resourceIdentifier": {
+        "errorCode": "webhooks[].errorCode"
+      }
+    }
+  },
+  "operations": {
+    "CreateCustomActionType": {
+      "version": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "version"
+          }
+        ]
+      },
+      "settings": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ActionType",
+            "resourceIdentifier": "settings"
+          }
+        ]
+      }
+    },
+    "DeleteCustomActionType": {
+      "version": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "version"
+          }
+        ]
+      }
+    },
+    "GetPipeline": {
+      "version": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "version"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/codestar/2017-04-19/completions-1.json
+++ b/awscli/data/codestar/2017-04-19/completions-1.json
@@ -1,0 +1,130 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Project": {
+      "operation": "ListProjects",
+      "resourceIdentifier": {
+        "projectId": "projects[].projectId"
+      }
+    },
+    "Resource": {
+      "operation": "ListResources",
+      "resourceIdentifier": {
+        "id": "resources[].id"
+      },
+      "inputParameters": [
+        "projectId"
+      ]
+    },
+    "TeamMember": {
+      "operation": "ListTeamMembers",
+      "resourceIdentifier": {
+        "remoteAccessAllowed": "teamMembers[].remoteAccessAllowed"
+      },
+      "inputParameters": [
+        "projectId"
+      ]
+    },
+    "UserProfile": {
+      "operation": "ListUserProfiles",
+      "resourceIdentifier": {
+        "userArn": "userProfiles[].userArn"
+      }
+    }
+  },
+  "operations": {
+    "AssociateTeamMember": {
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      },
+      "userArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "userArn"
+          }
+        ]
+      }
+    },
+    "CreateUserProfile": {
+      "userArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "userArn"
+          }
+        ]
+      }
+    },
+    "DeleteUserProfile": {
+      "userArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "userArn"
+          }
+        ]
+      }
+    },
+    "DisassociateTeamMember": {
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      },
+      "userArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "userArn"
+          }
+        ]
+      }
+    },
+    "UpdateTeamMember": {
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      },
+      "userArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "userArn"
+          }
+        ]
+      }
+    },
+    "UpdateUserProfile": {
+      "userArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "userArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/cognito-identity/2014-06-30/completions-1.json
+++ b/awscli/data/cognito-identity/2014-06-30/completions-1.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Identity": {
+      "operation": "ListIdentities",
+      "resourceIdentifier": {
+        "Logins": "Logins[]",
+        "IdentityId": "Identities[].IdentityId"
+      },
+      "inputParameters": [
+        "IdentityPoolId",
+        "MaxResults"
+      ]
+    },
+    "IdentityPool": {
+      "operation": "ListIdentityPools",
+      "resourceIdentifier": {
+        "IdentityPoolId": "IdentityPools[].IdentityPoolId"
+      },
+      "inputParameters": [
+        "MaxResults"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/cognito-idp/2016-04-18/completions-1.json
+++ b/awscli/data/cognito-idp/2016-04-18/completions-1.json
@@ -1,0 +1,89 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Device": {
+      "operation": "ListDevices",
+      "resourceIdentifier": {
+        "DeviceKey": "Devices[].DeviceKey"
+      },
+      "inputParameters": [
+        "AccessToken"
+      ]
+    },
+    "Group": {
+      "operation": "ListGroups",
+      "resourceIdentifier": {
+        "GroupName": "Groups[].GroupName"
+      },
+      "inputParameters": [
+        "UserPoolId"
+      ]
+    },
+    "IdentityProvider": {
+      "operation": "ListIdentityProviders",
+      "resourceIdentifier": {
+        "ProviderName": "Providers[].ProviderName"
+      },
+      "inputParameters": [
+        "UserPoolId"
+      ]
+    },
+    "ResourceServer": {
+      "operation": "ListResourceServers",
+      "resourceIdentifier": {
+        "UserPoolId": "ResourceServers[].UserPoolId"
+      },
+      "inputParameters": [
+        "UserPoolId"
+      ]
+    },
+    "UserImportJob": {
+      "operation": "ListUserImportJobs",
+      "resourceIdentifier": {
+        "ImportedUsers": "UserImportJobs[].ImportedUsers"
+      },
+      "inputParameters": [
+        "UserPoolId",
+        "MaxResults"
+      ]
+    },
+    "UserPoolClient": {
+      "operation": "ListUserPoolClients",
+      "resourceIdentifier": {
+        "UserPoolId": "UserPoolClients[].UserPoolId"
+      },
+      "inputParameters": [
+        "UserPoolId"
+      ]
+    },
+    "UserPool": {
+      "operation": "ListUserPools",
+      "resourceIdentifier": {
+        "CreationDate": "UserPools[].CreationDate"
+      },
+      "inputParameters": [
+        "MaxResults"
+      ]
+    },
+    "User": {
+      "operation": "ListUsers",
+      "resourceIdentifier": {
+        "UserStatus": "Users[].UserStatus"
+      },
+      "inputParameters": [
+        "UserPoolId"
+      ]
+    },
+    "UsersInGroup": {
+      "operation": "ListUsersInGroup",
+      "resourceIdentifier": {
+        "Username": "Users[].Username"
+      },
+      "inputParameters": [
+        "UserPoolId",
+        "GroupName"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/cognito-sync/2014-06-30/completions-1.json
+++ b/awscli/data/cognito-sync/2014-06-30/completions-1.json
@@ -1,0 +1,144 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Dataset": {
+      "operation": "ListDatasets",
+      "resourceIdentifier": {
+        "DatasetName": "Datasets[].DatasetName"
+      },
+      "inputParameters": [
+        "IdentityId",
+        "IdentityPoolId"
+      ]
+    },
+    "IdentityPoolUsage": {
+      "operation": "ListIdentityPoolUsage",
+      "resourceIdentifier": {
+        "IdentityPoolId": "IdentityPoolUsages[].IdentityPoolId"
+      }
+    }
+  },
+  "operations": {
+    "BulkPublish": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "DeleteDataset": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "GetBulkPublishDetails": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "GetCognitoEvents": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "GetIdentityPoolConfiguration": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "RegisterDevice": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "SetCognitoEvents": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "SetIdentityPoolConfiguration": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "SubscribeToDataset": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "UnsubscribeFromDataset": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    },
+    "UpdateRecords": {
+      "IdentityPoolId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdentityPoolUsage",
+            "resourceIdentifier": "IdentityPoolId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/comprehend/2017-11-27/completions-1.json
+++ b/awscli/data/comprehend/2017-11-27/completions-1.json
@@ -1,0 +1,146 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DominantLanguageDetectionJob": {
+      "operation": "ListDominantLanguageDetectionJobs",
+      "resourceIdentifier": {
+        "InputDataConfig": "DominantLanguageDetectionJobPropertiesList[].InputDataConfig"
+      }
+    },
+    "EntitiesDetectionJob": {
+      "operation": "ListEntitiesDetectionJobs",
+      "resourceIdentifier": {
+        "OutputDataConfig": "EntitiesDetectionJobPropertiesList[].OutputDataConfig"
+      }
+    },
+    "KeyPhrasesDetectionJob": {
+      "operation": "ListKeyPhrasesDetectionJobs",
+      "resourceIdentifier": {
+        "JobStatus": "KeyPhrasesDetectionJobPropertiesList[].JobStatus"
+      }
+    },
+    "SentimentDetectionJob": {
+      "operation": "ListSentimentDetectionJobs",
+      "resourceIdentifier": {
+        "InputDataConfig": "SentimentDetectionJobPropertiesList[].InputDataConfig"
+      }
+    },
+    "TopicsDetectionJob": {
+      "operation": "ListTopicsDetectionJobs",
+      "resourceIdentifier": {
+        "NumberOfTopics": "TopicsDetectionJobPropertiesList[].NumberOfTopics"
+      }
+    }
+  },
+  "operations": {
+    "StartDominantLanguageDetectionJob": {
+      "InputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SentimentDetectionJob",
+            "resourceIdentifier": "InputDataConfig"
+          }
+        ]
+      },
+      "OutputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EntitiesDetectionJob",
+            "resourceIdentifier": "OutputDataConfig"
+          }
+        ]
+      }
+    },
+    "StartEntitiesDetectionJob": {
+      "InputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SentimentDetectionJob",
+            "resourceIdentifier": "InputDataConfig"
+          }
+        ]
+      },
+      "OutputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EntitiesDetectionJob",
+            "resourceIdentifier": "OutputDataConfig"
+          }
+        ]
+      }
+    },
+    "StartKeyPhrasesDetectionJob": {
+      "InputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SentimentDetectionJob",
+            "resourceIdentifier": "InputDataConfig"
+          }
+        ]
+      },
+      "OutputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EntitiesDetectionJob",
+            "resourceIdentifier": "OutputDataConfig"
+          }
+        ]
+      }
+    },
+    "StartSentimentDetectionJob": {
+      "InputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SentimentDetectionJob",
+            "resourceIdentifier": "InputDataConfig"
+          }
+        ]
+      },
+      "OutputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EntitiesDetectionJob",
+            "resourceIdentifier": "OutputDataConfig"
+          }
+        ]
+      }
+    },
+    "StartTopicsDetectionJob": {
+      "InputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SentimentDetectionJob",
+            "resourceIdentifier": "InputDataConfig"
+          }
+        ]
+      },
+      "OutputDataConfig": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EntitiesDetectionJob",
+            "resourceIdentifier": "OutputDataConfig"
+          }
+        ]
+      },
+      "NumberOfTopics": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TopicsDetectionJob",
+            "resourceIdentifier": "NumberOfTopics"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/config/2014-11-12/completions-1.json
+++ b/awscli/data/config/2014-11-12/completions-1.json
@@ -1,0 +1,139 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AggregateComplianceByConfigRule": {
+      "operation": "DescribeAggregateComplianceByConfigRules",
+      "resourceIdentifier": {
+        "Compliance": "AggregateComplianceByConfigRules[].Compliance"
+      },
+      "inputParameters": [
+        "ConfigurationAggregatorName"
+      ]
+    },
+    "AggregationAuthorization": {
+      "operation": "DescribeAggregationAuthorizations",
+      "resourceIdentifier": {
+        "AggregationAuthorizationArn": "AggregationAuthorizations[].AggregationAuthorizationArn"
+      }
+    },
+    "ComplianceByConfigRule": {
+      "operation": "DescribeComplianceByConfigRule",
+      "resourceIdentifier": {
+        "Compliance": "ComplianceByConfigRules[].Compliance"
+      }
+    },
+    "ComplianceByResource": {
+      "operation": "DescribeComplianceByResource",
+      "resourceIdentifier": {
+        "Compliance": "ComplianceByResources[].Compliance"
+      }
+    },
+    "ConfigRuleEvaluationStatu": {
+      "operation": "DescribeConfigRuleEvaluationStatus",
+      "resourceIdentifier": {
+        "FirstEvaluationStarted": "ConfigRulesEvaluationStatus[].FirstEvaluationStarted"
+      }
+    },
+    "ConfigRule": {
+      "operation": "DescribeConfigRules",
+      "resourceIdentifier": {
+        "ConfigRuleId": "ConfigRules[].ConfigRuleId"
+      }
+    },
+    "ConfigurationAggregatorSourcesStatu": {
+      "operation": "DescribeConfigurationAggregatorSourcesStatus",
+      "resourceIdentifier": {
+        "LastUpdateStatus": "AggregatedSourceStatusList[].LastUpdateStatus"
+      },
+      "inputParameters": [
+        "ConfigurationAggregatorName"
+      ]
+    },
+    "ConfigurationAggregator": {
+      "operation": "DescribeConfigurationAggregators",
+      "resourceIdentifier": {
+        "ConfigurationAggregatorArn": "ConfigurationAggregators[].ConfigurationAggregatorArn"
+      }
+    },
+    "ConfigurationRecorderStatu": {
+      "operation": "DescribeConfigurationRecorderStatus",
+      "resourceIdentifier": {
+        "lastStatus": "ConfigurationRecordersStatus[].lastStatus"
+      }
+    },
+    "ConfigurationRecorder": {
+      "operation": "DescribeConfigurationRecorders",
+      "resourceIdentifier": {
+        "recordingGroup": "ConfigurationRecorders[].recordingGroup"
+      }
+    },
+    "DeliveryChannelStatu": {
+      "operation": "DescribeDeliveryChannelStatus",
+      "resourceIdentifier": {
+        "configStreamDeliveryInfo": "DeliveryChannelsStatus[].configStreamDeliveryInfo"
+      }
+    },
+    "DeliveryChannel": {
+      "operation": "DescribeDeliveryChannels",
+      "resourceIdentifier": {
+        "configSnapshotDeliveryProperties": "DeliveryChannels[].configSnapshotDeliveryProperties"
+      }
+    },
+    "PendingAggregationRequest": {
+      "operation": "DescribePendingAggregationRequests",
+      "resourceIdentifier": {
+        "RequesterAwsRegion": "PendingAggregationRequests[].RequesterAwsRegion"
+      }
+    },
+    "RetentionConfiguration": {
+      "operation": "DescribeRetentionConfigurations",
+      "resourceIdentifier": {
+        "RetentionPeriodInDays": "RetentionConfigurations[].RetentionPeriodInDays"
+      }
+    },
+    "DiscoveredResource": {
+      "operation": "ListDiscoveredResources",
+      "resourceIdentifier": {
+        "resourceId": "resourceIdentifiers[].resourceId"
+      },
+      "inputParameters": [
+        "resourceType"
+      ]
+    }
+  },
+  "operations": {
+    "DeletePendingAggregationRequest": {
+      "RequesterAwsRegion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PendingAggregationRequest",
+            "resourceIdentifier": "RequesterAwsRegion"
+          }
+        ]
+      }
+    },
+    "PutConfigRule": {
+      "ConfigRule": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ConfigRule",
+            "resourceIdentifier": "ConfigRule"
+          }
+        ]
+      }
+    },
+    "PutRetentionConfiguration": {
+      "RetentionPeriodInDays": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RetentionConfiguration",
+            "resourceIdentifier": "RetentionPeriodInDays"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/connect/2017-08-08/completions-1.json
+++ b/awscli/data/connect/2017-08-08/completions-1.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "resources": {
+    "RoutingProfile": {
+      "operation": "ListRoutingProfiles",
+      "resourceIdentifier": {
+        "Arn": "RoutingProfileSummaryList[].Arn"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    },
+    "SecurityProfile": {
+      "operation": "ListSecurityProfiles",
+      "resourceIdentifier": {
+        "Arn": "SecurityProfileSummaryList[].Arn"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    },
+    "UserHierarchyGroup": {
+      "operation": "ListUserHierarchyGroups",
+      "resourceIdentifier": {
+        "Arn": "UserHierarchyGroupSummaryList[].Arn"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    },
+    "User": {
+      "operation": "ListUsers",
+      "resourceIdentifier": {
+        "Username": "UserSummaryList[].Username"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/cur/2017-01-06/completions-1.json
+++ b/awscli/data/cur/2017-01-06/completions-1.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ReportDefinition": {
+      "operation": "DescribeReportDefinitions",
+      "resourceIdentifier": {
+        "ReportName": "ReportDefinitions[].ReportName"
+      }
+    }
+  },
+  "operations": {
+    "DeleteReportDefinition": {
+      "ReportName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReportDefinition",
+            "resourceIdentifier": "ReportName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/datapipeline/2012-10-29/completions-1.json
+++ b/awscli/data/datapipeline/2012-10-29/completions-1.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Object": {
+      "operation": "DescribeObjects",
+      "resourceIdentifier": {
+        "fields": "pipelineObjects[].fields"
+      },
+      "inputParameters": [
+        "pipelineId",
+        "objectIds"
+      ]
+    },
+    "Pipeline": {
+      "operation": "ListPipelines",
+      "resourceIdentifier": {
+        "pipelineId": "pipelineDescriptionList[].pipelineId",
+        "id": "pipelineIdList[].id"
+      },
+      "inputParameters": [
+        "pipelineIds"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/dax/2017-04-19/completions-1.json
+++ b/awscli/data/dax/2017-04-19/completions-1.json
@@ -1,0 +1,152 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Cluster": {
+      "operation": "DescribeClusters",
+      "resourceIdentifier": {
+        "ClusterArn": "Clusters[].ClusterArn"
+      }
+    },
+    "DefaultParameter": {
+      "operation": "DescribeDefaultParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "Message": "Events[].Message"
+      }
+    },
+    "ParameterGroup": {
+      "operation": "DescribeParameterGroups",
+      "resourceIdentifier": {
+        "ParameterGroupName": "ParameterGroups[].ParameterGroupName"
+      }
+    },
+    "Parameter": {
+      "operation": "DescribeParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      },
+      "inputParameters": [
+        "ParameterGroupName"
+      ]
+    },
+    "SubnetGroup": {
+      "operation": "DescribeSubnetGroups",
+      "resourceIdentifier": {
+        "SubnetGroupName": "SubnetGroups[].SubnetGroupName"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceName"
+      ]
+    }
+  },
+  "operations": {
+    "CreateCluster": {
+      "SubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubnetGroup",
+            "resourceIdentifier": "SubnetGroupName"
+          }
+        ]
+      },
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "CreateParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "CreateSubnetGroup": {
+      "SubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubnetGroup",
+            "resourceIdentifier": "SubnetGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteSubnetGroup": {
+      "SubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubnetGroup",
+            "resourceIdentifier": "SubnetGroupName"
+          }
+        ]
+      }
+    },
+    "UpdateCluster": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "UpdateParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "UpdateSubnetGroup": {
+      "SubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubnetGroup",
+            "resourceIdentifier": "SubnetGroupName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/devicefarm/2015-06-23/completions-1.json
+++ b/awscli/data/devicefarm/2015-06-23/completions-1.json
@@ -1,0 +1,365 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Artifact": {
+      "operation": "ListArtifacts",
+      "resourceIdentifier": {
+        "extension": "artifacts[].extension"
+      },
+      "inputParameters": [
+        "arn",
+        "type"
+      ]
+    },
+    "DeviceInstance": {
+      "operation": "ListDeviceInstances",
+      "resourceIdentifier": {
+        "instanceProfile": "deviceInstances[].instanceProfile"
+      }
+    },
+    "DevicePool": {
+      "operation": "ListDevicePools",
+      "resourceIdentifier": {
+        "description": "devicePools[].description"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "Device": {
+      "operation": "ListDevices",
+      "resourceIdentifier": {
+        "instances": "devices[].instances"
+      }
+    },
+    "InstanceProfile": {
+      "operation": "ListInstanceProfiles",
+      "resourceIdentifier": {
+        "name": "instanceProfiles[].name"
+      }
+    },
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "counters": "jobs[].counters"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "NetworkProfile": {
+      "operation": "ListNetworkProfiles",
+      "resourceIdentifier": {
+        "uplinkDelayMs": "networkProfiles[].uplinkDelayMs"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "OfferingPromotion": {
+      "operation": "ListOfferingPromotions",
+      "resourceIdentifier": {
+        "description": "offeringPromotions[].description"
+      }
+    },
+    "OfferingTransaction": {
+      "operation": "ListOfferingTransactions",
+      "resourceIdentifier": {
+        "offeringPromotionId": "offeringTransactions[].offeringPromotionId"
+      }
+    },
+    "Offering": {
+      "operation": "ListOfferings",
+      "resourceIdentifier": {
+        "recurringCharges": "offerings[].recurringCharges"
+      }
+    },
+    "Project": {
+      "operation": "ListProjects",
+      "resourceIdentifier": {
+        "created": "projects[].created"
+      }
+    },
+    "RemoteAccessSession": {
+      "operation": "ListRemoteAccessSessions",
+      "resourceIdentifier": {
+        "hostAddress": "remoteAccessSessions[].hostAddress"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "Run": {
+      "operation": "ListRuns",
+      "resourceIdentifier": {
+        "counters": "runs[].counters"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "Sample": {
+      "operation": "ListSamples",
+      "resourceIdentifier": {
+        "type": "samples[].type"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "Suite": {
+      "operation": "ListSuites",
+      "resourceIdentifier": {
+        "counters": "suites[].counters"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "Test": {
+      "operation": "ListTests",
+      "resourceIdentifier": {
+        "status": "tests[].status"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "Upload": {
+      "operation": "ListUploads",
+      "resourceIdentifier": {
+        "status": "uploads[].status"
+      },
+      "inputParameters": [
+        "arn"
+      ]
+    },
+    "VPCEConfiguration": {
+      "operation": "ListVPCEConfigurations",
+      "resourceIdentifier": {
+        "vpceConfigurationName": "vpceConfigurations[].vpceConfigurationName"
+      }
+    }
+  },
+  "operations": {
+    "CreateDevicePool": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      },
+      "description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingPromotion",
+            "resourceIdentifier": "description"
+          }
+        ]
+      }
+    },
+    "CreateInstanceProfile": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      },
+      "description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingPromotion",
+            "resourceIdentifier": "description"
+          }
+        ]
+      }
+    },
+    "CreateNetworkProfile": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      },
+      "description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingPromotion",
+            "resourceIdentifier": "description"
+          }
+        ]
+      }
+    },
+    "CreateProject": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      }
+    },
+    "CreateRemoteAccessSession": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      }
+    },
+    "CreateUpload": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      }
+    },
+    "CreateVPCEConfiguration": {
+      "vpceConfigurationName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VPCEConfiguration",
+            "resourceIdentifier": "vpceConfigurationName"
+          }
+        ]
+      }
+    },
+    "PurchaseOffering": {
+      "offeringPromotionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingTransaction",
+            "resourceIdentifier": "offeringPromotionId"
+          }
+        ]
+      }
+    },
+    "ScheduleRun": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      }
+    },
+    "UpdateDevicePool": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      },
+      "description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingPromotion",
+            "resourceIdentifier": "description"
+          }
+        ]
+      }
+    },
+    "UpdateInstanceProfile": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      },
+      "description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingPromotion",
+            "resourceIdentifier": "description"
+          }
+        ]
+      }
+    },
+    "UpdateNetworkProfile": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      },
+      "description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OfferingPromotion",
+            "resourceIdentifier": "description"
+          }
+        ]
+      }
+    },
+    "UpdateProject": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      }
+    },
+    "UpdateUpload": {
+      "name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceProfile",
+            "resourceIdentifier": "name"
+          }
+        ]
+      }
+    },
+    "UpdateVPCEConfiguration": {
+      "vpceConfigurationName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VPCEConfiguration",
+            "resourceIdentifier": "vpceConfigurationName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/directconnect/2012-10-25/completions-1.json
+++ b/awscli/data/directconnect/2012-10-25/completions-1.json
@@ -1,0 +1,437 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Connection": {
+      "operation": "DescribeConnections",
+      "resourceIdentifier": {
+        "connectionId": "connections[].connectionId"
+      }
+    },
+    "ConnectionsOnInterconnect": {
+      "operation": "DescribeConnectionsOnInterconnect",
+      "resourceIdentifier": {
+        "connectionState": "connections[].connectionState"
+      },
+      "inputParameters": [
+        "interconnectId"
+      ]
+    },
+    "DirectConnectGatewayAssociation": {
+      "operation": "DescribeDirectConnectGatewayAssociations",
+      "resourceIdentifier": {
+        "directConnectGatewayId": "directConnectGatewayAssociations[].directConnectGatewayId"
+      }
+    },
+    "DirectConnectGatewayAttachment": {
+      "operation": "DescribeDirectConnectGatewayAttachments",
+      "resourceIdentifier": {
+        "directConnectGatewayId": "directConnectGatewayAttachments[].directConnectGatewayId"
+      }
+    },
+    "DirectConnectGateway": {
+      "operation": "DescribeDirectConnectGateways",
+      "resourceIdentifier": {
+        "directConnectGatewayId": "directConnectGateways[].directConnectGatewayId"
+      }
+    },
+    "HostedConnection": {
+      "operation": "DescribeHostedConnections",
+      "resourceIdentifier": {
+        "connectionId": "connections[].connectionId"
+      },
+      "inputParameters": [
+        "connectionId"
+      ]
+    },
+    "Interconnect": {
+      "operation": "DescribeInterconnects",
+      "resourceIdentifier": {
+        "interconnectId": "interconnects[].interconnectId"
+      }
+    },
+    "Lag": {
+      "operation": "DescribeLags",
+      "resourceIdentifier": {
+        "lagId": "lags[].lagId"
+      }
+    },
+    "Location": {
+      "operation": "DescribeLocations",
+      "resourceIdentifier": {
+        "locationCode": "locations[].locationCode"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "tags": "resourceTags[].tags"
+      },
+      "inputParameters": [
+        "resourceArns"
+      ]
+    },
+    "VirtualGateway": {
+      "operation": "DescribeVirtualGateways",
+      "resourceIdentifier": {
+        "virtualGatewayId": "virtualGateways[].virtualGatewayId"
+      }
+    },
+    "VirtualInterface": {
+      "operation": "DescribeVirtualInterfaces",
+      "resourceIdentifier": {
+        "virtualInterfaceId": "virtualInterfaces[].virtualInterfaceId"
+      }
+    }
+  },
+  "operations": {
+    "AllocateConnectionOnInterconnect": {
+      "interconnectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Interconnect",
+            "resourceIdentifier": "interconnectId"
+          }
+        ]
+      }
+    },
+    "AllocateHostedConnection": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "AllocatePrivateVirtualInterface": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "AllocatePublicVirtualInterface": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "AssociateConnectionWithLag": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      },
+      "lagId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Lag",
+            "resourceIdentifier": "lagId"
+          }
+        ]
+      }
+    },
+    "AssociateHostedConnection": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "AssociateVirtualInterface": {
+      "virtualInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualInterface",
+            "resourceIdentifier": "virtualInterfaceId"
+          }
+        ]
+      },
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "ConfirmConnection": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "ConfirmPrivateVirtualInterface": {
+      "virtualInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualInterface",
+            "resourceIdentifier": "virtualInterfaceId"
+          }
+        ]
+      },
+      "virtualGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualGateway",
+            "resourceIdentifier": "virtualGatewayId"
+          }
+        ]
+      },
+      "directConnectGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectConnectGateway",
+            "resourceIdentifier": "directConnectGatewayId"
+          }
+        ]
+      }
+    },
+    "ConfirmPublicVirtualInterface": {
+      "virtualInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualInterface",
+            "resourceIdentifier": "virtualInterfaceId"
+          }
+        ]
+      }
+    },
+    "CreateBGPPeer": {
+      "virtualInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualInterface",
+            "resourceIdentifier": "virtualInterfaceId"
+          }
+        ]
+      }
+    },
+    "CreateConnection": {
+      "lagId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Lag",
+            "resourceIdentifier": "lagId"
+          }
+        ]
+      }
+    },
+    "CreateDirectConnectGatewayAssociation": {
+      "directConnectGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectConnectGateway",
+            "resourceIdentifier": "directConnectGatewayId"
+          }
+        ]
+      },
+      "virtualGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualGateway",
+            "resourceIdentifier": "virtualGatewayId"
+          }
+        ]
+      }
+    },
+    "CreateInterconnect": {
+      "lagId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Lag",
+            "resourceIdentifier": "lagId"
+          }
+        ]
+      }
+    },
+    "CreateLag": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "CreatePrivateVirtualInterface": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "CreatePublicVirtualInterface": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "DeleteBGPPeer": {
+      "virtualInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualInterface",
+            "resourceIdentifier": "virtualInterfaceId"
+          }
+        ]
+      }
+    },
+    "DeleteConnection": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      }
+    },
+    "DeleteDirectConnectGateway": {
+      "directConnectGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectConnectGateway",
+            "resourceIdentifier": "directConnectGatewayId"
+          }
+        ]
+      }
+    },
+    "DeleteDirectConnectGatewayAssociation": {
+      "directConnectGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DirectConnectGateway",
+            "resourceIdentifier": "directConnectGatewayId"
+          }
+        ]
+      },
+      "virtualGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualGateway",
+            "resourceIdentifier": "virtualGatewayId"
+          }
+        ]
+      }
+    },
+    "DeleteInterconnect": {
+      "interconnectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Interconnect",
+            "resourceIdentifier": "interconnectId"
+          }
+        ]
+      }
+    },
+    "DeleteLag": {
+      "lagId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Lag",
+            "resourceIdentifier": "lagId"
+          }
+        ]
+      }
+    },
+    "DeleteVirtualInterface": {
+      "virtualInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualInterface",
+            "resourceIdentifier": "virtualInterfaceId"
+          }
+        ]
+      }
+    },
+    "DisassociateConnectionFromLag": {
+      "connectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "connectionId"
+          }
+        ]
+      },
+      "lagId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Lag",
+            "resourceIdentifier": "lagId"
+          }
+        ]
+      }
+    },
+    "UpdateLag": {
+      "lagId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Lag",
+            "resourceIdentifier": "lagId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/discovery/2015-11-01/completions-1.json
+++ b/awscli/data/discovery/2015-11-01/completions-1.json
@@ -1,0 +1,79 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Agent": {
+      "operation": "DescribeAgents",
+      "resourceIdentifier": {
+        "agentId": "agentsInfo[].agentId"
+      }
+    },
+    "ContinuousExport": {
+      "operation": "DescribeContinuousExports",
+      "resourceIdentifier": {
+        "exportId": "descriptions[].exportId"
+      }
+    },
+    "ExportConfiguration": {
+      "operation": "DescribeExportConfigurations",
+      "resourceIdentifier": {
+        "configurationsDownloadUrl": "exportsInfo[].configurationsDownloadUrl"
+      }
+    },
+    "ExportTask": {
+      "operation": "DescribeExportTasks",
+      "resourceIdentifier": {
+        "exportStatus": "exportsInfo[].exportStatus"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "value": "tags[].value"
+      }
+    },
+    "ServerNeighbor": {
+      "operation": "ListServerNeighbors",
+      "resourceIdentifier": {
+        "sourceServerId": "neighbors[].sourceServerId"
+      },
+      "inputParameters": [
+        "configurationId"
+      ]
+    }
+  },
+  "operations": {
+    "StartDataCollectionByAgentIds": {
+      "agentIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Agent",
+            "resourceIdentifier": "agentIds"
+          }
+        ]
+      }
+    },
+    "StopContinuousExport": {
+      "exportId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ContinuousExport",
+            "resourceIdentifier": "exportId"
+          }
+        ]
+      }
+    },
+    "StopDataCollectionByAgentIds": {
+      "agentIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Agent",
+            "resourceIdentifier": "agentIds"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/dlm/2018-01-12/completions-1.json
+++ b/awscli/data/dlm/2018-01-12/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/dms/2016-01-01/completions-1.json
+++ b/awscli/data/dms/2016-01-01/completions-1.json
@@ -1,0 +1,322 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountAttribute": {
+      "operation": "DescribeAccountAttributes",
+      "resourceIdentifier": {
+        "AccountQuotaName": "AccountQuotas[].AccountQuotaName"
+      }
+    },
+    "Certificate": {
+      "operation": "DescribeCertificates",
+      "resourceIdentifier": {
+        "CertificatePem": "Certificates[].CertificatePem"
+      }
+    },
+    "Connection": {
+      "operation": "DescribeConnections",
+      "resourceIdentifier": {
+        "ReplicationInstanceArn": "Connections[].ReplicationInstanceArn"
+      }
+    },
+    "EndpointType": {
+      "operation": "DescribeEndpointTypes",
+      "resourceIdentifier": {
+        "EndpointType": "SupportedEndpointTypes[].EndpointType"
+      }
+    },
+    "Endpoint": {
+      "operation": "DescribeEndpoints",
+      "resourceIdentifier": {
+        "EndpointArn": "Endpoints[].EndpointArn"
+      }
+    },
+    "EventCategory": {
+      "operation": "DescribeEventCategories",
+      "resourceIdentifier": {
+        "EventCategories": "EventCategoryGroupList[].EventCategories"
+      }
+    },
+    "EventSubscription": {
+      "operation": "DescribeEventSubscriptions",
+      "resourceIdentifier": {
+        "CustSubscriptionId": "EventSubscriptionsList[].CustSubscriptionId"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "EventCategories": "Events[].EventCategories"
+      }
+    },
+    "OrderableReplicationInstance": {
+      "operation": "DescribeOrderableReplicationInstances",
+      "resourceIdentifier": {
+        "ReplicationInstanceClass": "OrderableReplicationInstances[].ReplicationInstanceClass"
+      }
+    },
+    "ReplicationInstanceTaskLog": {
+      "operation": "DescribeReplicationInstanceTaskLogs",
+      "resourceIdentifier": {
+        "ReplicationInstanceTaskLogSize": "ReplicationInstanceTaskLogs[].ReplicationInstanceTaskLogSize"
+      },
+      "inputParameters": [
+        "ReplicationInstanceArn"
+      ]
+    },
+    "ReplicationInstance": {
+      "operation": "DescribeReplicationInstances",
+      "resourceIdentifier": {
+        "ReplicationInstanceClass": "ReplicationInstances[].ReplicationInstanceClass"
+      }
+    },
+    "ReplicationSubnetGroup": {
+      "operation": "DescribeReplicationSubnetGroups",
+      "resourceIdentifier": {
+        "ReplicationSubnetGroupDescription": "ReplicationSubnetGroups[].ReplicationSubnetGroupDescription"
+      }
+    },
+    "ReplicationTaskAssessmentResult": {
+      "operation": "DescribeReplicationTaskAssessmentResults",
+      "resourceIdentifier": {
+        "ReplicationTaskLastAssessmentDate": "ReplicationTaskAssessmentResults[].ReplicationTaskLastAssessmentDate"
+      }
+    },
+    "ReplicationTask": {
+      "operation": "DescribeReplicationTasks",
+      "resourceIdentifier": {
+        "ReplicationTaskStats": "ReplicationTasks[].ReplicationTaskStats"
+      }
+    },
+    "Schema": {
+      "operation": "DescribeSchemas",
+      "resourceIdentifier": {
+        "Schemas": "Schemas[]"
+      },
+      "inputParameters": [
+        "EndpointArn"
+      ]
+    },
+    "TableStatistic": {
+      "operation": "DescribeTableStatistics",
+      "resourceIdentifier": {
+        "TableState": "TableStatistics[].TableState"
+      },
+      "inputParameters": [
+        "ReplicationTaskArn"
+      ]
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceArn"
+      ]
+    }
+  },
+  "operations": {
+    "CreateEndpoint": {
+      "EndpointType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EndpointType",
+            "resourceIdentifier": "EndpointType"
+          }
+        ]
+      }
+    },
+    "CreateEventSubscription": {
+      "EventCategories": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Event",
+            "resourceIdentifier": "EventCategories"
+          }
+        ]
+      }
+    },
+    "CreateReplicationInstance": {
+      "ReplicationInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationInstance",
+            "resourceIdentifier": "ReplicationInstanceClass"
+          }
+        ]
+      }
+    },
+    "CreateReplicationSubnetGroup": {
+      "ReplicationSubnetGroupDescription": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationSubnetGroup",
+            "resourceIdentifier": "ReplicationSubnetGroupDescription"
+          }
+        ]
+      }
+    },
+    "CreateReplicationTask": {
+      "ReplicationInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "ReplicationInstanceArn"
+          }
+        ]
+      }
+    },
+    "DeleteEndpoint": {
+      "EndpointArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Endpoint",
+            "resourceIdentifier": "EndpointArn"
+          }
+        ]
+      }
+    },
+    "DeleteReplicationInstance": {
+      "ReplicationInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "ReplicationInstanceArn"
+          }
+        ]
+      }
+    },
+    "ImportCertificate": {
+      "CertificatePem": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Certificate",
+            "resourceIdentifier": "CertificatePem"
+          }
+        ]
+      }
+    },
+    "ModifyEndpoint": {
+      "EndpointArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Endpoint",
+            "resourceIdentifier": "EndpointArn"
+          }
+        ]
+      },
+      "EndpointType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EndpointType",
+            "resourceIdentifier": "EndpointType"
+          }
+        ]
+      }
+    },
+    "ModifyEventSubscription": {
+      "EventCategories": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Event",
+            "resourceIdentifier": "EventCategories"
+          }
+        ]
+      }
+    },
+    "ModifyReplicationInstance": {
+      "ReplicationInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "ReplicationInstanceArn"
+          }
+        ]
+      },
+      "ReplicationInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationInstance",
+            "resourceIdentifier": "ReplicationInstanceClass"
+          }
+        ]
+      }
+    },
+    "ModifyReplicationSubnetGroup": {
+      "ReplicationSubnetGroupDescription": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationSubnetGroup",
+            "resourceIdentifier": "ReplicationSubnetGroupDescription"
+          }
+        ]
+      }
+    },
+    "RebootReplicationInstance": {
+      "ReplicationInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "ReplicationInstanceArn"
+          }
+        ]
+      }
+    },
+    "RefreshSchemas": {
+      "EndpointArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Endpoint",
+            "resourceIdentifier": "EndpointArn"
+          }
+        ]
+      },
+      "ReplicationInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "ReplicationInstanceArn"
+          }
+        ]
+      }
+    },
+    "TestConnection": {
+      "ReplicationInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Connection",
+            "resourceIdentifier": "ReplicationInstanceArn"
+          }
+        ]
+      },
+      "EndpointArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Endpoint",
+            "resourceIdentifier": "EndpointArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/ds/2015-04-16/completions-1.json
+++ b/awscli/data/ds/2015-04-16/completions-1.json
@@ -1,0 +1,432 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ConditionalForwarder": {
+      "operation": "DescribeConditionalForwarders",
+      "resourceIdentifier": {
+        "ReplicationScope": "ConditionalForwarders[].ReplicationScope"
+      },
+      "inputParameters": [
+        "DirectoryId"
+      ]
+    },
+    "Directory": {
+      "operation": "DescribeDirectories",
+      "resourceIdentifier": {
+        "DirectoryId": "DirectoryDescriptions[].DirectoryId"
+      }
+    },
+    "DomainController": {
+      "operation": "DescribeDomainControllers",
+      "resourceIdentifier": {
+        "DomainControllerId": "DomainControllers[].DomainControllerId"
+      },
+      "inputParameters": [
+        "DirectoryId"
+      ]
+    },
+    "EventTopic": {
+      "operation": "DescribeEventTopics",
+      "resourceIdentifier": {
+        "TopicArn": "EventTopics[].TopicArn"
+      }
+    },
+    "SharedDirectory": {
+      "operation": "DescribeSharedDirectories",
+      "resourceIdentifier": {
+        "SharedDirectoryId": "SharedDirectories[].SharedDirectoryId"
+      },
+      "inputParameters": [
+        "OwnerDirectoryId"
+      ]
+    },
+    "Snapshot": {
+      "operation": "DescribeSnapshots",
+      "resourceIdentifier": {
+        "SnapshotId": "Snapshots[].SnapshotId"
+      }
+    },
+    "Trust": {
+      "operation": "DescribeTrusts",
+      "resourceIdentifier": {
+        "TrustId": "Trusts[].TrustId"
+      }
+    },
+    "IpRoute": {
+      "operation": "ListIpRoutes",
+      "resourceIdentifier": {
+        "IpRouteStatusMsg": "IpRoutesInfo[].IpRouteStatusMsg"
+      },
+      "inputParameters": [
+        "DirectoryId"
+      ]
+    },
+    "LogSubscription": {
+      "operation": "ListLogSubscriptions",
+      "resourceIdentifier": {
+        "SubscriptionCreatedDateTime": "LogSubscriptions[].SubscriptionCreatedDateTime"
+      }
+    },
+    "SchemaExtension": {
+      "operation": "ListSchemaExtensions",
+      "resourceIdentifier": {
+        "SchemaExtensionId": "SchemaExtensionsInfo[].SchemaExtensionId"
+      },
+      "inputParameters": [
+        "DirectoryId"
+      ]
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceId"
+      ]
+    }
+  },
+  "operations": {
+    "AddIpRoutes": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CancelSchemaExtension": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CreateAlias": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CreateComputer": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CreateConditionalForwarder": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CreateLogSubscription": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CreateSnapshot": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "CreateTrust": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "DeleteConditionalForwarder": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "DeleteDirectory": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "DeleteLogSubscription": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "DeleteSnapshot": {
+      "SnapshotId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Snapshot",
+            "resourceIdentifier": "SnapshotId"
+          }
+        ]
+      }
+    },
+    "DeleteTrust": {
+      "TrustId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Trust",
+            "resourceIdentifier": "TrustId"
+          }
+        ]
+      }
+    },
+    "DeregisterEventTopic": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "DisableRadius": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "DisableSso": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "EnableRadius": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "EnableSso": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "GetSnapshotLimits": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "RegisterEventTopic": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "RemoveIpRoutes": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "ResetUserPassword": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "RestoreFromSnapshot": {
+      "SnapshotId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Snapshot",
+            "resourceIdentifier": "SnapshotId"
+          }
+        ]
+      }
+    },
+    "ShareDirectory": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "StartSchemaExtension": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "UnshareDirectory": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "UpdateConditionalForwarder": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "UpdateNumberOfDomainControllers": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "UpdateRadius": {
+      "DirectoryId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Directory",
+            "resourceIdentifier": "DirectoryId"
+          }
+        ]
+      }
+    },
+    "UpdateTrust": {
+      "TrustId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Trust",
+            "resourceIdentifier": "TrustId"
+          }
+        ]
+      }
+    },
+    "VerifyTrust": {
+      "TrustId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Trust",
+            "resourceIdentifier": "TrustId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/dynamodb/2012-08-10/completions-1.json
+++ b/awscli/data/dynamodb/2012-08-10/completions-1.json
@@ -1,0 +1,236 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Endpoint": {
+      "operation": "DescribeEndpoints",
+      "resourceIdentifier": {
+        "CachePeriodInMinutes": "Endpoints[].CachePeriodInMinutes"
+      }
+    },
+    "GlobalTableSetting": {
+      "operation": "DescribeGlobalTableSettings",
+      "resourceIdentifier": {
+        "ReplicaGlobalSecondaryIndexSettings": "ReplicaSettings[].ReplicaGlobalSecondaryIndexSettings"
+      },
+      "inputParameters": [
+        "GlobalTableName"
+      ]
+    },
+    "Backup": {
+      "operation": "ListBackups",
+      "resourceIdentifier": {
+        "BackupArn": "BackupSummaries[].BackupArn"
+      }
+    },
+    "GlobalTable": {
+      "operation": "ListGlobalTables",
+      "resourceIdentifier": {
+        "GlobalTableName": "GlobalTables[].GlobalTableName"
+      }
+    },
+    "Table": {
+      "operation": "ListTables",
+      "resourceIdentifier": {
+        "TableNames": "TableNames[]"
+      }
+    },
+    "TagsOfResource": {
+      "operation": "ListTagsOfResource",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceArn"
+      ]
+    }
+  },
+  "operations": {
+    "CreateBackup": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "CreateGlobalTable": {
+      "GlobalTableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GlobalTable",
+            "resourceIdentifier": "GlobalTableName"
+          }
+        ]
+      }
+    },
+    "CreateTable": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "DeleteBackup": {
+      "BackupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupArn"
+          }
+        ]
+      }
+    },
+    "DeleteItem": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "DeleteTable": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "GetItem": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "PutItem": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "Query": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "RestoreTableFromBackup": {
+      "BackupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupArn"
+          }
+        ]
+      }
+    },
+    "Scan": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "UpdateContinuousBackups": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "UpdateGlobalTable": {
+      "GlobalTableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GlobalTable",
+            "resourceIdentifier": "GlobalTableName"
+          }
+        ]
+      }
+    },
+    "UpdateGlobalTableSettings": {
+      "GlobalTableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GlobalTable",
+            "resourceIdentifier": "GlobalTableName"
+          }
+        ]
+      }
+    },
+    "UpdateItem": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "UpdateTable": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    },
+    "UpdateTimeToLive": {
+      "TableName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Table",
+            "resourceIdentifier": "TableName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/dynamodbstreams/2012-08-10/completions-1.json
+++ b/awscli/data/dynamodbstreams/2012-08-10/completions-1.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Stream": {
+      "operation": "ListStreams",
+      "resourceIdentifier": {
+        "StreamArn": "Streams[].StreamArn"
+      }
+    }
+  },
+  "operations": {
+    "GetShardIterator": {
+      "StreamArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/ec2/2016-11-15/completions-1.json
+++ b/awscli/data/ec2/2016-11-15/completions-1.json
@@ -1,0 +1,2753 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountAttribute": {
+      "operation": "DescribeAccountAttributes",
+      "resourceIdentifier": {
+        "AttributeValues": "AccountAttributes[].AttributeValues"
+      }
+    },
+    "Addresse": {
+      "operation": "DescribeAddresses",
+      "resourceIdentifier": {
+        "PrivateIpAddress": "Addresses[].PrivateIpAddress"
+      }
+    },
+    "AggregateIdFormat": {
+      "operation": "DescribeAggregateIdFormat",
+      "resourceIdentifier": {
+        "Deadline": "Statuses[].Deadline"
+      }
+    },
+    "AvailabilityZone": {
+      "operation": "DescribeAvailabilityZones",
+      "resourceIdentifier": {
+        "ZoneName": "AvailabilityZones[].ZoneName"
+      }
+    },
+    "BundleTask": {
+      "operation": "DescribeBundleTasks",
+      "resourceIdentifier": {
+        "BundleTaskError": "BundleTasks[].BundleTaskError"
+      }
+    },
+    "ClassicLinkInstance": {
+      "operation": "DescribeClassicLinkInstances",
+      "resourceIdentifier": {
+        "InstanceId": "Instances[].InstanceId"
+      }
+    },
+    "ConversionTask": {
+      "operation": "DescribeConversionTasks",
+      "resourceIdentifier": {
+        "ConversionTaskId": "ConversionTasks[].ConversionTaskId"
+      }
+    },
+    "CustomerGateway": {
+      "operation": "DescribeCustomerGateways",
+      "resourceIdentifier": {
+        "CustomerGatewayId": "CustomerGateways[].CustomerGatewayId"
+      }
+    },
+    "DhcpOption": {
+      "operation": "DescribeDhcpOptions",
+      "resourceIdentifier": {
+        "DhcpOptionsId": "DhcpOptions[].DhcpOptionsId"
+      }
+    },
+    "EgressOnlyInternetGateway": {
+      "operation": "DescribeEgressOnlyInternetGateways",
+      "resourceIdentifier": {
+        "EgressOnlyInternetGatewayId": "EgressOnlyInternetGateways[].EgressOnlyInternetGatewayId"
+      }
+    },
+    "ElasticGpu": {
+      "operation": "DescribeElasticGpus",
+      "resourceIdentifier": {
+        "ElasticGpuId": "ElasticGpuSet[].ElasticGpuId"
+      }
+    },
+    "ExportTask": {
+      "operation": "DescribeExportTasks",
+      "resourceIdentifier": {
+        "ExportTaskId": "ExportTasks[].ExportTaskId"
+      }
+    },
+    "FleetHistory": {
+      "operation": "DescribeFleetHistory",
+      "resourceIdentifier": {
+        "EventInformation": "HistoryRecords[].EventInformation"
+      },
+      "inputParameters": [
+        "FleetId",
+        "StartTime"
+      ]
+    },
+    "FleetInstance": {
+      "operation": "DescribeFleetInstances",
+      "resourceIdentifier": {
+        "InstanceId": "ActiveInstances[].InstanceId"
+      },
+      "inputParameters": [
+        "FleetId"
+      ]
+    },
+    "Fleet": {
+      "operation": "DescribeFleets",
+      "resourceIdentifier": {
+        "FleetId": "Fleets[].FleetId"
+      }
+    },
+    "FlowLog": {
+      "operation": "DescribeFlowLogs",
+      "resourceIdentifier": {
+        "FlowLogId": "FlowLogs[].FlowLogId"
+      }
+    },
+    "FpgaImage": {
+      "operation": "DescribeFpgaImages",
+      "resourceIdentifier": {
+        "FpgaImageId": "FpgaImages[].FpgaImageId"
+      }
+    },
+    "HostReservationOffering": {
+      "operation": "DescribeHostReservationOfferings",
+      "resourceIdentifier": {
+        "OfferingId": "OfferingSet[].OfferingId"
+      }
+    },
+    "HostReservation": {
+      "operation": "DescribeHostReservations",
+      "resourceIdentifier": {
+        "HostReservationId": "HostReservationSet[].HostReservationId"
+      }
+    },
+    "Host": {
+      "operation": "DescribeHosts",
+      "resourceIdentifier": {
+        "HostId": "Hosts[].HostId"
+      }
+    },
+    "IamInstanceProfileAssociation": {
+      "operation": "DescribeIamInstanceProfileAssociations",
+      "resourceIdentifier": {
+        "IamInstanceProfile": "IamInstanceProfileAssociations[].IamInstanceProfile"
+      }
+    },
+    "IdFormat": {
+      "operation": "DescribeIdFormat",
+      "resourceIdentifier": {
+        "Resource": "Statuses[].Resource"
+      }
+    },
+    "IdentityIdFormat": {
+      "operation": "DescribeIdentityIdFormat",
+      "resourceIdentifier": {
+        "Resource": "Statuses[].Resource"
+      },
+      "inputParameters": [
+        "PrincipalArn"
+      ]
+    },
+    "Image": {
+      "operation": "DescribeImages",
+      "resourceIdentifier": {
+        "ImageId": "Images[].ImageId"
+      }
+    },
+    "ImportImageTask": {
+      "operation": "DescribeImportImageTasks",
+      "resourceIdentifier": {
+        "ImportTaskId": "ImportImageTasks[].ImportTaskId"
+      }
+    },
+    "ImportSnapshotTask": {
+      "operation": "DescribeImportSnapshotTasks",
+      "resourceIdentifier": {
+        "SnapshotTaskDetail": "ImportSnapshotTasks[].SnapshotTaskDetail"
+      }
+    },
+    "InstanceCreditSpecification": {
+      "operation": "DescribeInstanceCreditSpecifications",
+      "resourceIdentifier": {
+        "InstanceId": "InstanceCreditSpecifications[].InstanceId"
+      }
+    },
+    "InstanceStatu": {
+      "operation": "DescribeInstanceStatus",
+      "resourceIdentifier": {
+        "InstanceStatus": "InstanceStatuses[].InstanceStatus"
+      }
+    },
+    "Instance": {
+      "operation": "DescribeInstances",
+      "resourceIdentifier": {
+        "Instances": "Reservations[].Instances"
+      }
+    },
+    "InternetGateway": {
+      "operation": "DescribeInternetGateways",
+      "resourceIdentifier": {
+        "InternetGatewayId": "InternetGateways[].InternetGatewayId"
+      }
+    },
+    "KeyPair": {
+      "operation": "DescribeKeyPairs",
+      "resourceIdentifier": {
+        "KeyName": "KeyPairs[].KeyName"
+      }
+    },
+    "LaunchTemplateVersion": {
+      "operation": "DescribeLaunchTemplateVersions",
+      "resourceIdentifier": {
+        "LaunchTemplateName": "LaunchTemplateVersions[].LaunchTemplateName"
+      }
+    },
+    "LaunchTemplate": {
+      "operation": "DescribeLaunchTemplates",
+      "resourceIdentifier": {
+        "LaunchTemplateId": "LaunchTemplates[].LaunchTemplateId"
+      }
+    },
+    "MovingAddresse": {
+      "operation": "DescribeMovingAddresses",
+      "resourceIdentifier": {
+        "MoveStatus": "MovingAddressStatuses[].MoveStatus"
+      }
+    },
+    "NatGateway": {
+      "operation": "DescribeNatGateways",
+      "resourceIdentifier": {
+        "NatGatewayId": "NatGateways[].NatGatewayId"
+      }
+    },
+    "NetworkAcl": {
+      "operation": "DescribeNetworkAcls",
+      "resourceIdentifier": {
+        "NetworkAclId": "NetworkAcls[].NetworkAclId"
+      }
+    },
+    "NetworkInterfaceAttribute": {
+      "operation": "DescribeNetworkInterfaceAttribute",
+      "resourceIdentifier": {
+        "GroupId": "Groups[].GroupId"
+      },
+      "inputParameters": [
+        "NetworkInterfaceId"
+      ]
+    },
+    "NetworkInterfacePermission": {
+      "operation": "DescribeNetworkInterfacePermissions",
+      "resourceIdentifier": {
+        "NetworkInterfacePermissionId": "NetworkInterfacePermissions[].NetworkInterfacePermissionId"
+      }
+    },
+    "NetworkInterface": {
+      "operation": "DescribeNetworkInterfaces",
+      "resourceIdentifier": {
+        "NetworkInterfaceId": "NetworkInterfaces[].NetworkInterfaceId"
+      }
+    },
+    "PlacementGroup": {
+      "operation": "DescribePlacementGroups",
+      "resourceIdentifier": {
+        "GroupName": "PlacementGroups[].GroupName"
+      }
+    },
+    "PrefixList": {
+      "operation": "DescribePrefixLists",
+      "resourceIdentifier": {
+        "PrefixListId": "PrefixLists[].PrefixListId"
+      }
+    },
+    "PrincipalIdFormat": {
+      "operation": "DescribePrincipalIdFormat",
+      "resourceIdentifier": {
+        "Arn": "Principals[].Arn"
+      }
+    },
+    "Region": {
+      "operation": "DescribeRegions",
+      "resourceIdentifier": {
+        "RegionName": "Regions[].RegionName"
+      }
+    },
+    "ReservedInstance": {
+      "operation": "DescribeReservedInstances",
+      "resourceIdentifier": {
+        "ReservedInstancesId": "ReservedInstances[].ReservedInstancesId"
+      }
+    },
+    "ReservedInstancesListing": {
+      "operation": "DescribeReservedInstancesListings",
+      "resourceIdentifier": {
+        "ReservedInstancesListingId": "ReservedInstancesListings[].ReservedInstancesListingId"
+      }
+    },
+    "ReservedInstancesModification": {
+      "operation": "DescribeReservedInstancesModifications",
+      "resourceIdentifier": {
+        "ReservedInstancesModificationId": "ReservedInstancesModifications[].ReservedInstancesModificationId"
+      }
+    },
+    "ReservedInstancesOffering": {
+      "operation": "DescribeReservedInstancesOfferings",
+      "resourceIdentifier": {
+        "ReservedInstancesOfferingId": "ReservedInstancesOfferings[].ReservedInstancesOfferingId"
+      }
+    },
+    "RouteTable": {
+      "operation": "DescribeRouteTables",
+      "resourceIdentifier": {
+        "RouteTableId": "RouteTables[].RouteTableId"
+      }
+    },
+    "ScheduledInstanceAvailability": {
+      "operation": "DescribeScheduledInstanceAvailability",
+      "resourceIdentifier": {
+        "TotalScheduledInstanceHours": "ScheduledInstanceAvailabilitySet[].TotalScheduledInstanceHours"
+      },
+      "inputParameters": [
+        "FirstSlotStartTimeRange",
+        "Recurrence"
+      ]
+    },
+    "ScheduledInstance": {
+      "operation": "DescribeScheduledInstances",
+      "resourceIdentifier": {
+        "ScheduledInstanceId": "ScheduledInstanceSet[].ScheduledInstanceId"
+      }
+    },
+    "SecurityGroupReference": {
+      "operation": "DescribeSecurityGroupReferences",
+      "resourceIdentifier": {
+        "ReferencingVpcId": "SecurityGroupReferenceSet[].ReferencingVpcId"
+      },
+      "inputParameters": [
+        "GroupId"
+      ]
+    },
+    "SecurityGroup": {
+      "operation": "DescribeSecurityGroups",
+      "resourceIdentifier": {
+        "Description": "SecurityGroups[].Description"
+      }
+    },
+    "Snapshot": {
+      "operation": "DescribeSnapshots",
+      "resourceIdentifier": {
+        "SnapshotId": "Snapshots[].SnapshotId"
+      }
+    },
+    "SpotFleetInstance": {
+      "operation": "DescribeSpotFleetInstances",
+      "resourceIdentifier": {
+        "SpotInstanceRequestId": "ActiveInstances[].SpotInstanceRequestId"
+      },
+      "inputParameters": [
+        "SpotFleetRequestId"
+      ]
+    },
+    "SpotFleetRequestHistory": {
+      "operation": "DescribeSpotFleetRequestHistory",
+      "resourceIdentifier": {
+        "Timestamp": "HistoryRecords[].Timestamp"
+      },
+      "inputParameters": [
+        "SpotFleetRequestId",
+        "StartTime"
+      ]
+    },
+    "SpotFleetRequest": {
+      "operation": "DescribeSpotFleetRequests",
+      "resourceIdentifier": {
+        "SpotFleetRequestId": "SpotFleetRequestConfigs[].SpotFleetRequestId"
+      }
+    },
+    "SpotInstanceRequest": {
+      "operation": "DescribeSpotInstanceRequests",
+      "resourceIdentifier": {
+        "SpotInstanceRequestId": "SpotInstanceRequests[].SpotInstanceRequestId"
+      }
+    },
+    "SpotPriceHistory": {
+      "operation": "DescribeSpotPriceHistory",
+      "resourceIdentifier": {
+        "SpotPrice": "SpotPriceHistory[].SpotPrice"
+      }
+    },
+    "StaleSecurityGroup": {
+      "operation": "DescribeStaleSecurityGroups",
+      "resourceIdentifier": {
+        "StaleIpPermissions": "StaleSecurityGroupSet[].StaleIpPermissions"
+      },
+      "inputParameters": [
+        "VpcId"
+      ]
+    },
+    "Subnet": {
+      "operation": "DescribeSubnets",
+      "resourceIdentifier": {
+        "SubnetId": "Subnets[].SubnetId"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      }
+    },
+    "VolumeAttribute": {
+      "operation": "DescribeVolumeAttribute",
+      "resourceIdentifier": {
+        "ProductCodeType": "ProductCodes[].ProductCodeType"
+      },
+      "inputParameters": [
+        "Attribute",
+        "VolumeId"
+      ]
+    },
+    "VolumeStatu": {
+      "operation": "DescribeVolumeStatus",
+      "resourceIdentifier": {
+        "VolumeStatus": "VolumeStatuses[].VolumeStatus"
+      }
+    },
+    "Volume": {
+      "operation": "DescribeVolumes",
+      "resourceIdentifier": {
+        "VolumeId": "Volumes[].VolumeId"
+      }
+    },
+    "VolumesModification": {
+      "operation": "DescribeVolumesModifications",
+      "resourceIdentifier": {
+        "ModificationState": "VolumesModifications[].ModificationState"
+      }
+    },
+    "VpcClassicLink": {
+      "operation": "DescribeVpcClassicLink",
+      "resourceIdentifier": {
+        "ClassicLinkEnabled": "Vpcs[].ClassicLinkEnabled"
+      }
+    },
+    "VpcClassicLinkDnsSupport": {
+      "operation": "DescribeVpcClassicLinkDnsSupport",
+      "resourceIdentifier": {
+        "ClassicLinkDnsSupported": "Vpcs[].ClassicLinkDnsSupported"
+      }
+    },
+    "VpcEndpointConnectionNotification": {
+      "operation": "DescribeVpcEndpointConnectionNotifications",
+      "resourceIdentifier": {
+        "ConnectionNotificationId": "ConnectionNotificationSet[].ConnectionNotificationId"
+      }
+    },
+    "VpcEndpointConnection": {
+      "operation": "DescribeVpcEndpointConnections",
+      "resourceIdentifier": {
+        "VpcEndpointOwner": "VpcEndpointConnections[].VpcEndpointOwner"
+      }
+    },
+    "VpcEndpointServiceConfiguration": {
+      "operation": "DescribeVpcEndpointServiceConfigurations",
+      "resourceIdentifier": {
+        "ServiceState": "ServiceConfigurations[].ServiceState"
+      }
+    },
+    "VpcEndpointServicePermission": {
+      "operation": "DescribeVpcEndpointServicePermissions",
+      "resourceIdentifier": {
+        "Principal": "AllowedPrincipals[].Principal"
+      },
+      "inputParameters": [
+        "ServiceId"
+      ]
+    },
+    "VpcEndpoint": {
+      "operation": "DescribeVpcEndpoints",
+      "resourceIdentifier": {
+        "VpcEndpointId": "VpcEndpoints[].VpcEndpointId"
+      }
+    },
+    "VpcPeeringConnection": {
+      "operation": "DescribeVpcPeeringConnections",
+      "resourceIdentifier": {
+        "VpcPeeringConnectionId": "VpcPeeringConnections[].VpcPeeringConnectionId"
+      }
+    },
+    "Vpc": {
+      "operation": "DescribeVpcs",
+      "resourceIdentifier": {
+        "VpcId": "Vpcs[].VpcId"
+      }
+    },
+    "VpnConnection": {
+      "operation": "DescribeVpnConnections",
+      "resourceIdentifier": {
+        "VpnConnectionId": "VpnConnections[].VpnConnectionId"
+      }
+    },
+    "VpnGateway": {
+      "operation": "DescribeVpnGateways",
+      "resourceIdentifier": {
+        "VpnGatewayId": "VpnGateways[].VpnGatewayId"
+      }
+    }
+  },
+  "operations": {
+    "AcceptReservedInstancesExchangeQuote": {
+      "ReservedInstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedInstance",
+            "resourceIdentifier": "ReservedInstanceIds"
+          }
+        ]
+      }
+    },
+    "AcceptVpcEndpointConnections": {
+      "VpcEndpointIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpoint",
+            "resourceIdentifier": "VpcEndpointIds"
+          }
+        ]
+      }
+    },
+    "AcceptVpcPeeringConnection": {
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "AssignIpv6Addresses": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "AssignPrivateIpAddresses": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      },
+      "PrivateIpAddresses": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "PrivateIpAddresses"
+          }
+        ]
+      }
+    },
+    "AssociateAddress": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      },
+      "PrivateIpAddress": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "PrivateIpAddress"
+          }
+        ]
+      }
+    },
+    "AssociateDhcpOptions": {
+      "DhcpOptionsId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DhcpOption",
+            "resourceIdentifier": "DhcpOptionsId"
+          }
+        ]
+      },
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "AssociateIamInstanceProfile": {
+      "IamInstanceProfile": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IamInstanceProfileAssociation",
+            "resourceIdentifier": "IamInstanceProfile"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "AssociateRouteTable": {
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      },
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      }
+    },
+    "AssociateSubnetCidrBlock": {
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      }
+    },
+    "AssociateVpcCidrBlock": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "AttachClassicLinkVpc": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "AttachInternetGateway": {
+      "InternetGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InternetGateway",
+            "resourceIdentifier": "InternetGatewayId"
+          }
+        ]
+      },
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "AttachNetworkInterface": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "AttachVolume": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "AttachVpnGateway": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      },
+      "VpnGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnGateway",
+            "resourceIdentifier": "VpnGatewayId"
+          }
+        ]
+      }
+    },
+    "AuthorizeSecurityGroupIngress": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    },
+    "BundleInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "CancelConversionTask": {
+      "ConversionTaskId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ConversionTask",
+            "resourceIdentifier": "ConversionTaskId"
+          }
+        ]
+      }
+    },
+    "CancelExportTask": {
+      "ExportTaskId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ExportTask",
+            "resourceIdentifier": "ExportTaskId"
+          }
+        ]
+      }
+    },
+    "CancelImportTask": {
+      "ImportTaskId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ImportImageTask",
+            "resourceIdentifier": "ImportTaskId"
+          }
+        ]
+      }
+    },
+    "CancelReservedInstancesListing": {
+      "ReservedInstancesListingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedInstancesListing",
+            "resourceIdentifier": "ReservedInstancesListingId"
+          }
+        ]
+      }
+    },
+    "CancelSpotFleetRequests": {
+      "SpotFleetRequestIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SpotFleetRequest",
+            "resourceIdentifier": "SpotFleetRequestIds"
+          }
+        ]
+      }
+    },
+    "CancelSpotInstanceRequests": {
+      "SpotInstanceRequestIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SpotInstanceRequest",
+            "resourceIdentifier": "SpotInstanceRequestIds"
+          }
+        ]
+      }
+    },
+    "ConfirmProductInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "CopyFpgaImage": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CopyImage": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CopySnapshot": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CreateEgressOnlyInternetGateway": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "CreateFpgaImage": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CreateImage": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "CreateInstanceExportTask": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "CreateKeyPair": {
+      "KeyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "KeyPair",
+            "resourceIdentifier": "KeyName"
+          }
+        ]
+      }
+    },
+    "CreateLaunchTemplate": {
+      "LaunchTemplateName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplateVersion",
+            "resourceIdentifier": "LaunchTemplateName"
+          }
+        ]
+      }
+    },
+    "CreateLaunchTemplateVersion": {
+      "LaunchTemplateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplate",
+            "resourceIdentifier": "LaunchTemplateId"
+          }
+        ]
+      },
+      "LaunchTemplateName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplateVersion",
+            "resourceIdentifier": "LaunchTemplateName"
+          }
+        ]
+      }
+    },
+    "CreateNatGateway": {
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      }
+    },
+    "CreateNetworkAcl": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "CreateNetworkAclEntry": {
+      "NetworkAclId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkAcl",
+            "resourceIdentifier": "NetworkAclId"
+          }
+        ]
+      }
+    },
+    "CreateNetworkInterface": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "PrivateIpAddress": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "PrivateIpAddress"
+          }
+        ]
+      },
+      "PrivateIpAddresses": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "PrivateIpAddresses"
+          }
+        ]
+      },
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      }
+    },
+    "CreateNetworkInterfacePermission": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "CreatePlacementGroup": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    },
+    "CreateReservedInstancesListing": {
+      "ReservedInstancesId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedInstance",
+            "resourceIdentifier": "ReservedInstancesId"
+          }
+        ]
+      }
+    },
+    "CreateRoute": {
+      "EgressOnlyInternetGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EgressOnlyInternetGateway",
+            "resourceIdentifier": "EgressOnlyInternetGatewayId"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "NatGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NatGateway",
+            "resourceIdentifier": "NatGatewayId"
+          }
+        ]
+      },
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      },
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      },
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "CreateRouteTable": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "CreateSecurityGroup": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      },
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "CreateSnapshot": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "CreateSubnet": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "CreateTags": {
+      "Resources": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdFormat",
+            "resourceIdentifier": "Resources"
+          }
+        ]
+      }
+    },
+    "CreateVolume": {
+      "SnapshotId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Snapshot",
+            "resourceIdentifier": "SnapshotId"
+          }
+        ]
+      }
+    },
+    "CreateVpcEndpoint": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      },
+      "RouteTableIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableIds"
+          }
+        ]
+      },
+      "SubnetIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetIds"
+          }
+        ]
+      }
+    },
+    "CreateVpcEndpointConnectionNotification": {
+      "VpcEndpointId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpoint",
+            "resourceIdentifier": "VpcEndpointId"
+          }
+        ]
+      }
+    },
+    "CreateVpcPeeringConnection": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "CreateVpnConnection": {
+      "CustomerGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CustomerGateway",
+            "resourceIdentifier": "CustomerGatewayId"
+          }
+        ]
+      },
+      "VpnGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnGateway",
+            "resourceIdentifier": "VpnGatewayId"
+          }
+        ]
+      }
+    },
+    "CreateVpnConnectionRoute": {
+      "VpnConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnConnection",
+            "resourceIdentifier": "VpnConnectionId"
+          }
+        ]
+      }
+    },
+    "DeleteCustomerGateway": {
+      "CustomerGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CustomerGateway",
+            "resourceIdentifier": "CustomerGatewayId"
+          }
+        ]
+      }
+    },
+    "DeleteDhcpOptions": {
+      "DhcpOptionsId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DhcpOption",
+            "resourceIdentifier": "DhcpOptionsId"
+          }
+        ]
+      }
+    },
+    "DeleteEgressOnlyInternetGateway": {
+      "EgressOnlyInternetGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EgressOnlyInternetGateway",
+            "resourceIdentifier": "EgressOnlyInternetGatewayId"
+          }
+        ]
+      }
+    },
+    "DeleteFleets": {
+      "FleetIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Fleet",
+            "resourceIdentifier": "FleetIds"
+          }
+        ]
+      }
+    },
+    "DeleteFlowLogs": {
+      "FlowLogIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FlowLog",
+            "resourceIdentifier": "FlowLogIds"
+          }
+        ]
+      }
+    },
+    "DeleteFpgaImage": {
+      "FpgaImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FpgaImage",
+            "resourceIdentifier": "FpgaImageId"
+          }
+        ]
+      }
+    },
+    "DeleteInternetGateway": {
+      "InternetGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InternetGateway",
+            "resourceIdentifier": "InternetGatewayId"
+          }
+        ]
+      }
+    },
+    "DeleteKeyPair": {
+      "KeyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "KeyPair",
+            "resourceIdentifier": "KeyName"
+          }
+        ]
+      }
+    },
+    "DeleteLaunchTemplate": {
+      "LaunchTemplateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplate",
+            "resourceIdentifier": "LaunchTemplateId"
+          }
+        ]
+      },
+      "LaunchTemplateName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplateVersion",
+            "resourceIdentifier": "LaunchTemplateName"
+          }
+        ]
+      }
+    },
+    "DeleteLaunchTemplateVersions": {
+      "LaunchTemplateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplate",
+            "resourceIdentifier": "LaunchTemplateId"
+          }
+        ]
+      },
+      "LaunchTemplateName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplateVersion",
+            "resourceIdentifier": "LaunchTemplateName"
+          }
+        ]
+      }
+    },
+    "DeleteNatGateway": {
+      "NatGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NatGateway",
+            "resourceIdentifier": "NatGatewayId"
+          }
+        ]
+      }
+    },
+    "DeleteNetworkAcl": {
+      "NetworkAclId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkAcl",
+            "resourceIdentifier": "NetworkAclId"
+          }
+        ]
+      }
+    },
+    "DeleteNetworkAclEntry": {
+      "NetworkAclId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkAcl",
+            "resourceIdentifier": "NetworkAclId"
+          }
+        ]
+      }
+    },
+    "DeleteNetworkInterface": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "DeleteNetworkInterfacePermission": {
+      "NetworkInterfacePermissionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterfacePermission",
+            "resourceIdentifier": "NetworkInterfacePermissionId"
+          }
+        ]
+      }
+    },
+    "DeletePlacementGroup": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    },
+    "DeleteRoute": {
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      }
+    },
+    "DeleteRouteTable": {
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      }
+    },
+    "DeleteSecurityGroup": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    },
+    "DeleteSnapshot": {
+      "SnapshotId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Snapshot",
+            "resourceIdentifier": "SnapshotId"
+          }
+        ]
+      }
+    },
+    "DeleteSubnet": {
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      }
+    },
+    "DeleteTags": {
+      "Resources": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdFormat",
+            "resourceIdentifier": "Resources"
+          }
+        ]
+      }
+    },
+    "DeleteVolume": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "DeleteVpc": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "DeleteVpcEndpointConnectionNotifications": {
+      "ConnectionNotificationIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpointConnectionNotification",
+            "resourceIdentifier": "ConnectionNotificationIds"
+          }
+        ]
+      }
+    },
+    "DeleteVpcEndpoints": {
+      "VpcEndpointIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpoint",
+            "resourceIdentifier": "VpcEndpointIds"
+          }
+        ]
+      }
+    },
+    "DeleteVpcPeeringConnection": {
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "DeleteVpnConnection": {
+      "VpnConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnConnection",
+            "resourceIdentifier": "VpnConnectionId"
+          }
+        ]
+      }
+    },
+    "DeleteVpnConnectionRoute": {
+      "VpnConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnConnection",
+            "resourceIdentifier": "VpnConnectionId"
+          }
+        ]
+      }
+    },
+    "DeleteVpnGateway": {
+      "VpnGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnGateway",
+            "resourceIdentifier": "VpnGatewayId"
+          }
+        ]
+      }
+    },
+    "DeregisterImage": {
+      "ImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Image",
+            "resourceIdentifier": "ImageId"
+          }
+        ]
+      }
+    },
+    "DetachClassicLinkVpc": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "DetachInternetGateway": {
+      "InternetGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InternetGateway",
+            "resourceIdentifier": "InternetGatewayId"
+          }
+        ]
+      },
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "DetachVolume": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "DetachVpnGateway": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      },
+      "VpnGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpnGateway",
+            "resourceIdentifier": "VpnGatewayId"
+          }
+        ]
+      }
+    },
+    "DisableVgwRoutePropagation": {
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      }
+    },
+    "DisableVpcClassicLink": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "DisableVpcClassicLinkDnsSupport": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "EnableVgwRoutePropagation": {
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      }
+    },
+    "EnableVolumeIO": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "EnableVpcClassicLink": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "EnableVpcClassicLinkDnsSupport": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "GetConsoleOutput": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "GetConsoleScreenshot": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "GetHostReservationPurchasePreview": {
+      "OfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HostReservationOffering",
+            "resourceIdentifier": "OfferingId"
+          }
+        ]
+      }
+    },
+    "GetLaunchTemplateData": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "GetPasswordData": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "GetReservedInstancesExchangeQuote": {
+      "ReservedInstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedInstance",
+            "resourceIdentifier": "ReservedInstanceIds"
+          }
+        ]
+      }
+    },
+    "ImportImage": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "ImportInstance": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "ImportKeyPair": {
+      "KeyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "KeyPair",
+            "resourceIdentifier": "KeyName"
+          }
+        ]
+      }
+    },
+    "ImportSnapshot": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "ImportVolume": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "ModifyFleet": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Fleet",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "ModifyFpgaImageAttribute": {
+      "FpgaImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FpgaImage",
+            "resourceIdentifier": "FpgaImageId"
+          }
+        ]
+      },
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "ModifyHosts": {
+      "HostIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Host",
+            "resourceIdentifier": "HostIds"
+          }
+        ]
+      }
+    },
+    "ModifyIdFormat": {
+      "Resource": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdFormat",
+            "resourceIdentifier": "Resource"
+          }
+        ]
+      }
+    },
+    "ModifyIdentityIdFormat": {
+      "Resource": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IdFormat",
+            "resourceIdentifier": "Resource"
+          }
+        ]
+      }
+    },
+    "ModifyImageAttribute": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "ImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Image",
+            "resourceIdentifier": "ImageId"
+          }
+        ]
+      },
+      "Value": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Tag",
+            "resourceIdentifier": "Value"
+          }
+        ]
+      }
+    },
+    "ModifyInstanceAttribute": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "Value": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Tag",
+            "resourceIdentifier": "Value"
+          }
+        ]
+      }
+    },
+    "ModifyInstancePlacement": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      },
+      "HostId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Host",
+            "resourceIdentifier": "HostId"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "ModifyLaunchTemplate": {
+      "LaunchTemplateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplate",
+            "resourceIdentifier": "LaunchTemplateId"
+          }
+        ]
+      },
+      "LaunchTemplateName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplateVersion",
+            "resourceIdentifier": "LaunchTemplateName"
+          }
+        ]
+      }
+    },
+    "ModifyNetworkInterfaceAttribute": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "ModifyReservedInstances": {
+      "ReservedInstancesIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedInstance",
+            "resourceIdentifier": "ReservedInstancesIds"
+          }
+        ]
+      }
+    },
+    "ModifySnapshotAttribute": {
+      "GroupNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupNames"
+          }
+        ]
+      },
+      "SnapshotId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Snapshot",
+            "resourceIdentifier": "SnapshotId"
+          }
+        ]
+      }
+    },
+    "ModifySpotFleetRequest": {
+      "SpotFleetRequestId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SpotFleetRequest",
+            "resourceIdentifier": "SpotFleetRequestId"
+          }
+        ]
+      }
+    },
+    "ModifySubnetAttribute": {
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      }
+    },
+    "ModifyVolume": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "ModifyVolumeAttribute": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "ModifyVpcAttribute": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "ModifyVpcEndpoint": {
+      "VpcEndpointId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpoint",
+            "resourceIdentifier": "VpcEndpointId"
+          }
+        ]
+      }
+    },
+    "ModifyVpcEndpointConnectionNotification": {
+      "ConnectionNotificationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpointConnectionNotification",
+            "resourceIdentifier": "ConnectionNotificationId"
+          }
+        ]
+      }
+    },
+    "ModifyVpcPeeringConnectionOptions": {
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "ModifyVpcTenancy": {
+      "VpcId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vpc",
+            "resourceIdentifier": "VpcId"
+          }
+        ]
+      }
+    },
+    "MonitorInstances": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "PurchaseHostReservation": {
+      "OfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HostReservationOffering",
+            "resourceIdentifier": "OfferingId"
+          }
+        ]
+      }
+    },
+    "PurchaseReservedInstancesOffering": {
+      "ReservedInstancesOfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedInstancesOffering",
+            "resourceIdentifier": "ReservedInstancesOfferingId"
+          }
+        ]
+      }
+    },
+    "RebootInstances": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "RegisterImage": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "RejectVpcEndpointConnections": {
+      "VpcEndpointIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcEndpoint",
+            "resourceIdentifier": "VpcEndpointIds"
+          }
+        ]
+      }
+    },
+    "RejectVpcPeeringConnection": {
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "ReleaseHosts": {
+      "HostIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Host",
+            "resourceIdentifier": "HostIds"
+          }
+        ]
+      }
+    },
+    "ReplaceIamInstanceProfileAssociation": {
+      "IamInstanceProfile": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IamInstanceProfileAssociation",
+            "resourceIdentifier": "IamInstanceProfile"
+          }
+        ]
+      }
+    },
+    "ReplaceNetworkAclAssociation": {
+      "NetworkAclId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkAcl",
+            "resourceIdentifier": "NetworkAclId"
+          }
+        ]
+      }
+    },
+    "ReplaceNetworkAclEntry": {
+      "NetworkAclId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkAcl",
+            "resourceIdentifier": "NetworkAclId"
+          }
+        ]
+      }
+    },
+    "ReplaceRoute": {
+      "EgressOnlyInternetGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EgressOnlyInternetGateway",
+            "resourceIdentifier": "EgressOnlyInternetGatewayId"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "NatGatewayId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NatGateway",
+            "resourceIdentifier": "NatGatewayId"
+          }
+        ]
+      },
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      },
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      },
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "ReplaceRouteTableAssociation": {
+      "RouteTableId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RouteTable",
+            "resourceIdentifier": "RouteTableId"
+          }
+        ]
+      }
+    },
+    "ReportInstanceStatus": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SecurityGroup",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "Instances": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "Instances"
+          }
+        ]
+      }
+    },
+    "RequestSpotInstances": {
+      "SpotPrice": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SpotPriceHistory",
+            "resourceIdentifier": "SpotPrice"
+          }
+        ]
+      }
+    },
+    "ResetFpgaImageAttribute": {
+      "FpgaImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FpgaImage",
+            "resourceIdentifier": "FpgaImageId"
+          }
+        ]
+      }
+    },
+    "ResetImageAttribute": {
+      "ImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Image",
+            "resourceIdentifier": "ImageId"
+          }
+        ]
+      }
+    },
+    "ResetInstanceAttribute": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "ResetNetworkInterfaceAttribute": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "ResetSnapshotAttribute": {
+      "SnapshotId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Snapshot",
+            "resourceIdentifier": "SnapshotId"
+          }
+        ]
+      }
+    },
+    "RevokeSecurityGroupIngress": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    },
+    "RunInstances": {
+      "ImageId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Image",
+            "resourceIdentifier": "ImageId"
+          }
+        ]
+      },
+      "KeyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "KeyPair",
+            "resourceIdentifier": "KeyName"
+          }
+        ]
+      },
+      "SubnetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subnet",
+            "resourceIdentifier": "SubnetId"
+          }
+        ]
+      },
+      "IamInstanceProfile": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IamInstanceProfileAssociation",
+            "resourceIdentifier": "IamInstanceProfile"
+          }
+        ]
+      },
+      "NetworkInterfaces": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaces"
+          }
+        ]
+      },
+      "PrivateIpAddress": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "PrivateIpAddress"
+          }
+        ]
+      },
+      "LaunchTemplate": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LaunchTemplate",
+            "resourceIdentifier": "LaunchTemplate"
+          }
+        ]
+      }
+    },
+    "RunScheduledInstances": {
+      "ScheduledInstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ScheduledInstance",
+            "resourceIdentifier": "ScheduledInstanceId"
+          }
+        ]
+      }
+    },
+    "StartInstances": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "StopInstances": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "TerminateInstances": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "UnassignIpv6Addresses": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      }
+    },
+    "UnassignPrivateIpAddresses": {
+      "NetworkInterfaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "NetworkInterface",
+            "resourceIdentifier": "NetworkInterfaceId"
+          }
+        ]
+      },
+      "PrivateIpAddresses": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "PrivateIpAddresses"
+          }
+        ]
+      }
+    },
+    "UnmonitorInstances": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceCreditSpecification",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "UpdateSecurityGroupRuleDescriptionsEgress": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    },
+    "UpdateSecurityGroupRuleDescriptionsIngress": {
+      "GroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlacementGroup",
+            "resourceIdentifier": "GroupName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/ecr/2015-09-21/completions-1.json
+++ b/awscli/data/ecr/2015-09-21/completions-1.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Image": {
+      "operation": "ListImages",
+      "resourceIdentifier": {
+        "imageTags": "imageDetails[].imageTags",
+        "imageDigest": "imageIds[].imageDigest"
+      },
+      "inputParameters": [
+        "repositoryName"
+      ]
+    },
+    "Repository": {
+      "operation": "DescribeRepositories",
+      "resourceIdentifier": {
+        "repositoryUri": "repositories[].repositoryUri"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/ecs/2014-11-13/completions-1.json
+++ b/awscli/data/ecs/2014-11-13/completions-1.json
@@ -1,0 +1,85 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Attribute": {
+      "operation": "ListAttributes",
+      "resourceIdentifier": {
+        "targetType": "attributes[].targetType"
+      },
+      "inputParameters": [
+        "targetType"
+      ]
+    },
+    "Cluster": {
+      "operation": "ListClusters",
+      "resourceIdentifier": {
+        "clusterArns": "clusterArns[]"
+      }
+    },
+    "ContainerInstance": {
+      "operation": "ListContainerInstances",
+      "resourceIdentifier": {
+        "containerInstanceArns": "containerInstanceArns[]"
+      }
+    },
+    "Service": {
+      "operation": "ListServices",
+      "resourceIdentifier": {
+        "serviceArns": "serviceArns[]"
+      }
+    },
+    "TaskDefinitionFamily": {
+      "operation": "ListTaskDefinitionFamilies",
+      "resourceIdentifier": {
+        "families": "families[]"
+      }
+    },
+    "TaskDefinition": {
+      "operation": "ListTaskDefinitions",
+      "resourceIdentifier": {
+        "taskDefinitionArns": "taskDefinitionArns[]"
+      }
+    },
+    "Task": {
+      "operation": "ListTasks",
+      "resourceIdentifier": {
+        "taskArns": "taskArns[]"
+      }
+    }
+  },
+  "operations": {
+    "RegisterContainerInstance": {
+      "containerInstanceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ContainerInstance",
+            "resourceIdentifier": "containerInstanceArn"
+          }
+        ]
+      }
+    },
+    "StartTask": {
+      "containerInstances": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ContainerInstance",
+            "resourceIdentifier": "containerInstances"
+          }
+        ]
+      }
+    },
+    "UpdateContainerInstancesState": {
+      "containerInstances": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ContainerInstance",
+            "resourceIdentifier": "containerInstances"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/efs/2015-02-01/completions-1.json
+++ b/awscli/data/efs/2015-02-01/completions-1.json
@@ -1,0 +1,114 @@
+{
+  "version": "1.0",
+  "resources": {
+    "FileSystem": {
+      "operation": "DescribeFileSystems",
+      "resourceIdentifier": {
+        "FileSystemId": "FileSystems[].FileSystemId"
+      }
+    },
+    "MountTargetSecurityGroup": {
+      "operation": "DescribeMountTargetSecurityGroups",
+      "resourceIdentifier": {
+        "SecurityGroups": "SecurityGroups[]"
+      },
+      "inputParameters": [
+        "MountTargetId"
+      ]
+    },
+    "MountTarget": {
+      "operation": "DescribeMountTargets",
+      "resourceIdentifier": {
+        "MountTargetId": "MountTargets[].MountTargetId"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "FileSystemId"
+      ]
+    }
+  },
+  "operations": {
+    "CreateMountTarget": {
+      "FileSystemId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FileSystem",
+            "resourceIdentifier": "FileSystemId"
+          }
+        ]
+      }
+    },
+    "CreateTags": {
+      "FileSystemId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FileSystem",
+            "resourceIdentifier": "FileSystemId"
+          }
+        ]
+      }
+    },
+    "DeleteFileSystem": {
+      "FileSystemId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FileSystem",
+            "resourceIdentifier": "FileSystemId"
+          }
+        ]
+      }
+    },
+    "DeleteMountTarget": {
+      "MountTargetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MountTarget",
+            "resourceIdentifier": "MountTargetId"
+          }
+        ]
+      }
+    },
+    "DeleteTags": {
+      "FileSystemId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FileSystem",
+            "resourceIdentifier": "FileSystemId"
+          }
+        ]
+      }
+    },
+    "ModifyMountTargetSecurityGroups": {
+      "MountTargetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MountTarget",
+            "resourceIdentifier": "MountTargetId"
+          }
+        ]
+      }
+    },
+    "UpdateFileSystem": {
+      "FileSystemId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FileSystem",
+            "resourceIdentifier": "FileSystemId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/eks/2017-11-01/completions-1.json
+++ b/awscli/data/eks/2017-11-01/completions-1.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Cluster": {
+      "operation": "ListClusters",
+      "resourceIdentifier": {
+        "clusters": "clusters[]"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/elasticache/2015-02-02/completions-1.json
+++ b/awscli/data/elasticache/2015-02-02/completions-1.json
@@ -1,0 +1,499 @@
+{
+  "version": "1.0",
+  "resources": {
+    "CacheCluster": {
+      "operation": "DescribeCacheClusters",
+      "resourceIdentifier": {
+        "CacheClusterId": "CacheClusters[].CacheClusterId"
+      }
+    },
+    "CacheEngineVersion": {
+      "operation": "DescribeCacheEngineVersions",
+      "resourceIdentifier": {
+        "EngineVersion": "CacheEngineVersions[].EngineVersion"
+      }
+    },
+    "CacheParameterGroup": {
+      "operation": "DescribeCacheParameterGroups",
+      "resourceIdentifier": {
+        "CacheParameterGroupName": "CacheParameterGroups[].CacheParameterGroupName"
+      }
+    },
+    "CacheSecurityGroup": {
+      "operation": "DescribeCacheSecurityGroups",
+      "resourceIdentifier": {
+        "CacheSecurityGroupName": "CacheSecurityGroups[].CacheSecurityGroupName"
+      }
+    },
+    "CacheSubnetGroup": {
+      "operation": "DescribeCacheSubnetGroups",
+      "resourceIdentifier": {
+        "CacheSubnetGroupName": "CacheSubnetGroups[].CacheSubnetGroupName"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "Message": "Events[].Message"
+      }
+    },
+    "ReplicationGroup": {
+      "operation": "DescribeReplicationGroups",
+      "resourceIdentifier": {
+        "ReplicationGroupId": "ReplicationGroups[].ReplicationGroupId"
+      }
+    },
+    "ReservedCacheNode": {
+      "operation": "DescribeReservedCacheNodes",
+      "resourceIdentifier": {
+        "ReservedCacheNodeId": "ReservedCacheNodes[].ReservedCacheNodeId"
+      }
+    },
+    "ReservedCacheNodesOffering": {
+      "operation": "DescribeReservedCacheNodesOfferings",
+      "resourceIdentifier": {
+        "ReservedCacheNodesOfferingId": "ReservedCacheNodesOfferings[].ReservedCacheNodesOfferingId"
+      }
+    },
+    "Snapshot": {
+      "operation": "DescribeSnapshots",
+      "resourceIdentifier": {
+        "NodeSnapshots": "Snapshots[].NodeSnapshots"
+      }
+    },
+    "AllowedNodeTypeModification": {
+      "operation": "ListAllowedNodeTypeModifications",
+      "resourceIdentifier": {
+        "ScaleUpModifications": "ScaleUpModifications[]"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceName"
+      ]
+    }
+  },
+  "operations": {
+    "AuthorizeCacheSecurityGroupIngress": {
+      "CacheSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "CreateCacheCluster": {
+      "CacheClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheCluster",
+            "resourceIdentifier": "CacheClusterId"
+          }
+        ]
+      },
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      },
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      },
+      "CacheSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSubnetGroup",
+            "resourceIdentifier": "CacheSubnetGroupName"
+          }
+        ]
+      },
+      "CacheSecurityGroupNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupNames"
+          }
+        ]
+      }
+    },
+    "CreateCacheParameterGroup": {
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      }
+    },
+    "CreateCacheSecurityGroup": {
+      "CacheSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "CreateCacheSubnetGroup": {
+      "CacheSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSubnetGroup",
+            "resourceIdentifier": "CacheSubnetGroupName"
+          }
+        ]
+      }
+    },
+    "CreateReplicationGroup": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      },
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      },
+      "CacheSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSubnetGroup",
+            "resourceIdentifier": "CacheSubnetGroupName"
+          }
+        ]
+      },
+      "CacheSecurityGroupNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupNames"
+          }
+        ]
+      }
+    },
+    "CreateSnapshot": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      },
+      "CacheClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheCluster",
+            "resourceIdentifier": "CacheClusterId"
+          }
+        ]
+      }
+    },
+    "DecreaseReplicaCount": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      }
+    },
+    "DeleteCacheCluster": {
+      "CacheClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheCluster",
+            "resourceIdentifier": "CacheClusterId"
+          }
+        ]
+      }
+    },
+    "DeleteCacheParameterGroup": {
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteCacheSecurityGroup": {
+      "CacheSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteCacheSubnetGroup": {
+      "CacheSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSubnetGroup",
+            "resourceIdentifier": "CacheSubnetGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteReplicationGroup": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      }
+    },
+    "IncreaseReplicaCount": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      }
+    },
+    "ModifyCacheCluster": {
+      "CacheClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheCluster",
+            "resourceIdentifier": "CacheClusterId"
+          }
+        ]
+      },
+      "CacheSecurityGroupNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupNames"
+          }
+        ]
+      },
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyCacheParameterGroup": {
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      }
+    },
+    "ModifyCacheSubnetGroup": {
+      "CacheSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSubnetGroup",
+            "resourceIdentifier": "CacheSubnetGroupName"
+          }
+        ]
+      }
+    },
+    "ModifyReplicationGroup": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      },
+      "CacheSecurityGroupNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupNames"
+          }
+        ]
+      },
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyReplicationGroupShardConfiguration": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      }
+    },
+    "PurchaseReservedCacheNodesOffering": {
+      "ReservedCacheNodesOfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedCacheNodesOffering",
+            "resourceIdentifier": "ReservedCacheNodesOfferingId"
+          }
+        ]
+      },
+      "ReservedCacheNodeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedCacheNode",
+            "resourceIdentifier": "ReservedCacheNodeId"
+          }
+        ]
+      }
+    },
+    "RebootCacheCluster": {
+      "CacheClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheCluster",
+            "resourceIdentifier": "CacheClusterId"
+          }
+        ]
+      }
+    },
+    "ResetCacheParameterGroup": {
+      "CacheParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheParameterGroup",
+            "resourceIdentifier": "CacheParameterGroupName"
+          }
+        ]
+      }
+    },
+    "RevokeCacheSecurityGroupIngress": {
+      "CacheSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CacheSecurityGroup",
+            "resourceIdentifier": "CacheSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "TestFailover": {
+      "ReplicationGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReplicationGroup",
+            "resourceIdentifier": "ReplicationGroupId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/elasticbeanstalk/2010-12-01/completions-1.json
+++ b/awscli/data/elasticbeanstalk/2010-12-01/completions-1.json
@@ -1,0 +1,233 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ApplicationVersion": {
+      "operation": "DescribeApplicationVersions",
+      "resourceIdentifier": {
+        "ApplicationVersionArn": "ApplicationVersions[].ApplicationVersionArn"
+      }
+    },
+    "Application": {
+      "operation": "DescribeApplications",
+      "resourceIdentifier": {
+        "ApplicationArn": "Applications[].ApplicationArn"
+      }
+    },
+    "ConfigurationOption": {
+      "operation": "DescribeConfigurationOptions",
+      "resourceIdentifier": {
+        "ValueOptions": "Options[].ValueOptions"
+      }
+    },
+    "ConfigurationSetting": {
+      "operation": "DescribeConfigurationSettings",
+      "resourceIdentifier": {
+        "OptionSettings": "ConfigurationSettings[].OptionSettings"
+      },
+      "inputParameters": [
+        "ApplicationName"
+      ]
+    },
+    "EnvironmentHealth": {
+      "operation": "DescribeEnvironmentHealth",
+      "resourceIdentifier": {
+        "Causes": "Causes[]"
+      }
+    },
+    "EnvironmentManagedActionHistory": {
+      "operation": "DescribeEnvironmentManagedActionHistory",
+      "resourceIdentifier": {
+        "ActionDescription": "ManagedActionHistoryItems[].ActionDescription"
+      }
+    },
+    "EnvironmentManagedAction": {
+      "operation": "DescribeEnvironmentManagedActions",
+      "resourceIdentifier": {
+        "ActionId": "ManagedActions[].ActionId"
+      }
+    },
+    "Environment": {
+      "operation": "DescribeEnvironments",
+      "resourceIdentifier": {
+        "EnvironmentId": "Environments[].EnvironmentId"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "EventDate": "Events[].EventDate"
+      }
+    },
+    "InstancesHealth": {
+      "operation": "DescribeInstancesHealth",
+      "resourceIdentifier": {
+        "InstanceType": "InstanceHealthList[].InstanceType"
+      }
+    },
+    "PlatformVersion": {
+      "operation": "ListPlatformVersions",
+      "resourceIdentifier": {
+        "PlatformArn": "PlatformSummaryList[].PlatformArn"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "ResourceTags[].Value"
+      },
+      "inputParameters": [
+        "ResourceArn"
+      ]
+    }
+  },
+  "operations": {
+    "AbortEnvironmentUpdate": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "ApplyEnvironmentManagedAction": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      },
+      "ActionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EnvironmentManagedAction",
+            "resourceIdentifier": "ActionId"
+          }
+        ]
+      }
+    },
+    "CreateConfigurationTemplate": {
+      "PlatformArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformVersion",
+            "resourceIdentifier": "PlatformArn"
+          }
+        ]
+      },
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "CreateEnvironment": {
+      "PlatformArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformVersion",
+            "resourceIdentifier": "PlatformArn"
+          }
+        ]
+      }
+    },
+    "DeletePlatformVersion": {
+      "PlatformArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformVersion",
+            "resourceIdentifier": "PlatformArn"
+          }
+        ]
+      }
+    },
+    "RebuildEnvironment": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "RequestEnvironmentInfo": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "RestartAppServer": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "RetrieveEnvironmentInfo": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "TerminateEnvironment": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      }
+    },
+    "UpdateEnvironment": {
+      "EnvironmentId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Environment",
+            "resourceIdentifier": "EnvironmentId"
+          }
+        ]
+      },
+      "PlatformArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformVersion",
+            "resourceIdentifier": "PlatformArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/elastictranscoder/2012-09-25/completions-1.json
+++ b/awscli/data/elastictranscoder/2012-09-25/completions-1.json
@@ -1,0 +1,81 @@
+{
+  "version": "1.0",
+  "resources": {
+    "JobsByPipeline": {
+      "operation": "ListJobsByPipeline",
+      "resourceIdentifier": {
+        "PipelineId": "Jobs[].PipelineId"
+      },
+      "inputParameters": [
+        "PipelineId"
+      ]
+    },
+    "JobsByStatu": {
+      "operation": "ListJobsByStatus",
+      "resourceIdentifier": {
+        "Status": "Jobs[].Status"
+      },
+      "inputParameters": [
+        "Status"
+      ]
+    },
+    "Pipeline": {
+      "operation": "ListPipelines",
+      "resourceIdentifier": {
+        "Notifications": "Pipelines[].Notifications"
+      }
+    },
+    "Preset": {
+      "operation": "ListPresets",
+      "resourceIdentifier": {
+        "Description": "Presets[].Description"
+      }
+    }
+  },
+  "operations": {
+    "CreatePipeline": {
+      "Notifications": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "Notifications"
+          }
+        ]
+      }
+    },
+    "CreatePreset": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Preset",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "UpdatePipeline": {
+      "Notifications": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "Notifications"
+          }
+        ]
+      }
+    },
+    "UpdatePipelineNotifications": {
+      "Notifications": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "Notifications"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/elb/2012-06-01/completions-1.json
+++ b/awscli/data/elb/2012-06-01/completions-1.json
@@ -1,0 +1,354 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountLimit": {
+      "operation": "DescribeAccountLimits",
+      "resourceIdentifier": {
+        "Name": "Limits[].Name"
+      }
+    },
+    "InstanceHealth": {
+      "operation": "DescribeInstanceHealth",
+      "resourceIdentifier": {
+        "InstanceId": "InstanceStates[].InstanceId"
+      },
+      "inputParameters": [
+        "LoadBalancerName"
+      ]
+    },
+    "LoadBalancerPolicy": {
+      "operation": "DescribeLoadBalancerPolicies",
+      "resourceIdentifier": {
+        "PolicyName": "PolicyDescriptions[].PolicyName"
+      }
+    },
+    "LoadBalancerPolicyType": {
+      "operation": "DescribeLoadBalancerPolicyTypes",
+      "resourceIdentifier": {
+        "PolicyTypeName": "PolicyTypeDescriptions[].PolicyTypeName"
+      }
+    },
+    "LoadBalancer": {
+      "operation": "DescribeLoadBalancers",
+      "resourceIdentifier": {
+        "LoadBalancerName": "LoadBalancerDescriptions[].LoadBalancerName"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Tags": "TagDescriptions[].Tags"
+      },
+      "inputParameters": [
+        "LoadBalancerNames"
+      ]
+    }
+  },
+  "operations": {
+    "AddTags": {
+      "LoadBalancerNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerNames"
+          }
+        ]
+      }
+    },
+    "ApplySecurityGroupsToLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "AttachLoadBalancerToSubnets": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "ConfigureHealthCheck": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "CreateAppCookieStickinessPolicy": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "CreateLBCookieStickinessPolicy": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "CreateLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "CreateLoadBalancerListeners": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "CreateLoadBalancerPolicy": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      },
+      "PolicyTypeName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicyType",
+            "resourceIdentifier": "PolicyTypeName"
+          }
+        ]
+      }
+    },
+    "DeleteLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "DeleteLoadBalancerListeners": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "DeleteLoadBalancerPolicy": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      },
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "DeregisterInstancesFromLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "DetachLoadBalancerFromSubnets": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "DisableAvailabilityZonesForLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "EnableAvailabilityZonesForLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "ModifyLoadBalancerAttributes": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "RegisterInstancesWithLoadBalancer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "RemoveTags": {
+      "LoadBalancerNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerNames"
+          }
+        ]
+      }
+    },
+    "SetLoadBalancerListenerSSLCertificate": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      }
+    },
+    "SetLoadBalancerPoliciesForBackendServer": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      },
+      "PolicyNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicy",
+            "resourceIdentifier": "PolicyNames"
+          }
+        ]
+      }
+    },
+    "SetLoadBalancerPoliciesOfListener": {
+      "LoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerName"
+          }
+        ]
+      },
+      "PolicyNames": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancerPolicy",
+            "resourceIdentifier": "PolicyNames"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/elbv2/2015-12-01/completions-1.json
+++ b/awscli/data/elbv2/2015-12-01/completions-1.json
@@ -1,0 +1,308 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountLimit": {
+      "operation": "DescribeAccountLimits",
+      "resourceIdentifier": {
+        "Name": "Limits[].Name"
+      }
+    },
+    "ListenerCertificate": {
+      "operation": "DescribeListenerCertificates",
+      "resourceIdentifier": {
+        "CertificateArn": "Certificates[].CertificateArn"
+      },
+      "inputParameters": [
+        "ListenerArn"
+      ]
+    },
+    "Listener": {
+      "operation": "DescribeListeners",
+      "resourceIdentifier": {
+        "ListenerArn": "Listeners[].ListenerArn"
+      }
+    },
+    "LoadBalancerAttribute": {
+      "operation": "DescribeLoadBalancerAttributes",
+      "resourceIdentifier": {
+        "Value": "Attributes[].Value"
+      },
+      "inputParameters": [
+        "LoadBalancerArn"
+      ]
+    },
+    "LoadBalancer": {
+      "operation": "DescribeLoadBalancers",
+      "resourceIdentifier": {
+        "LoadBalancerArn": "LoadBalancers[].LoadBalancerArn"
+      }
+    },
+    "Rule": {
+      "operation": "DescribeRules",
+      "resourceIdentifier": {
+        "RuleArn": "Rules[].RuleArn"
+      }
+    },
+    "SSLPolicy": {
+      "operation": "DescribeSSLPolicies",
+      "resourceIdentifier": {
+        "SslProtocols": "SslPolicies[].SslProtocols"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Tags": "TagDescriptions[].Tags"
+      },
+      "inputParameters": [
+        "ResourceArns"
+      ]
+    },
+    "TargetGroupAttribute": {
+      "operation": "DescribeTargetGroupAttributes",
+      "resourceIdentifier": {
+        "Value": "Attributes[].Value"
+      },
+      "inputParameters": [
+        "TargetGroupArn"
+      ]
+    },
+    "TargetGroup": {
+      "operation": "DescribeTargetGroups",
+      "resourceIdentifier": {
+        "TargetGroupArn": "TargetGroups[].TargetGroupArn"
+      }
+    },
+    "TargetHealth": {
+      "operation": "DescribeTargetHealth",
+      "resourceIdentifier": {
+        "TargetHealth": "TargetHealthDescriptions[].TargetHealth"
+      },
+      "inputParameters": [
+        "TargetGroupArn"
+      ]
+    }
+  },
+  "operations": {
+    "AddListenerCertificates": {
+      "ListenerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Listener",
+            "resourceIdentifier": "ListenerArn"
+          }
+        ]
+      }
+    },
+    "CreateListener": {
+      "LoadBalancerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerArn"
+          }
+        ]
+      }
+    },
+    "CreateLoadBalancer": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccountLimit",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "CreateRule": {
+      "ListenerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Listener",
+            "resourceIdentifier": "ListenerArn"
+          }
+        ]
+      }
+    },
+    "CreateTargetGroup": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccountLimit",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "DeleteListener": {
+      "ListenerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Listener",
+            "resourceIdentifier": "ListenerArn"
+          }
+        ]
+      }
+    },
+    "DeleteLoadBalancer": {
+      "LoadBalancerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerArn"
+          }
+        ]
+      }
+    },
+    "DeleteRule": {
+      "RuleArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleArn"
+          }
+        ]
+      }
+    },
+    "DeleteTargetGroup": {
+      "TargetGroupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TargetGroup",
+            "resourceIdentifier": "TargetGroupArn"
+          }
+        ]
+      }
+    },
+    "DeregisterTargets": {
+      "TargetGroupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TargetGroup",
+            "resourceIdentifier": "TargetGroupArn"
+          }
+        ]
+      }
+    },
+    "ModifyListener": {
+      "ListenerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Listener",
+            "resourceIdentifier": "ListenerArn"
+          }
+        ]
+      }
+    },
+    "ModifyLoadBalancerAttributes": {
+      "LoadBalancerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerArn"
+          }
+        ]
+      }
+    },
+    "ModifyRule": {
+      "RuleArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleArn"
+          }
+        ]
+      }
+    },
+    "ModifyTargetGroup": {
+      "TargetGroupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TargetGroup",
+            "resourceIdentifier": "TargetGroupArn"
+          }
+        ]
+      }
+    },
+    "ModifyTargetGroupAttributes": {
+      "TargetGroupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TargetGroup",
+            "resourceIdentifier": "TargetGroupArn"
+          }
+        ]
+      }
+    },
+    "RegisterTargets": {
+      "TargetGroupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TargetGroup",
+            "resourceIdentifier": "TargetGroupArn"
+          }
+        ]
+      }
+    },
+    "RemoveListenerCertificates": {
+      "ListenerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Listener",
+            "resourceIdentifier": "ListenerArn"
+          }
+        ]
+      }
+    },
+    "SetIpAddressType": {
+      "LoadBalancerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerArn"
+          }
+        ]
+      }
+    },
+    "SetSecurityGroups": {
+      "LoadBalancerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerArn"
+          }
+        ]
+      }
+    },
+    "SetSubnets": {
+      "LoadBalancerArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LoadBalancer",
+            "resourceIdentifier": "LoadBalancerArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/emr/2009-03-31/completions-1.json
+++ b/awscli/data/emr/2009-03-31/completions-1.json
@@ -1,0 +1,125 @@
+{
+  "version": "1.0",
+  "resources": {
+    "JobFlow": {
+      "operation": "DescribeJobFlows",
+      "resourceIdentifier": {
+        "JobFlowId": "JobFlows[].JobFlowId"
+      }
+    },
+    "BootstrapAction": {
+      "operation": "ListBootstrapActions",
+      "resourceIdentifier": {
+        "ScriptPath": "BootstrapActions[].ScriptPath"
+      },
+      "inputParameters": [
+        "ClusterId"
+      ]
+    },
+    "Cluster": {
+      "operation": "ListClusters",
+      "resourceIdentifier": {
+        "NormalizedInstanceHours": "Clusters[].NormalizedInstanceHours"
+      }
+    },
+    "InstanceFleet": {
+      "operation": "ListInstanceFleets",
+      "resourceIdentifier": {
+        "InstanceFleetType": "InstanceFleets[].InstanceFleetType"
+      },
+      "inputParameters": [
+        "ClusterId"
+      ]
+    },
+    "InstanceGroup": {
+      "operation": "ListInstanceGroups",
+      "resourceIdentifier": {
+        "InstanceGroupType": "InstanceGroups[].InstanceGroupType"
+      },
+      "inputParameters": [
+        "ClusterId"
+      ]
+    },
+    "Instance": {
+      "operation": "ListInstances",
+      "resourceIdentifier": {
+        "InstanceType": "Instances[].InstanceType"
+      },
+      "inputParameters": [
+        "ClusterId"
+      ]
+    },
+    "SecurityConfiguration": {
+      "operation": "ListSecurityConfigurations",
+      "resourceIdentifier": {
+        "CreationDateTime": "SecurityConfigurations[].CreationDateTime"
+      }
+    },
+    "Step": {
+      "operation": "ListSteps",
+      "resourceIdentifier": {
+        "Status": "Steps[].Status"
+      },
+      "inputParameters": [
+        "ClusterId"
+      ]
+    }
+  },
+  "operations": {
+    "AddInstanceGroups": {
+      "JobFlowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "JobFlow",
+            "resourceIdentifier": "JobFlowId"
+          }
+        ]
+      }
+    },
+    "AddJobFlowSteps": {
+      "JobFlowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "JobFlow",
+            "resourceIdentifier": "JobFlowId"
+          }
+        ]
+      }
+    },
+    "SetTerminationProtection": {
+      "JobFlowIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "JobFlow",
+            "resourceIdentifier": "JobFlowIds"
+          }
+        ]
+      }
+    },
+    "SetVisibleToAllUsers": {
+      "JobFlowIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "JobFlow",
+            "resourceIdentifier": "JobFlowIds"
+          }
+        ]
+      }
+    },
+    "TerminateJobFlows": {
+      "JobFlowIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "JobFlow",
+            "resourceIdentifier": "JobFlowIds"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/es/2015-01-01/completions-1.json
+++ b/awscli/data/es/2015-01-01/completions-1.json
@@ -1,0 +1,155 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ElasticsearchDomain": {
+      "operation": "DescribeElasticsearchDomains",
+      "resourceIdentifier": {
+        "ElasticsearchVersion": "DomainStatusList[].ElasticsearchVersion"
+      },
+      "inputParameters": [
+        "DomainNames"
+      ]
+    },
+    "ReservedElasticsearchInstanceOffering": {
+      "operation": "DescribeReservedElasticsearchInstanceOfferings",
+      "resourceIdentifier": {
+        "ReservedElasticsearchInstanceOfferingId": "ReservedElasticsearchInstanceOfferings[].ReservedElasticsearchInstanceOfferingId"
+      }
+    },
+    "ReservedElasticsearchInstance": {
+      "operation": "DescribeReservedElasticsearchInstances",
+      "resourceIdentifier": {
+        "ReservedElasticsearchInstanceId": "ReservedElasticsearchInstances[].ReservedElasticsearchInstanceId"
+      }
+    },
+    "DomainName": {
+      "operation": "ListDomainNames",
+      "resourceIdentifier": {
+        "DomainName": "DomainNames[].DomainName"
+      }
+    },
+    "ElasticsearchInstanceType": {
+      "operation": "ListElasticsearchInstanceTypes",
+      "resourceIdentifier": {
+        "ElasticsearchInstanceTypes": "ElasticsearchInstanceTypes[]"
+      },
+      "inputParameters": [
+        "ElasticsearchVersion"
+      ]
+    },
+    "ElasticsearchVersion": {
+      "operation": "ListElasticsearchVersions",
+      "resourceIdentifier": {
+        "ElasticsearchVersions": "ElasticsearchVersions[]"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ARN"
+      ]
+    }
+  },
+  "operations": {
+    "CreateElasticsearchDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      },
+      "ElasticsearchVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ElasticsearchVersion",
+            "resourceIdentifier": "ElasticsearchVersion"
+          }
+        ]
+      }
+    },
+    "DeleteElasticsearchDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetCompatibleElasticsearchVersions": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetUpgradeHistory": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetUpgradeStatus": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "PurchaseReservedElasticsearchInstanceOffering": {
+      "ReservedElasticsearchInstanceOfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedElasticsearchInstanceOffering",
+            "resourceIdentifier": "ReservedElasticsearchInstanceOfferingId"
+          }
+        ]
+      }
+    },
+    "UpdateElasticsearchDomainConfig": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "UpgradeElasticsearchDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DomainName",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/events/2015-10-07/completions-1.json
+++ b/awscli/data/events/2015-10-07/completions-1.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "resources": {
+    "RuleNamesByTarget": {
+      "operation": "ListRuleNamesByTarget",
+      "resourceIdentifier": {
+        "RuleNames": "RuleNames[]"
+      },
+      "inputParameters": [
+        "TargetArn"
+      ]
+    },
+    "Rule": {
+      "operation": "ListRules",
+      "resourceIdentifier": {
+        "RoleArn": "Rules[].RoleArn"
+      }
+    },
+    "TargetsByRule": {
+      "operation": "ListTargetsByRule",
+      "resourceIdentifier": {
+        "EcsParameters": "Targets[].EcsParameters"
+      },
+      "inputParameters": [
+        "Rule"
+      ]
+    }
+  },
+  "operations": {
+    "PutRule": {
+      "RoleArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RoleArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/firehose/2015-08-04/completions-1.json
+++ b/awscli/data/firehose/2015-08-04/completions-1.json
@@ -1,0 +1,99 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DeliveryStream": {
+      "operation": "ListDeliveryStreams",
+      "resourceIdentifier": {
+        "DeliveryStreamNames": "DeliveryStreamNames[]"
+      }
+    },
+    "TagsForDeliveryStream": {
+      "operation": "ListTagsForDeliveryStream",
+      "resourceIdentifier": {
+        "Key": "Tags[].Key"
+      },
+      "inputParameters": [
+        "DeliveryStreamName"
+      ]
+    }
+  },
+  "operations": {
+    "CreateDeliveryStream": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    },
+    "DeleteDeliveryStream": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    },
+    "PutRecord": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    },
+    "PutRecordBatch": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    },
+    "TagDeliveryStream": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    },
+    "UntagDeliveryStream": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    },
+    "UpdateDestination": {
+      "DeliveryStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DeliveryStream",
+            "resourceIdentifier": "DeliveryStreamName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/fms/2018-01-01/completions-1.json
+++ b/awscli/data/fms/2018-01-01/completions-1.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ComplianceStatu": {
+      "operation": "ListComplianceStatus",
+      "resourceIdentifier": {
+        "PolicyName": "PolicyComplianceStatusList[].PolicyName"
+      },
+      "inputParameters": [
+        "PolicyId"
+      ]
+    },
+    "MemberAccount": {
+      "operation": "ListMemberAccounts",
+      "resourceIdentifier": {
+        "MemberAccounts": "MemberAccounts[]"
+      }
+    },
+    "Policy": {
+      "operation": "ListPolicies",
+      "resourceIdentifier": {
+        "PolicyName": "PolicyList[].PolicyName"
+      }
+    }
+  },
+  "operations": {
+    "GetComplianceDetail": {
+      "MemberAccount": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MemberAccount",
+            "resourceIdentifier": "MemberAccount"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/gamelift/2015-10-01/completions-1.json
+++ b/awscli/data/gamelift/2015-10-01/completions-1.json
@@ -1,0 +1,511 @@
+{
+  "version": "1.0",
+  "resources": {
+    "EC2InstanceLimit": {
+      "operation": "DescribeEC2InstanceLimits",
+      "resourceIdentifier": {
+        "InstanceLimit": "EC2InstanceLimits[].InstanceLimit"
+      }
+    },
+    "FleetAttribute": {
+      "operation": "DescribeFleetAttributes",
+      "resourceIdentifier": {
+        "FleetArn": "FleetAttributes[].FleetArn"
+      }
+    },
+    "FleetCapacity": {
+      "operation": "DescribeFleetCapacity",
+      "resourceIdentifier": {
+        "FleetId": "FleetCapacity[].FleetId"
+      }
+    },
+    "FleetEvent": {
+      "operation": "DescribeFleetEvents",
+      "resourceIdentifier": {
+        "EventId": "Events[].EventId"
+      },
+      "inputParameters": [
+        "FleetId"
+      ]
+    },
+    "FleetPortSetting": {
+      "operation": "DescribeFleetPortSettings",
+      "resourceIdentifier": {
+        "FromPort": "InboundPermissions[].FromPort"
+      },
+      "inputParameters": [
+        "FleetId"
+      ]
+    },
+    "FleetUtilization": {
+      "operation": "DescribeFleetUtilization",
+      "resourceIdentifier": {
+        "FleetId": "FleetUtilization[].FleetId"
+      }
+    },
+    "GameSessionDetail": {
+      "operation": "DescribeGameSessionDetails",
+      "resourceIdentifier": {
+        "GameSession": "GameSessionDetails[].GameSession"
+      }
+    },
+    "GameSessionQueue": {
+      "operation": "DescribeGameSessionQueues",
+      "resourceIdentifier": {
+        "GameSessionQueueArn": "GameSessionQueues[].GameSessionQueueArn"
+      }
+    },
+    "GameSession": {
+      "operation": "DescribeGameSessions",
+      "resourceIdentifier": {
+        "GameSessionId": "GameSessions[].GameSessionId"
+      }
+    },
+    "Instance": {
+      "operation": "DescribeInstances",
+      "resourceIdentifier": {
+        "InstanceId": "Instances[].InstanceId"
+      },
+      "inputParameters": [
+        "FleetId"
+      ]
+    },
+    "Matchmaking": {
+      "operation": "DescribeMatchmaking",
+      "resourceIdentifier": {
+        "StatusReason": "TicketList[].StatusReason"
+      },
+      "inputParameters": [
+        "TicketIds"
+      ]
+    },
+    "MatchmakingConfiguration": {
+      "operation": "DescribeMatchmakingConfigurations",
+      "resourceIdentifier": {
+        "NotificationTarget": "Configurations[].NotificationTarget"
+      }
+    },
+    "MatchmakingRuleSet": {
+      "operation": "DescribeMatchmakingRuleSets",
+      "resourceIdentifier": {
+        "RuleSetName": "RuleSets[].RuleSetName"
+      }
+    },
+    "PlayerSession": {
+      "operation": "DescribePlayerSessions",
+      "resourceIdentifier": {
+        "PlayerSessionId": "PlayerSessions[].PlayerSessionId"
+      }
+    },
+    "ScalingPolicy": {
+      "operation": "DescribeScalingPolicies",
+      "resourceIdentifier": {
+        "ScalingAdjustment": "ScalingPolicies[].ScalingAdjustment"
+      },
+      "inputParameters": [
+        "FleetId"
+      ]
+    },
+    "VpcPeeringAuthorization": {
+      "operation": "DescribeVpcPeeringAuthorizations",
+      "resourceIdentifier": {
+        "ExpirationTime": "VpcPeeringAuthorizations[].ExpirationTime"
+      }
+    },
+    "VpcPeeringConnection": {
+      "operation": "DescribeVpcPeeringConnections",
+      "resourceIdentifier": {
+        "VpcPeeringConnectionId": "VpcPeeringConnections[].VpcPeeringConnectionId"
+      }
+    },
+    "Aliase": {
+      "operation": "ListAliases",
+      "resourceIdentifier": {
+        "AliasId": "Aliases[].AliasId"
+      }
+    },
+    "Build": {
+      "operation": "ListBuilds",
+      "resourceIdentifier": {
+        "BuildId": "Builds[].BuildId"
+      }
+    },
+    "Fleet": {
+      "operation": "ListFleets",
+      "resourceIdentifier": {
+        "FleetIds": "FleetIds[]"
+      }
+    }
+  },
+  "operations": {
+    "CreateFleet": {
+      "BuildId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Build",
+            "resourceIdentifier": "BuildId"
+          }
+        ]
+      }
+    },
+    "CreateGameSession": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      },
+      "AliasId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasId"
+          }
+        ]
+      },
+      "GameSessionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSession",
+            "resourceIdentifier": "GameSessionId"
+          }
+        ]
+      }
+    },
+    "CreateMatchmakingConfiguration": {
+      "GameSessionQueueArns": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSessionQueue",
+            "resourceIdentifier": "GameSessionQueueArns"
+          }
+        ]
+      },
+      "RuleSetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MatchmakingRuleSet",
+            "resourceIdentifier": "RuleSetName"
+          }
+        ]
+      },
+      "NotificationTarget": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MatchmakingConfiguration",
+            "resourceIdentifier": "NotificationTarget"
+          }
+        ]
+      }
+    },
+    "CreatePlayerSession": {
+      "GameSessionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSession",
+            "resourceIdentifier": "GameSessionId"
+          }
+        ]
+      }
+    },
+    "CreatePlayerSessions": {
+      "GameSessionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSession",
+            "resourceIdentifier": "GameSessionId"
+          }
+        ]
+      }
+    },
+    "CreateVpcPeeringConnection": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "DeleteAlias": {
+      "AliasId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasId"
+          }
+        ]
+      }
+    },
+    "DeleteBuild": {
+      "BuildId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Build",
+            "resourceIdentifier": "BuildId"
+          }
+        ]
+      }
+    },
+    "DeleteFleet": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "DeleteScalingPolicy": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "DeleteVpcPeeringConnection": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      },
+      "VpcPeeringConnectionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VpcPeeringConnection",
+            "resourceIdentifier": "VpcPeeringConnectionId"
+          }
+        ]
+      }
+    },
+    "GetGameSessionLogUrl": {
+      "GameSessionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSession",
+            "resourceIdentifier": "GameSessionId"
+          }
+        ]
+      }
+    },
+    "GetInstanceAccess": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "PutScalingPolicy": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "RequestUploadCredentials": {
+      "BuildId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Build",
+            "resourceIdentifier": "BuildId"
+          }
+        ]
+      }
+    },
+    "ResolveAlias": {
+      "AliasId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasId"
+          }
+        ]
+      }
+    },
+    "SearchGameSessions": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      },
+      "AliasId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasId"
+          }
+        ]
+      }
+    },
+    "StartFleetActions": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "StopFleetActions": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "UpdateAlias": {
+      "AliasId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasId"
+          }
+        ]
+      }
+    },
+    "UpdateBuild": {
+      "BuildId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Build",
+            "resourceIdentifier": "BuildId"
+          }
+        ]
+      }
+    },
+    "UpdateFleetAttributes": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "UpdateFleetCapacity": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "UpdateFleetPortSettings": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    },
+    "UpdateGameSession": {
+      "GameSessionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSession",
+            "resourceIdentifier": "GameSessionId"
+          }
+        ]
+      }
+    },
+    "UpdateMatchmakingConfiguration": {
+      "GameSessionQueueArns": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GameSessionQueue",
+            "resourceIdentifier": "GameSessionQueueArns"
+          }
+        ]
+      },
+      "RuleSetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MatchmakingRuleSet",
+            "resourceIdentifier": "RuleSetName"
+          }
+        ]
+      },
+      "NotificationTarget": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MatchmakingConfiguration",
+            "resourceIdentifier": "NotificationTarget"
+          }
+        ]
+      }
+    },
+    "UpdateRuntimeConfiguration": {
+      "FleetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "FleetUtilization",
+            "resourceIdentifier": "FleetId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/glacier/2012-06-01/completions-1.json
+++ b/awscli/data/glacier/2012-06-01/completions-1.json
@@ -1,0 +1,55 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "JobId": "JobList[].JobId"
+      },
+      "inputParameters": [
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "MultipartUpload": {
+      "operation": "ListMultipartUploads",
+      "resourceIdentifier": {
+        "MultipartUploadId": "UploadsList[].MultipartUploadId"
+      },
+      "inputParameters": [
+        "accountId",
+        "vaultName"
+      ]
+    },
+    "Part": {
+      "operation": "ListParts",
+      "resourceIdentifier": {
+        "RangeInBytes": "Parts[].RangeInBytes"
+      },
+      "inputParameters": [
+        "accountId",
+        "vaultName",
+        "uploadId"
+      ]
+    },
+    "ProvisionedCapacity": {
+      "operation": "ListProvisionedCapacity",
+      "resourceIdentifier": {
+        "CapacityId": "ProvisionedCapacityList[].CapacityId"
+      },
+      "inputParameters": [
+        "accountId"
+      ]
+    },
+    "Vault": {
+      "operation": "ListVaults",
+      "resourceIdentifier": {
+        "VaultARN": "VaultList[].VaultARN"
+      },
+      "inputParameters": [
+        "accountId"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/glue/2017-03-31/completions-1.json
+++ b/awscli/data/glue/2017-03-31/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/greengrass/2017-06-07/completions-1.json
+++ b/awscli/data/greengrass/2017-06-07/completions-1.json
@@ -1,0 +1,129 @@
+{
+  "version": "1.0",
+  "resources": {
+    "CoreDefinitionVersion": {
+      "operation": "ListCoreDefinitionVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "CoreDefinitionId"
+      ]
+    },
+    "CoreDefinition": {
+      "operation": "ListCoreDefinitions",
+      "resourceIdentifier": {
+        "CreationTimestamp": "Definitions[].CreationTimestamp"
+      }
+    },
+    "Deployment": {
+      "operation": "ListDeployments",
+      "resourceIdentifier": {
+        "DeploymentId": "Deployments[].DeploymentId"
+      },
+      "inputParameters": [
+        "GroupId"
+      ]
+    },
+    "DeviceDefinitionVersion": {
+      "operation": "ListDeviceDefinitionVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "DeviceDefinitionId"
+      ]
+    },
+    "DeviceDefinition": {
+      "operation": "ListDeviceDefinitions",
+      "resourceIdentifier": {
+        "CreationTimestamp": "Definitions[].CreationTimestamp"
+      }
+    },
+    "FunctionDefinitionVersion": {
+      "operation": "ListFunctionDefinitionVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "FunctionDefinitionId"
+      ]
+    },
+    "FunctionDefinition": {
+      "operation": "ListFunctionDefinitions",
+      "resourceIdentifier": {
+        "CreationTimestamp": "Definitions[].CreationTimestamp"
+      }
+    },
+    "GroupCertificateAuthority": {
+      "operation": "ListGroupCertificateAuthorities",
+      "resourceIdentifier": {
+        "GroupCertificateAuthorityId": "GroupCertificateAuthorities[].GroupCertificateAuthorityId"
+      },
+      "inputParameters": [
+        "GroupId"
+      ]
+    },
+    "GroupVersion": {
+      "operation": "ListGroupVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "GroupId"
+      ]
+    },
+    "Group": {
+      "operation": "ListGroups",
+      "resourceIdentifier": {
+        "CreationTimestamp": "Groups[].CreationTimestamp"
+      }
+    },
+    "LoggerDefinitionVersion": {
+      "operation": "ListLoggerDefinitionVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "LoggerDefinitionId"
+      ]
+    },
+    "LoggerDefinition": {
+      "operation": "ListLoggerDefinitions",
+      "resourceIdentifier": {
+        "LatestVersion": "Definitions[].LatestVersion"
+      }
+    },
+    "ResourceDefinitionVersion": {
+      "operation": "ListResourceDefinitionVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "ResourceDefinitionId"
+      ]
+    },
+    "ResourceDefinition": {
+      "operation": "ListResourceDefinitions",
+      "resourceIdentifier": {
+        "LatestVersion": "Definitions[].LatestVersion"
+      }
+    },
+    "SubscriptionDefinitionVersion": {
+      "operation": "ListSubscriptionDefinitionVersions",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "SubscriptionDefinitionId"
+      ]
+    },
+    "SubscriptionDefinition": {
+      "operation": "ListSubscriptionDefinitions",
+      "resourceIdentifier": {
+        "CreationTimestamp": "Definitions[].CreationTimestamp"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/guardduty/2017-11-28/completions-1.json
+++ b/awscli/data/guardduty/2017-11-28/completions-1.json
@@ -1,0 +1,414 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Detector": {
+      "operation": "ListDetectors",
+      "resourceIdentifier": {
+        "DetectorIds": "DetectorIds[]"
+      }
+    },
+    "Filter": {
+      "operation": "ListFilters",
+      "resourceIdentifier": {
+        "FilterNames": "FilterNames[]"
+      },
+      "inputParameters": [
+        "DetectorId"
+      ]
+    },
+    "Finding": {
+      "operation": "ListFindings",
+      "resourceIdentifier": {
+        "FindingIds": "FindingIds[]"
+      },
+      "inputParameters": [
+        "DetectorId"
+      ]
+    },
+    "IPSet": {
+      "operation": "ListIPSets",
+      "resourceIdentifier": {
+        "IpSetIds": "IpSetIds[]"
+      },
+      "inputParameters": [
+        "DetectorId"
+      ]
+    },
+    "Invitation": {
+      "operation": "ListInvitations",
+      "resourceIdentifier": {
+        "InvitationId": "Invitations[].InvitationId"
+      }
+    },
+    "Member": {
+      "operation": "ListMembers",
+      "resourceIdentifier": {
+        "MasterId": "Members[].MasterId"
+      },
+      "inputParameters": [
+        "DetectorId"
+      ]
+    },
+    "ThreatIntelSet": {
+      "operation": "ListThreatIntelSets",
+      "resourceIdentifier": {
+        "ThreatIntelSetIds": "ThreatIntelSetIds[]"
+      },
+      "inputParameters": [
+        "DetectorId"
+      ]
+    }
+  },
+  "operations": {
+    "AcceptInvitation": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      },
+      "InvitationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Invitation",
+            "resourceIdentifier": "InvitationId"
+          }
+        ]
+      }
+    },
+    "ArchiveFindings": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "CreateFilter": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "CreateIPSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "CreateMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "CreateSampleFindings": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "CreateThreatIntelSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DeleteDetector": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DeleteFilter": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DeleteIPSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DeleteMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DeleteThreatIntelSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DisassociateFromMasterAccount": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "DisassociateMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetDetector": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetFilter": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetFindings": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetFindingsStatistics": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetIPSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetMasterAccount": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "GetThreatIntelSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "InviteMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "StartMonitoringMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "StopMonitoringMembers": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "UnarchiveFindings": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "UpdateDetector": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "UpdateFilter": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "UpdateFindingsFeedback": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "UpdateIPSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    },
+    "UpdateThreatIntelSet": {
+      "DetectorId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Detector",
+            "resourceIdentifier": "DetectorId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/health/2016-08-04/completions-1.json
+++ b/awscli/data/health/2016-08-04/completions-1.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AffectedEntity": {
+      "operation": "DescribeAffectedEntities",
+      "resourceIdentifier": {
+        "entityValue": "entities[].entityValue"
+      },
+      "inputParameters": [
+        "filter"
+      ]
+    },
+    "EntityAggregate": {
+      "operation": "DescribeEntityAggregates",
+      "resourceIdentifier": {
+        "eventArn": "entityAggregates[].eventArn"
+      }
+    },
+    "EventAggregate": {
+      "operation": "DescribeEventAggregates",
+      "resourceIdentifier": {
+        "aggregateValue": "eventAggregates[].aggregateValue"
+      },
+      "inputParameters": [
+        "aggregateField"
+      ]
+    },
+    "EventType": {
+      "operation": "DescribeEventTypes",
+      "resourceIdentifier": {
+        "service": "eventTypes[].service"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "eventTypeCode": "events[].eventTypeCode"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/iam/2010-05-08/completions-1.json
+++ b/awscli/data/iam/2010-05-08/completions-1.json
@@ -1,0 +1,475 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccessKey": {
+      "operation": "ListAccessKeys",
+      "resourceIdentifier": {
+        "AccessKeyId": "AccessKeyMetadata[].AccessKeyId"
+      }
+    },
+    "AccountAliase": {
+      "operation": "ListAccountAliases",
+      "resourceIdentifier": {
+        "AccountAliases": "AccountAliases[]"
+      }
+    },
+    "AttachedGroupPolicy": {
+      "operation": "ListAttachedGroupPolicies",
+      "resourceIdentifier": {
+        "PolicyName": "AttachedPolicies[].PolicyName"
+      },
+      "inputParameters": [
+        "GroupName"
+      ]
+    },
+    "AttachedRolePolicy": {
+      "operation": "ListAttachedRolePolicies",
+      "resourceIdentifier": {
+        "PolicyName": "AttachedPolicies[].PolicyName"
+      },
+      "inputParameters": [
+        "RoleName"
+      ]
+    },
+    "AttachedUserPolicy": {
+      "operation": "ListAttachedUserPolicies",
+      "resourceIdentifier": {
+        "PolicyName": "AttachedPolicies[].PolicyName"
+      },
+      "inputParameters": [
+        "UserName"
+      ]
+    },
+    "GroupPolicy": {
+      "operation": "ListGroupPolicies",
+      "resourceIdentifier": {
+        "PolicyNames": "PolicyNames[]"
+      },
+      "inputParameters": [
+        "GroupName"
+      ]
+    },
+    "Group": {
+      "operation": "ListGroups",
+      "resourceIdentifier": {
+        "GroupId": "Groups[].GroupId"
+      }
+    },
+    "GroupsForUser": {
+      "operation": "ListGroupsForUser",
+      "resourceIdentifier": {
+        "GroupName": "Groups[].GroupName"
+      },
+      "inputParameters": [
+        "UserName"
+      ]
+    },
+    "InstanceProfile": {
+      "operation": "ListInstanceProfiles",
+      "resourceIdentifier": {
+        "InstanceProfileId": "InstanceProfiles[].InstanceProfileId"
+      }
+    },
+    "InstanceProfilesForRole": {
+      "operation": "ListInstanceProfilesForRole",
+      "resourceIdentifier": {
+        "InstanceProfileName": "InstanceProfiles[].InstanceProfileName"
+      },
+      "inputParameters": [
+        "RoleName"
+      ]
+    },
+    "MFADevice": {
+      "operation": "ListMFADevices",
+      "resourceIdentifier": {
+        "SerialNumber": "MFADevices[].SerialNumber"
+      }
+    },
+    "OpenIDConnectProvider": {
+      "operation": "ListOpenIDConnectProviders",
+      "resourceIdentifier": {
+        "Arn": "OpenIDConnectProviderList[].Arn"
+      }
+    },
+    "Policy": {
+      "operation": "ListPolicies",
+      "resourceIdentifier": {
+        "PolicyName": "Policies[].PolicyName"
+      }
+    },
+    "PolicyVersion": {
+      "operation": "ListPolicyVersions",
+      "resourceIdentifier": {
+        "VersionId": "Versions[].VersionId"
+      },
+      "inputParameters": [
+        "PolicyArn"
+      ]
+    },
+    "RolePolicy": {
+      "operation": "ListRolePolicies",
+      "resourceIdentifier": {
+        "PolicyNames": "PolicyNames[]"
+      },
+      "inputParameters": [
+        "RoleName"
+      ]
+    },
+    "Role": {
+      "operation": "ListRoles",
+      "resourceIdentifier": {
+        "RoleId": "Roles[].RoleId"
+      }
+    },
+    "SAMLProvider": {
+      "operation": "ListSAMLProviders",
+      "resourceIdentifier": {
+        "Arn": "SAMLProviderList[].Arn"
+      }
+    },
+    "SSHPublicKey": {
+      "operation": "ListSSHPublicKeys",
+      "resourceIdentifier": {
+        "SSHPublicKeyId": "SSHPublicKeys[].SSHPublicKeyId"
+      }
+    },
+    "ServerCertificate": {
+      "operation": "ListServerCertificates",
+      "resourceIdentifier": {
+        "ServerCertificateId": "ServerCertificateMetadataList[].ServerCertificateId"
+      }
+    },
+    "ServiceSpecificCredential": {
+      "operation": "ListServiceSpecificCredentials",
+      "resourceIdentifier": {
+        "ServiceSpecificCredentialId": "ServiceSpecificCredentials[].ServiceSpecificCredentialId"
+      }
+    },
+    "SigningCertificate": {
+      "operation": "ListSigningCertificates",
+      "resourceIdentifier": {
+        "CertificateId": "Certificates[].CertificateId"
+      }
+    },
+    "UserPolicy": {
+      "operation": "ListUserPolicies",
+      "resourceIdentifier": {
+        "PolicyNames": "PolicyNames[]"
+      },
+      "inputParameters": [
+        "UserName"
+      ]
+    },
+    "User": {
+      "operation": "ListUsers",
+      "resourceIdentifier": {
+        "UserId": "Users[].UserId"
+      }
+    },
+    "VirtualMFADevice": {
+      "operation": "ListVirtualMFADevices",
+      "resourceIdentifier": {
+        "SerialNumber": "VirtualMFADevices[].SerialNumber"
+      }
+    }
+  },
+  "operations": {
+    "CreateAccountAlias": {
+      "AccountAlias": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccountAliase",
+            "resourceIdentifier": "AccountAlias"
+          }
+        ]
+      }
+    },
+    "CreatePolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "DeactivateMFADevice": {
+      "SerialNumber": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualMFADevice",
+            "resourceIdentifier": "SerialNumber"
+          }
+        ]
+      }
+    },
+    "DeleteAccessKey": {
+      "AccessKeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccessKey",
+            "resourceIdentifier": "AccessKeyId"
+          }
+        ]
+      }
+    },
+    "DeleteAccountAlias": {
+      "AccountAlias": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccountAliase",
+            "resourceIdentifier": "AccountAlias"
+          }
+        ]
+      }
+    },
+    "DeleteGroupPolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "DeleteRolePolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "DeleteSSHPublicKey": {
+      "SSHPublicKeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SSHPublicKey",
+            "resourceIdentifier": "SSHPublicKeyId"
+          }
+        ]
+      }
+    },
+    "DeleteServiceSpecificCredential": {
+      "ServiceSpecificCredentialId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ServiceSpecificCredential",
+            "resourceIdentifier": "ServiceSpecificCredentialId"
+          }
+        ]
+      }
+    },
+    "DeleteSigningCertificate": {
+      "CertificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SigningCertificate",
+            "resourceIdentifier": "CertificateId"
+          }
+        ]
+      }
+    },
+    "DeleteUserPolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "DeleteVirtualMFADevice": {
+      "SerialNumber": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualMFADevice",
+            "resourceIdentifier": "SerialNumber"
+          }
+        ]
+      }
+    },
+    "EnableMFADevice": {
+      "SerialNumber": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualMFADevice",
+            "resourceIdentifier": "SerialNumber"
+          }
+        ]
+      }
+    },
+    "GetAccessKeyLastUsed": {
+      "AccessKeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccessKey",
+            "resourceIdentifier": "AccessKeyId"
+          }
+        ]
+      }
+    },
+    "GetGroupPolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "GetRolePolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "GetSSHPublicKey": {
+      "SSHPublicKeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SSHPublicKey",
+            "resourceIdentifier": "SSHPublicKeyId"
+          }
+        ]
+      }
+    },
+    "GetUserPolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "PutGroupPolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "PutRolePolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "PutUserPolicy": {
+      "PolicyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "PolicyName"
+          }
+        ]
+      }
+    },
+    "ResetServiceSpecificCredential": {
+      "ServiceSpecificCredentialId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ServiceSpecificCredential",
+            "resourceIdentifier": "ServiceSpecificCredentialId"
+          }
+        ]
+      }
+    },
+    "ResyncMFADevice": {
+      "SerialNumber": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "VirtualMFADevice",
+            "resourceIdentifier": "SerialNumber"
+          }
+        ]
+      }
+    },
+    "UpdateAccessKey": {
+      "AccessKeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AccessKey",
+            "resourceIdentifier": "AccessKeyId"
+          }
+        ]
+      }
+    },
+    "UpdateSSHPublicKey": {
+      "SSHPublicKeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SSHPublicKey",
+            "resourceIdentifier": "SSHPublicKeyId"
+          }
+        ]
+      }
+    },
+    "UpdateServiceSpecificCredential": {
+      "ServiceSpecificCredentialId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ServiceSpecificCredential",
+            "resourceIdentifier": "ServiceSpecificCredentialId"
+          }
+        ]
+      }
+    },
+    "UpdateSigningCertificate": {
+      "CertificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SigningCertificate",
+            "resourceIdentifier": "CertificateId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/importexport/2010-06-01/completions-1.json
+++ b/awscli/data/importexport/2010-06-01/completions-1.json
@@ -1,0 +1,46 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "JobId": "Jobs[].JobId"
+      }
+    }
+  },
+  "operations": {
+    "CancelJob": {
+      "JobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "JobId"
+          }
+        ]
+      }
+    },
+    "GetStatus": {
+      "JobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "JobId"
+          }
+        ]
+      }
+    },
+    "UpdateJob": {
+      "JobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "JobId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/inspector/2016-02-16/completions-1.json
+++ b/awscli/data/inspector/2016-02-16/completions-1.json
@@ -1,0 +1,98 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AssessmentRun": {
+      "operation": "ListAssessmentRuns",
+      "resourceIdentifier": {
+        "assessmentTemplateArn": "assessmentRuns[].assessmentTemplateArn",
+        "assessmentRunArns": "assessmentRunArns[]"
+      },
+      "inputParameters": [
+        "assessmentRunArns"
+      ]
+    },
+    "AssessmentTarget": {
+      "operation": "ListAssessmentTargets",
+      "resourceIdentifier": {
+        "resourceGroupArn": "assessmentTargets[].resourceGroupArn",
+        "assessmentTargetArns": "assessmentTargetArns[]"
+      },
+      "inputParameters": [
+        "assessmentTargetArns"
+      ]
+    },
+    "AssessmentTemplate": {
+      "operation": "ListAssessmentTemplates",
+      "resourceIdentifier": {
+        "assessmentTargetArn": "assessmentTemplates[].assessmentTargetArn",
+        "assessmentTemplateArns": "assessmentTemplateArns[]"
+      },
+      "inputParameters": [
+        "assessmentTemplateArns"
+      ]
+    },
+    "Finding": {
+      "operation": "ListFindings",
+      "resourceIdentifier": {
+        "id": "findings[].id",
+        "findingArns": "findingArns[]"
+      },
+      "inputParameters": [
+        "findingArns"
+      ]
+    },
+    "ResourceGroup": {
+      "operation": "DescribeResourceGroups",
+      "resourceIdentifier": {
+        "createdAt": "resourceGroups[].createdAt"
+      },
+      "inputParameters": [
+        "resourceGroupArns"
+      ]
+    },
+    "RulesPackage": {
+      "operation": "ListRulesPackages",
+      "resourceIdentifier": {
+        "description": "rulesPackages[].description",
+        "rulesPackageArns": "rulesPackageArns[]"
+      },
+      "inputParameters": [
+        "rulesPackageArns"
+      ]
+    },
+    "AssessmentRunAgent": {
+      "operation": "ListAssessmentRunAgents",
+      "resourceIdentifier": {
+        "assessmentRunArn": "assessmentRunAgents[].assessmentRunArn"
+      },
+      "inputParameters": [
+        "assessmentRunArn"
+      ]
+    },
+    "EventSubscription": {
+      "operation": "ListEventSubscriptions",
+      "resourceIdentifier": {
+        "eventSubscriptions": "subscriptions[].eventSubscriptions"
+      }
+    },
+    "Exclusion": {
+      "operation": "ListExclusions",
+      "resourceIdentifier": {
+        "exclusionArns": "exclusionArns[]"
+      },
+      "inputParameters": [
+        "assessmentRunArn"
+      ]
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "value": "tags[].value"
+      },
+      "inputParameters": [
+        "resourceArn"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/iot-data/2015-05-28/completions-1.json
+++ b/awscli/data/iot-data/2015-05-28/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/iot-jobs-data/2017-09-29/completions-1.json
+++ b/awscli/data/iot-jobs-data/2017-09-29/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/iot/2015-05-28/completions-1.json
+++ b/awscli/data/iot/2015-05-28/completions-1.json
@@ -1,0 +1,709 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ScheduledAudit": {
+      "operation": "ListScheduledAudits",
+      "resourceIdentifier": {
+        "targetCheckNames": "targetCheckNames[]",
+        "scheduledAuditArn": "scheduledAudits[].scheduledAuditArn"
+      },
+      "inputParameters": [
+        "scheduledAuditName"
+      ]
+    },
+    "SecurityProfile": {
+      "operation": "ListSecurityProfiles",
+      "resourceIdentifier": {
+        "criteria": "behaviors[].criteria",
+        "arn": "securityProfileIdentifiers[].arn"
+      },
+      "inputParameters": [
+        "securityProfileName"
+      ]
+    },
+    "ActiveViolation": {
+      "operation": "ListActiveViolations",
+      "resourceIdentifier": {
+        "violationId": "activeViolations[].violationId"
+      }
+    },
+    "AttachedPolicy": {
+      "operation": "ListAttachedPolicies",
+      "resourceIdentifier": {
+        "policyName": "policies[].policyName"
+      },
+      "inputParameters": [
+        "target"
+      ]
+    },
+    "AuditFinding": {
+      "operation": "ListAuditFindings",
+      "resourceIdentifier": {
+        "findingTime": "findings[].findingTime"
+      }
+    },
+    "AuditTask": {
+      "operation": "ListAuditTasks",
+      "resourceIdentifier": {
+        "taskId": "tasks[].taskId"
+      },
+      "inputParameters": [
+        "startTime",
+        "endTime"
+      ]
+    },
+    "Authorizer": {
+      "operation": "ListAuthorizers",
+      "resourceIdentifier": {
+        "authorizerArn": "authorizers[].authorizerArn"
+      }
+    },
+    "CACertificate": {
+      "operation": "ListCACertificates",
+      "resourceIdentifier": {
+        "certificateId": "certificates[].certificateId"
+      }
+    },
+    "Certificate": {
+      "operation": "ListCertificates",
+      "resourceIdentifier": {
+        "certificateId": "certificates[].certificateId"
+      }
+    },
+    "CertificatesByCA": {
+      "operation": "ListCertificatesByCA",
+      "resourceIdentifier": {
+        "certificateArn": "certificates[].certificateArn"
+      },
+      "inputParameters": [
+        "caCertificateId"
+      ]
+    },
+    "Indice": {
+      "operation": "ListIndices",
+      "resourceIdentifier": {
+        "indexNames": "indexNames[]"
+      }
+    },
+    "JobExecutionsForJob": {
+      "operation": "ListJobExecutionsForJob",
+      "resourceIdentifier": {
+        "jobExecutionSummary": "executionSummaries[].jobExecutionSummary"
+      },
+      "inputParameters": [
+        "jobId"
+      ]
+    },
+    "JobExecutionsForThing": {
+      "operation": "ListJobExecutionsForThing",
+      "resourceIdentifier": {
+        "jobExecutionSummary": "executionSummaries[].jobExecutionSummary"
+      },
+      "inputParameters": [
+        "thingName"
+      ]
+    },
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "jobId": "jobs[].jobId"
+      }
+    },
+    "OTAUpdate": {
+      "operation": "ListOTAUpdates",
+      "resourceIdentifier": {
+        "otaUpdateId": "otaUpdates[].otaUpdateId"
+      }
+    },
+    "OutgoingCertificate": {
+      "operation": "ListOutgoingCertificates",
+      "resourceIdentifier": {
+        "certificateId": "outgoingCertificates[].certificateId"
+      }
+    },
+    "Policy": {
+      "operation": "ListPolicies",
+      "resourceIdentifier": {
+        "policyName": "policies[].policyName"
+      }
+    },
+    "PolicyPrincipal": {
+      "operation": "ListPolicyPrincipals",
+      "resourceIdentifier": {
+        "principals": "principals[]"
+      },
+      "inputParameters": [
+        "policyName"
+      ]
+    },
+    "PolicyVersion": {
+      "operation": "ListPolicyVersions",
+      "resourceIdentifier": {
+        "isDefaultVersion": "policyVersions[].isDefaultVersion"
+      },
+      "inputParameters": [
+        "policyName"
+      ]
+    },
+    "PrincipalPolicy": {
+      "operation": "ListPrincipalPolicies",
+      "resourceIdentifier": {
+        "policyName": "policies[].policyName"
+      },
+      "inputParameters": [
+        "principal"
+      ]
+    },
+    "PrincipalThing": {
+      "operation": "ListPrincipalThings",
+      "resourceIdentifier": {
+        "things": "things[]"
+      },
+      "inputParameters": [
+        "principal"
+      ]
+    },
+    "RoleAliase": {
+      "operation": "ListRoleAliases",
+      "resourceIdentifier": {
+        "roleAliases": "roleAliases[]"
+      }
+    },
+    "SecurityProfilesForTarget": {
+      "operation": "ListSecurityProfilesForTarget",
+      "resourceIdentifier": {
+        "securityProfileIdentifier": "securityProfileTargetMappings[].securityProfileIdentifier"
+      },
+      "inputParameters": [
+        "securityProfileTargetArn"
+      ]
+    },
+    "Stream": {
+      "operation": "ListStreams",
+      "resourceIdentifier": {
+        "streamId": "streams[].streamId"
+      }
+    },
+    "TargetsForPolicy": {
+      "operation": "ListTargetsForPolicy",
+      "resourceIdentifier": {
+        "targets": "targets[]"
+      },
+      "inputParameters": [
+        "policyName"
+      ]
+    },
+    "TargetsForSecurityProfile": {
+      "operation": "ListTargetsForSecurityProfile",
+      "resourceIdentifier": {
+        "arn": "securityProfileTargets[].arn"
+      },
+      "inputParameters": [
+        "securityProfileName"
+      ]
+    },
+    "ThingGroup": {
+      "operation": "ListThingGroups",
+      "resourceIdentifier": {
+        "groupArn": "thingGroups[].groupArn"
+      }
+    },
+    "ThingGroupsForThing": {
+      "operation": "ListThingGroupsForThing",
+      "resourceIdentifier": {
+        "groupArn": "thingGroups[].groupArn"
+      },
+      "inputParameters": [
+        "thingName"
+      ]
+    },
+    "ThingPrincipal": {
+      "operation": "ListThingPrincipals",
+      "resourceIdentifier": {
+        "principals": "principals[]"
+      },
+      "inputParameters": [
+        "thingName"
+      ]
+    },
+    "ThingRegistrationTaskReport": {
+      "operation": "ListThingRegistrationTaskReports",
+      "resourceIdentifier": {
+        "resourceLinks": "resourceLinks[]"
+      },
+      "inputParameters": [
+        "taskId",
+        "reportType"
+      ]
+    },
+    "ThingRegistrationTask": {
+      "operation": "ListThingRegistrationTasks",
+      "resourceIdentifier": {
+        "taskIds": "taskIds[]"
+      }
+    },
+    "ThingType": {
+      "operation": "ListThingTypes",
+      "resourceIdentifier": {
+        "thingTypeArn": "thingTypes[].thingTypeArn"
+      }
+    },
+    "Thing": {
+      "operation": "ListThings",
+      "resourceIdentifier": {
+        "thingArn": "things[].thingArn"
+      }
+    },
+    "ThingsInThingGroup": {
+      "operation": "ListThingsInThingGroup",
+      "resourceIdentifier": {
+        "things": "things[]"
+      },
+      "inputParameters": [
+        "thingGroupName"
+      ]
+    },
+    "TopicRule": {
+      "operation": "ListTopicRules",
+      "resourceIdentifier": {
+        "topicPattern": "rules[].topicPattern"
+      }
+    },
+    "V2LoggingLevel": {
+      "operation": "ListV2LoggingLevels",
+      "resourceIdentifier": {
+        "logLevel": "logTargetConfigurations[].logLevel"
+      }
+    },
+    "ViolationEvent": {
+      "operation": "ListViolationEvents",
+      "resourceIdentifier": {
+        "violationEventType": "violationEvents[].violationEventType"
+      },
+      "inputParameters": [
+        "startTime",
+        "endTime"
+      ]
+    }
+  },
+  "operations": {
+    "AcceptCertificateTransfer": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "AddThingToThingGroup": {
+      "thingArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Thing",
+            "resourceIdentifier": "thingArn"
+          }
+        ]
+      }
+    },
+    "AssociateTargetsWithJob": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "AttachPolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "AttachPrincipalPolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "CancelAuditTask": {
+      "taskId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ThingRegistrationTask",
+            "resourceIdentifier": "taskId"
+          }
+        ]
+      }
+    },
+    "CancelCertificateTransfer": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "CancelJob": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "CancelJobExecution": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "CreateJob": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "CreateOTAUpdate": {
+      "otaUpdateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OTAUpdate",
+            "resourceIdentifier": "otaUpdateId"
+          }
+        ]
+      }
+    },
+    "CreatePolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "CreatePolicyVersion": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "CreateStream": {
+      "streamId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "streamId"
+          }
+        ]
+      }
+    },
+    "DeleteCACertificate": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "DeleteCertificate": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "DeleteJob": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "DeleteJobExecution": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "DeleteOTAUpdate": {
+      "otaUpdateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OTAUpdate",
+            "resourceIdentifier": "otaUpdateId"
+          }
+        ]
+      }
+    },
+    "DeletePolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "DeletePolicyVersion": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "DeleteStream": {
+      "streamId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "streamId"
+          }
+        ]
+      }
+    },
+    "DetachPolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "DetachPrincipalPolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "GetJobDocument": {
+      "jobId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "jobId"
+          }
+        ]
+      }
+    },
+    "GetOTAUpdate": {
+      "otaUpdateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OTAUpdate",
+            "resourceIdentifier": "otaUpdateId"
+          }
+        ]
+      }
+    },
+    "GetPolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "GetPolicyVersion": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "RejectCertificateTransfer": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "RemoveThingFromThingGroup": {
+      "thingArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Thing",
+            "resourceIdentifier": "thingArn"
+          }
+        ]
+      }
+    },
+    "SearchIndex": {
+      "indexName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Indice",
+            "resourceIdentifier": "indexName"
+          }
+        ]
+      }
+    },
+    "SetDefaultPolicyVersion": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Policy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "SetV2LoggingLevel": {
+      "logLevel": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "V2LoggingLevel",
+            "resourceIdentifier": "logLevel"
+          }
+        ]
+      }
+    },
+    "StopThingRegistrationTask": {
+      "taskId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ThingRegistrationTask",
+            "resourceIdentifier": "taskId"
+          }
+        ]
+      }
+    },
+    "TransferCertificate": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "UpdateCACertificate": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "UpdateCertificate": {
+      "certificateId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OutgoingCertificate",
+            "resourceIdentifier": "certificateId"
+          }
+        ]
+      }
+    },
+    "UpdateStream": {
+      "streamId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "streamId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/iot1click-devices/2018-05-14/completions-1.json
+++ b/awscli/data/iot1click-devices/2018-05-14/completions-1.json
@@ -1,0 +1,90 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DeviceEvent": {
+      "operation": "ListDeviceEvents",
+      "resourceIdentifier": {
+        "Device": "Events[].Device"
+      },
+      "inputParameters": [
+        "DeviceId",
+        "FromTimeStamp",
+        "ToTimeStamp"
+      ]
+    },
+    "Device": {
+      "operation": "ListDevices",
+      "resourceIdentifier": {
+        "DeviceId": "Devices[].DeviceId"
+      }
+    }
+  },
+  "operations": {
+    "FinalizeDeviceClaim": {
+      "DeviceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Device",
+            "resourceIdentifier": "DeviceId"
+          }
+        ]
+      }
+    },
+    "GetDeviceMethods": {
+      "DeviceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Device",
+            "resourceIdentifier": "DeviceId"
+          }
+        ]
+      }
+    },
+    "InitiateDeviceClaim": {
+      "DeviceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Device",
+            "resourceIdentifier": "DeviceId"
+          }
+        ]
+      }
+    },
+    "InvokeDeviceMethod": {
+      "DeviceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Device",
+            "resourceIdentifier": "DeviceId"
+          }
+        ]
+      }
+    },
+    "UnclaimDevice": {
+      "DeviceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Device",
+            "resourceIdentifier": "DeviceId"
+          }
+        ]
+      }
+    },
+    "UpdateDeviceState": {
+      "DeviceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Device",
+            "resourceIdentifier": "DeviceId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/iot1click-projects/2018-05-14/completions-1.json
+++ b/awscli/data/iot1click-projects/2018-05-14/completions-1.json
@@ -1,0 +1,121 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Placement": {
+      "operation": "ListPlacements",
+      "resourceIdentifier": {
+        "placementName": "placements[].placementName"
+      },
+      "inputParameters": [
+        "projectName"
+      ]
+    },
+    "Project": {
+      "operation": "ListProjects",
+      "resourceIdentifier": {
+        "projectName": "projects[].projectName"
+      }
+    }
+  },
+  "operations": {
+    "AssociateDeviceWithPlacement": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "CreatePlacement": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "CreateProject": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "DeletePlacement": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "DeleteProject": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "DisassociateDeviceFromPlacement": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "GetDevicesInPlacement": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "UpdatePlacement": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    },
+    "UpdateProject": {
+      "projectName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/iotanalytics/2017-11-27/completions-1.json
+++ b/awscli/data/iotanalytics/2017-11-27/completions-1.json
@@ -1,0 +1,258 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Channel": {
+      "operation": "ListChannels",
+      "resourceIdentifier": {
+        "channelName": "channelSummaries[].channelName"
+      }
+    },
+    "DatasetContent": {
+      "operation": "ListDatasetContents",
+      "resourceIdentifier": {
+        "creationTime": "datasetContentSummaries[].creationTime"
+      },
+      "inputParameters": [
+        "datasetName"
+      ]
+    },
+    "Dataset": {
+      "operation": "ListDatasets",
+      "resourceIdentifier": {
+        "datasetName": "datasetSummaries[].datasetName"
+      }
+    },
+    "Datastore": {
+      "operation": "ListDatastores",
+      "resourceIdentifier": {
+        "datastoreName": "datastoreSummaries[].datastoreName"
+      }
+    },
+    "Pipeline": {
+      "operation": "ListPipelines",
+      "resourceIdentifier": {
+        "pipelineName": "pipelineSummaries[].pipelineName"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "value": "tags[].value"
+      },
+      "inputParameters": [
+        "resourceArn"
+      ]
+    }
+  },
+  "operations": {
+    "BatchPutMessage": {
+      "channelName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "channelName"
+          }
+        ]
+      }
+    },
+    "CancelPipelineReprocessing": {
+      "pipelineName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "pipelineName"
+          }
+        ]
+      }
+    },
+    "CreateChannel": {
+      "channelName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "channelName"
+          }
+        ]
+      }
+    },
+    "CreateDataset": {
+      "datasetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Dataset",
+            "resourceIdentifier": "datasetName"
+          }
+        ]
+      }
+    },
+    "CreateDatasetContent": {
+      "datasetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Dataset",
+            "resourceIdentifier": "datasetName"
+          }
+        ]
+      }
+    },
+    "CreateDatastore": {
+      "datastoreName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Datastore",
+            "resourceIdentifier": "datastoreName"
+          }
+        ]
+      }
+    },
+    "CreatePipeline": {
+      "pipelineName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "pipelineName"
+          }
+        ]
+      }
+    },
+    "DeleteChannel": {
+      "channelName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "channelName"
+          }
+        ]
+      }
+    },
+    "DeleteDataset": {
+      "datasetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Dataset",
+            "resourceIdentifier": "datasetName"
+          }
+        ]
+      }
+    },
+    "DeleteDatasetContent": {
+      "datasetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Dataset",
+            "resourceIdentifier": "datasetName"
+          }
+        ]
+      }
+    },
+    "DeleteDatastore": {
+      "datastoreName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Datastore",
+            "resourceIdentifier": "datastoreName"
+          }
+        ]
+      }
+    },
+    "DeletePipeline": {
+      "pipelineName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "pipelineName"
+          }
+        ]
+      }
+    },
+    "GetDatasetContent": {
+      "datasetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Dataset",
+            "resourceIdentifier": "datasetName"
+          }
+        ]
+      }
+    },
+    "SampleChannelData": {
+      "channelName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "channelName"
+          }
+        ]
+      }
+    },
+    "StartPipelineReprocessing": {
+      "pipelineName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "pipelineName"
+          }
+        ]
+      }
+    },
+    "UpdateChannel": {
+      "channelName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "channelName"
+          }
+        ]
+      }
+    },
+    "UpdateDataset": {
+      "datasetName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Dataset",
+            "resourceIdentifier": "datasetName"
+          }
+        ]
+      }
+    },
+    "UpdateDatastore": {
+      "datastoreName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Datastore",
+            "resourceIdentifier": "datastoreName"
+          }
+        ]
+      }
+    },
+    "UpdatePipeline": {
+      "pipelineName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Pipeline",
+            "resourceIdentifier": "pipelineName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/kinesis-video-archived-media/2017-09-30/completions-1.json
+++ b/awscli/data/kinesis-video-archived-media/2017-09-30/completions-1.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Fragment": {
+      "operation": "ListFragments",
+      "resourceIdentifier": {
+        "FragmentNumber": "Fragments[].FragmentNumber"
+      },
+      "inputParameters": [
+        "StreamName"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/kinesis-video-media/2017-09-30/completions-1.json
+++ b/awscli/data/kinesis-video-media/2017-09-30/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/kinesis/2013-12-02/completions-1.json
+++ b/awscli/data/kinesis/2013-12-02/completions-1.json
@@ -1,0 +1,233 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Shard": {
+      "operation": "ListShards",
+      "resourceIdentifier": {
+        "ShardId": "Shards[].ShardId"
+      }
+    },
+    "StreamConsumer": {
+      "operation": "ListStreamConsumers",
+      "resourceIdentifier": {
+        "ConsumerStatus": "Consumers[].ConsumerStatus"
+      },
+      "inputParameters": [
+        "StreamARN"
+      ]
+    },
+    "Stream": {
+      "operation": "ListStreams",
+      "resourceIdentifier": {
+        "StreamNames": "StreamNames[]"
+      }
+    },
+    "TagsForStream": {
+      "operation": "ListTagsForStream",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "StreamName"
+      ]
+    }
+  },
+  "operations": {
+    "AddTagsToStream": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "CreateStream": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "DecreaseStreamRetentionPeriod": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "DeleteStream": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "DisableEnhancedMonitoring": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "EnableEnhancedMonitoring": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "GetShardIterator": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      },
+      "ShardId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Shard",
+            "resourceIdentifier": "ShardId"
+          }
+        ]
+      }
+    },
+    "IncreaseStreamRetentionPeriod": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "MergeShards": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "PutRecord": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "PutRecords": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "RemoveTagsFromStream": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "SplitShard": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "StartStreamEncryption": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "StopStreamEncryption": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    },
+    "SubscribeToShard": {
+      "ShardId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Shard",
+            "resourceIdentifier": "ShardId"
+          }
+        ]
+      }
+    },
+    "UpdateShardCount": {
+      "StreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/kinesisanalytics/2015-08-14/completions-1.json
+++ b/awscli/data/kinesisanalytics/2015-08-14/completions-1.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Application": {
+      "operation": "ListApplications",
+      "resourceIdentifier": {
+        "ApplicationARN": "ApplicationSummaries[].ApplicationARN"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/kinesisvideo/2017-09-30/completions-1.json
+++ b/awscli/data/kinesisvideo/2017-09-30/completions-1.json
@@ -1,0 +1,79 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Stream": {
+      "operation": "ListStreams",
+      "resourceIdentifier": {
+        "StreamARN": "StreamInfoList[].StreamARN"
+      }
+    }
+  },
+  "operations": {
+    "DeleteStream": {
+      "StreamARN": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamARN"
+          }
+        ]
+      }
+    },
+    "GetDataEndpoint": {
+      "StreamARN": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamARN"
+          }
+        ]
+      }
+    },
+    "TagStream": {
+      "StreamARN": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamARN"
+          }
+        ]
+      }
+    },
+    "UntagStream": {
+      "StreamARN": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamARN"
+          }
+        ]
+      }
+    },
+    "UpdateDataRetention": {
+      "StreamARN": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamARN"
+          }
+        ]
+      }
+    },
+    "UpdateStream": {
+      "StreamARN": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stream",
+            "resourceIdentifier": "StreamARN"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/kms/2014-11-01/completions-1.json
+++ b/awscli/data/kms/2014-11-01/completions-1.json
@@ -1,0 +1,319 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Aliase": {
+      "operation": "ListAliases",
+      "resourceIdentifier": {
+        "AliasName": "Aliases[].AliasName"
+      }
+    },
+    "Grant": {
+      "operation": "ListGrants",
+      "resourceIdentifier": {
+        "GrantId": "Grants[].GrantId"
+      },
+      "inputParameters": [
+        "KeyId"
+      ]
+    },
+    "KeyPolicy": {
+      "operation": "ListKeyPolicies",
+      "resourceIdentifier": {
+        "PolicyNames": "PolicyNames[]"
+      },
+      "inputParameters": [
+        "KeyId"
+      ]
+    },
+    "Key": {
+      "operation": "ListKeys",
+      "resourceIdentifier": {
+        "KeyId": "Keys[].KeyId"
+      }
+    },
+    "ResourceTag": {
+      "operation": "ListResourceTags",
+      "resourceIdentifier": {
+        "TagKey": "Tags[].TagKey"
+      },
+      "inputParameters": [
+        "KeyId"
+      ]
+    },
+    "RetirableGrant": {
+      "operation": "ListRetirableGrants",
+      "resourceIdentifier": {
+        "Constraints": "Grants[].Constraints"
+      },
+      "inputParameters": [
+        "RetiringPrincipal"
+      ]
+    }
+  },
+  "operations": {
+    "CancelKeyDeletion": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "CreateAlias": {
+      "AliasName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasName"
+          }
+        ]
+      }
+    },
+    "CreateGrant": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "DeleteAlias": {
+      "AliasName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasName"
+          }
+        ]
+      }
+    },
+    "DeleteImportedKeyMaterial": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "DisableKey": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "DisableKeyRotation": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "EnableKey": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "EnableKeyRotation": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "Encrypt": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "GenerateDataKey": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "GenerateDataKeyWithoutPlaintext": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "GetKeyPolicy": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "GetKeyRotationStatus": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "GetParametersForImport": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "ImportKeyMaterial": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "PutKeyPolicy": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "RetireGrant": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "RevokeGrant": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "ScheduleKeyDeletion": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "TagResource": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "UntagResource": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    },
+    "UpdateAlias": {
+      "AliasName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Aliase",
+            "resourceIdentifier": "AliasName"
+          }
+        ]
+      }
+    },
+    "UpdateKeyDescription": {
+      "KeyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Key",
+            "resourceIdentifier": "KeyId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/lambda/2015-03-31/completions-1.json
+++ b/awscli/data/lambda/2015-03-31/completions-1.json
@@ -1,0 +1,48 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Aliase": {
+      "operation": "ListAliases",
+      "resourceIdentifier": {
+        "AliasArn": "Aliases[].AliasArn"
+      },
+      "inputParameters": [
+        "FunctionName"
+      ]
+    },
+    "EventSourceMapping": {
+      "operation": "ListEventSourceMappings",
+      "resourceIdentifier": {
+        "EventSourceArn": "EventSourceMappings[].EventSourceArn"
+      }
+    },
+    "Function": {
+      "operation": "ListFunctions",
+      "resourceIdentifier": {
+        "FunctionArn": "Functions[].FunctionArn"
+      }
+    },
+    "VersionsByFunction": {
+      "operation": "ListVersionsByFunction",
+      "resourceIdentifier": {
+        "Version": "Versions[].Version"
+      },
+      "inputParameters": [
+        "FunctionName"
+      ]
+    }
+  },
+  "operations": {
+    "CreateEventSourceMapping": {
+      "EventSourceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EventSourceMapping",
+            "resourceIdentifier": "EventSourceArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/lex-models/2017-04-19/completions-1.json
+++ b/awscli/data/lex-models/2017-04-19/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/lex-runtime/2016-11-28/completions-1.json
+++ b/awscli/data/lex-runtime/2016-11-28/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/lightsail/2016-11-28/completions-1.json
+++ b/awscli/data/lightsail/2016-11-28/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/logs/2014-03-28/completions-1.json
+++ b/awscli/data/logs/2014-03-28/completions-1.json
@@ -1,0 +1,355 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Destination": {
+      "operation": "DescribeDestinations",
+      "resourceIdentifier": {
+        "destinationName": "destinations[].destinationName"
+      }
+    },
+    "ExportTask": {
+      "operation": "DescribeExportTasks",
+      "resourceIdentifier": {
+        "taskId": "exportTasks[].taskId"
+      }
+    },
+    "LogGroup": {
+      "operation": "DescribeLogGroups",
+      "resourceIdentifier": {
+        "logGroupName": "logGroups[].logGroupName"
+      }
+    },
+    "LogStream": {
+      "operation": "DescribeLogStreams",
+      "resourceIdentifier": {
+        "logStreamName": "logStreams[].logStreamName"
+      },
+      "inputParameters": [
+        "logGroupName"
+      ]
+    },
+    "MetricFilter": {
+      "operation": "DescribeMetricFilters",
+      "resourceIdentifier": {
+        "filterName": "metricFilters[].filterName"
+      }
+    },
+    "ResourcePolicy": {
+      "operation": "DescribeResourcePolicies",
+      "resourceIdentifier": {
+        "policyName": "resourcePolicies[].policyName"
+      }
+    },
+    "SubscriptionFilter": {
+      "operation": "DescribeSubscriptionFilters",
+      "resourceIdentifier": {
+        "creationTime": "subscriptionFilters[].creationTime"
+      },
+      "inputParameters": [
+        "logGroupName"
+      ]
+    }
+  },
+  "operations": {
+    "AssociateKmsKey": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "CancelExportTask": {
+      "taskId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ExportTask",
+            "resourceIdentifier": "taskId"
+          }
+        ]
+      }
+    },
+    "CreateExportTask": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "CreateLogGroup": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "CreateLogStream": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteDestination": {
+      "destinationName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Destination",
+            "resourceIdentifier": "destinationName"
+          }
+        ]
+      }
+    },
+    "DeleteLogGroup": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteLogStream": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteMetricFilter": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      },
+      "filterName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MetricFilter",
+            "resourceIdentifier": "filterName"
+          }
+        ]
+      }
+    },
+    "DeleteResourcePolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ResourcePolicy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "DeleteRetentionPolicy": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteSubscriptionFilter": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      },
+      "filterName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MetricFilter",
+            "resourceIdentifier": "filterName"
+          }
+        ]
+      }
+    },
+    "DisassociateKmsKey": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "FilterLogEvents": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "GetLogEvents": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "PutDestination": {
+      "destinationName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Destination",
+            "resourceIdentifier": "destinationName"
+          }
+        ]
+      }
+    },
+    "PutDestinationPolicy": {
+      "destinationName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Destination",
+            "resourceIdentifier": "destinationName"
+          }
+        ]
+      }
+    },
+    "PutLogEvents": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "PutMetricFilter": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      },
+      "filterName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MetricFilter",
+            "resourceIdentifier": "filterName"
+          }
+        ]
+      }
+    },
+    "PutResourcePolicy": {
+      "policyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ResourcePolicy",
+            "resourceIdentifier": "policyName"
+          }
+        ]
+      }
+    },
+    "PutRetentionPolicy": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "PutSubscriptionFilter": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      },
+      "filterName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MetricFilter",
+            "resourceIdentifier": "filterName"
+          }
+        ]
+      }
+    },
+    "TagLogGroup": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    },
+    "UntagLogGroup": {
+      "logGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "LogGroup",
+            "resourceIdentifier": "logGroupName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/machinelearning/2014-12-12/completions-1.json
+++ b/awscli/data/machinelearning/2014-12-12/completions-1.json
@@ -1,0 +1,290 @@
+{
+  "version": "1.0",
+  "resources": {
+    "BatchPrediction": {
+      "operation": "DescribeBatchPredictions",
+      "resourceIdentifier": {
+        "BatchPredictionId": "Results[].BatchPredictionId"
+      }
+    },
+    "DataSource": {
+      "operation": "DescribeDataSources",
+      "resourceIdentifier": {
+        "DataSourceId": "Results[].DataSourceId"
+      }
+    },
+    "Evaluation": {
+      "operation": "DescribeEvaluations",
+      "resourceIdentifier": {
+        "EvaluationId": "Results[].EvaluationId"
+      }
+    },
+    "MLModel": {
+      "operation": "DescribeMLModels",
+      "resourceIdentifier": {
+        "MLModelId": "Results[].MLModelId"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceId",
+        "ResourceType"
+      ]
+    }
+  },
+  "operations": {
+    "CreateBatchPrediction": {
+      "BatchPredictionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "BatchPrediction",
+            "resourceIdentifier": "BatchPredictionId"
+          }
+        ]
+      },
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "CreateDataSourceFromRDS": {
+      "DataSourceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DataSource",
+            "resourceIdentifier": "DataSourceId"
+          }
+        ]
+      }
+    },
+    "CreateDataSourceFromRedshift": {
+      "DataSourceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DataSource",
+            "resourceIdentifier": "DataSourceId"
+          }
+        ]
+      }
+    },
+    "CreateDataSourceFromS3": {
+      "DataSourceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DataSource",
+            "resourceIdentifier": "DataSourceId"
+          }
+        ]
+      }
+    },
+    "CreateEvaluation": {
+      "EvaluationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Evaluation",
+            "resourceIdentifier": "EvaluationId"
+          }
+        ]
+      },
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "CreateMLModel": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "CreateRealtimeEndpoint": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "DeleteBatchPrediction": {
+      "BatchPredictionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "BatchPrediction",
+            "resourceIdentifier": "BatchPredictionId"
+          }
+        ]
+      }
+    },
+    "DeleteDataSource": {
+      "DataSourceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DataSource",
+            "resourceIdentifier": "DataSourceId"
+          }
+        ]
+      }
+    },
+    "DeleteEvaluation": {
+      "EvaluationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Evaluation",
+            "resourceIdentifier": "EvaluationId"
+          }
+        ]
+      }
+    },
+    "DeleteMLModel": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "DeleteRealtimeEndpoint": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "GetBatchPrediction": {
+      "BatchPredictionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "BatchPrediction",
+            "resourceIdentifier": "BatchPredictionId"
+          }
+        ]
+      }
+    },
+    "GetDataSource": {
+      "DataSourceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DataSource",
+            "resourceIdentifier": "DataSourceId"
+          }
+        ]
+      }
+    },
+    "GetEvaluation": {
+      "EvaluationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Evaluation",
+            "resourceIdentifier": "EvaluationId"
+          }
+        ]
+      }
+    },
+    "GetMLModel": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "Predict": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    },
+    "UpdateBatchPrediction": {
+      "BatchPredictionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "BatchPrediction",
+            "resourceIdentifier": "BatchPredictionId"
+          }
+        ]
+      }
+    },
+    "UpdateDataSource": {
+      "DataSourceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DataSource",
+            "resourceIdentifier": "DataSourceId"
+          }
+        ]
+      }
+    },
+    "UpdateEvaluation": {
+      "EvaluationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Evaluation",
+            "resourceIdentifier": "EvaluationId"
+          }
+        ]
+      }
+    },
+    "UpdateMLModel": {
+      "MLModelId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MLModel",
+            "resourceIdentifier": "MLModelId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/macie/2017-12-19/completions-1.json
+++ b/awscli/data/macie/2017-12-19/completions-1.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.0",
+  "resources": {
+    "MemberAccount": {
+      "operation": "ListMemberAccounts",
+      "resourceIdentifier": {
+        "accountId": "memberAccounts[].accountId"
+      }
+    },
+    "S3Resource": {
+      "operation": "ListS3Resources",
+      "resourceIdentifier": {
+        "bucketName": "s3Resources[].bucketName"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/marketplace-entitlement/2017-01-11/completions-1.json
+++ b/awscli/data/marketplace-entitlement/2017-01-11/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/marketplacecommerceanalytics/2015-07-01/completions-1.json
+++ b/awscli/data/marketplacecommerceanalytics/2015-07-01/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/mediaconvert/2017-08-29/completions-1.json
+++ b/awscli/data/mediaconvert/2017-08-29/completions-1.json
@@ -1,0 +1,59 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Endpoint": {
+      "operation": "DescribeEndpoints",
+      "resourceIdentifier": {
+        "Url": "Endpoints[].Url"
+      }
+    },
+    "JobTemplate": {
+      "operation": "ListJobTemplates",
+      "resourceIdentifier": {
+        "CreatedAt": "JobTemplates[].CreatedAt"
+      }
+    },
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "JobTemplate": "Jobs[].JobTemplate"
+      }
+    },
+    "Preset": {
+      "operation": "ListPresets",
+      "resourceIdentifier": {
+        "CreatedAt": "Presets[].CreatedAt"
+      }
+    },
+    "Queue": {
+      "operation": "ListQueues",
+      "resourceIdentifier": {
+        "Status": "Queues[].Status"
+      }
+    }
+  },
+  "operations": {
+    "CreateJob": {
+      "JobTemplate": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Job",
+            "resourceIdentifier": "JobTemplate"
+          }
+        ]
+      }
+    },
+    "UpdateQueue": {
+      "Status": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "Status"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/medialive/2017-10-14/completions-1.json
+++ b/awscli/data/medialive/2017-10-14/completions-1.json
@@ -1,0 +1,157 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Schedule": {
+      "operation": "DescribeSchedule",
+      "resourceIdentifier": {
+        "ScheduleActionSettings": "ScheduleActions[].ScheduleActionSettings"
+      },
+      "inputParameters": [
+        "ChannelId"
+      ]
+    },
+    "Channel": {
+      "operation": "ListChannels",
+      "resourceIdentifier": {
+        "Name": "Channels[].Name"
+      }
+    },
+    "InputSecurityGroup": {
+      "operation": "ListInputSecurityGroups",
+      "resourceIdentifier": {
+        "Inputs": "InputSecurityGroups[].Inputs"
+      }
+    },
+    "Input": {
+      "operation": "ListInputs",
+      "resourceIdentifier": {
+        "Destinations": "Inputs[].Destinations"
+      }
+    },
+    "Offering": {
+      "operation": "ListOfferings",
+      "resourceIdentifier": {
+        "OfferingId": "Offerings[].OfferingId"
+      }
+    },
+    "Reservation": {
+      "operation": "ListReservations",
+      "resourceIdentifier": {
+        "ReservationId": "Reservations[].ReservationId"
+      }
+    }
+  },
+  "operations": {
+    "CreateChannel": {
+      "Destinations": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Input",
+            "resourceIdentifier": "Destinations"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "CreateInput": {
+      "Destinations": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Input",
+            "resourceIdentifier": "Destinations"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "DeleteReservation": {
+      "ReservationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Reservation",
+            "resourceIdentifier": "ReservationId"
+          }
+        ]
+      }
+    },
+    "PurchaseOffering": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "OfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Offering",
+            "resourceIdentifier": "OfferingId"
+          }
+        ]
+      }
+    },
+    "UpdateChannel": {
+      "Destinations": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Input",
+            "resourceIdentifier": "Destinations"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateInput": {
+      "Destinations": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Input",
+            "resourceIdentifier": "Destinations"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Channel",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/mediapackage/2017-10-12/completions-1.json
+++ b/awscli/data/mediapackage/2017-10-12/completions-1.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0",
+  "resources": {
+    "OriginEndpoint": {
+      "operation": "ListOriginEndpoints",
+      "resourceIdentifier": {
+        "Whitelist": "Whitelist[]",
+        "StartoverWindowSeconds": "OriginEndpoints[].StartoverWindowSeconds"
+      },
+      "inputParameters": [
+        "Id"
+      ]
+    },
+    "Channel": {
+      "operation": "ListChannels",
+      "resourceIdentifier": {
+        "HlsIngest": "Channels[].HlsIngest"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/mediastore-data/2017-09-01/completions-1.json
+++ b/awscli/data/mediastore-data/2017-09-01/completions-1.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Item": {
+      "operation": "ListItems",
+      "resourceIdentifier": {
+        "ContentType": "Items[].ContentType"
+      }
+    }
+  },
+  "operations": {
+    "PutObject": {
+      "ContentType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Item",
+            "resourceIdentifier": "ContentType"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/mediastore/2017-09-01/completions-1.json
+++ b/awscli/data/mediastore/2017-09-01/completions-1.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Container": {
+      "operation": "ListContainers",
+      "resourceIdentifier": {
+        "CreationTime": "Containers[].CreationTime"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/mediatailor/2018-04-23/completions-1.json
+++ b/awscli/data/mediatailor/2018-04-23/completions-1.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "resources": {
+    "PlaybackConfiguration": {
+      "operation": "ListPlaybackConfigurations",
+      "resourceIdentifier": {
+        "CdnConfiguration": "Items[].CdnConfiguration"
+      }
+    }
+  },
+  "operations": {
+    "PutPlaybackConfiguration": {
+      "CdnConfiguration": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlaybackConfiguration",
+            "resourceIdentifier": "CdnConfiguration"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/meteringmarketplace/2016-01-14/completions-1.json
+++ b/awscli/data/meteringmarketplace/2016-01-14/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/mgh/2017-05-31/completions-1.json
+++ b/awscli/data/mgh/2017-05-31/completions-1.json
@@ -1,0 +1,201 @@
+{
+  "version": "1.0",
+  "resources": {
+    "CreatedArtifact": {
+      "operation": "ListCreatedArtifacts",
+      "resourceIdentifier": {
+        "Description": "CreatedArtifactList[].Description"
+      },
+      "inputParameters": [
+        "ProgressUpdateStream",
+        "MigrationTaskName"
+      ]
+    },
+    "DiscoveredResource": {
+      "operation": "ListDiscoveredResources",
+      "resourceIdentifier": {
+        "Description": "DiscoveredResourceList[].Description"
+      },
+      "inputParameters": [
+        "ProgressUpdateStream",
+        "MigrationTaskName"
+      ]
+    },
+    "MigrationTask": {
+      "operation": "ListMigrationTasks",
+      "resourceIdentifier": {
+        "MigrationTaskName": "MigrationTaskSummaryList[].MigrationTaskName"
+      }
+    },
+    "ProgressUpdateStream": {
+      "operation": "ListProgressUpdateStreams",
+      "resourceIdentifier": {
+        "ProgressUpdateStreamName": "ProgressUpdateStreamSummaryList[].ProgressUpdateStreamName"
+      }
+    }
+  },
+  "operations": {
+    "AssociateCreatedArtifact": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    },
+    "AssociateDiscoveredResource": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    },
+    "CreateProgressUpdateStream": {
+      "ProgressUpdateStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStreamName"
+          }
+        ]
+      }
+    },
+    "DeleteProgressUpdateStream": {
+      "ProgressUpdateStreamName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStreamName"
+          }
+        ]
+      }
+    },
+    "DisassociateCreatedArtifact": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    },
+    "DisassociateDiscoveredResource": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    },
+    "ImportMigrationTask": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    },
+    "NotifyMigrationTaskState": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    },
+    "PutResourceAttributes": {
+      "ProgressUpdateStream": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ProgressUpdateStream",
+            "resourceIdentifier": "ProgressUpdateStream"
+          }
+        ]
+      },
+      "MigrationTaskName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MigrationTask",
+            "resourceIdentifier": "MigrationTaskName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/mobile/2017-07-01/completions-1.json
+++ b/awscli/data/mobile/2017-07-01/completions-1.json
@@ -1,0 +1,72 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Bundle": {
+      "operation": "ListBundles",
+      "resourceIdentifier": {
+        "bundleId": "bundleList[].bundleId"
+      }
+    },
+    "Project": {
+      "operation": "ListProjects",
+      "resourceIdentifier": {
+        "projectId": "projects[].projectId"
+      }
+    }
+  },
+  "operations": {
+    "DeleteProject": {
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      }
+    },
+    "ExportBundle": {
+      "bundleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Bundle",
+            "resourceIdentifier": "bundleId"
+          }
+        ]
+      },
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      }
+    },
+    "ExportProject": {
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      }
+    },
+    "UpdateProject": {
+      "projectId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Project",
+            "resourceIdentifier": "projectId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/mq/2017-11-27/completions-1.json
+++ b/awscli/data/mq/2017-11-27/completions-1.json
@@ -1,0 +1,135 @@
+{
+  "version": "1.0",
+  "resources": {
+    "User": {
+      "operation": "ListUsers",
+      "resourceIdentifier": {
+        "Groups": "Groups[]",
+        "Username": "Users[].Username"
+      },
+      "inputParameters": [
+        "BrokerId"
+      ]
+    },
+    "Broker": {
+      "operation": "ListBrokers",
+      "resourceIdentifier": {
+        "BrokerId": "BrokerSummaries[].BrokerId"
+      }
+    },
+    "ConfigurationRevision": {
+      "operation": "ListConfigurationRevisions",
+      "resourceIdentifier": {
+        "Revision": "Revisions[].Revision"
+      },
+      "inputParameters": [
+        "ConfigurationId"
+      ]
+    },
+    "Configuration": {
+      "operation": "ListConfigurations",
+      "resourceIdentifier": {
+        "EngineVersion": "Configurations[].EngineVersion"
+      }
+    }
+  },
+  "operations": {
+    "CreateBroker": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Configuration",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "CreateConfiguration": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Configuration",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "CreateUser": {
+      "BrokerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Broker",
+            "resourceIdentifier": "BrokerId"
+          }
+        ]
+      }
+    },
+    "DeleteBroker": {
+      "BrokerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Broker",
+            "resourceIdentifier": "BrokerId"
+          }
+        ]
+      }
+    },
+    "DeleteUser": {
+      "BrokerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Broker",
+            "resourceIdentifier": "BrokerId"
+          }
+        ]
+      }
+    },
+    "RebootBroker": {
+      "BrokerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Broker",
+            "resourceIdentifier": "BrokerId"
+          }
+        ]
+      }
+    },
+    "UpdateBroker": {
+      "BrokerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Broker",
+            "resourceIdentifier": "BrokerId"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Configuration",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "UpdateUser": {
+      "BrokerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Broker",
+            "resourceIdentifier": "BrokerId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/mturk/2017-01-17/completions-1.json
+++ b/awscli/data/mturk/2017-01-17/completions-1.json
@@ -1,0 +1,247 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AssignmentsForHIT": {
+      "operation": "ListAssignmentsForHIT",
+      "resourceIdentifier": {
+        "AssignmentId": "Assignments[].AssignmentId"
+      },
+      "inputParameters": [
+        "HITId"
+      ]
+    },
+    "BonusPayment": {
+      "operation": "ListBonusPayments",
+      "resourceIdentifier": {
+        "BonusAmount": "BonusPayments[].BonusAmount"
+      }
+    },
+    "HIT": {
+      "operation": "ListHITs",
+      "resourceIdentifier": {
+        "HITId": "HITs[].HITId"
+      }
+    },
+    "HITsForQualificationType": {
+      "operation": "ListHITsForQualificationType",
+      "resourceIdentifier": {
+        "QualificationRequirements": "HITs[].QualificationRequirements"
+      },
+      "inputParameters": [
+        "QualificationTypeId"
+      ]
+    },
+    "QualificationRequest": {
+      "operation": "ListQualificationRequests",
+      "resourceIdentifier": {
+        "QualificationRequestId": "QualificationRequests[].QualificationRequestId"
+      }
+    },
+    "QualificationType": {
+      "operation": "ListQualificationTypes",
+      "resourceIdentifier": {
+        "QualificationTypeId": "QualificationTypes[].QualificationTypeId"
+      },
+      "inputParameters": [
+        "MustBeRequestable"
+      ]
+    },
+    "ReviewableHIT": {
+      "operation": "ListReviewableHITs",
+      "resourceIdentifier": {
+        "HITReviewStatus": "HITs[].HITReviewStatus"
+      }
+    },
+    "WorkerBlock": {
+      "operation": "ListWorkerBlocks",
+      "resourceIdentifier": {
+        "WorkerId": "WorkerBlocks[].WorkerId"
+      }
+    },
+    "WorkersWithQualificationType": {
+      "operation": "ListWorkersWithQualificationType",
+      "resourceIdentifier": {
+        "QualificationTypeId": "Qualifications[].QualificationTypeId"
+      },
+      "inputParameters": [
+        "QualificationTypeId"
+      ]
+    }
+  },
+  "operations": {
+    "AcceptQualificationRequest": {
+      "QualificationRequestId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QualificationRequest",
+            "resourceIdentifier": "QualificationRequestId"
+          }
+        ]
+      }
+    },
+    "AssociateQualificationWithWorker": {
+      "WorkerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerId"
+          }
+        ]
+      }
+    },
+    "CreateAdditionalAssignmentsForHIT": {
+      "HITId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HIT",
+            "resourceIdentifier": "HITId"
+          }
+        ]
+      }
+    },
+    "CreateWorkerBlock": {
+      "WorkerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerId"
+          }
+        ]
+      }
+    },
+    "DeleteHIT": {
+      "HITId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HIT",
+            "resourceIdentifier": "HITId"
+          }
+        ]
+      }
+    },
+    "DeleteWorkerBlock": {
+      "WorkerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerId"
+          }
+        ]
+      }
+    },
+    "DisassociateQualificationFromWorker": {
+      "WorkerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerId"
+          }
+        ]
+      }
+    },
+    "GetHIT": {
+      "HITId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HIT",
+            "resourceIdentifier": "HITId"
+          }
+        ]
+      }
+    },
+    "GetQualificationScore": {
+      "WorkerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerId"
+          }
+        ]
+      }
+    },
+    "NotifyWorkers": {
+      "WorkerIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerIds"
+          }
+        ]
+      }
+    },
+    "RejectQualificationRequest": {
+      "QualificationRequestId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QualificationRequest",
+            "resourceIdentifier": "QualificationRequestId"
+          }
+        ]
+      }
+    },
+    "SendBonus": {
+      "WorkerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WorkerBlock",
+            "resourceIdentifier": "WorkerId"
+          }
+        ]
+      },
+      "BonusAmount": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "BonusPayment",
+            "resourceIdentifier": "BonusAmount"
+          }
+        ]
+      }
+    },
+    "UpdateExpirationForHIT": {
+      "HITId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HIT",
+            "resourceIdentifier": "HITId"
+          }
+        ]
+      }
+    },
+    "UpdateHITReviewStatus": {
+      "HITId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HIT",
+            "resourceIdentifier": "HITId"
+          }
+        ]
+      }
+    },
+    "UpdateHITTypeOfHIT": {
+      "HITId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HIT",
+            "resourceIdentifier": "HITId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/neptune/2014-10-31/completions-1.json
+++ b/awscli/data/neptune/2014-10-31/completions-1.json
@@ -1,0 +1,204 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DBClusterParameterGroup": {
+      "operation": "DescribeDBClusterParameterGroups",
+      "resourceIdentifier": {
+        "DBClusterParameterGroupArn": "DBClusterParameterGroups[].DBClusterParameterGroupArn"
+      }
+    },
+    "DBClusterParameter": {
+      "operation": "DescribeDBClusterParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      },
+      "inputParameters": [
+        "DBClusterParameterGroupName"
+      ]
+    },
+    "DBClusterSnapshot": {
+      "operation": "DescribeDBClusterSnapshots",
+      "resourceIdentifier": {
+        "DBClusterSnapshotArn": "DBClusterSnapshots[].DBClusterSnapshotArn"
+      }
+    },
+    "DBCluster": {
+      "operation": "DescribeDBClusters",
+      "resourceIdentifier": {
+        "DBClusterArn": "DBClusters[].DBClusterArn"
+      }
+    },
+    "DBEngineVersion": {
+      "operation": "DescribeDBEngineVersions",
+      "resourceIdentifier": {
+        "EngineVersion": "DBEngineVersions[].EngineVersion"
+      }
+    },
+    "DBInstance": {
+      "operation": "DescribeDBInstances",
+      "resourceIdentifier": {
+        "DBInstanceClass": "DBInstances[].DBInstanceClass"
+      }
+    },
+    "DBParameterGroup": {
+      "operation": "DescribeDBParameterGroups",
+      "resourceIdentifier": {
+        "DBParameterGroupArn": "DBParameterGroups[].DBParameterGroupArn"
+      }
+    },
+    "DBParameter": {
+      "operation": "DescribeDBParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      },
+      "inputParameters": [
+        "DBParameterGroupName"
+      ]
+    },
+    "DBSubnetGroup": {
+      "operation": "DescribeDBSubnetGroups",
+      "resourceIdentifier": {
+        "DBSubnetGroupArn": "DBSubnetGroups[].DBSubnetGroupArn"
+      }
+    },
+    "EventCategory": {
+      "operation": "DescribeEventCategories",
+      "resourceIdentifier": {
+        "EventCategories": "EventCategoriesMapList[].EventCategories"
+      }
+    },
+    "EventSubscription": {
+      "operation": "DescribeEventSubscriptions",
+      "resourceIdentifier": {
+        "EventSubscriptionArn": "EventSubscriptionsList[].EventSubscriptionArn"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "EventCategories": "Events[].EventCategories"
+      }
+    },
+    "OrderableDBInstanceOption": {
+      "operation": "DescribeOrderableDBInstanceOptions",
+      "resourceIdentifier": {
+        "DBInstanceClass": "OrderableDBInstanceOptions[].DBInstanceClass"
+      },
+      "inputParameters": [
+        "Engine"
+      ]
+    },
+    "PendingMaintenanceAction": {
+      "operation": "DescribePendingMaintenanceActions",
+      "resourceIdentifier": {
+        "PendingMaintenanceActionDetails": "PendingMaintenanceActions[].PendingMaintenanceActionDetails"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceName"
+      ]
+    }
+  },
+  "operations": {
+    "CreateDBCluster": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "CreateDBInstance": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "CreateEventSubscription": {
+      "EventCategories": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Event",
+            "resourceIdentifier": "EventCategories"
+          }
+        ]
+      }
+    },
+    "ModifyDBCluster": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyDBInstance": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyEventSubscription": {
+      "EventCategories": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Event",
+            "resourceIdentifier": "EventCategories"
+          }
+        ]
+      }
+    },
+    "RestoreDBClusterFromSnapshot": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/opsworks/2013-02-18/completions-1.json
+++ b/awscli/data/opsworks/2013-02-18/completions-1.json
@@ -1,0 +1,711 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AgentVersion": {
+      "operation": "DescribeAgentVersions",
+      "resourceIdentifier": {
+        "Version": "AgentVersions[].Version"
+      }
+    },
+    "App": {
+      "operation": "DescribeApps",
+      "resourceIdentifier": {
+        "AppId": "Apps[].AppId"
+      }
+    },
+    "Command": {
+      "operation": "DescribeCommands",
+      "resourceIdentifier": {
+        "CommandId": "Commands[].CommandId"
+      }
+    },
+    "Deployment": {
+      "operation": "DescribeDeployments",
+      "resourceIdentifier": {
+        "DeploymentId": "Deployments[].DeploymentId"
+      }
+    },
+    "EcsCluster": {
+      "operation": "DescribeEcsClusters",
+      "resourceIdentifier": {
+        "EcsClusterArn": "EcsClusters[].EcsClusterArn"
+      }
+    },
+    "ElasticIp": {
+      "operation": "DescribeElasticIps",
+      "resourceIdentifier": {
+        "InstanceId": "ElasticIps[].InstanceId"
+      }
+    },
+    "ElasticLoadBalancer": {
+      "operation": "DescribeElasticLoadBalancers",
+      "resourceIdentifier": {
+        "ElasticLoadBalancerName": "ElasticLoadBalancers[].ElasticLoadBalancerName"
+      }
+    },
+    "Instance": {
+      "operation": "DescribeInstances",
+      "resourceIdentifier": {
+        "InstanceId": "Instances[].InstanceId"
+      }
+    },
+    "Layer": {
+      "operation": "DescribeLayers",
+      "resourceIdentifier": {
+        "LayerId": "Layers[].LayerId"
+      }
+    },
+    "LoadBasedAutoScaling": {
+      "operation": "DescribeLoadBasedAutoScaling",
+      "resourceIdentifier": {
+        "DownScaling": "LoadBasedAutoScalingConfigurations[].DownScaling"
+      },
+      "inputParameters": [
+        "LayerIds"
+      ]
+    },
+    "OperatingSystem": {
+      "operation": "DescribeOperatingSystems",
+      "resourceIdentifier": {
+        "ConfigurationManagers": "OperatingSystems[].ConfigurationManagers"
+      }
+    },
+    "Permission": {
+      "operation": "DescribePermissions",
+      "resourceIdentifier": {
+        "IamUserArn": "Permissions[].IamUserArn"
+      }
+    },
+    "RaidArray": {
+      "operation": "DescribeRaidArrays",
+      "resourceIdentifier": {
+        "RaidArrayId": "RaidArrays[].RaidArrayId"
+      }
+    },
+    "RdsDbInstance": {
+      "operation": "DescribeRdsDbInstances",
+      "resourceIdentifier": {
+        "RdsDbInstanceArn": "RdsDbInstances[].RdsDbInstanceArn"
+      },
+      "inputParameters": [
+        "StackId"
+      ]
+    },
+    "ServiceError": {
+      "operation": "DescribeServiceErrors",
+      "resourceIdentifier": {
+        "ServiceErrorId": "ServiceErrors[].ServiceErrorId"
+      }
+    },
+    "Stack": {
+      "operation": "DescribeStacks",
+      "resourceIdentifier": {
+        "StackId": "Stacks[].StackId"
+      }
+    },
+    "TimeBasedAutoScaling": {
+      "operation": "DescribeTimeBasedAutoScaling",
+      "resourceIdentifier": {
+        "AutoScalingSchedule": "TimeBasedAutoScalingConfigurations[].AutoScalingSchedule"
+      },
+      "inputParameters": [
+        "InstanceIds"
+      ]
+    },
+    "UserProfile": {
+      "operation": "DescribeUserProfiles",
+      "resourceIdentifier": {
+        "IamUserArn": "UserProfiles[].IamUserArn"
+      }
+    },
+    "Volume": {
+      "operation": "DescribeVolumes",
+      "resourceIdentifier": {
+        "VolumeId": "Volumes[].VolumeId"
+      }
+    }
+  },
+  "operations": {
+    "AssignInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "LayerIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerIds"
+          }
+        ]
+      }
+    },
+    "AssignVolume": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "AssociateElasticIp": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "AttachElasticLoadBalancer": {
+      "ElasticLoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ElasticLoadBalancer",
+            "resourceIdentifier": "ElasticLoadBalancerName"
+          }
+        ]
+      },
+      "LayerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerId"
+          }
+        ]
+      }
+    },
+    "CloneStack": {
+      "ConfigurationManager": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OperatingSystem",
+            "resourceIdentifier": "ConfigurationManager"
+          }
+        ]
+      }
+    },
+    "CreateApp": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "CreateDeployment": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      },
+      "AppId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "App",
+            "resourceIdentifier": "AppId"
+          }
+        ]
+      },
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      },
+      "LayerIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerIds"
+          }
+        ]
+      }
+    },
+    "CreateInstance": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      },
+      "LayerIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerIds"
+          }
+        ]
+      }
+    },
+    "CreateLayer": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "CreateStack": {
+      "ConfigurationManager": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OperatingSystem",
+            "resourceIdentifier": "ConfigurationManager"
+          }
+        ]
+      }
+    },
+    "CreateUserProfile": {
+      "IamUserArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "IamUserArn"
+          }
+        ]
+      }
+    },
+    "DeleteApp": {
+      "AppId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "App",
+            "resourceIdentifier": "AppId"
+          }
+        ]
+      }
+    },
+    "DeleteInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "DeleteLayer": {
+      "LayerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerId"
+          }
+        ]
+      }
+    },
+    "DeleteStack": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "DeleteUserProfile": {
+      "IamUserArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "IamUserArn"
+          }
+        ]
+      }
+    },
+    "DeregisterEcsCluster": {
+      "EcsClusterArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EcsCluster",
+            "resourceIdentifier": "EcsClusterArn"
+          }
+        ]
+      }
+    },
+    "DeregisterInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "DeregisterVolume": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "DetachElasticLoadBalancer": {
+      "ElasticLoadBalancerName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ElasticLoadBalancer",
+            "resourceIdentifier": "ElasticLoadBalancerName"
+          }
+        ]
+      },
+      "LayerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerId"
+          }
+        ]
+      }
+    },
+    "GetHostnameSuggestion": {
+      "LayerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerId"
+          }
+        ]
+      }
+    },
+    "GrantAccess": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "RebootInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "RegisterEcsCluster": {
+      "EcsClusterArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "EcsCluster",
+            "resourceIdentifier": "EcsClusterArn"
+          }
+        ]
+      },
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "RegisterElasticIp": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "RegisterInstance": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "RegisterRdsDbInstance": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "RegisterVolume": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "SetLoadBasedAutoScaling": {
+      "LayerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerId"
+          }
+        ]
+      }
+    },
+    "SetPermission": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      },
+      "IamUserArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "IamUserArn"
+          }
+        ]
+      }
+    },
+    "SetTimeBasedAutoScaling": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "StartInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "StartStack": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "StopInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "StopStack": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      }
+    },
+    "UnassignInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "UnassignVolume": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    },
+    "UpdateApp": {
+      "AppId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "App",
+            "resourceIdentifier": "AppId"
+          }
+        ]
+      }
+    },
+    "UpdateInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Instance",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "LayerIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerIds"
+          }
+        ]
+      }
+    },
+    "UpdateLayer": {
+      "LayerId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Layer",
+            "resourceIdentifier": "LayerId"
+          }
+        ]
+      }
+    },
+    "UpdateStack": {
+      "StackId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Stack",
+            "resourceIdentifier": "StackId"
+          }
+        ]
+      },
+      "ConfigurationManager": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OperatingSystem",
+            "resourceIdentifier": "ConfigurationManager"
+          }
+        ]
+      }
+    },
+    "UpdateUserProfile": {
+      "IamUserArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "UserProfile",
+            "resourceIdentifier": "IamUserArn"
+          }
+        ]
+      }
+    },
+    "UpdateVolume": {
+      "VolumeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Volume",
+            "resourceIdentifier": "VolumeId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/opsworkscm/2016-11-01/completions-1.json
+++ b/awscli/data/opsworkscm/2016-11-01/completions-1.json
@@ -1,0 +1,77 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountAttribute": {
+      "operation": "DescribeAccountAttributes",
+      "resourceIdentifier": {
+        "Name": "Attributes[].Name"
+      }
+    },
+    "Backup": {
+      "operation": "DescribeBackups",
+      "resourceIdentifier": {
+        "BackupId": "Backups[].BackupId"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "Message": "ServerEvents[].Message"
+      },
+      "inputParameters": [
+        "ServerName"
+      ]
+    },
+    "NodeAssociationStatu": {
+      "operation": "DescribeNodeAssociationStatus",
+      "resourceIdentifier": {
+        "Name": "EngineAttributes[].Name"
+      },
+      "inputParameters": [
+        "NodeAssociationStatusToken",
+        "ServerName"
+      ]
+    },
+    "Server": {
+      "operation": "DescribeServers",
+      "resourceIdentifier": {
+        "ServerArn": "Servers[].ServerArn"
+      }
+    }
+  },
+  "operations": {
+    "CreateServer": {
+      "BackupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupId"
+          }
+        ]
+      }
+    },
+    "DeleteBackup": {
+      "BackupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupId"
+          }
+        ]
+      }
+    },
+    "RestoreServer": {
+      "BackupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Backup",
+            "resourceIdentifier": "BackupId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/organizations/2016-11-28/completions-1.json
+++ b/awscli/data/organizations/2016-11-28/completions-1.json
@@ -1,0 +1,163 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AWSServiceAccessForOrganization": {
+      "operation": "ListAWSServiceAccessForOrganization",
+      "resourceIdentifier": {
+        "ServicePrincipal": "EnabledServicePrincipals[].ServicePrincipal"
+      }
+    },
+    "Account": {
+      "operation": "ListAccounts",
+      "resourceIdentifier": {
+        "Arn": "Accounts[].Arn"
+      }
+    },
+    "AccountsForParent": {
+      "operation": "ListAccountsForParent",
+      "resourceIdentifier": {
+        "JoinedMethod": "Accounts[].JoinedMethod"
+      },
+      "inputParameters": [
+        "ParentId"
+      ]
+    },
+    "Children": {
+      "operation": "ListChildren",
+      "resourceIdentifier": {
+        "Id": "Children[].Id"
+      },
+      "inputParameters": [
+        "ParentId",
+        "ChildType"
+      ]
+    },
+    "CreateAccountStatu": {
+      "operation": "ListCreateAccountStatus",
+      "resourceIdentifier": {
+        "AccountName": "CreateAccountStatuses[].AccountName"
+      }
+    },
+    "HandshakesForAccount": {
+      "operation": "ListHandshakesForAccount",
+      "resourceIdentifier": {
+        "Action": "Handshakes[].Action"
+      }
+    },
+    "HandshakesForOrganization": {
+      "operation": "ListHandshakesForOrganization",
+      "resourceIdentifier": {
+        "ExpirationTimestamp": "Handshakes[].ExpirationTimestamp"
+      }
+    },
+    "OrganizationalUnitsForParent": {
+      "operation": "ListOrganizationalUnitsForParent",
+      "resourceIdentifier": {
+        "Arn": "OrganizationalUnits[].Arn"
+      },
+      "inputParameters": [
+        "ParentId"
+      ]
+    },
+    "Parent": {
+      "operation": "ListParents",
+      "resourceIdentifier": {
+        "Type": "Parents[].Type"
+      },
+      "inputParameters": [
+        "ChildId"
+      ]
+    },
+    "Policy": {
+      "operation": "ListPolicies",
+      "resourceIdentifier": {
+        "Description": "Policies[].Description"
+      },
+      "inputParameters": [
+        "Filter"
+      ]
+    },
+    "PoliciesForTarget": {
+      "operation": "ListPoliciesForTarget",
+      "resourceIdentifier": {
+        "AwsManaged": "Policies[].AwsManaged"
+      },
+      "inputParameters": [
+        "TargetId",
+        "Filter"
+      ]
+    },
+    "Root": {
+      "operation": "ListRoots",
+      "resourceIdentifier": {
+        "PolicyTypes": "Roots[].PolicyTypes"
+      }
+    },
+    "TargetsForPolicy": {
+      "operation": "ListTargetsForPolicy",
+      "resourceIdentifier": {
+        "TargetId": "Targets[].TargetId"
+      },
+      "inputParameters": [
+        "PolicyId"
+      ]
+    }
+  },
+  "operations": {
+    "CreateAccount": {
+      "AccountName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CreateAccountStatu",
+            "resourceIdentifier": "AccountName"
+          }
+        ]
+      }
+    },
+    "DisableAWSServiceAccess": {
+      "ServicePrincipal": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AWSServiceAccessForOrganization",
+            "resourceIdentifier": "ServicePrincipal"
+          }
+        ]
+      }
+    },
+    "DisablePolicyType": {
+      "PolicyType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Root",
+            "resourceIdentifier": "PolicyType"
+          }
+        ]
+      }
+    },
+    "EnableAWSServiceAccess": {
+      "ServicePrincipal": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AWSServiceAccessForOrganization",
+            "resourceIdentifier": "ServicePrincipal"
+          }
+        ]
+      }
+    },
+    "EnablePolicyType": {
+      "PolicyType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Root",
+            "resourceIdentifier": "PolicyType"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/pi/2018-02-27/completions-1.json
+++ b/awscli/data/pi/2018-02-27/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/pinpoint/2016-12-01/completions-1.json
+++ b/awscli/data/pinpoint/2016-12-01/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/polly/2016-06-10/completions-1.json
+++ b/awscli/data/polly/2016-06-10/completions-1.json
@@ -1,0 +1,65 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Voice": {
+      "operation": "DescribeVoices",
+      "resourceIdentifier": {
+        "LanguageCode": "Voices[].LanguageCode"
+      }
+    },
+    "Lexicon": {
+      "operation": "ListLexicons",
+      "resourceIdentifier": {
+        "Attributes": "Lexicons[].Attributes"
+      }
+    },
+    "SpeechSynthesisTask": {
+      "operation": "ListSpeechSynthesisTasks",
+      "resourceIdentifier": {
+        "SpeechMarkTypes": "SynthesisTasks[].SpeechMarkTypes"
+      }
+    }
+  },
+  "operations": {
+    "StartSpeechSynthesisTask": {
+      "SpeechMarkTypes": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SpeechSynthesisTask",
+            "resourceIdentifier": "SpeechMarkTypes"
+          }
+        ]
+      },
+      "LanguageCode": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Voice",
+            "resourceIdentifier": "LanguageCode"
+          }
+        ]
+      }
+    },
+    "SynthesizeSpeech": {
+      "SpeechMarkTypes": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SpeechSynthesisTask",
+            "resourceIdentifier": "SpeechMarkTypes"
+          }
+        ]
+      },
+      "LanguageCode": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Voice",
+            "resourceIdentifier": "LanguageCode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/pricing/2017-10-15/completions-1.json
+++ b/awscli/data/pricing/2017-10-15/completions-1.json
@@ -1,0 +1,35 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Service": {
+      "operation": "DescribeServices",
+      "resourceIdentifier": {
+        "ServiceCode": "Services[].ServiceCode"
+      }
+    }
+  },
+  "operations": {
+    "GetAttributeValues": {
+      "ServiceCode": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Service",
+            "resourceIdentifier": "ServiceCode"
+          }
+        ]
+      }
+    },
+    "GetProducts": {
+      "ServiceCode": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Service",
+            "resourceIdentifier": "ServiceCode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/rds/2014-10-31/completions-1.json
+++ b/awscli/data/rds/2014-10-31/completions-1.json
@@ -1,0 +1,374 @@
+{
+  "version": "1.0",
+  "resources": {
+    "AccountAttribute": {
+      "operation": "DescribeAccountAttributes",
+      "resourceIdentifier": {
+        "AccountQuotaName": "AccountQuotas[].AccountQuotaName"
+      }
+    },
+    "Certificate": {
+      "operation": "DescribeCertificates",
+      "resourceIdentifier": {
+        "CertificateArn": "Certificates[].CertificateArn"
+      }
+    },
+    "DBClusterBacktrack": {
+      "operation": "DescribeDBClusterBacktracks",
+      "resourceIdentifier": {
+        "BacktrackTo": "DBClusterBacktracks[].BacktrackTo"
+      },
+      "inputParameters": [
+        "DBClusterIdentifier"
+      ]
+    },
+    "DBClusterParameterGroup": {
+      "operation": "DescribeDBClusterParameterGroups",
+      "resourceIdentifier": {
+        "DBClusterParameterGroupArn": "DBClusterParameterGroups[].DBClusterParameterGroupArn"
+      }
+    },
+    "DBClusterParameter": {
+      "operation": "DescribeDBClusterParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      },
+      "inputParameters": [
+        "DBClusterParameterGroupName"
+      ]
+    },
+    "DBClusterSnapshot": {
+      "operation": "DescribeDBClusterSnapshots",
+      "resourceIdentifier": {
+        "DBClusterSnapshotArn": "DBClusterSnapshots[].DBClusterSnapshotArn"
+      }
+    },
+    "DBCluster": {
+      "operation": "DescribeDBClusters",
+      "resourceIdentifier": {
+        "DBClusterArn": "DBClusters[].DBClusterArn"
+      }
+    },
+    "DBEngineVersion": {
+      "operation": "DescribeDBEngineVersions",
+      "resourceIdentifier": {
+        "EngineVersion": "DBEngineVersions[].EngineVersion"
+      }
+    },
+    "DBInstance": {
+      "operation": "DescribeDBInstances",
+      "resourceIdentifier": {
+        "DBInstanceClass": "DBInstances[].DBInstanceClass"
+      }
+    },
+    "DBLogFile": {
+      "operation": "DescribeDBLogFiles",
+      "resourceIdentifier": {
+        "LogFileName": "DescribeDBLogFiles[].LogFileName"
+      },
+      "inputParameters": [
+        "DBInstanceIdentifier"
+      ]
+    },
+    "DBParameterGroup": {
+      "operation": "DescribeDBParameterGroups",
+      "resourceIdentifier": {
+        "DBParameterGroupArn": "DBParameterGroups[].DBParameterGroupArn"
+      }
+    },
+    "DBParameter": {
+      "operation": "DescribeDBParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      },
+      "inputParameters": [
+        "DBParameterGroupName"
+      ]
+    },
+    "DBSecurityGroup": {
+      "operation": "DescribeDBSecurityGroups",
+      "resourceIdentifier": {
+        "DBSecurityGroupArn": "DBSecurityGroups[].DBSecurityGroupArn"
+      }
+    },
+    "DBSnapshot": {
+      "operation": "DescribeDBSnapshots",
+      "resourceIdentifier": {
+        "DBSnapshotArn": "DBSnapshots[].DBSnapshotArn"
+      }
+    },
+    "DBSubnetGroup": {
+      "operation": "DescribeDBSubnetGroups",
+      "resourceIdentifier": {
+        "DBSubnetGroupArn": "DBSubnetGroups[].DBSubnetGroupArn"
+      }
+    },
+    "EventCategory": {
+      "operation": "DescribeEventCategories",
+      "resourceIdentifier": {
+        "EventCategories": "EventCategoriesMapList[].EventCategories"
+      }
+    },
+    "EventSubscription": {
+      "operation": "DescribeEventSubscriptions",
+      "resourceIdentifier": {
+        "EventSubscriptionArn": "EventSubscriptionsList[].EventSubscriptionArn"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "EventCategories": "Events[].EventCategories"
+      }
+    },
+    "OptionGroupOption": {
+      "operation": "DescribeOptionGroupOptions",
+      "resourceIdentifier": {
+        "OptionGroupOptionSettings": "OptionGroupOptions[].OptionGroupOptionSettings"
+      },
+      "inputParameters": [
+        "EngineName"
+      ]
+    },
+    "OptionGroup": {
+      "operation": "DescribeOptionGroups",
+      "resourceIdentifier": {
+        "OptionGroupArn": "OptionGroupsList[].OptionGroupArn"
+      }
+    },
+    "OrderableDBInstanceOption": {
+      "operation": "DescribeOrderableDBInstanceOptions",
+      "resourceIdentifier": {
+        "DBInstanceClass": "OrderableDBInstanceOptions[].DBInstanceClass"
+      },
+      "inputParameters": [
+        "Engine"
+      ]
+    },
+    "PendingMaintenanceAction": {
+      "operation": "DescribePendingMaintenanceActions",
+      "resourceIdentifier": {
+        "PendingMaintenanceActionDetails": "PendingMaintenanceActions[].PendingMaintenanceActionDetails"
+      }
+    },
+    "ReservedDBInstance": {
+      "operation": "DescribeReservedDBInstances",
+      "resourceIdentifier": {
+        "ReservedDBInstanceId": "ReservedDBInstances[].ReservedDBInstanceId"
+      }
+    },
+    "ReservedDBInstancesOffering": {
+      "operation": "DescribeReservedDBInstancesOfferings",
+      "resourceIdentifier": {
+        "ReservedDBInstancesOfferingId": "ReservedDBInstancesOfferings[].ReservedDBInstancesOfferingId"
+      }
+    },
+    "SourceRegion": {
+      "operation": "DescribeSourceRegions",
+      "resourceIdentifier": {
+        "RegionName": "SourceRegions[].RegionName"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceName"
+      ]
+    }
+  },
+  "operations": {
+    "CreateDBCluster": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "CreateDBInstance": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "CreateDBInstanceReadReplica": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      }
+    },
+    "CreateEventSubscription": {
+      "EventCategories": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Event",
+            "resourceIdentifier": "EventCategories"
+          }
+        ]
+      }
+    },
+    "ModifyDBCluster": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyDBInstance": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyDBSnapshot": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "ModifyEventSubscription": {
+      "EventCategories": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Event",
+            "resourceIdentifier": "EventCategories"
+          }
+        ]
+      }
+    },
+    "PurchaseReservedDBInstancesOffering": {
+      "ReservedDBInstancesOfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedDBInstancesOffering",
+            "resourceIdentifier": "ReservedDBInstancesOfferingId"
+          }
+        ]
+      },
+      "ReservedDBInstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedDBInstance",
+            "resourceIdentifier": "ReservedDBInstanceId"
+          }
+        ]
+      }
+    },
+    "RestoreDBClusterFromS3": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "RestoreDBClusterFromSnapshot": {
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "RestoreDBInstanceFromDBSnapshot": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      }
+    },
+    "RestoreDBInstanceFromS3": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      },
+      "EngineVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBEngineVersion",
+            "resourceIdentifier": "EngineVersion"
+          }
+        ]
+      }
+    },
+    "RestoreDBInstanceToPointInTime": {
+      "DBInstanceClass": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "DBInstance",
+            "resourceIdentifier": "DBInstanceClass"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/redshift/2012-12-01/completions-1.json
+++ b/awscli/data/redshift/2012-12-01/completions-1.json
@@ -1,0 +1,435 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ClusterDbRevision": {
+      "operation": "DescribeClusterDbRevisions",
+      "resourceIdentifier": {
+        "CurrentDatabaseRevision": "ClusterDbRevisions[].CurrentDatabaseRevision"
+      }
+    },
+    "ClusterParameterGroup": {
+      "operation": "DescribeClusterParameterGroups",
+      "resourceIdentifier": {
+        "ParameterGroupName": "ParameterGroups[].ParameterGroupName"
+      }
+    },
+    "ClusterParameter": {
+      "operation": "DescribeClusterParameters",
+      "resourceIdentifier": {
+        "ParameterName": "Parameters[].ParameterName"
+      },
+      "inputParameters": [
+        "ParameterGroupName"
+      ]
+    },
+    "ClusterSecurityGroup": {
+      "operation": "DescribeClusterSecurityGroups",
+      "resourceIdentifier": {
+        "ClusterSecurityGroupName": "ClusterSecurityGroups[].ClusterSecurityGroupName"
+      }
+    },
+    "ClusterSnapshot": {
+      "operation": "DescribeClusterSnapshots",
+      "resourceIdentifier": {
+        "SnapshotType": "Snapshots[].SnapshotType"
+      }
+    },
+    "ClusterSubnetGroup": {
+      "operation": "DescribeClusterSubnetGroups",
+      "resourceIdentifier": {
+        "ClusterSubnetGroupName": "ClusterSubnetGroups[].ClusterSubnetGroupName"
+      }
+    },
+    "ClusterTrack": {
+      "operation": "DescribeClusterTracks",
+      "resourceIdentifier": {
+        "MaintenanceTrackName": "MaintenanceTracks[].MaintenanceTrackName"
+      }
+    },
+    "ClusterVersion": {
+      "operation": "DescribeClusterVersions",
+      "resourceIdentifier": {
+        "ClusterVersion": "ClusterVersions[].ClusterVersion"
+      }
+    },
+    "Cluster": {
+      "operation": "DescribeClusters",
+      "resourceIdentifier": {
+        "ClusterNodes": "Clusters[].ClusterNodes"
+      }
+    },
+    "EventCategory": {
+      "operation": "DescribeEventCategories",
+      "resourceIdentifier": {
+        "Events": "EventCategoriesMapList[].Events"
+      }
+    },
+    "EventSubscription": {
+      "operation": "DescribeEventSubscriptions",
+      "resourceIdentifier": {
+        "CustSubscriptionId": "EventSubscriptionsList[].CustSubscriptionId"
+      }
+    },
+    "Event": {
+      "operation": "DescribeEvents",
+      "resourceIdentifier": {
+        "EventId": "Events[].EventId"
+      }
+    },
+    "HsmClientCertificate": {
+      "operation": "DescribeHsmClientCertificates",
+      "resourceIdentifier": {
+        "HsmClientCertificatePublicKey": "HsmClientCertificates[].HsmClientCertificatePublicKey"
+      }
+    },
+    "HsmConfiguration": {
+      "operation": "DescribeHsmConfigurations",
+      "resourceIdentifier": {
+        "HsmConfigurationIdentifier": "HsmConfigurations[].HsmConfigurationIdentifier"
+      }
+    },
+    "OrderableClusterOption": {
+      "operation": "DescribeOrderableClusterOptions",
+      "resourceIdentifier": {
+        "ClusterVersion": "OrderableClusterOptions[].ClusterVersion"
+      }
+    },
+    "ReservedNodeOffering": {
+      "operation": "DescribeReservedNodeOfferings",
+      "resourceIdentifier": {
+        "ReservedNodeOfferingId": "ReservedNodeOfferings[].ReservedNodeOfferingId"
+      }
+    },
+    "ReservedNode": {
+      "operation": "DescribeReservedNodes",
+      "resourceIdentifier": {
+        "ReservedNodeId": "ReservedNodes[].ReservedNodeId"
+      }
+    },
+    "SnapshotCopyGrant": {
+      "operation": "DescribeSnapshotCopyGrants",
+      "resourceIdentifier": {
+        "SnapshotCopyGrantName": "SnapshotCopyGrants[].SnapshotCopyGrantName"
+      }
+    },
+    "TableRestoreStatu": {
+      "operation": "DescribeTableRestoreStatus",
+      "resourceIdentifier": {
+        "TableRestoreRequestId": "TableRestoreStatusDetails[].TableRestoreRequestId"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Tag": "TaggedResources[].Tag"
+      }
+    }
+  },
+  "operations": {
+    "AcceptReservedNodeExchange": {
+      "ReservedNodeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedNode",
+            "resourceIdentifier": "ReservedNodeId"
+          }
+        ]
+      }
+    },
+    "AuthorizeClusterSecurityGroupIngress": {
+      "ClusterSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSecurityGroup",
+            "resourceIdentifier": "ClusterSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "CreateCluster": {
+      "ClusterSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSubnetGroup",
+            "resourceIdentifier": "ClusterSubnetGroupName"
+          }
+        ]
+      },
+      "ClusterVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OrderableClusterOption",
+            "resourceIdentifier": "ClusterVersion"
+          }
+        ]
+      },
+      "HsmConfigurationIdentifier": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HsmConfiguration",
+            "resourceIdentifier": "HsmConfigurationIdentifier"
+          }
+        ]
+      },
+      "MaintenanceTrackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterTrack",
+            "resourceIdentifier": "MaintenanceTrackName"
+          }
+        ]
+      }
+    },
+    "CreateClusterParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "CreateClusterSecurityGroup": {
+      "ClusterSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSecurityGroup",
+            "resourceIdentifier": "ClusterSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "CreateClusterSubnetGroup": {
+      "ClusterSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSubnetGroup",
+            "resourceIdentifier": "ClusterSubnetGroupName"
+          }
+        ]
+      }
+    },
+    "CreateHsmConfiguration": {
+      "HsmConfigurationIdentifier": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HsmConfiguration",
+            "resourceIdentifier": "HsmConfigurationIdentifier"
+          }
+        ]
+      }
+    },
+    "CreateSnapshotCopyGrant": {
+      "SnapshotCopyGrantName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SnapshotCopyGrant",
+            "resourceIdentifier": "SnapshotCopyGrantName"
+          }
+        ]
+      }
+    },
+    "DeleteClusterParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteClusterSecurityGroup": {
+      "ClusterSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSecurityGroup",
+            "resourceIdentifier": "ClusterSecurityGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteClusterSubnetGroup": {
+      "ClusterSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSubnetGroup",
+            "resourceIdentifier": "ClusterSubnetGroupName"
+          }
+        ]
+      }
+    },
+    "DeleteHsmConfiguration": {
+      "HsmConfigurationIdentifier": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HsmConfiguration",
+            "resourceIdentifier": "HsmConfigurationIdentifier"
+          }
+        ]
+      }
+    },
+    "DeleteSnapshotCopyGrant": {
+      "SnapshotCopyGrantName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SnapshotCopyGrant",
+            "resourceIdentifier": "SnapshotCopyGrantName"
+          }
+        ]
+      }
+    },
+    "EnableSnapshotCopy": {
+      "SnapshotCopyGrantName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SnapshotCopyGrant",
+            "resourceIdentifier": "SnapshotCopyGrantName"
+          }
+        ]
+      }
+    },
+    "GetReservedNodeExchangeOfferings": {
+      "ReservedNodeId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedNode",
+            "resourceIdentifier": "ReservedNodeId"
+          }
+        ]
+      }
+    },
+    "ModifyCluster": {
+      "ClusterVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "OrderableClusterOption",
+            "resourceIdentifier": "ClusterVersion"
+          }
+        ]
+      },
+      "HsmConfigurationIdentifier": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HsmConfiguration",
+            "resourceIdentifier": "HsmConfigurationIdentifier"
+          }
+        ]
+      },
+      "MaintenanceTrackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterTrack",
+            "resourceIdentifier": "MaintenanceTrackName"
+          }
+        ]
+      }
+    },
+    "ModifyClusterParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "ModifyClusterSubnetGroup": {
+      "ClusterSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSubnetGroup",
+            "resourceIdentifier": "ClusterSubnetGroupName"
+          }
+        ]
+      }
+    },
+    "PurchaseReservedNodeOffering": {
+      "ReservedNodeOfferingId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReservedNodeOffering",
+            "resourceIdentifier": "ReservedNodeOfferingId"
+          }
+        ]
+      }
+    },
+    "ResetClusterParameterGroup": {
+      "ParameterGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterParameterGroup",
+            "resourceIdentifier": "ParameterGroupName"
+          }
+        ]
+      }
+    },
+    "RestoreFromClusterSnapshot": {
+      "ClusterSubnetGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSubnetGroup",
+            "resourceIdentifier": "ClusterSubnetGroupName"
+          }
+        ]
+      },
+      "HsmConfigurationIdentifier": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HsmConfiguration",
+            "resourceIdentifier": "HsmConfigurationIdentifier"
+          }
+        ]
+      },
+      "MaintenanceTrackName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterTrack",
+            "resourceIdentifier": "MaintenanceTrackName"
+          }
+        ]
+      }
+    },
+    "RevokeClusterSecurityGroupIngress": {
+      "ClusterSecurityGroupName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ClusterSecurityGroup",
+            "resourceIdentifier": "ClusterSecurityGroupName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/rekognition/2016-06-27/completions-1.json
+++ b/awscli/data/rekognition/2016-06-27/completions-1.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Face": {
+      "operation": "ListFaces",
+      "resourceIdentifier": {
+        "FaceId": "Faces[].FaceId"
+      },
+      "inputParameters": [
+        "CollectionId"
+      ]
+    },
+    "StreamProcessor": {
+      "operation": "ListStreamProcessors",
+      "resourceIdentifier": {
+        "Status": "StreamProcessors[].Status"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/resource-groups/2017-11-27/completions-1.json
+++ b/awscli/data/resource-groups/2017-11-27/completions-1.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0",
+  "resources": {
+    "GroupResource": {
+      "operation": "ListGroupResources",
+      "resourceIdentifier": {
+        "ResourceArn": "ResourceIdentifiers[].ResourceArn"
+      },
+      "inputParameters": [
+        "GroupName"
+      ]
+    },
+    "Group": {
+      "operation": "ListGroups",
+      "resourceIdentifier": {
+        "GroupArn": "Groups[].GroupArn"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/resourcegroupstaggingapi/2017-01-26/completions-1.json
+++ b/awscli/data/resourcegroupstaggingapi/2017-01-26/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/route53/2013-04-01/completions-1.json
+++ b/awscli/data/route53/2013-04-01/completions-1.json
@@ -1,0 +1,228 @@
+{
+  "version": "1.0",
+  "resources": {
+    "GeoLocation": {
+      "operation": "ListGeoLocations",
+      "resourceIdentifier": {
+        "ContinentCode": "GeoLocationDetailsList[].ContinentCode"
+      }
+    },
+    "HealthCheck": {
+      "operation": "ListHealthChecks",
+      "resourceIdentifier": {
+        "HealthCheckVersion": "HealthChecks[].HealthCheckVersion"
+      }
+    },
+    "HostedZone": {
+      "operation": "ListHostedZones",
+      "resourceIdentifier": {
+        "LinkedService": "HostedZones[].LinkedService"
+      }
+    },
+    "HostedZonesByName": {
+      "operation": "ListHostedZonesByName",
+      "resourceIdentifier": {
+        "Name": "HostedZones[].Name"
+      }
+    },
+    "QueryLoggingConfig": {
+      "operation": "ListQueryLoggingConfigs",
+      "resourceIdentifier": {
+        "CloudWatchLogsLogGroupArn": "QueryLoggingConfigs[].CloudWatchLogsLogGroupArn"
+      }
+    },
+    "ResourceRecordSet": {
+      "operation": "ListResourceRecordSets",
+      "resourceIdentifier": {
+        "ResourceRecords": "ResourceRecordSets[].ResourceRecords"
+      },
+      "inputParameters": [
+        "HostedZoneId"
+      ]
+    },
+    "ReusableDelegationSet": {
+      "operation": "ListReusableDelegationSets",
+      "resourceIdentifier": {
+        "CallerReference": "DelegationSets[].CallerReference"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResources",
+      "resourceIdentifier": {
+        "ResourceId": "ResourceTagSets[].ResourceId"
+      },
+      "inputParameters": [
+        "ResourceType",
+        "ResourceIds"
+      ]
+    },
+    "TrafficPolicy": {
+      "operation": "ListTrafficPolicies",
+      "resourceIdentifier": {
+        "TrafficPolicyCount": "TrafficPolicySummaries[].TrafficPolicyCount"
+      }
+    },
+    "TrafficPolicyInstance": {
+      "operation": "ListTrafficPolicyInstances",
+      "resourceIdentifier": {
+        "TrafficPolicyId": "TrafficPolicyInstances[].TrafficPolicyId"
+      }
+    },
+    "TrafficPolicyInstancesByHostedZone": {
+      "operation": "ListTrafficPolicyInstancesByHostedZone",
+      "resourceIdentifier": {
+        "TrafficPolicyId": "TrafficPolicyInstances[].TrafficPolicyId"
+      },
+      "inputParameters": [
+        "HostedZoneId"
+      ]
+    },
+    "TrafficPolicyInstancesByPolicy": {
+      "operation": "ListTrafficPolicyInstancesByPolicy",
+      "resourceIdentifier": {
+        "TrafficPolicyId": "TrafficPolicyInstances[].TrafficPolicyId"
+      },
+      "inputParameters": [
+        "TrafficPolicyId",
+        "TrafficPolicyVersion"
+      ]
+    },
+    "TrafficPolicyVersion": {
+      "operation": "ListTrafficPolicyVersions",
+      "resourceIdentifier": {
+        "Version": "TrafficPolicies[].Version"
+      },
+      "inputParameters": [
+        "Id"
+      ]
+    },
+    "VPCAssociationAuthorization": {
+      "operation": "ListVPCAssociationAuthorizations",
+      "resourceIdentifier": {
+        "VPCRegion": "VPCs[].VPCRegion"
+      },
+      "inputParameters": [
+        "HostedZoneId"
+      ]
+    }
+  },
+  "operations": {
+    "CreateHealthCheck": {
+      "CallerReference": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReusableDelegationSet",
+            "resourceIdentifier": "CallerReference"
+          }
+        ]
+      }
+    },
+    "CreateHostedZone": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HostedZonesByName",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "CallerReference": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReusableDelegationSet",
+            "resourceIdentifier": "CallerReference"
+          }
+        ]
+      }
+    },
+    "CreateQueryLoggingConfig": {
+      "CloudWatchLogsLogGroupArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "QueryLoggingConfig",
+            "resourceIdentifier": "CloudWatchLogsLogGroupArn"
+          }
+        ]
+      }
+    },
+    "CreateReusableDelegationSet": {
+      "CallerReference": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ReusableDelegationSet",
+            "resourceIdentifier": "CallerReference"
+          }
+        ]
+      }
+    },
+    "CreateTrafficPolicy": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HostedZonesByName",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "CreateTrafficPolicyInstance": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HostedZonesByName",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "TrafficPolicyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TrafficPolicyInstance",
+            "resourceIdentifier": "TrafficPolicyId"
+          }
+        ]
+      }
+    },
+    "GetGeoLocation": {
+      "ContinentCode": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoLocation",
+            "resourceIdentifier": "ContinentCode"
+          }
+        ]
+      }
+    },
+    "UpdateHealthCheck": {
+      "HealthCheckVersion": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "HealthCheck",
+            "resourceIdentifier": "HealthCheckVersion"
+          }
+        ]
+      }
+    },
+    "UpdateTrafficPolicyInstance": {
+      "TrafficPolicyId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TrafficPolicyInstance",
+            "resourceIdentifier": "TrafficPolicyId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/route53domains/2014-05-15/completions-1.json
+++ b/awscli/data/route53domains/2014-05-15/completions-1.json
@@ -1,0 +1,226 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Domain": {
+      "operation": "ListDomains",
+      "resourceIdentifier": {
+        "DomainName": "Domains[].DomainName"
+      }
+    },
+    "Operation": {
+      "operation": "ListOperations",
+      "resourceIdentifier": {
+        "OperationId": "Operations[].OperationId"
+      }
+    },
+    "TagsForDomain": {
+      "operation": "ListTagsForDomain",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "DomainName"
+      ]
+    }
+  },
+  "operations": {
+    "CheckDomainAvailability": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "CheckDomainTransferability": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "DeleteTagsForDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "DisableDomainAutoRenew": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "DisableDomainTransferLock": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "EnableDomainAutoRenew": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "EnableDomainTransferLock": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetDomainDetail": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetDomainSuggestions": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetOperationDetail": {
+      "OperationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Operation",
+            "resourceIdentifier": "OperationId"
+          }
+        ]
+      }
+    },
+    "RegisterDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "RenewDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "RetrieveDomainAuthCode": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "TransferDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "UpdateDomainContact": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "UpdateDomainContactPrivacy": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "UpdateDomainNameservers": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "UpdateTagsForDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/s3/2006-03-01/completions-1.json
+++ b/awscli/data/s3/2006-03-01/completions-1.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "resources": {
+    "BucketAnalyticsConfiguration": {
+      "operation": "ListBucketAnalyticsConfigurations",
+      "resourceIdentifier": {
+        "StorageClassAnalysis": "AnalyticsConfigurationList[].StorageClassAnalysis"
+      },
+      "inputParameters": [
+        "Bucket"
+      ]
+    },
+    "BucketInventoryConfiguration": {
+      "operation": "ListBucketInventoryConfigurations",
+      "resourceIdentifier": {
+        "Destination": "InventoryConfigurationList[].Destination"
+      },
+      "inputParameters": [
+        "Bucket"
+      ]
+    },
+    "BucketMetricsConfiguration": {
+      "operation": "ListBucketMetricsConfigurations",
+      "resourceIdentifier": {
+        "Filter": "MetricsConfigurationList[].Filter"
+      },
+      "inputParameters": [
+        "Bucket"
+      ]
+    },
+    "Bucket": {
+      "operation": "ListBuckets",
+      "resourceIdentifier": {
+        "CreationDate": "Buckets[].CreationDate"
+      }
+    },
+    "Part": {
+      "operation": "ListParts",
+      "resourceIdentifier": {
+        "PartNumber": "Parts[].PartNumber"
+      },
+      "inputParameters": [
+        "Bucket",
+        "Key",
+        "UploadId"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/sagemaker-runtime/2017-05-13/completions-1.json
+++ b/awscli/data/sagemaker-runtime/2017-05-13/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/sagemaker/2017-07-24/completions-1.json
+++ b/awscli/data/sagemaker/2017-07-24/completions-1.json
@@ -1,0 +1,84 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Endpoint": {
+      "operation": "ListEndpoints",
+      "resourceIdentifier": {
+        "VariantName": "ProductionVariants[].VariantName",
+        "EndpointArn": "Endpoints[].EndpointArn"
+      },
+      "inputParameters": [
+        "EndpointName"
+      ]
+    },
+    "EndpointConfig": {
+      "operation": "ListEndpointConfigs",
+      "resourceIdentifier": {
+        "InitialVariantWeight": "ProductionVariants[].InitialVariantWeight",
+        "EndpointConfigArn": "EndpointConfigs[].EndpointConfigArn"
+      },
+      "inputParameters": [
+        "EndpointConfigName"
+      ]
+    },
+    "NotebookInstance": {
+      "operation": "ListNotebookInstances",
+      "resourceIdentifier": {
+        "SecurityGroups": "SecurityGroups[]",
+        "NotebookInstanceArn": "NotebookInstances[].NotebookInstanceArn"
+      },
+      "inputParameters": [
+        "NotebookInstanceName"
+      ]
+    },
+    "HyperParameterTuningJob": {
+      "operation": "ListHyperParameterTuningJobs",
+      "resourceIdentifier": {
+        "HyperParameterTuningJobArn": "HyperParameterTuningJobSummaries[].HyperParameterTuningJobArn"
+      }
+    },
+    "Model": {
+      "operation": "ListModels",
+      "resourceIdentifier": {
+        "ModelArn": "Models[].ModelArn"
+      }
+    },
+    "NotebookInstanceLifecycleConfig": {
+      "operation": "ListNotebookInstanceLifecycleConfigs",
+      "resourceIdentifier": {
+        "NotebookInstanceLifecycleConfigArn": "NotebookInstanceLifecycleConfigs[].NotebookInstanceLifecycleConfigArn"
+      }
+    },
+    "Tag": {
+      "operation": "ListTags",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceArn"
+      ]
+    },
+    "TrainingJob": {
+      "operation": "ListTrainingJobs",
+      "resourceIdentifier": {
+        "TrainingJobArn": "TrainingJobSummaries[].TrainingJobArn"
+      }
+    },
+    "TrainingJobsForHyperParameterTuningJob": {
+      "operation": "ListTrainingJobsForHyperParameterTuningJob",
+      "resourceIdentifier": {
+        "FinalHyperParameterTuningJobObjectiveMetric": "TrainingJobSummaries[].FinalHyperParameterTuningJobObjectiveMetric"
+      },
+      "inputParameters": [
+        "HyperParameterTuningJobName"
+      ]
+    },
+    "TransformJob": {
+      "operation": "ListTransformJobs",
+      "resourceIdentifier": {
+        "TransformJobArn": "TransformJobSummaries[].TransformJobArn"
+      }
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/sdb/2009-04-15/completions-1.json
+++ b/awscli/data/sdb/2009-04-15/completions-1.json
@@ -1,0 +1,101 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Domain": {
+      "operation": "ListDomains",
+      "resourceIdentifier": {
+        "DomainNames": "DomainNames[]"
+      }
+    }
+  },
+  "operations": {
+    "BatchDeleteAttributes": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "BatchPutAttributes": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "CreateDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "DeleteAttributes": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "DeleteDomain": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "DomainMetadata": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "GetAttributes": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    },
+    "PutAttributes": {
+      "DomainName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Domain",
+            "resourceIdentifier": "DomainName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/secretsmanager/2017-10-17/completions-1.json
+++ b/awscli/data/secretsmanager/2017-10-17/completions-1.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Secret": {
+      "operation": "ListSecrets",
+      "resourceIdentifier": {
+        "Key": "Tags[].Key",
+        "SecretVersionsToStages": "SecretList[].SecretVersionsToStages"
+      },
+      "inputParameters": [
+        "SecretId"
+      ]
+    },
+    "SecretVersionId": {
+      "operation": "ListSecretVersionIds",
+      "resourceIdentifier": {
+        "VersionId": "Versions[].VersionId"
+      },
+      "inputParameters": [
+        "SecretId"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/serverlessrepo/2017-09-08/completions-1.json
+++ b/awscli/data/serverlessrepo/2017-09-08/completions-1.json
@@ -1,0 +1,99 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ApplicationVersion": {
+      "operation": "ListApplicationVersions",
+      "resourceIdentifier": {
+        "ApplicationId": "Versions[].ApplicationId"
+      },
+      "inputParameters": [
+        "ApplicationId"
+      ]
+    },
+    "Application": {
+      "operation": "ListApplications",
+      "resourceIdentifier": {
+        "ApplicationId": "Applications[].ApplicationId"
+      }
+    }
+  },
+  "operations": {
+    "CreateApplicationVersion": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    },
+    "CreateCloudFormationChangeSet": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    },
+    "DeleteApplication": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    },
+    "GetApplication": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    },
+    "GetApplicationPolicy": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    },
+    "PutApplicationPolicy": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    },
+    "UpdateApplication": {
+      "ApplicationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Application",
+            "resourceIdentifier": "ApplicationId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/servicecatalog/2015-12-10/completions-1.json
+++ b/awscli/data/servicecatalog/2015-12-10/completions-1.json
@@ -1,0 +1,237 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Product": {
+      "operation": "DescribeProduct",
+      "resourceIdentifier": {
+        "Id": "ProvisioningArtifacts[].Id"
+      },
+      "inputParameters": [
+        "Id"
+      ]
+    },
+    "ProductView": {
+      "operation": "DescribeProductView",
+      "resourceIdentifier": {
+        "CreatedTime": "ProvisioningArtifacts[].CreatedTime"
+      },
+      "inputParameters": [
+        "Id"
+      ]
+    },
+    "ProvisionedProduct": {
+      "operation": "DescribeProvisionedProduct",
+      "resourceIdentifier": {
+        "Name": "CloudWatchDashboards[].Name"
+      },
+      "inputParameters": [
+        "Id"
+      ]
+    },
+    "ProvisionedProductPlan": {
+      "operation": "ListProvisionedProductPlans",
+      "resourceIdentifier": {
+        "PhysicalResourceId": "ResourceChanges[].PhysicalResourceId",
+        "ProvisionProductName": "ProvisionedProductPlans[].ProvisionProductName"
+      },
+      "inputParameters": [
+        "PlanId"
+      ]
+    },
+    "Record": {
+      "operation": "DescribeRecord",
+      "resourceIdentifier": {
+        "Description": "RecordOutputs[].Description"
+      },
+      "inputParameters": [
+        "Id"
+      ]
+    },
+    "AcceptedPortfolioShare": {
+      "operation": "ListAcceptedPortfolioShares",
+      "resourceIdentifier": {
+        "CreatedTime": "PortfolioDetails[].CreatedTime"
+      }
+    },
+    "ConstraintsForPortfolio": {
+      "operation": "ListConstraintsForPortfolio",
+      "resourceIdentifier": {
+        "ConstraintId": "ConstraintDetails[].ConstraintId"
+      },
+      "inputParameters": [
+        "PortfolioId"
+      ]
+    },
+    "LaunchPath": {
+      "operation": "ListLaunchPaths",
+      "resourceIdentifier": {
+        "ConstraintSummaries": "LaunchPathSummaries[].ConstraintSummaries"
+      },
+      "inputParameters": [
+        "ProductId"
+      ]
+    },
+    "PortfolioAcces": {
+      "operation": "ListPortfolioAccess",
+      "resourceIdentifier": {
+        "AccountIds": "AccountIds[]"
+      },
+      "inputParameters": [
+        "PortfolioId"
+      ]
+    },
+    "Portfolio": {
+      "operation": "ListPortfolios",
+      "resourceIdentifier": {
+        "Description": "PortfolioDetails[].Description"
+      }
+    },
+    "PortfoliosForProduct": {
+      "operation": "ListPortfoliosForProduct",
+      "resourceIdentifier": {
+        "Description": "PortfolioDetails[].Description"
+      },
+      "inputParameters": [
+        "ProductId"
+      ]
+    },
+    "PrincipalsForPortfolio": {
+      "operation": "ListPrincipalsForPortfolio",
+      "resourceIdentifier": {
+        "PrincipalARN": "Principals[].PrincipalARN"
+      },
+      "inputParameters": [
+        "PortfolioId"
+      ]
+    },
+    "ProvisioningArtifact": {
+      "operation": "ListProvisioningArtifacts",
+      "resourceIdentifier": {
+        "Description": "ProvisioningArtifactDetails[].Description"
+      },
+      "inputParameters": [
+        "ProductId"
+      ]
+    },
+    "RecordHistory": {
+      "operation": "ListRecordHistory",
+      "resourceIdentifier": {
+        "RecordErrors": "RecordDetails[].RecordErrors"
+      }
+    },
+    "ResourcesForTagOption": {
+      "operation": "ListResourcesForTagOption",
+      "resourceIdentifier": {
+        "Description": "ResourceDetails[].Description"
+      },
+      "inputParameters": [
+        "TagOptionId"
+      ]
+    },
+    "TagOption": {
+      "operation": "ListTagOptions",
+      "resourceIdentifier": {
+        "Active": "TagOptionDetails[].Active"
+      }
+    }
+  },
+  "operations": {
+    "CreateConstraint": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CreatePortfolio": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CreateProduct": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "UpdateConstraint": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "UpdatePortfolio": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "UpdateProduct": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "UpdateProvisioningArtifact": {
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Portfolio",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      },
+      "Active": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TagOption",
+            "resourceIdentifier": "Active"
+          }
+        ]
+      }
+    },
+    "UpdateTagOption": {
+      "Active": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TagOption",
+            "resourceIdentifier": "Active"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/servicediscovery/2017-03-14/completions-1.json
+++ b/awscli/data/servicediscovery/2017-03-14/completions-1.json
@@ -1,0 +1,105 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Instance": {
+      "operation": "ListInstances",
+      "resourceIdentifier": {
+        "Attributes": "Instances[].Attributes"
+      },
+      "inputParameters": [
+        "ServiceId"
+      ]
+    },
+    "Namespace": {
+      "operation": "ListNamespaces",
+      "resourceIdentifier": {
+        "Name": "Namespaces[].Name"
+      }
+    },
+    "Operation": {
+      "operation": "ListOperations",
+      "resourceIdentifier": {
+        "Status": "Operations[].Status"
+      }
+    },
+    "Service": {
+      "operation": "ListServices",
+      "resourceIdentifier": {
+        "Description": "Services[].Description"
+      }
+    }
+  },
+  "operations": {
+    "CreatePrivateDnsNamespace": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Namespace",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Service",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CreatePublicDnsNamespace": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Namespace",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Service",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "CreateService": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Namespace",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "Description": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Service",
+            "resourceIdentifier": "Description"
+          }
+        ]
+      }
+    },
+    "UpdateInstanceCustomHealthStatus": {
+      "Status": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Operation",
+            "resourceIdentifier": "Status"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/ses/2010-12-01/completions-1.json
+++ b/awscli/data/ses/2010-12-01/completions-1.json
@@ -1,0 +1,138 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ActiveReceiptRuleSet": {
+      "operation": "DescribeActiveReceiptRuleSet",
+      "resourceIdentifier": {
+        "Recipients": "Rules[].Recipients"
+      }
+    },
+    "ConfigurationSet": {
+      "operation": "ListConfigurationSets",
+      "resourceIdentifier": {
+        "CloudWatchDestination": "EventDestinations[].CloudWatchDestination",
+        "Name": "ConfigurationSets[].Name"
+      },
+      "inputParameters": [
+        "ConfigurationSetName"
+      ]
+    },
+    "ReceiptRuleSet": {
+      "operation": "ListReceiptRuleSets",
+      "resourceIdentifier": {
+        "Recipients": "Rules[].Recipients",
+        "CreatedTimestamp": "RuleSets[].CreatedTimestamp"
+      },
+      "inputParameters": [
+        "RuleSetName"
+      ]
+    },
+    "CustomVerificationEmailTemplate": {
+      "operation": "ListCustomVerificationEmailTemplates",
+      "resourceIdentifier": {
+        "FromEmailAddress": "CustomVerificationEmailTemplates[].FromEmailAddress"
+      }
+    },
+    "Identity": {
+      "operation": "ListIdentities",
+      "resourceIdentifier": {
+        "Identities": "Identities[]"
+      }
+    },
+    "IdentityPolicy": {
+      "operation": "ListIdentityPolicies",
+      "resourceIdentifier": {
+        "PolicyNames": "PolicyNames[]"
+      },
+      "inputParameters": [
+        "Identity"
+      ]
+    },
+    "ReceiptFilter": {
+      "operation": "ListReceiptFilters",
+      "resourceIdentifier": {
+        "IpFilter": "Filters[].IpFilter"
+      }
+    },
+    "Template": {
+      "operation": "ListTemplates",
+      "resourceIdentifier": {
+        "CreatedTimestamp": "TemplatesMetadata[].CreatedTimestamp"
+      }
+    },
+    "VerifiedEmailAddresse": {
+      "operation": "ListVerifiedEmailAddresses",
+      "resourceIdentifier": {
+        "VerifiedEmailAddresses": "VerifiedEmailAddresses[]"
+      }
+    }
+  },
+  "operations": {
+    "CreateCustomVerificationEmailTemplate": {
+      "FromEmailAddress": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CustomVerificationEmailTemplate",
+            "resourceIdentifier": "FromEmailAddress"
+          }
+        ]
+      }
+    },
+    "GetIdentityDkimAttributes": {
+      "Identities": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Identity",
+            "resourceIdentifier": "Identities"
+          }
+        ]
+      }
+    },
+    "GetIdentityMailFromDomainAttributes": {
+      "Identities": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Identity",
+            "resourceIdentifier": "Identities"
+          }
+        ]
+      }
+    },
+    "GetIdentityNotificationAttributes": {
+      "Identities": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Identity",
+            "resourceIdentifier": "Identities"
+          }
+        ]
+      }
+    },
+    "GetIdentityVerificationAttributes": {
+      "Identities": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Identity",
+            "resourceIdentifier": "Identities"
+          }
+        ]
+      }
+    },
+    "UpdateCustomVerificationEmailTemplate": {
+      "FromEmailAddress": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "CustomVerificationEmailTemplate",
+            "resourceIdentifier": "FromEmailAddress"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/shield/2016-06-02/completions-1.json
+++ b/awscli/data/shield/2016-06-02/completions-1.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DRTAcces": {
+      "operation": "DescribeDRTAccess",
+      "resourceIdentifier": {
+        "LogBucketList": "LogBucketList[]"
+      }
+    },
+    "EmergencyContactSetting": {
+      "operation": "DescribeEmergencyContactSettings",
+      "resourceIdentifier": {
+        "EmailAddress": "EmergencyContactList[].EmailAddress"
+      }
+    },
+    "Attack": {
+      "operation": "ListAttacks",
+      "resourceIdentifier": {
+        "AttackId": "AttackSummaries[].AttackId"
+      }
+    },
+    "Protection": {
+      "operation": "ListProtections",
+      "resourceIdentifier": {
+        "ResourceArn": "Protections[].ResourceArn"
+      }
+    }
+  },
+  "operations": {
+    "CreateProtection": {
+      "ResourceArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Protection",
+            "resourceIdentifier": "ResourceArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/signer/2017-08-25/completions-1.json
+++ b/awscli/data/signer/2017-08-25/completions-1.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0",
+  "resources": {
+    "SigningJob": {
+      "operation": "ListSigningJobs",
+      "resourceIdentifier": {
+        "signingMaterial": "jobs[].signingMaterial"
+      }
+    },
+    "SigningPlatform": {
+      "operation": "ListSigningPlatforms",
+      "resourceIdentifier": {
+        "signingImageFormat": "platforms[].signingImageFormat"
+      }
+    },
+    "SigningProfile": {
+      "operation": "ListSigningProfiles",
+      "resourceIdentifier": {
+        "signingParameters": "profiles[].signingParameters"
+      }
+    }
+  },
+  "operations": {
+    "PutSigningProfile": {
+      "signingMaterial": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SigningJob",
+            "resourceIdentifier": "signingMaterial"
+          }
+        ]
+      },
+      "signingParameters": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SigningProfile",
+            "resourceIdentifier": "signingParameters"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/sms/2016-10-24/completions-1.json
+++ b/awscli/data/sms/2016-10-24/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/snowball/2016-06-30/completions-1.json
+++ b/awscli/data/snowball/2016-06-30/completions-1.json
@@ -1,0 +1,116 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Addresse": {
+      "operation": "DescribeAddresses",
+      "resourceIdentifier": {
+        "AddressId": "Addresses[].AddressId"
+      }
+    },
+    "Job": {
+      "operation": "ListJobs",
+      "resourceIdentifier": {
+        "JobId": "JobListEntries[].JobId"
+      },
+      "inputParameters": [
+        "JobId"
+      ]
+    },
+    "ClusterJob": {
+      "operation": "ListClusterJobs",
+      "resourceIdentifier": {
+        "IsMaster": "JobListEntries[].IsMaster"
+      },
+      "inputParameters": [
+        "ClusterId"
+      ]
+    },
+    "Cluster": {
+      "operation": "ListClusters",
+      "resourceIdentifier": {
+        "ClusterId": "ClusterListEntries[].ClusterId"
+      }
+    },
+    "CompatibleImage": {
+      "operation": "ListCompatibleImages",
+      "resourceIdentifier": {
+        "AmiId": "CompatibleImages[].AmiId"
+      }
+    }
+  },
+  "operations": {
+    "CancelCluster": {
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      }
+    },
+    "CreateCluster": {
+      "AddressId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "AddressId"
+          }
+        ]
+      }
+    },
+    "CreateJob": {
+      "AddressId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "AddressId"
+          }
+        ]
+      },
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      }
+    },
+    "UpdateCluster": {
+      "ClusterId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Cluster",
+            "resourceIdentifier": "ClusterId"
+          }
+        ]
+      },
+      "AddressId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "AddressId"
+          }
+        ]
+      }
+    },
+    "UpdateJob": {
+      "AddressId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Addresse",
+            "resourceIdentifier": "AddressId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/sns/2010-03-31/completions-1.json
+++ b/awscli/data/sns/2010-03-31/completions-1.json
@@ -1,0 +1,236 @@
+{
+  "version": "1.0",
+  "resources": {
+    "EndpointsByPlatformApplication": {
+      "operation": "ListEndpointsByPlatformApplication",
+      "resourceIdentifier": {
+        "EndpointArn": "Endpoints[].EndpointArn"
+      },
+      "inputParameters": [
+        "PlatformApplicationArn"
+      ]
+    },
+    "PhoneNumbersOptedOut": {
+      "operation": "ListPhoneNumbersOptedOut",
+      "resourceIdentifier": {
+        "phoneNumbers": "phoneNumbers[]"
+      }
+    },
+    "PlatformApplication": {
+      "operation": "ListPlatformApplications",
+      "resourceIdentifier": {
+        "PlatformApplicationArn": "PlatformApplications[].PlatformApplicationArn"
+      }
+    },
+    "Subscription": {
+      "operation": "ListSubscriptions",
+      "resourceIdentifier": {
+        "SubscriptionArn": "Subscriptions[].SubscriptionArn"
+      }
+    },
+    "SubscriptionsByTopic": {
+      "operation": "ListSubscriptionsByTopic",
+      "resourceIdentifier": {
+        "SubscriptionArn": "Subscriptions[].SubscriptionArn"
+      },
+      "inputParameters": [
+        "TopicArn"
+      ]
+    },
+    "Topic": {
+      "operation": "ListTopics",
+      "resourceIdentifier": {
+        "TopicArn": "Topics[].TopicArn"
+      }
+    }
+  },
+  "operations": {
+    "AddPermission": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "CheckIfPhoneNumberIsOptedOut": {
+      "phoneNumber": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PhoneNumbersOptedOut",
+            "resourceIdentifier": "phoneNumber"
+          }
+        ]
+      }
+    },
+    "ConfirmSubscription": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "CreatePlatformEndpoint": {
+      "PlatformApplicationArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformApplication",
+            "resourceIdentifier": "PlatformApplicationArn"
+          }
+        ]
+      }
+    },
+    "DeletePlatformApplication": {
+      "PlatformApplicationArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformApplication",
+            "resourceIdentifier": "PlatformApplicationArn"
+          }
+        ]
+      }
+    },
+    "DeleteTopic": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "GetPlatformApplicationAttributes": {
+      "PlatformApplicationArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformApplication",
+            "resourceIdentifier": "PlatformApplicationArn"
+          }
+        ]
+      }
+    },
+    "GetSubscriptionAttributes": {
+      "SubscriptionArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subscription",
+            "resourceIdentifier": "SubscriptionArn"
+          }
+        ]
+      }
+    },
+    "GetTopicAttributes": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "OptInPhoneNumber": {
+      "phoneNumber": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PhoneNumbersOptedOut",
+            "resourceIdentifier": "phoneNumber"
+          }
+        ]
+      }
+    },
+    "Publish": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "RemovePermission": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "SetPlatformApplicationAttributes": {
+      "PlatformApplicationArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PlatformApplication",
+            "resourceIdentifier": "PlatformApplicationArn"
+          }
+        ]
+      }
+    },
+    "SetSubscriptionAttributes": {
+      "SubscriptionArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subscription",
+            "resourceIdentifier": "SubscriptionArn"
+          }
+        ]
+      }
+    },
+    "SetTopicAttributes": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "Subscribe": {
+      "TopicArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Topic",
+            "resourceIdentifier": "TopicArn"
+          }
+        ]
+      }
+    },
+    "Unsubscribe": {
+      "SubscriptionArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Subscription",
+            "resourceIdentifier": "SubscriptionArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/sqs/2012-11-05/completions-1.json
+++ b/awscli/data/sqs/2012-11-05/completions-1.json
@@ -1,0 +1,187 @@
+{
+  "version": "1.0",
+  "resources": {
+    "DeadLetterSourceQueue": {
+      "operation": "ListDeadLetterSourceQueues",
+      "resourceIdentifier": {
+        "queueUrls": "queueUrls[]"
+      },
+      "inputParameters": [
+        "QueueUrl"
+      ]
+    },
+    "Queue": {
+      "operation": "ListQueues",
+      "resourceIdentifier": {
+        "QueueUrls": "QueueUrls[]"
+      }
+    }
+  },
+  "operations": {
+    "AddPermission": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "ChangeMessageVisibility": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "ChangeMessageVisibilityBatch": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "DeleteMessage": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "DeleteMessageBatch": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "DeleteQueue": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "GetQueueAttributes": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "PurgeQueue": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "ReceiveMessage": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "RemovePermission": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "SendMessage": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "SendMessageBatch": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "SetQueueAttributes": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "TagQueue": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    },
+    "UntagQueue": {
+      "QueueUrl": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Queue",
+            "resourceIdentifier": "QueueUrl"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/ssm/2014-11-06/completions-1.json
+++ b/awscli/data/ssm/2014-11-06/completions-1.json
@@ -1,0 +1,885 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Activation": {
+      "operation": "DescribeActivations",
+      "resourceIdentifier": {
+        "ActivationId": "ActivationList[].ActivationId"
+      }
+    },
+    "AssociationExecutionTarget": {
+      "operation": "DescribeAssociationExecutionTargets",
+      "resourceIdentifier": {
+        "AssociationVersion": "AssociationExecutionTargets[].AssociationVersion"
+      },
+      "inputParameters": [
+        "AssociationId",
+        "ExecutionId"
+      ]
+    },
+    "AssociationExecution": {
+      "operation": "DescribeAssociationExecutions",
+      "resourceIdentifier": {
+        "AssociationVersion": "AssociationExecutions[].AssociationVersion"
+      },
+      "inputParameters": [
+        "AssociationId"
+      ]
+    },
+    "AutomationExecution": {
+      "operation": "DescribeAutomationExecutions",
+      "resourceIdentifier": {
+        "AutomationExecutionId": "AutomationExecutionMetadataList[].AutomationExecutionId"
+      }
+    },
+    "AutomationStepExecution": {
+      "operation": "DescribeAutomationStepExecutions",
+      "resourceIdentifier": {
+        "StepExecutionId": "StepExecutions[].StepExecutionId"
+      },
+      "inputParameters": [
+        "AutomationExecutionId"
+      ]
+    },
+    "AvailablePatche": {
+      "operation": "DescribeAvailablePatches",
+      "resourceIdentifier": {
+        "ReleaseDate": "Patches[].ReleaseDate"
+      }
+    },
+    "DocumentPermission": {
+      "operation": "DescribeDocumentPermission",
+      "resourceIdentifier": {
+        "AccountIds": "AccountIds[]"
+      },
+      "inputParameters": [
+        "Name",
+        "PermissionType"
+      ]
+    },
+    "EffectiveInstanceAssociation": {
+      "operation": "DescribeEffectiveInstanceAssociations",
+      "resourceIdentifier": {
+        "AssociationId": "Associations[].AssociationId"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    },
+    "EffectivePatchesForPatchBaseline": {
+      "operation": "DescribeEffectivePatchesForPatchBaseline",
+      "resourceIdentifier": {
+        "PatchStatus": "EffectivePatches[].PatchStatus"
+      },
+      "inputParameters": [
+        "BaselineId"
+      ]
+    },
+    "InstanceAssociationsStatu": {
+      "operation": "DescribeInstanceAssociationsStatus",
+      "resourceIdentifier": {
+        "AssociationName": "InstanceAssociationStatusInfos[].AssociationName"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    },
+    "InstanceInformation": {
+      "operation": "DescribeInstanceInformation",
+      "resourceIdentifier": {
+        "InstanceId": "InstanceInformationList[].InstanceId"
+      }
+    },
+    "InstancePatchState": {
+      "operation": "DescribeInstancePatchStates",
+      "resourceIdentifier": {
+        "InstanceId": "InstancePatchStates[].InstanceId"
+      },
+      "inputParameters": [
+        "InstanceIds"
+      ]
+    },
+    "InstancePatchStatesForPatchGroup": {
+      "operation": "DescribeInstancePatchStatesForPatchGroup",
+      "resourceIdentifier": {
+        "PatchGroup": "InstancePatchStates[].PatchGroup"
+      },
+      "inputParameters": [
+        "PatchGroup"
+      ]
+    },
+    "InstancePatche": {
+      "operation": "DescribeInstancePatches",
+      "resourceIdentifier": {
+        "InstalledTime": "Patches[].InstalledTime"
+      },
+      "inputParameters": [
+        "InstanceId"
+      ]
+    },
+    "InventoryDeletion": {
+      "operation": "DescribeInventoryDeletions",
+      "resourceIdentifier": {
+        "DeletionId": "InventoryDeletions[].DeletionId"
+      }
+    },
+    "MaintenanceWindowExecutionTaskInvocation": {
+      "operation": "DescribeMaintenanceWindowExecutionTaskInvocations",
+      "resourceIdentifier": {
+        "WindowExecutionId": "WindowExecutionTaskInvocationIdentities[].WindowExecutionId"
+      },
+      "inputParameters": [
+        "WindowExecutionId",
+        "TaskId"
+      ]
+    },
+    "MaintenanceWindowExecutionTask": {
+      "operation": "DescribeMaintenanceWindowExecutionTasks",
+      "resourceIdentifier": {
+        "WindowExecutionId": "WindowExecutionTaskIdentities[].WindowExecutionId"
+      },
+      "inputParameters": [
+        "WindowExecutionId"
+      ]
+    },
+    "MaintenanceWindowExecution": {
+      "operation": "DescribeMaintenanceWindowExecutions",
+      "resourceIdentifier": {
+        "WindowExecutionId": "WindowExecutions[].WindowExecutionId"
+      },
+      "inputParameters": [
+        "WindowId"
+      ]
+    },
+    "MaintenanceWindowTarget": {
+      "operation": "DescribeMaintenanceWindowTargets",
+      "resourceIdentifier": {
+        "WindowTargetId": "Targets[].WindowTargetId"
+      },
+      "inputParameters": [
+        "WindowId"
+      ]
+    },
+    "MaintenanceWindowTask": {
+      "operation": "DescribeMaintenanceWindowTasks",
+      "resourceIdentifier": {
+        "WindowTaskId": "Tasks[].WindowTaskId"
+      },
+      "inputParameters": [
+        "WindowId"
+      ]
+    },
+    "MaintenanceWindow": {
+      "operation": "DescribeMaintenanceWindows",
+      "resourceIdentifier": {
+        "WindowId": "WindowIdentities[].WindowId"
+      }
+    },
+    "Parameter": {
+      "operation": "DescribeParameters",
+      "resourceIdentifier": {
+        "Name": "Parameters[].Name"
+      }
+    },
+    "PatchBaseline": {
+      "operation": "DescribePatchBaselines",
+      "resourceIdentifier": {
+        "DefaultBaseline": "BaselineIdentities[].DefaultBaseline"
+      }
+    },
+    "PatchGroup": {
+      "operation": "DescribePatchGroups",
+      "resourceIdentifier": {
+        "PatchGroup": "Mappings[].PatchGroup"
+      }
+    },
+    "Session": {
+      "operation": "DescribeSessions",
+      "resourceIdentifier": {
+        "SessionId": "Sessions[].SessionId"
+      },
+      "inputParameters": [
+        "State"
+      ]
+    },
+    "AssociationVersion": {
+      "operation": "ListAssociationVersions",
+      "resourceIdentifier": {
+        "AssociationVersion": "AssociationVersions[].AssociationVersion"
+      },
+      "inputParameters": [
+        "AssociationId"
+      ]
+    },
+    "Association": {
+      "operation": "ListAssociations",
+      "resourceIdentifier": {
+        "AssociationId": "Associations[].AssociationId"
+      }
+    },
+    "CommandInvocation": {
+      "operation": "ListCommandInvocations",
+      "resourceIdentifier": {
+        "CommandPlugins": "CommandInvocations[].CommandPlugins"
+      }
+    },
+    "Command": {
+      "operation": "ListCommands",
+      "resourceIdentifier": {
+        "CommandId": "Commands[].CommandId"
+      }
+    },
+    "ComplianceItem": {
+      "operation": "ListComplianceItems",
+      "resourceIdentifier": {
+        "ComplianceType": "ComplianceItems[].ComplianceType"
+      }
+    },
+    "ComplianceSummary": {
+      "operation": "ListComplianceSummaries",
+      "resourceIdentifier": {
+        "CompliantSummary": "ComplianceSummaryItems[].CompliantSummary"
+      }
+    },
+    "DocumentVersion": {
+      "operation": "ListDocumentVersions",
+      "resourceIdentifier": {
+        "DocumentVersion": "DocumentVersions[].DocumentVersion"
+      },
+      "inputParameters": [
+        "Name"
+      ]
+    },
+    "Document": {
+      "operation": "ListDocuments",
+      "resourceIdentifier": {
+        "DocumentType": "DocumentIdentifiers[].DocumentType"
+      }
+    },
+    "ResourceComplianceSummary": {
+      "operation": "ListResourceComplianceSummaries",
+      "resourceIdentifier": {
+        "NonCompliantSummary": "ResourceComplianceSummaryItems[].NonCompliantSummary"
+      }
+    },
+    "ResourceDataSync": {
+      "operation": "ListResourceDataSync",
+      "resourceIdentifier": {
+        "LastSyncTime": "ResourceDataSyncItems[].LastSyncTime"
+      }
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceType",
+        "ResourceId"
+      ]
+    }
+  },
+  "operations": {
+    "CancelCommand": {
+      "CommandId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Command",
+            "resourceIdentifier": "CommandId"
+          }
+        ]
+      },
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "CreateAssociation": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "CreateDocument": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "DocumentType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Document",
+            "resourceIdentifier": "DocumentType"
+          }
+        ]
+      }
+    },
+    "CreateMaintenanceWindow": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "CreatePatchBaseline": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "DeleteActivation": {
+      "ActivationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Activation",
+            "resourceIdentifier": "ActivationId"
+          }
+        ]
+      }
+    },
+    "DeleteAssociation": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      },
+      "AssociationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Association",
+            "resourceIdentifier": "AssociationId"
+          }
+        ]
+      }
+    },
+    "DeleteDocument": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "DeleteMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      }
+    },
+    "DeleteParameter": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "DeregisterManagedInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "DeregisterPatchBaselineForPatchGroup": {
+      "PatchGroup": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PatchGroup",
+            "resourceIdentifier": "PatchGroup"
+          }
+        ]
+      }
+    },
+    "DeregisterTargetFromMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      }
+    },
+    "DeregisterTaskFromMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      }
+    },
+    "GetAutomationExecution": {
+      "AutomationExecutionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutomationExecution",
+            "resourceIdentifier": "AutomationExecutionId"
+          }
+        ]
+      }
+    },
+    "GetCommandInvocation": {
+      "CommandId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Command",
+            "resourceIdentifier": "CommandId"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "GetDeployablePatchSnapshotForInstance": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "GetDocument": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "GetMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      }
+    },
+    "GetMaintenanceWindowTask": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      }
+    },
+    "GetParameter": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "GetParameterHistory": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "GetPatchBaselineForPatchGroup": {
+      "PatchGroup": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PatchGroup",
+            "resourceIdentifier": "PatchGroup"
+          }
+        ]
+      }
+    },
+    "LabelParameterVersion": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "ModifyDocumentPermission": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "PutComplianceItems": {
+      "ComplianceType": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ComplianceItem",
+            "resourceIdentifier": "ComplianceType"
+          }
+        ]
+      }
+    },
+    "PutInventory": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "PutParameter": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "RegisterPatchBaselineForPatchGroup": {
+      "PatchGroup": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "PatchGroup",
+            "resourceIdentifier": "PatchGroup"
+          }
+        ]
+      }
+    },
+    "RegisterTargetWithMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "RegisterTaskWithMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "SendAutomationSignal": {
+      "AutomationExecutionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutomationExecution",
+            "resourceIdentifier": "AutomationExecutionId"
+          }
+        ]
+      }
+    },
+    "SendCommand": {
+      "InstanceIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceIds"
+          }
+        ]
+      }
+    },
+    "StartAssociationsOnce": {
+      "AssociationIds": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Association",
+            "resourceIdentifier": "AssociationIds"
+          }
+        ]
+      }
+    },
+    "StopAutomationExecution": {
+      "AutomationExecutionId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "AutomationExecution",
+            "resourceIdentifier": "AutomationExecutionId"
+          }
+        ]
+      }
+    },
+    "UpdateAssociation": {
+      "AssociationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Association",
+            "resourceIdentifier": "AssociationId"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateAssociationStatus": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      },
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "UpdateDocument": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateDocumentDefaultVersion": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateMaintenanceWindow": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateMaintenanceWindowTarget": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateMaintenanceWindowTask": {
+      "WindowId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "MaintenanceWindow",
+            "resourceIdentifier": "WindowId"
+          }
+        ]
+      },
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    },
+    "UpdateManagedInstanceRole": {
+      "InstanceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "InstanceInformation",
+            "resourceIdentifier": "InstanceId"
+          }
+        ]
+      }
+    },
+    "UpdatePatchBaseline": {
+      "Name": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Parameter",
+            "resourceIdentifier": "Name"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/stepfunctions/2016-11-23/completions-1.json
+++ b/awscli/data/stepfunctions/2016-11-23/completions-1.json
@@ -1,0 +1,83 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Activity": {
+      "operation": "ListActivities",
+      "resourceIdentifier": {
+        "activityArn": "activities[].activityArn"
+      }
+    },
+    "Execution": {
+      "operation": "ListExecutions",
+      "resourceIdentifier": {
+        "executionArn": "executions[].executionArn"
+      },
+      "inputParameters": [
+        "stateMachineArn"
+      ]
+    },
+    "StateMachine": {
+      "operation": "ListStateMachines",
+      "resourceIdentifier": {
+        "stateMachineArn": "stateMachines[].stateMachineArn"
+      }
+    }
+  },
+  "operations": {
+    "DeleteActivity": {
+      "activityArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Activity",
+            "resourceIdentifier": "activityArn"
+          }
+        ]
+      }
+    },
+    "DeleteStateMachine": {
+      "stateMachineArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StateMachine",
+            "resourceIdentifier": "stateMachineArn"
+          }
+        ]
+      }
+    },
+    "GetActivityTask": {
+      "activityArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Activity",
+            "resourceIdentifier": "activityArn"
+          }
+        ]
+      }
+    },
+    "StartExecution": {
+      "stateMachineArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StateMachine",
+            "resourceIdentifier": "stateMachineArn"
+          }
+        ]
+      }
+    },
+    "UpdateStateMachine": {
+      "stateMachineArn": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "StateMachine",
+            "resourceIdentifier": "stateMachineArn"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/storagegateway/2013-06-30/completions-1.json
+++ b/awscli/data/storagegateway/2013-06-30/completions-1.json
@@ -1,0 +1,186 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Cache": {
+      "operation": "DescribeCache",
+      "resourceIdentifier": {
+        "DiskIds": "DiskIds[]"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "CachediSCSIVolume": {
+      "operation": "DescribeCachediSCSIVolumes",
+      "resourceIdentifier": {
+        "VolumeStatus": "CachediSCSIVolumes[].VolumeStatus"
+      },
+      "inputParameters": [
+        "VolumeARNs"
+      ]
+    },
+    "ChapCredential": {
+      "operation": "DescribeChapCredentials",
+      "resourceIdentifier": {
+        "SecretToAuthenticateTarget": "ChapCredentials[].SecretToAuthenticateTarget"
+      },
+      "inputParameters": [
+        "TargetARN"
+      ]
+    },
+    "GatewayInformation": {
+      "operation": "DescribeGatewayInformation",
+      "resourceIdentifier": {
+        "MacAddress": "GatewayNetworkInterfaces[].MacAddress"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "NFSFileShare": {
+      "operation": "DescribeNFSFileShares",
+      "resourceIdentifier": {
+        "NFSFileShareDefaults": "NFSFileShareInfoList[].NFSFileShareDefaults"
+      },
+      "inputParameters": [
+        "FileShareARNList"
+      ]
+    },
+    "SMBFileShare": {
+      "operation": "DescribeSMBFileShares",
+      "resourceIdentifier": {
+        "FileShareId": "SMBFileShareInfoList[].FileShareId"
+      },
+      "inputParameters": [
+        "FileShareARNList"
+      ]
+    },
+    "StorediSCSIVolume": {
+      "operation": "DescribeStorediSCSIVolumes",
+      "resourceIdentifier": {
+        "VolumeStatus": "StorediSCSIVolumes[].VolumeStatus"
+      },
+      "inputParameters": [
+        "VolumeARNs"
+      ]
+    },
+    "TapeArchive": {
+      "operation": "DescribeTapeArchives",
+      "resourceIdentifier": {
+        "TapeBarcode": "TapeArchives[].TapeBarcode"
+      }
+    },
+    "TapeRecoveryPoint": {
+      "operation": "DescribeTapeRecoveryPoints",
+      "resourceIdentifier": {
+        "TapeRecoveryPointTime": "TapeRecoveryPointInfos[].TapeRecoveryPointTime"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "Tape": {
+      "operation": "ListTapes",
+      "resourceIdentifier": {
+        "TapeARN": "TapeInfos[].TapeARN"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "UploadBuffer": {
+      "operation": "DescribeUploadBuffer",
+      "resourceIdentifier": {
+        "DiskIds": "DiskIds[]"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "VTLDevice": {
+      "operation": "DescribeVTLDevices",
+      "resourceIdentifier": {
+        "VTLDeviceARN": "VTLDevices[].VTLDeviceARN"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "WorkingStorage": {
+      "operation": "DescribeWorkingStorage",
+      "resourceIdentifier": {
+        "DiskIds": "DiskIds[]"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "FileShare": {
+      "operation": "ListFileShares",
+      "resourceIdentifier": {
+        "FileShareId": "FileShareInfoList[].FileShareId"
+      }
+    },
+    "Gateway": {
+      "operation": "ListGateways",
+      "resourceIdentifier": {
+        "GatewayId": "Gateways[].GatewayId"
+      }
+    },
+    "LocalDisk": {
+      "operation": "ListLocalDisks",
+      "resourceIdentifier": {
+        "DiskId": "Disks[].DiskId"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "TagsForResource": {
+      "operation": "ListTagsForResource",
+      "resourceIdentifier": {
+        "Value": "Tags[].Value"
+      },
+      "inputParameters": [
+        "ResourceARN"
+      ]
+    },
+    "VolumeInitiator": {
+      "operation": "ListVolumeInitiators",
+      "resourceIdentifier": {
+        "Initiators": "Initiators[]"
+      },
+      "inputParameters": [
+        "VolumeARN"
+      ]
+    },
+    "VolumeRecoveryPoint": {
+      "operation": "ListVolumeRecoveryPoints",
+      "resourceIdentifier": {
+        "VolumeRecoveryPointTime": "VolumeRecoveryPointInfos[].VolumeRecoveryPointTime"
+      },
+      "inputParameters": [
+        "GatewayARN"
+      ]
+    },
+    "Volume": {
+      "operation": "ListVolumes",
+      "resourceIdentifier": {
+        "VolumeId": "VolumeInfos[].VolumeId"
+      }
+    }
+  },
+  "operations": {
+    "CreateTapeWithBarcode": {
+      "TapeBarcode": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "TapeArchive",
+            "resourceIdentifier": "TapeBarcode"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/sts/2011-06-15/completions-1.json
+++ b/awscli/data/sts/2011-06-15/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/support/2013-04-15/completions-1.json
+++ b/awscli/data/support/2013-04-15/completions-1.json
@@ -1,0 +1,83 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Case": {
+      "operation": "DescribeCases",
+      "resourceIdentifier": {
+        "caseId": "cases[].caseId"
+      }
+    },
+    "Communication": {
+      "operation": "DescribeCommunications",
+      "resourceIdentifier": {
+        "caseId": "communications[].caseId"
+      },
+      "inputParameters": [
+        "caseId"
+      ]
+    },
+    "Service": {
+      "operation": "DescribeServices",
+      "resourceIdentifier": {
+        "categories": "services[].categories"
+      }
+    },
+    "SeverityLevel": {
+      "operation": "DescribeSeverityLevels",
+      "resourceIdentifier": {
+        "code": "severityLevels[].code"
+      }
+    },
+    "TrustedAdvisorCheckRefreshStatuse": {
+      "operation": "DescribeTrustedAdvisorCheckRefreshStatuses",
+      "resourceIdentifier": {
+        "millisUntilNextRefreshable": "statuses[].millisUntilNextRefreshable"
+      },
+      "inputParameters": [
+        "checkIds"
+      ]
+    },
+    "TrustedAdvisorCheckSummary": {
+      "operation": "DescribeTrustedAdvisorCheckSummaries",
+      "resourceIdentifier": {
+        "resourcesSummary": "summaries[].resourcesSummary"
+      },
+      "inputParameters": [
+        "checkIds"
+      ]
+    },
+    "TrustedAdvisorCheck": {
+      "operation": "DescribeTrustedAdvisorChecks",
+      "resourceIdentifier": {
+        "category": "checks[].category"
+      },
+      "inputParameters": [
+        "language"
+      ]
+    }
+  },
+  "operations": {
+    "AddCommunicationToCase": {
+      "caseId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Case",
+            "resourceIdentifier": "caseId"
+          }
+        ]
+      }
+    },
+    "ResolveCase": {
+      "caseId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Case",
+            "resourceIdentifier": "caseId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/swf/2012-01-25/completions-1.json
+++ b/awscli/data/swf/2012-01-25/completions-1.json
@@ -1,0 +1,54 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ActivityType": {
+      "operation": "ListActivityTypes",
+      "resourceIdentifier": {
+        "activityType": "typeInfos[].activityType"
+      },
+      "inputParameters": [
+        "domain",
+        "registrationStatus"
+      ]
+    },
+    "ClosedWorkflowExecution": {
+      "operation": "ListClosedWorkflowExecutions",
+      "resourceIdentifier": {
+        "execution": "executionInfos[].execution"
+      },
+      "inputParameters": [
+        "domain"
+      ]
+    },
+    "Domain": {
+      "operation": "ListDomains",
+      "resourceIdentifier": {
+        "status": "domainInfos[].status"
+      },
+      "inputParameters": [
+        "registrationStatus"
+      ]
+    },
+    "OpenWorkflowExecution": {
+      "operation": "ListOpenWorkflowExecutions",
+      "resourceIdentifier": {
+        "execution": "executionInfos[].execution"
+      },
+      "inputParameters": [
+        "domain",
+        "startTimeFilter"
+      ]
+    },
+    "WorkflowType": {
+      "operation": "ListWorkflowTypes",
+      "resourceIdentifier": {
+        "workflowType": "typeInfos[].workflowType"
+      },
+      "inputParameters": [
+        "domain",
+        "registrationStatus"
+      ]
+    }
+  },
+  "operations": {}
+}

--- a/awscli/data/transcribe/2017-10-26/completions-1.json
+++ b/awscli/data/transcribe/2017-10-26/completions-1.json
@@ -1,0 +1,63 @@
+{
+  "version": "1.0",
+  "resources": {
+    "TranscriptionJob": {
+      "operation": "ListTranscriptionJobs",
+      "resourceIdentifier": {
+        "TranscriptionJobStatus": "TranscriptionJobSummaries[].TranscriptionJobStatus"
+      }
+    },
+    "Vocabulary": {
+      "operation": "ListVocabularies",
+      "resourceIdentifier": {
+        "VocabularyName": "Vocabularies[].VocabularyName"
+      }
+    }
+  },
+  "operations": {
+    "CreateVocabulary": {
+      "VocabularyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vocabulary",
+            "resourceIdentifier": "VocabularyName"
+          }
+        ]
+      }
+    },
+    "DeleteVocabulary": {
+      "VocabularyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vocabulary",
+            "resourceIdentifier": "VocabularyName"
+          }
+        ]
+      }
+    },
+    "GetVocabulary": {
+      "VocabularyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vocabulary",
+            "resourceIdentifier": "VocabularyName"
+          }
+        ]
+      }
+    },
+    "UpdateVocabulary": {
+      "VocabularyName": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Vocabulary",
+            "resourceIdentifier": "VocabularyName"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/translate/2017-07-01/completions-1.json
+++ b/awscli/data/translate/2017-07-01/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}

--- a/awscli/data/waf-regional/2016-11-28/completions-1.json
+++ b/awscli/data/waf-regional/2016-11-28/completions-1.json
@@ -1,0 +1,535 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ActivatedRulesInRuleGroup": {
+      "operation": "ListActivatedRulesInRuleGroup",
+      "resourceIdentifier": {
+        "RuleId": "ActivatedRules[].RuleId"
+      }
+    },
+    "ByteMatchSet": {
+      "operation": "ListByteMatchSets",
+      "resourceIdentifier": {
+        "ByteMatchSetId": "ByteMatchSets[].ByteMatchSetId"
+      }
+    },
+    "GeoMatchSet": {
+      "operation": "ListGeoMatchSets",
+      "resourceIdentifier": {
+        "GeoMatchSetId": "GeoMatchSets[].GeoMatchSetId"
+      }
+    },
+    "IPSet": {
+      "operation": "ListIPSets",
+      "resourceIdentifier": {
+        "IPSetId": "IPSets[].IPSetId"
+      }
+    },
+    "LoggingConfiguration": {
+      "operation": "ListLoggingConfigurations",
+      "resourceIdentifier": {
+        "LogDestinationConfigs": "LoggingConfigurations[].LogDestinationConfigs"
+      }
+    },
+    "RateBasedRule": {
+      "operation": "ListRateBasedRules",
+      "resourceIdentifier": {
+        "RuleId": "Rules[].RuleId"
+      }
+    },
+    "RegexMatchSet": {
+      "operation": "ListRegexMatchSets",
+      "resourceIdentifier": {
+        "RegexMatchSetId": "RegexMatchSets[].RegexMatchSetId"
+      }
+    },
+    "RegexPatternSet": {
+      "operation": "ListRegexPatternSets",
+      "resourceIdentifier": {
+        "RegexPatternSetId": "RegexPatternSets[].RegexPatternSetId"
+      }
+    },
+    "ResourcesForWebACL": {
+      "operation": "ListResourcesForWebACL",
+      "resourceIdentifier": {
+        "ResourceArns": "ResourceArns[]"
+      },
+      "inputParameters": [
+        "WebACLId"
+      ]
+    },
+    "RuleGroup": {
+      "operation": "ListRuleGroups",
+      "resourceIdentifier": {
+        "RuleGroupId": "RuleGroups[].RuleGroupId"
+      }
+    },
+    "Rule": {
+      "operation": "ListRules",
+      "resourceIdentifier": {
+        "RuleId": "Rules[].RuleId"
+      }
+    },
+    "SizeConstraintSet": {
+      "operation": "ListSizeConstraintSets",
+      "resourceIdentifier": {
+        "SizeConstraintSetId": "SizeConstraintSets[].SizeConstraintSetId"
+      }
+    },
+    "SqlInjectionMatchSet": {
+      "operation": "ListSqlInjectionMatchSets",
+      "resourceIdentifier": {
+        "SqlInjectionMatchSetId": "SqlInjectionMatchSets[].SqlInjectionMatchSetId"
+      }
+    },
+    "SubscribedRuleGroup": {
+      "operation": "ListSubscribedRuleGroups",
+      "resourceIdentifier": {
+        "RuleGroupId": "RuleGroups[].RuleGroupId"
+      }
+    },
+    "WebACL": {
+      "operation": "ListWebACLs",
+      "resourceIdentifier": {
+        "WebACLId": "WebACLs[].WebACLId"
+      }
+    },
+    "XssMatchSet": {
+      "operation": "ListXssMatchSets",
+      "resourceIdentifier": {
+        "XssMatchSetId": "XssMatchSets[].XssMatchSetId"
+      }
+    }
+  },
+  "operations": {
+    "AssociateWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "DeleteByteMatchSet": {
+      "ByteMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ByteMatchSet",
+            "resourceIdentifier": "ByteMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteGeoMatchSet": {
+      "GeoMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoMatchSet",
+            "resourceIdentifier": "GeoMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteIPSet": {
+      "IPSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IPSet",
+            "resourceIdentifier": "IPSetId"
+          }
+        ]
+      }
+    },
+    "DeleteRateBasedRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "DeleteRegexMatchSet": {
+      "RegexMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexMatchSet",
+            "resourceIdentifier": "RegexMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteRegexPatternSet": {
+      "RegexPatternSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexPatternSet",
+            "resourceIdentifier": "RegexPatternSetId"
+          }
+        ]
+      }
+    },
+    "DeleteRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "DeleteRuleGroup": {
+      "RuleGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubscribedRuleGroup",
+            "resourceIdentifier": "RuleGroupId"
+          }
+        ]
+      }
+    },
+    "DeleteSizeConstraintSet": {
+      "SizeConstraintSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SizeConstraintSet",
+            "resourceIdentifier": "SizeConstraintSetId"
+          }
+        ]
+      }
+    },
+    "DeleteSqlInjectionMatchSet": {
+      "SqlInjectionMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SqlInjectionMatchSet",
+            "resourceIdentifier": "SqlInjectionMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "DeleteXssMatchSet": {
+      "XssMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "XssMatchSet",
+            "resourceIdentifier": "XssMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetByteMatchSet": {
+      "ByteMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ByteMatchSet",
+            "resourceIdentifier": "ByteMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetGeoMatchSet": {
+      "GeoMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoMatchSet",
+            "resourceIdentifier": "GeoMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetIPSet": {
+      "IPSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IPSet",
+            "resourceIdentifier": "IPSetId"
+          }
+        ]
+      }
+    },
+    "GetRateBasedRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetRateBasedRuleManagedKeys": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetRegexMatchSet": {
+      "RegexMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexMatchSet",
+            "resourceIdentifier": "RegexMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetRegexPatternSet": {
+      "RegexPatternSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexPatternSet",
+            "resourceIdentifier": "RegexPatternSetId"
+          }
+        ]
+      }
+    },
+    "GetRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetRuleGroup": {
+      "RuleGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubscribedRuleGroup",
+            "resourceIdentifier": "RuleGroupId"
+          }
+        ]
+      }
+    },
+    "GetSampledRequests": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetSizeConstraintSet": {
+      "SizeConstraintSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SizeConstraintSet",
+            "resourceIdentifier": "SizeConstraintSetId"
+          }
+        ]
+      }
+    },
+    "GetSqlInjectionMatchSet": {
+      "SqlInjectionMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SqlInjectionMatchSet",
+            "resourceIdentifier": "SqlInjectionMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "GetXssMatchSet": {
+      "XssMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "XssMatchSet",
+            "resourceIdentifier": "XssMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateByteMatchSet": {
+      "ByteMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ByteMatchSet",
+            "resourceIdentifier": "ByteMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateGeoMatchSet": {
+      "GeoMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoMatchSet",
+            "resourceIdentifier": "GeoMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateIPSet": {
+      "IPSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IPSet",
+            "resourceIdentifier": "IPSetId"
+          }
+        ]
+      }
+    },
+    "UpdateRateBasedRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "UpdateRegexMatchSet": {
+      "RegexMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexMatchSet",
+            "resourceIdentifier": "RegexMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateRegexPatternSet": {
+      "RegexPatternSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexPatternSet",
+            "resourceIdentifier": "RegexPatternSetId"
+          }
+        ]
+      }
+    },
+    "UpdateRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "UpdateRuleGroup": {
+      "RuleGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubscribedRuleGroup",
+            "resourceIdentifier": "RuleGroupId"
+          }
+        ]
+      }
+    },
+    "UpdateSizeConstraintSet": {
+      "SizeConstraintSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SizeConstraintSet",
+            "resourceIdentifier": "SizeConstraintSetId"
+          }
+        ]
+      }
+    },
+    "UpdateSqlInjectionMatchSet": {
+      "SqlInjectionMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SqlInjectionMatchSet",
+            "resourceIdentifier": "SqlInjectionMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "UpdateXssMatchSet": {
+      "XssMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "XssMatchSet",
+            "resourceIdentifier": "XssMatchSetId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/waf/2015-08-24/completions-1.json
+++ b/awscli/data/waf/2015-08-24/completions-1.json
@@ -1,0 +1,515 @@
+{
+  "version": "1.0",
+  "resources": {
+    "ActivatedRulesInRuleGroup": {
+      "operation": "ListActivatedRulesInRuleGroup",
+      "resourceIdentifier": {
+        "RuleId": "ActivatedRules[].RuleId"
+      }
+    },
+    "ByteMatchSet": {
+      "operation": "ListByteMatchSets",
+      "resourceIdentifier": {
+        "ByteMatchSetId": "ByteMatchSets[].ByteMatchSetId"
+      }
+    },
+    "GeoMatchSet": {
+      "operation": "ListGeoMatchSets",
+      "resourceIdentifier": {
+        "GeoMatchSetId": "GeoMatchSets[].GeoMatchSetId"
+      }
+    },
+    "IPSet": {
+      "operation": "ListIPSets",
+      "resourceIdentifier": {
+        "IPSetId": "IPSets[].IPSetId"
+      }
+    },
+    "LoggingConfiguration": {
+      "operation": "ListLoggingConfigurations",
+      "resourceIdentifier": {
+        "LogDestinationConfigs": "LoggingConfigurations[].LogDestinationConfigs"
+      }
+    },
+    "RateBasedRule": {
+      "operation": "ListRateBasedRules",
+      "resourceIdentifier": {
+        "RuleId": "Rules[].RuleId"
+      }
+    },
+    "RegexMatchSet": {
+      "operation": "ListRegexMatchSets",
+      "resourceIdentifier": {
+        "RegexMatchSetId": "RegexMatchSets[].RegexMatchSetId"
+      }
+    },
+    "RegexPatternSet": {
+      "operation": "ListRegexPatternSets",
+      "resourceIdentifier": {
+        "RegexPatternSetId": "RegexPatternSets[].RegexPatternSetId"
+      }
+    },
+    "RuleGroup": {
+      "operation": "ListRuleGroups",
+      "resourceIdentifier": {
+        "RuleGroupId": "RuleGroups[].RuleGroupId"
+      }
+    },
+    "Rule": {
+      "operation": "ListRules",
+      "resourceIdentifier": {
+        "RuleId": "Rules[].RuleId"
+      }
+    },
+    "SizeConstraintSet": {
+      "operation": "ListSizeConstraintSets",
+      "resourceIdentifier": {
+        "SizeConstraintSetId": "SizeConstraintSets[].SizeConstraintSetId"
+      }
+    },
+    "SqlInjectionMatchSet": {
+      "operation": "ListSqlInjectionMatchSets",
+      "resourceIdentifier": {
+        "SqlInjectionMatchSetId": "SqlInjectionMatchSets[].SqlInjectionMatchSetId"
+      }
+    },
+    "SubscribedRuleGroup": {
+      "operation": "ListSubscribedRuleGroups",
+      "resourceIdentifier": {
+        "RuleGroupId": "RuleGroups[].RuleGroupId"
+      }
+    },
+    "WebACL": {
+      "operation": "ListWebACLs",
+      "resourceIdentifier": {
+        "WebACLId": "WebACLs[].WebACLId"
+      }
+    },
+    "XssMatchSet": {
+      "operation": "ListXssMatchSets",
+      "resourceIdentifier": {
+        "XssMatchSetId": "XssMatchSets[].XssMatchSetId"
+      }
+    }
+  },
+  "operations": {
+    "DeleteByteMatchSet": {
+      "ByteMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ByteMatchSet",
+            "resourceIdentifier": "ByteMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteGeoMatchSet": {
+      "GeoMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoMatchSet",
+            "resourceIdentifier": "GeoMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteIPSet": {
+      "IPSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IPSet",
+            "resourceIdentifier": "IPSetId"
+          }
+        ]
+      }
+    },
+    "DeleteRateBasedRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "DeleteRegexMatchSet": {
+      "RegexMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexMatchSet",
+            "resourceIdentifier": "RegexMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteRegexPatternSet": {
+      "RegexPatternSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexPatternSet",
+            "resourceIdentifier": "RegexPatternSetId"
+          }
+        ]
+      }
+    },
+    "DeleteRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "DeleteRuleGroup": {
+      "RuleGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubscribedRuleGroup",
+            "resourceIdentifier": "RuleGroupId"
+          }
+        ]
+      }
+    },
+    "DeleteSizeConstraintSet": {
+      "SizeConstraintSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SizeConstraintSet",
+            "resourceIdentifier": "SizeConstraintSetId"
+          }
+        ]
+      }
+    },
+    "DeleteSqlInjectionMatchSet": {
+      "SqlInjectionMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SqlInjectionMatchSet",
+            "resourceIdentifier": "SqlInjectionMatchSetId"
+          }
+        ]
+      }
+    },
+    "DeleteWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "DeleteXssMatchSet": {
+      "XssMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "XssMatchSet",
+            "resourceIdentifier": "XssMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetByteMatchSet": {
+      "ByteMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ByteMatchSet",
+            "resourceIdentifier": "ByteMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetGeoMatchSet": {
+      "GeoMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoMatchSet",
+            "resourceIdentifier": "GeoMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetIPSet": {
+      "IPSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IPSet",
+            "resourceIdentifier": "IPSetId"
+          }
+        ]
+      }
+    },
+    "GetRateBasedRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetRateBasedRuleManagedKeys": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetRegexMatchSet": {
+      "RegexMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexMatchSet",
+            "resourceIdentifier": "RegexMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetRegexPatternSet": {
+      "RegexPatternSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexPatternSet",
+            "resourceIdentifier": "RegexPatternSetId"
+          }
+        ]
+      }
+    },
+    "GetRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetRuleGroup": {
+      "RuleGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubscribedRuleGroup",
+            "resourceIdentifier": "RuleGroupId"
+          }
+        ]
+      }
+    },
+    "GetSampledRequests": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "GetSizeConstraintSet": {
+      "SizeConstraintSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SizeConstraintSet",
+            "resourceIdentifier": "SizeConstraintSetId"
+          }
+        ]
+      }
+    },
+    "GetSqlInjectionMatchSet": {
+      "SqlInjectionMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SqlInjectionMatchSet",
+            "resourceIdentifier": "SqlInjectionMatchSetId"
+          }
+        ]
+      }
+    },
+    "GetWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "GetXssMatchSet": {
+      "XssMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "XssMatchSet",
+            "resourceIdentifier": "XssMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateByteMatchSet": {
+      "ByteMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "ByteMatchSet",
+            "resourceIdentifier": "ByteMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateGeoMatchSet": {
+      "GeoMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "GeoMatchSet",
+            "resourceIdentifier": "GeoMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateIPSet": {
+      "IPSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "IPSet",
+            "resourceIdentifier": "IPSetId"
+          }
+        ]
+      }
+    },
+    "UpdateRateBasedRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "UpdateRegexMatchSet": {
+      "RegexMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexMatchSet",
+            "resourceIdentifier": "RegexMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateRegexPatternSet": {
+      "RegexPatternSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "RegexPatternSet",
+            "resourceIdentifier": "RegexPatternSetId"
+          }
+        ]
+      }
+    },
+    "UpdateRule": {
+      "RuleId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Rule",
+            "resourceIdentifier": "RuleId"
+          }
+        ]
+      }
+    },
+    "UpdateRuleGroup": {
+      "RuleGroupId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SubscribedRuleGroup",
+            "resourceIdentifier": "RuleGroupId"
+          }
+        ]
+      }
+    },
+    "UpdateSizeConstraintSet": {
+      "SizeConstraintSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SizeConstraintSet",
+            "resourceIdentifier": "SizeConstraintSetId"
+          }
+        ]
+      }
+    },
+    "UpdateSqlInjectionMatchSet": {
+      "SqlInjectionMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "SqlInjectionMatchSet",
+            "resourceIdentifier": "SqlInjectionMatchSetId"
+          }
+        ]
+      }
+    },
+    "UpdateWebACL": {
+      "WebACLId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "WebACL",
+            "resourceIdentifier": "WebACLId"
+          }
+        ]
+      }
+    },
+    "UpdateXssMatchSet": {
+      "XssMatchSetId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "XssMatchSet",
+            "resourceIdentifier": "XssMatchSetId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/workdocs/2016-05-01/completions-1.json
+++ b/awscli/data/workdocs/2016-05-01/completions-1.json
@@ -1,0 +1,85 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Activity": {
+      "operation": "DescribeActivities",
+      "resourceIdentifier": {
+        "Participants": "UserActivities[].Participants"
+      }
+    },
+    "Comment": {
+      "operation": "DescribeComments",
+      "resourceIdentifier": {
+        "CommentId": "Comments[].CommentId"
+      },
+      "inputParameters": [
+        "DocumentId",
+        "VersionId"
+      ]
+    },
+    "DocumentVersion": {
+      "operation": "DescribeDocumentVersions",
+      "resourceIdentifier": {
+        "ContentType": "DocumentVersions[].ContentType"
+      },
+      "inputParameters": [
+        "DocumentId"
+      ]
+    },
+    "Group": {
+      "operation": "DescribeGroups",
+      "resourceIdentifier": {
+        "Id": "Groups[].Id"
+      },
+      "inputParameters": [
+        "SearchQuery"
+      ]
+    },
+    "NotificationSubscription": {
+      "operation": "DescribeNotificationSubscriptions",
+      "resourceIdentifier": {
+        "SubscriptionId": "Subscriptions[].SubscriptionId"
+      },
+      "inputParameters": [
+        "OrganizationId"
+      ]
+    },
+    "ResourcePermission": {
+      "operation": "DescribeResourcePermissions",
+      "resourceIdentifier": {
+        "Roles": "Principals[].Roles"
+      },
+      "inputParameters": [
+        "ResourceId"
+      ]
+    },
+    "RootFolder": {
+      "operation": "DescribeRootFolders",
+      "resourceIdentifier": {
+        "ParentFolderId": "Folders[].ParentFolderId"
+      },
+      "inputParameters": [
+        "AuthenticationToken"
+      ]
+    },
+    "User": {
+      "operation": "DescribeUsers",
+      "resourceIdentifier": {
+        "Username": "Users[].Username"
+      }
+    }
+  },
+  "operations": {
+    "CreateUser": {
+      "Username": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "User",
+            "resourceIdentifier": "Username"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/workmail/2017-10-01/completions-1.json
+++ b/awscli/data/workmail/2017-10-01/completions-1.json
@@ -1,0 +1,289 @@
+{
+  "version": "1.0",
+  "resources": {
+    "Aliase": {
+      "operation": "ListAliases",
+      "resourceIdentifier": {
+        "Aliases": "Aliases[]"
+      },
+      "inputParameters": [
+        "OrganizationId",
+        "EntityId"
+      ]
+    },
+    "GroupMember": {
+      "operation": "ListGroupMembers",
+      "resourceIdentifier": {
+        "Type": "Members[].Type"
+      },
+      "inputParameters": [
+        "OrganizationId",
+        "GroupId"
+      ]
+    },
+    "Group": {
+      "operation": "ListGroups",
+      "resourceIdentifier": {
+        "DisabledDate": "Groups[].DisabledDate"
+      },
+      "inputParameters": [
+        "OrganizationId"
+      ]
+    },
+    "MailboxPermission": {
+      "operation": "ListMailboxPermissions",
+      "resourceIdentifier": {
+        "PermissionValues": "Permissions[].PermissionValues"
+      },
+      "inputParameters": [
+        "OrganizationId",
+        "EntityId"
+      ]
+    },
+    "Organization": {
+      "operation": "ListOrganizations",
+      "resourceIdentifier": {
+        "OrganizationId": "OrganizationSummaries[].OrganizationId"
+      }
+    },
+    "ResourceDelegate": {
+      "operation": "ListResourceDelegates",
+      "resourceIdentifier": {
+        "Type": "Delegates[].Type"
+      },
+      "inputParameters": [
+        "OrganizationId",
+        "ResourceId"
+      ]
+    },
+    "Resource": {
+      "operation": "ListResources",
+      "resourceIdentifier": {
+        "EnabledDate": "Resources[].EnabledDate"
+      },
+      "inputParameters": [
+        "OrganizationId"
+      ]
+    },
+    "User": {
+      "operation": "ListUsers",
+      "resourceIdentifier": {
+        "UserRole": "Users[].UserRole"
+      },
+      "inputParameters": [
+        "OrganizationId"
+      ]
+    }
+  },
+  "operations": {
+    "AssociateDelegateToResource": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "AssociateMemberToGroup": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "CreateAlias": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "CreateGroup": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "CreateResource": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "CreateUser": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DeleteAlias": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DeleteGroup": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DeleteMailboxPermissions": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DeleteResource": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DeleteUser": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DeregisterFromWorkMail": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DisassociateDelegateFromResource": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "DisassociateMemberFromGroup": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "PutMailboxPermissions": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "RegisterToWorkMail": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "ResetPassword": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "UpdatePrimaryEmailAddress": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    },
+    "UpdateResource": {
+      "OrganizationId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Organization",
+            "resourceIdentifier": "OrganizationId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/workspaces/2015-04-08/completions-1.json
+++ b/awscli/data/workspaces/2015-04-08/completions-1.json
@@ -1,0 +1,68 @@
+{
+  "version": "1.0",
+  "resources": {
+    "IpGroup": {
+      "operation": "DescribeIpGroups",
+      "resourceIdentifier": {
+        "groupDesc": "Result[].groupDesc"
+      }
+    },
+    "Tag": {
+      "operation": "DescribeTags",
+      "resourceIdentifier": {
+        "Value": "TagList[].Value"
+      },
+      "inputParameters": [
+        "ResourceId"
+      ]
+    },
+    "WorkspaceBundle": {
+      "operation": "DescribeWorkspaceBundles",
+      "resourceIdentifier": {
+        "BundleId": "Bundles[].BundleId"
+      }
+    },
+    "WorkspaceDirectory": {
+      "operation": "DescribeWorkspaceDirectories",
+      "resourceIdentifier": {
+        "WorkspaceCreationProperties": "Directories[].WorkspaceCreationProperties"
+      }
+    },
+    "Workspace": {
+      "operation": "DescribeWorkspaces",
+      "resourceIdentifier": {
+        "WorkspaceId": "Workspaces[].WorkspaceId"
+      }
+    },
+    "WorkspacesConnectionStatu": {
+      "operation": "DescribeWorkspacesConnectionStatus",
+      "resourceIdentifier": {
+        "ConnectionState": "WorkspacesConnectionStatus[].ConnectionState"
+      }
+    }
+  },
+  "operations": {
+    "ModifyWorkspaceProperties": {
+      "WorkspaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Workspace",
+            "resourceIdentifier": "WorkspaceId"
+          }
+        ]
+      }
+    },
+    "ModifyWorkspaceState": {
+      "WorkspaceId": {
+        "completions": [
+          {
+            "parameters": {},
+            "resourceName": "Workspace",
+            "resourceIdentifier": "WorkspaceId"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/awscli/data/xray/2016-04-12/completions-1.json
+++ b/awscli/data/xray/2016-04-12/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}


### PR DESCRIPTION
Couple of things worth nothing from the last PR:

* We're adding completions for every service, even they're empty.
* Resources are still added for a service even if no operations can use them right now (primarily due to required input parameters not being mapped).

This should serve as a reasonable baseline to diff against as we make changes to the autogen module.

cc @kyleknap 