### PR TITLE
[EKS] Add parameter to keep current context when updating kubeconfig

### DIFF
--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -239,7 +239,8 @@ class KubeconfigAppender(object):
             ("name", user["name"])
         ])
 
-    def insert_cluster_user_pair(self, config, cluster, user):
+    def insert_cluster_user_pair(self, config, cluster, user,
+                                 keep_current_context=False):
         """
         Insert the passed cluster entry and user entry,
         then make a context to associate them
@@ -255,6 +256,9 @@ class KubeconfigAppender(object):
         :param user: the user entry
         :type user: OrderedDict
 
+        :param keep_current_context: do not change the current context
+        :type keep_current_context: bool
+
         :return: The generated context
         :rtype: OrderedDict
         """
@@ -263,6 +267,7 @@ class KubeconfigAppender(object):
         self.insert_entry(config, "users", user)
         self.insert_entry(config, "contexts", context)
 
-        config.content["current-context"] = context["name"]
+        if not keep_current_context:
+            config.content["current-context"] = context["name"]
 
         return context

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -104,6 +104,14 @@ class UpdateKubeconfigCommand(BasicCommand):
             'required': False
         },
         {
+            'name': 'keep-current-context',
+            'action': 'store_true',
+            'default': False,
+            'help_text': ("Do not change the current-context when "
+                          "writing kubeconfig file."),
+            'required': False
+        },
+        {
             'name': 'dry-run',
             'action': 'store_true',
             'default': False,
@@ -140,6 +148,7 @@ class UpdateKubeconfigCommand(BasicCommand):
                            parsed_globals)
         new_cluster_dict = client.get_cluster_entry()
         new_user_dict = client.get_user_entry()
+        keep_curr_context = parsed_args.keep_current_context
 
         config_selector = KubeconfigSelector(
             os.environ.get("KUBECONFIG", ""),
@@ -152,7 +161,8 @@ class UpdateKubeconfigCommand(BasicCommand):
         appender = KubeconfigAppender()
         new_context_dict = appender.insert_cluster_user_pair(config,
                                                              new_cluster_dict,
-                                                             new_user_dict)
+                                                             new_user_dict,
+                                                             keep_curr_context)
 
         if parsed_args.dry_run:
             uni_print(config.dump_content())

--- a/awscli/examples/eks/update-kubeconfig/_description.rst
+++ b/awscli/examples/eks/update-kubeconfig/_description.rst
@@ -14,6 +14,6 @@ The resulting kubeconfig is created as a new file or merged with an existing kub
 * Or, if you have the KUBECONFIG environment variable set, then the resulting configuration file is created at the first entry in that variable or merged with an existing kubeconfig at that location. 
 * Otherwise, by default, the resulting configuration file is created at the default kubeconfig path (.kube/config) in your home directory or merged with an existing kubeconfig at that location.
 * If a previous cluster configuration exists for an Amazon EKS cluster with the same name at the specified path, the existing configuration is overwritten with the new configuration.
-* When update-kubeconfig writes a configuration to a kubeconfig file, the current-context of the kubeconfig file is set to that configuration.
+* When update-kubeconfig writes a configuration to a kubeconfig file, the current-context of the kubeconfig file is set to that configuration unless --keep-current-context option is used.
 
 You can use the --dry-run option to print the resulting configuration to stdout instead of writing it to the specified location.

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -274,3 +274,77 @@ class TestKubeconfigAppender(unittest.TestCase):
         ])
         context = self._appender._make_context(cluster, user)
         self.assertDictEqual(context, context_correct)
+
+    def test_update_current_context(self):
+        initial = OrderedDict([
+            ("apiVersion", "v1"),
+            ("clusters", [
+                OrderedDict([
+                    ("cluster", OrderedDict([
+                        ("certificate-authority-data", "data1"),
+                        ("server", "endpoint1")
+                    ])),
+                    ("name", "oldclustername")
+                ])
+            ]),
+            ("contexts", []),
+            ("current-context", "simple"),
+            ("kind", "Config"),
+            ("preferences", OrderedDict()),
+            ("users", [])
+        ])
+        cluster = OrderedDict([
+            ("cluster", OrderedDict([
+                ("certificate-authority-data", "data2"),
+                ("server", "endpoint2")
+            ])),
+            ("name", "clustername")
+        ])
+        user = OrderedDict([
+            ("name", "myusername"),
+            ("user", OrderedDict())
+        ])
+
+        config = Kubeconfig(None, initial)
+        self._appender.insert_cluster_user_pair(config,
+                                                cluster,
+                                                user,
+                                                False)
+        self.assertEqual(config.content["current-context"], "myusername")
+
+    def test_keep_current_context(self):
+        initial = OrderedDict([
+            ("apiVersion", "v1"),
+            ("clusters", [
+                OrderedDict([
+                    ("cluster", OrderedDict([
+                        ("certificate-authority-data", "data1"),
+                        ("server", "endpoint1")
+                    ])),
+                    ("name", "oldclustername")
+                ])
+            ]),
+            ("contexts", []),
+            ("current-context", "simple"),
+            ("kind", "Config"),
+            ("preferences", OrderedDict()),
+            ("users", [])
+        ])
+        cluster = OrderedDict([
+            ("cluster", OrderedDict([
+                ("certificate-authority-data", "data2"),
+                ("server", "endpoint2")
+            ])),
+            ("name", "clustername")
+        ])
+        user = OrderedDict([
+            ("name", "myusername"),
+            ("user", OrderedDict())
+        ])
+
+        config = Kubeconfig(None, initial)
+        self._appender.insert_cluster_user_pair(config,
+                                                cluster,
+                                                user,
+                                                True)
+        self.assertEqual(config.content["current-context"], "simple")


### PR DESCRIPTION
This PR adds a new parameter called `--keep-current-context` to the `eks update-kubeconfig` command allowing the user to choose when an update of the `current-context` is **not** desired.

Please let me know if I'm missing something.