### PR TITLE
Removed automatic addition of trailing slash in LIST API call when a S3 prefix is specified as source in cp/sync/mv/rm commands

### DIFF
--- a/awscli/customizations/s3/fileformat.py
+++ b/awscli/customizations/s3/fileformat.py
@@ -111,8 +111,6 @@ class FileFormat(object):
                to the source name.
         """
         if dir_op:
-            if not path.endswith('/'):
-                path += '/'
             return path, True
         else:
             if not path.endswith('/'):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -241,7 +241,7 @@ def find_dest_path_comp_key(files, src_path=None):
 
     sep_table = {'s3': '/', 'local': os.sep}
 
-    if files['dir_op']:
+    if files['dir_op'] and src['path'].endswith('/'):
         rel_path = src_path[len(src['path']):]
     else:
         rel_path = src_path.split(sep_table[src_type])[-1]


### PR DESCRIPTION
*Issue #1454:*

**Description**
Use case : Download S3 server access logs of a certain day from the logging bucket. 

Example command : 
`aws s3 cp s3://bucketname/2019-07-22 . --recursive`

The above command tries to download the log files under the "2019-07-22/" path. But, in fact there won't be such path(folder) when S3 tries to write logs to a logging bucket. The idea is to download all the S3 objects that match the prefix : 2019-07-22. Today, AWS CLI cp/sync/mv/rm commands add unwanted / in the LIST API call(with --recursive). 

The alternative today is to use include/exclude filters or use AWS Athena. This is a lot of time if the bucket has billion log files. 

However, aws s3 ls behaves in a right way i..e, it shows the objects that match the prefix but, doesn't add a '/' in the LIST API call. 

So, this commit will fix this issue. 

If anyone wants to cp/sync/mv/rm an actual 'folder' from S3, they can simply specify a trailing slash '/' in the command. 

This issue has been faced by several users and removing the '/' will help them. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
