### PR TITLE
Added Windows OS support using PowerShell

### DIFF
--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -277,6 +277,13 @@ class ExternalAliasCommand(BaseAliasCommand):
         ]
         command_components.extend(compat_shell_quote(a) for a in args)
         command = ' '.join(command_components)
+        if os.name == 'nt':
+            command = command.replace('\\\n', '')
+            command = command.replace('\n', ' ')
+            command = command.replace('"', '\\"')
+            # escape symbol for powershell
+            command = command.replace('@', '`@')
+            command = 'powershell -Command "function ' + command + '"'
         LOG.debug(
             'Using external alias %r with value: %r to run: %r',
             self._alias_name, self._alias_value, command)


### PR DESCRIPTION
*Description of changes:*
The alias file syntax is designed for the
bash shell on linux. Running as-is causes
the following error:

$ aws myip
'f' is not recognized as an internal or external command,
operable program or batch file.

Using PowerShell with a few character
replacements allows the aliases to work.
The bash shell was considered but it needed
commands to end with a semicolon to work reliably
and it created an external dependency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
