### PR TITLE
Fixed Syntax Errors

### DIFF
--- a/awscli/examples/ec2/describe-instances.rst
+++ b/awscli/examples/ec2/describe-instances.rst
@@ -100,12 +100,14 @@ Linux Command::
         --filter Name=tag-key,Values=Name \
         --query 'Reservations[*].Instances[*].{Instance:InstanceId,AZ:Placement.AvailabilityZone,Name:Tags[?Key==`Name`]|[0].Value}' \
         --output table
+        
+
 
 Windows Command::
 
     aws ec2 describe-instances ^
         --filter Name=tag-key,Values=Name ^
-        --query "Reservations[*].Instances[*].{Instance:InstanceId,AZ:Placement.AvailabilityZone,Name:Tags[?Key==`Name`]|[0].Value}" ^
+        --query "Reservations[*].Instances[*].{Instance:InstanceId,AZ:Placement.AvailabilityZone,Name:Tags[?Key=='Name']|[0].Value}" ^
         --output table
 
 Output::


### PR DESCRIPTION
` is treated as an escape char in windows powershell, encapsulating Name with >'<

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
