### PR TITLE
Fix and speed up functional tests for autocompleter

### DIFF
--- a/tests/functional/autocomplete/test_server_index.py
+++ b/tests/functional/autocomplete/test_server_index.py
@@ -1,12 +1,11 @@
-import tempfile
-import copy
+import os
 
 from awscli import clidriver
 from awscli.autocomplete import db, generator
 from awscli.autocomplete.serverside import model
 from awscli.autocomplete.serverside.indexer import APICallIndexer
 from awscli.autocomplete.local.indexer import ModelIndexer
-from awscli.testutils import unittest, temporary_file
+from awscli.testutils import unittest
 
 
 def _ddb_only_command_table(command_table, **kwargs):
@@ -18,8 +17,7 @@ def _ddb_only_command_table(command_table, **kwargs):
 class TestCanGenerateServerIndex(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.tempfile = tempfile.NamedTemporaryFile('r+')
-        cls.db_connection = db.DatabaseConnection(cls.tempfile.name)
+        cls.db_connection = db.DatabaseConnection(":memory:")
         index_generator = generator.IndexGenerator(
             [ModelIndexer(cls.db_connection),
              APICallIndexer(cls.db_connection)],
@@ -39,9 +37,9 @@ class TestCanGenerateServerIndex(unittest.TestCase):
             result,
             {'completions': [
                 {'jp_expr': 'TableNames[]',
-                  'operation': 'list_tables',
-                  'parameters': {},
-                  'service': 'dynamodb'}]}
+                 'operation': 'list_tables',
+                 'parameters': {},
+                 'service': 'dynamodb'}]}
         )
         result = lookup.get_server_completion_data(
             ['aws', 'dynamodb'], 'update-global-table', 'global-table-name')
@@ -49,9 +47,9 @@ class TestCanGenerateServerIndex(unittest.TestCase):
             result,
             {'completions': [
                 {'jp_expr': 'GlobalTables[].GlobalTableName',
-                  'operation': 'list_global_tables',
-                  'parameters': {},
-                  'service': 'dynamodb'}]}
+                 'operation': 'list_global_tables',
+                 'parameters': {},
+                 'service': 'dynamodb'}]}
         )
 
     def test_returns_none_if_no_lookup_data_found(self):
@@ -68,32 +66,36 @@ class TestCanGenerateServerIndex(unittest.TestCase):
 
 
 class TestCanHandleNoCompletionData(unittest.TestCase):
+    def setUp(self):
+        self.db_connection = db.DatabaseConnection(":memory:")
+
+    def tearDown(self):
+        self.db_connection.close()
+
     def _disable_cli_loaders(self, event_name, session, **kwargs):
         loader = session.get_component('data_loader')
         for path in loader.search_paths[::]:
-            if path.endswith('awscli/data'):
+            if path.endswith(os.path.join('awscli', 'data')):
                 loader.search_paths.remove(path)
 
     def test_no_errors_when_missing_completion_data(self):
-        with temporary_file('r+') as f:
-            db_connection = db.DatabaseConnection(f.name)
-            index_generator = generator.IndexGenerator(
-                [ModelIndexer(db_connection),
-                APICallIndexer(db_connection)],
-            )
-            driver = clidriver.create_clidriver()
-            # We're going to remove the CLI data path from the loader.
-            # This will result in the loader not being able to find any
-            # completion data, which allows us to verify the behavior when
-            # there's no completion data.
-            driver.session.register('building-command-table.main',
-                                    _ddb_only_command_table)
-            driver.session.register('building-command-table.dynamodb',
-                                    self._disable_cli_loaders)
-            index_generator.generate_index(driver)
-            # We shouldn't get any data now because we couldn't load
-            # completion data.
-            lookup = model.DBCompletionLookup(db_connection)
-            result = lookup.get_server_completion_data(
-                ['aws', 'dynamodb'], 'delete-table', 'table-name')
-            self.assertIsNone(result)
+        index_generator = generator.IndexGenerator(
+            [ModelIndexer(self.db_connection),
+             APICallIndexer(self.db_connection)],
+        )
+        driver = clidriver.create_clidriver()
+        # We're going to remove the CLI data path from the loader.
+        # This will result in the loader not being able to find any
+        # completion data, which allows us to verify the behavior when
+        # there's no completion data.
+        driver.session.register('building-command-table.main',
+                                _ddb_only_command_table)
+        driver.session.register('building-command-table.dynamodb',
+                                self._disable_cli_loaders)
+        index_generator.generate_index(driver)
+        # We shouldn't get any data now because we couldn't load
+        # completion data.
+        lookup = model.DBCompletionLookup(self.db_connection)
+        result = lookup.get_server_completion_data(
+            ['aws', 'dynamodb'], 'delete-table', 'table-name')
+        self.assertIsNone(result)


### PR DESCRIPTION
Use in-memory sqlite db to speed up the tests and prevent open
connections being leaked between tests. The disable loader method
also did not work on windows due to a hardcoded linux path.
