### PR TITLE
Unroll YAML anchors in cloudformation package

### DIFF
--- a/.changes/next-release/enhancment-cloudformation-6120.json
+++ b/.changes/next-release/enhancment-cloudformation-6120.json
@@ -1,0 +1,5 @@
+{
+  "category": "cloudformation", 
+  "type": "enhancment", 
+  "description": "Unroll yaml anchors in cloudformation package."
+}

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -60,7 +60,11 @@ def yaml_dump(dict_to_dump):
     :param dict_to_dump:
     :return:
     """
-    return yaml.safe_dump(dict_to_dump, default_flow_style=False)
+    return yaml.dump(
+        dict_to_dump,
+        default_flow_style=False,
+        Dumper=FlattenAliasDumper,
+    )
 
 
 def yaml_parse(yamlstr):
@@ -74,3 +78,8 @@ def yaml_parse(yamlstr):
         yaml.SafeLoader.add_multi_constructor(
             "!", intrinsics_multi_constructor)
         return yaml.safe_load(yamlstr)
+
+
+class FlattenAliasDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data):
+        return True

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -69,9 +69,10 @@ class TestYaml(unittest.TestCase):
         self.assertEquals(output, output_again)
 
     def test_yaml_getatt(self):
-        # This is an invalid syntax for !GetAtt. But make sure the code does not crash when we encouter this syntax
-        # Let CloudFormation interpret this value at runtime
-        input = """
+        # This is an invalid syntax for !GetAtt. But make sure the code does
+        # not crash when we encounter this syntax. Let CloudFormation
+        # interpret this value at runtime
+        yaml_input = """
         Resource:
             Key: !GetAtt ["a", "b"]
         """
@@ -85,11 +86,37 @@ class TestYaml(unittest.TestCase):
             }
         }
 
-        actual_output = yaml_parse(input)
+        actual_output = yaml_parse(yaml_input)
         self.assertEquals(actual_output, output)
 
     def test_parse_json_with_tabs(self):
         template = '{\n\t"foo": "bar"\n}'
         output = yaml_parse(template)
         self.assertEqual(output, {'foo': 'bar'})
+
+    def test_unroll_yaml_anchors(self):
+        properties = {
+            "Foo": "bar",
+            "Spam": "eggs",
+        }
+        template = {
+            "Resources": {
+                "Resource1": {"Properties": properties},
+                "Resource2": {"Properties": properties}
+            }
+        }
+
+        expected = (
+            'Resources:\n'
+            '  Resource1:\n'
+            '    Properties:\n'
+            '      Foo: bar\n'
+            '      Spam: eggs\n'
+            '  Resource2:\n'
+            '    Properties:\n'
+            '      Foo: bar\n'
+            '      Spam: eggs\n'
+        )
+        actual = yaml_dump(template)
+        self.assertEqual(actual, expected)
 


### PR DESCRIPTION
This updates the YAML dumper for the package command to ignore aliases
/ anchors. For context, YAML lets you do something like:

```yaml
Foo: &anchor
  Bar: Baz
Bin:
  <<: *anchor
  Spam: Eggs
```

Which will result in the `Bin` key being a copy of the `Foo` key, but
with an additional member `Spam`. CloudFormation won't accept
templates that contain these, but they can be useful in the cases
where CloudFormation conditions aren't supported, causing you to have
to duplicate a resource with one or two changes.

With this change users can write their template using anchors and then
call package to resolve them along with anything else package needs to
do.

Inspired by #3825