### PR TITLE
New examples for SSM commands

### DIFF
--- a/awscli/examples/ssm/cancel-maintenance-window-execution.rst
+++ b/awscli/examples/ssm/cancel-maintenance-window-execution.rst
@@ -1,0 +1,13 @@
+**To cancel a Maintenance Window execution**
+
+This example stops a Maintenance Window execution that is already in progress.
+
+Command::
+
+  aws ssm cancel-maintenance-window-execution --window-execution-id j2l8d5b5c-mw66-tk4d-r3g9-1d4d1EXAMPLE
+
+Output::
+
+  {
+    "WindowExecutionId": "j2l8d5b5c-mw66-tk4d-r3g9-1d4d1EXAMPLE"
+  }

--- a/awscli/examples/ssm/create-activation.rst
+++ b/awscli/examples/ssm/create-activation.rst
@@ -12,3 +12,18 @@ Output::
     "ActivationCode": "Zqr175DJ+sPQRHsmbzzf",
     "ActivationId": "5b9e0074-65d3-4587-8620-3e0b0938db9e"
   }
+
+**To create an activation with an expiration date**
+
+This example creates an Activation code for a managed instance that expires on a specific date.
+
+Command::
+
+  aws ssm create-activation --default-instance-name "MyWebServers" --iam-role "service-role/AmazonEC2RunCommandRoleForManagedInstances" --registration-limit 10 --expiration-date 2019-02-13T19:00:00Z
+
+Output::
+
+{
+    "ActivationCode": "i90uMgyDzjCX/EXAMPLE",
+    "ActivationId": "cf3cb0a5-c6fb-41fc-96a6-d4096EXAMPLE"
+}

--- a/awscli/examples/ssm/create-association.rst
+++ b/awscli/examples/ssm/create-association.rst
@@ -43,4 +43,11 @@ This example associates a configuration document with an instance, using targets
 Command::
 
   aws ssm create-association --name "AWS-UpdateSSMAgent" --targets "Key=instanceids,Values=i-0cb2b964d3e14fd9f"
-  
+
+**To associate a document using tags**
+
+This example associates a configuration document with an instance, using tag based targeting.  The Association executes Tuesdays at 16:00 UTC.
+
+Command::
+
+  aws ssm create-association --name "AWS-UpdateSSMAgent" --targets "Key=tag:Environment,Values=Prod"  --schedule-expression "cron(0 16 ? * TUE *)"

--- a/awscli/examples/ssm/create-document.rst
+++ b/awscli/examples/ssm/create-document.rst
@@ -1,8 +1,8 @@
 **To create a document**
 
-This example creates a document in your account. The document must be in JSON format. Note that ``file://`` must be referenced followed by the path of the content file. For more information about writing a configuration document, see `Configuration Document`_ in the *SSM API Reference*.
+This example creates a document in your account using the JSON format. Note that ``file://`` must be referenced followed by the path of the content file. For more information about writing a Systems Manager document, see `Creating Systems Manager Documents`_ in the *AWS Systems Manager User Guide*.
 
-.. _`Configuration Document`: http://docs.aws.amazon.com/ssm/latest/APIReference/aws-ssm-document.html
+.. _`Creating Systems Manager Documents`: https://docs.aws.amazon.com/systems-manager/latest/userguide/create-ssm-doc.html
 
 Command::
 
@@ -36,3 +36,11 @@ Output::
         "Description": "Run a script"
     }
   }
+
+**To create a document using the YAML document format**
+
+This example creates a document in your account using the YAML format which targets the EC2 instance type. Note that ``file://`` must be referenced followed by the path of the content file.
+
+Command::
+
+  aws ssm create-document --content file://RunShellScript.yaml --name "RunShellScript" --document-type "Command" --document-format YAML --target-type "/AWS::EC2::Instance"

--- a/awscli/examples/ssm/create-maintenance-window.rst
+++ b/awscli/examples/ssm/create-maintenance-window.rst
@@ -1,10 +1,24 @@
-**To create a maintenance window**
+**To create a Maintenance Window**
 
