### PR TITLE
Add support for VPC and FIPS endpoints in AWS CodeCommit credential h…

### DIFF
--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -133,10 +133,10 @@ class CodeCommitGetCommand(BasicCommand):
         return url
 
     def extract_region(self, parameters, parsed_globals):
-        match = re.match(r'git-codecommit\.([^.]+)\.amazonaws\.com',
+        match = re.match(r'(vpce-.+\.)?git-codecommit(-fips)?\.([^.]+)\.(vpce\.)?amazonaws\.com',
                          parameters['host'])
         if match is not None:
-            return match.group(1)
+            return match.group(3)
         elif parsed_globals.region is not None:
             return parsed_globals.region
         else:

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -32,6 +32,14 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
                           'host=git-codecommit.us-east-1.amazonaws.com\n'
                           'path=/v1/repos/myrepo')
 
+    FIPS_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                               'host=git-codecommit-fips.us-east-1.amazonaws.com\n'
+                               'path=/v1/repos/myrepo')
+
+    VPC_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                              'host=vpce-0b47ea360adebf88a-jkl88hez.git-codecommit.us-east-1.vpce.amazonaws.com\n'
+                              'path=/v1/repos/myrepo')
+
     def setUp(self):
         self.orig_id = os.environ.get('AWS_ACCESS_KEY_ID')
         self.orig_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
@@ -60,6 +68,36 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
             ('username=foo\n'
              'password=20101008T000000Z'
              '7dc259e2d505af354a1219b9bcd784bd384dc706efa0d9aefc571f214be4c89c'),
+             output)
+        self.assertEquals(0, rc)
+
+    @patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
+    @patch('sys.stdout', new_callable=StringIOWithFileNo)
+    @patch.object(awscli.customizations.codecommit.datetime, 'datetime')
+    def test_integration_fips_using_cli_driver(self, dt_mock, stdout_mock):
+        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        driver = create_clidriver()
+        rc = driver.main('codecommit credential-helper get'.split())
+        output = stdout_mock.getvalue().strip()
+        self.assertEquals(
+            ('username=foo\n'
+             'password=20101008T000000Z'
+             '500037cb3514b3fe01ebcda7c80973f5b4c0d8199a7a6563b85fd6edf272d460'),
+             output)
+        self.assertEquals(0, rc)
+
+    @patch('sys.stdin', StringIO(VPC_PROTOCOL_HOST_PATH))
+    @patch('sys.stdout', new_callable=StringIOWithFileNo)
+    @patch.object(awscli.customizations.codecommit.datetime, 'datetime')
+    def test_integration_vpc_using_cli_driver(self, dt_mock, stdout_mock):
+        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        driver = create_clidriver()
+        rc = driver.main('codecommit credential-helper get'.split())
+        output = stdout_mock.getvalue().strip()
+        self.assertEquals(
+            ('username=foo\n'
+             'password=20101008T000000Z'
+             '9ed987cc6336c3de2d9f06b9236c7a9fd76b660b080db15983290e636dbfbd6b'),
              output)
         self.assertEquals(0, rc)
 

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -32,6 +32,26 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
                           'host=git-codecommit.us-east-1.amazonaws.com\n'
                           'path=/v1/repos/myrepo')
 
+    FIPS_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                               'host=git-codecommit-fips.us-east-1.amazonaws.com\n'
+                               'path=/v1/repos/myrepo')
+
+    VPC_1_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                                'host=vpce-0b47ea360adebf88a-jkl88hez.git-codecommit.us-east-1.vpce.amazonaws.com\n'
+                                'path=/v1/repos/myrepo')
+
+    VPC_2_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                                'host=vpce-0b47ea360adebf88a-jkl88hez-us-east-1a.git-codecommit.us-east-1.vpce.amazonaws.com\n'
+                                'path=/v1/repos/myrepo')
+
+    FIPS_VPC_1_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                                     'host=vpce-0b47ea360adebf88a-jkl88hez.git-codecommit-fips.us-east-1.vpce.amazonaws.com\n'
+                                     'path=/v1/repos/myrepo')
+
+    FIPS_VPC_2_PROTOCOL_HOST_PATH = ('protocol=https\n'
+                                     'host=vpce-0b47ea360adebf88a-jkl88hez-us-west-2b.git-codecommit-fips.us-east-1.vpce.amazonaws.com\n'
+                                     'path=/v1/repos/myrepo')
+
     NO_REGION_PROTOCOL_HOST_PATH = ('protocol=https\n'
                                     'host=git-codecommit.amazonaws.com\n'
                                     'path=/v1/repos/myrepo')
@@ -56,6 +76,61 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
     def test_generate_credentials(self, stdout_mock):
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
+    def test_generate_credentials_fips_reads_region_from_url(self, stdout_mock):
+        self.globals.region = None
+        self.session.get_config_variable.return_value = None
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(VPC_1_PROTOCOL_HOST_PATH))
+    def test_generate_credentials_vpc_reads_region_from_url(self, stdout_mock):
+        self.globals.region = None
+        self.session.get_config_variable.return_value = None
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(VPC_2_PROTOCOL_HOST_PATH))
+    def test_generate_credentials_vpc_2_reads_region_from_url(self, stdout_mock):
+        self.globals.region = None
+        self.session.get_config_variable.return_value = None
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(FIPS_VPC_1_PROTOCOL_HOST_PATH))
+    def test_generate_credentials_fips_vpc_1_reads_region_from_url(self, stdout_mock):
+        self.globals.region = None
+        self.session.get_config_variable.return_value = None
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(FIPS_VPC_2_PROTOCOL_HOST_PATH))
+    def test_generate_credentials_fips_vpc_2_reads_region_from_url(self, stdout_mock):
+        self.globals.region = None
+        self.session.get_config_variable.return_value = None
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()


### PR DESCRIPTION
…elper customization

*Issue #, if available:*
- CodeCommit credential helper customization does not currently support VPC endpoints (recently launched) https://aws.amazon.com/about-aws/whats-new/2019/03/aws-codecommit-supports-vpc-endpoints/. Specifically, if a CLI user does not have a default profile region, and does not specify one in the request, then the customization will attempt to parse the region from the CodeCommit url. This needs to be updated to supporting parsing from VPC urls. 
- FIPS endpoint support is also being added, as it suffers from the same problem as the new VPC endpoints.

*Description of changes:*
- This change modifies the url-parsing regex which obtains the AWS region from the CodeCommit repository url.

(note - VPC endpoint urls in the tests are made up and not from real VPCs).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
