### PR TITLE
Add adaptive timeout to 'ecs deploy' command

### DIFF
--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -126,8 +126,9 @@ class ECSDeploy(BasicCommand):
             region_name=parsed_globals.region,
             verify=parsed_globals.verify_ssl)
 
-        self.wait_time = \
-            self._validate_code_deploy_resources(codedeploy_client)
+        self._validate_code_deploy_resources(codedeploy_client)
+        
+        self.wait_time = self._cd_validator.get_deployment_wait_time()
 
         self.task_def_arn = self._register_task_def(
             register_task_def_kwargs, ecs_client_wrapper)
@@ -204,7 +205,7 @@ class ECSDeploy(BasicCommand):
         validator = CodeDeployValidator(client, self.resources)
         validator.describe_cd_resources()
         validator.validate_all()
-        return validator.get_deployment_wait_time()
+        self._cd_validator = validator
 
 
 class CodeDeployer():

--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -22,6 +22,10 @@ from awscli.compat import compat_open
 from awscli.customizations.ecs import exceptions, filehelpers
 from awscli.customizations.commands import BasicCommand
 
+TIMEOUT_BUFFER_MIN = 10
+DEFAULT_DELAY_SEC = 15
+MAX_WAIT_MIN = 360  # 6 hours
+
 
 class ECSDeploy(BasicCommand):
     NAME = 'deploy'
@@ -33,7 +37,9 @@ class ECSDeploy(BasicCommand):
         "CodeDeploy appspec with the new task definition revision, create a "
         "CodeDeploy deployment, and wait for the deployment to successfully "
         "complete. This command will exit with a return code of 255 if the "
-        "deployment does not succeed within 30 minutes."
+        "deployment does not succeed within 30 minutes by default or "
+        "up to 10 minutes more than your deployment group's configured wait "
+        "time (max of 6 hours)."
     )
 
     ARG_TABLE = [
@@ -100,8 +106,6 @@ class ECSDeploy(BasicCommand):
 
     MSG_CREATED_DEPLOYMENT = "Successfully created deployment {id}\n"
 
-    MSG_WAITING = "Waiting for {deployment_id} to succeed...\n"
-
     MSG_SUCCESS = ("Successfully deployed {task_def} to "
                    "service '{service}'\n")
 
@@ -122,7 +126,8 @@ class ECSDeploy(BasicCommand):
             region_name=parsed_globals.region,
             verify=parsed_globals.verify_ssl)
 
-        self._validate_code_deploy_resources(codedeploy_client)
+        self.wait_time = \
+            self._validate_code_deploy_resources(codedeploy_client)
 
         self.task_def_arn = self._register_task_def(
             register_task_def_kwargs, ecs_client_wrapper)
@@ -138,11 +143,8 @@ class ECSDeploy(BasicCommand):
 
         sys.stdout.write(self.MSG_CREATED_DEPLOYMENT.format(
             id=deployment_id))
-        sys.stdout.write(
-            self.MSG_WAITING.format(deployment_id=deployment_id))
-        sys.stdout.flush()
 