-This example creates a new maintenance window with the specified name that runs at 4 PM on every Tuesday for 4 hours, with a 1 hour cutoff, and that allows unassociated targets.
+This example creates a new Maintenance Window with the specified name that runs at 4 PM UTC on every Tuesday for 4 hours, with a 1 hour cutoff, and that allows unassociated targets.
 
 Command::
 
   aws ssm create-maintenance-window --name "My-First-Maintenance-Window" --schedule "cron(0 16 ? * TUE *)" --duration 4 --cutoff 1 --allow-unassociated-targets
+
+Output::
+
+  {
+	"WindowId": "mw-ab12cd34ef56gh78"
+  }
+
+**To create a Maintenance Window with a specific start and end date**
+
+This example creates a new Maintenance Window with the specified name that runs at 4 PM UTC on every Tuesday for 4 hours, with a 1 hour cutoff, and that allows unassociated targets.  The Maintenance Window created will not become active until the specified start date and becomes inactive at the specified end date.
+
+Command::
+
+  aws ssm create-maintenance-window --name "My-First-Maintenance-Window" --start-date 2019-03-13T19:00:00Z --end-date 2019-03-23T19:00:00Z --duration 4 --cutoff 1 --allow-unassociated-targets --schedule "cron(0 16 ? * TUE *)"
 
 Output::
 

--- a/awscli/examples/ssm/delete-maintenance-window.rst
+++ b/awscli/examples/ssm/delete-maintenance-window.rst
@@ -1,6 +1,6 @@
-**To delete a maintenance window**
+**To delete a Maintenance Window**
 
-This example removes a maintenance window.
+This example removes a Maintenance Window.
 
 Command::
 

--- a/awscli/examples/ssm/deregister-target-from-maintenance-window.rst
+++ b/awscli/examples/ssm/deregister-target-from-maintenance-window.rst
@@ -1,6 +1,6 @@
-**To remove a target from a maintenance window**
+**To remove a target from a Maintenance Window**
 
-This example removes a target from a maintenance window.
+This example removes a target from a Maintenance Window.
 
 Command::
 

--- a/awscli/examples/ssm/deregister-task-from-maintenance-window.rst
+++ b/awscli/examples/ssm/deregister-task-from-maintenance-window.rst
@@ -1,6 +1,6 @@
-**To remove a task from a maintenance window**
+**To remove a task from a Maintenance Window**
 
-This example removes a task from a maintenance window.
+This example removes a task from a Maintenance Window.
 
 Command::
 

--- a/awscli/examples/ssm/describe-maintenance-window-execution-task-invocations.rst
+++ b/awscli/examples/ssm/describe-maintenance-window-execution-task-invocations.rst
@@ -1,6 +1,6 @@
 **To get the specific task invocations performed for a task execution**
 
-This example lists the invocations for a task executed as part of a maintenance window execution.
+This example lists the invocations for a task executed as part of a Maintenance Window execution.
 
 Command::
 

--- a/awscli/examples/ssm/describe-maintenance-window-execution-tasks.rst
+++ b/awscli/examples/ssm/describe-maintenance-window-execution-tasks.rst
@@ -1,6 +1,6 @@
 **To list all tasks associated with a Maintenance Window Execution**
 
-This example lists the tasks associated with a maintenance window execution.
+This example lists the tasks associated with a Maintenance Window execution.
 
 Command::
 

--- a/awscli/examples/ssm/describe-maintenance-window-executions.rst
+++ b/awscli/examples/ssm/describe-maintenance-window-executions.rst
@@ -1,6 +1,6 @@
 **To list all executions for a Maintenance Window**
 
-This example lists all of the executions for a maintenance window.
+This example lists all of the executions for a Maintenance Window.
 
 Command::
 
@@ -20,17 +20,17 @@ Output::
     ]
   }
 
-**To list all executions for a maintenance window before a specified date**
+**To list all executions for a Maintenance Window before a specified date**
 
-This example lists all of the executions for a maintenance window before a specific date.
+This example lists all of the executions for a Maintenance Window before a specific date.
 
 Command::
 
   aws ssm describe-maintenance-window-executions --window-id "mw-ab12cd34ef56gh78" --filters "Key=ExecutedBefore,Values=2016-11-04T05:00:00Z"
   
-**To list all executions for a maintenance window after a specified date**
+**To list all executions for a Maintenance Window after a specified date**
 
-This example lists all of the executions for maintenance window after a specific date.
+This example lists all of the executions for Maintenance Window after a specific date.
 
 Command::
 

