### PR TITLE
Updated output for describe-activations

### DIFF
--- a/awscli/examples/ssm/describe-activations.rst
+++ b/awscli/examples/ssm/describe-activations.rst
@@ -11,14 +11,15 @@ Output::
   {
     "ActivationList": [
         {
-            "IamRole": "AutomationRole",
-            "RegistrationLimit": 10,
             "ActivationId": "bcf6faa8-83fd-419e-9534-96ad14131eb7",
-            "ExpirationDate": 1487887903.045,
-            "CreatedDate": 1487801503.045,
-            "DefaultInstanceName": "MyWebServers",
-            "Expired": false,
+			"Description": "test",
+			"DefaultInstanceName": "MyWebServers",
+			"IamRole": "AutomationRole",
+            "RegistrationLimit": 10,
             "RegistrationsCount": 0
+            "ExpirationDate": 1550176478.734,
+            "Expired": false,
+			"CreatedDate": 1550090078.734
         }
     ]
   }

--- a/awscli/examples/ssm/describe-activations.rst
+++ b/awscli/examples/ssm/describe-activations.rst
@@ -12,14 +12,14 @@ Output::
     "ActivationList": [
         {
             "ActivationId": "bcf6faa8-83fd-419e-9534-96ad14131eb7",
-			"Description": "test",
-			"DefaultInstanceName": "MyWebServers",
-			"IamRole": "AutomationRole",
+            "Description": "test",
+            "DefaultInstanceName": "MyWebServers",
+            "IamRole": "AutomationRole",
             "RegistrationLimit": 10,
             "RegistrationsCount": 0
             "ExpirationDate": 1550176478.734,
             "Expired": false,
-			"CreatedDate": 1550090078.734
+            "CreatedDate": 1550090078.734
         }
     ]
   }


### PR DESCRIPTION
The output provided in the example is no longer accurate to that which is returned by the SSM service.  This request is to simply update the output of the example