### PR TITLE
Disable Printing For Sensitive Configuration Inputs

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -18,6 +18,7 @@ import platform
 import zipfile
 import signal
 import contextlib
+import getpass
 
 from botocore.compat import six
 #import botocore.compat
@@ -223,6 +224,13 @@ def compat_input(prompt):
     sys.stdout.write(prompt)
     sys.stdout.flush()
     return raw_input()
+
+
+def compat_getpass(prompt):
+    """
+    This function is used to get sensitive input without printing it.
+    """
+    return getpass.getpass(prompt)
 
 
 def compat_shell_quote(s, platform=None):

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -230,7 +230,9 @@ def compat_getpass(prompt):
     """
     This function is used to get sensitive input without printing it.
     """
-    return getpass.getpass(prompt)
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    return getpass.getpass('')
 
 
 def compat_shell_quote(s, platform=None):

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -15,7 +15,7 @@ import logging
 
 from botocore.exceptions import ProfileNotFound
 
-from awscli.compat import compat_input
+from awscli.compat import compat_input, compat_getpass
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.configure.addmodel import AddModelCommand
 from awscli.customizations.configure.set import ConfigureSetCommand
@@ -39,7 +39,9 @@ class InteractivePrompter(object):
     def get_value(self, current_value, config_name, prompt_text=''):
         if config_name in ('aws_access_key_id', 'aws_secret_access_key'):
             current_value = mask_value(current_value)
-        response = compat_input("%s [%s]: " % (prompt_text, current_value))
+            response = compat_getpass("%s [%s]: " % (prompt_text, current_value))
+        else:
+            response = compat_input("%s [%s]: " % (prompt_text, current_value))
         if not response:
             # If the user hits enter, we return a value of None
             # instead of an empty string.  That way we can determine


### PR DESCRIPTION
*Issue:* Configure command does not disable printing for sensitive configuration inputs. This can lead to problems when using aws-cli in computational notebook cells, where printed console values are stored by default and can be automatically committed to git repositories.


*Description of changes:* This pull request adds compat_getpass functionality and leverages the existing branching in get_value of configure to disable printing using new function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
