### PR TITLE
configure import - to import credentials.csv

### DIFF
--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -22,6 +22,7 @@ from awscli.customizations.configure.set import ConfigureSetCommand
 from awscli.customizations.configure.get import ConfigureGetCommand
 from awscli.customizations.configure.list import ConfigureListCommand
 from awscli.customizations.configure.writer import ConfigFileWriter
+from awscli.customizations.configure.imp import ConfigureImportCommand
 
 from . import mask_value, profile_to_section
 
@@ -70,6 +71,7 @@ class ConfigureCommand(BasicCommand):
         '    Default output format [None]:\n'
     )
     SUBCOMMANDS = [
+        {'name': 'import', 'command_class': ConfigureImportCommand},
         {'name': 'list', 'command_class': ConfigureListCommand},
         {'name': 'get', 'command_class': ConfigureGetCommand},
         {'name': 'set', 'command_class': ConfigureSetCommand},

--- a/awscli/customizations/configure/imp.py
+++ b/awscli/customizations/configure/imp.py
@@ -1,0 +1,63 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import csv
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.configure.writer import ConfigFileWriter
+
+from . import PREDEFINED_SECTION_NAMES, profile_to_section
+
+
+class ConfigureImportCommand(BasicCommand):
+    NAME = 'import'
+    DESCRIPTION = BasicCommand.FROM_FILE('configure', 'import',
+                                         '_description.rst')
+    SYNOPSIS = 'aws configure import profile_name filename'
+    EXAMPLES = BasicCommand.FROM_FILE('configure', 'import', '_examples.rst')
+    ARG_TABLE = [
+        {'name': 'profile_name',
+         'help_text': 'The name of the new profile',
+         'action': 'store',
+         'cli_type_name': 'string', 'positional_arg': True}, 
+        {'name': 'filename',
+         'help_text': 'The name of the csv',
+         'action': 'store',
+         'cli_type_name': 'string', 'positional_arg': True}
+    ]
+    
+    def __init__(self, session, config_writer=None):
+        super(ConfigureImportCommand, self).__init__(session)
+        if config_writer is None:
+            config_writer = ConfigFileWriter()
+        self._config_writer = config_writer
+
+    def _run_main(self, args, parsed_globals):
+        #importing the csv file into a nice hash
+        with open(args.filename,"r") as f:
+            i = csv.reader(f) 
+            keys = next(i)
+            values = next(i)
+            data = dict(zip(keys, values))
+
+        config_filename = os.path.expanduser(
+            self._session.get_config_variable('credentials_file'))
+        
+        profile_name = args.profile_name
+        
+        updated_config = {
+            '__section__' : profile_name,
+            'aws_access_key_id' : data['Access key ID'],
+            'aws_secret_access_key' : data['Secret access key']     
+        }
+        self._config_writer.update_config(updated_config, config_filename)
+        

--- a/awscli/examples/configure/import/_description.rst
+++ b/awscli/examples/configure/import/_description.rst
@@ -1,0 +1,3 @@
+Imports an IAM generated CSV file into the credential file.
+You have to define the profile name for the new import and the
+location of the csv file.

--- a/awscli/examples/configure/import/_examples.rst
+++ b/awscli/examples/configure/import/_examples.rst
@@ -1,0 +1,9 @@
+Given an empty config file, and a credentials.csv downloaded from IAM the following command::
+
+    $ aws configure import test ./credentials.csv
+
+will produce the following ``~/.aws/credentials`` file::
+
+    [test]
+    aws_access_key_id = <access key from csv>
+    aws_secret_access_key = <secret access key from csv>


### PR DESCRIPTION
A little addition to configure commands
With this addtion 'configure import <profile name> <filename>' you can
import IAM generated credentials.csv into the ''~/.aws/credentials''
file.

My very first try to give back to open source. I think we could use a new feature, which can easily import the IAM generated credentials.csv into our local config file.
This is what I got so far, by reverse engineering the "set" and "get" commands from configure.
Please review, and be brutal and honest, I will fix up whatever needed, as I'm super keen to get this addition to my command line.

Thanks a lot in advance!
