### PR TITLE
Support packaging readme and license files for ServerlessRepo metadata

### DIFF
--- a/.changes/next-release/enhancement-cloudformation-60553.json
+++ b/.changes/next-release/enhancement-cloudformation-60553.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``cloudformation``",
+  "description": "Update ``cloudformation package`` command to upload readme and license files"
+}

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -385,6 +385,18 @@ class ServerlessLayerVersionResource(Resource):
     FORCE_ZIP = True
 
 
+class ServerlessRepoApplicationReadme(Resource):
+    RESOURCE_TYPE = "AWS::ServerlessRepo::Application"
+    PROPERTY_NAME = "ReadmeUrl"
+    PACKAGE_NULL_PROPERTY = False
+
+
+class ServerlessRepoApplicationLicense(Resource):
+    RESOURCE_TYPE = "AWS::ServerlessRepo::Application"
+    PROPERTY_NAME = "LicenseUrl"
+    PACKAGE_NULL_PROPERTY = False
+
+
 class CloudFormationStackResource(Resource):
     """
     Represents CloudFormation::Stack resource that can refer to a nested
@@ -444,7 +456,7 @@ class ServerlessApplicationResource(CloudFormationStackResource):
     PROPERTY_NAME = "Location"
 
 
-EXPORT_LIST = [
+RESOURCES_EXPORT_LIST = [
     ServerlessFunctionResource,
     ServerlessApiResource,
     GraphQLSchemaResource,
@@ -459,6 +471,12 @@ EXPORT_LIST = [
     LambdaLayerVersionResource,
 ]
 
+METADATA_EXPORT_LIST = [
+    ServerlessRepoApplicationReadme,
+    ServerlessRepoApplicationLicense
+]
+
+
 def include_transform_export_handler(template_dict, uploader):
     if template_dict.get("Name", None) != "AWS::Include":
         return template_dict
@@ -466,6 +484,7 @@ def include_transform_export_handler(template_dict, uploader):
     if (is_local_file(include_location)):
         template_dict["Parameters"]["Location"] = uploader.upload_with_dedup(include_location)
     return template_dict
+
 
 GLOBAL_EXPORT_DICT = {
     "Fn::Transform": include_transform_export_handler
@@ -478,7 +497,8 @@ class Template(object):
     """
 
     def __init__(self, template_path, parent_dir, uploader,
-                 resources_to_export=EXPORT_LIST):
+                 resources_to_export=RESOURCES_EXPORT_LIST,
+                 metadata_to_export=METADATA_EXPORT_LIST):
         """
         Reads the template and makes it ready for export
         """
@@ -497,6 +517,7 @@ class Template(object):
         self.template_dict = yaml_parse(template_str)
         self.template_dir = template_dir
         self.resources_to_export = resources_to_export
+        self.metadata_to_export = metadata_to_export
         self.uploader = uploader
 
     def export_global_artifacts(self, template_dict):
@@ -517,6 +538,26 @@ class Template(object):
                         self.export_global_artifacts(item)
         return template_dict
 
+    def export_metadata(self, template_dict):
+        """
+        Exports the local artifacts referenced by the metadata section in
+        the given template to an s3 bucket.
+
+        :return: The template with references to artifacts that have been
+        exported to s3.
+        """
+        if "Metadata" not in template_dict:
+            return template_dict
+
+        for metadata_type, metadata_dict in template_dict["Metadata"].items():
+            for exporter_class in self.metadata_to_export:
+                if exporter_class.RESOURCE_TYPE != metadata_type:
+                    continue
+
+                exporter = exporter_class(self.uploader)
+                exporter.export(metadata_type, metadata_dict, self.template_dir)
+
+        return template_dict
 
     def export(self):
         """
@@ -526,6 +567,8 @@ class Template(object):
         :return: The template with references to artifacts that have been
         exported to s3.
         """
