### PR TITLE
Update sample command set-identity-pool-roles

### DIFF
--- a/awscli/examples/cognito-identity/set-identity-pool-roles.rst
+++ b/awscli/examples/cognito-identity/set-identity-pool-roles.rst
@@ -1,4 +1,4 @@
-**To get identity pool roles**
+**To set identity pool roles**
 
 The following ``set-identity-pool-roles``  example sets an identity pool role. ::
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added missing option [--roles] for setting identity pool role and title.
https://docs.aws.amazon.com/cli/latest/reference/cognito-identity/set-identity-pool-roles.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
