### PR TITLE
Updated docs to add --user-attributes to example command

### DIFF
--- a/awscli/examples/cognito-idp/admin-update-user-attributes.rst
+++ b/awscli/examples/cognito-idp/admin-update-user-attributes.rst
@@ -4,5 +4,5 @@ This example updates a custom user attribute CustomAttr1 for user diego@example.
 
 Command::
 
-  aws cognito-idp admin-update-user-attributes --user-pool-id us-west-2_aaaaaaaaa --username diego@example.com  Name="custom:CustomAttr1",Value="Purple"
+  aws cognito-idp admin-update-user-attributes --user-pool-id us-west-2_aaaaaaaaa --username diego@example.com  --user-attributes Name="custom:CustomAttr1",Value="Purple"
 


### PR DESCRIPTION
Added --user-attributes as required by awscli to example.

`aws: error: argument --user-attributes is required
`
