### PR TITLE
Fixed output example indent

### DIFF
--- a/awscli/examples/robomaker/describe-deployment-job.rst
+++ b/awscli/examples/robomaker/describe-deployment-job.rst
@@ -8,7 +8,7 @@ Command::
 
 Output::
 
-{
+  {
     "arn": "arn:aws:robomaker:us-west-2:111111111111:deployment-job/deployment-xl8qssl6pbcn",
     "fleet": "arn:aws:robomaker:us-west-2:111111111111:deployment-fleet/Trek/1539894765711",
     "status": "InProgress",
@@ -36,4 +36,4 @@ Output::
         }
     ],
     "tags": {}
-}
+  }

--- a/awscli/examples/robomaker/describe-fleet.rst
+++ b/awscli/examples/robomaker/describe-fleet.rst
@@ -8,7 +8,7 @@ Command::
 
 Output::
 
-{
+  {
     "name": "MyFleet",
     "arn": "arn:aws:robomaker:us-west-2:111111111111:deployment-fleet/MyFleet/1539894765711",
     "robots": [
@@ -26,4 +26,4 @@ Output::
     "lastDeploymentJob": "arn:aws:robomaker:us-west-2:111111111111:deployment-job/deployment-xl8qssl6pbcn",
     "lastDeploymentTime": 1551218369.0,
     "tags": {}
-}
+  }


### PR DESCRIPTION
Two example JSON outputs were missing opening and closing brace indents. They were displayed as text in docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
