### PR TITLE
[CLIv2] Support ddb expression substitution

### DIFF
--- a/awscli/customizations/dynamodb/ast.py
+++ b/awscli/customizations/dynamodb/ast.py
@@ -1,0 +1,57 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+def literal(value):
+    return {"type": "literal", "children": [], "value": value}
+
+
+def identifier(name):
+    return {"type": "identifier", "children": [], "value": name}
+
+
+def sequence(elements):
+    return {"type": "sequence", "children": elements}
+
+
+def or_expression(left, right):
+    return {"type": "or_expression", "children": [left, right]}
+
+
+def and_expression(left, right):
+    return {"type": "and_expression", "children": [left, right]}
+
+
+def not_expression(expression):
+    return {"type": "not_expression", "children": [expression]}
+
+
+def subexpression(expression):
+    return {"type": "subexpression", "children": [expression]}
+
+
+def function_expression(name, arguments):
+    return {"type": "function", "children": arguments, "value": name}
+
+
+def in_expression(left, right):
+    return {"type": "in_expression", "children": [left, right]}
+
+
+def between_expression(left, center, right):
+    return {"type": "between_expression", "children": [left, center, right]}
+
+
+def comparison_expression(name, left, right):
+    return {"type": "comparator", "children": [left, right], "value": name}
+

--- a/awscli/customizations/dynamodb/exceptions.py
+++ b/awscli/customizations/dynamodb/exceptions.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+class DDBError(Exception):
+    pass
+
+
+class EmptyExpressionError(DDBError):
+    def __init__(self):
+        super(EmptyExpressionError, self).__init__(
+            "Expressions must not be empty"
+        )
+
+
+class LexerError(DDBError):
+    def __init__(self, expression, position, message):
+        underline = ' ' * position + '^'
+        error_message = '%s\n%s\n%s' % (message, expression, underline)
+        super(LexerError, self).__init__(error_message)

--- a/awscli/customizations/dynamodb/exceptions.py
+++ b/awscli/customizations/dynamodb/exceptions.py
@@ -28,3 +28,64 @@ class LexerError(DDBError):
         underline = ' ' * position + '^'
         error_message = '%s\n%s\n%s' % (message, expression, underline)
         super(LexerError, self).__init__(error_message)
+
+
+class ParserError(DDBError):
+    pass
+
+
+class UnexpectedTokenError(ParserError):
+    def __init__(self, token, expected_type, expression):
+        message = (
+            "Unexpected token `{value}` of type `{token_type}`. "
+            "Expected type: {expected_type}\n"
+            "{expression}\n{underline}"
+        )
+        token_length = token['end'] - token['start']
+        message = message.format(
+            value=token['value'],
+            token_type=token['type'],
+            expected_type=expected_type,
+            expression=expression,
+            underline=' ' * token['start'] + '^' * (max(token_length, 1)),
+        )
+        self.token = token
+        self.expression = expression
+        self.expected_type = expected_type
+        super(UnexpectedTokenError, self).__init__(message)
+
+
+class InvalidLiteralValueError(ParserError):
+    def __init__(self, token, message, expression):
+        error_message = (
+            'Invalid token value: {message}\n'
+            '{expression}\n{underline}\n'
+        )
+        token_length = token['end'] - token['start']
+        underline = ' ' * token['start'] + '^' * (max(token_length, 1))
+        error_message = error_message.format(
+            message=message,
+            expression=expression,
+            underline=underline,
+        )
+        self.token = token
+        self.expression = expression
+        super(InvalidLiteralValueError, self).__init__(error_message)
+
+
+class UnknownExpressionError(ParserError):
+    def __init__(self, start_token, expression):
+        message = (
+            'Unknown expression type starting at token `{token_value}`\n'
+            '{expression}\n{underline}'
+        )
+        token_length = start_token['end'] - start_token['start']
+        underline = ' ' * start_token['start'] + '^' * (max(token_length, 1))
+        message = message.format(
+            token_value=start_token['value'],
+            expression=expression,
+            underline=underline,
+        )
+        self.start_token = start_token
+        self.expression = expression
+        super(UnknownExpressionError, self).__init__(message)

--- a/awscli/customizations/dynamodb/extractor.py
+++ b/awscli/customizations/dynamodb/extractor.py
@@ -1,0 +1,109 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from .parser import Parser
+
+
+class AttributeExtractor(object):
+    COMPARATORS = {
+        'eq': '=',
+        'ne': '<>',
+        'lt': '<',
+        'lte': '<=',
+        'gt': '>',
+        'gte': '>=',
+    }
+
+    def __init__(self, parser=None):
+        self._parser = parser
+        if parser is None:
+            self._parser = Parser()
+        self._identifiers = {}
+        self._literals = {}
+        self._index_offset = 0
+
+    def extract(self, expression, index_offset=0):
+        self._identifiers = {}
+        self._literals = {}
+        self._index_offset = index_offset
+        root = self._parser.parse(expression)
+        expression = self._visit(root).strip()
+        return {
+            'expression': expression,
+            'identifiers': self._identifiers,
+            'values': self._literals,
+            'substitution_count': len(self._identifiers) + len(self._literals)
+        }
+
+    def _substitution_index(self):
+        num_substituted = len(self._identifiers) + len(self._literals)
+        return num_substituted + self._index_offset
+
+    def _visit(self, node):
+        method = getattr(self, '_visit_%s' % node['type'])
+        return method(node)
+
+    def _visit_comparator(self, node):
+        left = self._visit(node['children'][0])
+        right = self._visit(node['children'][1])
+        expression = '%s%s %s' % (
+            left, self.COMPARATORS[node['value']], right
+        )
+        return expression
+
+    def _visit_identifier(self, node):
+        identifier_replacement = '#n%s' % self._substitution_index()
+        self._identifiers[identifier_replacement] = node['value']
+        return '%s ' % identifier_replacement
+
+    def _visit_literal(self, node):
+        literal_replacement = ':n%s' % self._substitution_index()
+        self._literals[literal_replacement] = node['value']
+        return '%s ' % literal_replacement
+
+    def _visit_sequence(self, node):
+        visited_children = []
+        for child in node['children']:
+            visited_children.append(self._visit(child).strip())
+        return '%s' % ', '.join(visited_children)
+
+    def _visit_or_expression(self, node):
+        left = self._visit(node['children'][0])
+        right = self._visit(node['children'][1])
+        return '%sOR %s' % (left, right)
+
+    def _visit_and_expression(self, node):
+        left = self._visit(node['children'][0])
+        right = self._visit(node['children'][1])
+        return '%sAND %s' % (left, right)
+
+    def _visit_not_expression(self, node):
+        return 'NOT %s' % self._visit(node['children'][0])
+
+    def _visit_subexpression(self, node):
+        return '( %s) ' % self._visit(node['children'][0])
+
+    def _visit_function(self, node):
+        return '%s(%s) ' % (node['value'], self._visit_sequence(node).strip())
+
+    def _visit_in_expression(self, node):
+        return '%sIN (%s) ' % (
+            self._visit(node['children'][0]),
+            self._visit(node['children'][1]).strip(),
+        )
+
+    def _visit_between_expression(self, node):
+        return '%sBETWEEN %sAND %s' % (
+            self._visit(node['children'][0]),
+            self._visit(node['children'][1]),
+            self._visit(node['children'][2]),
+        )

