### PR TITLE
[CLIv2] Default a variable to null if it doesn't exist

### DIFF
--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -232,7 +232,7 @@ class Executor(object):
         varname = condition['variable']
         if 'equals' in condition:
             expected = condition['equals']
-            return parameters[varname] == expected
+            return parameters.get(varname) == expected
         return False
 
 

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -541,6 +541,22 @@ class TestExecutor(unittest.TestCase):
         self.assertFalse(self.session.create_client.called)
         self.assertFalse(self.client.create_user.called)
 
+    def test_can_make_conditional_on_env_var_not_exists(self):
+        loaded = load_wizard("""
+        execute:
+          default:
+            - type: apicall
+              condition:
+                variable: does_not_exist
+                equals: null
+              operation: iam.CreateUser
+              params:
+                UserName: admin
+        """)
+        self.executor.run(loaded['execute'], {})
+        self.assertTrue(self.session.create_client.called)
+        self.assertTrue(self.client.create_user.called)
+
     def test_can_recursively_template_variables_in_params(self):
         loaded = load_wizard("""
         execute:


### PR DESCRIPTION
This prevents you from having to create separate variables
that track whether a condition should be taken.  You can just
rely on the fact that if the variable was never defined, it's
equal to `null`.

cc @kyleknap 