--- a/awscli/examples/ssm/describe-maintenance-window-schedule.rst
+++ b/awscli/examples/ssm/describe-maintenance-window-schedule.rst
@@ -1,0 +1,25 @@
+**To list upcoming executions for a Maintenance Window**
+
+This example lists upcoming executions for a Maintenance Window.
+
+Command::
+
+  aws ssm describe-maintenance-window-schedule --window-id mw-ab12cd34ef56gh78
+
+Output::
+
+  {
+    "ScheduledWindowExecutions": [
+        {
+            "WindowId": "mw-ab12cd34ef56gh78",
+            "Name": "My-First-Maintenance-Window",
+            "ExecutionTime": "2019-02-19T16:00Z"
+        },
+		{
+            "WindowId": "mw-ab12cd34ef56gh78",
+            "Name": "My-First-Maintenance-Window",
+            "ExecutionTime": "2019-02-26T16:00Z"
+        },
+		...
+    ]
+  }

--- a/awscli/examples/ssm/describe-maintenance-window-targets.rst
+++ b/awscli/examples/ssm/describe-maintenance-window-targets.rst
@@ -1,6 +1,6 @@
-**To list all targets for a maintenance window**
+**To list all targets for a Maintenance Window**
 
-This example lists all of the targets for a maintenance window.
+This example lists all of the targets for a Maintenance Window.
 
 Command::
 
@@ -42,9 +42,9 @@ Output::
     ]
   }
 
-**To list all targets for a maintenance window matching a specific owner information value**
+**To list all targets for a Maintenance Window matching a specific owner information value**
 
-This example lists all of the targets for a maintenance window with a specific value.
+This example lists all of the targets for a Maintenance Window with a specific value.
 
 Command::
 

--- a/awscli/examples/ssm/describe-maintenance-window-tasks.rst
+++ b/awscli/examples/ssm/describe-maintenance-window-tasks.rst
@@ -1,6 +1,6 @@
 **To list all tasks for a Maintenance Window**
 
-This example lists all of the tasks for a maintenance window.
+This example lists all of the tasks for a Maintenance Window.
 
 Command::
 
@@ -38,25 +38,25 @@ Output::
     ]
   }
 
-**To list all tasks for a maintenance window that invoke the AWS-RunPowerShellScript Run Command**
+**To list all tasks for a Maintenance Window that invoke the AWS-RunPowerShellScript Run Command**
 
-This example lists all of the tasks for a maintenance window that invoke the ``AWS-RunPowerShellScript`` Run Command.
+This example lists all of the tasks for a Maintenance Window that invoke the ``AWS-RunPowerShellScript`` Run Command.
 
 Command::
 
   aws ssm describe-maintenance-window-tasks --window-id "mw-ab12cd34ef56gh78" --filters "Key=TaskArn,Values=AWS-RunPowerShellScript"
 
-**To list all tasks for a maintenance window that have a Priority of 3**
+**To list all tasks for a Maintenance Window that have a Priority of 3**
 
-This example lists all of the tasks for a maintenance window that have a ``Priority`` of ``3``.
+This example lists all of the tasks for a Maintenance Window that have a ``Priority`` of ``3``.
 
 Command::
 
   aws ssm describe-maintenance-window-tasks --window-id "mw-ab12cd34ef56gh78" --filters "Key=Priority,Values=3"
   
-**To list all tasks for a maintenance window that have a Priority of 1 and use Run Command**
+**To list all tasks for a Maintenance Window that have a Priority of 1 and use Run Command**
 
-This example lists all of the tasks for a maintenance window that have a ``Priority`` of ``1`` and use ``Run Command``.
+This example lists all of the tasks for a Maintenance Window that have a ``Priority`` of ``1`` and use ``Run Command``.
 
 Command::
 

--- a/awscli/examples/ssm/describe-maintenance-windows-for-target.rst
+++ b/awscli/examples/ssm/describe-maintenance-windows-for-target.rst
@@ -1,0 +1,18 @@
+**To list all Maintenance Windows associated with a specific instance**
+
+This example lists the Maintenance Windows which have targets or tasks that the specified instance is asscoiated with.
+
+Command::
+
+  aws ssm describe-maintenance-windows-for-target --targets Key=InstanceIds,Values=i-1234567890EXAMPLE --resource-type INSTANCE
+
+Output::
+
+  {
+    "WindowIdentities": [
+        {
+            "WindowId": "mw-0c5ed765acEXAMPLE",
+            "Name": "My-First-Maintenance-Window"
+        }
+    ]
+  }

