### PR TITLE
Added region argument to eks update-kubeconfig

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -101,7 +101,7 @@ class UpdateKubeconfigCommand(BasicCommand):
     ]
 
     def _display_entries(self, entries):
-        """ 
+        """
         Display entries in yaml format
 
         :param entries: a list of OrderedDicts to be printed
@@ -248,7 +248,7 @@ class EKSClient(object):
                 client = self._session.create_client("eks")
             else:
                 client = self._session.create_client(
-                    "eks", 
+                    "eks",
                     region_name=self._globals.region,
                     endpoint_url=self._globals.endpoint_url,
                     verify=self._globals.verify_ssl
@@ -287,6 +287,9 @@ class EKSClient(object):
         Return a user entry generated using
         the previously obtained description.
         """
+
+        region = self._get_cluster_description().get("arn").split(":")[3]
+
         generated_user = OrderedDict([
             ("name", self._get_cluster_description().get("arn", "")),
             ("user", OrderedDict([
@@ -294,10 +297,12 @@ class EKSClient(object):
                     ("apiVersion", API_VERSION),
                     ("args",
                         [
+                            "--region",
+                            region,
                             "eks",
                             "get-token",
                             "--cluster-name",
-                            self._cluster_name
+                            self._cluster_name,
                         ]),
                     ("command", "aws")
                 ]))

--- a/tests/functional/eks/testdata/invalid_string_cluster_entry
+++ b/tests/functional/eks/testdata/invalid_string_cluster_entry
@@ -15,6 +15,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/invalid_string_clusters
+++ b/tests/functional/eks/testdata/invalid_string_clusters
@@ -14,6 +14,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/invalid_string_context_entry
+++ b/tests/functional/eks/testdata/invalid_string_context_entry
@@ -15,6 +15,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/invalid_string_contexts
+++ b/tests/functional/eks/testdata/invalid_string_contexts
@@ -14,6 +14,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/output_combined
+++ b/tests/functional/eks/testdata/output_combined
@@ -26,6 +26,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name
@@ -36,6 +38,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - region
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/output_combined_changed_ordering
+++ b/tests/functional/eks/testdata/output_combined_changed_ordering
@@ -4,6 +4,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name
@@ -14,6 +16,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - region
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/output_single
+++ b/tests/functional/eks/testdata/output_single
@@ -18,6 +18,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - region
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_bad_cluster
+++ b/tests/functional/eks/testdata/valid_bad_cluster
@@ -15,6 +15,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_bad_cluster2
+++ b/tests/functional/eks/testdata/valid_bad_cluster2
@@ -17,6 +17,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_bad_context
+++ b/tests/functional/eks/testdata/valid_bad_context
@@ -15,6 +15,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_bad_context2
+++ b/tests/functional/eks/testdata/valid_bad_context2
@@ -17,6 +17,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_bad_user
+++ b/tests/functional/eks/testdata/valid_bad_user
@@ -17,6 +17,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_changed_ordering
+++ b/tests/functional/eks/testdata/valid_changed_ordering
@@ -4,6 +4,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_existing
+++ b/tests/functional/eks/testdata/valid_existing
@@ -18,6 +18,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_no_cluster
+++ b/tests/functional/eks/testdata/valid_no_cluster
@@ -13,6 +13,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_no_context
+++ b/tests/functional/eks/testdata/valid_no_context
@@ -13,6 +13,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_no_current_context
+++ b/tests/functional/eks/testdata/valid_no_current_context
@@ -17,6 +17,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/functional/eks/testdata/valid_old_data
+++ b/tests/functional/eks/testdata/valid_old_data
@@ -26,6 +26,8 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
       args:
+      - --region
+      - us-west-2
       - eks
       - get-token
       - --cluster-name

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -174,6 +174,8 @@ class TestEKSClient(unittest.TestCase):
                     ("apiVersion", API_VERSION),
                     ("args",
                         [
+                            "--region",
+                            "region",
                             "eks",
                             "get-token",
                             "--cluster-name",


### PR DESCRIPTION
*Issue #, if available:*

#4145

*Description of changes:*

The region of an EKS cluster will never change, so we add the --region
flag for users who have not setup a region via the config file or
environment variable. Fixes #4145

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
