### PR TITLE
Special case docs for single element lists

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -453,6 +453,10 @@ class ParamShorthandDocGen(ParamShorthand):
                 self._uses_old_list_case(
                     service_id, operation_name, cli_argument.name):
             member_name = list(model.member.members)[0]
+            # Handle special case where the min/max is exactly one.
+            metadata = model.metadata
+            if metadata.get('min') == 1 and metadata.get('max') == 1:
+                return '%s %s1' % (cli_argument.cli_name, member_name)
             return '%s %s1 %s2 %s3' % (cli_argument.cli_name, member_name,
                                        member_name, member_name)
         elif model.type_name == 'structure' and \

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -581,6 +581,27 @@ class TestDocGen(BaseArgProcessTest):
         with mock.patch(uses_old_list, mock.Mock(return_value=True)):
             self.assert_generated_example_is(argument, '--arg Bar1 Bar2 Bar3')
 
+    def test_generates_single_example_with_min_max_1(self):
+        # An example of this is
+        # 'workspaces rebuild-workspaces --rebuild-workspace-requests'
+        argument = self.create_argument({
+            'Arg': {
+                'type': 'list',
+                'max': 1,
+                'min': 1,
+                'member': {
+                    'type': 'structure',
+                    'members': {
+                        'Bar': {'type': 'string'}
+                    }
+                }
+            }
+        }, 'arg')
+        argument.argument_model = argument.argument_model.members['Arg']
+        uses_old_list = 'awscli.argprocess.ParamShorthand._uses_old_list_case'
+        with mock.patch(uses_old_list, mock.Mock(return_value=True)):
+            self.assert_generated_example_is(argument, '--arg Bar1')
+
     def test_does_not_flatten_unmarked_single_member_structure_list(self):
         argument = self.create_argument({
             'Arg': {


### PR DESCRIPTION
Some params have lists that can only be a single
element (presumably to be forward compatible).  We can
detect this special case and provide better examples.
With this change, here's an example of what this looks like:

```
       --rebuild-workspace-requests (list)
          The WorkSpace to rebuild. You can specify a single WorkSpace.

       Shorthand Syntax:

          --rebuild-workspace-requests WorkspaceId1

       JSON Syntax:

          [
            {
              "WorkspaceId": "string"
            }
            ...
          ]

```

Previously we'd have `--my-arg Arg1 Arg2 Arg3`.

NOTE: This will fail until https://github.com/boto/botocore/pull/1712 is merged.