--- a/awscli/examples/ssm/describe-maintenance-windows.rst
+++ b/awscli/examples/ssm/describe-maintenance-windows.rst
@@ -1,6 +1,6 @@
-**To list all maintenance windows**
+**To list all Maintenance Windows**
 
-This example lists all maintenance windows on your account.
+This example lists all Maintenance Windows on your account.
 
 Command::
 
@@ -20,11 +20,19 @@ Output::
     ]
   }
 
-**To list all enabled maintenance windows**
+**To list all enabled Maintenance Windows**
   
-This example lists all enabled maintenance windows.
+This example lists all enabled Maintenance Windows.
 
 Command::
 
   aws ssm describe-maintenance-windows --filters "Key=Enabled,Values=true"
+  
+**To list Maintenance Windows matching a specific name**
+  
+This example lists all Maintenance Windows with a specific name value.
+
+Command::
+
+  aws ssm describe-maintenance-windows --filters "Key=Name,Values=MyMaintenanceWindow"
   

--- a/awscli/examples/ssm/get-document.rst
+++ b/awscli/examples/ssm/get-document.rst
@@ -26,8 +26,10 @@ Command::
 Output::
 
   {
-    "Content": "{\n   \"schemaVersion\":\"2.0\",\n   \"description\":\"Run a script\",\n   \"parameters\":{\n      \"commands\":{\n         \"type\":\"StringList\",\n         \"description\":\"(Required) Specify a shell script or a command to run.\",\n         \"minItems\":1,\n         \"displayType\":\"textarea\"\n      }\n   },\n   \"mainSteps\":[\n      {\n         \"action\":\"aws:runShellScript\",\n         \"name\":\"runShellScript\",\n         \"inputs\":{\n            \"commands\":\"{{ commands }}\"\n         }\n      },\n      {\n         \"action\":\"aws:runPowerShellScript\",\n         \"name\":\"runPowerShellScript\",\n         \"inputs\":{\n            \"commands\":\"{{ commands }}\"\n         }\n      }\n   ]\n}\n",
-    "Name": "RunShellScript.json",
+    "Name": "A-Document-yaml2",
     "DocumentVersion": "1",
-    "DocumentType": "Command"
+    "Status": "Active",
+    "Content": "---\nschemaVersion: '1.2'\ndescription: Run a PowerShell script or specify the paths to scripts to run.\nparameters:\n  commands:\n    type: StringList\n    description: \"(Required) Specify the commands to run or the paths to existing\n      scripts on the instance.\"\n    minItems: 1\n    displayType: textarea\n  workingDirectory:\n    type: String\n    default: ''\n    description: \"(Optional) The path to the working directory on your instance.\"\n    maxChars: 4096\n  executionTimeout:\n    type: String\n    default: '3600'\n    description: \"(Optional) The time in seconds for a command to be completed before\n      it is considered to have failed. Default is 3600 (1 hour). Maximum is 172800\n      (48 hours).\"\n    allowedPattern: \"([1-9][0-9]{0,4})|(1[0-6][0-9]{4})|(17[0-1][0-9]{3})|(172[0-7][0-9]{2})|(172800)\"\nruntimeConfig:\n  aws:runPowerShellScript:\n    properties:\n    - id: 0.aws:runPowerShellScript\n      runCommand: \"{{ commands }}\"\n      workingDirectory: \"{{ workingDirectory }}\"\n      timeoutSeconds: \"{{ executionTimeout }}\"\n",
+    "DocumentType": "Command",
+    "DocumentFormat": "YAML"
   }

--- a/awscli/examples/ssm/get-document.rst
+++ b/awscli/examples/ssm/get-document.rst
@@ -14,3 +14,20 @@ Output::
     "DocumentVersion": "1",
     "DocumentType": "Command"
   }
