### PR TITLE
Unset termination protection in create-cluster

### DIFF
--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -210,30 +210,33 @@ class CreateCluster(Command):
                 parsed_args.auto_terminate is False):
             parsed_args.no_auto_terminate = True
 
-        instances_config['KeepJobFlowAliveWhenNoSteps'] = \
-            emrutils.apply_boolean_options(
-                parsed_args.no_auto_terminate,
-                '--no-auto-terminate',
-                parsed_args.auto_terminate,
-                '--auto-terminate')
+        keep_job_flow_alive_when_no_steps = emrutils.apply_boolean_options(
+            parsed_args.no_auto_terminate,
+            '--no-auto-terminate',
+            parsed_args.auto_terminate,
+            '--auto-terminate')
+        if keep_job_flow_alive_when_no_steps is not None:
+            instances_config['KeepJobFlowAliveWhenNoSteps'] = keep_job_flow_alive_when_no_steps
 
-        instances_config['TerminationProtected'] = \
-            emrutils.apply_boolean_options(
-                parsed_args.termination_protected,
-                '--termination-protected',
-                parsed_args.no_termination_protected,
-                '--no-termination-protected')
+        termination_protected = emrutils.apply_boolean_options(
+            parsed_args.termination_protected,
+            '--termination-protected',
+            parsed_args.no_termination_protected,
+            '--no-termination-protected')
+        if termination_protected is not None:
+            instances_config['TerminationProtected'] = termination_protected
 
         if (parsed_args.visible_to_all_users is False and
                 parsed_args.no_visible_to_all_users is False):
             parsed_args.visible_to_all_users = True
 
-        params['VisibleToAllUsers'] = \
-            emrutils.apply_boolean_options(
-                parsed_args.visible_to_all_users,
-                '--visible-to-all-users',
-                parsed_args.no_visible_to_all_users,
-                '--no-visible-to-all-users')
+        visible_to_all_users = emrutils.apply_boolean_options(
+            parsed_args.visible_to_all_users,
+            '--visible-to-all-users',
+            parsed_args.no_visible_to_all_users,
+            '--no-visible-to-all-users')
+        if visible_to_all_users is not None:
+            params['VisibleToAllUsers'] = visible_to_all_users
 
         params['Tags'] = emrutils.parse_tags(parsed_args.tags)
         params['Instances'] = instances_config

--- a/awscli/customizations/emr/emrutils.py
+++ b/awscli/customizations/emr/emrutils.py
@@ -64,8 +64,10 @@ def apply_boolean_options(
         raise ValueError(error_message)
     elif true_option:
         return True
-    else:
+    elif false_option:
         return False
+    else:
+        return None
 
 
 # Deprecate. Rename to apply_dict

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -57,7 +57,6 @@ DEFAULT_CMD = ('emr create-cluster --ami-version 3.0.4 --use-default-roles'
                ' --instance-groups ' + DEFAULT_INSTANCE_GROUPS_ARG + ' ')
 
 DEFAULT_INSTANCES = {'KeepJobFlowAliveWhenNoSteps': True,
-                     'TerminationProtected': False,
                      'InstanceGroups': DEFAULT_INSTANCE_GROUPS
                      }
 
@@ -460,7 +459,11 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
 
     def test_no_termination_protected(self):
         cmd = DEFAULT_CMD + '--no-termination-protected'
-        self.assert_params_for_cmd(cmd, DEFAULT_RESULT)
+        result = copy.deepcopy(DEFAULT_RESULT)
+        instances = copy.deepcopy(DEFAULT_INSTANCES)
+        instances['TerminationProtected'] = False
+        result['Instances'] = instances
+        self.assert_params_for_cmd(cmd, result)
 
     def test_termination_protected_and_no_termination_protected(self):
         cmd = DEFAULT_CMD + \
@@ -577,7 +580,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_result = copy.deepcopy(DEFAULT_RESULT)
         expected_result['Instances'] = \
             {'KeepJobFlowAliveWhenNoSteps': True,
-             'TerminationProtected': False,
              'InstanceGroups':
                 [{'InstanceRole': 'MASTER',
                   'InstanceCount': 1,
@@ -592,7 +594,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_result = copy.deepcopy(DEFAULT_RESULT)
         expected_result['Instances'] = \
             {'KeepJobFlowAliveWhenNoSteps': True,
-             'TerminationProtected': False,
              'InstanceGroups':
                 [{'InstanceRole': 'MASTER',
                   'InstanceCount': 1,
@@ -1344,7 +1345,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_AUTOSCALING_POLICY
                               },
                 'AmiVersion': '3.1.0',
@@ -1384,7 +1384,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups':
                                                 CONSTANTS.INSTANCE_GROUPS_WITH_EBS
                             },
@@ -1413,7 +1412,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_VOLSPEC
                                       },
                 'AmiVersion': '3.1.0',
@@ -1429,7 +1427,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_IOPS
                              },
                 'AmiVersion': '3.1.0',
@@ -1445,7 +1442,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.MULTIPLE_INSTANCE_GROUPS_WITH_EBS_VOLUMES
                              },
                 'AmiVersion': '3.1.0',
@@ -1501,7 +1497,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_ON_DEMAND_MASTER_ONLY
                             },
@@ -1518,7 +1513,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY
                             },
@@ -1535,7 +1529,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY_WITH_EBS_CONF
                             },
@@ -1553,7 +1546,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY,
                               'Placement': {'AvailabilityZones': ['us-east-1a','us-east-1b']}
@@ -1572,7 +1564,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY,
                               'Ec2SubnetIds': ['subnetid-1','subnetid-2']
