### PR TITLE
Support ':' char in shorthand syntax key names

### DIFF
--- a/.changes/next-release/enhancement-Shorthand-33683.json
+++ b/.changes/next-release/enhancement-Shorthand-33683.json
@@ -1,0 +1,5 @@
+{
+  "category": "Shorthand", 
+  "type": "enhancement", 
+  "description": "Support colon char in shorthand syntax key names (#4348)"
+}

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -163,7 +163,7 @@ class ShorthandParser(object):
 
     def _key(self):
         # key = 1*(alpha / %x30-39 / %x5f / %x2e / %x23)  ; [a-zA-Z0-9\-_.#/]
-        valid_chars = string.ascii_letters + string.digits + '-_.#/'
+        valid_chars = string.ascii_letters + string.digits + '-_.#/:'
         start = self._index
         while not self._at_eof():
             if self._current() not in valid_chars:

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -62,6 +62,10 @@ def test_parse():
     # Forward slashes are allowed in keys.
     yield (_can_parse, 'some/thing=value', {'some/thing': 'value'})
 
+    # Colon chars are allowed in keys:
+    yield (_can_parse, 'aws:service:region:124:foo/bar=baz',
+           {'aws:service:region:124:foo/bar': 'baz'})
+
     # Explicit lists.
     yield (_can_parse, 'foo=[]', {'foo': []})
     yield (_can_parse, 'foo=[a]', {'foo': ['a']})


### PR DESCRIPTION
Fixes #4348.