### PR TITLE
Improve s3 integ test robustness

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -211,7 +211,7 @@ def random_chars(num_chars):
     return binascii.hexlify(os.urandom(int(num_chars / 2))).decode('ascii')
 
 
-def random_bucket_name(prefix='awscli-s3integ-', num_random=10):
+def random_bucket_name(prefix='awscli-s3integ-', num_random=15):
     """Generate a random S3 bucket name.
 
     :param prefix: A prefix to use in the bucket name.  Useful
@@ -758,6 +758,7 @@ class BaseS3CLICommand(unittest.TestCase):
         return client
 
     def assert_key_contents_equal(self, bucket, key, expected_contents):
+        self.wait_until_key_exists(bucket, key)
         if isinstance(expected_contents, six.BytesIO):
             expected_contents = expected_contents.getvalue().decode('utf-8')
         actual_contents = self.get_key_contents(bucket, key)

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1999,11 +1999,13 @@ class TestSSERelatedParams(BaseS3IntegrationTest):
         p = aws('s3 sync %s s3://%s/foo/ --sse AES256' % (
             self.files.rootdir, bucket))
         self.assert_no_errors(p)
+        self.wait_until_key_exists(bucket, 'foo/foo.txt')
 
         # Copy sync
         p = aws('s3 sync s3://%s/foo/ s3://%s/bar/ --sse AES256' % (
             bucket, bucket))
         self.assert_no_errors(p)
+        self.wait_until_key_exists(bucket, 'bar/foo.txt')
 
         # Remove the original file
         os.remove(file_name)


### PR DESCRIPTION
This adds additional waiters for object creation to make our integration tests a little more resilient to eventual consistency. This also bumps up the length of the randomly generated bucket names to lower the chance of collision.