### PR TITLE
[CLIv2] Add wizard subcommands

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE.txt
 include requirements.txt
 recursive-include awscli/examples *.rst
 recursive-include awscli/data *.json
+recursive-include awscli/customizations/wizard/wizards *.yml

--- a/awscli/customizations/wizard/commands.py
+++ b/awscli/customizations/wizard/commands.py
@@ -10,8 +10,73 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.customizations.wizard import devcommands
+from awscli.customizations.wizard import devcommands, factory
+from awscli.customizations.wizard.loader import WizardLoader
+from awscli.customizations.commands import BasicCommand
 
 
 def register_wizard_commands(event_handlers):
     devcommands.register_dev_commands(event_handlers)
+    loader = WizardLoader()
+    commands = loader.list_commands_with_wizards()
+    _register_wizards_for_commands(commands, event_handlers)
+
+
+def _register_wizards_for_commands(commands, event_handlers):
+    for command in commands:
+        event_handlers.register('building-command-table.%s' % command,
+                                _add_wizard_command)
+
+
+
+
+def _add_wizard_command(session, command_object, command_table, **kwargs):
+    runner = factory.create_default_wizard_runner(session)
+    cmd = WizardCommand(
+        session=session,
+        loader=WizardLoader(),
+        parent_command=command_object.name,
+        runner=runner,
+    )
+    command_table['wizard'] = cmd
+
+
+class WizardCommand(BasicCommand):
+    def __init__(self, session, loader, parent_command, runner,
+                 wizard_name='_main'):
+        self._session = session
+        self._loader = loader
+        self._parent_command = parent_command
+        self._runner = runner
+        self._wizard_name = wizard_name
+
+    def _build_subcommand_table(self):
+        subcommand_table = super(WizardCommand, self)._build_subcommand_table()
+        wizards = self._loader.list_available_wizards(self._parent_command)
+        for name in wizards:
+            cmd = WizardCommand(self._session, self._loader,
+                                self._parent_command, self._runner,
+                                wizard_name=name)
+            subcommand_table[name] = cmd
+        self._add_lineage(subcommand_table)
+        return subcommand_table
+
+    def _run_main(self, parsed_args, parsed_globals):
+        if self._wizard_exists():
+            self._run_wizard()
+            return 0
+        else:
+            self._raise_usage_error()
+
+    def _wizard_exists(self):
+        return self._loader.wizard_exists(self._parent_command,
+                                          self._wizard_name)
+
+    def _run_wizard(self):
+        loaded = self._loader.load_wizard(
+            self._parent_command, self._wizard_name)
+        self._runner.run(loaded)
+
+    def _raise_usage_error(self):
+        raise ValueError("usage: aws [options] <command> <subcommand> "
+                            "[parameters]\naws: error: too few arguments")

--- a/awscli/customizations/wizard/commands.py
+++ b/awscli/customizations/wizard/commands.py
@@ -121,7 +121,6 @@ class SingleWizardCommand(TopLevelWizardCommand):
         )
         return WizardHelpCommand(self._session, self, self.subcommand_table,
                                 self.arg_table, loaded)
-        return super(WizardCommand, self).create_help_command()
 
 
 class WizardHelpCommand(BasicHelp):

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -262,9 +262,18 @@ class Executor(object):
         handler.run_step(step, parameters)
 
     def _check_step_condition(self, condition, parameters):
-        varname = condition['variable']
-        if 'equals' in condition:
-            expected = condition['equals']
+        statuses = []
+        if not isinstance(condition, list):
+            condition = [condition]
+        for single in condition:
+            statuses.append(self._check_single_condition(
+                single, parameters))
+        return all(statuses)
+
+    def _check_single_condition(self, single, parameters):
+        varname = single['variable']
+        if 'equals' in single:
+            expected = single['equals']
             return parameters.get(varname) == expected
         return False
 

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -127,6 +127,15 @@ class PromptStep(BaseStep):
             return choices
 
 
+class FilePromptStep(BaseStep):
+    def __init__(self, prompter):
+        self._prompter = prompter
+
+    def run_step(self, step_definition, parameters):
+        response = self._prompter.prompt(step_definition['description'])
+        return os.path.expanduser(os.path.abspath(response))
+
+
 class TemplateStep(BaseStep):
 
     def run_step(self, step_definition, parameters):
