### PR TITLE
No longer special case Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,22 @@
 language: python
-dist: xenial
 sudo: false
 
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
-  - 3.7
+matrix:
+  include:
+    - python: 2.6
+      dist: trusty
+    - python: 2.7
+      dist: xenial
+    - python: 3.3
+      dist: trusty
+    - python: 3.4
+      dist: xenial
+    - python: 3.5
+      dist: xenial
+    - python: 3.6
+      dist: xenial
+    - python: 3.7
+      dist: xenial
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,15 @@
 language: python
-matrix:
-  include:
-    - python: 2.6
-      dist: trusty
-      sudo: false
-    - python: 2.7
-      dist: trusty
-      sudo: false
-    - python: 3.3
-      dist: trusty
-      sudo: false
-    - python: 3.4
-      dist: trusty
-      sudo: false
-    - python: 3.5
-      dist: trusty
-      sudo: false
-    - python: 3.6
-      dist: trusty
-      sudo: false
-    - python: 3.7
-      dist: xenial
-      sudo: true
+dist: xenial
+sudo: false
+
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then


### PR DESCRIPTION
Now that the Xenial builds of Travis CI are officially supported, it makes sense to run ~all~ most builds on it. Python 3.7 is not supported on Trusty.

Sudo is no longer required to run builds on Xenial, so we can set this globally back to `false` and not have to worry.