### PR TITLE
[CLIv2] Add help topic and examples for ddb commands

### DIFF
--- a/awscli/customizations/dynamodb/params.py
+++ b/awscli/customizations/dynamodb/params.py
@@ -68,6 +68,9 @@ PROJECTION_EXPRESSION = {
         'developerguide/Expressions.ProjectionExpressions.html">'
         'Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer '
         'Guide</i>.'
+        '<p>For CLI specific syntax see '
+        '<a href="https://docs.aws.amazon.com/cli/latest/topic/'
+        'ddb-expressions.html">aws help ddb-expressions</a></p>'
     )
 }
 
@@ -84,6 +87,9 @@ FILTER_EXPRESSION = {
         '<a href="http://docs.aws.amazon.com/amazondynamodb/latest/'
         'developerguide/QueryAndScan.html#FilteringResults">Filter '
         'Expressions</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>'
+        '<p>For CLI specific syntax see '
+        '<a href="https://docs.aws.amazon.com/cli/latest/topic/'
+        'ddb-expressions.html">aws help ddb-expressions</a></p>'
     )
 }
 
@@ -92,6 +98,14 @@ CONDITION_EXPRESSION = {
     'help_text': (
         '<p>A condition that must be satisfied in order for a conditional '
         '<code>put</code> operation to succeed.</p>'
+        '<p>For more information, see '
+        '<a href="https://docs.aws.amazon.com/amazondynamodb/latest/'
+        'developerguide/Expressions.OperatorsAndFunctions.html">Comparison '
+        'Operator and Function Reference</a> in the <i>Amazon DynamoDB '
+        'Developer Guide</i></p>'
+        '<p>For CLI specific syntax see '
+        '<a href="https://docs.aws.amazon.com/cli/latest/topic/'
+        'ddb-expressions.html">aws help ddb-expressions</a></p>'
     )
 }
 
@@ -135,6 +149,9 @@ KEY_CONDITION_EXPRESSION = {
         'Number.) Note that the function name <code>begins_with</code> is '
         'case-sensitive.</p></li>'
         '</ul>'
+        '<p>For CLI specific syntax see '
+        '<a href="https://docs.aws.amazon.com/cli/latest/topic/'
+        'ddb-expressions.html">aws help ddb-expressions</a></p>'
     )
 }
 

--- a/awscli/customizations/dynamodb/params.py
+++ b/awscli/customizations/dynamodb/params.py
@@ -160,7 +160,7 @@ ITEMS = {
     'positional_arg': True,
     'synopsis': '<items>',
     'help_text': (
-        '<p>One or more items to put into the table.</p>'
+        '<p>One or more items to put into the table, in YAML format.</p>'
     )
 }
 

--- a/awscli/examples/ddb/put.rst
+++ b/awscli/examples/ddb/put.rst
@@ -1,0 +1,58 @@
+**To add an item to a table**
+
+This example adds a new item to the *MusicCollection* table.
+
+Command::
+
+    aws ddb put MusicCollection '{Artist: "No One You Know", SongTitle: "Call Me Today", AlbumTitle: "Somewhat Famous"}'
+
+**To add items to a table from a file**
+
+This example adds two new items from a file to the *MusicCollection* table.
+
+Command::
+
+    aws ddb put MusicCollection file://items.json
+
+The items to add to the table are in a JSON file, ``items.json``. Here are the
+contents of that file::
+
+    [
+        {
+            "Artist": "No One You Know",
+            "SongTitle": "Call Me Today",
+            "AlbumTitle": "Somewhat Famous"
+        },
+        {
+            "Artist": "No One You Know",
+            "SongTitle": "Scared of My Shadow",
+            "AlbumTitle": "Blue Sky Blues"
+        }
+    ]
+
+**To add items to a table from stdin**
+
+This example adds a new item to the *MusicCollection* table by reading it from
+stdin.
+
+Command::
+
+    echo '{Artist: "No One You Know", SongTitle: "Call Me Today"}' \
+        | aws ddb put MusicCollection -
+
+**Conditional Expressions**
+
+This example shows how to perform a one-line conditional operation.
+This put call to the table *MusicCollection* table will only succeed if the
+artist "Obscure Indie Band" does not exist in the table.
+
+Command::
+
+    aws ddb put MusicCollection '{Artist: "Obscure Indie Band", SongTitle: "Atlas"}' \
+        --condition 'attribute_not_exists(Artist)'
+
+If the key already exists, you should see:
+
+Output::
+
+    A client error (ConditionalCheckFailedException) occurred when calling the PutItem operation: The conditional request failed

--- a/awscli/examples/ddb/select.rst
+++ b/awscli/examples/ddb/select.rst
@@ -1,0 +1,40 @@
+**To scan an entire table**
+
+This example scans the entire *MusicCollection* table, and then narrows the
+results to songs by the artist "No One You Know". For each item, only the album
+title and song title are returned.
+
+Command::
+
+    aws ddb select MusicCollection --projection 'SongTitle, AlbumTitle' \
+        --filter 'Artist = "No One You Know"'
+
+Output::
+
+    Count: 2
+    Items:
+    - SongTitle: "Call Me Today"
+      AlbumTitle: "Somewhat Famous"
+    - SongTitle: "Scared of My Shadow"
+      AlbumTitle: "Blue Sky Blues"
+    ScannedCount: 3
+
+**To query for specific primary keys**
+
+This example queries items in the *MusicCollection* table. The table has a
+hash-and-range primary key (*Artist* and *SongTitle*), but this query only
+specifies the hash key value. It returns song titles by the artist named "No
+One You Know".
+
+Command::
+
+    aws ddb select MusicCollection --projection SongTitle \
+        --key-condition-expression 'Artist = "No One You Know"'
+
+Output::
+
+    Count: 2
+    Items:
+    - SongTitle: "Call Me Today"
+    - SongTitle: "Scared of My Shadow"
+    ScannedCount: 2

