### PR TITLE
Use new keys when testing metadata directive options

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -585,7 +585,9 @@ class TestCp(BaseS3IntegrationTest):
         for name, value in metadata_ref.items():
             self.assertEqual(response[name], value)
 
-        # Use REPLACE to wipe out all of the metadata.
+        # Use REPLACE to wipe out all of the metadata when copying to a new
+        # key.
+        new_key = '%s-c' % random_chars(6)
         p = aws('s3 cp s3://%s/%s s3://%s/%s --metadata-directive REPLACE' %
                 (bucket_name, original_key, bucket_name, new_key))
         self.assert_no_errors(p)
@@ -596,6 +598,7 @@ class TestCp(BaseS3IntegrationTest):
 
         # Use REPLACE to wipe out all of the metadata but include a new
         # metadata value.
+        new_key = '%s-d' % random_chars(6)
         p = aws('s3 cp s3://%s/%s s3://%s/%s --metadata-directive REPLACE '
                 '--content-type bar' %
                 (bucket_name, original_key, bucket_name, new_key))


### PR DESCRIPTION
There were several cases tested for metadata directives.  This involved
copying an object with specific md values and checking what happens to the
various metadata on the copied object.  We were using the same
destination object for each of those cases.  This could occasionally
cause eventually consistency issues and test failures.  I've updated the
test to use a new destination object each time.  This is slightly
different behavior than what we were testing previously (checking if we
can wipe out existing metadata of an object vs. checking that metadata
is not copied to a new object), but given the test is about metadata
directives, I think from our perspective testing the behavior when
copying to a new object each time is still sufficient to show that we've
implemented this behavior correctly.