### PR TITLE
Remote Etag sync strategy

### DIFF
--- a/awscli/customizations/s3/syncstrategy/register.py
+++ b/awscli/customizations/s3/syncstrategy/register.py
@@ -13,6 +13,7 @@
 from awscli.customizations.s3.syncstrategy.sizeonly import SizeOnlySync
 from awscli.customizations.s3.syncstrategy.exacttimestamps import \
     ExactTimestampsSync
+from awscli.customizations.s3.syncstrategy.remoteetag import RemoteEtagSync
 from awscli.customizations.s3.syncstrategy.delete import DeleteSync
 
 
@@ -42,6 +43,9 @@ def register_sync_strategies(command_table, session, **kwargs):
 
     # Register the exact timestamps sync strategy.
     register_sync_strategy(session, ExactTimestampsSync)
+
+    # Register the remote etag sync strategy.
+    register_sync_strategy(session, RemoteEtagSync)
 
     # Register the delete sync strategy.
     register_sync_strategy(session, DeleteSync, 'file_not_at_src')

--- a/awscli/customizations/s3/syncstrategy/remoteetag.py
+++ b/awscli/customizations/s3/syncstrategy/remoteetag.py
@@ -1,0 +1,53 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+
+from awscli.customizations.s3.syncstrategy.base import BaseSync
+
+
+LOG = logging.getLogger(__name__)
+
+REMOTE_ETAG = {
+    'name': 'remote-etag',
+    'action': 'store_true',
+    'help_text': ('Compare remote ETags to decide whether to sync from source to destination.')
+}
+
+
+class RemoteEtagSync(BaseSync):
+
+    ARGUMENT = REMOTE_ETAG
+
+    def determine_should_sync(self, src_file, dest_file):
+        src_etag = '""'
+        if src_file and src_file.response_data:
+            src_etag = src_file.response_data.get('ETag', '""').lower()
+
+        dest_etag = '""'
+        if dest_file and dest_file.response_data:
+            dest_etag = dest_file.response_data.get('ETag', '""').lower()
+
+        should_sync = False
+
+        cmd = src_file.operation_name
+        if cmd == 'copy':
+            should_sync = not (src_etag == dest_etag)
+
+        if should_sync:
+            LOG.debug(
+                "syncing: %s -> %s, etag: %s -> %s",
+                src_file.src, src_file.dest,
+                src_etag, dest_etag)
+
+        return should_sync
+

--- a/tests/unit/customizations/s3/syncstrategy/test_remoteetag.py
+++ b/tests/unit/customizations/s3/syncstrategy/test_remoteetag.py
@@ -1,0 +1,67 @@
+# Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import datetime
+
+from awscli.customizations.s3.filegenerator import FileStat
+from awscli.customizations.s3.syncstrategy.remoteetag import RemoteEtagSync
+
+from awscli.testutils import unittest
+
+
+class TestRemoteEtagSync(unittest.TestCase):
+    def setUp(self):
+        self.sync_strategy = RemoteEtagSync()
+
+    def test_compare_remote_etag_different(self):
+        """
+        Confirm that files are synced when remote etag differs.
+        """
+        response_data_src = { u'ETag': '"AnEtag"' }
+        response_data_dst = { u'ETag': '"AnotherEtag"' }
+
+        src_file = FileStat(src='', dest='',
+                            compare_key='test.py', src_type='s3',
+                            dest_type='s3', operation_name='copy',
+                            response_data=response_data_src)
+
+        dst_file = FileStat(src='', dest='',
+                            compare_key='test.py', src_type='s3',
+                            dest_type='s3', operation_name='',
+                            response_data=response_data_dst)
+
+        should_sync = self.sync_strategy.determine_should_sync(src_file, dst_file)
+        self.assertTrue(should_sync)
+
+    def test_compare_remote_etag_same(self):
+        """
+        Confirm that files are not synced when remote etags are the same.
+        """
+        response_data_src = { u'ETag': '"AnEtag"' }
+        response_data_dst = { u'ETag': '"AnEtag"' }
+
+        src_file = FileStat(src='', dest='',
+                            compare_key='test.py', src_type='s3',
+                            dest_type='s3', operation_name='copy',
+                            response_data=response_data_src)
+
+        dst_file = FileStat(src='', dest='',
+                            compare_key='test.py', src_type='s3',
+                            dest_type='s3', operation_name='',
+                            response_data=response_data_src)
+
+        should_sync = self.sync_strategy.determine_should_sync(src_file, dst_file)
+        self.assertFalse(should_sync)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Remote-to-remote syncs fail to copy if the source and destination files have the same byte size and if the destination file has a more recently modified date.  This patch fixes that with a new sync strategy and command line switch, --remote-etag, that will compare the ETag values of remote files and trigger a sync if they are different.

It will not matter with remote-to-local or local-to-remote syncs.