-        deployer.wait_for_deploy_success(deployment_id)
+        deployer.wait_for_deploy_success(deployment_id, self.wait_time)
         service_name = self.resources['service']
 
         sys.stdout.write(
@@ -202,9 +204,16 @@ class ECSDeploy(BasicCommand):
         validator = CodeDeployValidator(client, self.resources)
         validator.describe_cd_resources()
         validator.validate_all()
+        return validator.get_deployment_wait_time()
 
 
 class CodeDeployer():
+
+    MSG_WAITING = ("Waiting for {deployment_id} to "
+                   "succeed{custom_wait_msg}...\n")
+
+    MSG_CUSTOM_WAIT = " (will timeout after {wait} minutes)"
+
     def __init__(self, cd_client, appspec_dict):
         self._client = cd_client
         self._appspec_dict = appspec_dict
@@ -282,9 +291,30 @@ class CodeDeployer():
         appspec_obj[resources_key] = updated_resources
         self._appspec_dict = appspec_obj
 
-    def wait_for_deploy_success(self, id):
+    def wait_for_deploy_success(self, id, wait_min):
         waiter = self._client.get_waiter("deployment_successful")
-        waiter.wait(deploymentId=id)
+        wait_msg = ""
+
+        if wait_min <= 30 or wait_min > MAX_WAIT_MIN:
+            self._show_deploy_wait_msg(id, wait_msg)
+            waiter.wait(deploymentId=id)
+        else:
+            wait_msg = self.MSG_CUSTOM_WAIT.format(wait=wait_min)
+            delay_sec = DEFAULT_DELAY_SEC
+            max_attempts = (wait_min * 60)/delay_sec
+            config = {
+                'Delay': delay_sec,
+                'MaxAttempts': max_attempts
+            }
+
+            self._show_deploy_wait_msg(id, wait_msg)
+            waiter.wait(deploymentId=id, WaiterConfig=config)
+
+    def _show_deploy_wait_msg(self, id, wait_msg):
+        sys.stdout.write(
+            self.MSG_WAITING.format(deployment_id=id,
+                                    custom_wait_msg=wait_msg))
+        sys.stdout.flush()
 
 
 class CodeDeployValidator():
@@ -308,6 +338,26 @@ class CodeDeployValidator():
         except ClientError as e:
             raise exceptions.ServiceClientError(
                 action='describe Code Deploy deployment group', error=e)
+
+    def get_deployment_wait_time(self):
+
+        if (not hasattr(self, 'deployment_group_details') or
+                self.deployment_group_details is None):
+            return 0
+        else:
+            dgp_info = self.deployment_group_details['deploymentGroupInfo']
+            blue_green_info = dgp_info['blueGreenDeploymentConfiguration']
+
+            deploy_ready_wait_min = \
+                blue_green_info['deploymentReadyOption']['waitTimeInMinutes']
+
+            terminate_key = 'terminateBlueInstancesOnDeploymentSuccess'
+            termination_wait_min = \
+                blue_green_info[terminate_key]['terminationWaitTimeInMinutes']
+
+            configured_wait = deploy_ready_wait_min + termination_wait_min
+
+            return configured_wait + TIMEOUT_BUFFER_MIN
 
     def validate_all(self):
         self.validate_application()

--- a/tests/functional/ecs/test_deploy.py
+++ b/tests/functional/ecs/test_deploy.py
@@ -14,7 +14,9 @@
 import json
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
-from awscli.customizations.ecs.deploy import CodeDeployer, TIMEOUT_BUFFER_MIN
+from awscli.customizations.ecs.deploy import (CodeDeployer,
+                                              MAX_WAIT_MIN,
+                                              TIMEOUT_BUFFER_MIN)
 from awscli.customizations.ecs.filehelpers import (get_app_name,
                                                    get_deploy_group_name)
 
@@ -117,7 +119,8 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                                 "Successfully created deployment " +
                                 self.deployment_id + "\n"
                                 "Waiting for " + self.deployment_id +
-                                " to succeed...\nSuccessfully deployed "
+                                " to succeed (will wait up to 30 minutes)..."
+                                "\nSuccessfully deployed "
                                 + self.task_definition_arn + " to service '"
                                 + self.service_name + "'\n")
 
@@ -257,6 +260,66 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                            self.deployment_id + "\n"
                            "Waiting for " + self.deployment_id +
                            " to succeed (will wait up to " + custom_timeout
