### PR TITLE
Add --query example for describe-instance-patches

### DIFF
--- a/awscli/examples/ssm/describe-instance-patches.rst
+++ b/awscli/examples/ssm/describe-instance-patches.rst
@@ -15,7 +15,7 @@ Output::
                 "Classification": "SecurityUpdates",
                 "Severity": "Critical",
                 "State": "Installed",
-                "InstalledTime": 1546992000.0
+                "InstalledTime": "2019-01-09T00:00:00+00:00"
             },
             {
                 "Title": "",
@@ -23,7 +23,7 @@ Output::
                 "Classification": "",
                 "Severity": "",
                 "State": "InstalledOther",
-                "InstalledTime": 1549584000.0
+                "InstalledTime": "2019-02-08T00:00:00+00:00"
             },
             ...
         ],
@@ -41,18 +41,44 @@ The following ``describe-instance-patches`` example retrieves information about 
 Output::
 
     {
-      "Patches": [
-          {
-              "Title": "Windows Malicious Software Removal Tool x64 - February 2019 (KB890830)",
-              "KBId": "KB890830",
-              "Classification": "UpdateRollups",
-              "Severity": "Unspecified",
-              "State": "Missing",
-              "InstalledTime": 0.0
-          },
-          ...
-      ],
-      "NextToken": "--token string truncated--"
+        "Patches": [
+            {
+                "Title": "Windows Malicious Software Removal Tool x64 - February 2019 (KB890830)",
+                "KBId": "KB890830",
+                "Classification": "UpdateRollups",
+                "Severity": "Unspecified",
+                "State": "Missing",
+                "InstalledTime": "1970-01-01T00:00:00+00:00"
+            },
+            ...
+        ],
+        "NextToken": "--token string truncated--"
     }
 
 For more information, see `About Patch Compliance States <https://docs.aws.amazon.com/systems-manager/latest/userguide/about-patch-compliance-states.html>`__ in the *AWS Systems Manager User Guide*.
+
+**Example 3: To get a list of patches installed since a specified InstalledTime for an instance**
+
+The following ``describe-instance-patches`` example retrieves information about patches installed since a specified time for the specified instance by combining the use of ``--filters`` and ``--query``. ::
+
+    aws ssm describe-instance-patches \
+        --instance-id "i-1234567890abcdef0" \
+        --filters Key=State,Values=Installed \
+        --query "Patches[?InstalledTime >= `2023-01-01T16:00:00`]"
+
+Output::
+
+    {
+        "Patches": [
+            {
+                "Title": "2023-03 Cumulative Update for Windows Server 2019 (1809) for x64-based Systems (KB5023702)",
+                "KBId": "KB5023702",
+                "Classification": "SecurityUpdates",
+                "Severity": "Critical",
+                "State": "Installed",
+                "InstalledTime": "2023-03-16T11:00:00+00:00"
+            },
+            ...
+        ],
+        "NextToken": "--token string truncated--"
+    }


### PR DESCRIPTION
This commit adds an example usage of using --query to retrieve information based on "InstalledTime" as it is not a valid filter key.

Can also be used for the "Title" of the patch as that is also not a valid filter key

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
