### PR TITLE
Enable logs for urllib3 when the debug flag is passed

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -264,6 +264,8 @@ class CLIDriver(object):
                                            format_string=LOG_FORMAT)
             self.session.set_stream_logger('s3transfer', logging.DEBUG,
                                            format_string=LOG_FORMAT)
+            self.session.set_stream_logger('urllib3', logging.DEBUG,
+                                           format_string=LOG_FORMAT)
             LOG.debug("CLI version: %s", self.session.user_agent())
             LOG.debug("Arguments entered to CLI: %s", sys.argv[1:])
 


### PR DESCRIPTION
After the switch to upstream `urllib3` the debug logs for `urllib3` are no longer under the `botocore` namespace and need to be enabled explicitly. 