### PR TITLE
[CLIv2] Add cli-dev command and wizard-dev command

### DIFF
--- a/awscli/customizations/devcommands.py
+++ b/awscli/customizations/devcommands.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.commands import BasicCommand
+
+
+def register_dev_commands(event_handlers):
+    event_handlers.register('building-command-table.main',
+                            CLIDevCommand.add_command)
+
+
+# This is adding a top level placeholder command to add dev commands.
+# Each specific customization can add to this command via the
+# building-command-table event name.
+class CLIDevCommand(BasicCommand):
+    NAME = 'cli-dev'
+    DESCRIPTION = (
+        'Internal commands for AWS CLI development.\n'
+        'These commands are not intended for normal end usage. These '
+        'commands are used to help develop and debug the AWS CLI.\n'
+        'Do not rely on these commands, backwards compatibility '
+        'is not guaranteed.  Any of these commands under "aws cli-dev" '
+        'may be removed in future versions.\n'
+    )
+    SYNOPSIS = 'aws cli-dev [dev-command]'

--- a/awscli/customizations/wizard/commands.py
+++ b/awscli/customizations/wizard/commands.py
@@ -1,0 +1,17 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.wizard import devcommands
+
+
+def register_wizard_commands(event_handlers):
+    devcommands.register_dev_commands(event_handlers)

--- a/awscli/customizations/wizard/devcommands.py
+++ b/awscli/customizations/wizard/devcommands.py
@@ -1,0 +1,76 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import ruamel.yaml as yaml
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.wizard import factory
+
+
+def register_dev_commands(event_handlers):
+    event_handlers.register('building-command-table.cli-dev',
+                            WizardDev.add_command)
+
+
+def create_default_wizard_dev_runner(session):
+    runner = factory.create_default_wizard_runner(session)
+    return WizardDevRunner(
+        wizard_loader=WizardLoader(),
+        wizard_runner=runner
+    )
+
+
+class WizardLoader(object):
+    def load(self, contents):
+        data = yaml.load(contents, Loader=yaml.RoundTripLoader)
+        return data
+
+
+class WizardDevRunner(object):
+    def __init__(self, wizard_loader, wizard_runner):
+        self._wizard_loader = wizard_loader
+        self._wizard_runner = wizard_runner
+
+    def run_wizard(self, wizard_contents):
+        """Run a single wizard given the contents as a string."""
+        loaded = self._wizard_loader.load(wizard_contents)
+        self._wizard_runner.run(loaded)
+
+
+class WizardDev(BasicCommand):
+    NAME = 'wizard-dev'
+    DESCRIPTION = (
+        'Internal command from developing, testing and debugging wizards.\n'
+        'This command is not intended for normal end usage. '
+        'Do not rely on this command, backwards compatibility '
+        'is not guaranteed.  This command may be removed in '
+        'future versions.\n'
+    )
+    ARG_TABLE = [
+        {'name': 'run-wizard',
+         'help_text': 'Run a wizard given a wizard file.',
+         'action': 'store',
+         'cli_type_name': 'string'}
+    ]
+
+    def __init__(self, session, dev_runner=None):
+        super(WizardDev, self).__init__(session)
+        if dev_runner is None:
+            dev_runner = create_default_wizard_dev_runner(session)
+        self._dev_runner = dev_runner
+
+    def _run_main(self, args, parsed_globals):
+        if args.run_wizard is not None:
+            return self._run_wizard(args.run_wizard)
+
+    def _run_wizard(self, wizard_contents):
+        self._dev_runner.run_wizard(wizard_contents)
+        return 0