+        self.template_dict = self.export_metadata(self.template_dict)
+
         if "Resources" not in self.template_dict:
             return self.template_dict
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -21,7 +21,8 @@ from awscli.customizations.cloudformation.artifact_exporter \
     ElasticBeanstalkApplicationVersion, CloudFormationStackResource, \
     ServerlessApplicationResource, LambdaLayerVersionResource, \
     copy_to_temp_dir, include_transform_export_handler, GLOBAL_EXPORT_DICT, \
-    ServerlessLayerVersionResource
+    ServerlessLayerVersionResource, ServerlessRepoApplicationLicense, \
+    ServerlessRepoApplicationReadme
 
 
 def test_is_s3_url():
@@ -107,6 +108,14 @@ def test_all_resources_export():
             "class": ServerlessLayerVersionResource,
             "expected_result": uploaded_s3_url
         },
+        {
+            "class": ServerlessRepoApplicationReadme,
+            "expected_result": uploaded_s3_url
+        },
+        {
+            "class": ServerlessRepoApplicationLicense,
+            "expected_result": uploaded_s3_url
+        }
     ]
 
     with patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts") as upload_local_artifacts_mock:
@@ -808,6 +817,66 @@ class TestArtifactExporter(unittest.TestCase):
         stack_resource.export(resource_id, resource_dict, "dir")
         self.assertEquals(resource_dict[property_name], location)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+
+    @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
+    def test_template_export_metadata(self, yaml_parse_mock):
+        parent_dir = os.path.sep
+        template_dir = os.path.join(parent_dir, 'foo', 'bar')
+        template_path = os.path.join(template_dir, 'path')
+        template_str = self.example_yaml_template()
+
+        metadata_type1_class = Mock()
+        metadata_type1_class.RESOURCE_TYPE = "metadata_type1"
+        metadata_type1_class.PROPERTY_NAME = "property_1"
+        metadata_type1_instance = Mock()
+        metadata_type1_class.return_value = metadata_type1_instance
+
+        metadata_type2_class = Mock()
+        metadata_type2_class.RESOURCE_TYPE = "metadata_type2"
+        metadata_type2_class.PROPERTY_NAME = "property_2"
+        metadata_type2_instance = Mock()
+        metadata_type2_class.return_value = metadata_type2_instance
+
+        metadata_to_export = [
+            metadata_type1_class,
+            metadata_type2_class
+        ]
+
+        template_dict = {
+            "Metadata": {
+                "metadata_type1": {
+                    "property_1": "abc"
+                },
+                "metadata_type2": {
+                    "property_2": "def"
+                }
+            }
+        }
+        open_mock = mock.mock_open()
+        yaml_parse_mock.return_value = template_dict
+
+        # Patch the file open method to return template string
+        with patch(
+                "awscli.customizations.cloudformation.artifact_exporter.open",
+                open_mock(read_data=template_str)) as open_mock:
+
+            template_exporter = Template(
+                template_path, parent_dir, self.s3_uploader_mock,
+                metadata_to_export=metadata_to_export)
+            exported_template = template_exporter.export()
+            self.assertEquals(exported_template, template_dict)
+
+            open_mock.assert_called_once_with(
+                    make_abs_path(parent_dir, template_path), "r")
+
+            self.assertEquals(1, yaml_parse_mock.call_count)
+
+            metadata_type1_class.assert_called_once_with(self.s3_uploader_mock)
+            metadata_type1_instance.export.assert_called_once_with(
+                "metadata_type1", mock.ANY, template_dir)
+            metadata_type2_class.assert_called_once_with(self.s3_uploader_mock)
+            metadata_type2_instance.export.assert_called_once_with(
+                "metadata_type2", mock.ANY, template_dir)
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
     def test_template_export(self, yaml_parse_mock):


### PR DESCRIPTION
AWS Serverless Application Repository introduced a new Metadata section called
"AWS::ServerlessRepo::Application". The metadata contains ReadmeUrl and LicenseUrl
which can point to local files. The aws cloudformation package command will now
support packaging local readme and license files.