--- a/awscli/customizations/dynamodb/lexer.py
+++ b/awscli/customizations/dynamodb/lexer.py
@@ -1,0 +1,266 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from base64 import b64decode
+import binascii
+from decimal import Decimal
+import re
+import string
+
+
+from .exceptions import LexerError, EmptyExpressionError
+from .types import Binary
+
+
+VALID_BASE64 = re.compile(r'[A-Za-z0-9+/=]+')
+
+
+class Lexer(object):
+    START_IDENTIFIER = set(string.ascii_letters + '_')
+    VALID_IDENTIFIER = set(string.ascii_letters + string.digits + '_')
+    WHITESPACE = set(' \t\n\r')
+    SIMPLE_TOKENS = {
+        '.': 'dot',
+        ',': 'comma',
+        ':': 'colon',
+        '(': 'lparen',
+        ')': 'rparen',
+        '{': 'lbrace',
+        '}': 'rbrace',
+        '[': 'lbracket',
+        ']': 'rbracket',
+        '=': 'eq',
+    }
+    DIGITS = set(string.digits)
+    INT_CHARS = set(string.digits + '-')
+    OPERATION_TOKENS = {
+        'and', 'between', 'in', 'or', 'not',
+    }
+
+    def tokenize(self, expression):
+        self._init_expression(expression)
+        while self._current is not None:
+            if self._current in self.SIMPLE_TOKENS:
+                yield {
+                    'type': self.SIMPLE_TOKENS[self._current],
+                    'value': self._current,
+                    'start': self._position,
+                    'end': self._position + 1,
+                }
+                self._next()
+            elif self._current in self.START_IDENTIFIER:
+                yield self._consume_unquoted_identifier()
+            elif self._current == "'":
+                yield self._consume_quoted_identifier()
+            elif self._current == '"':
+                yield self._consume_string_literal()
+            elif self._current in self.WHITESPACE:
+                self._next()
+            elif self._current in self.INT_CHARS:
+                yield self._consume_number()
+            elif self._current in ['<', '>']:
+                yield self._consume_comparator()
+            else:
+                raise LexerError(
+                    message='Unrecognized character %s' % self._current,
+                    expression=self._expression,
+                    position=self._position,
+                )
+        yield {
+            'type': 'eof', 'value': '',
+            'start': self._length, 'end': self._length
+        }
+
+    def _consume_unquoted_identifier(self):
+        start = self._position
+        buff = self._current
+
+        if self._current in {'b', "B"}:
+            if self._next() == '"':
+                return self._consume_base64_string()
+            elif self._current in self.VALID_IDENTIFIER:
+                buff += self._current
+
+        while self._next() in self.VALID_IDENTIFIER:
+            buff += self._current
+
+        lower = buff.lower()
+        if lower in self.OPERATION_TOKENS:
+            return {
+                'type': lower, 'value': buff,
+                'start': start, 'end': start + len(buff)
+            }
+        return {
+            'type': 'unquoted_identifier', 'value': buff,
+            'start': start, 'end': start + len(buff)
+        }
+
+    def _consume_quoted_identifier(self):
+        start = self._position
+        lexeme = self._consume_until("'").replace("\\'", "'")
+        token_len = self._position - start
+        return {
+            'type': 'identifier', 'value': lexeme,
+            'start': start, 'end': token_len
+        }
+
+    def _consume_string_literal(self):
+        start = self._position
+        lexeme = self._consume_until('"').replace('\\"', '"')
+        token_len = self._position - start
+        return {
+            'type': 'literal', 'value': lexeme,
+            'start': start, 'end': token_len
+        }
+
+    def _consume_base64_string(self):
+        start = self._position - 1
+        raw_string = self._consume_string_literal()
+
+        # Python will simply ignore invalid characters, so we have to
+        # validate manually.
+        if raw_string['value'] and not VALID_BASE64.match(raw_string['value']):
+            message = 'Invalid base64 string b"%s"'
+            raise LexerError(
+                message=message % raw_string['value'],
+                expression=self._expression,
+                position=start,
+            )
+
+        try:
+            decoded = b64decode(raw_string['value'])
+        except (TypeError, binascii.Error) as e:
+            message = 'Invalid base64 string b"%s": %s'
+            message = message % (raw_string['value'], str(e))
+            raise LexerError(
+                message=message,
+                expression=self._expression,
+                position=start,
+            )
+
+        raw_string['value'] = Binary(decoded)
+        raw_string['start'] = start
+        return raw_string
+
+    def _consume_number(self):
+        start = self._position
+        buff = self._consume_int()
+
+        if self._current == '.':
+            buff += self._current
+            if self._next() not in self.DIGITS:
+                raise LexerError(
+                    message='Invalid fractional character %s' % self._current,
+                    position=self._position,
+                    expression=self._expression,
+                )
+            buff += self._consume_int()
+
+        if self._current and self._current.lower() == 'e':
+            buff += self._current
+            if self._next() not in self.INT_CHARS and self._current != '+':
+                raise LexerError(
+                    message='Invalid exponential character %s' % self._current,
+                    position=self._position,
+                    expression=self._expression,
+                )
+            buff += self._consume_int()
+
+        return {
+            'type': 'literal', 'value': Decimal(buff),
+            'start': start, 'end': start + len(buff)
+        }
+
+    def _consume_int(self):
+        buff = self._current
+        is_positive = self._current != '-'
+        while self._next() in self.DIGITS:
+            buff += self._current
+        if not is_positive and len(buff) < 2:
+            raise LexerError(
+                message='Unknown token %s' % buff,
+                position=self._position,
+                expression=self._expression,
+            )
+        return buff
+
+    def _consume_comparator(self):
+        if self._current == '<':
+            if self._next() == '>':
+                self._next()
+                return {
+                    'type': 'ne', 'value': '<>',
+                    'start': self._position - 2, 'end': self._position,
+                }
+            elif self._current == '=':
+                self._next()
+                return {
+                    'type': 'lte', 'value': '<=',
+                    'start': self._position - 2, 'end': self._position,
+                }
+            else:
+                return {
+                    'type': 'lt', 'value': '<',
+                    'start': self._position - 1, 'end': self._position
+                }
+        elif self._current == '>':
+            if self._next() == '=':
+                self._next()
+                return {
+                    'type': 'gte', 'value': '>=',
+                    'start': self._position - 2, 'end': self._position,
+                }
+            else:
+                return {
+                    'type': 'gt', 'value': '>',
+                    'start': self._position - 1, 'end': self._position,
+                }
+
+    def _init_expression(self, expression):
+        if not expression:
+            raise EmptyExpressionError()
+        self._position = 0
+        self._expression = expression
+        self._chars = list(expression)
+        self._current = self._chars[0]
+        self._length = len(expression)
+
+    def _next(self):
+        if self._position == self._length - 1:
+            self._current = None
+        else:
+            self._position += 1
+            self._current = self._chars[self._position]
+        return self._current
+
+    def _consume_until(self, delimiter):
+        # Consume until the delimiter is reached,
+        # allowing for the delimiter to be escaped with "\".
+        start = self._position
+        buff = ''
+        self._next()
+        while self._current != delimiter:
+            if self._current == '\\':
+                buff += '\\'
+                self._next()
+            if self._current is None:
+                # We're at the EOF.
+                raise LexerError(
+                    message="Unclosed %s delimiter" % delimiter,
+                    position=start,
+                    expression=self._expression,
+                )
+            buff += self._current
+            self._next()
+        # Skip the closing delimiter.
+        self._next()
+        return buff

