### PR TITLE
Add GLACIER to s3 transfer commands

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -249,11 +249,11 @@ SSE_C_COPY_SOURCE_KEY = {
 
 STORAGE_CLASS = {'name': 'storage-class',
                  'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA',
-                             'ONEZONE_IA', 'INTELLIGENT_TIERING'],
+                             'ONEZONE_IA', 'INTELLIGENT_TIERING', 'GLACIER'],
                  'help_text': (
                      "The type of storage to use for the object. "
                      "Valid choices are: STANDARD | REDUCED_REDUNDANCY "
-                     "| STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING. "
+                     "| STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER. "
                      "Defaults to 'STANDARD'")}
 
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -144,6 +144,21 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(args['Bucket'], 'bucket')
         self.assertEqual(args['StorageClass'], 'INTELLIGENT_TIERING')
 
+    def test_upload_glacier(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = ('%s %s s3://bucket/key.txt --storage-class GLACIER' %
+                   (self.prefix, full_path))
+        self.parsed_responses = \
+            [{'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 1,
+                         self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        args = self.operations_called[0][1]
+        self.assertEqual(args['Key'], 'key.txt')
+        self.assertEqual(args['Bucket'], 'bucket')
+        self.assertEqual(args['StorageClass'], 'GLACIER')
+
     def test_operations_used_in_download_file(self):
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},


### PR DESCRIPTION
Add the GLACIER option to the argument --storage-class on the three
s3 transfer commands sync, mv and cp.

#3759 