--- a/awscli/customizations/wizard/devcommands.py
+++ b/awscli/customizations/wizard/devcommands.py
@@ -56,9 +56,7 @@ class WizardDev(BasicCommand):
     )
     ARG_TABLE = [
         {'name': 'run-wizard',
-         'help_text': 'Run a wizard given a wizard file.',
-         'action': 'store',
-         'cli_type_name': 'string'}
+         'help_text': 'Run a wizard given a wizard file.'}
     ]
 
     def __init__(self, session, dev_runner=None):

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -1,0 +1,26 @@
+from awscli.customizations.wizard import core, ui
+from awscli.customizations.configure.writer import ConfigFileWriter
+
+
+def create_default_wizard_runner(session):
+    api_invoker = core.APIInvoker(session=session)
+    shared_config = core.SharedConfigAPI(session=session,
+                                         config_writer=ConfigFileWriter())
+    planner = core.Planner(
+        step_handlers={
+            'static': core.StaticStep(),
+            'prompt': core.PromptStep(ui.UIPrompter()),
+            'template': core.TemplateStep(),
+            'apicall': core.APICallStep(api_invoker=api_invoker),
+            'sharedconfig': core.SharedConfigStep(config_api=shared_config),
+        }
+    )
+    executor = core.Executor(
+        step_handlers={
+            'apicall': core.APICallExecutorStep(api_invoker),
+            'sharedconfig': core.SharedConfigExecutorStep(shared_config),
+        }
+    )
+    runner = core.Runner(planner, executor)
+    return runner
+

--- a/awscli/customizations/wizard/selectmenu.py
+++ b/awscli/customizations/wizard/selectmenu.py
@@ -1,0 +1,185 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from prompt_toolkit import Application
+from prompt_toolkit.utils import get_cwidth
+from prompt_toolkit.layout import Layout, FloatContainer, Float
+from prompt_toolkit.layout.controls import UIControl, UIContent
+from prompt_toolkit.layout.screen import Point
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.key_binding.key_bindings import KeyBindings
+from prompt_toolkit.layout.margins import ScrollbarMargin
+from prompt_toolkit.layout.containers import ScrollOffsets, Window
+
+
+def select_menu(items, display_format=None, max_height=10):
+    """ Presents a list of options and allows the user to select one.
+
+    This presents a static list of options and prompts the user to select one.
+    This is similar to a completion menu but is different in that it does not
+    allow a user to type and the returned value is always a member of the list.
+
+    :type items: list
+    :param list: The list of items to be selected from. If this list contains
+    elements that are not strings the display_format option must be specified.
+
+    :type display_format: Callable[[Any], str]
+    :param display_format: A callable that takes a single element from the
+    items list as input and returns a string used to represent the item in the
+    menu.
+
+    :type max_height: int
+    :param max_height: The max number of items to show in the list at a time.
+
+    :returns: The selected element from the items list.
+    """
+    app_bindings = KeyBindings()
+
+    @app_bindings.add('c-c')
+    def exit_app(event):
+        event.app.exit(exception=KeyboardInterrupt, style='class:aborting')
+
+    min_height = min(max_height, len(items))
+    menu_window = Window(
+        SelectionMenuControl(items, display_format=display_format),
+        always_hide_cursor=False,
+        height=Dimension(min=min_height, max=min_height),
+        scroll_offsets=ScrollOffsets(),
+        right_margins=[ScrollbarMargin()],
+    )
+
+    # Using a FloatContainer was the only way I was able to succesfully
+    # limit the height and width of the window.
+    content = FloatContainer(
+        Window(height=Dimension(min=min_height, max=min_height)),
+        [Float(menu_window, top=0, left=0)])
+    app = Application(
+        layout=Layout(content),
+        key_bindings=app_bindings,
+        erase_when_done=True,
+    )
+    return app.run()
+
+
+def _trim_text(text, max_width):
+    """
+    Trim the text to `max_width`, append dots when the text is too long.
+    Returns (text, width) tuple.
+    """
+    width = get_cwidth(text)
+
+    # When the text is too wide, trim it.
+    if width > max_width:
+        # When there are no double width characters, just use slice operation.
+        if len(text) == width:
+            trimmed_text = (text[:max(1, max_width - 3)] + '...')[:max_width]
+            return trimmed_text, len(trimmed_text)
+
+        # Otherwise, loop until we have the desired width. (Rather
+        # inefficient, but ok for now.)
+        else:
+            trimmed_text = ''
+            for c in text:
+                if get_cwidth(trimmed_text + c) <= max_width - 3:
+                    trimmed_text += c
+            trimmed_text += '...'
+
+            return (trimmed_text, get_cwidth(trimmed_text))
+    else:
+        return text, width
+
+
+class SelectionMenuControl(UIControl):
+    MIN_WIDTH = 7
+    # The char width overhead of formatting the text into the menu
+
+    def __init__(self, items, display_format=None, cursor='>'):
+        self._items = items
+        self._selection = 0
+        self._cursor = cursor
+        self._display_format = display_format
+        self._format_overhead = 3 + len(cursor)
+
+    def _get_items(self):
+        return self._items
+
+    def is_focusable(self):
+        return True
+
+    def preferred_width(self, max_width):
+        items = self._get_items()
+        if self._display_format:
+            items = (self._display_format(i) for i in items)
+        max_item_width = max(get_cwidth(i) for i in items)
+        max_item_width += self._format_overhead
+        if max_item_width < self.MIN_WIDTH:
+            max_item_width = self.MIN_WIDTH
+        return min(max_width, max_item_width)
+
+    def preferred_height(self, width, max_height, wrap_lines, get_line_prefix):
+        return min(max_height, len(self._get_items()))
+
+    def _menu_item_fragment(self, item, is_selected, menu_width):
+        if is_selected:
+            cursor = self._cursor
+            style_str = 'class:completion-menu.completion.current'
+        else:
+            cursor = ' ' * len(self._cursor)
+            style_str = 'class:completion-menu.completion'
+
+        if self._display_format:
+            item = self._display_format(item)
+
+        text, tw = _trim_text(item, menu_width - self._format_overhead)
+        padding = ' ' * (menu_width - self._format_overhead - tw)
+        return [(style_str, '%s %s%s  ' % (cursor, text, padding))]
+
+    def create_content(self, width, height):
+        menu_width = self.preferred_width(width)
+
+        def get_line(i):
+            item = self._get_items()[i]
+            is_selected = (i == self._selection)
+            return self._menu_item_fragment(item, is_selected, menu_width)
+
+        return UIContent(
+            get_line=get_line,
+            cursor_position=Point(x=0, y=self._selection or 0),
+            line_count=len(self._get_items())
+        )
+
+    def _move_cursor(self, delta):
+        self._selection += delta
+
+        num_items = len(self._get_items())
+        if self._selection >= num_items:
+            self._selection = 0
+        elif self._selection < 0:
+            self._selection = num_items - 1
+
+    def get_key_bindings(self):
+        kb = KeyBindings()
+
+        @kb.add('up')
+        def move_up(event):
+            self._move_cursor(-1)
+
+        @kb.add('down')
+        def move_down(event):
+            self._move_cursor(1)
+
+        @kb.add('enter')
+        def app_result(event):
+            result = self._get_items()[self._selection]
+            event.app.exit(result=result)
+
+        return kb