--- a/awscli/customizations/dynamodb/params.py
+++ b/awscli/customizations/dynamodb/params.py
@@ -56,7 +56,7 @@ SELECT = {
 }
 
 PROJECTION_EXPRESSION = {
-    'name': 'projection',
+    'name': 'projection', 'nargs': '+',
     'help_text': (
         '<p>A string that identifies one or more attributes to retrieve from '
         'the specified table or index. These attributes can include scalars, '
@@ -72,7 +72,7 @@ PROJECTION_EXPRESSION = {
 }
 
 FILTER_EXPRESSION = {
-    'name': 'filter',
+    'name': 'filter', 'nargs': '+',
     'help_text': (
         '<p>A string that contains conditions that DynamoDB applies after the '
         'operation, but before the data is returned to you. Items that do '
@@ -88,7 +88,7 @@ FILTER_EXPRESSION = {
 }
 
 KEY_CONDITION_EXPRESSION = {
-    'name': 'key-condition',
+    'name': 'key-condition', 'nargs': '+',
     'help_text': (
         '<p>The condition that specifies the key value(s) for items to be '
         'retrieved. Must perform an equality test on a single partition key '

--- a/awscli/customizations/dynamodb/parser.py
+++ b/awscli/customizations/dynamodb/parser.py
@@ -1,0 +1,299 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from decimal import Decimal
+
+from awscli.compat import six
+import awscli.customizations.dynamodb.ast as ast
+from .exceptions import (
+    EmptyExpressionError, UnexpectedTokenError, UnknownExpressionError,
+    InvalidLiteralValueError,
+)
+
+from .lexer import Lexer
+from .types import Binary
+
+
+class Parser(object):
+    COMPARATORS = ['eq', 'ne', 'lt', 'lte', 'gt', 'gte']
+
+    def __init__(self, lexer=None):
+        self._lexer = lexer
+        if lexer is None:
+            self._lexer = Lexer()
+        self._position = 0
+        self._tokens = []
+        self._current = None
+        self._expression = None
+
+    def parse(self, expression):
+        self._position = 0
+        self._expression = expression
+        self._tokens = list(self._lexer.tokenize(expression))
+        self._current = self._tokens[0]
+
+        parsed = self._parse_expression()
+
+        if not self._match('eof'):
+            raise UnexpectedTokenError(
+                token=self._current,
+                expression=self._expression,
+                expected_type='eof',
+            )
+        return parsed
+
+    def _parse_expression(self):
+        if self._match('eof') or self._current is None:
+            raise EmptyExpressionError()
+
+        if self._match(['identifier', 'unquoted_identifier', 'literal']) and \
+                self._match_next(['comma', 'eof']):
+            return self._parse_sequence()
+        return self._parse_and_or()
+
+    def _parse_and_or(self):
+        expression = self._parse_simple_expression()
+
+        while self._match(['and', 'or']):
+            conjunction_type = self._current['type']
+            self._advance()
+            right = self._parse_simple_expression()
+            if conjunction_type == 'and':
+                expression = ast.and_expression(expression, right)
+            else:
+                expression = ast.or_expression(expression, right)
+
+        return expression
+
+    def _parse_simple_expression(self):
+        if self._match('lparen'):
+            return self._parse_subexpression()
+        if self._match('not'):
+            return self._parse_not_expression()
+        return self._parse_condition_expression()
+
+    def _parse_subexpression(self):
+        self._advance_if_match('lparen')
+        expression = self._parse_simple_expression()
+        self._advance_if_match('rparen')
+        return ast.subexpression(expression)
+
+    def _parse_not_expression(self):
+        self._advance_if_match('not')
+        expression = self._parse_simple_expression()
+        return ast.not_expression(expression)
+
+    def _parse_condition_expression(self):
+        if self._match_next('lparen'):
+            return self._parse_function()
+        elif self._match_next('in'):
+            return self._parse_in_expression()
+        elif self._match_next('between'):
+            return self._parse_between_expression()
+        elif self._match_next(self.COMPARATORS):
+            return self._parse_comparison_expression()
+        else:
+            raise UnknownExpressionError(
+                start_token=self._current,
+                expression=self._expression,
+            )
+
+    def _parse_function(self):
+        function_name = self._current.get('value')
+        self._advance_if_match(['identifier', 'unquoted_identifier'])
+        self._advance_if_match('lparen')
+        arguments = self._parse_sequence()["children"]
+        self._advance_if_match('rparen')
+        return ast.function_expression(function_name, arguments)
+
+    def _parse_in_expression(self):
+        left = self._parse_operand()
+        self._advance_if_match('in')
+        self._advance_if_match('lparen')
+        right = self._parse_sequence()
+        self._advance_if_match('rparen')
+        return ast.in_expression(left, right)
+
+    def _parse_between_expression(self):
+        left = self._parse_operand()
+        self._advance_if_match('between')
+        middle = self._parse_operand()
+        self._advance_if_match('and')
+        right = self._parse_operand()
+        return ast.between_expression(left, middle, right)
+
+    def _parse_comparison_expression(self):
+        left = self._parse_operand()
+        comparator = self._current['type']
+        self._advance_if_match(self.COMPARATORS)
+        right = self._parse_operand()
+        return ast.comparison_expression(comparator, left, right)
+
+    def _parse_sequence(self):
+        # parses a sequence of literals or identifiers. There must be at
+        # least one.
+        elements = []
+        while True:
+            elements.append(self._parse_operand())
+            if not self._match('comma'):
+                break
+            self._advance()
+        return ast.sequence(elements)
+
+    def _parse_operand(self):
+        if self._match(['literal', 'lbracket', 'lbrace']):
+            return self._parse_literal()
+        elif self._match(['identifier', 'unquoted_identifier']):
+            value = self._current['value']
+            self._advance()
+            return ast.identifier(value)
+        else:
+            raise UnexpectedTokenError(
+                token=self._current,
+                expression=self._expression,
+                expected_type=[
+                    'literal', 'lbracket', 'lbrace', 'identifier',
+                    'unquoted_identiifer',
+                ],
+            )
+
+    def _parse_literal(self):
+        if self._match('literal'):
+            value = self._current['value']
+            self._advance()
+        elif self._match('lbracket'):
+            self._advance()
+            value = self._parse_literal_sequence()
+            self._advance_if_match('rbracket')
+        elif self._match('lbrace'):
+            self._advance()
+            if self._match_next('colon'):
+                value = self._parse_literal_map()
+            else:
+                value = self._parse_literal_set()
+            self._advance_if_match('rbrace')
+        else:
+            raise UnexpectedTokenError(
+                token=self._current,
+                expression=self._expression,
+                expected_type=['literal', 'lbracket', 'lbrace'],
+            )
+        return ast.literal(value)
+
+    def _parse_literal_set(self):
+        if self._match('rbrace'):
+            return set()
+
+        valid_types = (six.string_types, Binary, Decimal)
+        first_type = type(self._current['value'])
+
+        elements = set()
+        while True:
+            element = self._current
+            if not self._match('literal'):
+                raise UnexpectedTokenError(
+                    token=self._current,
+                    expression=self._expression,
+                    expected_type='literal',
+                )
+            if not isinstance(element['value'], valid_types):
+                message = (
+                    'Sets may only contain numbers, strings, or bytes, '
+                    'but literal of type `%s` was found'
+                )
+                raise InvalidLiteralValueError(
+                    token=self._current,
+                    expression=self._expression,
+                    message=message % type(element['type']),
+                )
+            if not isinstance(element['value'], first_type):
+                message = (
+                    'Set values must all be of the same type. First type was '
+                    '`%s`, but found value of type `%s`'
+                )
+                raise InvalidLiteralValueError(
+                    token=self._current,
+                    expression=self._expression,
+                    message=message % (first_type, type(element['type'])),
+                )
+
+            elements.add(self._current['value'])
+            self._advance()
+            if not self._match('comma'):
+                break
+            self._advance()
+        return elements
+
+    def _parse_literal_map(self):
+        elements = {}
+        while True:
+            key = self._current['value']
+            if not isinstance(key, six.string_types):
+                raise InvalidLiteralValueError(
+                    token=self._current,
+                    expression=self._expression,
+                    message=(
+                        'Keys must be of type `str`, found `%s`' % type(key)
+                    )
+                )
+            self._advance_if_match('literal')
+            self._advance_if_match('colon')
+            value = self._parse_literal()['value']
+            elements[key] = value
+            if not self._match('comma'):
+                break
+            self._advance()
+        return elements
+
+    def _parse_literal_sequence(self):
+        elements = []
+        while True:
+            elements.append(self._parse_literal()['value'])
+            if not self._match('comma'):
+                break
+            self._advance()
+        return elements
+
+    def _advance(self):
+        if self._position == len(self._tokens) - 1:
+            self._current = None
+        else:
+            self._position += 1
+            self._current = self._tokens[self._position]
+
+    def _peek(self):
+        if self._position == len(self._tokens) - 1:
+            return None
+        return self._tokens[self._position + 1]
+
+    def _match(self, expected_type):
+        return self._do_match(self._current, expected_type)
+
+    def _match_next(self, expected_type):
+        return self._do_match(self._peek(), expected_type)
+
+    def _do_match(self, token, expected_type):
+        if token is None:
+            return False
+        if isinstance(expected_type, list):
+            return any(token['type'] == t for t in expected_type)
+        return token['type'] == expected_type
+
+    def _advance_if_match(self, token_type):
+        if self._match(token_type):
+            self._advance()
+        else:
+            raise UnexpectedTokenError(
+                token=self._current,
+                expected_type=token_type,
+                expression=self._expression,
+            )

--- a/awscli/customizations/dynamodb/parser.py
+++ b/awscli/customizations/dynamodb/parser.py
@@ -83,7 +83,7 @@ class Parser(object):
 
     def _parse_subexpression(self):
         self._advance_if_match('lparen')
-        expression = self._parse_simple_expression()
+        expression = self._parse_and_or()
         self._advance_if_match('rparen')
         return ast.subexpression(expression)
 

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -197,7 +197,10 @@ class SelectCommand(PaginatedDDBCommand):
 
     def _add_expression_args(self, expression_name, expression, args,
                              substitution_count=0):
-        result = self._extractor.extract(expression, substitution_count)
+        result = self._extractor.extract(
+            ' '.join(expression),
+            substitution_count
+        )
         args[expression_name] = result['expression']
 
         if result['identifiers']:

--- a/tests/unit/customizations/dynamodb/test_extractor.py
+++ b/tests/unit/customizations/dynamodb/test_extractor.py
@@ -1,0 +1,262 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.dynamodb.extractor import AttributeExtractor
+from awscli.testutils import unittest
+
+
+class FakeParser(object):
+    def __init__(self, parsed_result):
+        self.parsed_result = parsed_result
+
+    def parse(self, expression):
+        return self.parsed_result
+
+
+class TestExtractor(unittest.TestCase):
+    def test_extract_identifier(self):
+        parsed_result = {'type': 'identifier', 'value': 'spam'}
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam')
+        expected = {
+            'expression': '#n0',
+            'identifiers': {'#n0': 'spam'},
+            'values': {},
+            'substitution_count': 1,
+        }
+        self.assertEqual(result, expected)
+
+    def test_extract_string(self):
+        parsed_result = {'type': 'literal', 'value': 'spam'}
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('"spam"')
+        expected = {
+            'expression': ':n0',
+            'identifiers': {},
+            'values': {':n0': 'spam'},
+            'substitution_count': 1,
+        }
+        self.assertEqual(result, expected)
+
+    def test_extract_bytes(self):
+        parsed_result = {'type': 'literal', 'value': b'spam'}
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('b"spam"')
+        expected = {
+            'expression': ':n0',
+            'identifiers': {},
+            'values': {':n0': b'spam'},
+            'substitution_count': 1,
+        }
+        self.assertEqual(result, expected)
+
+    def test_extract_number(self):
+        parsed_result = {'type': 'literal', 'value': 7}
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract("7")
+        expected = {
+            'expression': ':n0',
+            'identifiers': {},
+            'values': {':n0': 7},
+            'substitution_count': 1,
+        }
+        self.assertEqual(result, expected)
+
+    def test_set_index_offset(self):
+        parsed_result = {'type': 'identifier', 'value': 'spam'}
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam', 5)
+        expected = {
+            'expression': '#n5',
+            'identifiers': {'#n5': 'spam'},
+            'values': {},
+            'substitution_count': 1,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_comparator(self):
+        parsed_result = {
+            'type': 'comparator', 'value': 'eq',
+            'children': [
+                {'type': 'identifier', 'value': 'spam'},
+                {'type': 'literal', 'value': 7}
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam = 7')
+        expected = {
+            'expression': '#n0 = :n1',
+            'identifiers': {'#n0': 'spam'},
+            'values': {':n1': 7},
+            'substitution_count': 2,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_or(self):
+        parsed_result = {
+            'type': 'or_expression',
+            'children': [
+                {'type': 'comparator', 'value': 'eq', 'children': [
+                    {'type': 'identifier', 'value': 'spam'},
+                    {'type': 'literal', 'value': 7}
+                ]},
+                {'type': 'comparator', 'value': 'eq', 'children': [
+                    {'type': 'identifier', 'value': 'eggs'},
+                    {'type': 'literal', 'value': 6}
+                ]}
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam = 7 or eggs = 6')
+        expected = {
+            'expression': '#n0 = :n1 OR #n2 = :n3',
+            'identifiers': {'#n0': 'spam', '#n2': 'eggs'},
+            'values': {':n1': 7, ':n3': 6},
+            'substitution_count': 4,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_and(self):
+        parsed_result = {
+            'type': 'and_expression',
+            'children': [
+                {'type': 'comparator', 'value': 'eq', 'children': [
+                    {'type': 'identifier', 'value': 'spam'},
+                    {'type': 'literal', 'value': 7}
+                ]},
+                {'type': 'comparator', 'value': 'eq', 'children': [
+                    {'type': 'identifier', 'value': 'eggs'},
+                    {'type': 'literal', 'value': 6}
+                ]}
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam = 7 and eggs = 6')
+        expected = {
+            'expression': '#n0 = :n1 AND #n2 = :n3',
+            'identifiers': {'#n0': 'spam', '#n2': 'eggs'},
+            'values': {':n1': 7, ':n3': 6},
+            'substitution_count': 4,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_in(self):
+        parsed_result = {
+            'type': 'in_expression',
+            'children': [
+                {'type': 'identifier', 'value': 'spam'},
+                {'type': 'sequence', 'children': [
+                    {'type': 'literal', 'value': 1},
+                    {'type': 'literal', 'value': 2},
+                ]}
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam IN (2, 3)')
+        expected = {
+            'expression': '#n0 IN (:n1, :n2)',
+            'identifiers': {'#n0': 'spam'},
+            'values': {':n1': 1, ':n2': 2},
+            'substitution_count': 3,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_not(self):
+        parsed_result = {
+            'type': 'not_expression',
+            'children': [
+                {'type': 'comparator', 'value': 'ne', 'children': [
+                    {'type': 'identifier', 'value': 'spam'},
+                    {'type': 'literal', 'value': 7}
+                ]},
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('NOT spam <> 7')
+        expected = {
+            'expression': 'NOT #n0 <> :n1',
+            'identifiers': {'#n0': 'spam'},
+            'values': {':n1': 7},
+            'substitution_count': 2,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_subexpression(self):
+        parsed_result = {
+            'type': 'subexpression',
+            'children': [
+                {'type': 'comparator', 'value': 'lte', 'children': [
+                    {'type': 'identifier', 'value': 'spam'},
+                    {'type': 'literal', 'value': 7}
+                ]},
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('( spam <= 7 )')
+        expected = {
+            'expression': '( #n0 <= :n1 )',
+            'identifiers': {'#n0': 'spam'},
+            'values': {':n1': 7},
+            'substitution_count': 2,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_between(self):
+        parsed_result = {
+            'type': 'between_expression',
+            'children': [
+                {'type': 'identifier', 'value': 'spam'},
+                {'type': 'literal', 'value': 1},
+                {'type': 'literal', 'value': 2},
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('spam between 1 and 2')
+        expected = {
+            'expression': '#n0 BETWEEN :n1 AND :n2',
+            'identifiers': {'#n0': 'spam'},
+            'values': {':n1': 1, ':n2': 2},
+            'substitution_count': 3,
+        }
+        self.assertEqual(result, expected)
+
+    def test_represent_function(self):
+        parsed_result = {
+            'type': 'function', 'value': 'myfunction',
+            'children': [
+                {'type': 'identifier', 'value': 'spam'},
+                {'type': 'literal', 'value': 1},
+            ]
+        }
+        parser = FakeParser(parsed_result)
+        extractor = AttributeExtractor(parser)
+        result = extractor.extract('myfunction(1, 2)')
+        expected = {
+            'expression': 'myfunction(#n0, :n1)',
+            'identifiers': {'#n0': 'spam'},
+            'values': {':n1': 1},
+            'substitution_count': 2,
+        }
+        self.assertEqual(result, expected)
+

--- a/tests/unit/customizations/dynamodb/test_lexer.py
+++ b/tests/unit/customizations/dynamodb/test_lexer.py
@@ -1,0 +1,132 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from decimal import Decimal
+
+from nose.tools import assert_equal, assert_raises, assert_in
+
+from awscli.customizations.dynamodb.exceptions import (
+    LexerError, EmptyExpressionError,
+)
+from awscli.customizations.dynamodb.lexer import Lexer
+
+
+def test_lexer():
+    cases = [
+        ('foo', [{'type': 'unquoted_identifier', 'value': 'foo'}]),
+        ("'foo'", [{'type': 'identifier', 'value': 'foo'}]),
+        ("'f\\'oo'", [{'type': 'identifier', 'value': "f'oo"}]),
+        ('"spam"', [{'type': 'literal', 'value': 'spam'}]),
+        ('"s\\"pam"', [{'type': 'literal', 'value': 's"pam'}]),
+        ('100', [{'type': 'literal', 'value': Decimal('100')}]),
+        ('-100', [{'type': 'literal', 'value': Decimal('-100')}]),
+        ('1.01', [{'type': 'literal', 'value': Decimal('1.01')}]),
+        ('1.01e6', [{'type': 'literal', 'value': Decimal('1.01e6')}]),
+        ('1.01E6', [{'type': 'literal', 'value': Decimal('1.01e6')}]),
+        ('1.01e+6', [{'type': 'literal', 'value': Decimal('1.01e6')}]),
+        ('1.01e-6', [{'type': 'literal', 'value': Decimal('1.01e-6')}]),
+        ("foo, 'bar', \"baz\"", [
+            {'type': 'unquoted_identifier', 'value': 'foo'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 'baz'},
+        ]),
+        ('b"4pyT"', [{'type': 'literal', 'value': b'\xe2\x9c\x93'}]),
+        ('boo', [{'type': 'unquoted_identifier', 'value': 'boo'}]),
+    ]
+
+    tester = LexTester()
+    for case in cases:
+        yield tester.assert_tokens, case[0], case[1]
+
+    simple_tokens = {
+        '.': 'dot',
+        ',': 'comma',
+        ':': 'colon',
+        '(': 'lparen',
+        ')': 'rparen',
+        '{': 'lbrace',
+        '}': 'rbrace',
+        '[': 'lbracket',
+        ']': 'rbracket',
+        '=': 'eq',
+        '>': 'gt',
+        '>=': 'gte',
+        '<': 'lt',
+        '<=': 'lte',
+        '<>': 'ne',
+    }
+    for token, token_type  in simple_tokens.items():
+        expected = [{'type': token_type, 'value': token}]
+        yield tester.assert_tokens, token, expected
+
+    string_tokens = ['and', 'between', 'in', 'or', 'not']
+    for token in string_tokens:
+        expected = [{'type': token, 'value': token}]
+        yield tester.assert_tokens, token, expected
+
+        expected = [{'type': token, 'value': token.upper()}]
+        yield tester.assert_tokens, token.upper(), expected
+
+        expected = [{'type': token, 'value': token.capitalize()}]
+        yield tester.assert_tokens, token.capitalize(), expected
+
+
+def test_lexer_error():
+    cases = {
+        "'": "'\n^",
+        '"': '"\n^',
+        '-': '-\n^',
+        '1e-': '1e-\n  ^',
+        '1ex': '1ex\n  ^',
+        '1.': '1.\n ^',
+        '1.x': '1.x\n  ^',
+        '&': '&\n^',
+        '|': '|\n^',
+        'b"': 'b"\n ^',
+        'b"&"': 'b"&"\n^',
+        # Invalid padding
+        'b"898989;;"': 'b"898989;;"\n^',
+    }
+
+    tester = LexTester()
+    yield tester.assert_empty_error, ''
+
+    for expression, error_part in cases.items():
+        yield tester.assert_lex_error, expression, error_part
+
+
+class LexTester(object):
+    def __init__(self):
+        self.lexer = Lexer()
+
+    def assert_tokens(self, expression, expected):
+        actual = self.lexer.tokenize(expression)
+        simple_tokens = [
+            {'type': t['type'], 'value': t['value']} for t in actual
+        ]
+        assert_equal(simple_tokens.pop()['type'], 'eof')
+        assert_equal(simple_tokens, expected)
+
+    def assert_lex_error(self, expression, error_part):
+        try:
+            list(self.lexer.tokenize(expression))
+            raise AssertionError(
+                'LexerError not raised for expression: %s' % expression
+            )
+        except LexerError as e:
+            assert_in(error_part, str(e))
+
+    def assert_empty_error(self, expression):
+        with assert_raises(EmptyExpressionError):
+            list(self.lexer.tokenize(expression))

--- a/tests/unit/customizations/dynamodb/test_parser.py
+++ b/tests/unit/customizations/dynamodb/test_parser.py
@@ -1,0 +1,743 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from decimal import Decimal
+
+from awscli.customizations.dynamodb.exceptions import (
+    UnexpectedTokenError, UnknownExpressionError, InvalidLiteralValueError,
+)
+from awscli.customizations.dynamodb.parser import Parser
+from awscli.testutils import unittest
+
+
+class FakeLexer(object):
+    def __init__(self, tokens):
+        self._tokens = tokens
+
+    def tokenize(self, expression):
+        return self._tokens
+
+
+class TestParser(unittest.TestCase):
+    maxDiff = None
+
+    def assert_parse(self, tokens, expected):
+        self.assertEqual(expected, self._parse(tokens))
+
+    def _parse(self, tokens, expression=None):
+        if expression is None:
+            self._insert_token_positions(tokens)
+            expression = ''
+            for token in tokens:
+                expression += str(token['value']) + ' '
+            expression = expression.strip()
+        lexer = FakeLexer(tokens)
+        parser = Parser(lexer)
+        return parser.parse(expression)
+
+    def _insert_token_positions(self, tokens):
+        position = 0
+        for token in tokens:
+            if 'start' not in token:
+                token['start'] = position
+            if 'end' not in token:
+                token['end'] = token['start'] + len(str(token['value']))
+            position = token['end'] + 1
+
+    def test_parse_sequence(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'sequence',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'identifier', 'value': 'bar', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_single_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'sequence',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_and_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bam'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'and_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'baz', 'children': []},
+                        {'type': 'literal', 'value': 'bam', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_multiple_and_expressions(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bam'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'identifier', 'value': 'spam'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'eggs'},
+            {'type': 'eof', 'value': ''},
+        ]
+        left_and_expression = {
+            'type': 'and_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'baz', 'children': []},
+                        {'type': 'literal', 'value': 'bam', 'children': []},
+                    ],
+                },
+            ]
+        }
+        expected = {
+            'type': 'and_expression',
+            'children': [
+                left_and_expression,
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {
+                            'type': 'identifier',
+                            'value': 'spam', 'children': []
+                        },
+                        {'type': 'literal', 'value': 'eggs', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_and_missing_second_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnknownExpressionError):
+            self._parse(tokens)
+
+    def test_parse_or_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'or', 'value': 'or'},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bam'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'or_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'baz', 'children': []},
+                        {'type': 'literal', 'value': 'bam', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_multiple_or_expressions(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'or', 'value': 'or'},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bam'},
+            {'type': 'or', 'value': 'or'},
+            {'type': 'identifier', 'value': 'spam'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'eggs'},
+            {'type': 'eof', 'value': ''},
+        ]
+        left_or_expression = {
+            'type': 'or_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'baz', 'children': []},
+                        {'type': 'literal', 'value': 'bam', 'children': []},
+                    ],
+                },
+            ]
+        }
+        expected = {
+            'type': 'or_expression',
+            'children': [
+                left_or_expression,
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {
+                            'type': 'identifier',
+                            'value': 'spam', 'children': []
+                        },
+                        {'type': 'literal', 'value': 'eggs', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_or_missing_second_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'or', 'value': 'or'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnknownExpressionError):
+            self._parse(tokens)
+
+    def test_parse_mixed_and_or_expressions(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bam'},
+            {'type': 'or', 'value': 'or'},
+            {'type': 'identifier', 'value': 'spam'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'eggs'},
+            {'type': 'eof', 'value': ''},
+        ]
+        left_and_expression = {
+            'type': 'and_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'baz', 'children': []},
+                        {'type': 'literal', 'value': 'bam', 'children': []},
+                    ],
+                },
+            ]
+        }
+        expected = {
+            'type': 'or_expression',
+            'children': [
+                left_and_expression,
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {
+                            'type': 'identifier',
+                            'value': 'spam', 'children': []
+                        },
+                        {'type': 'literal', 'value': 'eggs', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_subexpression(self):
+        tokens = [
+            {'type': 'lparen', 'value': '('},
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'rparen', 'value': ')'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'subexpression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_subexpression_unmatched_paren(self):
+        tokens = [
+            {'type': 'lparen', 'value': '('},
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_not_expression(self):
+        tokens = [
+            {'type': 'not', 'value': 'not'},
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'not_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_not_missing_expression(self):
+        tokens = [
+            {'type': 'not', 'value': 'not'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnknownExpressionError):
+            self._parse(tokens)
+
+    def test_parse_function(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lparen', 'value': '('},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 'baz'},
+            {'type': 'rparen', 'value': ')'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'function', 'value': 'foo',
+            'children': [
+                {'type': 'literal', 'value': 'bar', 'children': []},
+                {'type': 'literal', 'value': 'baz', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_function_missing_closing_paren(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lparen', 'value': '('},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_function_args_missing_comma(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lparen', 'value': '('},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'literal', 'value': 'baz'},
+            {'type': 'rparen', 'value': ')'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_in_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'in', 'value': 'in'},
+            {'type': 'lparen', 'value': '('},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 'baz'},
+            {'type': 'rparen', 'value': ')'},
+            {'type': 'eof', 'value': ''},
+        ]
+        sequence = {
+            'type': 'sequence',
+            'children': [
+                {'type': 'literal', 'value': 'bar', 'children': []},
+                {'type': 'literal', 'value': 'baz', 'children': []},
+            ]
+        }
+        expected = {
+            'type': 'in_expression',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                sequence,
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_in_missing_operand(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'in', 'value': 'in'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_in_missing_parens(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'in', 'value': 'in'},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 'baz'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_between_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'between', 'value': 'between'},
+            {'type': 'literal', 'value': 1},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'literal', 'value': 3},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'between_expression',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'literal', 'value': 1, 'children': []},
+                {'type': 'literal', 'value': 3, 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_between_missing_and(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'between', 'value': 'between'},
+            {'type': 'literal', 'value': 1},
+            {'type': 'literal', 'value': 3},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_between_missing_right_operand(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'between', 'value': 'between'},
+            {'type': 'literal', 'value': 1},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_between_missing_center_operand(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'between', 'value': 'between'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'literal', 'value': 3},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_comparison_expression(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lte', 'value': '<='},
+            {'type': 'literal', 'value': 8},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'comparator', 'value': 'lte',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'literal', 'value': 8, 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_unmatched_comparator(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'gte', 'value': '>='},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_list_literal(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': 8},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 9},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'comparator', 'value': 'eq',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'literal', 'children': [], 'value': [8, 9]},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_list_literal_can_only_contain_literals(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 9},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_list_with_unmatched_bracket(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': 9},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_set_literal(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': Decimal('8')},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': Decimal('9')},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'comparator', 'value': 'eq',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'literal', 'children': [], 'value': {8, 9}},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_set_literal_can_only_contain_literals(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_sets_dont_take_floats(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': 1.1},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(InvalidLiteralValueError):
+            self._parse(tokens)
+
+    def test_sets_cant_contain_collections(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': 9},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_set_values_must_all_be_same_type(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': Decimal('9')},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(InvalidLiteralValueError):
+            self._parse(tokens)
+
+    def test_set_with_unmatched_brace(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': Decimal('8')},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_parse_map_literal(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'colon', 'value': ':'},
+            {'type': 'literal', 'value': 4},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'comparator', 'value': 'eq',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'literal', 'children': [], 'value': {"bar": 4}},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_map_with_unmatched_brace(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'colon', 'value': ':'},
+            {'type': 'literal', 'value': 4},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_map_missing_colon(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'literal', 'value': 4},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(UnexpectedTokenError):
+            self._parse(tokens)
+
+    def test_map_key_must_be_string(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'lbrace', 'value': '{'},
+            {'type': 'literal', 'value': 9},
+            {'type': 'colon', 'value': ':'},
+            {'type': 'literal', 'value': 4},
+            {'type': 'rbrace', 'value': '}'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(InvalidLiteralValueError):
+            self._parse(tokens)

--- a/tests/unit/customizations/dynamodb/test_parser.py
+++ b/tests/unit/customizations/dynamodb/test_parser.py
@@ -347,6 +347,44 @@ class TestParser(unittest.TestCase):
         }
         self.assert_parse(tokens, expected)
 
+    def test_parse_subexpression_with_and(self):
+        tokens = [
+            {'type': 'lparen', 'value': '('},
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eq', 'value': '='},
+            {'type': 'literal', 'value': 'bam'},
+            {'type': 'rparen', 'value': ')'},
+            {'type': 'eof', 'value': ''},
+        ]
+        and_expression = {
+            'type': 'and_expression',
+            'children': [
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'foo', 'children': []},
+                        {'type': 'literal', 'value': 'bar', 'children': []},
+                    ],
+                },
+                {
+                    'type': 'comparator', 'value': 'eq',
+                    'children': [
+                        {'type': 'identifier', 'value': 'baz', 'children': []},
+                        {'type': 'literal', 'value': 'bam', 'children': []},
+                    ],
+                },
+            ]
+        }
+        expected = {
+            'type': 'subexpression',
+            'children': [and_expression]
+        }
+        self.assert_parse(tokens, expected)
+
     def test_parse_subexpression_unmatched_paren(self):
         tokens = [
             {'type': 'lparen', 'value': '('},


### PR DESCRIPTION
This adds support for substitution of attribute names and
values in ddb expressions. This means that you can write an expression
without having to worry about manually pulling out values.

So you can write:

```
$ aws ddb select mytable --filter 'price BETWEEN 25.50 AND 40'
[...]
$ aws ddb select mytable --key-condition 'name = "foo"'
[...]
$ aws ddb select mytable --projection 'attribute, other[0].nested.attribute'
[...]
```

etc.

What this supports:

* attribute names, either as unquoted string (`foo`) or quoted with ***single quotes*** (`'foo'`)
* scalar attribute values
    * strings are ***double quoted*** (`"foo"`)
    * numbers are just numbers, but support full JSON semantics (`1`, `1.1`, `1.01e-7`, etc.)
    * bytes are ***base64-encoded***, ***double quoted***, and preceeded with a `b` (`b"4pyT"`)
* collection values
    * json-style lists (`[1, 2, 3]`)
    * json-style maps (`{"foo": "bar"}`)
    * python-style sets (`{1, 2, 3}`)