### PR TITLE
Update Configurations schema for Instance Fleets and Instance Groups

### DIFF
--- a/awscli/customizations/emr/argumentschema.py
+++ b/awscli/customizations/emr/argumentschema.py
@@ -14,6 +14,48 @@
 from awscli.customizations.emr import helptext
 from awscli.customizations.emr.createdefaultroles import EC2_ROLE_NAME
 
+CONFIGURATIONS_PROPERTIES_SCHEMA = {
+    "type": "map",
+    "key": {
+        "type": "string",
+        "description": "Configuration key"
+    },
+    "value": {
+        "type": "string",
+        "description": "Configuration value"
+    },
+    "description": "Application configuration properties"
+}
+
+CONFIGURATIONS_CLASSIFICATION_SCHEMA = {
+    "type": "string",
+    "description": "Application configuration classification name",
+}
+
+INNER_CONFIGURATIONS_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Classification": CONFIGURATIONS_CLASSIFICATION_SCHEMA,
+            "Properties": CONFIGURATIONS_PROPERTIES_SCHEMA
+        }
+    },
+    "description": "Instance group application configurations."
+}
+
+OUTER_CONFIGURATIONS_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "Classification": CONFIGURATIONS_CLASSIFICATION_SCHEMA,
+            "Properties": CONFIGURATIONS_PROPERTIES_SCHEMA,
+            "Configurations": INNER_CONFIGURATIONS_SCHEMA
+        }
+    },
+    "description": "Instance group application configurations."
+}
 
 INSTANCE_GROUPS_SCHEMA = {
     "type": "array",
@@ -236,7 +278,8 @@ INSTANCE_GROUPS_SCHEMA = {
                         }
                     }
                 }
-            }
+            },
+            "Configurations": OUTER_CONFIGURATIONS_SCHEMA
         }
     }
 }
@@ -336,12 +379,7 @@ INSTANCE_FLEETS_SCHEMA = {
                                 }
                             }
                         },
-
-                        "Configurations": {
-                            "type": "string",
-                            "description":
-                                "Additional configiration data."
-                        }
+                        "Configurations": OUTER_CONFIGURATIONS_SCHEMA
                     }
                 }
             },

--- a/awscli/customizations/emr/instancegroupsutils.py
+++ b/awscli/customizations/emr/instancegroupsutils.py
@@ -46,6 +46,9 @@ def build_instance_groups(parsed_instance_groups):
         if 'AutoScalingPolicy' in keys:
             ig_config['AutoScalingPolicy'] = instance_group['AutoScalingPolicy']
 
+        if 'Configurations' in keys:
+            ig_config['Configurations'] = instance_group['Configurations']
+
         instance_groups.append(ig_config)
     return instance_groups
 

--- a/tests/unit/customizations/emr/input_instance_groups_with_configurations.json
+++ b/tests/unit/customizations/emr/input_instance_groups_with_configurations.json
@@ -1,0 +1,29 @@
+[
+  {
+    "InstanceCount": 1,
+    "InstanceGroupType": "MASTER",
+    "InstanceType": "m1.large",
+    "Name": "MASTER"
+  },
+  {
+    "InstanceCount": 1,
+    "InstanceGroupType": "CORE",
+    "InstanceType": "m1.large",
+    "Name": "CORE",
+    "Configurations": [
+      {
+        "Classification": "hdfs-site",
+        "Properties": {
+          "test-key1": "test-value1",
+          "test-key2": "test-value2"
+        }
+      }
+    ]
+  },
+  {
+    "InstanceCount": 1,
+    "InstanceGroupType": "TASK",
+    "InstanceType": "m1.large",
+    "Name": "TASK"
+  }
+]

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -14,8 +14,9 @@
 import copy
 import os
 
-
 from botocore.compat import json
+from botocore.compat import OrderedDict
+
 from tests.unit.customizations.emr import test_constants as \
     CONSTANTS
 from tests.unit.customizations.emr import test_constants_instance_fleets as \
@@ -692,6 +693,25 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                  }
         ]
         self.assert_params_for_cmd(cmd, result)
+
+    def test_instance_groups_adds_configurations(self):
+        data_path = os.path.join(
+            os.path.dirname(__file__), 'input_instance_groups_with_configurations.json')
+        cmd = ('emr create-cluster --use-default-roles'
+                ' --release-label emr-4.0.0 '
+                '--instance-groups file://' + data_path)
+        result = copy.deepcopy(DEFAULT_RESULT)
+        result['Instances']['InstanceGroups'][1]['Configurations'] = [
+            OrderedDict([
+                ("Classification", "hdfs-site"),
+                ("Properties", OrderedDict([
+                    ("test-key1", "test-value1"),
+                    ("test-key2", "test-value2")
+                ]))
+            ])
+        ]
+        self.assert_params_for_cmd(cmd, result)
+
 
     def test_ec2_attributes_no_az(self):
         cmd = ('emr create-cluster --release-label emr-4.0.0 '


### PR DESCRIPTION
*Description of changes:* This change allows for instance fleets and instance groups to be given specific application configurations when creating a cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
