### PR TITLE
fix delete a user pool domain example

### DIFF
--- a/awscli/examples/cognito-idp/delete-user-pool-domain.rst
+++ b/awscli/examples/cognito-idp/delete-user-pool-domain.rst
@@ -4,5 +4,5 @@ This example deletes a user pool domain named my-domain.
 
 Command::
 
-  aws cognito-idp delete-user-pool --user-pool-id us-west-2_aaaaaaaaa --domain my-domain
+  aws cognito-idp delete-user-pool-domain --user-pool-id us-west-2_aaaaaaaaa --domain my-domain
 


### PR DESCRIPTION
*Description of changes:* fix delete a user pool domain example. 
the document says `aws cognito-idp delete-user-pool --user-pool-id us-west-2_aaaaaaaaa --domain my-domain` , but the correct cli command is `aws cognito-idp delete-user-pool-domain --user-pool-id us-west-2_aaaaaaaaa --domain my-domain`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
