### PR TITLE
Add Mac PKG installer uninstall and test script

### DIFF
--- a/macpkg/scripts/postinstall
+++ b/macpkg/scripts/postinstall
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 sudo mkdir -p /usr/local/bin
+# Files created here are not stored in the bill of materials for the pkg.
+# This means we cannot find and remove them during an installation. We add a
+# custom .install-metadata file here which is read and used by our
+# scripts/installers/uninstall-mac-pkg to clean up any extra files created
+# here. If any new files are added, be sure to add them to the .install-metadata
+# file as well.
+sudo echo "/usr/local/aws/.install-metadata" >> /usr/local/aws/.install-metadata
 sudo ln -sf /usr/local/aws/aws /usr/local/bin/aws
+sudo echo "/usr/local/bin/aws" >> /usr/local/aws/.install-metadata
 sudo ln -sf /usr/local/aws/aws_completer /usr/local/bin/aws_completer
+sudo echo "/usr/local/bin/aws_completer" >> /usr/local/aws/.install-metadata
 
 CLI_VERSION=$(/usr/local/bin/aws --version | cut -d' ' -f 1 | cut -d'/' -f 2)
 mkdir -p ~/.aws/cli/cache

--- a/scripts/installers/make-macpkg
+++ b/scripts/installers/make-macpkg
@@ -29,7 +29,7 @@ def make_pkg(output_dir):
     distribution_path = os.path.join(PKG_DIR, 'distribution.xml')
     print(run(
         (
-            'pkgbuild --identifier com.amazon.awscli '
+            'pkgbuild --identifier com.amazon.aws.cli2 '
             '--root ./aws '
             '--install-location /usr/local/aws/ '
             '--scripts %s '

--- a/scripts/installers/test-installer
+++ b/scripts/installers/test-installer
@@ -3,6 +3,9 @@
 import argparse
 import sys
 import os
+import re
+from subprocess import check_output
+from subprocess import check_call
 
 SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(SCRIPTS_DIR)
@@ -13,6 +16,8 @@ REPO_ROOT = os.path.dirname(SCRIPTS_DIR)
 DIST_DIR = os.path.join(REPO_ROOT, 'dist')
 SMOKE_TEST_PATH = os.path.join(
     REPO_ROOT, 'tests', 'integration', 'test_smoke.py')
+UNINSTALL_MAC_PKG_PATH = os.path.join(
+    SCRIPTS_DIR, 'installers', 'uninstall-mac-pkg')
 
 
 class InstallerTester(object):
@@ -66,9 +71,33 @@ class ExeTester(InstallerTester):
         return self._installer_location
 
 
+class PkgTester(InstallerTester):
+    DEFAULT_INSTALLER_LOCATION = os.path.join(DIST_DIR, 'AWS-CLI-Installer.pkg')
+    _PKG_ID = 'com.amazon.aws.cli2'
+
+    def get_aws_cmd(self):
+        value = run('%s %s check' % (sys.executable, UNINSTALL_MAC_PKG_PATH))
+        match = re.search('installed at (.+)?\n', value)
+        base_path = match.group(1)
+        cmd_path = os.path.join(base_path, 'aws')
+        return cmd_path
+
+    def setup(self):
+        run('sudo installer -pkg %s -target /' % self._installer_location)
+
+    def cleanup(self):
+        run('sudo %s %s uninstall' % (sys.executable, UNINSTALL_MAC_PKG_PATH))
+
+    def __call__(self):
+        assert os.geteuid() == 0, \
+            'Mac PKG installer must be run as root (with sudo).'
+        super(PkgTester, self).__call__()
+
+
 def main():
     installer_to_tester_cls = {
-        'exe': ExeTester
+        'exe': ExeTester,
+        'pkg': PkgTester,
     }
     parser = argparse.ArgumentParser(usage=__doc__)
     parser.add_argument(
@@ -90,4 +119,8 @@ def main():
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except AssertionError as e:
+        print(e)
+        sys.exit(1)

--- a/scripts/installers/uninstall-mac-pkg
+++ b/scripts/installers/uninstall-mac-pkg
@@ -3,6 +3,7 @@
 import argparse
 import sys
 import os
+import re
 from datetime import datetime
 from subprocess import check_output
 from subprocess import CalledProcessError
@@ -16,33 +17,41 @@ from utils import BadRCError
 
 
 _PKG_ID = 'com.amazon.aws.cli2'
-
+_PKGUTIL_PATTERN = re.compile(
+    (
+        r'version: (?P<version>.*?)\n'
+        r'volume: (?P<volume>.*?)\n'
+        r'location: (?P<location>.*?)\n'
+        r'install-time: (?P<install_time>.*?)\n'
+    ),
+    re.X
+)
 
 def uninstall():
-    assert _is_installed() is True, 'Could not find AWS CLI installation.'
+    assert _is_installed(), 'Could not find AWS CLI installation.'
     assert os.geteuid() == 0, 'Script must be run as root (with sudo).'
 
+    # First we remove all the files listed in the pkg's receipt file,
+    # and our own custom metadata file.
     root_dir = _get_root_dir()
     list_files = _get_file_list(root_dir)
     _erase_files(list_files)
+
+    # Once these are all removed the directories should all be empty and can
+    # be deleted.
     list_dirs = _get_dir_list(root_dir)
     _erase_dirs(list_dirs)
+
+    # Finally we forget the package receipt.
     _forget()
     return 0
 
 
 def _get_root_dir():
-    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False).split('\n')
-    volume_line = lines[2]
-    volume = _trim_before_space(volume_line)
-    location_line = lines[3]
-    location = _trim_before_space(location_line)
-    path = os.path.join(volume, location)
+    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False)
+    output = _PKGUTIL_PATTERN.search(lines)
+    path = os.path.join(output.group('volume'), output.group('location'))
     return path
-
-
-def _trim_before_space(value):
-    return value[value.find(' ') + 1:]
 
 
 def _get_file_list(root):
@@ -54,6 +63,11 @@ def _get_file_list(root):
 
 
 def _read_install_metadata(root):
+    # Install metadata is a list of files that were installed by helper scripts
+    # executed by the PKG. In the AWS CLI V2's case, we use a postinstall
+    # script to add binaries symlinks to /usr/bin. These are untracked by the
+    # pkg receipt. To track them we add them to a special .install-metdata file
+    # in the installer directory.
     metadata_path = os.path.join(root, '.install-metadata')
     if not os.path.isfile(metadata_path):
         return []
@@ -86,21 +100,22 @@ def _erase_dirs(dir_list):
 
 
 def _forget():
+    # Forget is the pkgutil command to delete the pkg installer receipt.
+    # Once the files have been deleted, the pkgutil command will continue to
+    # report that they are installed until the pkg id has been forgotten.
     run('pkgutil --forget %s' % _PKG_ID, echo=False)
 
 
 def check():
-    assert _is_installed() is True, 'Could not find AWS CLI installation.'
+    assert _is_installed(), 'Could not find AWS CLI installation.'
 
-    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False).split('\n')
-    version = _trim_before_space(lines[1])
-    volume = _trim_before_space(lines[2])
-    location = _trim_before_space(lines[3])
-    timestamp = int(_trim_before_space(lines[4]))
-    root = os.path.join(volume, location)
+    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False)
+    output = _PKGUTIL_PATTERN.search(lines)
+    root = os.path.join(output.group('volume'), output.group('location'))
     print('Found AWS CLI version %s installed at %s' % (
-        version, root))
-    print('Installed on %s' % datetime.fromtimestamp(timestamp))
+        output.group('version'), root))
+    print('Installed on %s' % datetime.fromtimestamp(
+        int(output.group('install_time'))))
     command = 'sudo %s uninstall' % os.path.abspath(__file__)
     print('To uninstall run the command:')
     print(command)

