### PR TITLE
Force idna codec import in clidriver

### DIFF
--- a/.changes/next-release/bugfix-MSI-87086.json
+++ b/.changes/next-release/bugfix-MSI-87086.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "MSI",
+  "description": "Fix race condition when running S3 commands on windows `#4247 <https://github.com/aws/aws-cli/issues/4247>`__"
+}

--- a/awscli/__main__.py
+++ b/awscli/__main__.py
@@ -11,17 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-# Don't remove this line.  The idna encoding
-# is used by getaddrinfo when dealing with unicode hostnames,
-# and in some cases, there appears to be a race condition
-# where threads will get a LookupError on getaddrinfo() saying
-# that the encoding doesn't exist.  Using the idna encoding before
-# running any CLI code (and any threads it may create) ensures that
-# the encodings.idna is imported and registered in the codecs registry,
-# which will stop the LookupErrors from happening.
-# See: https://bugs.python.org/issue29288
-u''.encode('idna')
-
 
 import sys
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -52,6 +52,16 @@ LOG = logging.getLogger('awscli.clidriver')
 LOG_FORMAT = (
     '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
 HISTORY_RECORDER = get_global_history_recorder()
+# Don't remove this line.  The idna encoding
+# is used by getaddrinfo when dealing with unicode hostnames,
+# and in some cases, there appears to be a race condition
+# where threads will get a LookupError on getaddrinfo() saying
+# that the encoding doesn't exist.  Using the idna encoding before
+# running any CLI code (and any threads it may create) ensures that
+# the encodings.idna is imported and registered in the codecs registry,
+# which will stop the LookupErrors from happening.
+# See: https://bugs.python.org/issue29288
+u''.encode('idna')
 
 
 def main():


### PR DESCRIPTION

The previous fix, #4073, didn't work for the aws.exe executable
used in the py3 MSIs.  The `__main__.py` is only used for aws.cmd,
which is not what's used by default when you run the `aws` exe.

Fixes #4247