### PR TITLE
CFN Package: MD5 Files In Zip For Proper Dedupe

### DIFF
--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -169,8 +169,7 @@ class S3Uploader(object):
         return "s3://{0}/{1}".format(
             self.bucket_name, obj_path)
 
-    def file_checksum(self, file_name):
-
+    def _md5_file(self, file_name):
         with open(file_name, "rb") as file_handle:
             md5 = hashlib.md5()
             # Read file in chunks of 4096 bytes
@@ -188,7 +187,10 @@ class S3Uploader(object):
             # Restore file cursor's position
             file_handle.seek(curpos)
 
-            return md5.hexdigest()
+            return md5
+
+    def file_checksum(self, file_name):
+        return self._md5_file(file_name).hexdigest()
 
     def to_path_style_s3_url(self, key, version=None):
         """

--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -49,7 +49,7 @@ class TestPackageZipFiles(TestCase):
         os.symlink(data_file, link_name)
 
         # Zip up the contents of folder `ziproot` which contains the symlink
-        zipfile_path = make_zip(os.path.join(self.rootdir, "archive"), self.ziproot)
+        zipfile_path, zipfile_hash = make_zip(os.path.join(self.rootdir, "archive"), self.ziproot)
 
         # Now verify that the zipfile includes contents of the data file we created
         myzip = zipfile.ZipFile(zipfile_path)
@@ -59,3 +59,20 @@ class TestPackageZipFiles(TestCase):
 
         # Its content should be equal the value we wrote.
         self.assertEquals(data.encode("utf-8"), myfile.read())
+
+    def test_returns_proper_hash(self):
+        data = "hello world"
+        data_file = os.path.join(self.rootdir, "data.txt")
+
+        with open(data_file, "w") as fp:
+            fp.write(data)
+
+        # Create symlink within the zip root
+        link_name = os.path.join(self.ziproot, "data-link.txt")
+        os.symlink(data_file, link_name)
+
+        # Zip up the contents of folder `ziproot` which contains the symlink
+        _zipfile_path, zipfile_hash = make_zip(os.path.join(self.rootdir, "archive"), self.ziproot)
+
+        self.assertEquals(zipfile_hash, "123")
+

--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -59,20 +59,3 @@ class TestPackageZipFiles(TestCase):
 
         # Its content should be equal the value we wrote.
         self.assertEquals(data.encode("utf-8"), myfile.read())
-
-    def test_returns_proper_hash(self):
-        data = "hello world"
-        data_file = os.path.join(self.rootdir, "data.txt")
-
-        with open(data_file, "w") as fp:
-            fp.write(data)
-
-        # Create symlink within the zip root
-        link_name = os.path.join(self.ziproot, "data-link.txt")
-        os.symlink(data_file, link_name)
-
-        # Zip up the contents of folder `ziproot` which contains the symlink
-        _zipfile_path, zipfile_hash = make_zip(os.path.join(self.rootdir, "archive"), self.ziproot)
-
-        self.assertEquals(zipfile_hash, "123")
-

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -422,10 +422,11 @@ class TestArtifactExporter(unittest.TestCase):
     @patch("awscli.customizations.cloudformation.artifact_exporter.make_zip")
     def test_zip_folder(self, make_zip_mock):
         zip_file_name = "name.zip"
-        make_zip_mock.return_value = zip_file_name
+        zip_file_hash = "hash"
+        make_zip_mock.return_value = zip_file_name, zip_file_hash
 
         with self.make_temp_dir() as dirname:
-            with zip_folder(dirname) as actual_zip_file_name:
+            with zip_folder(dirname) as (actual_zip_file_name, _actual_zip_file_hash):
                 self.assertEqual(actual_zip_file_name, zip_file_name)
 
         make_zip_mock.assert_called_once_with(mock.ANY, dirname)
@@ -1167,7 +1168,7 @@ class TestArtifactExporter(unittest.TestCase):
 
         zipfile_name = None
         try:
-            zipfile_name = make_zip(outfile, dirname)
+            zipfile_name, zipfile_hash = make_zip(outfile, dirname)
 
             test_zip_file = zipfile.ZipFile(zipfile_name, "r")
             with closing(test_zip_file) as zf:


### PR DESCRIPTION
*Issue #, if available:* #3131

*Description of changes:* When creating the zip file to be uploaded to s3 as part of `aws cloudformation package` it now:
1. stores the file names
1. sorts them
1. loops over all files and adds the file name and content to an md5
1. creates a hex digest
1. uploads the zip to s3 with the hex digest as the name

This means next time `aws cloudformation package` is run, it won't duplicate, and in turn the changeset will be empty - effectively a noop. This is more useful when your package code is more discrete, so your lambda functions can be deployed independently of each other if no code has changed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
