### PR TITLE
Get functional tests passing on windows

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -363,7 +363,6 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         self.operations_called = []
         self.parsed_responses = None
         self.driver = create_clidriver()
-        self.files = FileCreator()
 
     def tearDown(self):
         # This clears all the previous registrations.
@@ -371,7 +370,6 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         if self.make_request_is_patched:
             self.make_request_patch.stop()
             self.make_request_is_patched = False
-        self.files.remove_all()
 
     def before_call(self, params, **kwargs):
         self._store_params(params)

--- a/tests/functional/test_streaming_output.py
+++ b/tests/functional/test_streaming_output.py
@@ -13,9 +13,18 @@
 # language governing permissions and limitations under the License.
 from awscli.compat import six
 from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import FileCreator
 
 
 class TestStreamingOutput(BaseAWSCommandParamsTest):
+
+    def setUp(self):
+        super(TestStreamingOutput, self).setUp()
+        self.files = FileCreator()
+
+    def tearDown(self):
+        super(TestStreamingOutput, self).tearDown()
+        self.files.remove_all()
 
     def test_get_media_streaming_output(self):
         cmdline = (


### PR DESCRIPTION
The streaming tests added a .files property to the base Params test
class that is used by many other test cases. The history recorder tests
in particular needed control of how the files were then cleaned up to
prevent file connections from preventing their deletion on
windows. Since the cleanup was added to the base class as well this was
now happening in the superclass before all the connections to the file
had been correctly closed in the subclass's tearDown method.

The fix was just to move the files property down to the specific test
subclass that needed it. All the subclasses of this do not need it and
we probably shouldn't modify a heavily used base class for functionality
needed by a very small set of subclasses.