### PR TITLE
Fix shorthand parser integration tests

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -126,7 +126,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
 
     def test_param_shorthand(self):
         p = aws(
-            'ec2 describe-instances --filters Name=instance-id,Values=i-123')
+            'ec2 describe-instances --filters Name=instance-id,Values=[i-123]')
         self.assertEqual(p.rc, 0)
         self.assertIn('Reservations', p.json)
 

--- a/tests/integration/test_ec2.py
+++ b/tests/integration/test_ec2.py
@@ -58,7 +58,7 @@ class TestDescribeVolumes(unittest.TestCase):
 
     def test_describe_volumes_with_filter(self):
         command = self.prefix
-        command += ' --filters Name=volume-id,Values=malformed-id'
+        command += ' --filters Name=volume-id,Values=[malformed-id]'
         result = aws(command)
         volumes = result.json['Volumes']
         self.assertEqual(len(volumes), 0)


### PR DESCRIPTION
Integration tests failures caused by the removal of the backwards compat
shim that was type-aware. Tests that were not wrapping their list
arguments with a single element in [ ] would fail due to it no longer
checking the type and realizing it is a list.

Not really sure how we missed these before.


```
======================================================================
ERROR: test_describe_volumes_with_filter (tests.integration.test_ec2.TestDescribeVolumes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\codebuild\tmp\src637293875\src\github.com\stealthycoin\aws-cli\tests\integration\test_ec2.py", line 63, in test_describe_volumes_with_filter
    volumes = result.json['Volumes']
  File "C:\codebuild\tmp\src637293875\src\github.com\stealthycoin\aws-cli\awscli\testutils.py", line 574, in json
    return json.loads(self.stdout)
  File "c:\python\lib\json\__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "c:\python\lib\json\decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "c:\python\lib\json\decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
-------------------- >> begin captured logging << --------------------
awscli.tests.integration: DEBUG: Running command: python C:\Python\Scripts\aws ec2 describe-volumes --region us-west-2 --filters Name=volume-id,Values=malformed-id
awscli.tests.integration: DEBUG: rc: 255
awscli.tests.integration: DEBUG: stdout:
awscli.tests.integration: DEBUG: stderr:

Parameter validation failed:

Invalid type for parameter Filters[0].Values, value: malformed-id, type: <class 'str'>, valid types: <class 'list'>, <class 'tuple'>


--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: test_param_shorthand (tests.integration.test_cli.TestBasicCommandFunctionality)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\codebuild\tmp\src637293875\src\github.com\stealthycoin\aws-cli\tests\integration\test_cli.py", line 130, in test_param_shorthand
    self.assertEqual(p.rc, 0)
AssertionError: 255 != 0
-------------------- >> begin captured logging << --------------------
awscli.tests.integration: DEBUG: Running command: python C:\Python\Scripts\aws ec2 describe-instances --filters Name=instance-id,Values=i-123
awscli.tests.integration: DEBUG: rc: 255
awscli.tests.integration: DEBUG: stdout:
awscli.tests.integration: DEBUG: stderr:

Parameter validation failed:

Invalid type for parameter Filters[0].Values, value: i-123, type: <class 'str'>, valid types: <class 'list'>, <class 'tuple'>


--------------------- >> end captured logging << ---------------------
```

```
nosetests -s tests.integration.test_ec2
......
----------------------------------------------------------------------
Ran 6 tests in 10.248s
```
```
nosetests -s tests.integration.test_cli\:TestBasicCommandFunctionality
................................
----------------------------------------------------------------------
Ran 32 tests in 99.429s
```