### PR TITLE
[CLIv2] support complex identifiers

### DIFF
--- a/awscli/customizations/dynamodb/ast.py
+++ b/awscli/customizations/dynamodb/ast.py
@@ -20,6 +20,14 @@ def identifier(name):
     return {"type": "identifier", "children": [], "value": name}
 
 
+def path_identifier(left, right):
+    return {"type": "path_identifier", "children": [left, right]}
+
+
+def index_identifier(name, index):
+    return {"type": "index_identifier", "children": [name], "value": index}
+
+
 def sequence(elements):
     return {"type": "sequence", "children": elements}
 

--- a/awscli/customizations/dynamodb/extractor.py
+++ b/awscli/customizations/dynamodb/extractor.py
@@ -65,6 +65,15 @@ class AttributeExtractor(object):
         self._identifiers[identifier_replacement] = node['value']
         return '%s ' % identifier_replacement
 
+    def _visit_path_identifier(self, node):
+        left = self._visit(node['children'][0]).strip()
+        right = self._visit(node['children'][1])
+        return '%s.%s' % (left, right)
+
+    def _visit_index_identifier(self, node):
+        left = self._visit(node['children'][0]).strip()
+        return '%s[%s] ' % (left, node['value'])
+
     def _visit_literal(self, node):
         literal_replacement = ':n%s' % self._substitution_index()
         self._literals[literal_replacement] = node['value']

--- a/awscli/customizations/dynamodb/lexer.py
+++ b/awscli/customizations/dynamodb/lexer.py
@@ -89,6 +89,11 @@ class Lexer(object):
                 return self._consume_base64_string()
             elif self._current in self.VALID_IDENTIFIER:
                 buff += self._current
+            else:
+                return {
+                    'type': 'unquoted_identifier', 'value': buff,
+                    'start': start, 'end': start + 1,
+                }
 
         while self._next() in self.VALID_IDENTIFIER:
             buff += self._current

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -433,6 +433,33 @@ class TestSelect(BaseSelectTest):
             command, expected, expected_rc=0
         )
 
+    def test_select_project_complex_identifier(self):
+        self.parsed_response = {
+            'Count': 1,
+            'Items': [{
+                'name': {'S': 'spam n eggs'},
+                'ingredients': {'L': [{'M': {'name': {'S': 'spam'}}}]},
+            }]
+        }
+        command = [
+            'ddb', 'select', 'recipes',
+            '--projection', 'name, ingredients[8].name',
+        ]
+        expected = {
+            'TableName': 'recipes',
+            'ReturnConsumedCapacity': 'NONE',
+            'ConsistentRead': True,
+            'ProjectionExpression': '#n0, #n1[8].#n2',
+            'ExpressionAttributeNames': {
+                '#n0': 'name',
+                '#n1': 'ingredients',
+                '#n2': 'name',
+            }
+        }
+        self.assert_params_for_cmd(
+            command, expected, expected_rc=0
+        )
+
 
 class TestSelectPagination(BaseSelectTest):
     def setUp(self):

--- a/tests/unit/customizations/dynamodb/test_lexer.py
+++ b/tests/unit/customizations/dynamodb/test_lexer.py
@@ -43,6 +43,12 @@ def test_lexer():
         ]),
         ('b"4pyT"', [{'type': 'literal', 'value': b'\xe2\x9c\x93'}]),
         ('boo', [{'type': 'unquoted_identifier', 'value': 'boo'}]),
+        ('b[0]', [
+            {'type': 'unquoted_identifier', 'value': 'b'},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': Decimal('0')},
+            {'type': 'rbracket', 'value': ']'},
+        ])
     ]
 
     tester = LexTester()

--- a/tests/unit/customizations/dynamodb/test_parser.py
+++ b/tests/unit/customizations/dynamodb/test_parser.py
@@ -857,6 +857,17 @@ class TestParser(unittest.TestCase):
         }
         self.assert_parse(tokens, expected)
 
+    def test_index_identifier_must_be_whole_number(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': Decimal(1.1)},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'eof', 'value': ''},
+        ]
+        with self.assertRaises(InvalidLiteralValueError):
+            self._parse(tokens)
+
     def test_dotted_index_identifier(self):
         tokens = [
             {'type': 'identifier', 'value': 'foo'},

--- a/tests/unit/customizations/dynamodb/test_parser.py
+++ b/tests/unit/customizations/dynamodb/test_parser.py
@@ -75,12 +75,7 @@ class TestParser(unittest.TestCase):
             {'type': 'identifier', 'value': 'foo'},
             {'type': 'eof', 'value': ''},
         ]
