### PR TITLE
Update docs for delete-user-pool-domain

### DIFF
--- a/awscli/examples/cognito-idp/delete-user-pool-domain.rst
+++ b/awscli/examples/cognito-idp/delete-user-pool-domain.rst
@@ -2,6 +2,6 @@
 
 The following ``delete-user-pool-domain`` example deletes a user pool domain named ``my-domain`` ::
 
-    aws cognito-idp delete-user-pool \
+    aws cognito-idp delete-user-pool-domain \
         --user-pool-id us-west-2_aaaaaaaaa \
         --domain my-domain


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Update docs for delete-user-pool-domain
Example was missing `-domain` in the command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
