### PR TITLE
Update wheel version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,7 @@ tox>=2.3.1,<3.0.0
 -e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
 nose==1.3.7
 mock==1.3.0
-wheel==0.24.0
+# 0.30.0 dropped support for python2.6
+# remove this upper bound on the wheel version once 2.6 support
+# is dropped from aws-cli
+wheel>0.24.0,<0.30.0


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/4243

*Description of changes:* wheel 0.24.0 will fail to build PyYAML on Mac with Python 3.7.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
