### PR TITLE
Support caching web identity credentials

### DIFF
--- a/.changes/next-release/enhancement-Credentials-12710.json
+++ b/.changes/next-release/enhancement-Credentials-12710.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Credentials",
+  "description": "Add support for a credential provider that handles resolving credentials via STS AssumeRoleWithWebIdentity"
+}

--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -37,5 +37,9 @@ def inject_assume_role_provider_cache(session, **kwargs):
                   "assume-role cred provider cache.  Not configuring "
                   "JSONFileCache for assume-role.")
         return
-    provider = cred_chain.get_provider('assume-role')
-    provider.cache = JSONFileCache(CACHE_DIR)
+    assume_role_provider = cred_chain.get_provider('assume-role')
+    assume_role_provider.cache = JSONFileCache(CACHE_DIR)
+    web_identity_provider = cred_chain.get_provider(
+        'assume-role-with-web-identity'
+    )
+    web_identity_provider.cache = JSONFileCache(CACHE_DIR)

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -284,6 +284,62 @@ the source credentials for the assume role call::
   role_arn=arn:aws:iam:...
   credential_source=Ec2InstanceMetadata
 
+Assume Role With Web Identity
+--------------------------------------
+
+Within the ``~/.aws/config`` file, you can also configure a profile to indicate
+that the AWS CLI should assume a role.  When you do this, the AWS CLI will
+automatically make the corresponding ``AssumeRoleWithWebIdentity`` calls to AWS
+STS on your behalf.
+
+When you specify a profile that has IAM role configuration, the AWS CLI will
+make an ``AssumeRoleWithWebIdentity`` call to retrieve temporary credentials.
+These credentials are then stored (in ``~/.aws/cli/cache``).  Subsequent AWS
+CLI commands will use the cached temporary credentials until they expire, in
+which case the AWS CLI will automatically refresh credentials.
+
+You can specify the following configuration values for configuring an
+assume role with web identity profile in the shared config:
+
+
+* ``role_arn`` - The ARN of the role you want to assume.
+* ``web_identity_token_file`` - The path to a file which contains an OAuth 2.0
+  access token or OpenID Connect ID token that is provided by the identity
+  provider. The contents of this file will be loaded and passed as the
+  ``WebIdentityToken`` argument to the ``AssumeRoleWithWebIdentity`` operation.
+* ``role_session_name`` - The name applied to this assume-role session. This
+  value affects the assumed role user ARN  (such as
+  arn:aws:sts::123456789012:assumed-role/role_name/role_session_name). This
+  maps to the ``RoleSessionName`` parameter in the
+  ``AssumeRoleWithWebIdentity`` operation.  This is an optional parameter. If
+  you do not provide this value, a session name will be automatically
+  generated.
+
+Below is an example configuration for the minimal amount of configuration
+needed to configure an assume role with web identity profile::
+
+  # In ~/.aws/config
+  [profile web-identity]
+  role_arn=arn:aws:iam:...
+  web_identity_token_file=/path/to/a/token
+
+This provider can also be configured via the environment:
+
+``AWS_ROLE_ARN``
+    The ARN of the role you want to assume.
+
+``AWS_WEB_IDENTITY_TOKEN_FILE``
+    The path to the web identity token file.
+
+``AWS_ROLE_SESSION_NAME``
+    The name applied to this assume-role session.
+
+.. note::
+
+    These environment variables currently only apply to the assume role with
+    web identity provider and do not apply to the general assume role provider
+    configuration.
+
 
 Sourcing Credentials From External Processes
 --------------------------------------------


### PR DESCRIPTION
This updates the assume role file caching handler to inject the file cache onto both the assume role and assume role with web identity provider.