### PR TITLE
Allow sync/cp/rm/mv S3 objects based on a prefix instead of using include/exclude filters

### DIFF
--- a/awscli/customizations/s3/fileformat.py
+++ b/awscli/customizations/s3/fileformat.py
@@ -47,18 +47,18 @@ class FileFormat(object):
         #     directory/objects under a common prefix or false when it
         #     is a single file
         dir_op = parameters['dir_op']
-        src_path = format_table[src_type](src_path, dir_op)[0]
+        src_path = format_table[src_type]('src', src_path, dir_op)[0]
         # :var use_src_name: True when the destination file/object will take on
         #     the name of the source file/object.  False when it
         #     will take on the name the user specified in the
         #     command line.
-        dest_path, use_src_name = format_table[dest_type](dest_path, dir_op)
+        dest_path, use_src_name = format_table[dest_type]('dest', dest_path, dir_op)
         files = {'src': {'path': src_path, 'type': src_type},
                  'dest': {'path': dest_path, 'type': dest_type},
                  'dir_op': dir_op, 'use_src_name': use_src_name}
         return files
 
-    def local_format(self, path, dir_op):
+    def local_format(self, typ, path, dir_op):
         """
         This function formats the path of local files and returns whether the
         destination will keep its own name or take the source's name along with
@@ -92,7 +92,7 @@ class FileFormat(object):
             else:
                 return full_path, False
 
-    def s3_format(self, path, dir_op):
+    def s3_format(self, typ, path, dir_op):
         """
         This function formats the path of source files and returns whether the
         destination will keep its own name or take the source's name along
@@ -111,7 +111,7 @@ class FileFormat(object):
                to the source name.
         """
         if dir_op:
-            if not path.endswith('/'):
+            if ('dest' == typ) and (not path.endswith('/')):
                 path += '/'
             return path, True
         else:

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -241,7 +241,7 @@ def find_dest_path_comp_key(files, src_path=None):
 
     sep_table = {'s3': '/', 'local': os.sep}
 
-    if files['dir_op']:
+    if files['dir_op'] and src['path'].endswith('/'):
         rel_path = src_path[len(src['path']):]
     else:
         rel_path = src_path.split(sep_table[src_type])[-1]


### PR DESCRIPTION
*Issue #1454 #4240 :*

**Description**
Use case : Download S3 server access logs of a certain day from the logging bucket. 

Example command : 
`aws s3 cp s3://example-bucketname/2019-07-22 . --recursive`

Today, the above command tries to download the log files under the "2019-07-22/" path(CLI adds / in the LIST API call). 

But, in fact there won't be such path(folder) in S3 bucket. The idea is to download all the S3 objects that match the prefix : 2019-07-22.

So, the solution provided today to users is to use include/exclude filters or use AWS Athena. This takes a lot of time if the bucket has billion log files. 

However, aws s3 ls behaves in a right way i.e., it shows the objects that match the prefix but, doesn't add a '/' in the LIST API call. 

So, this commit will fix this issue. 

If anyone wants to cp/sync/mv/rm an actual 'folder' from S3, they can simply specify a trailing slash '/' in the command. Even if they specify, CLI will still delete all objects that matches the prefix  and in 99% of the cases, the prefix will be same as the folder name. 

This issue has been faced by several users and removing the '/' will help them a lot. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
