### PR TITLE
Emit Non Aggregate Keys when Using Text Output

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -231,8 +231,12 @@ class TextFormatter(Formatter):
         try:
             if is_response_paginated(response):
                 result_keys = response.result_keys
-                for page in response:
-                    current = {}
+                for i, page in enumerate(response):
+                    if i > 0:
+                        current = {}
+                    else:
+                        current = response.non_aggregate_part
+
                     for result_key in result_keys:
                         data = result_key.search(page)
                         set_value_from_jmespath(

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -77,6 +77,70 @@ class TestListUsers(BaseAWSCommandParamsTest):
             'ENGINEDEFAULTS\tNone\n')
 
 
+class TestDescribeChangesets(BaseAWSCommandParamsTest):
+
+    def setUp(self):
+        super(TestDescribeChangesets, self).setUp()
+        self.first_parsed_response = {
+            'Capabilities': ['CAPABILITY_IAM'],
+            'ChangeSetId': (
+                'arn:aws:cloudformation:us-west-2:12345:changeSet'
+                '/mychangeset/12345'
+            ),
+            'ChangeSetName': 'mychangeset',
+            'Changes': [{"ChangeId": "1"}],
+            'CreationTime': '2019-04-08T14:21:53.765Z',
+            'ExecutionStatus': 'AVAILABLE',
+            'NotificationARNs': [],
+            'RollbackConfiguration': {'RollbackTriggers': []},
+            'StackId': (
+                'arn:aws:cloudformation:us-west-2:12345:stack'
+                '/MyStack/12345'
+            ),
+            'StackName': 'MyStack',
+            'Status': 'CREATE_COMPLETE',
+            'NextToken': "more stuff"
+        }
+        self.second_parsed_response = {
+            'Capabilities': ['CAPABILITY_IAM'],
+            'ChangeSetId': (
+                'arn:aws:cloudformation:us-west-2:12345:changeSet'
+                '/mychangeset/12345'
+            ),
+            'ChangeSetName': 'mychangeset',
+            'Changes': [{"ChangeId": "2"}],
+            'CreationTime': '2019-04-08T14:21:53.765Z',
+            'ExecutionStatus': 'AVAILABLE',
+            'NotificationARNs': [],
+            'RollbackConfiguration': {'RollbackTriggers': []},
+            'StackId': (
+                'arn:aws:cloudformation:us-west-2:12345:stack'
+                '/MyStack/12345'
+            ),
+            'StackName': 'MyStack',
+            'Status': 'CREATE_COMPLETE'
+        }
+        self.parsed_responses = [
+            self.first_parsed_response,
+            self.second_parsed_response,
+        ]
+
+    def test_non_aggregate_keys(self):
+        output = self.run_cmd(
+            ('cloudformation describe-change-set --change-set-name mychangeset'
+             ' --stack-name MyStack --output text'),
+            expected_rc=0
+        )[0]
+        self.assertEqual(
+            output,
+            ("arn:aws:cloudformation:us-west-2:12345:changeSet/mychangeset/"
+             "12345\tmychangeset\t2019-04-08T14:21:53.765Z\tNone\tAVAILABLE"
+             "\tNone\tarn:aws:cloudformation:us-west-2:12345:stack/MyStack"
+             "/12345\tMyStack\tCREATE_COMPLETE\tNone\tNone\n"
+             "CAPABILITIES\tCAPABILITY_IAM\nCHANGES\t1\nCHANGES\t2\n")
+        )
+
+
 class CustomFormatter(Formatter):
     def __call__(self, operation, response, stream=None):
         self.stream = self._get_default_stream()


### PR DESCRIPTION
Fixes #3962 

Changes the ``TextFormatter`` so that it will properly emit non aggregate keys in the response set upon the first iteration of a paginated response.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
