### PR TITLE
Remove this test's dependency on EnvironmentVariables

### DIFF
--- a/tests/integration/customizations/s3/test_filegenerator.py
+++ b/tests/integration/customizations/s3/test_filegenerator.py
@@ -22,7 +22,6 @@ import os
 import itertools
 
 import botocore.session
-from awscli import EnvironmentVariables
 from awscli.customizations.s3.filegenerator import FileGenerator, FileStat
 from tests.unit.customizations.s3 import compare_files
 from tests.integration.customizations.s3 import make_s3_files, s3_cleanup
@@ -30,7 +29,7 @@ from tests.integration.customizations.s3 import make_s3_files, s3_cleanup
 
 class S3FileGeneratorIntTest(unittest.TestCase):
     def setUp(self):
-        self.session = botocore.session.get_session(EnvironmentVariables)
+        self.session = botocore.session.get_session()
         # Use the datetime and and blob parsing of the CLI
         factory = self.session.get_component('response_parser_factory')
         factory.set_parser_defaults(


### PR DESCRIPTION
This variable was removed in v2, and wasn't needed by the test anyway.