### PR TITLE
Load idna encoding before running any CLI code

### DIFF
--- a/awscli/__main__.py
+++ b/awscli/__main__.py
@@ -11,6 +11,18 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+# Don't remove this line.  The idna encoding
+# is used by getaddrinfo when dealing with unicode hostnames,
+# and in some cases, there appears to be a race condition
+# where threads will get a LookupError on getaddrinfo() saying
+# that the encoding doesn't exist.  Using the idna encoding before
+# running any CLI code (and any threads it may create) ensures that
+# the encodings.idna is imported and registered in the codecs registry,
+# which will stop the LookupErrors from happening.
+# See: https://bugs.python.org/issue29288
+u''.encode('idna')
+
+
 import sys
 
 from awscli.clidriver import main


### PR DESCRIPTION
There's a reported issue on py36 MSI installs
of the CLI where you'll occasionally see idna LookupErrors.

```
Traceback (most recent call last):
  File ".\runtime\lib\site-packages\botocore\httpsession.py", line 258, in send
    decode_content=False,
  File ".\runtime\lib\site-packages\urllib3\connectionpool.py", line 600, in urlopen
    chunked=chunked)
  File ".\runtime\lib\site-packages\urllib3\connectionpool.py", line 343, in _make_request
    self._validate_conn(conn)
  File ".\runtime\lib\site-packages\urllib3\connectionpool.py", line 839, in _validate_conn
    conn.connect()
  File ".\runtime\lib\site-packages\urllib3\connection.py", line 301, in connect
    conn = self._new_conn()
  File ".\runtime\lib\site-packages\urllib3\connection.py", line 159, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw)
  File ".\runtime\lib\site-packages\urllib3\util\connection.py", line 57, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "socket.py", line 743, in getaddrinfo
LookupError: unknown encoding: idna
```

There appears to be some sort of race condition where
worker threads aren't able to find this encoding.  Ensuring
the encoding is used before any CLI code will prevent this
issue.

Note that we're encoding a string instead of just importing
the apropriate module to ensure the encoding is registered with
the codecs registry.  Encoding a string will implicitly import the
`encodings.idna` module:

```
>>> import sys
>>> [m for m in sys.modules if m.startswith('encodings.')]
['encodings.aliases', 'encodings.utf_8', 'encodings.latin_1']
>>> u''.encode('idna')
b''
>>> [m for m in sys.modules if m.startswith('encodings.')]
['encodings.aliases', 'encodings.utf_8', 'encodings.latin_1', 'encodings.idna']
```

See: https://bugs.python.org/issue29288

There's not really a good way to test this, it only repros when you
use the python's embeddable package for windows.
