### PR TITLE
Support base64-encoded parameters for binary types

### DIFF
--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -13,6 +13,7 @@
 import logging
 import os
 import copy
+import base64
 
 from botocore.awsrequest import AWSRequest
 from botocore.httpsession import URLLib3Session
@@ -232,6 +233,14 @@ def get_file(prefix, path, mode):
             path, e))
 
 
+def get_base64(prefix, value):
+    try:
+        return base64.b64decode(value[len(prefix):])
+    except Exception as e:
+        raise ResourceLoadingError('Unable to decode %s: %s' % (
+            value, e))
+
+
 def get_uri(prefix, uri):
     try:
         session = URLLib3Session()
@@ -247,6 +256,7 @@ def get_uri(prefix, uri):
 
 
 LOCAL_PREFIX_MAP = {
+    'base64://': (get_base64, {}),
     'file://': (get_file, {'mode': 'r'}),
     'fileb://': (get_file, {'mode': 'rb'}),
 }

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -94,6 +94,17 @@ class TestCLIFollowParamURLDefault(BaseTestCLIFollowParamURL):
             expected_param=b'file content'
         )
 
+    def test_does_use_base64_prefix(self):
+        # The command will fail with error code 255 since bytes type does
+        # not work for this parameter, however we still record the raw
+        # parameter that we passed, which is all this test is concerend about.
+        param = 'base64://YmxvYiBjb250ZW50'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=b'blob content'
+        )
+
+
 
 class TestCLIFollowParamURLDisabled(BaseTestCLIFollowParamURL):
     def setUp(self):
@@ -147,6 +158,16 @@ class TestCLIFollowParamURLDisabled(BaseTestCLIFollowParamURL):
             expected_param=b'file content'
         )
 
+    def test_does_use_base64_prefix(self):
+        # The command will fail with error code 255 since bytes type does
+        # not work for this parameter, however we still record the raw
+        # parameter that we passed, which is all this test is concerend about.
+        param = 'base64://YmxvYiBjb250ZW50'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=b'blob content'
+        )
+
 
 class TestCLIFollowParamURLEnabled(BaseTestCLIFollowParamURL):
     def setUp(self):
@@ -196,4 +217,14 @@ class TestCLIFollowParamURLEnabled(BaseTestCLIFollowParamURL):
         self.assert_param_expansion_is_correct(
             provided_param=param,
             expected_param=b'file content'
+        )
+
+    def test_does_use_base64_prefix(self):
+        # The command will fail with error code 255 since bytes type does
+        # not work for this parameter, however we still record the raw
+        # parameter that we passed, which is all this test is concerend about.
+        param = 'base64://YmxvYiBjb250ZW50'
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param=b'blob content'
         )

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -48,6 +48,13 @@ class TestParamFile(unittest.TestCase):
         self.assertEqual(data, b'This is a test')
         self.assertIsInstance(data, six.binary_type)
 
+    def test_base64_string(self):
+        base64_string = 'VGhpcyBpcyBhIHRlc3Q='
+        prefixed_base64_string = 'base64://' + base64_string
+        data = self.get_paramfile(prefixed_base64_string)
+        self.assertEqual(data, b'This is a test')
+        self.assertIsInstance(data, six.binary_type)
+
     @skip_if_windows('Binary content error only occurs '
                      'on non-Windows platforms.')
     def test_cannot_load_text_file(self):
@@ -66,6 +73,10 @@ class TestParamFile(unittest.TestCase):
 
     def test_non_string_type_returns_none(self):
         self.assertIsNone(self.get_paramfile(100))
+
+    def test_cannot_decode_base64_string(self):
+        with self.assertRaises(ResourceLoadingError):
+            self.get_paramfile('base64://VGhpcyBpcyBhIHRlc3Q')
 
 
 class TestHTTPBasedResourceLoading(unittest.TestCase):
@@ -111,6 +122,7 @@ class TestConfigureURIArgumentHandler(unittest.TestCase):
         register_uri_param_handler(session)
         cases = mock_handler_cls.call_args[0][0]
 
+        self.assertIn('base64://', cases)
         self.assertIn('file://', cases)
         self.assertIn('fileb://', cases)
         self.assertIn('http://', cases)
@@ -124,6 +136,7 @@ class TestConfigureURIArgumentHandler(unittest.TestCase):
         register_uri_param_handler(session)
         cases = mock_handler_cls.call_args[0][0]
 
+        self.assertIn('base64://', cases)
         self.assertIn('file://', cases)
         self.assertIn('fileb://', cases)
         self.assertIn('http://', cases)
@@ -138,6 +151,7 @@ class TestConfigureURIArgumentHandler(unittest.TestCase):
         register_uri_param_handler(session)
         cases = mock_handler_cls.call_args[0][0]
 
+        self.assertIn('base64://', cases)
         self.assertIn('file://', cases)
         self.assertIn('fileb://', cases)
         self.assertIn('http://', cases)
@@ -152,6 +166,7 @@ class TestConfigureURIArgumentHandler(unittest.TestCase):
         register_uri_param_handler(session)
         cases = mock_handler_cls.call_args[0][0]
 
+        self.assertIn('base64://', cases)
         self.assertIn('file://', cases)
         self.assertIn('fileb://', cases)
         self.assertNotIn('http://', cases)


### PR DESCRIPTION
Add a "base64://" protocol for passing binary parameters, such as KMS
Decrypt's "CiphertextBlob", as a base64 string. Currently the only way
to specify a binary blob parameter is by writing the parameter value to
a file and providing the filepath prefixed with "fileb://".

*Issue #, if available:* https://github.com/aws/aws-cli/issues/2063

*Description of changes:* This allows the user to provide a binary blob parameter by prefixing its base64 representation with `base64://`. 

For example:
```
aws kms decrypt --ciphertext-blob base64://AQECAHitN+klEybSwklcQTh51VcQ6NVha5fJMHrZ5CwkWpD35AAAAGMwYQYJKoZIhvcNAQcGoFQwUgIBADBNBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDANWxamzybey0ZE8bQIBEIAgCqJfaUHxCYbRZ3Q53VH0wrLr1bD8bs7HYuytgIP62Y8=
```

Currently, the only way to provide a binary parameter is by saving it to disk and using `fileb://`:
```
echo -n 'AQECAHitN+klEybSwklcQTh51VcQ6NVha5fJMHrZ5CwkWpD35AAAAGMwYQYJKoZIhvcNAQcGoFQwUgIBADBNBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDANWxamzybey0ZE8bQIBEIAgCqJfaUHxCYbRZ3Q53VH0wrLr1bD8bs7HYuytgIP62Y8=' | base64 -d > ciphertext.blob
aws kms decrypt --ciphertext-blob fileb://ciphertext.blob
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
