### PR TITLE
[CLIv2] Add the list-profiles command to configure

### DIFF
--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -23,6 +23,7 @@ from awscli.customizations.configure.get import ConfigureGetCommand
 from awscli.customizations.configure.list import ConfigureListCommand
 from awscli.customizations.configure.writer import ConfigFileWriter
 from awscli.customizations.configure.importer import ConfigureImportCommand
+from awscli.customizations.configure.listprofiles import ListProfilesCommand
 
 from . import mask_value, profile_to_section
 
@@ -76,6 +77,7 @@ class ConfigureCommand(BasicCommand):
         {'name': 'set', 'command_class': ConfigureSetCommand},
         {'name': 'add-model', 'command_class': AddModelCommand},
         {'name': 'import', 'command_class': ConfigureImportCommand},
+        {'name': 'list-profiles', 'command_class': ListProfilesCommand},
     ]
 
     # If you want to add new values to prompt, update this list here.

--- a/awscli/customizations/configure/listprofiles.py
+++ b/awscli/customizations/configure/listprofiles.py
@@ -1,0 +1,37 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import sys
+
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.utils import uni_print
+
+
+class ListProfilesCommand(BasicCommand):
+    NAME = 'list-profiles'
+    DESCRIPTION = (
+        'List the profiles available to the AWS CLI.'
+    )
+    EXAMPLES = (
+        'aws configure list-profiles\n\n'
+    )
+
+    def __init__(self, session, out_stream=None):
+        super(ListProfilesCommand, self).__init__(session)
+
+        if out_stream is None:
+            out_stream = sys.stdout
+        self._out_stream = out_stream
+
+    def _run_main(self, parsed_args, parsed_globals):
+        for profile in self._session.available_profiles:
+            uni_print('%s\n' % profile, out_file=self._out_stream)

--- a/tests/unit/customizations/configure/__init__.py
+++ b/tests/unit/customizations/configure/__init__.py
@@ -17,7 +17,7 @@ class FakeSession(object):
 
     def __init__(self, all_variables, profile_does_not_exist=False,
                  config_file_vars=None, environment_vars=None,
-                 credentials=None, profile=None):
+                 credentials=None, profile=None, available_profiles=None):
         self.variables = all_variables
         self.profile_does_not_exist = profile_does_not_exist
         self.config = {}
@@ -26,9 +26,16 @@ class FakeSession(object):
         self.config_file_vars = config_file_vars
         if environment_vars is None:
             environment_vars = {}
+        if available_profiles is None:
+            available_profiles = ['default']
+        self._available_profiles = available_profiles
         self.environment_vars = environment_vars
         self._credentials = credentials
         self.profile = profile
+
+    @property
+    def available_profiles(self):
+        return self._available_profiles
 
     def get_credentials(self):
         return self._credentials

--- a/tests/unit/customizations/configure/test_listprofiles.py
+++ b/tests/unit/customizations/configure/test_listprofiles.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from . import FakeSession
+from awscli.compat import six
+from awscli.testutils import unittest
+from awscli.customizations.configure.listprofiles import ListProfilesCommand
+
+
+class TestListProfilesCommand(unittest.TestCase):
+    def _create_command(self, profiles=None):
+        session = FakeSession({}, available_profiles=profiles)
+        stdout = six.StringIO()
+        command = ListProfilesCommand(session, out_stream=stdout)
+        return stdout, command
+
+    def test_lists_profile_default(self):
+        stdout, list_profiles = self._create_command()
+        list_profiles(args=[], parsed_globals=None)
+        self.assertEqual('default\n', stdout.getvalue())
+
+    def test_lists_profile_multiple(self):
+        profiles = [
+            'default',
+            'profile-foo',
+            'profile-baz',
+            'some profile',
+        ]
+        stdout, list_profiles = self._create_command(profiles=profiles)
+        list_profiles(args=[], parsed_globals=None)
+        self.assertEqual('\n'.join(profiles) + '\n', stdout.getvalue())


### PR DESCRIPTION
This adds a simple command to enumerate all known profiles by iterating the `available_profiles` property of the session. 

#3587 