### PR TITLE
Updated example for cloud9 describe-environments command.

### DIFF
--- a/awscli/examples/cloud9/describe-environments.rst
+++ b/awscli/examples/cloud9/describe-environments.rst
@@ -11,19 +11,26 @@ Output::
   {
     "environments": [
       {
-        "description": "Created from CodeStar.",
-        "ownerArn": "arn:aws:iam::123456789012:user/MyDemoUser",
-        "type": "ec2",
         "id": "685f892f431b45c2b28cb69eadcdb0EX",
+        "name": "my-demo-ec2-env",
+        "description": "Created from CodeStar.",
+        "type": "ec2",
         "arn": "arn:aws:cloud9:us-east-1:123456789012:environment:685f892f431b45c2b28cb69eadcdb0EX",
-        "name": "my-demo-ec2-env"
+        "ownerArn": "arn:aws:iam::123456789012:user/MyDemoUser",
+        "lifecycle": {
+          "status": "CREATED"
+        }
       },
       {
-        "ownerArn": "arn:aws:iam::123456789012:user/MyDemoUser",
-        "type": "ssh",
         "id": "349c86d4579e4e7298d500ff57a6b2EX",
+        "name": my-demo-ssh-env",
+        "description": "",
+        "type": "ssh",
         "arn": "arn:aws:cloud9:us-east-1:123456789012:environment:349c86d4579e4e7298d500ff57a6b2EX",
-        "name": my-demo-ssh-env"
+        "ownerArn": "arn:aws:iam::123456789012:user/MyDemoUser",
+        "lifecycle": {
+          "status": "CREATED"
+        }
       }
     ]
   }


### PR DESCRIPTION
Added a new 'lifecycle' output field to the example for the 'cloud9 describe-environments' command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
