### PR TITLE
[CLIv2] Add custom completers for tail and ddb commands

### DIFF
--- a/awscli/autocomplete/custom.py
+++ b/awscli/autocomplete/custom.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.dynamodb.autocomplete import add_ddb_completers
+from awscli.customizations.logs.autocomplete import add_log_completers
+
+
+def get_custom_completers():
+    custom_completers = []
+    add_ddb_completers(custom_completers)
+    add_log_completers(custom_completers)
+    return custom_completers

--- a/awscli/autocomplete/local/indexer.py
+++ b/awscli/autocomplete/local/indexer.py
@@ -34,6 +34,7 @@ class ModelIndexer(object):
           command TEXT,
           parent TEXT,
           nargs TEXT,
+          positional_arg TEXT,
           FOREIGN KEY (command, parent) REFERENCES
             command_table(command, parent)
         );
@@ -64,11 +65,12 @@ class ModelIndexer(object):
         for name, value in arg_table.items():
             self._db_connection.execute(
                 'INSERT INTO param_table '
-                '(argname, type_name, command, parent, nargs)'
-                ' VALUES (:argname, :type_name, :command, :parent, :nargs)',
+                '(argname, type_name, command, parent, nargs, positional_arg)'
+                ' VALUES (:argname, :type_name, :command, :parent, :nargs, '
+                '         :positional_arg)',
                 argname=name, type_name=value.cli_type_name,
                 command=command, parent=parent,
-                nargs=value.nargs,
+                nargs=value.nargs, positional_arg=value.positional_arg
             )
 
     def _generate_command_index(self, command_table, parent):

--- a/awscli/autocomplete/local/model.py
+++ b/awscli/autocomplete/local/model.py
@@ -27,7 +27,8 @@ from awscli.autocomplete import db
 
 
 CLIArgument = namedtuple('CLIArgument', ['argname', 'type_name',
-                                         'command', 'parent', 'nargs'])
+                                         'command', 'parent', 'nargs',
+                                         'positional_arg'])
 
 
 class ModelIndex(object):
@@ -47,11 +48,12 @@ class ModelIndex(object):
         SELECT argname FROM param_table
         WHERE
           parent = :parent AND
-          command = :command
+          command = :command AND
+          positional_arg = :positional_arg
     """
 
     _ARG_DATA_QUERY = """\
-        SELECT argname, type_name, command, parent, nargs FROM param_table
+        SELECT  argname, type_name, command, parent, nargs, positional_arg FROM param_table
         WHERE
           parent = :parent AND
           command = :command AND
@@ -86,7 +88,7 @@ class ModelIndex(object):
         results = db.execute(self._COMMAND_NAME_QUERY, parent=parent)
         return [row[0] for row in results]
 
