### PR TITLE
fixed several mediaconvert example syntax errors

### DIFF
--- a/awscli/examples/mediaconvert/cancel-job.rst
+++ b/awscli/examples/mediaconvert/cancel-job.rst
@@ -3,9 +3,9 @@
 The following ``cancel-job`` example cancels the job with ID ``1234567891234-abc123``. You can't cancel a job that the service has started processing. ::
 
     aws mediaconvert cancel-job \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
-        --region=region-name-1 \
-        --id=1234567891234-abc123
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
+        --region region-name-1 \
+        --id 1234567891234-abc123
 
 To get your account-specific endpoint, use ``describe-endpoints``, or send the command without the endpoint. The service returns an error and your endpoint.
 

--- a/awscli/examples/mediaconvert/create-job-template.rst
+++ b/awscli/examples/mediaconvert/create-job-template.rst
@@ -3,10 +3,10 @@
 The following ``create-job-template`` example creates a job template with the transcoding settings that are specified in the file ``job-template.json`` that resides on your system. ::
 
     aws mediaconvert create-job-template \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
-        --region=region-name-1 \
-        --name=JobTemplate1 \
-        --cli-input-json=file://~/job-template.json
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
+        --region region-name-1 \
+        --name JobTemplate1 \
+        --cli-input-json file://~/job-template.json
 
 If you create your job template JSON file by using ``get-job-template`` and then modifying the file, remove the ``JobTemplate`` object, but keep the `Settings` child object inside it. Also, make sure to remove the following key-value pairs: ``LastUpdated``, ``Arn``, ``Type``, and ``CreatedAt``. You can specific the category, description, name, and queue either in the JSON file or at the command line.
 

--- a/awscli/examples/mediaconvert/create-job.rst
+++ b/awscli/examples/mediaconvert/create-job.rst
@@ -3,9 +3,9 @@
 The following ``create-job`` example creates a transcoding job with the settings that are specified in a file ``job.json`` that resides on the system that you send the command from. This JSON job specification might specify each setting individually, reference a job template, or reference output presets. ::
 
     aws mediaconvert create-job \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
-        --region=region-name-1 \
-        --cli-input-json=file://~/job.json
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
+        --region region-name-1 \
+        --cli-input-json file://~/job.json
 
 You can use the AWS Elemental MediaConvert console to generate the JSON job specification by choosing your job settings, and then choosing **Show job JSON** at the bottom of the **Job** section. 
 

--- a/awscli/examples/mediaconvert/create-preset.rst
+++ b/awscli/examples/mediaconvert/create-preset.rst
@@ -3,8 +3,8 @@
 The following ``create-preset`` example creates a custom output preset based on the output settings that are specified in the file ``preset.json``. You can specify the category, description, and name either in the JSON file or at the command line. ::
 
     aws mediaconvert create-preset \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com 
-        --region=region-name-1 \
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com 
+        --region region-name-1 \
         --cli-input-json file://~/preset.json
 
 If you create your preset JSON file by using ``get-preset`` and then modifying the output file, ensure that you remove the following key-value pairs: ``LastUpdated``, ``Arn``, ``Type``, and ``CreatedAt``.

--- a/awscli/examples/mediaconvert/create-queue.rst
+++ b/awscli/examples/mediaconvert/create-queue.rst
@@ -3,10 +3,10 @@
 The following ``create-queue`` example creates a custom transcoding queue. ::
 
     aws mediaconvert create-queue \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
-        --region=region-name-1 \
-        --name=Queue1 \
-        --description="Keep this queue empty unless job is urgent."
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
+        --region region-name-1 \
+        --name Queue1 \
+        --description "Keep this queue empty unless job is urgent."
 
 To get your account-specific endpoint, use ``describe-endpoints``, or send the command without the endpoint. The service returns an error and your endpoint.
 

--- a/awscli/examples/mediaconvert/get-job.rst
+++ b/awscli/examples/mediaconvert/get-job.rst
@@ -3,9 +3,9 @@
 The following example requests the information for the job with ID ``1234567890987-1ab2c3``, which in this example ended in an error. ::
 
     aws mediaconvert get-job \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
-        --region=region-name-1 \
-        --id=1234567890987-1ab2c3
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
+        --region region-name-1 \
+        --id 1234567890987-1ab2c3
 
 To get your account-specific endpoint, use ``describe-endpoints``, or send the command without the endpoint. The service returns an error and your endpoint.
 

--- a/awscli/examples/mediaconvert/list-jobs.rst
+++ b/awscli/examples/mediaconvert/list-jobs.rst
@@ -3,8 +3,8 @@
 The following example requests the information for all of your jobs in the specified region. ::
 
     aws mediaconvert list-jobs \
-        --endpoint-url=https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
-        --region=region-name-1
+        --endpoint-url https://abcd1234.mediaconvert.region-name-1.amazonaws.com \
+        --region region-name-1
 
 To get your account-specific endpoint, use ``describe-endpoints``, or send the command without the endpoint. The service returns an error and your endpoint.
 


### PR DESCRIPTION
Found several examples that incorrectly had = separating the CLI parameters from their values. Replaced with spaces.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
