### PR TITLE
Fixed example that expected list of strings instead of list of JSON structures

### DIFF
--- a/awscli/examples/iam/get-context-keys-for-custom-policy.rst
+++ b/awscli/examples/iam/get-context-keys-for-custom-policy.rst
@@ -1,11 +1,35 @@
-**To list the context keys referenced by one or more custom JSON policies**
+**Example 1: To list the context keys referenced by one or more custom JSON policies provided as a parameter on the command line**
 
 The following ``get-context-keys-for-custom-policy`` command parses each supplied policy and lists the context keys used by those policies. Use this command to identify which context key values you must supply to successfully use the policy simulator commands ``simulate-custom-policy`` and ``simulate-custom-policy``. You can also retrieve the list of context keys used by all policies associated by an IAM user or role by using the ``get-context-keys-for-custom-policy`` command. Parameter values that begin with ``file://`` instruct the command to read the file and use the contents as the value for the parameter instead of the file name itself.::
 
     aws iam get-context-keys-for-custom-policy \
         --policy-input-list '{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"dynamodb:*","Resource":"arn:aws:dynamodb:us-west-2:123456789012:table/${aws:username}","Condition":{"DateGreaterThan":{"aws:CurrentTime":"2015-08-16T12:00:00Z"}}}}'
 
-**Known issue**: At this time, you can't submit a file to the ``--policy-input-list`` parameter using the ``file://`` syntax. You must instead collapse the content into a single line and submit the policy content directly on the command line as shown in the previous example.
+Output::
+
+    {
+        "ContextKeyNames": [
+            "aws:username",
+            "aws:CurrentTime"
+        ]
+    }
+
+**Example 2: To list the context keys referenced by one or more custom JSON policies provided as a file input**
+
+The following ``get-context-keys-for-custom-policy`` command is the same as the previous example, except that the policies are provided in a file instead of as a parameter. Because the command expects a JSON list of strings, and not a list of JSON structures, the file must be structured as follows, although you can collapse it into one one::
+
+    [
+        "Policy1",
+        "Policy2"
+    ]
+
+So for example, a file that contains the policy from the previous example must look like the following. You must escape each embedded double-quote inside the policy string by preceding it with a backslash '\'. ::
+
+    [ "{\"Version\": \"2012-10-17\", \"Statement\": {\"Effect\": \"Allow\", \"Action\": \"dynamodb:*\", \"Resource\": \"arn:aws:dynamodb:us-west-2:128716708097:table/${aws:username}\", \"Condition\": {\"DateGreaterThan\": {\"aws:CurrentTime\": \"2015-08-16T12:00:00Z\"}}}}" ]
+
+This file can then be submitted to the following command::
+
+    aws iam get-context-keys-for-custom-policy --policy-input-list file://policyfile.json
 
 Output::
 

--- a/awscli/examples/iam/simulate-principal-policy.rst
+++ b/awscli/examples/iam/simulate-principal-policy.rst
@@ -1,30 +1,29 @@
-**To simulate the effects of all IAM policies associated with an IAM user or role**
+**To simulate the effects of an arbitrary IAM policy**
 
-The following ``simulate-custom-policy`` shows how to provide both the policy and define variable values and simulate an API call to see if it is allowed or denied. The following example shows a policy that enables database access only after a specified date and time. The simulation succeeds because the simulated actions and the specified ``aws:CurrentTime`` variable all match the requirements of the policy. ::
+The following ``simulate-principal-policy`` shows how to simulate a user calling an API action and determining whether the policies associated with that user allow or deny the action. In the following example, the user has a policy that allows only the ``codecommit:ListRepositories`` action. ::
 
-    aws iam simulate-custom-policy \
-        --policy-input-list '{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"dynamodb:*","Resource":"*","Condition":{"DateGreaterThan":{"aws:CurrentTime":"2018-08-16T12:00:00Z"}}}}' \
-        --action-names dynamodb:CreateBackup \
-        --context-entries "ContextKeyName='aws:CurrentTime',ContextKeyValues='2019-04-25T11:00:00Z',ContextKeyType=date"
+    aws iam simulate-principal-policy \
+        --policy-source-arn arn:aws:iam::123456789012:user/alejandro \
+        --action-names codecommit:ListRepositories
 
 Output::
 
     {
         "EvaluationResults": [
             {
-                "EvalActionName": "dynamodb:CreateBackup",
+                "EvalActionName": "codecommit:ListRepositories",
                 "EvalResourceName": "*",
                 "EvalDecision": "allowed",
                 "MatchedStatements": [
                     {
-                        "SourcePolicyId": "PolicyInputList.1",
+                        "SourcePolicyId": "Grant-Access-To-CodeCommit-ListRepo",
                         "StartPosition": {
-                            "Line": 1,
-                            "Column": 38
+                            "Line": 3,
+                            "Column": 19
                         },
                         "EndPosition": {
-                            "Line": 1,
-                            "Column": 167
+                            "Line": 9,
+                            "Column": 10
                         }
                     }
                 ],
@@ -33,12 +32,12 @@ Output::
         ]
     }
 
-The following ``simulate-custom-policy`` example shows the results of simulating a command that is prohibited by the policy. In this example, the provided date is before that required by the policy's condition. ::
+The following ``simulate-custom-policy`` example shows the results of simulating a command that is prohibited by one of the user's policies. In the following example, the user has a policy that permits access to a DynamoDB database only after a certain date and time. The simulation has the user attempting to access the database with an ``aws:CurrentTime`` value that is earlier than the policy's condition permits. ::
 
-    aws iam simulate-custom-policy \
-        --policy-input-list '{"Version":"2012-10-17","Statement":{"Effect":"Allow","Action":"dynamodb:*","Resource":"*","Condition":{"DateGreaterThan":{"aws:CurrentTime":"2018-08-16T12:00:00Z"}}}}' \
+    aws iam simulate-principal-policy \
+        --policy-source-arn arn:aws:iam::123456789012:user/alejandro \
         --action-names dynamodb:CreateBackup \
-        --context-entries "ContextKeyName='aws:CurrentTime',ContextKeyValues='2014-04-25T11:00:00Z',ContextKeyType=date"
+        --context-entries "ContextKeyName='aws:CurrentTime',ContextKeyValues='2018-04-25T11:00:00Z',ContextKeyType=date"
 
 Output::
 


### PR DESCRIPTION
Fixed the IAM get-context-keys-for-custom-policies command to indicate how the file:// input to the policies must be formatted. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
