### PR TITLE
Support long types for pagination params

### DIFF
--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -255,6 +255,7 @@ class PageArgument(BaseCLIArgument):
     type_map = {
         'string': str,
         'integer': int,
+        'long': int,
     }
 
     def __init__(self, name, documentation, parse_type, serialized_name):


### PR DESCRIPTION
Several tests fail without this due to some of our new paginators.

Specifically `list-fragments` from `kinesis-video-archived-media` has a long typed limit key.