### PR TITLE
Support Chinese regions in the S3Uploader

### DIFF
--- a/.changes/next-release/bugfix-Cloudformation-75127.json
+++ b/.changes/next-release/bugfix-Cloudformation-75127.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Cloudformation",
+  "description": "Support non-AWS partition regions in CloudFormation deploy and package. Fixes `#3635 <https://github.com/aws/aws-cli/issues/3635>`__."
+}

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -280,7 +280,6 @@ class DeployCommand(BasicCommand):
 
             s3_uploader = S3Uploader(s3_client,
                                       bucket,
-                                      parsed_globals.region,
                                       parsed_args.s3_prefix,
                                       parsed_args.kms_key_id,
                                       parsed_args.force_upload)

--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -139,7 +139,6 @@ class PackageCommand(BasicCommand):
 
         self.s3_uploader = S3Uploader(s3_client,
                                       bucket,
-                                      parsed_globals.region,
                                       parsed_args.s3_prefix,
                                       parsed_args.kms_key_id,
                                       parsed_args.force_upload)

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -197,7 +197,11 @@ class S3Uploader(object):
         """
         base = "https://s3.amazonaws.com"
         if self.region and self.region != "us-east-1":
-            base = "https://s3-{0}.amazonaws.com".format(self.region)
+            if self.region.startswith("cn-"):
+                base = "https://s3.{0}.amazonaws.com.cn".format(self.region)
+            else:
+                base = "https://s3-{0}.amazonaws.com".format(self.region)
+
 
         result = "{0}/{1}/{2}".format(base, self.bucket_name, key)
         if version:

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -59,7 +59,6 @@ class S3Uploader(object):
 
     def __init__(self, s3_client,
                  bucket_name,
-                 region,
                  prefix=None,
                  kms_key_id=None,
                  force_upload=False,
@@ -69,7 +68,6 @@ class S3Uploader(object):
         self.kms_key_id = kms_key_id or None
         self.force_upload = force_upload
         self.s3 = s3_client
-        self.region = region
 
         self.transfer_manager = transfer_manager
         if not transfer_manager:
@@ -195,14 +193,7 @@ class S3Uploader(object):
             This link describes the format of Path Style URLs
             http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro
         """
-        base = "https://s3.amazonaws.com"
-        if self.region and self.region != "us-east-1":
-            if self.region.startswith("cn-"):
-                base = "https://s3.{0}.amazonaws.com.cn".format(self.region)
-            else:
-                base = "https://s3-{0}.amazonaws.com".format(self.region)
-
-
+        base = self.s3.meta.endpoint_url
         result = "{0}/{1}/{2}".format(base, self.bucket_name, key)
         if version:
             result = "{0}?versionId={1}".format(result, version)

--- a/awscli/customizations/servicecatalog/generatebase.py
+++ b/awscli/customizations/servicecatalog/generatebase.py
@@ -30,7 +30,6 @@ class GenerateBaseCommand(BasicCommand):
         )
         self.s3_uploader = S3Uploader(self.s3_client,
                                       parsed_args.bucket_name,
-                                      self.region,
                                       force_upload=True)
         try:
             self.s3_uploader.upload(parsed_args.file_path,

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -212,7 +212,6 @@ class TestDeployCommand(unittest.TestCase):
 
             s3UploaderMock.assert_called_once_with(mock.ANY,
                     bucket_name,
-                    mock.ANY,
                     self.parsed_args.s3_prefix,
                     self.parsed_args.kms_key_id,
                     self.parsed_args.force_upload)

--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -314,6 +314,27 @@ class TestS3Uploader(unittest.TestCase):
                 "https://s3-{0}.amazonaws.com/{1}/{2}".format(
                         region, self.bucket_name, key))
 
+
+    def test_to_path_style_s3_url_china_regions(self):
+        key = "path/to/file"
+        version = "someversion"
+        region = "cn-northwest-1"
+
+        s3uploader = S3Uploader(self.s3client, self.bucket_name, region)
+        result = s3uploader.to_path_style_s3_url(key, version)
+        self.assertEqual(
+                result,
+                "https://s3.{0}.amazonaws.com.cn/{1}/{2}?versionId={3}".format(
+                        region, self.bucket_name, key, version))
+
+        # Without versionId, that query parameter should be omitted
+        s3uploader = S3Uploader(self.s3client, self.bucket_name, region)
+        result = s3uploader.to_path_style_s3_url(key)
+        self.assertEqual(
+                result,
+                "https://s3.{0}.amazonaws.com.cn/{1}/{2}".format(
+                        region, self.bucket_name, key))
+
     def test_artifact_metadata_invalid_type(self):
         prefix = "SomePrefix"
         s3uploader = S3Uploader(


### PR DESCRIPTION
This updates the S3Uploader customization to support creating path style URLs to objects in the Chinese regions (or any region we support, really).

Fixes #3635 