### PR TITLE
Support update-kubeconfig during cluster update

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -258,8 +258,10 @@ class EKSClient(object):
 
             if "status" not in self._cluster_description:
                 raise EKSClusterError("Cluster not found")
-            if self._cluster_description["status"] != "ACTIVE":
-                raise EKSClusterError("Cluster status not active")
+            if self._cluster_description["status"] not in ["ACTIVE", "UPDATING"]:
+                raise EKSClusterError("Cluster status is {0}".format(
+                    self._cluster_description["status"]
+                ))
 
         return self._cluster_description
 


### PR DESCRIPTION
Fixes #3914 

Allows update-kubeconfig to run while cluster is either `ACTIVE` or `UPDATING`.  Only `ACTIVE` was supported currently.  Presumably this is because the `UPDATING` status did not exist when the functionality was added.  I confirmed that all information required to build the kubeconfig is present in the DescribeCluster output while in the `UPDATING` status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
