### PR TITLE
For "s3" command introduces new "--date" argument (in transfer argume…

### DIFF
--- a/awscli/customizations/s3/fileformat.py
+++ b/awscli/customizations/s3/fileformat.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -47,6 +48,7 @@ class FileFormat(object):
         #     directory/objects under a common prefix or false when it
         #     is a single file
         dir_op = parameters['dir_op']
+        date = parameters.get('date')
         src_path = format_table[src_type](src_path, dir_op)[0]
         # :var use_src_name: True when the destination file/object will take on
         #     the name of the source file/object.  False when it
@@ -55,7 +57,7 @@ class FileFormat(object):
         dest_path, use_src_name = format_table[dest_type](dest_path, dir_op)
         files = {'src': {'path': src_path, 'type': src_type},
                  'dest': {'path': dest_path, 'type': dest_type},
-                 'dir_op': dir_op, 'use_src_name': use_src_name}
+                 'dir_op': dir_op, 'use_src_name': use_src_name, 'date': date}
         return files
 
     def local_format(self, path, dir_op):

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -95,7 +96,7 @@ class FileDecodingError(Exception):
 class FileStat(object):
     def __init__(self, src, dest=None, compare_key=None, size=None,
                  last_update=None, src_type=None, dest_type=None,
-                 operation_name=None, response_data=None):
+                 operation_name=None, response_data=None, version_id=None):
         self.src = src
         self.dest = dest
         self.compare_key = compare_key
@@ -105,6 +106,7 @@ class FileStat(object):
         self.dest_type = dest_type
         self.operation_name = operation_name
         self.response_data = response_data
+        self.version_id = version_id
 
 
 class FileGenerator(object):
@@ -138,7 +140,9 @@ class FileGenerator(object):
         source = files['src']['path']
         src_type = files['src']['type']
         dest_type = files['dest']['type']
-        file_iterator = function_table[src_type](source, files['dir_op'])
+        file_iterator = function_table[src_type](
+            source, files['dir_op'], files.get('date')
+        )
         for src_path, extra_information in file_iterator:
             dest_path, compare_key = find_dest_path_comp_key(files, src_path)
             file_stat_kwargs = {
@@ -153,13 +157,14 @@ class FileGenerator(object):
         src_type = file_stat_kwargs['src_type']
         file_stat_kwargs['size'] = extra_information['Size']
         file_stat_kwargs['last_update'] = extra_information['LastModified']
+        file_stat_kwargs['version_id'] = extra_information.get('VersionId', '')
 
         # S3 objects require the response data retrieved from HeadObject
         # and ListObject
         if src_type == 's3':
             file_stat_kwargs['response_data'] = extra_information
 
-    def list_files(self, path, dir_op):
+    def list_files(self, path, dir_op, *args):
         """
         This function yields the appropriate local file or local files
         under a directory depending on if the operation is on a directory.
@@ -303,23 +308,24 @@ class FileGenerator(object):
             return True
         return False
 
-    def list_objects(self, s3_path, dir_op):
+    def list_objects(self, s3_path, dir_op, date=None):
         """
         This function yields the appropriate object or objects under a
         common prefix depending if the operation is on objects under a
         common prefix.  It yields the file's source path, size, and last
-        update.
+        update. Object version selection is capped by date.
         """
         # Short circuit path: if we are not recursing into the s3
         # bucket and a specific path was given, we can just yield
         # that path and not have to call any operation in s3.
         bucket, prefix = find_bucket_key(s3_path)
         if not dir_op and prefix:
-            yield self._list_single_object(s3_path)
+            yield self._list_single_object(s3_path, date=date)
         else:
             lister = BucketLister(self._client)
             extra_args = self.request_parameters.get('ListObjectsV2', {})
             for key in lister.list_objects(bucket=bucket, prefix=prefix,
+                                           date=date,
                                            page_size=self.page_size,
                                            extra_args=extra_args):
                 source_path, response_data = key
@@ -337,7 +343,7 @@ class FileGenerator(object):
                 else:
                     yield source_path, response_data
 
-    def _list_single_object(self, s3_path):
+    def _list_single_object(self, s3_path, date=None):
         # When we know we're dealing with a single object, we can avoid
         # a ListObjects operation (which causes concern for anyone setting
         # IAM policies with the smallest set of permissions needed) and
@@ -349,9 +355,18 @@ class FileGenerator(object):
             # object.
             return s3_path, {'Size': None, 'LastModified': None}
         bucket, key = find_bucket_key(s3_path)
+        params = {'Bucket': bucket, 'Key': key}
+        if date:
+            lister = BucketLister(self._client)
+            version_id = lister.date2version(bucket, key, date)
+            if version_id:
+                params['VersionId'] = version_id
+            else:
+                raise RuntimeError('Key %s doesn\'t have any versions for %s' %
+                    (key, date)
+                )
+        params.update(self.request_parameters.get('HeadObject', {}))
         try:
-            params = {'Bucket': bucket, 'Key': key}
-            params.update(self.request_parameters.get('HeadObject', {}))
             response = self._client.head_object(**params)
         except ClientError as e:
             # We want to try to give a more helpful error message.

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -1,4 +1,5 @@
 # Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -37,12 +38,14 @@ class FileInfo(object):
         the ``FileGenerator`` to create this task. It is either an dictionary
         from the list of a ListObjects or the response from a HeadObject. It
         will only be filled if the task was generated from an S3 bucket.
+    :param version_id: Version-Id of the object
+    :type version_id: string
     """
     def __init__(self, src, dest=None, compare_key=None, size=None,
                  last_update=None, src_type=None, dest_type=None,
                  operation_name=None, client=None, parameters=None,
                  source_client=None, is_stream=False,
-                 associated_response_data=None):
+                 associated_response_data=None, version_id=None):
         self.src = src
         self.src_type = src_type
         self.operation_name = operation_name
