### PR TITLE
Fixed eks get-token customization

### DIFF
--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -83,7 +83,7 @@ class TokenGenerator(object):
     def get_token(self, cluster_name, role_arn):
         """ Generate a presigned url token to pass to kubectl. """
         url = self._get_presigned_url(cluster_name, role_arn)
-        token = TOKEN_PREFIX + base64.urlsafe_b64encode(url.encode('utf-8')).decode('utf-8')
+        token = TOKEN_PREFIX + base64.urlsafe_b64encode(url.encode('utf-8')).decode('utf-8').rstrip('=')
         return token
 
     def _get_presigned_url(self, cluster_name, role_arn):

--- a/tests/unit/customizations/eks/test_get_token.py
+++ b/tests/unit/customizations/eks/test_get_token.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import mock
+from mock import patch
 import base64
 import datetime
 import botocore
@@ -84,6 +85,12 @@ class TestTokenGenerator(unittest.TestCase):
             token_no_prefix.encode()
         ).decode()
         self.assert_url_correct(decrypted_token, False)
+
+    @patch.object(TokenGenerator, '_get_presigned_url', return_value='aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8=')
+    def test_token_no_padding(self, mock_presigned_url):
+        generator = TokenGenerator(REGION, self._session_handler)
+        tok = generator.get_token(CLUSTER_NAME, None)
+        self.assertTrue('=' not in tok)
 
     def test_token_sess(self):
         generator = TokenGenerator(REGION, self._assuming_handler)


### PR DESCRIPTION
When python base64 encodes bytes, it will add padding characters (equal
signs, `=`) to the end of strings that where the encoded length is not
divisible by 4. aws-iam-authenticator [1] uses go's implementation of
base64 url encoding [2] which strips padding characters. The difference
of behavior causes padded tokens to be rejected by the authenticator
server.

[1] https://github.com/kubernetes-sigs/aws-iam-authenticator
[2] https://golang.org/pkg/encoding/base64/#RawURLEncoding

*Issue #, if available:*
N/A

*Description of changes:*
Strip padding to match go's base64 encoding behavior. The aws-iam-authenticator server rejects tokens that contain padding

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
