### PR TITLE
Update EMR Configurations schema to support three-layer nested configurations

### DIFF
--- a/awscli/customizations/emr/argumentschema.py
+++ b/awscli/customizations/emr/argumentschema.py
@@ -32,13 +32,23 @@ CONFIGURATIONS_CLASSIFICATION_SCHEMA = {
     "description": "Application configuration classification name",
 }
 
+PSEUDO_CONFIGURATIONS_SCHEMA = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {}
+    },
+    "description": "Instance group application configurations."
+}
+
 INNER_CONFIGURATIONS_SCHEMA = {
     "type": "array",
     "items": {
         "type": "object",
         "properties": {
             "Classification": CONFIGURATIONS_CLASSIFICATION_SCHEMA,
-            "Properties": CONFIGURATIONS_PROPERTIES_SCHEMA
+            "Properties": CONFIGURATIONS_PROPERTIES_SCHEMA,
+            "Configurations": PSEUDO_CONFIGURATIONS_SCHEMA
         }
     },
     "description": "Instance group application configurations."

--- a/tests/unit/customizations/emr/input_instance_groups_with_configurations.json
+++ b/tests/unit/customizations/emr/input_instance_groups_with_configurations.json
@@ -2,7 +2,7 @@
   {
     "InstanceCount": 1,
     "InstanceGroupType": "MASTER",
-    "InstanceType": "m1.large",
+    "InstanceType": "m1.large",       
     "Name": "MASTER"
   },
   {
@@ -12,11 +12,18 @@
     "Name": "CORE",
     "Configurations": [
       {
-        "Classification": "hdfs-site",
-        "Properties": {
-          "test-key1": "test-value1",
-          "test-key2": "test-value2"
-        }
+        "Classification": "hadoop-env",
+        "Properties": {},
+        "Configurations": [
+          {
+            "Classification": "export",
+            "Properties": {
+              "HADOOP_DATANODE_HEAPSIZE": "2048",
+              "HADOOP_NAMENODE_OPTS": "-XX:GCTimeRatio=19"
+            },
+            "Configurations": []
+          }
+        ]
       }
     ]
   },

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -701,15 +701,24 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                 ' --release-label emr-4.0.0 '
                 '--instance-groups file://' + data_path)
         result = copy.deepcopy(DEFAULT_RESULT)
-        result['Instances']['InstanceGroups'][1]['Configurations'] = [
+        configurations_layer_one = []
+        configurations_layer_two = [
             OrderedDict([
-                ("Classification", "hdfs-site"),
+                ("Classification", "export"),
                 ("Properties", OrderedDict([
-                    ("test-key1", "test-value1"),
-                    ("test-key2", "test-value2")
-                ]))
+                    ("HADOOP_DATANODE_HEAPSIZE", "2048"),
+                    ("HADOOP_NAMENODE_OPTS", "-XX:GCTimeRatio=19")])),
+                ("Configurations", configurations_layer_one)
             ])
         ]
+        configurations_layer_three = [
+            OrderedDict([
+                ("Classification", "hadoop-env"),
+                ("Properties", OrderedDict()),
+                ("Configurations", configurations_layer_two)
+            ])
+        ]
+        result['Instances']['InstanceGroups'][1]['Configurations'] = configurations_layer_three
         self.assert_params_for_cmd(cmd, result)
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change allows configurations given to instance groups and instance fleets
when creating an EMR cluster to be an up-to-three-layer nested structure with
the most inner layer of configuration always being empty. In this way, syntax
check of create-cluster command is consistent with current EMR API validation
for configuration objects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
