### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -536,8 +536,8 @@ class CreateCluster(Command):
                                                 parsed_args, parsed_configs):
         if parsed_args.use_default_roles:
             configurations = [x for x in configurations
-                              if x.name is not 'service_role' and
-                              x.name is not 'instance_profile']
+                              if x.name not in ('service_role',
+                                                'instance_profile')]
         return configurations
 
     def _handle_emrfs_parameters(self, cluster, emrfs_args, release_label):

--- a/awscli/customizations/emr/emrutils.py
+++ b/awscli/customizations/emr/emrutils.py
@@ -240,7 +240,7 @@ def join(values, separator=',', lastSeparator='and'):
     values = [str(x) for x in values]
     if len(values) < 1:
         return ""
-    elif len(values) is 1:
+    elif len(values) == 1:
         return values[0]
     else:
         separator = '%s ' % separator


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals.

$ __python__
```
>>> name = 'instance_'
>>> name += 'profile'
>>> name == 'instance_profile'
True
>>> name is 'instance_profile'
False
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
