### PR TITLE
Update _package_description.rst

### DIFF
--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -14,6 +14,7 @@ This command can upload local artifacts referenced in the following places:
     - ``BodyS3Location`` property for the ``AWS::ApiGateway::RestApi`` resource
     - ``Code`` property for the ``AWS::Lambda::Function`` resource
     - ``CodeUri`` property for the ``AWS::Serverless::Function`` resource
+    - ``ContentUri`` property for the ``AWS::Serverless::LayerVersion`` resource
     - ``DefinitionS3Location`` property for the ``AWS::AppSync::GraphQLSchema`` resource
     - ``RequestMappingTemplateS3Location`` property for the ``AWS::AppSync::Resolver`` resource
     - ``ResponseMappingTemplateS3Location`` property for the ``AWS::AppSync::Resolver`` resource


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I believe, documentation was bit outdated because it wasn't mentioned in the documentation for package command that it supports ContentUri property for 'AWS::Serverless::LayerVersion' where in fact it does support and works as expected. I wasn't able to find anything about it in documentation hence submitting this PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