@@ -1590,7 +1581,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_CORE_CLUSTER
                             },
@@ -1609,7 +1599,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_COMPLEX_CONFIG_FROM_JSON
                             },

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -61,7 +61,6 @@ DEFAULT_CMD = ('emr create-cluster --release-label emr-4.0.0'
                ' --instance-groups ' + DEFAULT_INSTANCE_GROUPS_ARG + ' ')
 
 DEFAULT_INSTANCES = {'KeepJobFlowAliveWhenNoSteps': True,
-                     'TerminationProtected': False,
                      'InstanceGroups': DEFAULT_INSTANCE_GROUPS
                      }
 
@@ -417,7 +416,11 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
 
     def test_no_termination_protected(self):
         cmd = DEFAULT_CMD + '--no-termination-protected'
-        self.assert_params_for_cmd(cmd, DEFAULT_RESULT)
+        result = copy.deepcopy(DEFAULT_RESULT)
+        instances = copy.deepcopy(DEFAULT_INSTANCES)
+        instances['TerminationProtected'] = False
+        result['Instances'] = instances
+        self.assert_params_for_cmd(cmd, result)
 
     def test_termination_protected_and_no_termination_protected(self):
         cmd = DEFAULT_CMD + \
@@ -526,7 +529,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_result = copy.deepcopy(DEFAULT_RESULT)
         expected_result['Instances'] = \
             {'KeepJobFlowAliveWhenNoSteps': True,
-             'TerminationProtected': False,
              'InstanceGroups':
                 [{'InstanceRole': 'MASTER',
                   'InstanceCount': 1,
@@ -541,7 +543,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_result = copy.deepcopy(DEFAULT_RESULT)
         expected_result['Instances'] = \
             {'KeepJobFlowAliveWhenNoSteps': True,
-             'TerminationProtected': False,
              'InstanceGroups':
                 [{'InstanceRole': 'MASTER',
                   'InstanceCount': 1,
@@ -1056,7 +1057,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_AUTOSCALING_POLICY
                               },
                 'ReleaseLabel': 'emr-4.2.0',
@@ -1096,7 +1096,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_EBS
                               },
                 'ReleaseLabel': 'emr-4.2.0',
@@ -1124,7 +1123,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_VOLSPEC
                               },
                 'ReleaseLabel': 'emr-4.2.0',
@@ -1140,7 +1138,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_IOPS
                               },
                 'ReleaseLabel': 'emr-4.2.0',
@@ -1156,7 +1153,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceGroups': CONSTANTS.MULTIPLE_INSTANCE_GROUPS_WITH_EBS_VOLUMES
                               },
                 'ReleaseLabel': 'emr-4.2.0',
@@ -1172,7 +1168,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_ON_DEMAND_MASTER_ONLY
                             },
@@ -1189,7 +1184,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY_WITH_EBS_CONF
                             },
@@ -1207,7 +1201,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY,
                               'Placement': {'AvailabilityZones': ['us-east-1a','us-east-1b']}
@@ -1226,7 +1219,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_ONLY,
                               'Ec2SubnetIds': ['subnetid-1','subnetid-2']
@@ -1244,7 +1236,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_SPOT_MASTER_CORE_CLUSTER
                             },
@@ -1263,7 +1254,6 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             {
                 'Name': DEFAULT_CLUSTER_NAME,
                 'Instances': {'KeepJobFlowAliveWhenNoSteps': True,
-                              'TerminationProtected': False,
                               'InstanceFleets':
                                                 CONSTANTS_FLEET.RES_INSTANCE_FLEETS_WITH_COMPLEX_CONFIG_FROM_JSON
                             },

--- a/tests/unit/customizations/emr/test_emr_utils.py
+++ b/tests/unit/customizations/emr/test_emr_utils.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from awscli.customizations.emr.emrutils import which
+from awscli.customizations.emr.emrutils import apply_boolean_options
 from nose.tools import assert_equal
 from nose.tools import assert_not_equal
 
@@ -25,3 +26,15 @@ class TestEMRutils(object):
     def test_which_with_non_existing_command(self):
         path = which('klajsflklj')
         assert_equal(path, None)
+
+    def test_apply_boolean_options_true_option(self):
+        boolean_option = apply_boolean_options(True, '', None, '')
+        assert_equal(boolean_option, True)
+
+    def test_apply_boolean_options_false_option(self):
+        boolean_option = apply_boolean_options(None, '', True, '')
+        assert_equal(boolean_option, False)
+
+    def test_apply_boolean_options_none_option(self):
+        boolean_option = apply_boolean_options(None, '', None, '')
+        assert_equal(boolean_option, None)

--- a/tests/unit/customizations/emr/test_emrfs_utils.py
+++ b/tests/unit/customizations/emr/test_emrfs_utils.py
@@ -27,7 +27,6 @@ from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
 
 DEFAULT_INSTANCES = {
     'KeepJobFlowAliveWhenNoSteps': True,
-    'TerminationProtected': False,
     'InstanceGroups': [{
         'InstanceRole': 'MASTER',
         'InstanceCount': 1,


### PR DESCRIPTION
The purpose of this change is to rely on the EMR service for determining the termination protection value when running the following CLI command:

```
aws emr create-cluster [...]
```

Currently the RunJobFlow `JobFlowInstancesConfig` model treats `TerminationProtected` as an optional value, but RunJobFlow requests from create-cluster will always send `false` for this field unless this is overridden in the CLI using `--no-termination-protected`.

This is a cosmetic fix to the EMR CLI.  The current behaviour of the CLI and EMR is not changing.

https://docs.aws.amazon.com/emr/latest/APIReference/API_JobFlowInstancesConfig.html