-        expected = {
-            'type': 'sequence',
-            'children': [
-                {'type': 'identifier', 'value': 'foo', 'children': []},
-            ]
-        }
+        expected = {'type': 'identifier', 'value': 'foo', 'children': []}
         self.assert_parse(tokens, expected)
 
     def test_parse_and_expression(self):
@@ -829,3 +824,157 @@ class TestParser(unittest.TestCase):
         ]
         with self.assertRaises(UnexpectedTokenError):
             self._parse(tokens)
+
+    def test_dotted_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'dot', 'value': '.'},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'path_identifier',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'identifier', 'value': 'bar', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_index_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': Decimal(0)},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'index_identifier', 'value': Decimal(0),
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_dotted_index_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': Decimal(0)},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'dot', 'value': '.'},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'path_identifier',
+            'children': [
+                {'type': 'index_identifier', 'value': Decimal(0), 'children': [
+                    {'type': 'identifier', 'value': 'foo', 'children': []},
+                ]},
+                {'type': 'identifier', 'value': 'bar', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_between_complex_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'dot', 'value': '.'},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'between', 'value': 'between'},
+            {'type': 'literal', 'value': 1},
+            {'type': 'and', 'value': 'and'},
+            {'type': 'literal', 'value': 3},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'between_expression',
+            'children': [
+                {'type': 'path_identifier', 'children': [
+                    {'type': 'identifier', 'value': 'foo', 'children': []},
+                    {'type': 'identifier', 'value': 'bar', 'children': []},
+                ]},
+                {'type': 'literal', 'value': 1, 'children': []},
+                {'type': 'literal', 'value': 3, 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_in_complex_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'lbracket', 'value': '['},
+            {'type': 'literal', 'value': Decimal(0)},
+            {'type': 'rbracket', 'value': ']'},
+            {'type': 'in', 'value': 'in'},
+            {'type': 'lparen', 'value': '('},
+            {'type': 'literal', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'literal', 'value': 'baz'},
+            {'type': 'rparen', 'value': ')'},
+            {'type': 'eof', 'value': ''},
+        ]
+        sequence = {
+            'type': 'sequence',
+            'children': [
+                {'type': 'literal', 'value': 'bar', 'children': []},
+                {'type': 'literal', 'value': 'baz', 'children': []},
+            ]
+        }
+        expected = {
+            'type': 'in_expression',
+            'children': [
+                {'type': 'index_identifier', 'value': Decimal(0), 'children': [
+                    {'type': 'identifier', 'value': 'foo', 'children': []},
+                ]},
+                sequence,
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_compare_complex_identifier(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'dot', 'value': '.'},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'gte', 'value': '>='},
+            {'type': 'literal', 'value': 8},
+            {'type': 'eof', 'value': ''},
+        ]
+        expected = {
+            'type': 'comparator', 'value': 'gte',
+            'children': [
+                {'type': 'path_identifier', 'children': [
+                    {'type': 'identifier', 'value': 'foo', 'children': []},
+                    {'type': 'identifier', 'value': 'bar', 'children': []},
+                ]},
+                {'type': 'literal', 'value': 8, 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)
+
+    def test_parse_complex_identifier_sequence(self):
+        tokens = [
+            {'type': 'identifier', 'value': 'foo'},
+            {'type': 'dot', 'value': '.'},
+            {'type': 'identifier', 'value': 'bar'},
+            {'type': 'comma', 'value': ','},
+            {'type': 'identifier', 'value': 'baz'},
+            {'type': 'eof', 'value': ''},
+        ]
+        first = {
+            'type': 'path_identifier',
+            'children': [
+                {'type': 'identifier', 'value': 'foo', 'children': []},
+                {'type': 'identifier', 'value': 'bar', 'children': []},
+            ]
+        }
+        expected = {
+            'type': 'sequence', 'children': [
+                first,
+                {'type': 'identifier', 'value': 'baz', 'children': []},
+            ]
+        }
+        self.assert_parse(tokens, expected)


### PR DESCRIPTION
This adds support for attribute paths, like:

* `foo.bar`
* `foo[0].bar`

etc