### PR TITLE
Prepare create-subscription for deprecation

### DIFF
--- a/awscli/customizations/cloudtrail/subscribe.py
+++ b/awscli/customizations/cloudtrail/subscribe.py
@@ -58,8 +58,8 @@ class CloudTrailSubscribe(BasicCommand):
         {'name': 'sns-custom-policy',
          'help_text': 'Custom SNS policy template or URL'}
     ]
-
     UPDATE = False
+    _UNDOCUMENTED = True
 
     def _run_main(self, args, parsed_globals):
         self.setup_services(args, parsed_globals)


### PR DESCRIPTION
*Issue #, if available:*
Internal

*Description of changes:*
Remove create-subscription from the documentation in preparation for its deprecation from the API.  The CloudTrail team *strongly* encourages AWS CLI users to avoid this synthetic command and use the actual CloudTrail API calls when managing CloudTrail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
