### PR TITLE
Disable paramfile for service catalog support-url

### DIFF
--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -101,6 +101,9 @@ PARAMFILE_DISABLED = set([
     'serverlessapplicationrepository.update-application.home-page-url',
     'serverlessapplicationrepository.update-application.readme-url',
 
+    'service-catalog.create-product.support-url',
+    'service-catalog.update-product.support-url',
+
     'sqs.add-permission.queue-url',
     'sqs.change-message-visibility.queue-url',
     'sqs.change-message-visibility-batch.queue-url',


### PR DESCRIPTION
Fixes #4427 

Disable remote fetching for the `support-url` parameter.