### PR TITLE
Make sms-voice doc hiding use get instead of directly index

### DIFF
--- a/awscli/customizations/sms_voice.py
+++ b/awscli/customizations/sms_voice.py
@@ -18,4 +18,6 @@ def register_sms_voice_hide(event_emitter):
 
 
 def hide_sms_voice(command_table, session, **kwargs):
-    command_table['sms-voice']._UNDOCUMENTED = True
+    cmd = command_table.get('sms-voice')
+    if cmd is not None:
+        cmd._UNDOCUMENTED = True


### PR DESCRIPTION
Prevent failure if people have installed an incorrect version of botocore.