### PR TITLE
Add support for AWS::CodeCommit::Repository in aws cloudformation pac…

### DIFF
--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -22,6 +22,7 @@ This command can upload local artifacts referenced in the following places:
     - ``SourceBundle`` property for the ``AWS::ElasticBeanstalk::ApplicationVersion`` resource
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
     - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
+    - ``Code`` property for the ``AWS::CodeCommit::Repository`` resource
 
 
 To specify a local artifact in your template, specify a path to a local file or folder,
@@ -45,4 +46,3 @@ present in the S3 bucket to prevent unnecessary uploads. The command uses MD5
 checksums to compare files. If the values match, the command doesn't upload the
 artifacts. Use the ``--force flag`` to skip this check and always upload the
 artifacts.
-


### PR DESCRIPTION
…kage

*Issue #, if available:* #4316

*Description of changes:*

Add support for ``AWS::CodeCommit::Repository`` in ``aws cloudformation package``. E.g.
```yaml
Resources:
  MyRepository:
    Type: AWS::CodeCommit::Repository
    Properties:
      Code: ./seed/
```

Will translate to:
```yaml
Resources:
  MyRepository:
    Type: AWS::CodeCommit::Repository
    Properties:
      Code:
        S3:
          Bucket: "..."
          Key: "..."
          ObjectVersion: "..."
```

This also add a helper function that takes a dotted path and transform it into a dict or inject it into an existing dict. E.g.:
```python
>>> my_dict = { "S3": {
...    "Bucket": "Test"
... }}
>>> parse_dotted_path_to_dict("S3.Object", my_dict, "Value")
>>> my_dict
{ "S3": {
    "Bucket": "Test",
    "Object": "Value"
}}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