@@ -212,9 +221,22 @@ class APIInvoker(object):
             final = {}
             for k, v in value.items():
                 final[k] = self._resolve_vars(v, plan_vars)
+            final = self._resolve_functions(final)
             return final
         else:
             return value
+
+    def _resolve_functions(self, value):
+        if len(value) != 1:
+            return value
+        only_key = list(value)[0]
+        # The built in functions will likely move to another module
+        # as we start to add more.
+        if only_key == '__wizard__:File':
+            filename = value[only_key]['path']
+            with open(filename, 'rb') as f:
+                return f.read()
+        return value
 
 
 class Executor(object):

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -10,6 +10,8 @@ def create_default_wizard_runner(session):
         step_handlers={
             'static': core.StaticStep(),
             'prompt': core.PromptStep(ui.UIPrompter()),
+            'fileprompt': core.FilePromptStep(
+                ui.UIFilePrompter(ui.FileCompleter())),
             'template': core.TemplateStep(),
             'apicall': core.APICallStep(api_invoker=api_invoker),
             'sharedconfig': core.SharedConfigStep(config_api=shared_config),

--- a/awscli/customizations/wizard/loader.py
+++ b/awscli/customizations/wizard/loader.py
@@ -1,0 +1,99 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""Load wizards included in the AWS CLI.
+
+Data Layout
+===========
+
+Within this directory, there's a ``wizards`` directory.  Each directory
+maps to an existing CLI command name.
+
+For each command directory, the filename corresponds to the name of
+a wizard (with the .yml prefix stripped).  Any file that starts with
+an underscore character is not listed as a wizard in the ``help`` command
+output.
+
+This means that wizards (at least these built-in ones) are only supported
+from a top level CLI command.  For example::
+
+    $ aws ec2 wizard <wizard-name>
+
+You can also add a special file, `_main.yml` in a directory to indicate
+the main wizard used when no wizard name is given.  For example::
+
+    $ aws dynamodb wizard
+
+will check if there's a ``dynamodb/_main.yml`` file.  If no file
+exists, then a usage error will be printed.
+
+
+"""
+import os
+import ruamel.yaml as yaml
+
+
+WIZARD_SPEC_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'wizards',
+)
+
+
+class WizardNotExistError(Exception):
+    pass
+
+
+class WizardLoader(object):
+    def __init__(self, spec_dir=None):
+        if spec_dir is None:
+            spec_dir = WIZARD_SPEC_DIR
+        self._spec_dir = spec_dir
+
+    def list_commands_with_wizards(self):
+        """Returns a list of commands with at least one wizard.
+        """
+        return os.listdir(self._spec_dir)
+
+    def list_available_wizards(self, command_name):
+        """List the names of wizards available for a service.
+
+        If no wizards are avaiable, then an empty list is returned.
+        """
+        files = os.listdir(os.path.join(self._spec_dir, command_name))
+        return [os.path.splitext(f)[0] for f in files]
+
+    def load_wizard(self, command_name, wizard_name):
+        """Load a specific wizard.
+
+        Given a command and wizard name (i.e something from the
+        output of ``list_available_wizards``), return the loaded file.
+        This will open the file and return the parsed yaml contents
+        of the file.
+
+        """
+        filename = os.path.join(self._spec_dir, command_name,
+                                wizard_name + '.yml')
+        try:
+            with open(filename) as f:
+                return self._load_yaml(f.read())
+        except (OSError, IOError):
+            raise WizardNotExistError("Wizard does not exist for command "
+                                      "'%s', name: '%s'" % (command_name,
+                                                            wizard_name))
+
+    def _load_yaml(self, contents):
+        data = yaml.load(contents, Loader=yaml.RoundTripLoader)
+        return data
+
+    def wizard_exists(self, command_name, wizard_name):
+        filename = os.path.join(self._spec_dir, command_name,
+                                wizard_name + '.yml')
+        return os.path.isfile(filename)

--- a/awscli/customizations/wizard/wizards/configure/_main.yml
+++ b/awscli/customizations/wizard/wizards/configure/_main.yml
@@ -1,0 +1,113 @@
+version: "0.1"
+title: Configure the AWS CLI
+description: This wizard will create a new CLI config profile for you
+plan:
+  decide_profile_type:
+    values:
+      config_type:
+        type: prompt
+        description: "What would you like to configure"
+        choices:
+          # There's also Web Identity and SAML but we're skipping that.
+          - display: Static Credentials
+            actual_value: static_creds
+          - display: Assume Role
+            actual_value: assume_role
+          - display: Process Provider
+            actual_value: proc_provider
+          - display: Additional CLI configuration
+            actual_value: additional_config
+      profile_name:
+        type: prompt
+        description: Enter the name of the profile
+    next_step:
+      switch: config_type
+      static_creds: get_static_creds
+      assume_role: get_assume_role
+      proc_provider: get_process_provider
+      additional_config: get_extra_cli_config
+  get_static_creds:
+    values:
+      access_key_id:
+        type: prompt
+        description: Enter your Access Key Id
+      secret_key:
+        type: prompt
+        description: Enter your Secret Access Key
+    next_step: DONE
+  get_process_provider:
+    values:
+      creds_process:
+        type: prompt
+        description: Enter the credential process command
+    next_step: DONE
+  get_assume_role:
+    values:
+      existing_profiles:
+        type: sharedconfig
+        operation: ListProfiles
+      existing_roles:
+        type: apicall
+        operation: iam.ListRoles
+        params: {}
+        query: "sort_by(Roles[].{display: RoleName, actual_value: Arn}, &display)"
+      role_arn:
+        type: prompt
+        description: Select the role you want to assume
+        choices: existing_roles
+      credential_source_type:
+        type: prompt
+        description: Select your credentials source type
+        choices:
+          - display: Source Profile
+            actual_value: source_profile
+          - display: Environment Variables
+            actual_value: Environment
+          - display: Amazon EC2 Instance Metadata
+            actual_value: Ec2InstanceMetadata
+          - display: Amazon ECS Container Credentials
+            actual_value: EcsContainer
+    next_step:
+      switch: credential_source_type
+      source_profile: get_source_profile
+      Environment: DONE
+      Ec2InstanceMetadata: DONE
+      EcsContainer: DONE
+  get_source_profile:
+    values:
+      source_profile:
+        type: prompt
+        description: Select the source profile
+        choices: existing_profiles
+    next_step: DONE
+  get_extra_cli_config:
+    # TODO: Not implemented yet. I think we want a loop for this?
+    # Keep prompting for as many key/value pairs as they want.
+    values:
+      foo:
+        type: static
+        value: bar
+execute:
+  default:
+    - type: sharedconfig
+      operation: SetValues
+      profile: "{profile_name}"
+      params:
+        role_arn: "{role_arn}"
+    - type: sharedconfig
+      operation: SetValues
+      condition:
+        variable: credential_source_type
+        equals: source_profile
+      profile: "{profile_name}"
+      params:
+        source_profile: "{source_profile}"
+    - type: sharedconfig
+      operation: SetValues
+      condition:
+        variable: source_profile
+        equals: null
+      profile: "{profile_name}"
+      params:
+        credential_source: "{credential_source_type}"
+

--- a/awscli/customizations/wizard/wizards/configure/_main.yml
+++ b/awscli/customizations/wizard/wizards/configure/_main.yml
@@ -84,14 +84,18 @@ plan:
     # TODO: Not implemented yet. I think we want a loop for this?
     # Keep prompting for as many key/value pairs as they want.
     values:
-      foo:
-        type: static
-        value: bar
+      region:
+        type: prompt
+        description: "Enter the region name"
 execute:
-  default:
+  # All the logic needed when the user selects assume role.
+  assume_role:
     - type: sharedconfig
       operation: SetValues
       profile: "{profile_name}"
+      condition:
+        variable: config_type
+        equals: assume_role
       params:
         role_arn: "{role_arn}"
     - type: sharedconfig
@@ -105,9 +109,38 @@ execute:
     - type: sharedconfig
       operation: SetValues
       condition:
-        variable: source_profile
-        equals: null
+        - variable: source_profile
+          equals: null
+        - variable: config_type
+          equals: assume_role
       profile: "{profile_name}"
       params:
         credential_source: "{credential_source_type}"
-
+  static_creds:
+    - type: sharedconfig
+      operation: SetValues
+      profile: "{profile_name}"
+      condition:
+        variable: config_type
+        equals: static_creds
+      params:
+        aws_access_key_id: "{access_key_id}"
+        aws_secret_access_key: "{secret_key}"
+  proc_provider:
+    - type: sharedconfig
+      operation: SetValues
+      profile: "{profile_name}"
+      condition:
+        variable: config_type
+        equals: proc_provider
+      params:
+        credential_process: "{creds_process}"
+  additional_config:
+    - type: sharedconfig
+      operation: SetValues
+      profile: "{profile_name}"
+      condition:
+        variable: config_type
+        equals: additional_config
+      params:
+        region: "{region}"

--- a/awscli/customizations/wizard/wizards/iam/new-role.yml
+++ b/awscli/customizations/wizard/wizards/iam/new-role.yml
@@ -1,0 +1,146 @@
+version: "0.1"
+title: Create An IAM Role and Policy
+description: This wizard will create a new IAM role for you
+plan:
+  decide_role_type:
+    values:
+      # This will prompt the user using the 'description' value.
+      # The value the user enters is saved under the global variable
+      # 'name'.
+      role_type:
+        type: prompt
+        description: Select type of trusted entity
+        choices:
+          # There's also Web Identity and SAML but we're skipping that.
+          - display: AWS Service
+            actual_value: aws_service
+          - display: Another AWS Account
+            actual_value: aws_account
+    next_step:
+      switch: role_type
+      aws_service: get_role_service
+      aws_account: get_account_info
+  get_role_service:
+    values:
+      service_name:
+        type: prompt
+        description: Choose the service that will use this role
+        choices:
+          - display: Amazon EC2
+            actual_value: ec2
+          - display: AWS Lambda
+            actual_value: lambda
+      trust_policy:
+        type: template
+        value: |
+          {{
+            "Version": "2008-10-17",
+            "Statement": [
+                {{
+                    "Action": "sts:AssumeRole",
+                    "Principal": {{
+                        "Service": "{service_name}.amazonaws.com"
+                    }},
+                    "Effect": "Allow",
+                    "Sid": ""
+                }}
+            ]
+          }}
+    next_step: ask_role_permissions
+  get_account_info:
+    values:
+      account_id:
+        type: prompt
+        description: Enter the Account ID that can use this role
+      trust_policy:
+        type: template
+        value: |
+          {{
+            "Version": "2008-10-17",
+            "Statement": [
+                {{
+                    "Action": "sts:AssumeRole",
+                    "Principal": {{
+                        "AWS": "arn:aws:iam::{account_id}:root"
+                    }},
+                    "Effect": "Allow",
+                    "Sid": ""
+                    }}
+            ]
+          }}
+    next_step: ask_role_permissions
+  ask_role_permissions:
+    # The console by default asks you to pick an existing policy
+    # to attach to.  We'll just go with that behavior for now.
+    values:
+      existing_policies:
+        type: apicall
+        operation: iam.ListPolicies
+        params:
+          Scope: AWS
+        query: "sort_by(Policies[].{display: PolicyName, actual_value: Arn}, &display)"
+      policy_arn:
+        type: prompt
+        description: Choose a policy to attach to your new role
+        choices: existing_policies
+  ask_role_name:
+    values:
+      role_name:
+        type: prompt
+        description: Role name
+      role_description:
+        type: prompt
+        description: Role description
+  ask_profile_config:
+    values:
+      wants_config_profile:
+        type: prompt
+        description: Do you want to create a new CLI profile with this role?
+        choices:
+          - display: Yes
+            actual_value: yes
+          - display: No
+            actual_value: no
+    next_step:
+      switch: wants_config_profile
+      yes: get_profile_info
+      no: DONE
+  get_profile_info:
+    values:
+      new_profile_name:
+        type: prompt
+        description: Enter the name of the new profile
+      existing_profiles:
+        type: sharedconfig
+        operation: ListProfiles
+      source_profile:
+        type: prompt
+        description: Name of the source profile
+        choices: existing_profiles
+execute:
+  default:
+    - type: apicall
+      operation: iam.CreateRole
+      params:
+        RoleName: "{role_name}"
+        AssumeRolePolicyDocument: "{trust_policy}"
+        Description: "{role_description}"
+      output_var: role_arn
+      query: Role.Arn
+    - type: apicall
+      operation: iam.AttachRolePolicy
+      params:
+        RoleName: "{role_name}"
+        PolicyArn: "{policy_arn}"
+  write_config_file:
+    - type: sharedconfig
+      operation: SetValues
+      condition:
+        variable: wants_config_profile
+        equals: yes
+      profile: "{new_profile_name}"
+      params:
+        source_profile: "{source_profile}"
+        # This role_arn comes from the `output_var` in the previous
+        # executor step.
+        role_arn: "{role_arn}"

--- a/awscli/customizations/wizard/wizards/lambda/new-function.yml
+++ b/awscli/customizations/wizard/wizards/lambda/new-function.yml
@@ -1,6 +1,6 @@
 version: "0.1"
-title: Create An IAM Role and Policy
-description: This wizard will create a new IAM role for you
+title: Create An AWS Lambda Function
+description: This wizard will create a new AWS Lambda function for you
 plan:
   basics:
     values:

--- a/awscli/customizations/wizard/wizards/lambda/new-function.yml
+++ b/awscli/customizations/wizard/wizards/lambda/new-function.yml
@@ -59,5 +59,5 @@ execute:
         Handler: "{handler}"
         Code:
           ZipFile:
-            Fn::File:
-              path: "{zip_file}"
+            __wizard__:File:
+              path: "{zip_filename}"

--- a/awscli/customizations/wizard/wizards/lambda/new-function.yml
+++ b/awscli/customizations/wizard/wizards/lambda/new-function.yml
@@ -1,0 +1,63 @@
+version: "0.1"
+title: Create An IAM Role and Policy
+description: This wizard will create a new IAM role for you
+plan:
+  basics:
+    values:
+      function_name:
+        type: prompt
+        description: Enter the function name
+      runtime:
+        type: prompt
+        description: Select the Lambda runtime
+        choices:
+          - actual_value: python2.7
+            display: Python 2.7
+          - actual_value: python3.6
+            display: Python 3.6
+          - actual_value: python3.7
+            display:  Python 3.7
+          - actual_value: nodejs4.3
+            display: Node.js 4.3
+          - actual_value: nodejs6.10
+            display:  Node.js 6.10
+          - actual_value: nodejs8.10
+            display:  Node.js 8.10
+          - actual_value: java8
+            display:  Java 8
+          - actual_value: dotnetcore1.0
+            display: .NET Core 1.0 (C#)
+          - actual_value: dotnetcore2.0
+            display: .NET Core 2.0 (C#)
+          - actual_value: dotnetcore2.1
+            display: .NET Core 2.1 (C#)
+          - actual_value: go1.
+            display:  Go 1.x
+      existing_roles:
+        type: apicall
+        operation: iam.ListRoles
+        params: {}
+        query: "sort_by(Roles[].{display: RoleName, actual_value: Arn}, &display)"
+      role_arn:
+        type: prompt
+        description: Select the role to use
+        choices: existing_roles
+      handler:
+        type: prompt
+        description: Enter the handler for your function
+      zip_filename:
+        type: fileprompt
+        description: Enter the new location of your code zip file
+execute:
+  default:
+    - type: apicall
+      operation: lambda.CreateFunction
+      params:
+        FunctionName: "{function_name}"
+        Role: "{role_arn}"
+        Runtime: "{runtime}"
+        Handler: "{handler}"
+        Code:
+          ZipFile:
+            Fn::File:
+              path: "{zip_file}"

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -326,6 +326,16 @@ def capture_input(input_bytes=b''):
         yield input_data
 
 
+@contextlib.contextmanager
+def cd(path):
+    try:
+        original_dir = os.getcwd()
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original_dir)
+
+
 class BaseAWSCommandParamsTest(unittest.TestCase):
     maxDiff = None
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup_options = dict(
     packages=find_packages(exclude=['tests*']),
     package_data={'awscli': ['data/*.json', 'examples/*/*.rst',
                              'examples/*/*/*.rst', 'topics/*.rst',
+                             'customizations/wizard/wizards/*/*.yml',
                              'topics/*.json']},
     install_requires=requires,
     license="Apache License 2.0",

--- a/tests/functional/wizards/test_command.py
+++ b/tests/functional/wizards/test_command.py
@@ -1,0 +1,60 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import tempfile
+import shutil
+
+from awscli.testutils import BaseAWSCommandParamsTest, mock, cd
+
+
+class TestRunWizard(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestRunWizard, self).setUp()
+        self.tempdir = tempfile.mkdtemp()
+        with cd(self.tempdir):
+            os.mkdir('iam')
+        self.parsed_responses = [{"Roles": []}]
+        self.root_dir_patch = mock.patch(
+            'awscli.customizations.wizard.loader.WIZARD_SPEC_DIR',
+            self.tempdir
+        )
+        self.root_dir_patch.start()
+
+    def tearDown(self):
+        super(TestRunWizard, self).tearDown()
+        shutil.rmtree(self.tempdir)
+        self.root_dir_patch.stop()
+
+    def test_can_run_wizard(self):
+        wizard_path = os.path.join(self.tempdir, 'iam', 'test-wizard.yml')
+        with open(wizard_path, 'w') as f:
+            f.write(
+                'version: "0.9"\n'
+                'plan:\n'
+                '  start:\n'
+                '    values:\n'
+                '      myprefix:\n'
+                '        type: static\n'
+                '        value: /foo/\n'
+                'execute:\n'
+                '  default:\n'
+                '    - type: apicall\n'
+                '      operation: iam.ListRoles\n'
+                '      params:\n'
+                '        PathPrefix: "{myprefix}"\n'
+            )
+        stdout, _, _ = self.assert_params_for_cmd(
+            'iam wizard test-wizard',
+            params={'PathPrefix': '/foo/'}
+        )
+        self.assertEqual(self.operations_called[0][0].name, 'ListRoles')

--- a/tests/functional/wizards/test_command.py
+++ b/tests/functional/wizards/test_command.py
@@ -15,6 +15,7 @@ import tempfile
 import shutil
 
 from awscli.testutils import BaseAWSCommandParamsTest, mock, cd
+from awscli.testutils import BaseAWSHelpOutputTest
 
 
 class TestRunWizard(BaseAWSCommandParamsTest):
@@ -58,3 +59,36 @@ class TestRunWizard(BaseAWSCommandParamsTest):
             params={'PathPrefix': '/foo/'}
         )
         self.assertEqual(self.operations_called[0][0].name, 'ListRoles')
+
+    def test_can_run_main_wizard(self):
+        wizard_path = os.path.join(self.tempdir, 'iam', '_main.yml')
+        with open(wizard_path, 'w') as f:
+            f.write(
+                'version: "0.9"\n'
+                'plan:\n'
+                '  start:\n'
+                '    values:\n'
+                '      myprefix:\n'
+                '        type: static\n'
+                '        value: /foo/\n'
+                'execute:\n'
+                '  default:\n'
+                '    - type: apicall\n'
+                '      operation: iam.ListRoles\n'
+                '      params: {}\n'
+            )
+        stdout, _, _ = self.assert_params_for_cmd(
+            'iam wizard',
+            params={},
+        )
+        self.assertEqual(self.operations_called[0][0].name, 'ListRoles')
+
+
+class TestWizardHelpCommand(BaseAWSHelpOutputTest):
+    def test_wait_help_command(self):
+        self.driver.main(['iam', 'wizard', 'help'])
+        self.assert_contains('new-role')
+
+    def test_wait_help_command(self):
+        self.driver.main(['iam', 'wizard', 'new-role', 'help'])
+        self.assert_contains('new-role')

--- a/tests/functional/wizards/test_loader.py
+++ b/tests/functional/wizards/test_loader.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.customizations.wizard import loader
+
+
+class TestLoader(unittest.TestCase):
+    def setUp(self):
+        self.loader = loader.WizardLoader()
+
+    def test_can_list_commands_with_wizards(self):
+        # This list is going to change over time so we'll only pick a few
+        # commands as a sanity check.
+        commands = self.loader.list_commands_with_wizards()
+        self.assertIn('configure', commands)
+        self.assertIn('iam', commands)
+
+    def test_can_list_wizards_for_service(self):
+        wizard_names = self.loader.list_available_wizards('iam')
+        self.assertIn('new-role', wizard_names)
+
+    def test_can_load_wizard_file(self):
+        loaded = self.loader.load_wizard('iam', 'new-role')
+        self.assertIn('version', loaded)
+
+    def test_exception_raised_when_wizard_does_not_exists(self):
+        with self.assertRaises(loader.WizardNotExistError):
+            self.loader.load_wizard('iam', 'wizard-foo-does-not-exist')
+
+    def test_wizard_exists(self):
+        self.assertTrue(self.loader.wizard_exists('iam', 'new-role'))

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -847,4 +847,4 @@ class TestAPIInvoker(unittest.TestCase):
                 },
             )
         call_method_args = self.get_call_args(self.mock_session)
-        self.assertEqual(call_method_args, mock.call(UserName='admin'))
+        self.assertEqual(call_method_args, mock.call(UserName=b'admin'))

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -10,13 +10,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import ruamel.yaml as yaml
 
 from botocore.session import Session
 
 from awscli.customizations.configure.writer import ConfigFileWriter
 from awscli.customizations.wizard import core
-from awscli.testutils import unittest, mock
+from awscli.customizations.wizard import ui
+from awscli.testutils import unittest, mock, temporary_file
 
 
 def load_wizard(yaml_str):
@@ -335,6 +337,26 @@ class TestPlanner(unittest.TestCase):
                                             {'display': 'Developer',
                                              'actual_value': 'dev'}])],
         )
+
+    def test_can_run_fileprompt_step(self):
+        loaded = load_wizard("""
+        plan:
+          start:
+            values:
+              foo:
+                type: fileprompt
+                description: Select file
+        """)
+        prompter = mock.Mock(spec=ui.UIFilePrompter)
+        prompter.prompt.return_value = 'myfile.txt'
+        planner = core.Planner(
+            step_handlers={
+                'fileprompt': core.FilePromptStep(prompter=prompter),
+            },
+        )
+        parameters = planner.run(loaded['plan'])
+        self.assertEqual(parameters['foo'],
+                         os.path.abspath('myfile.txt'))
 
     def test_can_jump_around_to_next_steps(self):
         # This test shows that you can specify an explicit
@@ -740,3 +762,54 @@ class TestRunner(unittest.TestCase):
 
         self.planner.run.assert_called_with(loaded['plan'])
         self.executor.run.assert_called_with(loaded['execute'], params)
+
+
+class TestAPIInvoker(unittest.TestCase):
+    def setUp(self):
+        self.mock_session = mock.Mock(spec=Session)
+
+    def get_call_args(self, session):
+        return session.create_client.return_value.create_user.call_args
+
+    def test_can_make_api_call(self):
+        invoker = core.APIInvoker(self.mock_session)
+        invoker.invoke(
+            'iam',
+            'CreateUser',
+            api_params={'UserName': 'admin'},
+            plan_variables={}
+        )
+        call_method_args = self.get_call_args(self.mock_session)
+        self.assertEqual(call_method_args, mock.call(UserName='admin'))
+
+    def test_can_invoke_with_plan_variables(self):
+        invoker = core.APIInvoker(self.mock_session)
+        invoker.invoke(
+            'iam',
+            'CreateUser',
+            api_params={'UserName': '{username}'},
+            plan_variables={'username': 'admin'}
+        )
+        call_method_args = self.get_call_args(self.mock_session)
+        self.assertEqual(call_method_args, mock.call(UserName='admin'))
+
+    def test_can_open_file_with_builtin_function(self):
+        invoker = core.APIInvoker(self.mock_session)
+        with temporary_file('r+') as f:
+            f.write('admin')
+            f.flush()
+            invoker.invoke(
+                'iam',
+                'CreateUser',
+                # There's two parts to this test.  First, we have the
+                # filename stored as a variable.
+                plan_variables={'myfile': f.name},
+                api_params={
+                    # Then we reference the file with the builtin File
+                    # type.  We should replace this entire value with
+                    # the contents of the temp file ('admin').
+                    'UserName': {'__wizard__:File': {'path': '{myfile}'}},
+                },
+            )
+        call_method_args = self.get_call_args(self.mock_session)
+        self.assertEqual(call_method_args, mock.call(UserName='admin'))

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -579,6 +579,41 @@ class TestExecutor(unittest.TestCase):
         self.assertTrue(self.session.create_client.called)
         self.assertTrue(self.client.create_user.called)
 
+    def test_can_have_multiple_conditions(self):
+        loaded = load_wizard("""
+        execute:
+          default:
+            - type: apicall
+              condition:
+                - variable: foo
+                  equals: one
+                - variable: bar
+                  equals: two
+              operation: iam.CreateUser
+              params:
+                UserName: admin
+        """)
+        self.executor.run(loaded['execute'], {'foo': 'one', 'bar': 'two'})
+        self.assertTrue(self.session.create_client.called)
+        self.assertTrue(self.client.create_user.called)
+
+    def test_multiple_conditions_one_false(self):
+        loaded = load_wizard("""
+        execute:
+          default:
+            - type: apicall
+              condition:
+                - variable: foo
+                  equals: one
+                - variable: bar
+                  equals: two
+              operation: iam.CreateUser
+              params:
+                UserName: admin
+        """)
+        self.executor.run(loaded['execute'], {'foo': 'one', 'bar': 'NOTTWO'})
+        self.assertFalse(self.session.create_client.called)
+
     def test_can_recursively_template_variables_in_params(self):
         loaded = load_wizard("""
         execute:

--- a/tests/unit/customizations/wizard/test_ui.py
+++ b/tests/unit/customizations/wizard/test_ui.py
@@ -28,7 +28,7 @@ class TestFileCompleter(unittest.TestCase):
         shutil.rmtree(self.temporary_directory)
 
     def touch_file(self, filename):
-        with open(os.path.join(self.temporary_directory, filename), 'w') as f:
+        with open(os.path.join(self.temporary_directory, filename), 'w'):
             pass
 
     def get_completions_given_user_input(self, user_input):
@@ -38,7 +38,6 @@ class TestFileCompleter(unittest.TestCase):
             completions = list(
                 self.completer.get_completions(user_input, None))
             return completions
-
 
     def test_can_list_children_of_dir_with_prefix(self):
         self.touch_file('foo.txt')

--- a/tests/unit/customizations/wizard/test_ui.py
+++ b/tests/unit/customizations/wizard/test_ui.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import tempfile
+import shutil
+
+from awscli.compat import ensure_text_type
+from awscli.customizations.wizard import ui
+from awscli.testutils import unittest, mock, cd
+
+
+class TestFileCompleter(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.mkdtemp()
+        self.completer = ui.FileCompleter()
+
+    def tearDown(self):
+        shutil.rmtree(self.temporary_directory)
+
+    def touch_file(self, filename):
+        with open(os.path.join(self.temporary_directory, filename), 'w') as f:
+            pass
+
+    def get_completions_given_user_input(self, user_input):
+        user_input = mock.Mock(text=ensure_text_type(user_input))
+
+        with cd(self.temporary_directory):
+            completions = list(
+                self.completer.get_completions(user_input, None))
+            return completions
+
+
+    def test_can_list_children_of_dir_with_prefix(self):
+        self.touch_file('foo.txt')
+        self.touch_file('bar.txt')
+        self.touch_file('baz.txt')
+
+        completions = self.get_completions_given_user_input(u'./b')
+        self.assertEqual(
+            [c.text for c in completions], ['./bar.txt', './baz.txt'])
+
+    def test_full_path_included_if_full_path_used_as_text(self):
+        self.touch_file('foo.txt')
+
+        completions = self.get_completions_given_user_input(
+            self.temporary_directory + u'/'
+        )
+        self.assertEqual(
+            [c.text for c in completions],
+            [os.path.join(self.temporary_directory, 'foo.txt')]
+        )
+
+    def test_file_not_exists_returns_empy_list(self):
+        completions = self.get_completions_given_user_input(
+            self.temporary_directory + u'/asdf/does-not-exist'
+        )
+        self.assertEqual(completions, [])


### PR DESCRIPTION
This adds support for `aws <service> wizard <wizardname>`.  I've also added 3 starter wizards.
To support one of the new wizards, I've added a new type that allows you to prompt for file paths along with support for reading values from a file.  I wanted to pick a key that was unlikely to conflate with other values (that's why I avoided `Fn::`).