### PR TITLE
Add description param to security group commands

### DIFF
--- a/tests/functional/ec2/test_security_group_operations.py
+++ b/tests/functional/ec2/test_security_group_operations.py
@@ -94,6 +94,18 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
                                       [{'GroupId': 'sg-12345678'}]}]}
         self.assert_params_for_cmd(args, result)
 
+    def test_description(self):
+        args = self.prefix + (
+            '--group-name foobar --protocol tcp --port 22-25 --cidr 0.0.0.0/0 '
+            '--description sample_desc')
+        result = {'GroupName': 'foobar',
+                  'IpPermissions': [{'FromPort': 22, 'IpProtocol': 'tcp',
+                                      'IpRanges':
+                                        [{'CidrIp': '0.0.0.0/0',
+                                          'Description': 'sample_desc'}],
+                                      'ToPort': 25}]}
+        self.assert_params_for_cmd(args, result)
+
     def test_IpPermissions(self):
         json = (
             '[{"FromPort":8000,"ToPort":9000,'
@@ -120,7 +132,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
         json = (
             '[{"FromPort":8000,"ToPort":9000,"IpProtocol":"tcp",'
             '"IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]')
-        args = self.prefix + '--group-name foobar --port 100 --ip-permissions %s' % json
+        args = self.prefix + '--group-name foobar --port 100 --description sample_desc --ip-permissions %s' % json
         self.assert_params_for_cmd(args, expected_rc=255)
 
 


### PR DESCRIPTION
*Issue #, if available:*
#6981 

*Description of changes:*
This adds the ability to add a description when creating security group rules via a dedicated option (--description) instead of only via the --ip-permissions option.

I also added a unit test for the new functionality. Total code coverage for this file (awscli/customizations/ec2/secgroupsimplify.py) has improved from 89% to 92%.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