+
+**To get the contents of a document in YAML format**
+
+This example returns the content of a document in YAML format.
+
+Command::
+
+  aws ssm get-document --name "RunShellScript" --document-format YAML
+
+Output::
+
+  {
+    "Content": "{\n   \"schemaVersion\":\"2.0\",\n   \"description\":\"Run a script\",\n   \"parameters\":{\n      \"commands\":{\n         \"type\":\"StringList\",\n         \"description\":\"(Required) Specify a shell script or a command to run.\",\n         \"minItems\":1,\n         \"displayType\":\"textarea\"\n      }\n   },\n   \"mainSteps\":[\n      {\n         \"action\":\"aws:runShellScript\",\n         \"name\":\"runShellScript\",\n         \"inputs\":{\n            \"commands\":\"{{ commands }}\"\n         }\n      },\n      {\n         \"action\":\"aws:runPowerShellScript\",\n         \"name\":\"runPowerShellScript\",\n         \"inputs\":{\n            \"commands\":\"{{ commands }}\"\n         }\n      }\n   ]\n}\n",
+    "Name": "RunShellScript.json",
+    "DocumentVersion": "1",
+    "DocumentType": "Command"
+  }

--- a/awscli/examples/ssm/get-maintenance-window-execution-task-invocation.rst
+++ b/awscli/examples/ssm/get-maintenance-window-execution-task-invocation.rst
@@ -1,0 +1,22 @@
+**To get information about a Maintenance Window task invocation**
+
+This example lists information about a task invocation that was part of a Maintenance Window execution.
+
+Command::
+
+  aws ssm get-maintenance-window-execution-task-invocation --window-execution-id "bc494bfa-e63b-49f6-8ad1-aa9f2EXAMPLE" --task-id "96f2ad59-97e3-461d-a63d-40c8aEXAMPLE" --invocation-id "a5273e2c-d2c6-4880-b3e1-5e550EXAMPLE"
+
+Output::
+
+  {
+    "Status": "SUCCESS",
+    "Parameters": "{\"comment\":\"\",\"documentName\":\"AWS-RunPowerShellScript\",\"instanceIds\":[\"i-1234567890EXAMPLE\"],\"maxConcurrency\":\"1\",\"maxErrors\":\"1\",\"parameters\":{\"executionTimeout\":[\"3600\"],\"workingDirectory\":[\"\"],\"commands\":[\"echo Hello\"]},\"timeoutSeconds\":600}",
+    "ExecutionId": "03b6baa0-5460-4e15-83f2-ea685EXAMPLE",
+    "InvocationId": "a5273e2c-d2c6-4880-b3e1-5e550EXAMPLE",
+    "StartTime": 1549998326.421,
+    "TaskType": "RUN_COMMAND",
+    "EndTime": 1550001931.784,
+    "WindowExecutionId": "bc494bfa-e63b-49f6-8ad1-aa9f2EXAMPLE",
+    "StatusDetails": "Failed",
+    "TaskExecutionId": "96f2ad59-97e3-461d-a63d-40c8aEXAMPLE"
+  }

--- a/awscli/examples/ssm/get-maintenance-window-execution-task.rst
+++ b/awscli/examples/ssm/get-maintenance-window-execution-task.rst
@@ -1,6 +1,6 @@
 **To get information about a Maintenance Window task execution**
 
-This example lists information about a task that was part of a maintenance window execution.
+This example lists information about a task that was part of a Maintenance Window execution.
 
 Command::
 

--- a/awscli/examples/ssm/get-maintenance-window-execution.rst
+++ b/awscli/examples/ssm/get-maintenance-window-execution.rst
@@ -1,6 +1,6 @@
 **To get information about a Maintenance Window task execution**
 
-This example lists information about a task executed as part of a maintenance window execution.
+This example lists information about a task executed as part of a Maintenance Window execution.
 
 Command::
 

