### PR TITLE
Bump PyYAML version from 5.1 to 5.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,6 @@ requires-dist =
         docutils>=0.10,<0.15
         rsa>=3.1.2,<=3.5.0
         PyYAML>=3.10,<=3.13; python_version=="2.6"
-        PyYAML>=3.10,<=5.1;python_version!="2.6"
+        PyYAML>=3.10,<=5.2;python_version!="2.6"
         s3transfer>=0.2.0,<0.3.0
         argparse>=1.1; python_version=="2.6"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if sys.version_info[:2] == (2, 6):
     # versions dropped support for Python 2.6.
     requires.append('PyYAML>=3.10,<=3.13')
 else:
-    requires.append('PyYAML>=3.10,<=5.1')
+    requires.append('PyYAML>=3.10,<=5.2')
 
 
 setup_options = dict(


### PR DESCRIPTION
*Issue #, if available:* #4350 #4042 #4243

*Description of changes:* Changes required version of PyYAML from 5.1 to 5.2

This is a modified version of PR #4355, which bumps PyYAML from 5.1 to 5.1.1. Hoping for a review-n-merge to resolve this version dependency issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
