### PR TITLE
Add source code link in projects_urls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,8 @@ setup_options = dict(
     ],
     project_urls={
         'Source': 'https://github.com/aws/aws-cli',
+        'Reference': 'https://docs.aws.amazon.com/cli/latest/reference/',
+        'Changelog': 'https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst',
     },
 )
 

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ setup_options = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
+    project_urls={
+        'Source': 'https://github.com/aws/aws-cli',
+    },
 )
 
 if 'py2exe' in sys.argv:


### PR DESCRIPTION
Warehouse now uses the `project_urls` provided to display links in the sidebar on [this screen](https://pypi.org/project/awscli/), as well as including them in API responses to help automation tools find the source code for AWS CLI. For example, see Django's [setup.py](https://github.com/django/django/blob/master/setup.py) and [PyPI listing](https://pypi.org/project/Django/).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
