### PR TITLE
Adding the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.6
+
+RUN mkdir -p /awscli
+COPY . /awscli
+
+WORKDIR /
+
+RUN apk --no-cache update && \
+    apk --no-cache add python py-pip py-setuptools && \
+    pip install --upgrade pip && \
+    pip --no-cache-dir install -e /awscli/ && \
+    rm -rf /var/cache/apk/*


### PR DESCRIPTION
*Issue #3553*

*Description of changes:*
So, I'm creating the Dockerfile to `aws-cli`, it's a simple Dockerfile but it's very helpful to CI/CD :).

For some tests, I'm pushing the image to my account in the docker hub: `https://hub.docker.com/r/marcieltorres/aws-cli`

Would be nice if the AWS push this image to the docker hub official account :)

*Special thanks [@shikow](https://github.com/shikow)