+                           + " minutes)...\nSuccessfully deployed "
+                           + self.task_definition_arn + " to service '"
+                           + self.service_name + "'\n")
+
+        stdout, _, _ = self.assert_params_list_for_cmd(
+            cmdline, expected_params, None)
+
+        self.assertEqual(stdout, expected_stdout)
+
+    def test_deploy_with_max_timeout(self):
+        cmdline = self.PREFIX
+        cmdline += '--service ' + self.service_name
+        cmdline += ' --task-definition ' + self.task_def_file
+        cmdline += ' --codedeploy-appspec ' + self.appspec_file
+
+        expected_create_deployment_params = \
+            self.mock_deployer._get_create_deploy_request(
+                self.application_name, self.deployment_group_name)
+
+        custom_deployment_grp_response = {
+            'deploymentGroupInfo': {
+                'applicationName': self.application_name,
+                'deploymentGroupName': self.deployment_group_name,
+                'computePlatform': 'ECS',
+                'blueGreenDeploymentConfiguration': {
+                    'deploymentReadyOption': {
+                        'waitTimeInMinutes': 90
+                    },
+                    'terminateBlueInstancesOnDeploymentSuccess': {
+                        'terminationWaitTimeInMinutes': 300
+                    }
+                },
+                'ecsServices': [{
+                    'serviceName': self.service_name,
+                    'clusterName': self.cluster_name
+                }]
+            }
+        }
+        max_timeout = str(MAX_WAIT_MIN)
+
+        self.parsed_responses = self._get_parsed_responses(
+                                    self.cluster_name,
+                                    self.application_name,
+                                    self.deployment_group_name)
+
+        self.parsed_responses[2] = custom_deployment_grp_response
+
+        expected_params = self._get_expected_params(
+                                    self.service_name,
+                                    self.cluster_name,
+                                    self.application_name,
+                                    self.deployment_group_name,
+                                    expected_create_deployment_params)
+
+        expected_stdout = ("Successfully registered new ECS task "
+                           "definition " + self.task_definition_arn + "\n"
+                           "Successfully created deployment " +
+                           self.deployment_id + "\n"
+                           "Waiting for " + self.deployment_id +
+                           " to succeed (will wait up to " + max_timeout
                            + " minutes)...\nSuccessfully deployed "
                            + self.task_definition_arn + " to service '"
                            + self.service_name + "'\n")

--- a/tests/functional/ecs/test_deploy.py
+++ b/tests/functional/ecs/test_deploy.py
@@ -14,7 +14,7 @@
 import json
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
-from awscli.customizations.ecs.deploy import CodeDeployer
+from awscli.customizations.ecs.deploy import CodeDeployer, TIMEOUT_BUFFER_MIN
 from awscli.customizations.ecs.filehelpers import (get_app_name,
                                                    get_deploy_group_name)
 
@@ -206,6 +206,66 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
 
         self.assertEqual(stdout, self.expected_stdout)
 
+    def test_deploy_with_custom_timeout(self):
+        cmdline = self.PREFIX
+        cmdline += '--service ' + self.service_name
+        cmdline += ' --task-definition ' + self.task_def_file
+        cmdline += ' --codedeploy-appspec ' + self.appspec_file
+
+        expected_create_deployment_params = \
+            self.mock_deployer._get_create_deploy_request(
+                self.application_name, self.deployment_group_name)
+
+        custom_deployment_grp_response = {
+            'deploymentGroupInfo': {
+                'applicationName': self.application_name,
+                'deploymentGroupName': self.deployment_group_name,
+                'computePlatform': 'ECS',
+                'blueGreenDeploymentConfiguration': {
+                    'deploymentReadyOption': {
+                        'waitTimeInMinutes': 5
+                    },
+                    'terminateBlueInstancesOnDeploymentSuccess': {
+                        'terminationWaitTimeInMinutes': 60
+                    }
+                },
+                'ecsServices': [{
+                    'serviceName': self.service_name,
+                    'clusterName': self.cluster_name
+                }]
+            }
+        }
+        custom_timeout = str(60 + 5 + TIMEOUT_BUFFER_MIN)
+
+        self.parsed_responses = self._get_parsed_responses(
+                                    self.cluster_name,
+                                    self.application_name,
+                                    self.deployment_group_name)
+
+        self.parsed_responses[2] = custom_deployment_grp_response
+
+        expected_params = self._get_expected_params(
+                                    self.service_name,
+                                    self.cluster_name,
+                                    self.application_name,
+                                    self.deployment_group_name,
+                                    expected_create_deployment_params)
+
+        expected_stdout = ("Successfully registered new ECS task "
+                           "definition " + self.task_definition_arn + "\n"
+                           "Successfully created deployment " +
+                           self.deployment_id + "\n"
+                           "Waiting for " + self.deployment_id +
+                           " to succeed (will timeout after " + custom_timeout
+                           + " minutes)...\nSuccessfully deployed "
+                           + self.task_definition_arn + " to service '"
+                           + self.service_name + "'\n")
+
+        stdout, _, _ = self.assert_params_list_for_cmd(
+            cmdline, expected_params, None)
+
+        self.assertEqual(stdout, expected_stdout)
+
     def test_deploy_with_optional_values(self):
         custom_app = 'myOtherApp'
         custom_dgp = 'myOtherDgp'
