### PR TITLE
Check if AWS::Include location is a string before packacing. Fixes #4087

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -516,9 +516,13 @@ def include_transform_export_handler(template_dict, uploader, parent_dir):
         return template_dict
 
     include_location = template_dict.get("Parameters", {}).get("Location", None)
-    if not include_location or is_s3_url(include_location):
+    if not include_location \
+            or not is_path_value_valid(include_location) \
+            or is_s3_url(include_location):
+        # `include_location` is either empty, or not a string, or an S3 URI
         return template_dict
 
+    # We are confident at this point that `include_location` is a string containing the local path
     abs_include_location = os.path.join(parent_dir, include_location)
     if is_local_file(abs_include_location):
         template_dict["Parameters"]["Location"] = uploader.upload_with_dedup(abs_include_location)

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -148,7 +148,7 @@ def test_all_resources_export():
         {
             "class": GlueJobCommandScriptLocationResource,
             "expected_result": {
-                    "ScriptLocation": uploaded_s3_url 
+                    "ScriptLocation": uploaded_s3_url
             }
         }
     ]
@@ -1096,6 +1096,20 @@ class TestArtifactExporter(unittest.TestCase):
 
         is_local_file_mock.assert_not_called()
         self.s3_uploader_mock.assert_not_called()
+
+    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    def test_include_transform_export_handler_with_dict_value_for_location(self, is_local_file_mock):
+
+        handler_output = include_transform_export_handler(
+            {"Name": "AWS::Include", "Parameters": {"Location": {"Fn::Sub": "${S3Bucket}/file.txt"}}},
+            self.s3_uploader_mock,
+            "parent_dir")
+        # Input is returned unmodified
+        self.assertEquals(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": {"Fn::Sub": "${S3Bucket}/file.txt"}}})
+
+        is_local_file_mock.assert_not_called()
+        self.s3_uploader_mock.assert_not_called()
+
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_non_local_file(self, is_local_file_mock):


### PR DESCRIPTION
Fixes #4087 

If the value of Location in AWS::Include is *not* a string, we should skip
packaging it. This can happen if customers use, say, an intrinsic function
to construct the Include location:

Example:
```
AWS::Include:
  Location:
    Fn::Sub: "${S3Bucket}/file.txt"
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
