### PR TITLE
Fixed eks get-token to use provided session

### DIFF
--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -54,11 +54,13 @@ class GetTokenCommand(BasicCommand):
         }
     ]
 
-    def _run_main(self, parsed_args, parsed_globals):
-        token_generator = TokenGenerator(parsed_globals.region)
+    def _run_main(self, parsed_args, parsed_globals, token_generator=None):
+        if token_generator is None:
+            token_generator = TokenGenerator(self._session)
         token = token_generator.get_token(
             parsed_args.cluster_name,
-            parsed_args.role_arn
+            parsed_args.role_arn,
+            parsed_globals.region,
         )
 
         full_object = {
@@ -74,37 +76,34 @@ class GetTokenCommand(BasicCommand):
         uni_print('\n')
 
 class TokenGenerator(object):
-    def __init__(self, region_name, session_handler=None):
-        if session_handler is None:
-            session_handler = SessionHandler()
-        self._session_handler = session_handler
-        self._region_name = region_name
+    def __init__(self, botocore_session):
+        self._session_handler = SessionHandler(botocore_session)
 
-    def get_token(self, cluster_name, role_arn):
+    def get_token(self, cluster_name, role_arn, region_name=None):
         """ Generate a presigned url token to pass to kubectl. """
-        url = self._get_presigned_url(cluster_name, role_arn)
+        url = self._get_presigned_url(cluster_name, role_arn, region_name)
         token = TOKEN_PREFIX + base64.urlsafe_b64encode(url.encode('utf-8')).decode('utf-8').rstrip('=')
         return token
 
-    def _get_presigned_url(self, cluster_name, role_arn):
+    def _get_presigned_url(self, cluster_name, role_arn, region_name=None):
         session = self._session_handler.get_session(
-            self._region_name,
+            region_name,
             role_arn
         )
 
-        if self._region_name is None:
-            self._region_name = session.get_config_variable('region')
+        if region_name is None:
+            region_name = session.get_config_variable('region')
 
         loader = botocore.loaders.create_loader()
         data = loader.load_data("endpoints")
         endpoint_resolver = botocore.regions.EndpointResolver(data)
         endpoint = endpoint_resolver.construct_endpoint(
             AUTH_SERVICE,
-            self._region_name
+            region_name
         )
         signer = RequestSigner(
             ServiceId(AUTH_SERVICE),
-            self._region_name,
+            region_name,
             AUTH_SERVICE,
             AUTH_SIGNING_VERSION,
             session.get_credentials(),
@@ -128,11 +127,14 @@ class TokenGenerator(object):
         return url
 
 class SessionHandler(object):
+    def __init__(self, botocore_session):
+        self._session = botocore_session
+
     def get_session(self, region_name, role_arn):
         """
         Assumes the given role and returns a session object assuming said role.
         """
-        session = botocore.session.get_session()
+        session = self._session
         if region_name is not None:
             session.set_config_variable('region', region_name)
 


### PR DESCRIPTION
Fixes #4163
N/A

*Description of changes:*

When trying to use get-token with an MFA role and AWS_PROFILE set, it
would prompt for a MFA token on every call. The command now uses the
built-in session in order to leverage cached assume role credentials.

The command will still be able to assume an additional role by handling
`--role-arn`, but only for non-MFA roles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