--- a/awscli/examples/ssm/get-maintenance-window-task.rst
+++ b/awscli/examples/ssm/get-maintenance-window-task.rst
@@ -1,0 +1,47 @@
+**To get information about a Maintenance Window task**
+
+This example gets details about a Maintenance Window task.
+
+Command::
+
+  aws ssm get-maintenance-window-task --window-id mw-0c5ed765acEXAMPLE --window-task-id 0e842a8d-2d44-4886-bb62-af8dcEXAMPLE
+
+Output::
+
+  {
+    "ServiceRoleArn": "arn:aws:iam::111222333444:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM",
+    "MaxErrors": "1",
+    "TaskArn": "AWS-RunPowerShellScript",
+    "MaxConcurrency": "1",
+    "WindowTaskId": "0e842a8d-2d44-4886-bb62-af8dcEXAMPLE",
+    "TaskParameters": {},
+    "Priority": 1,
+    "TaskInvocationParameters": {
+        "RunCommand": {
+            "Comment": "",
+            "TimeoutSeconds": 600,
+            "Parameters": {
+                "commands": [
+                    "echo Hello"
+                ],
+                "executionTimeout": [
+                    "3600"
+                ],
+                "workingDirectory": [
+                    ""
+                ]
+            }
+        }
+    },
+    "WindowId": "mw-0c5ed765acEXAMPLE",
+    "TaskType": "RUN_COMMAND",
+    "Targets": [
+        {
+            "Values": [
+                "84c818da-b619-4d3d-9651-946f3EXAMPLE"
+            ],
+            "Key": "WindowTargetIds"
+        }
+    ],
+    "Name": "ExampleTask"
+  }

--- a/awscli/examples/ssm/get-maintenance-window.rst
+++ b/awscli/examples/ssm/get-maintenance-window.rst
@@ -1,6 +1,6 @@
-**To get information about a maintenance window**
+**To get information about a Maintenance Window**
 
-This example gets details about a maintenance window.
+This example gets details about a Maintenance Window.
 
 Command::
 

--- a/awscli/examples/ssm/list-documents.rst
+++ b/awscli/examples/ssm/list-documents.rst
@@ -34,3 +34,40 @@ Output::
 		...
 	]
   }
+
+**To list all Command configuration documents in your account that you own**
+
+This example lists all Command documents in your account that you own.
+
+Command::
+
+  aws ssm list-documents --document-filter-list key=Owner,value=Self key=DocumentType,value=Command
+
+Output::
+
+  {
+	"DocumentIdentifiers": [
+		{
+			"Name": "RunPowerShellScript",
+			"PlatformTypes": [
+				"Windows",
+				"Linux"
+			],
+			"DocumentVersion": "1",
+			"DocumentType": "Command",
+			"Owner": "111222333444",
+			"SchemaVersion": "2.0"
+		},
+		{
+			"Name": "RunShellScript",
+			"PlatformTypes": [
+				"Linux"
+			],
+			"DocumentVersion": "1",
+			"DocumentType": "Command",
+			"Owner": "111222333444",
+			"SchemaVersion": "1.2"
+		},
+		...
+	]
+  }

--- a/awscli/examples/ssm/register-target-with-maintenance-window.rst
+++ b/awscli/examples/ssm/register-target-with-maintenance-window.rst
@@ -1,6 +1,6 @@
-**To register a single target with a maintenance window**
+**To register a single target with a Maintenance Window**
 
-This example registers an instance with a maintenance window.
+This example registers an instance with a Maintenance Window.
 
 Command::
 
@@ -12,17 +12,17 @@ Output::
 	"WindowTargetId":"1a2b3c4d-1a2b-1a2b-1a2b-1a2b3c4d-1a2"
   }
 
-**To register multiple targets with a maintenance window**
+**To register multiple targets with a Maintenance Window**
 	
-This example registers two instances with a maintenance window.
+This example registers two instances with a Maintenance Window.
 
 Command::
 
   aws ssm register-target-with-maintenance-window --window-id "mw-ab12cd34ef56gh78" --target "Key=InstanceIds,Values=i-0000293ffd8c57862,i-0cb2b964d3e14fd9f" --owner-information "Two instances in a list" --resource-type "INSTANCE"
 
-**To register a target with a maintenance window using EC2 tags**
+**To register a target with a Maintenance Window using EC2 tags**
 
-This example registers an instance with a maintenance window using EC2 tags.
+This example registers an instance with a Maintenance Window using EC2 tags.
 
 Command::
 

--- a/awscli/examples/ssm/register-task-with-maintenance-window.rst
+++ b/awscli/examples/ssm/register-task-with-maintenance-window.rst
@@ -56,7 +56,7 @@ Output::
 	
 **To register a task using a Maintenance Windows target ID**
 	