@@ -59,6 +62,7 @@ class FileInfo(object):
         self.source_client = source_client
         self.is_stream = is_stream
         self.associated_response_data = associated_response_data
+        self.version_id = version_id
 
     def is_glacier_compatible(self):
         """Determines if a file info object is glacier compatible

--- a/awscli/customizations/s3/fileinfobuilder.py
+++ b/awscli/customizations/s3/fileinfobuilder.py
@@ -1,4 +1,5 @@
 # Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -45,6 +46,7 @@ class FileInfoBuilder(object):
         file_info_attr['parameters'] = self._parameters
         file_info_attr['is_stream'] = self._is_stream
         file_info_attr['associated_response_data'] = file_base.response_data
+        file_info_attr['version_id'] = file_base.version_id
 
         # This is a bit quirky. The below conditional hinges on the --delete
         # flag being set, which only occurs during a sync command. The source

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -405,6 +406,8 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
     def _submit_transfer_request(self, fileinfo, extra_args, subscribers):
         bucket, key = find_bucket_key(fileinfo.src)
         fileout = self._get_fileout(fileinfo)
+        if fileinfo.version_id:
+            extra_args['VersionId'] = fileinfo.version_id
         return self._transfer_manager.download(
             fileobj=fileout, bucket=bucket, key=key,
             extra_args=extra_args, subscribers=subscribers

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1,4 +1,5 @@
 # Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -429,6 +430,18 @@ REQUEST_PAYER = {
     )
 }
 
+DATE = {
+    'name': 'date',
+    'help_text': (
+        'Instead of selecting the last version of the object (or objects, for '
+        'a recursive operation), selects the most recent version(s) capped by '
+        'the date specified in one of formats supported by dateutil '
+        '(see: https://dateutil.readthedocs.io/en/stable/parser.html). '
+        'Makes sense only for a versioned bucket as a source, '
+        'otherwise gets ignored.'
+    )
+}
+
 TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  FOLLOW_SYMLINKS, NO_FOLLOW_SYMLINKS, NO_GUESS_MIME_TYPE,
                  SSE, SSE_C, SSE_C_KEY, SSE_KMS_KEY_ID, SSE_C_COPY_SOURCE,
@@ -437,7 +450,7 @@ TRANSFER_ARGS = [DRYRUN, QUIET, INCLUDE, EXCLUDE, ACL,
                  CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LANGUAGE,
                  EXPIRES, SOURCE_REGION, ONLY_SHOW_ERRORS, NO_PROGRESS,
                  PAGE_SIZE, IGNORE_GLACIER_WARNINGS, FORCE_GLACIER_TRANSFER,
-                 REQUEST_PAYER]
+                 REQUEST_PAYER, DATE]
 
 
 def get_client(session, region, endpoint_url, verify, config=None):

--- a/tests/integration/customizations/s3/test_cp_date.py
+++ b/tests/integration/customizations/s3/test_cp_date.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+# Written by Al Nikolov <root@toor.fi.eu.org>
+#
+# The following tests are performed to ensure that the `aws s3 cp --date`
+# command works as expected at a glance
+
+import filecmp
+import os.path
+import time
+
+import awscli.testutils
+
+def dircmp(dcmp):
+    """Recursively compare directories and files"""
+    if dcmp.left_only:
+        return "Left %s (%s %s)" % (dcmp.left_only, dcmp.left, dcmp.right)
+    if dcmp.right_only:
+        return "Right %s (%s %s)" % (dcmp.right_only, dcmp.left, dcmp.right)
+    if dcmp.diff_files:
+        return "Diff %s (%s %s)" % (dcmp.diff_files, dcmp.left, dcmp.right)
+    for sub in dcmp.subdirs.values():
+        res = dircmp(sub)
+        if res:
+            return res
+
+class S3CpDateTest(awscli.testutils.BaseS3CLICommand):
+    """Test `cp --date` command capability to copy older versions of S3 files
+
+    5 local direcories represent distint revisions of the same files. They are
+    uploaded consecutively with a significant delay.
+    """
+
+    delay = 5
+    s3_scheme = "s3://"
+    s3_prefix = "s3-"
+    mod = {}
+
+    def sync_up(self, ver):
+        """Call `s3 sync` and assert success, record the latest modification
+        timestamp for this version
+        """
+        res = awscli.testutils.aws(
+            "s3 sync --delete %s %s"
+            % (self.files.full_path(ver), self.s3_scheme + self.t_bucket)
+        )
+        self.assert_no_errors(res)
+        time.sleep(self.delay)
+        versions = self.client.list_object_versions(
+            Bucket=self.t_bucket
+        )
+        scope = versions.get("DeleteMarkers", []) + versions.get("Versions", [])
+        self.mod[ver] = sorted(
+            [ mark["LastModified"] for mark in scope ]
+        )[-1]
+
+    def purge_versions(self):
+        """Purge all versions from S3"""
+        versions = self.client.list_object_versions(
+            Bucket=self.t_bucket
+        )
+        scope = versions.get("DeleteMarkers", []) + versions.get("Versions", [])
+        self.client.delete_objects(
+            Bucket=self.t_bucket,
+            Delete={
+                "Objects": [
+                    {"Key": mark["Key"], "VersionId": mark["VersionId"]}
+                    for mark in scope
+                ]
+            }
+        )
+
+    def extra_setup(self):
+        # Create a versionned bucket
+        self.t_bucket = self.create_bucket()
+        self.addCleanup(self.purge_versions)
+        self.client.put_bucket_versioning(
+            Bucket=self.t_bucket,
+            VersioningConfiguration={"Status": "Enabled"})
+
+        # Create the 1st revision of files
+        ver = "v1"
+        self.files.create_file(os.path.join(ver, "foo"), "")
+        self.files.create_file(os.path.join(ver, "bar"), "")
+        self.files.create_file(os.path.join(ver, "dir", "foo"), "")
+        self.files.create_file(os.path.join(ver, "dir", "bar"), "")
+        self.sync_up(ver)
+
+        # Create the 2nd revision of files:
+        # "foo" is modified
+        # "dir/foo" is removed
+        ver = "v2"
+        self.files.create_file(os.path.join(ver, "foo"), "x")
+        self.files.create_file(os.path.join(ver, "bar"), "")
+        self.files.create_file(os.path.join(ver, "dir", "bar"), "")
+        self.sync_up(ver)
+
+        # Create the 3rd revision of files:
+        # "foo" is modified
+        # "dir/foo" is restored as in v1
+        ver = "v3"
+        self.files.create_file(os.path.join(ver, "foo"), "xx")
+        self.files.create_file(os.path.join(ver, "bar"), "")
+        self.files.create_file(os.path.join(ver, "dir", "foo"), "")
+        self.files.create_file(os.path.join(ver, "dir", "bar"), "")
+        self.sync_up(ver)
+
+        # Create the 4th revision of files:
+        # "foo" and "bar" are removed
+        # "dir/foo" is modified
+        ver = "v4"
+        self.files.create_file(os.path.join(ver, "dir", "foo"), "x")
+        self.files.create_file(os.path.join(ver, "dir", "bar"), "")
+        self.sync_up(ver)
+
+        # Create the 5th revision of files:
+        # "foo" and "bar" are restored as in v1
+        # "dir" is removed
+        # create a bunch of numbered files
+        ver = "v5"
+        self.files.create_file(os.path.join(ver, "foo"), "")
+        self.files.create_file(os.path.join(ver, "bar"), "")
+        self.sync_up(ver)
+
+    def test_cp_date(self):
+        """Using pre-recorded modification dates, recursively download each 
+        version of the file tree with forced pagination and compare to the local
+        file tree.
+
+        Check that transfer of a single existing object not yet existed by the 
+        date raises an error.
+
+        Check that transfer of a single nonexisting object raises an error.
+        """
+        for ver in "v1", "v2", "v3", "v4", "v5":
+            date = self.mod[ver].isoformat()
+            res = awscli.testutils.aws(
+                "s3 cp --recursive --page-size 1 --date %s %s %s" % (
+                    date,
+                    self.s3_scheme + self.t_bucket,
+                    self.files.full_path(self.s3_prefix + ver)
+                )
+            )
+            self.assert_no_errors(res)
+            compare = filecmp.dircmp(
+                self.files.full_path(ver),
+                self.files.full_path(self.s3_prefix + ver)
+            )
+            self.assertIsNone(dircmp(compare))
+        res = awscli.testutils.aws("s3 cp --date 100 %s/foo %s" % (
+            self.s3_scheme + self.t_bucket,
+            self.files.full_path(self.s3_prefix + ver))
+        )
+        self.assertNotEqual(res, 0)
+        res = awscli.testutils.aws("s3 cp --date 100 %s/nonexisting %s" % (
+            self.s3_scheme + self.t_bucket,
+            self.files.full_path(self.s3_prefix + ver))
+        )
+        self.assertNotEqual(res, 0)

--- a/tests/unit/customizations/s3/test_fileformat.py
+++ b/tests/unit/customizations/s3/test_fileformat.py
@@ -1,4 +1,5 @@
 # Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -33,7 +34,7 @@ class FileFormatTest(unittest.TestCase):
         ref_files = {'src': {'path': os.path.abspath(src) + os.sep,
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/', 'type': 's3'},
-                     'dir_op': True, 'use_src_name': True}
+                     'dir_op': True, 'use_src_name': True,'date': None}
         self.assertEqual(files, ref_files)
 
     def test_op_dir_noslash(self):
@@ -49,7 +50,7 @@ class FileFormatTest(unittest.TestCase):
         ref_files = {'src': {'path': os.path.abspath(src) + os.sep,
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/', 'type': 's3'},
-                     'dir_op': True, 'use_src_name': True}
+                     'dir_op': True, 'use_src_name': True, 'date': None}
         self.assertEqual(files, ref_files)
 
     def test_local_use_src_name(self):
@@ -66,7 +67,7 @@ class FileFormatTest(unittest.TestCase):
                              'type': 's3'},
                      'dest': {'path': os.path.abspath(dest) + os.sep,
                               'type': 'local'},
-                     'dir_op': False, 'use_src_name': True}
+                     'dir_op': False, 'use_src_name': True, 'date': None}
         self.assertEqual(files, ref_files)
 
     def test_local_noexist_file(self):
@@ -83,7 +84,7 @@ class FileFormatTest(unittest.TestCase):
                              'type': 's3'},
                      'dest': {'path': os.path.abspath(dest) + os.sep,
                               'type': 'local'},
-                     'dir_op': False, 'use_src_name': True}
+                     'dir_op': False, 'use_src_name': True, 'date': None}
         self.assertEqual(files, ref_files)
 
     def test_local_keep_dest_name(self):
@@ -100,7 +101,7 @@ class FileFormatTest(unittest.TestCase):
                              'type': 's3'},
                      'dest': {'path': os.path.abspath(dest),
                               'type': 'local'},
-                     'dir_op': False, 'use_src_name': False}
+                     'dir_op': False, 'use_src_name': False, 'date': None}
         self.assertEqual(files, ref_files)
 
     def test_s3_use_src_name(self):
@@ -116,7 +117,7 @@ class FileFormatTest(unittest.TestCase):
         ref_files = {'src': {'path': os.path.abspath(src),
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/', 'type': 's3'},
-                     'dir_op': False, 'use_src_name': True}
+                     'dir_op': False, 'use_src_name': True, 'date': None}
         self.assertEqual(files, ref_files)
 
     def test_s3_keep_dest_name(self):
@@ -132,7 +133,7 @@ class FileFormatTest(unittest.TestCase):
         ref_files = {'src': {'path': os.path.abspath(src),
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/file.py', 'type': 's3'},
-                     'dir_op': False, 'use_src_name': False}
+                     'dir_op': False, 'use_src_name': False, 'date': None}
         self.assertEqual(files, ref_files)
 
 

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -1,4 +1,5 @@
 # Copyright 2014 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018 Transposit Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -28,7 +29,8 @@ class TestFileInfoBuilder(unittest.TestCase):
                           size='size', last_update='last_update',
                           src_type='src_type', dest_type='dest_type',
                           operation_name='operation_name',
-                          response_data='associated_response_data')]
+                          response_data='associated_response_data',
+                          version_id='version_id')]
         file_infos = info_setter.call(files)
         for file_info in file_infos:
             attributes = file_info.__dict__.keys()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -311,7 +311,7 @@ class TestBucketVersionsList(unittest.TestCase):
             [('foo/my-image.jpg', self.individual_response_elements[0])]
         )
 
-    def test_list__single_object_with_date(self):
+    def test_list_single_object_with_date(self):
         objects = list(self.lister.list_objects(
             bucket='foo', date='2010', prefix='foo/my-image.jpg'
         ))


### PR DESCRIPTION
…nts group).

Excerpt from the new argument help text:

        'Instead of selecting the last version of the object (or objects, for '
        'a recursive operation), selects the most recent version(s) capped by '
        'the date specified in one of formats supported by dateutil '
        '(see: https://dateutil.readthedocs.io/en/stable/parser.html). '
        'Makes sense only for a versioned bucket as a source, '
        'otherwise gets ignored.'

Closes aws/aws-cli#3807