### PR TITLE
chore: Use OrderedDict in yamlhelper to preserve template elements order

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -83,6 +83,8 @@ def yaml_dump(dict_to_dump):
 
 
 def _dict_constructor(loader, node):
+    # Necessary in order to make yaml merge tags work
+    loader.flatten_mapping(node)
     return OrderedDict(loader.construct_pairs(node))
 
 

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -10,12 +10,15 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import json
 import sys
 
+# OrderedDict was introduced in Python 2.7, if we're in 2.6 import
+# from the ordereddict library, and use simplejson to get object_pairs_hook.
 if sys.version_info[:2] == (2, 6):
+    import simplejson as json
     from ordereddict import OrderedDict
 else:
+    import json
     from collections import OrderedDict
 
 import yaml

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -11,6 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
+import sys
+
+if sys.version_info[:2] == (2, 6):
+    from ordereddict import OrderedDict
+else:
+    from collections import OrderedDict
+
 import yaml
 from yaml.resolver import ScalarNode, SequenceNode
 
@@ -54,17 +61,26 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
     return {cfntag: value}
 
 
+def _dict_representer(dumper, data):
+    return dumper.represent_dict(data.items())
+
+
 def yaml_dump(dict_to_dump):
     """
     Dumps the dictionary as a YAML document
     :param dict_to_dump:
     :return:
     """
+    FlattenAliasDumper.add_representer(OrderedDict, _dict_representer)
     return yaml.dump(
         dict_to_dump,
         default_flow_style=False,
         Dumper=FlattenAliasDumper,
     )
+
+
+def _dict_constructor(loader, node):
+    return OrderedDict(loader.construct_pairs(node))
 
 
 def yaml_parse(yamlstr):
@@ -73,8 +89,9 @@ def yaml_parse(yamlstr):
         # PyYAML doesn't support json as well as it should, so if the input
         # is actually just json it is better to parse it with the standard
         # json parser.
-        return json.loads(yamlstr)
+        return json.loads(yamlstr, object_pairs_hook=OrderedDict)
     except ValueError:
+        yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor)
         yaml.SafeLoader.add_multi_constructor(
             "!", intrinsics_multi_constructor)
         return yaml.safe_load(yamlstr)

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -10,16 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import sys
-
-# OrderedDict was introduced in Python 2.7, if we're in 2.6 import
-# from the ordereddict library, and use simplejson to get object_pairs_hook.
-if sys.version_info[:2] == (2, 6):
-    import simplejson as json
-    from ordereddict import OrderedDict
-else:
-    import json
-    from collections import OrderedDict
+from botocore.compat import json
+from botocore.compat import OrderedDict
 
 import yaml
 from yaml.resolver import ScalarNode, SequenceNode

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,1 +1,2 @@
 unittest2==0.8.0
+ordereddict==1.1

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,2 +1,3 @@
 unittest2==0.8.0
-ordereddict==1.1
+ordereddict==1.1.0
+simplejson>=3.10.0

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,3 +1,1 @@
 unittest2==0.8.0
-ordereddict==1.1.0
-simplejson>=3.10.0

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -12,16 +12,10 @@
 # language governing permissions and limitations under the License.
 import mock
 import tempfile
-import re
-import sys
 from mock import patch, Mock, MagicMock
 
-# OrderedDict was introduced in Python 2.7, if we're in 2.6 import
-# from the ordereddict library.
-if sys.version_info[:2] == (2, 6):
-    from ordereddict import OrderedDict
-else:
-    from collections import OrderedDict
+from botocore.compat import json
+from botocore.compat import OrderedDict
 
 from awscli.testutils import unittest
 from awscli.customizations.cloudformation.deployer import Deployer
@@ -132,18 +126,18 @@ class TestYaml(unittest.TestCase):
         self.assertEqual(expected_dict, output_dict)
 
     def test_parse_yaml_preserve_elements_order(self):
-        input_template = """
-        B_Resource:
-            Key2:
-                Name: name2
-            Key1:
-                Name: name1
-        A_Resource:
-            Key2:
-                Name: name2
-            Key1:
-                Name: name1
-        """
+        input_template = (
+        'B_Resource:\n'
+        '  Key2:\n'
+        '    Name: name2\n'
+        '  Key1:\n'
+        '    Name: name1\n'
+        'A_Resource:\n'
+        '  Key2:\n'
+        '    Name: name2\n'
+        '  Key1:\n'
+        '    Name: name1\n'
+        )
         output_dict = yaml_parse(input_template)
         expected_dict = OrderedDict([
             ('B_Resource', OrderedDict([('Key2', {'Name': 'name2'}), ('Key1', {'Name': 'name1'})])),
@@ -152,9 +146,7 @@ class TestYaml(unittest.TestCase):
         self.assertEqual(expected_dict, output_dict)
 
         output_template = yaml_dump(output_dict)
-        # yaml dump changes indentation, remove spaces and new line characters to just compare the text
-        self.assertEqual(re.sub(r'\n|\s', '', input_template),
-                         re.sub(r'\n|\s', '', output_template))
+        self.assertEqual(input_template, output_template)
 
     def test_yaml_merge_tag(self):
         test_yaml = """

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -156,6 +156,17 @@ class TestYaml(unittest.TestCase):
         self.assertEqual(re.sub(r'\n|\s', '', input_template),
                          re.sub(r'\n|\s', '', output_template))
 
+    def test_yaml_merge_tag(self):
+        test_yaml = """
+        base: &base
+            property: value
+        test:
+            <<: *base
+        """
+        output = yaml_parse(test_yaml)
+        self.assertTrue(isinstance(output, OrderedDict))
+        self.assertEqual(output.get('test').get('property'), 'value')
+
     def test_unroll_yaml_anchors(self):
         properties = {
             "Foo": "bar",

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -13,8 +13,15 @@
 import mock
 import tempfile
 import re
-from collections import OrderedDict
+import sys
 from mock import patch, Mock, MagicMock
+
+# OrderedDict was introduced in Python 2.7, if we're in 2.6 import
+# from the ordereddict library.
+if sys.version_info[:2] == (2, 6):
+    from ordereddict import OrderedDict
+else:
+    from collections import OrderedDict
 
 from awscli.testutils import unittest
 from awscli.customizations.cloudformation.deployer import Deployer


### PR DESCRIPTION
**Description of changes:**
Currently elements in cloudformation templates are scrambled after parsing and dumping, use OrderedDict to preserve elements order.

Note: 
Original PR: https://github.com/aws/aws-cli/pull/3841
Wasn't able to update the original PR as I don't have permissions. Since the submitter of that PR is away on vacation, and we want to get this addressed as soon as possible, I am creating a new PR with the changes pulled in from the original PR. Comments have been addressed. 

