### PR TITLE
[CLIv2] ddb put

### DIFF
--- a/awscli/customizations/dynamodb/ddb.py
+++ b/awscli/customizations/dynamodb/ddb.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.dynamodb.subcommands import (
-    SelectCommand,
+    SelectCommand, PutCommand,
 )
 
 
@@ -30,6 +30,7 @@ class DDB(BasicCommand):
     SYNOPSIS = "aws ddb <Command> [<Arg> ...]"
     SUBCOMMANDS = [
         {'name': 'select', 'command_class': SelectCommand},
+        {'name': 'put', 'command_class': PutCommand},
     ]
 
     def _run_main(self, parsed_args, parsed_globals):

--- a/awscli/customizations/dynamodb/params.py
+++ b/awscli/customizations/dynamodb/params.py
@@ -87,6 +87,14 @@ FILTER_EXPRESSION = {
     )
 }
 
+CONDITION_EXPRESSION = {
+    'name': 'condition', 'nargs': '+',
+    'help_text': (
+        '<p>A condition that must be satisfied in order for a conditional '
+        '<code>put</code> operation to succeed.</p>'
+    )
+}
+
 KEY_CONDITION_EXPRESSION = {
     'name': 'key-condition', 'nargs': '+',
     'help_text': (
@@ -127,6 +135,15 @@ KEY_CONDITION_EXPRESSION = {
         'Number.) Note that the function name <code>begins_with</code> is '
         'case-sensitive.</p></li>'
         '</ul>'
+    )
+}
+
+ITEMS = {
+    'name': 'items',
+    'positional_arg': True,
+    'synopsis': '<items>',
+    'help_text': (
+        '<p>One or more items to put into the table.</p>'
     )
 }
 

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -314,16 +314,15 @@ def capture_output():
             yield CapturedOutput(stdout, stderr)
 
 
+class BufferedBytesIO(six.BytesIO):
+    def buffer(self):
+        return self
+
+
 @contextlib.contextmanager
 def capture_input(input_bytes=b''):
-    input_data = six.BytesIO(input_bytes)
-    if six.PY3:
-        mock_object = mock.Mock()
-        mock_object.buffer = input_data
-    else:
-        mock_object = input_data
-
-    with mock.patch('sys.stdin', mock_object):
+    input_data = BufferedBytesIO(input_bytes)
+    with mock.patch('sys.stdin', input_data):
         yield input_data
 
 

--- a/tests/functional/ddb/test_put.py
+++ b/tests/functional/ddb/test_put.py
@@ -1,0 +1,211 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import json
+import os
+import shutil
+import tempfile
+
+import ruamel.yaml as yaml
+
+from awscli.testutils import BaseAWSCommandParamsTest, capture_input
+
+
+class TestPut(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestPut, self).setUp()
+        self.parsed_response = {}
+        self.tempdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        super(TestPut, self).tearDown()
+        shutil.rmtree(self.tempdir)
+
+    def assert_yaml_response_equal(self, response, expected):
+        with self.assertRaises(ValueError):
+            json.loads(response)
+        loaded = yaml.safe_load(response)
+        self.assertEqual(loaded, expected)
+
+    def test_simple_put(self):
+        command = ['ddb', 'put', 'mytable', '{foo: bar}']
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'Item': {"foo": {"S": "bar"}},
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )
+        operations_called = [o[0].name for o in self.operations_called]
+        self.assertEqual(operations_called, ['PutItem'])
+
+    def test_batch_write(self):
+        command = [
+            'ddb', 'put', 'mytable', '[{foo: bar}, {foo: bar}]'
+        ]
+        expected_params = {
+            'ReturnConsumedCapacity': 'NONE',
+            'RequestItems': {
+                'mytable': [
+                    {'PutRequest': {'Item': {'foo': {'S': 'bar'}}}},
+                    {'PutRequest': {'Item': {'foo': {'S': 'bar'}}}},
+                ]
+            }
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )
+        operations_called = [o[0].name for o in self.operations_called]
+        self.assertEqual(operations_called, ['BatchWriteItem'])
+
+    def test_batch_write_multiple_batches(self):
+        items = ', '.join(["{foo: bar}" for _ in range(40)])
+        command = [
+            'ddb', 'put', 'mytable', '[%s]' % items
+        ]
+        self.run_cmd(command, expected_rc=0)
+        operations_called = [o[0].name for o in self.operations_called]
+        self.assertEqual(operations_called, [
+            'BatchWriteItem', 'BatchWriteItem'
+        ])
+
+        first_params = self.operations_called[0][1]
+        num_items = len(first_params['RequestItems']['mytable'])
+        self.assertEqual(num_items, 25)
+        self.assertEqual(first_params.get('ReturnConsumedCapacity'), 'NONE')
+
+        second_params = self.operations_called[1][1]
+        num_items = len(second_params['RequestItems']['mytable'])
+        self.assertEqual(num_items, 15)
+        self.assertEqual(second_params.get('ReturnConsumedCapacity'), 'NONE')
+
+    def test_batch_write_unprocessed_items(self):
+        self.parsed_responses = [
+            {
+                'UnprocessedItems': {'mytable': [
+                    {'PutRequest': {'Item': {'foo': {'S': 'bar'}}}},
+                ]}
+            },
+            {
+                'UnprocessedItems': {'mytable': [
+                    {'PutRequest': {'Item': {'foo': {'S': 'bar'}}}},
+                ]}
+            },
+            {},
+        ]
+
+        items = ', '.join(["{foo: bar}" for _ in range(40)])
+        command = [
+            'ddb', 'put', 'mytable', '[%s]' % items
+        ]
+        self.run_cmd(command, expected_rc=0)
+        operations_called = [o[0].name for o in self.operations_called]
+        self.assertEqual(operations_called, [
+            'BatchWriteItem', 'BatchWriteItem', 'BatchWriteItem',
+        ])
+
+        first_params = self.operations_called[0][1]
+        num_items = len(first_params['RequestItems']['mytable'])
+        self.assertEqual(num_items, 25)
+
+        second_params = self.operations_called[1][1]
+        num_items = len(second_params['RequestItems']['mytable'])
+        self.assertEqual(num_items, 16)
+
+        third_params = self.operations_called[2][1]
+        num_items = len(third_params['RequestItems']['mytable'])
+        self.assertEqual(num_items, 1)
+
+    def test_put_with_condition(self):
+        command = [
+            'ddb', 'put', 'mytable', '{foo: bar}',
+            '--condition', 'attribute_exists(foo)',
+        ]
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'ConditionExpression': 'attribute_exists(#n0)',
+            'ExpressionAttributeNames': {'#n0': 'foo'},
+            'Item': {"foo": {"S": "bar"}},
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )
+
+    def test_batch_write_with_condition(self):
+        command = [
+            'ddb', 'put', 'mytable', '[{foo: bar}, {foo: bar}]',
+            '--condition', 'attribute_exists(foo)',
+        ]
+        _, stderr, _ = self.assert_params_for_cmd(command, expected_rc=255)
+        self.assertIn('--condition is not supported', stderr)
+
+    def test_load_items_from_file(self):
+        filename = os.path.join(self.tempdir, 'items.yml')
+        with open(filename, 'w') as f:
+            f.write('{foo: bar}\n')
+
+        command = ['ddb', 'put', 'mytable', 'file://%s' % filename]
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'Item': {"foo": {"S": "bar"}},
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )
+
+    def test_load_items_from_stdin(self):
+        command = ['ddb', 'put', 'mytable', '-']
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'Item': {"foo": {"S": "bar"}},
+        }
+        with capture_input(b'{foo: bar}'):
+            self.assert_params_for_cmd(
+                command, expected_params, expected_rc=0
+            )
+
+    def test_put_bytes(self):
+        command = ['ddb', 'put', 'mytable', '{foo: !!binary "4pyT"}']
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'Item': {"foo": {"B": b'\xe2\x9c\x93'}},
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )
+
+    def test_put_int(self):
+        command = ['ddb', 'put', 'mytable', '{foo: 1}']
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'Item': {"foo": {"N": "1"}},
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )
+
+    def test_put_float(self):
+        command = ['ddb', 'put', 'mytable', '{foo: 1.1}']
+        expected_params = {
+            'TableName': 'mytable',
+            'ReturnConsumedCapacity': 'NONE',
+            'Item': {"foo": {"N": "1.1"}},
+        }
+        self.assert_params_for_cmd(
+            command, expected_params, expected_rc=0
+        )


### PR DESCRIPTION
This adds support for a new command under the `aws ddb` namespace: `put`. The `put` command is an abstraction on top of `put_item` and `batch_write_item`. It will be able to tell, based on your underlying arguments, which command to use. If you attempt to put multiple items it will use `batch_write_item` unless you have specified a `--condition` (as `batch_write_item` does not support condition expressions).

Like select, it supports simple expressions so you don't have to manually extract attribute names and values. It supports direct input, file input, and input from stdin. It will automatically retry any unprocessed items.

Old way:
```
$ UNPROCESSED=$(aws dynamodb batch-write-item --request-items '{"mytable": [{"foo": {"S": "bar"}}, {"foo": {"S": "baz"}}]}' --query 'UnprocessedItems["mytable"]')
```
Now you have to check that $UNPROCESSED != null, and make a new request otherwise.

New ways:
```
$ aws ddb put mytable '[{foo: bar}, {foo: baz}]'
$ echo '[{foo: bar}, {foo: baz}]' | aws ddb put mytable -
$ cat items.json
[
    {"foo": "bar"},
    {"foo": "baz"},
]
$ aws ddb put mytable file://items.json
```