### PR TITLE
Support for packaging GlueJob resources

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -106,17 +106,13 @@ def get_nested_property_value(resource_dict, property_name):
     :return:                Value of the property
     """
 
-    # Support nested properties by allowing '.' in the PROPERTY_NAME
-    if '.' in property_name:
-        sub_property_names = property_name.split('.')
-        property_value = resource_dict.get(sub_property_names[0], None)
-        for sub_property_name in sub_property_names[1:]:
-            if property_value:
-                property_value = property_value.get(sub_property_name, None)
-    else:
-        property_value = resource_dict.get(property_name, None)
-
-    return property_value
+    if '.' not in property_name:
+        return resource_dict.get(property_name, None)
+    
+    property_names = property_name.split('.', 1)
+    # default to empty dictionary so recursion has something to operate on
+    sub_property_dict = resource_dict.get(property_names[0], {}) 
+    return get_nested_property_value(sub_property_dict, property_names[1])
 
 
 def set_nested_property_value(resource_dict, property_name, new_value):
@@ -133,14 +129,14 @@ def set_nested_property_value(resource_dict, property_name, new_value):
     """
     # Support nested properties by allowing '.' in the PROPERTY_NAME
     # Assumes that the property exists in the dictionary
-    if '.' in property_name:
-        sub_property_names = property_name.split('.')
-        property_dict = resource_dict[sub_property_names[0]]
-        for sub_property_name in sub_property_names[1:-1]:
-            property_dict = property_dict[sub_property_name]
-        property_dict[sub_property_names[-1]] = new_value
-    else:
+
+    if '.' not in property_name:
         resource_dict[property_name] = new_value