--- a/awscli/topics/ddb-expressions.rst
+++ b/awscli/topics/ddb-expressions.rst
@@ -1,0 +1,125 @@
+:title: AWS DDB Expressions
+:description: Details on the expression syntax for the ddb commands
+:category: ddb
+:related command: ddb select, ddb put
+
+The ``ddb`` commands provide a simplified expression-writing experince by
+adding some additional syntax which allows for specifying attribute names and
+attribute values without having to define placeholders.
+
+For example, one might write the following command using the base ``dynamodb``
+commands::
+
+    aws dynamodb scan \
+        --table-name ProductCatalog \
+        --condition-expression "Price between :lo and :hi" \
+        --expression-attribute-values file://values.json
+
+With the contents of ``values.json`` being::
+
+    {
+        ":lo": {"N": "500"},
+        ":hi": {"N": "600"}
+    }
+
+With ``ddb select`` you would write::
+
+    aws ddb select ProductCatalog --condition 'Price between 500 and 600'
+
+Then the CLI would handle extracting the the numbers to make the final request.
+The CLI can handle extracting any values in this way.
+
+Attribute Name Syntax
+---------------------
+
+Attribute names may be specified as unquoted strings, or as strings quoted
+using single quotes. Using single quotes will be necessary if an attribute name
+starts with a digit or contains any characters outsize of ascii letters and
+digits. For example, the following would be valid attribute names: ``foo``,
+``'foo bar'``, ``'foo.bar'`` etc.
+
+Attribute Paths
+===============
+
+When specifying an attribute path, each attribute name in the path may be
+individually quoted. For example: ``foo.'bar baz'[0]``.
+
+Reserved Words
+==============
+
+The following words are reserved in the CLI, and so they MUST be quoted if you
+intend to use them as an attribute name. Each word is case-insensitive.
+
+* ``AND``
+* ``BETWEEN``
+* ``IN``
+* ``OR``
+* ``NOT``
+* ``SET``
+* ``REMOVE``
+* ``ADD``
+* ``DELETE``
+* ``TRUE``
+* ``FALSE``
+* ``NULL``
+
+Attribute Value Syntax
+----------------------
+
+Numbers
+=======
+
+Numbers may be specified as you would specify them in JSON. For example, each
+of the following would be valid numbers: ``1``, ``1.1``, ``1.1e3``,
+``-1.1e-3``, etc.
+
+Strings
+=======
+
+Strings may be specified as you would specify them in JSON. This means that
+they must be enclosed by double quotes, and any internal double quote
+characters must be escaped with a backslash. For example, each of the following
+would be a valid string: ``"foo"``, ``"\"hello\" world"``, etc. Note that you
+may need to escape the backslash itself depending on your shell.
+
+Bytes
+=====
+
+Binary values are base64-encoded values prefixed by ``b"`` and suffixed by
+``"``. For example, the follwoing would be a valid binary value: ``b"4pyT"``.
+
+Booleans
+========
+
+Boolean values may be specified as ``true`` or ``false``.
+
+Null
+====
+
+Null values are specified simply as ``null``
+
+Lists
+=====
+
+Lists may be specified as you would specify them in JSON, with the exception
+that binary values and set values are valid elements. This means that the list
+must start with ``[`` and end with ``]``. Each element in the list must be
+separated by a comma. For example: ``["foo", b"4pyT", 8]``.
+
+Sets
+====
+
+Sets must begin with ``{`` and end with ``}``. Each item in the set must be
+separated by a comma. Sets may only contain numbers, strings, and bytes. All
+values in the set must be of the same type. Sets must contain at least one
+value. For example, each of the following is a valid set: ``{1, 2, 3}``,
+``{"foo", "bar"}``, ``{b"4pyT"}``.
+
+Maps
+====
+
+Maps may be specified as you would specify them in JSON, with the exception
+that bytes and sets are valid values. This means that the map must start with
+``{`` and end with ``}``. It may contain any number of key-value pairs where
+the key and value are separated by a colon (``:``). Keys must be strings, but
+values may be any type. For example: ``{"foo": {"bar": {b"4pyT"}}}``.

--- a/awscli/topics/topic-tags.json
+++ b/awscli/topics/topic-tags.json
@@ -69,5 +69,16 @@
         "title": [
             "AWS CLI S3 FAQ"
         ]
+    },
+    "ddb-expressions": {
+        "category": ["ddb"],
+        "description": [
+            "Details on the expression syntax for the ddb commands"
+        ],
+        "related command": [
+            "ddb select",
+            "ddb put"
+        ],
+        "title": ["AWS DDB Expressions"]
     }
 }


### PR DESCRIPTION
This adds a help topic that explains the ddb expression syntax, linking to it in each of the expression parameters. Additionally it adds in some examples for each command, which are largely renditions of the existing examples for the corresponding commands in `dynamodb`.