### PR TITLE
[CLIv2] Add support for generating mac pkg files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
+macpkg/dist/aws
+macpkg/build

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # Packages
 *.egg
 *.egg-info
-dist
+./dist/*
 build
 eggs
 parts

--- a/macpkg/Makefile
+++ b/macpkg/Makefile
@@ -1,0 +1,16 @@
+all: exe macpkg
+
+exe:
+	rm -rf ./dist/aws
+	pyinstaller aws.spec && echo "aws exe built"
+	pyinstaller aws_completer.spec && echo "aws_completer exe built"
+	cp -r dist/aws_completer/* dist/aws/
+	rm -rf dist/aws_completer/
+
+macpkg:
+	rm -f dist/aws-cli.pkg
+	$(eval CLI_VERSION=$(shell dist/aws/aws --version 2>&1 | cut -d' ' -f 1 | cut -d'/' -f 2))
+	cd dist && pkgbuild --identifier com.amazon.awscli --root ./aws/ --install-location /usr/local/aws/ --scripts ../scripts/ --version $(CLI_VERSION) aws-cli.pkg
+	cd dist && productbuild --distribution distribution.xml --resources ../resources/ "AWS-CLI-Installer.pkg"
+	rm dist/aws-cli.pkg
+	@echo Mac PKG file is available at dist/AWS-CLI-Installer.pkg

--- a/macpkg/aws.spec
+++ b/macpkg/aws.spec
@@ -1,0 +1,33 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+
+aws_a = Analysis(['../bin/aws'],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=['.'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+aws_pyz = PYZ(aws_a.pure, aws_a.zipped_data, cipher=block_cipher)
+aws_exe = EXE(aws_pyz,
+          aws_a.scripts,
+          [],
+          exclude_binaries=True,
+          name='aws',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True )
+coll = COLLECT(aws_exe,
+               aws_a.binaries,
+               aws_a.zipfiles,
+               aws_a.datas,
+               strip=False,
+               upx=True,
+               name='aws')

--- a/macpkg/aws_completer.spec
+++ b/macpkg/aws_completer.spec
@@ -1,0 +1,33 @@
+# -*- mode: python -*-
+
+block_cipher = None
+
+
+completer_a = Analysis(['../bin/aws_completer'],
+             binaries=[],
+             datas=[],
+             hiddenimports=[],
+             hookspath=['.'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher)
+completer_pyz = PYZ(completer_a.pure, completer_a.zipped_data, cipher=block_cipher)
+completer_exe = EXE(completer_pyz,
+          completer_a.scripts,
+          [],
+          exclude_binaries=True,
+          name='aws_completer',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True)
+coll = COLLECT(completer_exe,
+               completer_a.binaries,
+               completer_a.zipfiles,
+               completer_a.datas,
+               strip=False,
+               upx=True,
+               name='aws_completer')

--- a/macpkg/dist/distribution.xml
+++ b/macpkg/dist/distribution.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="1">
+    <title>AWS Command Line Interface</title>
+    <license file="LICENSE.txt" />
+    <readme file="README.html" mimetype="text/html" />
+    <pkg-ref id="com.amazon.awscli"/>
+    <options customize="never" require-scripts="false"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.amazon.awscli"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.amazon.awscli" visible="false">
+        <pkg-ref id="com.amazon.awscli"/>
+    </choice>
+    <pkg-ref id="com.amazon.awscli" version="0" onConclusion="none">aws-cli.pkg</pkg-ref>
+</installer-gui-script>

--- a/macpkg/hook-awscli.py
+++ b/macpkg/hook-awscli.py
@@ -1,0 +1,7 @@
+from PyInstaller.utils.hooks import collect_data_files
+
+hiddenimports = ['docutils', 'urllib', 'httplib', 'html.parser',
+                 'configparser', 'xml.etree', 'pipes', 'colorama',
+                 'awscli.handlers']
+datas = collect_data_files('awscli')
+

--- a/macpkg/hook-botocore.py
+++ b/macpkg/hook-botocore.py
@@ -1,0 +1,5 @@
+#from PyInstaller.hooks.hookutils import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files
+
+hiddenimports = ['configparser', 'html.parser', 'markupbase', 'pipes', 'six']
+datas = collect_data_files('botocore')

--- a/macpkg/resources/LICENSE.txt
+++ b/macpkg/resources/LICENSE.txt
@@ -1,0 +1,12 @@
+Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"). You
+may not use this file except in compliance with the License. A copy of
+the License is located at
+
+    http://aws.amazon.com/apache2.0/
+
+or in the "license" file accompanying this file. This file is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/macpkg/resources/README.html
+++ b/macpkg/resources/README.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+  <p>This will install the AWS CLI v2.0.0.</p>
+
+  <p><b>The AWS CLI v2.0.0 is not recommended for production use and is offered as a developer preview.</b></p>
+
+  <p>For more information on installing AWS CLI 1.x, see our <a href="https://docs.aws.amazon.com/cli/latest/userguide/installing.html">Installation Guide</a>.</p>
+</body>
+</html>

--- a/macpkg/scripts/postinstall
+++ b/macpkg/scripts/postinstall
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+sudo mkdir -p /usr/local/bin
+
+sudo ln -sf /usr/local/aws/aws /usr/local/bin/aws
+sudo ln -sf /usr/local/aws/aws_completer /usr/local/bin/aws_completer

--- a/macpkg/scripts/preinstall
+++ b/macpkg/scripts/preinstall
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sudo rm -rf /usr/local/aws

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ wheel==0.24.0
 ruamel.yaml>=0.15.0,<0.16.0
 PyYAML>=3.10,<=3.13
 jsonschema==2.5.1
+PyInstaller==3.4


### PR DESCRIPTION
This adds a new macpkg file that can generate a .pkg installer.
There's two parts to this:

* Generating an .exe file using pyinstaller
* Generating a pkg file based on the .exe files

To generate this yourself, on a mac run:

```
$ # Activate a python3.6 virtualenv
$ pip install PyInstaller==3.4
$ cd macpkg
$ make
```