+        return
+    
+    property_names = property_name.split('.', 1)
+    property_dict = resource_dict[property_names[0]]
+    return set_nested_property_value(property_dict, property_names[1], new_value)
 
 
 def upload_local_artifacts(resource_id, resource_dict, property_name,

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -21,6 +21,7 @@ This command can upload local artifacts referenced in the following places:
     - ``Location`` parameter for the ``AWS::Include`` transform
     - ``SourceBundle`` property for the ``AWS::ElasticBeanstalk::ApplicationVersion`` resource
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
+    - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
 
 
 To specify a local artifact in your template, specify a path to a local file or folder,

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -275,6 +275,11 @@ class TestArtifactExporter(unittest.TestCase):
         property_value = get_nested_property_value(resource_dict, 'Foo')
         self.assertEquals(property_value, 'testfile.yaml')
 
+    def test_get_nested_property_value_1level_missing_returns_None(self):
+        resource_dict = {}
+        property_value = get_nested_property_value(resource_dict, 'Foo')
+        self.assertEquals(property_value, None)
+
     def test_get_nested_property_value_2levels(self):
         resource_dict = { 
             'Foo': {
@@ -283,6 +288,15 @@ class TestArtifactExporter(unittest.TestCase):
         }
         property_value = get_nested_property_value(resource_dict, 'Foo.Bar')
         self.assertEquals(property_value, 'testfile.yaml')
+
+    def test_get_nested_property_value_2levels_missing_returns_None(self):
+        resource_dict = { 
+            'Foo': {
+                'Bar': 'testfile.yaml'
+            }
+        }
+        property_value = get_nested_property_value(resource_dict, 'other.other.other')
+        self.assertEquals(property_value, None)
 
     def test_get_nested_property_value_multiplelevels(self):
         resource_dict = { 
@@ -296,6 +310,19 @@ class TestArtifactExporter(unittest.TestCase):
         }
         property_value = get_nested_property_value(resource_dict, 'Foo.Bar.Fizz.Buzz')
         self.assertEquals(property_value, 'testfile.yaml')
+
+    def test_get_nested_property_value_multiplelevels_missing_returns_None(self):
+        resource_dict = { 
+            'Foo': {
+                'Bar': {
+                    'Fizz': {
+                        'Buzz': 'testfile.yaml'
+                    }
+                }
+            }
+        }
+        property_value = get_nested_property_value(resource_dict, 'Foo.Bar.Fizz.other')
+        self.assertEquals(property_value, None)
 
     def test_set_nested_property_value_1levels(self):
         resource_dict = { 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -15,6 +15,7 @@ from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.artifact_exporter \
     import is_s3_url, parse_s3_url, is_local_file, is_local_folder, \
     upload_local_artifacts, zip_folder, make_abs_path, make_zip, \
+    get_nested_property_value, set_nested_property_value, \
     Template, Resource, ResourceWithS3UrlDict, ServerlessApiResource, \
     ServerlessFunctionResource, GraphQLSchemaResource, \
     LambdaFunctionResource, ApiGatewayRestApiResource, \
@@ -26,7 +27,8 @@ from awscli.customizations.cloudformation.artifact_exporter \
     AppSyncResolverRequestTemplateResource, \
     AppSyncResolverResponseTemplateResource, \
     AppSyncFunctionConfigurationRequestTemplateResource, \
-    AppSyncFunctionConfigurationResponseTemplateResource
+    AppSyncFunctionConfigurationResponseTemplateResource, \
+    GlueJobCommandScriptLocationResource
 
 
 def test_is_s3_url():
@@ -143,6 +145,12 @@ def test_all_resources_export():
         {
             "class": ServerlessRepoApplicationLicense,
             "expected_result": uploaded_s3_url
+        },
+        {
+            "class": GlueJobCommandScriptLocationResource,
+            "expected_result": {
+                    "ScriptLocation": uploaded_s3_url 
+            }
         }
     ]
 
@@ -162,9 +170,22 @@ def _helper_verify_export_resources(
     upload_local_artifacts_mock.reset_mock()
 
     resource_id = "id"
-    resource_dict = {
-        test_class.PROPERTY_NAME: "foo"
-    }
+
+    if '.' in test_class.PROPERTY_NAME:
+        reversed_property_names = test_class.PROPERTY_NAME.split('.')
+        reversed_property_names.reverse()
+        property_dict = {
+            reversed_property_names[0]: "foo"
+        }
+        for sub_property_name in reversed_property_names[1:]:
+            property_dict = {
+                sub_property_name: property_dict
+            }
+        resource_dict = property_dict
+    else:
+        resource_dict = {
+            test_class.PROPERTY_NAME: "foo"
+        }
     parent_dir = "dir"
 
     upload_local_artifacts_mock.return_value = uploaded_s3_url
@@ -178,7 +199,11 @@ def _helper_verify_export_resources(
                                                         test_class.PROPERTY_NAME,
                                                         parent_dir,
                                                         s3_uploader_mock)
-    result = resource_dict[test_class.PROPERTY_NAME]
+    if '.' in test_class.PROPERTY_NAME:
+        top_level_property_name = test_class.PROPERTY_NAME.split('.')[0]
+        result = resource_dict[top_level_property_name]
+    else:
+        result = resource_dict[test_class.PROPERTY_NAME]
     assert_equal(result, expected_result)
 
 
@@ -243,6 +268,81 @@ class TestArtifactExporter(unittest.TestCase):
             self.assertTrue(is_local_folder(filename))
             self.assertFalse(is_local_file(filename))
 
+    def test_get_nested_property_value_1levels(self):
+        resource_dict = { 
+            'Foo': 'testfile.yaml'
+        }
+        property_value = get_nested_property_value(resource_dict, 'Foo')
+        self.assertEquals(property_value, 'testfile.yaml')
+
+    def test_get_nested_property_value_2levels(self):
+        resource_dict = { 
+            'Foo': {
+                'Bar': 'testfile.yaml'
+            }
+        }
+        property_value = get_nested_property_value(resource_dict, 'Foo.Bar')
+        self.assertEquals(property_value, 'testfile.yaml')
+
+    def test_get_nested_property_value_multiplelevels(self):
+        resource_dict = { 
+            'Foo': {
+                'Bar': {
+                    'Fizz': {
+                        'Buzz': 'testfile.yaml'
+                    }
+                }
+            }
+        }
+        property_value = get_nested_property_value(resource_dict, 'Foo.Bar.Fizz.Buzz')
+        self.assertEquals(property_value, 'testfile.yaml')
+
+    def test_set_nested_property_value_1levels(self):
+        resource_dict = { 
+            'Foo': 'testfile.yaml'
+        }
+        set_nested_property_value(resource_dict, 'Foo', 'otherfile.yaml')
+        expected_resource_dict = { 
+            'Foo': 'otherfile.yaml'
+        }
+        self.assertEquals(resource_dict, expected_resource_dict)
+
+    def test_set_nested_property_value_2levels(self):
+        resource_dict = { 
+            'Foo': {
+                'Bar': 'testfile.yaml'
+            }
+        }
+        set_nested_property_value(resource_dict, 'Foo.Bar', 'otherfile.yaml')
+        expected_resource_dict = { 
+            'Foo': {
+                'Bar': 'otherfile.yaml'
+            }
+        }
+        self.assertEquals(resource_dict, expected_resource_dict)
+
+    def test_set_nested_property_value_multiplelevels(self):
+        resource_dict = { 
+            'Foo': {
+                'Bar': {
+                    'Fizz': {
+                        'Buzz': 'testfile.yaml'
+                    }
+                }
+            }
+        }
+        set_nested_property_value(resource_dict, 'Foo.Bar.Fizz.Buzz', 'otherfile.yaml')
+        expected_resource_dict = { 
+            'Foo': {
+                'Bar': {
+                    'Fizz': {
+                        'Buzz': 'otherfile.yaml'
+                    }
+                }
+            }
+        }
+        self.assertEquals(resource_dict, expected_resource_dict)
+
     @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_local_file(self, zip_and_upload_mock):
         # Case 1: Artifact path is a relative path
@@ -298,7 +398,6 @@ class TestArtifactExporter(unittest.TestCase):
             self.s3_uploader_mock.upload_with_dedup.assert_called_with(artifact_path)
             zip_and_upload_mock.assert_not_called()
 
-
     @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_local_folder(self, zip_and_upload_mock):
         property_name = "property"
@@ -324,8 +423,6 @@ class TestArtifactExporter(unittest.TestCase):
 
             zip_and_upload_mock.assert_called_once_with(absolute_artifact_path,
                                                         mock.ANY)
-
-
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_no_path(self, zip_and_upload_mock):
@@ -396,7 +493,6 @@ class TestArtifactExporter(unittest.TestCase):
 
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
-
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.make_zip")
     def test_zip_folder(self, make_zip_mock):
@@ -512,7 +608,6 @@ class TestArtifactExporter(unittest.TestCase):
         is_zipfile_mock.assert_called_once_with(original_path)
         assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
 
-
     @patch("shutil.rmtree")
     @patch("zipfile.is_zipfile")
     @patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
@@ -546,7 +641,6 @@ class TestArtifactExporter(unittest.TestCase):
         rmtree_mock.assert_not_called()
         is_zipfile_mock.assert_called_once_with(original_path)
         assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
-
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_empty_property_value(self, upload_local_artifacts_mock):
@@ -633,7 +727,6 @@ class TestArtifactExporter(unittest.TestCase):
         with self.assertRaises(exceptions.ExportFailedError):
             resource.export(resource_id, resource_dict, parent_dir)
 
-
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_with_s3_url_dict(self, upload_local_artifacts_mock):
         """
@@ -673,7 +766,6 @@ class TestArtifactExporter(unittest.TestCase):
             "o": "key1/key2",
             "v": "SomeVersionNumber"
         })
-
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.Template")
     def test_export_cloudformation_stack(self, TemplateMock):
@@ -1056,7 +1148,6 @@ class TestArtifactExporter(unittest.TestCase):
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
         self.assertEquals(handler_output, {"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}})
 
-
     def test_template_export_path_be_folder(self):
 
         template_path = "/path/foo"
@@ -1109,7 +1200,6 @@ class TestArtifactExporter(unittest.TestCase):
 
         self.assertEqual(returned_dir, temp_dir)
         copyfile_mock.assert_called_once_with(filename, temp_dir + filename)
-
 
     @contextmanager
     def make_temp_dir(self):

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -15,7 +15,6 @@ from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.artifact_exporter \
     import is_s3_url, parse_s3_url, is_local_file, is_local_folder, \
     upload_local_artifacts, zip_folder, make_abs_path, make_zip, \
-    get_nested_property_value, set_nested_property_value, \
     Template, Resource, ResourceWithS3UrlDict, ServerlessApiResource, \
     ServerlessFunctionResource, GraphQLSchemaResource, \
     LambdaFunctionResource, ApiGatewayRestApiResource, \
@@ -267,108 +266,6 @@ class TestArtifactExporter(unittest.TestCase):
         with self.make_temp_dir() as filename:
             self.assertTrue(is_local_folder(filename))
             self.assertFalse(is_local_file(filename))
-
-    def test_get_nested_property_value_1levels(self):
-        resource_dict = { 
-            'Foo': 'testfile.yaml'
-        }
-        property_value = get_nested_property_value(resource_dict, 'Foo')
-        self.assertEquals(property_value, 'testfile.yaml')
-
-    def test_get_nested_property_value_1level_missing_returns_None(self):
-        resource_dict = {}
-        property_value = get_nested_property_value(resource_dict, 'Foo')
-        self.assertEquals(property_value, None)
-
-    def test_get_nested_property_value_2levels(self):
-        resource_dict = { 
-            'Foo': {
-                'Bar': 'testfile.yaml'
-            }
-        }
-        property_value = get_nested_property_value(resource_dict, 'Foo.Bar')
-        self.assertEquals(property_value, 'testfile.yaml')
-
-    def test_get_nested_property_value_2levels_missing_returns_None(self):
-        resource_dict = { 
-            'Foo': {
-                'Bar': 'testfile.yaml'
-            }
-        }
-        property_value = get_nested_property_value(resource_dict, 'other.other.other')
-        self.assertEquals(property_value, None)
-
-    def test_get_nested_property_value_multiplelevels(self):
-        resource_dict = { 
-            'Foo': {
-                'Bar': {
-                    'Fizz': {
-                        'Buzz': 'testfile.yaml'
-                    }
-                }
-            }
-        }
-        property_value = get_nested_property_value(resource_dict, 'Foo.Bar.Fizz.Buzz')
-        self.assertEquals(property_value, 'testfile.yaml')
-
-    def test_get_nested_property_value_multiplelevels_missing_returns_None(self):
-        resource_dict = { 
-            'Foo': {
-                'Bar': {
-                    'Fizz': {
-                        'Buzz': 'testfile.yaml'
-                    }
-                }
-            }
-        }
-        property_value = get_nested_property_value(resource_dict, 'Foo.Bar.Fizz.other')
-        self.assertEquals(property_value, None)
-
-    def test_set_nested_property_value_1levels(self):
-        resource_dict = { 
-            'Foo': 'testfile.yaml'
-        }
-        set_nested_property_value(resource_dict, 'Foo', 'otherfile.yaml')
-        expected_resource_dict = { 
-            'Foo': 'otherfile.yaml'
-        }
-        self.assertEquals(resource_dict, expected_resource_dict)
-
-    def test_set_nested_property_value_2levels(self):
-        resource_dict = { 
-            'Foo': {
-                'Bar': 'testfile.yaml'
-            }
-        }
-        set_nested_property_value(resource_dict, 'Foo.Bar', 'otherfile.yaml')
-        expected_resource_dict = { 
-            'Foo': {
-                'Bar': 'otherfile.yaml'
-            }
-        }
-        self.assertEquals(resource_dict, expected_resource_dict)
-
-    def test_set_nested_property_value_multiplelevels(self):
-        resource_dict = { 
-            'Foo': {
-                'Bar': {
-                    'Fizz': {
-                        'Buzz': 'testfile.yaml'
-                    }
-                }
-            }
-        }
-        set_nested_property_value(resource_dict, 'Foo.Bar.Fizz.Buzz', 'otherfile.yaml')
-        expected_resource_dict = { 
-            'Foo': {
-                'Bar': {
-                    'Fizz': {
-                        'Buzz': 'otherfile.yaml'
-                    }
-                }
-            }
-        }
-        self.assertEquals(resource_dict, expected_resource_dict)
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_local_file(self, zip_and_upload_mock):


### PR DESCRIPTION
Fixes #3570 

The AWS::Glue::Job resource has a ScriptLocation property under a Command property.  This adds support for packaging that file. 

In order to support this the base Resource property was updated to support nested properties.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