--- a/awscli/customizations/wizard/selectmenu.py
+++ b/awscli/customizations/wizard/selectmenu.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from __future__ import unicode_literals
 from prompt_toolkit import Application
 from prompt_toolkit.utils import get_cwidth
 from prompt_toolkit.layout import Layout, FloatContainer, Float

--- a/awscli/customizations/wizard/ui.py
+++ b/awscli/customizations/wizard/ui.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from __future__ import unicode_literals
+
+import prompt_toolkit
+
+from awscli.customizations.wizard import selectmenu
+
+
+class Prompter(object):
+    def prompt(self, display_text, choices=None):
+        raise NotImplementedError('prompt')
+
+
+class UIPrompter(Prompter):
+    def prompt(self, display_text, choices=None):
+        if not choices:
+            return prompt_toolkit.prompt('%s: ' % display_text)
+        else:
+            prompt_toolkit.print_formatted_text(display_text)
+            if isinstance(choices[0], str):
+                return selectmenu.select_menu(choices)
+            else:
+                response = selectmenu.select_menu(
+                    choices, display_format=self._display_text)
+                result = response['actual_value']
+                return result
+
+    def _display_text(self, obj):
+        return obj['display']

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -84,6 +84,7 @@ from awscli.customizations.s3events import register_event_stream_arg
 from awscli.customizations.sessionmanager import register_ssm_session
 from awscli.customizations.logs import register_logs_commands
 from awscli.customizations.devcommands import register_dev_commands
+from awscli.customizations.wizard.commands import register_wizard_commands
 
 
 def awscli_initialize(event_handlers):
