### PR TITLE
Ensure classifiers is an array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_options = dict(
         ]
     },
     license="Apache License 2.0",
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
@@ -74,7 +74,7 @@ setup_options = dict(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-    ),
+    ],
 )
 
 if 'py2exe' in sys.argv:


### PR DESCRIPTION
Same fix as in: https://github.com/boto/botocore/pull/1540

This should be an array, defining this as a tuple can cause issues when running `setup.py upload`.