### PR TITLE
Add a note on git commits and workflow

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -83,6 +83,45 @@ Also, ensure your commit messages match this format::
     to 80 characters or less.
 
 
+Example Git Workflow
+~~~~~~~~~~~~~~~~~~~~
+
+Below is an example of how you can use git to create a feature branch.
+First, make sure you've created a fork of ``aws/aws-cli``.  Then you
+can run these commands::
+
+
+    # Clone the repo and set up the remotes.
+
+    $ git clone git@github.com:myusername/aws-cli.git
+    $ cd aws-cli
+    $ git remote add upstream https://github.com/aws/aws-cli.git
+    $ git fetch upstream
+    $ git merge upstream/develop
+
+    # Now to create a feature branch:
+    $ git checkout -b my-branch-name
+
+    # Now add your commits for your features.
+    $ git add path/to/my/files
+
+    # Make sure our commit message matches format described in the
+    # previous section.
+    $ git commit -m "Add support for foo"
+
+    # If we want to sync with the latest upstream changes before
+    # sending our pull request we can run:
+    $ git fetch upstream
+    $ git rebase upstream/develop
+
+    # When you're ready to send a PR, make sure you push your commits
+    # to your fork:
+    $ git push origin my-branch-name
+
+When you push to your remote, the output will contain a URL you
+can use to open a pull request.
+
+
 Reporting Issues
 ----------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,6 +38,51 @@ contributions as well:
   `issue <https://github.com/aws/aws-cli/issues>`__
   to discuss the feature request further.
 
+
+Git Commits and Workflow
+------------------------
+
+When sending a pull request, please follow these guidelines:
+
+* The PR should target the ``develop`` branch.  If you send a PR to the
+  ``master`` branch, the travis CI jobs will fail.
+* Your PR branch should be based off a recent commit of the ``develop`` branch.
+  Preferably the base commit for the PR should use the latest commit of
+  ``develop`` at the time the PR was created.  This helps to ensure there are
+  no merge conflicts or test failures when the PR is merged back to the develop
+  branch.
+* Make separate commits for logically separate changes.  Avoid commits such as
+  "update", "fix typo again", "more updates".  Rebase your commits before
+  submitting your PR to ensure they represent a logical change.
+* Avoid merge commits in your PRs.  If you want to pull in the latest changes
+  from the ``develop`` branch, rebase on top of the ``develop`` branch instead
+  of merging the ``develop`` branch into your feature branch.
+
+Also, ensure your commit messages match this format::
+
+    Short (50 chars or less) summary
+
+    After the 50 char summary and a blank line, you can
+    include a body if necessary.  Note that the
+    50 char summary does not end with any punctuation.
+    Describe your changes in the imperative mood, e.g.
+    "Add foo to bar", "Update foo component for bar",
+    "Fix race condition for foo".
+    
+    The body of the commit message can include:
+
+    * an explanation of the problem and what this change
+    tries to solve.
+
+    * rationale behind the specific implementation
+
+    * alternatives considered and why they were discarded,
+    if appropriate.
+
+    Please limit the line length in the body of a commit message
+    to 80 characters or less.
+
+
 Reporting Issues
 ----------------
 


### PR DESCRIPTION
This is already the standard we follow, but I think it helps
to have it in our contributing guide.