### PR TITLE
Fixed link and updated formatting

### DIFF
--- a/awscli/examples/cloudformation/update-stack.rst
+++ b/awscli/examples/cloudformation/update-stack.rst
@@ -1,16 +1,16 @@
 **To update AWS CloudFormation stacks**
 
-The following ``update-stack`` command updates the template and input parameters for the ``mystack`` stack::
+The following ``update-stack`` command updates the template and input parameters for the ``MyStack`` stack::
 
-  aws cloudformation update-stack --stack-name mystack --template-url https://s3.amazonaws.com/sample/updated.template --parameters ParameterKey=KeyPairName,ParameterValue=SampleKeyPair ParameterKey=SubnetIDs,ParameterValue=SampleSubnetID1\\,SampleSubnetID2
+  aws cloudformation update-stack --stack-name MyStack --template-url https://s3.amazonaws.com/sample/updated.template --parameters ParameterKey=KeyPairName,ParameterValue=SampleKeyPair ParameterKey=SubnetIDs,ParameterValue=SampleSubnetID1\\,SampleSubnetID2
 
-The following ``update-stack`` command updates just the ``SubnetIDs`` parameter value for the ``mystack`` stack. If you
+The following ``update-stack`` command updates just the ``SubnetIDs`` parameter value for the ``MyStack`` stack. If you
 don't specify a parameter value, the default value that is specified in the template is used::
 
-  aws cloudformation update-stack --stack-name mystack --template-url https://s3.amazonaws.com/sample/updated.template --parameters ParameterKey=KeyPairName,UsePreviousValue=true ParameterKey=SubnetIDs,ParameterValue=SampleSubnetID1\\,UpdatedSampleSubnetID2
+  aws cloudformation update-stack --stack-name MyStack --template-url https://s3.amazonaws.com/sample/updated.template --parameters ParameterKey=KeyPairName,UsePreviousValue=true ParameterKey=SubnetIDs,ParameterValue=SampleSubnetID1\\,UpdatedSampleSubnetID2
 
-The following ``update-stack`` command adds two stack notification topics to the ``mystack`` stack::
+The following ``update-stack`` command adds two stack notification topics to the ``MyStack`` stack::
 
-  aws cloudformation update-stack --stack-name mystack --use-previous-template --notification-arns "arn:aws:sns:use-east-1:123456789012:mytopic1" "arn:aws:sns:us-east-1:123456789012:mytopic2"
+  aws cloudformation update-stack --stack-name MyStack --use-previous-template --notification-arns "arn:aws:sns:use-east-1:123456789012:mytopic1" "arn:aws:sns:us-east-1:123456789012:mytopic2"
 
-For more information, see `Updating a Stack`_ in the *AWS CloudFormation User Guide*.
+For more information, see `Updating Stacks <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks.html>`_ in the `AWS CloudFormation User Guide <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html>`_.


### PR DESCRIPTION
*Issue #, if available:*
Nil

*Description of changes:*
Updated the example document for the 'aws cloudformation update-stack' command. Fixed a link to AWS Documentation, added a new link, and capitalized the stack name to improve readability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
