### PR TITLE
Support for packaging extra Python files in Glue Job resources.

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -119,7 +119,7 @@ def upload_local_artifacts(resource_id, resource_dict, property_name,
 
     If path is already a path to S3 object, this method does nothing.
 
-    An additional property called append_filename has been added. This property
+    An additional parameter called append_filename has been added. This property
     will append the end of the filename as part of the uploaded S3 path after the
     md5hash. For example, if the absolute path referenced in the CloudFormation template
     is /path/to/file/bar.txt, the uploaded file will be of the format {md5hash}/bar.txt.
@@ -134,9 +134,12 @@ def upload_local_artifacts(resource_id, resource_dict, property_name,
     :param parent_dir:      Resolve all relative paths with respect to this
                             directory
     :param uploader:        Method to upload files to S3
+    :param append_filename: Controls whether the original short filename will be appended.
 
-    :return:                S3 URL of the uploaded object
-    :raise:                 ValueError if path is not a S3 URL or a local path
+    :return:                S3 URL of the uploaded object, or a comma-delimited list of S3 URLs of
+                            the uploaded objects.
+    :raise:                 ValueError if path is not a S3 URL or a local path, or a comma-delimited-list
+                            of local paths.
     """
 
     local_path = jmespath.search(property_name, resource_dict)

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -59,6 +59,8 @@ def is_local_file(path):
     return is_path_value_valid(path) and os.path.isfile(path)
 
 def is_local_file_comma_delimited_list(path):
+    if type(path) != str:
+        return False
     paths = path.split(',')
     for p in paths:
         if (not is_path_value_valid(p)) or (not (os.path.isfile(p))):

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -529,7 +529,7 @@ class GlueJobDefaultArgumentsExtraPyFilesResource(Resource):
     def do_export(self, resource_id, resource_dict, parent_dir):
         uploaded_url = upload_local_artifacts(resource_id, resource_dict,
                                    self.PROPERTY_NAME,
-                                   parent_dir, self.uploader)
+                                   parent_dir, self.uploader, append_filename=True)
 
         # Need to remove quotes from the path for it to be output correctly.
         set_value_from_jmespath(resource_dict, self.PROPERTY_NAME.replace('"', ''), uploaded_url)

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -159,9 +159,9 @@ class S3Uploader(object):
         :param extension: String of file extension to append to the object
         :return: S3 URL of the uploaded object
         """
-        
+
         filemd5 = self.file_checksum(file_name)
-        remote_path = "{}/{}".format(filemd5, file_name.split('/')[-1])
+        remote_path = "{0}/{1}".format(filemd5, file_name.split('/')[-1])
         if extension:
             remote_path = remote_path + "." + extension
 

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -149,7 +149,17 @@ class S3Uploader(object):
 
     def upload_with_dedup_with_original_name_appended(self, file_name, extension=None):
         """
+        Makes and returns name of the S3 object based on the file's MD5 sum.
+        Unlike upload_with_dedup, this method uses the MD5 sum as a prefix/folder and 
+        appends the original name of the file (without parent directories). For example,
+        if the file_name /path/to/foo.txt is provided, the uploaded file will have the
+        format {md5sum}/foo.txt.
+
+        :param file_name: file to upload
+        :param extension: String of file extension to append to the object
+        :return: S3 URL of the uploaded object
         """
+        
         filemd5 = self.file_checksum(file_name)
         remote_path = "{}/{}".format(filemd5, file_name.split('/')[-1])
         if extension:

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -147,6 +147,16 @@ class S3Uploader(object):
 
         return self.upload(file_name, remote_path)
 
+    def upload_with_dedup_with_original_name_appended(self, file_name, extension=None):
+        """
+        """
+        filemd5 = self.file_checksum(file_name)
+        remote_path = "{}/{}".format(filemd5, file_name.split('/')[-1])
+        if extension:
+            remote_path = remote_path + "." + extension
+
+        return self.upload(file_name, remote_path)
+
     def file_exists(self, remote_path):
         """
         Check if the file we are trying to upload already exists in S3

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -161,7 +161,7 @@ class S3Uploader(object):
         """
 
         filemd5 = self.file_checksum(file_name)
-        remote_path = "{0}/{1}".format(filemd5, file_name.split('/')[-1])
+        remote_path = "{0}/{1}".format(filemd5, file_name.split(os.sep)[-1])
         if extension:
             remote_path = remote_path + "." + extension
 

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -155,6 +155,8 @@ class S3Uploader(object):
         if the file_name /path/to/foo.txt is provided, the uploaded file will have the
         format {md5sum}/foo.txt.
 
+        Because the path separator can vary by os, we must use os.sep instead of '/'.
+
         :param file_name: file to upload
         :param extension: String of file extension to append to the object
         :return: S3 URL of the uploaded object

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -712,6 +712,7 @@ class TestArtifactExporter(unittest.TestCase):
         upload_local_artifacts_mock.assert_not_called()
         self.assertNotIn(resource.PROPERTY_NAME, resource_dict)
 
+
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_export_fails(self, upload_local_artifacts_mock):
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -712,9 +712,6 @@ class TestArtifactExporter(unittest.TestCase):
         upload_local_artifacts_mock.assert_not_called()
         self.assertNotIn(resource.PROPERTY_NAME, resource_dict)
 
-    # @patch("awscli.customization.cloudformation.artifact_exporter.upload_local_artifacts")
-    # def test_resource_has_package
-
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_export_fails(self, upload_local_artifacts_mock):
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -333,11 +333,12 @@ class TestArtifactExporter(unittest.TestCase):
             self.assertFalse(is_local_file(filename))
 
     def test_is_local_file_comma_delimited_list_two_files(self):
-        with tempfile.NamedTemporaryFile() as handle1, tempfile.NamedTemporaryFile() as handle2:
-            filelist = '{},{}'.format(handle1.name, handle2.name)
-            self.assertTrue(is_local_file_comma_delimited_list(filelist))
-            self.assertFalse(is_local_file(filelist))
-            self.assertFalse(is_local_folder(filelist))
+        with tempfile.NamedTemporaryFile() as handle1:
+            with tempfile.NamedTemporaryFile() as handle2:
+                filelist = '{},{}'.format(handle1.name, handle2.name)
+                self.assertTrue(is_local_file_comma_delimited_list(filelist))
+                self.assertFalse(is_local_file(filelist))
+                self.assertFalse(is_local_folder(filelist))
 
     def test_is_local_file_comma_delimited_list_trailing_comma(self):
         with tempfile.NamedTemporaryFile() as handle1:
@@ -739,7 +740,7 @@ class TestArtifactExporter(unittest.TestCase):
         self.s3_uploader_mock.upload_with_dedup_with_original_name_appended.return_value = "s3://foo/file"
 
         resource.export(resource_id, resource_dict, parent_dir)
-        
+
         self.s3_uploader_mock.upload_with_dedup_with_original_name_appended.assert_called_once_with(filepath)
 
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -656,6 +656,9 @@ class TestArtifactExporter(unittest.TestCase):
         upload_local_artifacts_mock.assert_not_called()
         self.assertNotIn(resource.PROPERTY_NAME, resource_dict)
 
+    # @patch("awscli.customization.cloudformation.artifact_exporter.upload_local_artifacts")
+    # def test_resource_has_package
+
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_export_fails(self, upload_local_artifacts_mock):
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -161,6 +161,11 @@ def test_all_resources_export():
                     upload_local_artifacts_mock, \
                     test["expected_result"]
 
+
+        # The GlueJobDefaultArgumentsExtraPyFilesResource must be tested separately, as it expects upload_local_artifacts_mock
+        # to be called with an extra argument, which the _helper_verify_export_resources does not take into account.
+        # A different appropriately named helper, _helper_verify_export_resources_with_append_filename, i used for this
+        # test case instead.
         test_glue_extra_py_files = {
             "class": GlueJobDefaultArgumentsExtraPyFilesResource,
             "expected_result": {

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -335,14 +335,14 @@ class TestArtifactExporter(unittest.TestCase):
     def test_is_local_file_comma_delimited_list_two_files(self):
         with tempfile.NamedTemporaryFile() as handle1:
             with tempfile.NamedTemporaryFile() as handle2:
-                filelist = '{},{}'.format(handle1.name, handle2.name)
+                filelist = '{0},{1}'.format(handle1.name, handle2.name)
                 self.assertTrue(is_local_file_comma_delimited_list(filelist))
                 self.assertFalse(is_local_file(filelist))
                 self.assertFalse(is_local_folder(filelist))
 
     def test_is_local_file_comma_delimited_list_trailing_comma(self):
         with tempfile.NamedTemporaryFile() as handle1:
-            filelist = '{},'.format(handle1.name)
+            filelist = '{0},'.format(handle1.name)
             self.assertFalse(is_local_file_comma_delimited_list(filelist))
             self.assertFalse(is_local_file(filelist))
             self.assertFalse(is_local_folder(filelist))

--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -248,6 +248,42 @@ class TestS3Uploader(unittest.TestCase):
         remotepath = "{0}.{1}".format(checksum, extension)
         self.s3uploader.upload.assert_called_once_with(filename, remotepath)
 
+    def test_upload_with_dedup_with_original_name_appended(self):
+        
+        checksum = "somemd5checksum"
+        filename_full = "/path/to/filename"
+        filename_short = "filename"
+        extension = "extn"
+
+
+        self.s3uploader.file_checksum = Mock()
+        self.s3uploader.file_checksum.return_value = checksum
+
+        self.s3uploader.upload = Mock()
+
+        self.s3uploader.upload_with_dedup_with_original_name_appended(filename_full, extension)
+
+        remotepath = "{0}/{1}.{2}".format(checksum, filename_short, extension)
+
+        self.s3uploader.upload.assert_called_once_with(filename_full, remotepath)
+
+    def test_upload_with_dedup_with_original_name_appended_no_extension(self):
+
+        checksum = "somemd5checksum"
+        filename = "/path/to/filename.file"
+        filename_short = "filename.file"
+
+        self.s3uploader.file_checksum = Mock()
+        self.s3uploader.file_checksum.return_value = checksum
+
+        self.s3uploader.upload = Mock()
+
+        self.s3uploader.upload_with_dedup_with_original_name_appended(filename)
+
+        remotepath = "{0}/{1}".format(checksum, filename_short)
+
+        self.s3uploader.upload.assert_called_once_with(filename, remotepath)
+
     def test_file_exists(self):
         key = "some/path"
         expected_params = {

--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -248,6 +248,7 @@ class TestS3Uploader(unittest.TestCase):
         remotepath = "{0}.{1}".format(checksum, extension)
         self.s3uploader.upload.assert_called_once_with(filename, remotepath)
 
+    @patch("os.sep", '/')
     def test_upload_with_dedup_with_original_name_appended(self):
         
         checksum = "somemd5checksum"
@@ -267,10 +268,29 @@ class TestS3Uploader(unittest.TestCase):
 
         self.s3uploader.upload.assert_called_once_with(filename_full, remotepath)
 
+    @patch("os.sep", '/')
     def test_upload_with_dedup_with_original_name_appended_no_extension(self):
 
         checksum = "somemd5checksum"
         filename = "/path/to/filename.file"
+        filename_short = "filename.file"
+
+        self.s3uploader.file_checksum = Mock()
+        self.s3uploader.file_checksum.return_value = checksum
+
+        self.s3uploader.upload = Mock()
+
+        self.s3uploader.upload_with_dedup_with_original_name_appended(filename)
+
+        remotepath = "{0}/{1}".format(checksum, filename_short)
+
+        self.s3uploader.upload.assert_called_once_with(filename, remotepath)
+
+    @patch("os.sep", '\\')
+    def test_upload_with_dedup_with_original_name_appended_no_extension_windows_sep(self):
+
+        checksum = "somemd5checksum"
+        filename = "C:\\path\\to\\filename.file"
         filename_short = "filename.file"
 
         self.s3uploader.file_checksum = Mock()


### PR DESCRIPTION
*Description of changes:*
Builds upon [#4019](https://github.com/aws/aws-cli/pull/4019) to support packaging extra Python files within `AWS::Glue::Job` resources.

The `AWS::Glue::Job` resource has an optional `extra-py-files` argument under the `DefaultArguments`  property where either a Python file or a comma-delimited list of Python files to include in the Python path for a Glue job can be specified.'

This PR adds support for packaging those files.

To support this, a new Resource (`GlueJobDefaultArgumentsExtraPyFilesResource`) with custom logic to handle the comma-delimited list of files was added.

Because Glue requires the original Python file name to be preserved, an option to upload a file with the original file name appended after the md5sum was added. For example, if the file `/path/to/file.py` is to be uploaded as an extra Python file for a Glue job, it will be uploaded with the format `{md5sum}/file.py` with this option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
