### PR TITLE
Upgrading pyyaml<=5.1 to pyyaml<=5.1.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,6 @@ requires-dist =
         docutils>=0.10,<0.15
         rsa>=3.1.2,<=3.5.0
         PyYAML>=3.10,<=3.13; python_version=="2.6"
-        PyYAML>=3.10,<=5.1;python_version!="2.6"
+        PyYAML>=3.10,<=5.1.1;python_version!="2.6"
         s3transfer>=0.2.0,<0.3.0
         argparse>=1.1; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if sys.version_info[:2] == (2, 6):
     # versions dropped support for Python 2.6.
     requires.append('PyYAML>=3.10,<=3.13')
 else:
-    requires.append('PyYAML>=3.10,<=5.1')
+    requires.append('PyYAML>=3.10,<=5.1.1')
 
 
 setup_options = dict(


### PR DESCRIPTION
*Issue #, if available:*
fixes: #4350 #4042 #4243

*Description of changes:*
[PyYAML 5.1.1 released on June 6, 2019](https://pypi.org/project/PyYAML/#history) is not compatible with the latest version of the CLI.   

If you try to install PyYAML and the CLI is already installed, the following error returns: "PyYAML 5.1.1 which is incompatible."  This is due to PIP trying to install the latest PyYAML version (5.1.1).  Command used to install PyYAML is: 

pip3 install --force-reinstall --no-cache-dir pyyaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
