### PR TITLE
eks update-kubeconfig: use current aws executable

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import os
+import sys
 import logging
 
 from botocore.compat import OrderedDict
@@ -304,7 +305,8 @@ class EKSClient(object):
                             "--cluster-name",
                             self._cluster_name,
                         ]),
-                    ("command", "aws")
+                    ("command", sys.argv[0] if os.path.basename(sys.argv[0]) \
+                         == 'aws' else 'aws')
                 ]))
             ]))
         ])


### PR DESCRIPTION
set the aws executable in kube config to be the one currently invoked.
This makes it not depend on $PATH and select the aws-cli from the right
environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
