### PR TITLE
Add snapcraft support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: aws-cli
+summary: Universal Command Line Interface for Amazon Web Services
+description: |
+ This package provides a unified command line interface to Amazon Web
+ Services.
+version: git
+version-script: cat $SNAPCRAFT_STAGE/version
+
+confinement: classic
+grade: stable
+
+apps:
+  aws:
+    # Workaround https://bugs.launchpad.net/snappy/+bug/1664427
+    command: usr/bin/python3 $SNAP/bin/aws
+    completer: bin/aws_bash_completer
+
+parts:
+  aws:
+    plugin: python
+    source: https://github.com/aws/aws-cli.git
+    override-build: |
+      git describe --tags $(git rev-list --tags --max-count=1) > $SNAPCRAFT_STAGE/version
+      TAG=$(cat $SNAPCRAFT_STAGE/version)
+      git checkout tags/$TAG
+      snapcraftctl build
+    stage-packages:
+      - groff-base  # for `aws help`


### PR DESCRIPTION
*Issues:* 
https://github.com/awsdocs/aws-cli-user-guide/issues/17

*Description of changes: Add support for building and updating aws-cli snap*

This includes the snapcraft.yaml that supports the build for aws-cli. By including the snapcraft in the official repository, the snap can be generated upon each release without manual intervention by the Amazon Partner Network team responsible for publication to the snap store. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