--- a/scripts/installers/uninstall-mac-pkg
+++ b/scripts/installers/uninstall-mac-pkg
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+"""Script to uninstall AWS CLI V2 Mac PKG"""
+import argparse
+import sys
+import os
+from datetime import datetime
+from subprocess import check_output
+from subprocess import CalledProcessError
+from subprocess import PIPE
+
+SCRIPTS_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(SCRIPTS_DIR)
+
+from utils import run
+from utils import BadRCError
+
+
+_PKG_ID = 'com.amazon.aws.cli2'
+
+
+def uninstall():
+    assert _is_installed() is True, 'Could not find AWS CLI installation.'
+    assert os.geteuid() == 0, 'Script must be run as root (with sudo).'
+
+    root_dir = _get_root_dir()
+    list_files = _get_file_list(root_dir)
+    _erase_files(list_files)
+    list_dirs = _get_dir_list(root_dir)
+    _erase_dirs(list_dirs)
+    _forget()
+    return 0
+
+
+def _get_root_dir():
+    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False).split('\n')
+    volume_line = lines[2]
+    volume = _trim_before_space(volume_line)
+    location_line = lines[3]
+    location = _trim_before_space(location_line)
+    path = os.path.join(volume, location)
+    return path
+
+
+def _trim_before_space(value):
+    return value[value.find(' ') + 1:]
+
+
+def _get_file_list(root):
+    lines = run(
+        'pkgutil --only-files --files %s /' % _PKG_ID, echo=False).split('\n')
+    pkg_file_list = [os.path.join(root, line) for line in lines]
+    extra_files = _read_install_metadata(root)
+    return pkg_file_list + extra_files
+
+
+def _read_install_metadata(root):
+    metadata_path = os.path.join(root, '.install-metadata')
+    if not os.path.isfile(metadata_path):
+        return []
+    extra_files = open(metadata_path, 'r').read()
+    return extra_files.split('\n')[:-1]
+
+
+def _get_dir_list(root):
+    lines = run(
+        'pkgutil --only-dirs --files %s /' % _PKG_ID, echo=False).split('\n')
+    # Longer directory names are listed first to force them to come before
+    # their parent directories. This ensures that child directories are
+    # deleted before their parents.
+    return sorted(
+        [os.path.join(root, line) for line in lines],
+        key=lambda x: -len(x)
+    )
+
+
+def _erase_files(file_list):
+    for path in file_list:
+        if os.path.isfile(path) or os.path.islink(path):
+            os.remove(path)
+
+
+def _erase_dirs(dir_list):
+    for path in dir_list:
+        if os.path.isdir(path):
+            os.rmdir(path)
+
+
+def _forget():
+    run('pkgutil --forget %s' % _PKG_ID, echo=False)
+
+
+def check():
+    assert _is_installed() is True, 'Could not find AWS CLI installation.'
+
+    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False).split('\n')
+    version = _trim_before_space(lines[1])
+    volume = _trim_before_space(lines[2])
+    location = _trim_before_space(lines[3])
+    timestamp = int(_trim_before_space(lines[4]))
+    root = os.path.join(volume, location)
+    print('Found AWS CLI version %s installed at %s' % (
+        version, root))
+    print('Installed on %s' % datetime.fromtimestamp(timestamp))
+    command = 'sudo %s uninstall' % os.path.abspath(__file__)
+    print('To uninstall run the command:')
+    print(command)
+    return 0
+
+
+def _is_installed():
+    try:
+        result = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False)
+    except BadRCError:
+        return False
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(usage=__doc__)
+    subparsers = parser.add_subparsers()
+    check_parser = subparsers.add_parser(
+        'check',
+        help=(
+            'Check if the AWS CLI is currently installed from a PKG '
+            'installer.'
+        )
+    )
+    check_parser.set_defaults(func=check)
+    uninstall_parser = subparsers.add_parser(
+        'uninstall',
+        help='Uninstall the AWS CLI installed from the Mac PKG'
+    )
+    uninstall_parser.set_defaults(func=uninstall)
+
+    args = parser.parse_args()
+    return args.func()
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except AssertionError as e:
+        print(e)
+        sys.exit(1)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -6,8 +6,9 @@ class BadRCError(Exception):
     pass
 
 
-def run(cmd, cwd=None, env=None):
-    sys.stdout.write("Running cmd: %s\n" % cmd)
+def run(cmd, cwd=None, env=None, echo=True):
+    if echo:
+        sys.stdout.write("Running cmd: %s\n" % cmd)
     kwargs = {
         'shell': True,
         'stdout': subprocess.PIPE,


### PR DESCRIPTION
Uninstalling a Mac PKG is not straightforward, so a utility script has
been added that can uninstall the AWS CLI. The installer tester script
has been updated with a pkg format option. This requires sudo access for
now to both install and uninstall the package.

Another tangential change to the postinstall script was made to keep
a manifest of extra files created by the installation process. This
file is checked at uninstall time and used to clean up any files not
registered with the PKG receipt (the receipt cannot be updated manually
by a postinstall script, so this must be a separate metadata file).
Any new files added in the future should be added to this manifest as
well.