@@ -170,3 +171,4 @@ def awscli_initialize(event_handlers):
     register_ssm_session(event_handlers)
     register_logs_commands(event_handlers)
     register_dev_commands(event_handlers)
+    register_wizard_commands(event_handlers)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -83,6 +83,7 @@ from awscli.customizations.servicecatalog import register_servicecatalog_command
 from awscli.customizations.s3events import register_event_stream_arg
 from awscli.customizations.sessionmanager import register_ssm_session
 from awscli.customizations.logs import register_logs_commands
+from awscli.customizations.devcommands import register_dev_commands
 
 
 def awscli_initialize(event_handlers):
@@ -168,3 +169,4 @@ def awscli_initialize(event_handlers):
     dlm_initialize(event_handlers)
     register_ssm_session(event_handlers)
     register_logs_commands(event_handlers)
+    register_dev_commands(event_handlers)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ requires-dist =
         rsa>=3.1.2,<=3.5.0
         ruamel.yaml>=0.15.0,<0.16.0
         s3transfer>=0.1.12,<0.2.0
+        prompt-toolkit>=2.0.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ requires = ['botocore==1.12.48',
             'rsa>=3.1.2,<=3.5.0',
             's3transfer>=0.1.12,<0.2.0',
             'ruamel.yaml>=0.15.0,<0.16.0',
+            'prompt-toolkit>=2.0.0,<3.0.0',
             ]
 
 

--- a/tests/functional/wizards/test_devcommand.py
+++ b/tests/functional/wizards/test_devcommand.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest, temporary_file
+
+
+class TestRunWizard(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestRunWizard, self).setUp()
+        self.parsed_responses = [{"Roles": []}]
+
+    def test_can_run_wizard(self):
+        with temporary_file('r+') as f:
+            f.write(
+                'version: "0.9"\n'
+                'plan:\n'
+                '  start:\n'
+                '    values:\n'
+                '      foo:\n'
+                '        type: static\n'
+                '        value: myvalue\n'
+                'execute:\n'
+                '  default:\n'
+                '    - type: apicall\n'
+                '      operation: iam.ListRoles\n'
+                '      params: {}\n'
+            )
+            f.flush()
+            stdout, _, _ = self.assert_params_for_cmd(
+                'cli-dev wizard-dev --run-wizard file://%s' % f.name, params={}
+            )

--- a/tests/unit/customizations/wizard/test_factory.py
+++ b/tests/unit/customizations/wizard/test_factory.py
@@ -1,0 +1,23 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.session import Session
+
+from awscli.customizations.wizard import factory, core
+from awscli.testutils import unittest, mock
+
+
+class TestCanCreateWizardComponents(unittest.TestCase):
+    def test_can_create_default_runner(self):
+        session = mock.Mock(spec=Session)
+        runner = factory.create_default_wizard_runner(session)
+        self.assertIsInstance(runner, core.Runner)

--- a/tests/unit/customizations/wizard/test_wizarddev.py
+++ b/tests/unit/customizations/wizard/test_wizarddev.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from botocore.session import Session
+
+from awscli.customizations.wizard.devcommands import WizardDev
+from awscli.customizations.wizard.devcommands import WizardDevRunner
+from awscli.testutils import mock, unittest
+
+
+class TestWizardDevCommand(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock(spec=Session)
+        self.session.emit_first_non_none_response.return_value = None
+        self.dev_runner = mock.Mock(spec=WizardDevRunner)
+
+    def test_will_delegate_to_runner(self):
+        cmd = WizardDev(self.session, dev_runner=self.dev_runner)
+        cmd(['--run-wizard', 'mywizard.yml'], parsed_globals=None)
+        self.dev_runner.run_wizard.assert_called_with('mywizard.yml')


### PR DESCRIPTION
This PRs adds the remaining functionality to actually run a wizard.  This includes several components.

* Adds the selectmenu from @joguSD, which is an extension over the built in prompt toolkit values.  This also includes pulling in prompt-tookit.
* Adds the runner and loader for wizards.
* Adds a `wizard-dev` command that allows you to run a wizard by directly specifying a path to the wizard file.
* Adds a top level `cli-dev` command.  This is a command that we can use to add misc. debugging and developer commands to the CLI.