-This example registers a task using a Maintenance Window target ID. The maintenance window target ID was in the output of the ``aws ssm register-target-with-maintenance-window`` command, otherwise you can retrieve it from the output of the ``aws ssm describe-maintenance-window-targets`` command.
+This example registers a task using a Maintenance Window target ID. The Maintenance Window target ID was in the output of the ``aws ssm register-target-with-maintenance-window`` command, otherwise you can retrieve it from the output of the ``aws ssm describe-maintenance-window-targets`` command.
 
 Command::
 

--- a/awscli/examples/ssm/update-maintenance-window-target.rst
+++ b/awscli/examples/ssm/update-maintenance-window-target.rst
@@ -1,0 +1,26 @@
+**To update a Maintenance Window target**
+
+This example updates the name of a Maintenance Window target.
+
+Command::
+
+  aws ssm update-maintenance-window-target --window-id "mw-0c5ed765acEXAMPLE" --window-target-id "57e8344e-fe64-4023-8191-6bf05EXAMPLE" --name "NewName"
+
+Output::
+
+  {
+    "Description": "",
+    "OwnerInformation": "",
+    "WindowTargetId": "57e8344e-fe64-4023-8191-6bf05EXAMPLE",
+    "WindowId": "mw-0c5ed765acEXAMPLE",
+    "Targets": [
+        {
+            "Values": [
+                "i-1234567890EXAMPLE"
+            ],
+            "Key": "InstanceIds"
+        }
+    ],
+    "Name": "NewName"
+  }
+  

--- a/awscli/examples/ssm/update-maintenance-window-task.rst
+++ b/awscli/examples/ssm/update-maintenance-window-task.rst
@@ -1,0 +1,40 @@
+**To update a Maintenance Window task**
+
+This example updates the service role for a Maintenance Window task.
+
+Command::
+
+  aws ssm update-maintenance-window-task --window-id "mw-0c5ed765acEXAMPLE" --window-task-id "23d3809e-9fbe-4ddf-b41a-b49d7EXAMPLE" --service-role-arn "arn:aws:iam::111222333444:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM"
+
+Output::
+
+  {
+    "ServiceRoleArn": "arn:aws:iam::111222333444:role/aws-service-role/ssm.amazonaws.com/AWSServiceRoleForAmazonSSM",
+    "MaxErrors": "1",
+    "TaskArn": "AWS-UpdateEC2Config",
+    "MaxConcurrency": "1",
+    "WindowTaskId": "23d3809e-9fbe-4ddf-b41a-b49d7EXAMPLE",
+    "TaskParameters": {},
+    "Priority": 1,
+    "TaskInvocationParameters": {
+        "RunCommand": {
+            "TimeoutSeconds": 600,
+            "Parameters": {
+                "allowDowngrade": [
+                    "false"
+                ]
+            }
+        }
+    },
+    "WindowId": "mw-0c5ed765acEXAMPLE",
+    "Description": "UpdateEC2Config",
+    "Targets": [
+        {
+            "Values": [
+                "57e8344e-fe64-4023-8191-6bf05EXAMPLE"
+            ],
+            "Key": "WindowTargetIds"
+        }
+    ],
+    "Name": "UpdateEC2Config"
+  }

--- a/awscli/examples/ssm/update-maintenance-window.rst
+++ b/awscli/examples/ssm/update-maintenance-window.rst
@@ -1,6 +1,6 @@
-**To update a maintenance window**
+**To update a Maintenance Window**
 
-This example updates the name of a maintenance window.
+This example updates the name of a Maintenance Window.
 
 Command::
 
@@ -18,17 +18,17 @@ Output::
 	"Duration": 4
   }
 
-**To enable a maintenance window**
+**To enable a Maintenance Window**
 
-This example enables a maintenance window.
+This example enables a Maintenance Window.
 
 Command::
 
   aws ssm update-maintenance-window --window-id "mw-1a2b3c4d5e6f7g8h9" --enabled
   
-**To disable a maintenance window**
+**To disable a Maintenance Window**
   
-This example disables a maintenance window.
+This example disables a Maintenance Window.
 
 Command::
 


### PR DESCRIPTION
Added examples to create-activation, create-association, create-document, get-document, and list-documents.

The URL reference in create-document is no longer working.  Changed this to the User Guide reference for creating documents.