### PR TITLE
Fix for Code Deploy Ruby2.0 dependency for Ubuntu 18 / Ubuntu 16

### DIFF
--- a/awscli/customizations/codedeploy/systems.py
+++ b/awscli/customizations/codedeploy/systems.py
@@ -213,7 +213,7 @@ class Linux(System):
 class Ubuntu(Linux):
     def _update_system(self, params):
         subprocess.check_call(['apt-get', '-y', 'update'])
-        subprocess.check_call(['apt-get', '-y', 'install', 'ruby2.0'])
+        subprocess.check_call(['apt-get', '-y', 'install', 'ruby'])
 
     def _remove_agent(self, params):
         subprocess.check_call(['dpkg', '-r', 'codedeploy-agent'])


### PR DESCRIPTION
***Issue #, if available:*** #2976 https://github.com/aws/aws-codedeploy-agent/issues/174

***Description of changes:*** Change package install to just "ruby", so that an on premises deploy install works on Ubuntu 16 and Ubuntu 18. 

Ruby should be installed anyway, as running the code deploy install script will do ruby checks. https://github.com/aws/aws-codedeploy-agent/blob/866632b98447312962e629c31da94e756127c620/bin/install#L79

Might be best to do something similar to the code deploy agent, by checking 2.*? Not sure of the implications of changing from "ruby2.0" to just "ruby" for older versions of Ubuntu.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.