### PR TITLE
Improved security of s3 acl example to not include public bucket access

### DIFF
--- a/awscli/examples/s3api/put-bucket-logging.rst
+++ b/awscli/examples/s3api/put-bucket-logging.rst
@@ -1,5 +1,5 @@
-The example below sets the logging policy for *MyBucket*. The AWS user *user@example.com* will have full control over
-the log files, and all users will have access to them. First, grant S3 permission with ``put-bucket-acl``::
+The example below sets the logging policy for *MyBucket*. The AWS user *bob@example.com* will have full control over
+the log files, and no one else has any access. First, grant S3 permission with ``put-bucket-acl``::
 
    aws s3api put-bucket-acl --bucket MyBucket --grant-write URI=http://acs.amazonaws.com/groups/s3/LogDelivery --grant-read-acp URI=http://acs.amazonaws.com/groups/s3/LogDelivery
 
@@ -9,28 +9,23 @@ Then apply the logging policy::
 
 ``logging.json`` is a JSON document in the current folder that contains the logging policy::
 
-   {
-     "LoggingEnabled": {
-       "TargetBucket": "MyBucket",
-       "TargetPrefix": "MyBucketLogs/",
-       "TargetGrants": [
-         {
-           "Grantee": {
-             "Type": "AmazonCustomerByEmail",
-             "EmailAddress": "user@example.com"
-           },
-           "Permission": "FULL_CONTROL"
-         },
-         {
-           "Grantee": {
-             "Type": "Group",
-             "URI": "http://acs.amazonaws.com/groups/global/AllUsers"
-           },
-           "Permission": "READ"
-         }
-       ]
-     }
-   }
+    {
+      "LoggingEnabled": {
+        "TargetBucket": "MyBucket",
+        "TargetPrefix": "MyBucketLogs/",
+        "TargetGrants": [
+          {
+            "Grantee": {
+              "Type": "AmazonCustomerByEmail",
+              "EmailAddress": "bob@example.com"
+            },
+            "Permission": "FULL_CONTROL"
+          }
+        ]
+      }
+    }
 
 .. note:: the ``put-bucket-acl`` command is required to grant S3's log delivery system the necessary permissions (write
    and read-acp permissions).
+
+For more information, see `Amazon S3 Server Access Logging <https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerLogs.html>`__ in the *Amazon S3 Developer Guide*.


### PR DESCRIPTION
Original example gave public access to bucket, which is bad practice.  Removed that from the example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