-    def arg_names(self, lineage, command_name):
+    def arg_names(self, lineage, command_name, positional_arg=False):
         """Return arg names for a given lineage.
 
         The return values do not have the `--` added, e.g
@@ -100,7 +102,8 @@ class ModelIndex(object):
         db = self._get_db_connection()
         parent = '.'.join(lineage)
         results = db.execute(self._ARG_NAME_QUERY,
-                             parent=parent, command=command_name)
+                             parent=parent, command=command_name,
+                             positional_arg=positional_arg)
         return [row[0] for row in results]
 
     def get_argument_data(self, lineage, command_name, arg_name):

--- a/awscli/autocomplete/main.py
+++ b/awscli/autocomplete/main.py
@@ -36,10 +36,10 @@ def create_autocompleter(index_filename=INDEX_FILE, custom_completers=None):
         custom_completers = custom.get_custom_completers()
     index = model.ModelIndex(index_filename)
     cli_parser = parser.CLIParser(index)
-    completers = custom_completers + [
+    completers = [
         basic.ModelIndexCompleter(index),
         serverside.create_server_side_completer(index_filename)
-    ]
+    ] + custom_completers
     cli_completer = completer.AutoCompleter(cli_parser, completers)
     return cli_completer
 

--- a/awscli/autocomplete/main.py
+++ b/awscli/autocomplete/main.py
@@ -21,6 +21,7 @@ from awscli import __version__ as cli_version
 from awscli.autocomplete import parser, completer
 from awscli.autocomplete.local import model, basic
 from awscli.autocomplete import serverside
+from awscli.autocomplete import custom
 
 
 # We may eventually include a pre-generated version of this index as part
@@ -30,14 +31,16 @@ INDEX_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
 INDEX_FILE = os.path.join(INDEX_DIR, '%s.index' % cli_version)
 
 
-def create_autocompleter(index_filename=INDEX_FILE):
+def create_autocompleter(index_filename=INDEX_FILE, custom_completers=None):
+    if custom_completers is None:
+        custom_completers = custom.get_custom_completers()
     index = model.ModelIndex(index_filename)
     cli_parser = parser.CLIParser(index)
-    cli_completer = completer.AutoCompleter(
-        cli_parser,
-        [basic.ModelIndexCompleter(index),
-         serverside.create_server_side_completer(index_filename)]
-    )
+    completers = custom_completers + [
+        basic.ModelIndexCompleter(index),
+        serverside.create_server_side_completer(index_filename)
+    ]
+    cli_completer = completer.AutoCompleter(cli_parser, completers)
     return cli_completer
 
 

--- a/awscli/autocomplete/parser.py
+++ b/awscli/autocomplete/parser.py
@@ -278,7 +278,7 @@ class CLIParser(object):
         # We're one off here, we need to compute a new *potential*
         # lineage.
         command_names = self._index.command_names(state.full_lineage)
-        positional_argname = self._get_positional_argname(state)
+        positional_argname = None
         if current in command_names:
             state.current_command = current
             # We also need to get the next set of command line options.
@@ -286,11 +286,15 @@ class CLIParser(object):
                 lineage=state.lineage,
                 command_name=state.current_command)
             return current_args
-        elif (not command_names and
-              positional_argname and
-              positional_argname not in parsed.parsed_params):
+        if not command_names:
+            # If there are no more command names check. See if the command
+            # has a positional argument. This will require an additional
+            # select on the argument index.
+            positional_argname = self._get_positional_argname(state)
+        if (positional_argname and
+            positional_argname not in parsed.parsed_params):
             # Parse the current string to be a positional argument
-            # if there are no more commands left and the positional arg
+            # if the command has the a positional arg and the positional arg
             # has not already been parsed.
             if not remaining_parts:
                 # We are currently parsing the positional argument

--- a/awscli/autocomplete/serverside/servercomp.py
+++ b/awscli/autocomplete/serverside/servercomp.py
@@ -126,7 +126,7 @@ class ServerSideCompleter(BaseCompleter):
             # so the best we can do is log the exception.
             LOG.debug("Exception raised when calling %s on client %s",
                       client, py_name, exc_info=True)
-            return []
+            return {}
 
     def _map_command_to_api_params(self, parsed, completion_data):
         # Right now we don't autogenerate any completion with the 'parameters'

--- a/awscli/customizations/dynamodb/autocomplete.py
+++ b/awscli/customizations/dynamodb/autocomplete.py
@@ -1,0 +1,32 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.autocomplete.serverside import servercomp
+
+
+def add_ddb_completers(custom_completers):
+    custom_completers.append(DDBTableNameCompleter())
+
+
+class DDBTableNameCompleter(servercomp.BaseCustomServerSideCompleter):
+    _PARAM_NAME = 'table_name'
+    _LINEAGE = ['aws', 'ddb']
+    _COMMAND_NAMES = ['select', 'put']
+
+    def _get_remote_results(self, parsed):
+        client = self._client_creator.create_client('dynamodb')
+        response = self._invoke_api(client, 'list_tables', {})
+        return [
+            table_name for table_name in response['TableNames']
+        ]
+
+

--- a/awscli/customizations/dynamodb/autocomplete.py
+++ b/awscli/customizations/dynamodb/autocomplete.py
@@ -14,10 +14,10 @@ from awscli.autocomplete.serverside import servercomp
 
 
 def add_ddb_completers(custom_completers):
-    custom_completers.append(DDBTableNameCompleter())
+    custom_completers.append(TableNameCompleter())
 
 
-class DDBTableNameCompleter(servercomp.BaseCustomServerSideCompleter):
+class TableNameCompleter(servercomp.BaseCustomServerSideCompleter):
     _PARAM_NAME = 'table_name'
     _LINEAGE = ['aws', 'ddb']
     _COMMAND_NAMES = ['select', 'put']
@@ -26,7 +26,7 @@ class DDBTableNameCompleter(servercomp.BaseCustomServerSideCompleter):
         client = self._client_creator.create_client('dynamodb')
         response = self._invoke_api(client, 'list_tables', {})
         return [
-            table_name for table_name in response['TableNames']
+            table_name for table_name in response.get('TableNames', [])
         ]
 
 

--- a/awscli/customizations/logs/__init__.py
+++ b/awscli/customizations/logs/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.logs.tail import TailCommand
+
+
+def register_logs_commands(event_emitter):
+    event_emitter.register('building-command-table.logs', inject_tail_command)
+
+
+def inject_tail_command(command_table, session, **kwargs):
+    command_table['tail'] = TailCommand(session)
+

--- a/awscli/customizations/logs/autocomplete.py
+++ b/awscli/customizations/logs/autocomplete.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.autocomplete.serverside import servercomp
+
+
+def add_log_completers(custom_completers):
+    custom_completers.append(GroupNameCompleter())
+
+
+class GroupNameCompleter(servercomp.BaseCustomServerSideCompleter):
+    _PARAM_NAME = 'group_name'
+    _LINEAGE = ['aws', 'logs']
+    _COMMAND_NAMES = ['tail']
+
+    def _get_remote_results(self, parsed):
+        client = self._client_creator.create_client('logs')
+        response = self._invoke_api(client, 'describe_log_groups', {})
+        return [
+            log_group['logGroupName'] for log_group in response['logGroups']
+        ]

--- a/awscli/customizations/logs/autocomplete.py
+++ b/awscli/customizations/logs/autocomplete.py
@@ -26,5 +26,5 @@ class GroupNameCompleter(servercomp.BaseCustomServerSideCompleter):
         client = self._client_creator.create_client('logs')
         response = self._invoke_api(client, 'describe_log_groups', {})
         return [
-            log_group['logGroupName'] for log_group in response['logGroups']
+            group['logGroupName'] for group in response.get('logGroups', [])
         ]

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -23,14 +23,6 @@ from awscli.utils import is_a_tty
 from awscli.customizations.commands import BasicCommand
 
 
-def register_logs_commands(event_emitter):
-    event_emitter.register('building-command-table.logs', inject_tail_command)
-
-
-def inject_tail_command(command_table, session, **kwargs):
-    command_table['tail'] = TailCommand(session)
-
-
 class BaseLogEventsFormatter(object):
     _TIMESTAMP_COLOR = colorama.Fore.GREEN
 

--- a/tests/functional/logs/test_tail.py
+++ b/tests/functional/logs/test_tail.py
@@ -154,7 +154,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
         datetime_mock = mock.Mock(wraps=datetime)
         datetime_mock.utcnow = mock.Mock(
             return_value=datetime(1970, 1, 1, 0, 10, 1, tzinfo=tz.tzutc()))
-        with mock.patch('awscli.customizations.logs.datetime',
+        with mock.patch('awscli.customizations.logs.tail.datetime',
                         new=datetime_mock):
             self.assert_params_for_cmd(
                 'logs tail %s' % self.group_name,
@@ -179,7 +179,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
         datetime_mock = mock.Mock(wraps=datetime)
         datetime_mock.utcnow = mock.Mock(
             return_value=datetime(1970, 1, 1, 0, 0, 2, tzinfo=tz.tzutc()))
-        with mock.patch('awscli.customizations.logs.datetime',
+        with mock.patch('awscli.customizations.logs.tail.datetime',
                         new=datetime_mock):
             self.assert_params_for_cmd(
                 'logs tail %s --since 1s' % self.group_name,
@@ -229,7 +229,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_no_color_when_tty(self):
         with mock.patch(
-                'awscli.customizations.logs.is_a_tty') as mock_is_a_tty:
+                'awscli.customizations.logs.tail.is_a_tty') as mock_is_a_tty:
             mock_is_a_tty.return_value = True
             stdout, _, _ = self.run_cmd(
                 'logs tail %s' % self.group_name)

--- a/tests/unit/autocomplete/__init__.py
+++ b/tests/unit/autocomplete/__init__.py
@@ -30,7 +30,8 @@ class InMemoryIndex(model.ModelIndex):
              'get_argument_data': {
                  'dot.lineage': {
                      'command-name': {
-                         'arg-name': (argname, type, command, parent, nargs)
+                         'arg-name': (argname, type, command, parent,
+                                      nargs, positional_arg)
                      }
                  }
             }
@@ -42,9 +43,16 @@ class InMemoryIndex(model.ModelIndex):
         parent = '.'.join(lineage)
         return self.index['command_names'].get(parent, [])
 
-    def arg_names(self, lineage, command_name):
+    def arg_names(self, lineage, command_name, positional_arg=False):
         parent = '.'.join(lineage)
-        return self.index['arg_names'].get(parent, {}).get(command_name, [])
+        arg_names = self.index['arg_names'].get(parent, {}).get(
+            command_name, [])
+        filtered_arg_names = []
+        for arg_name in arg_names:
+            arg_data = self.get_argument_data(lineage, command_name, arg_name)
+            if arg_data.positional_arg == positional_arg:
+                filtered_arg_names.append(arg_name)
+        return filtered_arg_names
 
     def get_argument_data(self, lineage, command_name, arg_name):
         parent = '.'.join(lineage)

--- a/tests/unit/autocomplete/local/test_indexer.py
+++ b/tests/unit/autocomplete/local/test_indexer.py
@@ -47,10 +47,12 @@ class DummyCommand(object):
 
 
 class DummyArg(object):
-    def __init__(self, name, cli_type_name='string', nargs=None):
+    def __init__(self, name, cli_type_name='string', nargs=None,
+                 positional_arg=False):
         self.name = name
         self.cli_type_name = cli_type_name
         self.nargs = nargs
+        self.positional_arg = positional_arg
 
 
 class TestCanRetrieveCommands(unittest.TestCase):
@@ -168,6 +170,7 @@ class TestCanRetrieveCommands(unittest.TestCase):
             lineage=['aws', 'ec2'],
             command_name='describe-instances',
             arg_name='filters',
+
         )
         self.assertEqual(
             arg_data,
@@ -177,6 +180,7 @@ class TestCanRetrieveCommands(unittest.TestCase):
                 command='describe-instances',
                 parent='aws.ec2',
                 nargs='+',
+                positional_arg='0',
             ),
         )
 

--- a/tests/unit/autocomplete/serverside/test_servercomp.py
+++ b/tests/unit/autocomplete/serverside/test_servercomp.py
@@ -49,6 +49,27 @@ class TestServerSideAutocompleter(unittest.TestCase):
                     'delete-user': ['user-name'],
                 },
             },
+            'arg_data': {
+                '': {
+                    'aws': {
+                        'endpoint-url': ('endpoint-url', 'string',
+                                         'aws', '', None, False),
+                        'region': ('region', 'string', 'aws', '', None, False),
+                    }
+                },
+                'aws.iam': {
+                    'delete-user-policy': {
+                        'policy-name': (
+                            'policy-name', 'string',
+                            'delete-user-policy', 'aws.iam.', None, False),
+                    },
+                    'delete-user': {
+                        'user-name': (
+                            'user-name', 'string',
+                            'delete-user', 'aws.iam.', None, False),
+                    }
+                }
+            }
         })
         key = (('aws', 'iam'), 'delete-user-policy', 'policy-name')
         self.completion_data = {

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -105,6 +105,25 @@ class TestModelIndexCompleter(unittest.TestCase):
                     'describe-instances': ['instance-ids', 'reserve'],
                 }
             },
+            'arg_data': {
+                '': {
+                    'aws': {
+                        'endpoint-url': ('endpoint-url', 'string',
+                                         'aws', '', None, False),
+                        'region': ('region', 'string', 'aws', '', None, False),
+                    }
+                },
+                'aws.ec2': {
+                    'describe-instances': {
+                        'instance-ids': (
+                            'instance-ids', 'string',
+                            'describe-instances', 'aws.ec2.', None, False),
+                        'reserve': (
+                            'reserve', 'string',
+                            'describe-instances', 'aws.ec2.', None, False),
+                    }
+                }
+            }
         })
         self.parser = parser.CLIParser(self.index)
 

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -102,7 +102,8 @@ class TestModelIndexCompleter(unittest.TestCase):
                     'aws': ['region', 'endpoint-url'],
                 },
                 'aws.ec2': {
-                    'describe-instances': ['instance-ids', 'reserve'],
+                    'describe-instances': [
+                        'instance-ids', 'reserve', 'positional'],
                 }
             },
             'arg_data': {
@@ -121,6 +122,9 @@ class TestModelIndexCompleter(unittest.TestCase):
                         'reserve': (
                             'reserve', 'string',
                             'describe-instances', 'aws.ec2.', None, False),
+                        'positional': (
+                            'positional', 'string',
+                            'describe-instances', 'aws.ec2.', None, True),
                     }
                 }
             }
@@ -180,4 +184,8 @@ class TestModelIndexCompleter(unittest.TestCase):
 
     def test_no_autocompletions_if_nothing_matches(self):
         parsed = self.parser.parse('aws --foo')
+        self.assertEqual(self.completer.complete(parsed), [])
+
+    def test_no_complete_positional_arguments(self):
+        parsed = self.parser.parse('aws ec2 describe-instances --pos')
         self.assertEqual(self.completer.complete(parsed), [])

--- a/tests/unit/autocomplete/test_parser.py
+++ b/tests/unit/autocomplete/test_parser.py
@@ -42,20 +42,20 @@ SAMPLE_MODEL = InMemoryIndex(
         'arg_data': {
             '': {
                 'aws': {
-                    'debug': ('debug', 'boolean', 'aws', '', None),
+                    'debug': ('debug', 'boolean', 'aws', '', None, False),
                     'endpoint-url': ('endpoint-url', 'string',
-                                     'aws', '', None),
-                    'region': ('region', 'string', 'aws', '', None),
+                                     'aws', '', None, False),
+                    'region': ('region', 'string', 'aws', '', None, False),
                 }
             },
             'aws.ec2': {
                 'stop-instances': {
                     'instance-ids': (
                         'instance-ids', 'string',
-                        'stop-instances', 'aws.ec2.', '*'),
+                        'stop-instances', 'aws.ec2.', '*', False),
                     'foo-arg': (
                         'foo-arg', 'string', 'stop-instances',
-                        'aws.ec2', None),
+                        'aws.ec2', None, False),
                 }
             }
         }
@@ -257,7 +257,7 @@ class TestCanParseCLICommand(unittest.TestCase):
         nargs_one_or_more = '?'
         model.index['arg_data']['aws.ec2']['stop-instances']['foo-arg'] = (
             'foo-arg', 'string',
-            'stop-instances', 'aws.ec2', nargs_one_or_more)
+            'stop-instances', 'aws.ec2', nargs_one_or_more, False)
         p = parser.CLIParser(model)
         self.assertEqual(
             p.parse(

--- a/tests/unit/customizations/dynamodb/test_autocomplete.py
+++ b/tests/unit/customizations/dynamodb/test_autocomplete.py
@@ -1,0 +1,106 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, mock
+from awscli.autocomplete.completer import CompletionResult
+from awscli.autocomplete import parser
+from awscli.customizations.dynamodb.autocomplete import TableNameCompleter
+from tests.unit.autocomplete import InMemoryIndex
+
+
+class TestTableNameCompleter(unittest.TestCase):
+    def setUp(self):
+        self.index = InMemoryIndex({
+            'command_names': {
+                '': ['aws'],
+                'aws': ['ddb'],
+                'aws.ddb': ['put', 'select'],
+            },
+            'arg_names': {
+                '': {},
+                'aws.ddb': {
+                    'put': ['table_name'],
+                    'select': ['table_name']
+                },
+            },
+            'arg_data': {
+                '': {},
+                'aws.ddb': {
+                    'put': {
+                        'table_name': (
+                            'table_name', 'string',
+                            'put', 'aws.ddb.', None, True),
+                    },
+                    'select': {
+                        'table_name': (
+                            'table_name', 'string',
+                            'select', 'aws.ddb.', None, True),
+                    },
+                }
+            }
+        })
+        self.parser = parser.CLIParser(self.index)
+        self.mock_client = mock.Mock()
+        self.mock_create_client = mock.Mock()
+        self.mock_create_client.create_client.return_value = self.mock_client
+        self.completer = TableNameCompleter(self.mock_create_client)
+
+    def test_complete_table_name(self):
+        self.mock_client.list_tables.return_value = {
+            'TableNames': [
+                'tablename',
+                'mytable'
+            ]
+        }
+        parsed = self.parser.parse('aws ddb select ')
+        results = self.completer.complete(parsed)
+        self.assertEqual(
+            results,
+            [CompletionResult('tablename', 0),
+             CompletionResult('mytable', 0)]
+        )
+
+    def test_complete_table_name_with_put(self):
+        self.mock_client.list_tables.return_value = {
+            'TableNames': [
+                'tablename',
+                'mytable'
+            ]
+        }
+        parsed = self.parser.parse('aws ddb put ')
+        results = self.completer.complete(parsed)
+        self.assertEqual(
+            results,
+            [CompletionResult('tablename', 0),
+             CompletionResult('mytable', 0)]
+        )
+
+    def test_complete_group_name_filters_startswith(self):
+        self.mock_client.list_tables.return_value = {
+            'TableNames': [
+                'tablename',
+                'mytable'
+            ]
+        }
+        parsed = self.parser.parse('aws ddb select my')
+        results = self.completer.complete(parsed)
+        self.assertEqual(
+            results,
+            [CompletionResult('mytable', -2)]
+        )
+
+    def test_complete_group_name_handles_errors(self):
+        self.mock_client.list_tables.side_effect = Exception(
+            "Something went wrong.")
+        parsed = self.parser.parse('aws ddb select ')
+        results = self.completer.complete(parsed)
+        self.assertEqual(results, [])

--- a/tests/unit/customizations/logs/__init__.py
+++ b/tests/unit/customizations/logs/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/customizations/logs/test_autocomplete.py
+++ b/tests/unit/customizations/logs/test_autocomplete.py
@@ -1,0 +1,86 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, mock
+from awscli.autocomplete.completer import CompletionResult
+from awscli.autocomplete import parser
+from awscli.customizations.logs.autocomplete import GroupNameCompleter
+from tests.unit.autocomplete import InMemoryIndex
+
+
+class TestGroupNameCompleter(unittest.TestCase):
+    def setUp(self):
+        self.index = InMemoryIndex({
+            'command_names': {
+                '': ['aws'],
+                'aws': ['logs'],
+                'aws.logs': ['tail'],
+            },
+            'arg_names': {
+                '': {},
+                'aws.logs': {
+                    'tail': ['group_name'],
+                },
+            },
+            'arg_data': {
+                '': {},
+                'aws.logs': {
+                    'tail': {
+                        'group_name': (
+                            'group_name', 'string',
+                            'tail', 'aws.logs.', None, True),
+                    },
+                }
+            }
+        })
+        self.parser = parser.CLIParser(self.index)
+        self.mock_client = mock.Mock()
+        self.mock_create_client = mock.Mock()
+        self.mock_create_client.create_client.return_value = self.mock_client
+        self.completer = GroupNameCompleter(self.mock_create_client)
+
+    def test_complete_group_name(self):
+        self.mock_client.describe_log_groups.return_value = {
+            'logGroups': [
+                {'logGroupName': 'group'},
+                {'logGroupName': 'mygroup'},
+            ]
+        }
+        parsed = self.parser.parse('aws logs tail ')
+        results = self.completer.complete(parsed)
+        self.assertEqual(
+            results,
+            [CompletionResult('group', 0),
+             CompletionResult('mygroup', 0)]
+        )
+
+    def test_complete_group_name_filters_startswith(self):
+        self.mock_client.describe_log_groups.return_value = {
+            'logGroups': [
+                {'logGroupName': 'group'},
+                {'logGroupName': 'mygroup'},
+            ]
+        }
+        parsed = self.parser.parse('aws logs tail my')
+        results = self.completer.complete(parsed)
+        self.assertEqual(
+            results,
+            [CompletionResult('mygroup', -2)]
+        )
+
+    def test_complete_group_name_handles_errors(self):
+        self.mock_client.describe_log_groups.side_effect = Exception(
+            "Something went wrong.")
+        parsed = self.parser.parse('aws logs tail ')
+        results = self.completer.complete(parsed)
+        self.assertEqual(results, [])
+

--- a/tests/unit/customizations/logs/test_tail.py
+++ b/tests/unit/customizations/logs/test_tail.py
@@ -19,11 +19,11 @@ from botocore.session import Session
 from botocore.stub import Stubber
 
 from awscli.compat import StringIO
-from awscli.customizations.logs import ShortLogEventsFormatter
-from awscli.customizations.logs import DetailedLogEventsFormatter
-from awscli.customizations.logs import TimestampUtils
-from awscli.customizations.logs import NoFollowLogEventsGenerator
-from awscli.customizations.logs import FollowLogEventsGenerator
+from awscli.customizations.logs.tail import ShortLogEventsFormatter
+from awscli.customizations.logs.tail import DetailedLogEventsFormatter
+from awscli.customizations.logs.tail import TimestampUtils
+from awscli.customizations.logs.tail import NoFollowLogEventsGenerator
+from awscli.customizations.logs.tail import FollowLogEventsGenerator
 
 
 class BaseLogEventsFormatterTest(unittest.TestCase):


### PR DESCRIPTION
In order to get this working, I had to do a few things:

* Add support for positional parameters in our parser.
* Add support for loading custom completers
* Add support for the specific completers for `ddb put/select` and `logs tail`