@@ -262,6 +322,14 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                     'applicationName': self.application_name,
                     'deploymentGroupName': self.deployment_group_name,
                     'computePlatform': 'ECS',
+                    'blueGreenDeploymentConfiguration': {
+                        'deploymentReadyOption': {
+                            'waitTimeInMinutes': 5
+                        },
+                        'terminateBlueInstancesOnDeploymentSuccess': {
+                            'terminationWaitTimeInMinutes': 10
+                        }
+                    },
                     'ecsServices': [{
                         'serviceName': self.service_name,
                         'clusterName': self.cluster_name
@@ -451,6 +519,14 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                     'applicationName': app_name,
                     'deploymentGroupName': dgp_name,
                     'computePlatform': 'ECS',
+                    'blueGreenDeploymentConfiguration': {
+                        'deploymentReadyOption': {
+                            'waitTimeInMinutes': 5
+                        },
+                        'terminateBlueInstancesOnDeploymentSuccess': {
+                            'terminationWaitTimeInMinutes': 10
+                        }
+                    },
                     'ecsServices': [{
                         'serviceName': self.service_name,
                         'clusterName': cluster_name

--- a/tests/functional/ecs/test_deploy.py
+++ b/tests/functional/ecs/test_deploy.py
@@ -256,7 +256,7 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                            "Successfully created deployment " +
                            self.deployment_id + "\n"
                            "Waiting for " + self.deployment_id +
-                           " to succeed (will timeout after " + custom_timeout
+                           " to succeed (will wait up to " + custom_timeout
                            + " minutes)...\nSuccessfully deployed "
                            + self.task_definition_arn + " to service '"
                            + self.service_name + "'\n")

--- a/tests/unit/customizations/ecs/test_codedeployer.py
+++ b/tests/unit/customizations/ecs/test_codedeployer.py
@@ -17,7 +17,7 @@ import mock
 
 from botocore import compat
 from awscli.testutils import capture_output, unittest
-from awscli.customizations.ecs.deploy import CodeDeployer
+from awscli.customizations.ecs.deploy import CodeDeployer, MAX_WAIT_MIN
 from awscli.customizations.ecs.exceptions import MissingPropertyError
 
 
@@ -99,7 +99,7 @@ class TestCodeDeployer(unittest.TestCase):
     def test_wait_for_deploy_success_default_wait(self):
         mock_id = 'd-1234567XX'
         expected_stdout = self.deployer.MSG_WAITING.format(
-            deployment_id=mock_id, custom_wait_msg='')
+            deployment_id=mock_id, wait=30)
 
         with capture_output() as captured:
             self.deployer.wait_for_deploy_success('d-1234567XX', 0)
@@ -108,10 +108,20 @@ class TestCodeDeployer(unittest.TestCase):
     def test_wait_for_deploy_success_custom_wait(self):
         mock_id = 'd-1234567XX'
         mock_wait = 40
-        custom_msg = self.deployer.MSG_CUSTOM_WAIT.format(wait=mock_wait)
 
         expected_stdout = self.deployer.MSG_WAITING.format(
-            deployment_id=mock_id, custom_wait_msg=custom_msg)
+            deployment_id=mock_id, wait=mock_wait)
+
+        with capture_output() as captured:
+            self.deployer.wait_for_deploy_success('d-1234567XX', mock_wait)
+            self.assertEqual(expected_stdout, captured.stdout.getvalue())
+
+    def test_wait_for_deploy_success_max_wait_exceeded(self):
+        mock_id = 'd-1234567XX'
+        mock_wait = MAX_WAIT_MIN + 15
+
+        expected_stdout = self.deployer.MSG_WAITING.format(
+            deployment_id=mock_id, wait=MAX_WAIT_MIN)
 
         with capture_output() as captured:
             self.deployer.wait_for_deploy_success('d-1234567XX', mock_wait)

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -70,7 +70,7 @@ class TestCodeDeployValidator(unittest.TestCase):
     def test_get_deployment_wait_time_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)
         actual_wait = empty_validator.get_deployment_wait_time()
-        self.assertEqual(0, actual_wait)
+        self.assertEqual(None, actual_wait)
 
     def test_validations(self):
         self.validator.validate_application()

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -12,7 +12,8 @@
 # language governing permissions and limitations under the License.
 
 from awscli.testutils import unittest
