### PR TITLE
Use yaml safe load in ecs customization

### DIFF
--- a/awscli/customizations/ecs/filehelpers.py
+++ b/awscli/customizations/ecs/filehelpers.py
@@ -78,4 +78,4 @@ def parse_appspec(appspec_str):
     try:
         return json.loads(appspec_str)
     except ValueError:
-        return yaml.load(appspec_str)
+        return yaml.safe_load(appspec_str)


### PR DESCRIPTION
`yaml.load` is insecure - it can potentially execute arbitrary code. We use `yaml.safe_load` in most places to get around this, but one usage of `load` slipped in. This fixes that.

Resolves #3788