### PR TITLE
Fix #3618 s3uploader writing to stdout

### DIFF
--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -220,8 +220,8 @@ class ProgressPercentage(BaseSubscriber):
         with self._lock:
             self._seen_so_far += bytes_transferred
             percentage = (self._seen_so_far / self._size) * 100
-            sys.stdout.write(
+            sys.stderr.write(
                     "\rUploading to %s  %s / %s  (%.2f%%)" %
                     (self._remote_path, self._seen_so_far,
                      self._size, percentage))
-            sys.stdout.flush()
+            sys.stderr.flush()


### PR DESCRIPTION
The package command writes the template out to stdout.  Having the
status written on stderr results in the standard practice of piping
stdout to a template file to break.

eg.  aws cloudformation package --template-file cloudformation.yaml
--s3-bucket goehd-test > cloudformation.pkg

This results in the value

\rUploading ...

In the first line of the output with deploy complaining about
mapped values not being allowed in <unicode string>.

Redirecting this to stderr reverts the behavior to be compliant with
standard practice.

*Issue #3618*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