-from awscli.customizations.ecs.deploy import CodeDeployValidator
+from awscli.customizations.ecs.deploy import (CodeDeployValidator,
+                                              TIMEOUT_BUFFER_MIN)
 from awscli.customizations.ecs.exceptions import (InvalidPlatformError,
                                                   InvalidProperyError)
 
@@ -40,6 +41,14 @@ class TestCodeDeployValidator(unittest.TestCase):
             'applicationName': 'test-application',
             'deploymentGroupName': 'test-deployment-group',
             'computePlatform': 'ECS',
+            'blueGreenDeploymentConfiguration': {
+                'deploymentReadyOption': {
+                    'waitTimeInMinutes': 5
+                },
+                'terminateBlueInstancesOnDeploymentSuccess': {
+                    'terminationWaitTimeInMinutes': 10
+                }
+            },
             'ecsServices': [{
                 'serviceName': 'test-service',
                 'clusterName': 'test-cluster'
@@ -52,6 +61,16 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.validator.app_details = self.TEST_APP_DETAILS
         self.validator.deployment_group_details = \
             self.TEST_DEPLOYMENT_GROUP_DETAILS
+
+    def test_get_deployment_wait_time(self):
+        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
+        actual_wait = self.validator.get_deployment_wait_time()
+        self.assertEqual(expected_wait, actual_wait)
+
+    def test_get_deployment_wait_time_no_dgp(self):
+        empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)
+        actual_wait = empty_validator.get_deployment_wait_time()
+        self.assertEqual(0, actual_wait)
 
     def test_validations(self):
         self.validator.validate_application()


### PR DESCRIPTION
Adjusts the `ecs deploy` command timeout to accommodate deployments with configured "wait" steps [[1](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_DeploymentReadyOption.html#CodeDeploy-Type-DeploymentReadyOption-waitTimeInMinutes)][[2](https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_BlueInstanceTerminationOption.html#CodeDeploy-Type-BlueInstanceTerminationOption-terminationWaitTimeInMinutes)] that add up to more than 30 min (default wait).

New expected timeout is combined "wait" minutes + 10 minute buffer, up to 6 hours. 

## Tests

configured deployment wait less than 30 min (current behavior)
```
$~\aws-cli> aws ecs deploy --service testService --task-definition cd-task-def.json --codedeploy-appspec AppSpec.yml --cluster ecs-demo --codedeploy-deployment-group DpgECS-ecs-demo-testService --region us-east-1
Successfully registered new ECS task definition arn:aws:ecs:us-east-1:##########:task-definition/ecs-demo:137
Successfully created deployment d-TVXJ80###
Waiting for d-TVXJ80### to succeed...
Successfully deployed arn:aws:ecs:us-east-1:##########:task-definition/ecs-demo:137 to service 'testService'
$~>
```

configured deployment wait over 30 min (additional msg re: timeout)
```
$~\aws-cli> aws ecs deploy --service testService --task-definition cd-task-def.json --codedeploy-appspec AppSpec.yml --cluster ecs-demo --codedeploy-deployment-group DpgECS-ecs-demo-testService --region us-east-1
Successfully registered new ECS task definition arn:aws:ecs:us-east-1:#########:task-definition/ecs-demo:136
Successfully created deployment d-7BMEO7###
Waiting for d-7BMEO7### to succeed (will timeout after 45 minutes)...
Successfully deployed arn:aws:ecs:us-east-1:##########:task-definition/ecs-demo:136 to service 'testService'
$~>
```

configured deployment wait over 6 hours (default 30 wait + expected timeout):
```
$~\aws-cli> aws ecs deploy --service testService --task-definition cd-task-def.json --codedeploy-appspec AppSpec.yml --cluster ecs-demo --codedeploy-deployment-group DpgECS-ecs-demo-testService --region us-east-1
Successfully registered new ECS task definition arn:aws:ecs:us-east-1:##########:task-definition/ecs-demo:138
Successfully created deployment d-EHRQ6U###
Waiting for d-EHRQ6U### to succeed...

Waiter DeploymentSuccessful failed: Max attempts exceeded
$~>
```


