### PR TITLE
Wait until newly created objects are available in integ tests

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -790,6 +790,7 @@ class BaseS3CLICommand(unittest.TestCase):
             call_args.update(extra_args)
         response = client.put_object(**call_args)
         self.addCleanup(self.delete_key, bucket_name, key_name)
+        self.wait_until_key_exists(bucket_name, key_name)
 
     def delete_bucket(self, bucket_name, attempts=5, delay=5):
         self.remove_all_objects(bucket_name)


### PR DESCRIPTION
This adds a `wait_until_key_exists` in the `put_object` helper method for our S3 integration tests. This helps make the tests a little more robust in cases where we called `put_object` immediately followed by call to an `aws cp/mv`, etc.