### PR TITLE
Update streaming output customization to use service_id

### DIFF
--- a/awscli/customizations/streamingoutputarg.py
+++ b/awscli/customizations/streamingoutputarg.py
@@ -86,10 +86,10 @@ class StreamingOutputArgument(BaseCLIArgument):
 
     def add_to_params(self, parameters, value):
         self._output_file = value
-        service_name = self._operation_model.service_model.endpoint_prefix
+        service_id = self._operation_model.service_model.service_id.hyphenize()
         operation_name = self._operation_model.name
         self._session.register('after-call.%s.%s' % (
-            service_name, operation_name), self.save_file)
+            service_id, operation_name), self.save_file)
 
     def save_file(self, parsed, **kwargs):
         if self._response_key not in parsed:

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -363,6 +363,7 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         self.operations_called = []
         self.parsed_responses = None
         self.driver = create_clidriver()
+        self.files = FileCreator()
 
     def tearDown(self):
         # This clears all the previous registrations.
@@ -370,6 +371,7 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         if self.make_request_is_patched:
             self.make_request_patch.stop()
             self.make_request_is_patched = False
+        self.files.remove_all()
 
     def before_call(self, params, **kwargs):
         self._store_params(params)
@@ -520,7 +522,8 @@ class FileCreator(object):
         self.rootdir = tempfile.mkdtemp()
 
     def remove_all(self):
-        shutil.rmtree(self.rootdir)
+        if os.path.exists(self.rootdir):
+            shutil.rmtree(self.rootdir)
 
     def create_file(self, filename, contents, mtime=None, mode='w'):
         """Creates a file in a tmpdir

--- a/tests/functional/test_streaming_output.py
+++ b/tests/functional/test_streaming_output.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# Copyright 2012-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.compat import six
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestStreamingOutput(BaseAWSCommandParamsTest):
+
+    def test_get_media_streaming_output(self):
+        cmdline = (
+            'kinesis-video-media get-media --stream-name test-stream '
+            '--start-selector StartSelectorType=EARLIEST %s'
+        )
+        self.parsed_response = {
+            'ContentType': 'video/webm',
+            'Payload': six.BytesIO(b'testbody')
+        }
+        outpath = self.files.full_path('outfile')
+        params = {
+            'StartSelector': {'StartSelectorType': 'EARLIEST'},
+            'StreamName': 'test-stream'
+        }
+        self.assert_params_for_cmd(cmdline % outpath, params)
+        with open(outpath, 'rb') as outfile:
+            self.assertEqual(outfile.read(), b'testbody')


### PR DESCRIPTION
This updates the streaming output customization to register using `service_id` instead of the `endpoint_prefix` and relying on the aliasing in `botocore`.