### PR TITLE
Fixed several typos and other minor errors in CLI example descriptions.

### DIFF
--- a/awscli/examples/docdb/describe-db-instances.rst
+++ b/awscli/examples/docdb/describe-db-instances.rst
@@ -2,7 +2,7 @@
 
 The following ``describe-db-instances`` example displays details for about the Amazon DocumentDB instance ``sample-cluster-instance``. By omitting the ``--db-instance-identifier`` parameter you get information on up to 100 instances. ::
 
-    awd docdb describe-db-instances \
+    aws docdb describe-db-instances \
         --db-instance-identifier sample-cluster-instance
 
 Output::

--- a/awscli/examples/qldb/describe-ledger.rst
+++ b/awscli/examples/qldb/describe-ledger.rst
@@ -1,6 +1,6 @@
 **To describe a ledger**
 
-The following ``describe-ledger`` example displays the for about the specfied ledger. ::
+The following ``describe-ledger`` example displays the details for the specified ledger. ::
 
     aws qldb describe-ledger \
         --name myExampleLedger

--- a/awscli/examples/qldb/list-journal-s3-exports-for-ledger.rst
+++ b/awscli/examples/qldb/list-journal-s3-exports-for-ledger.rst
@@ -5,7 +5,6 @@ The following ``list-journal-s3-exports-for-ledger`` example lists journal expor
     aws qldb list-journal-s3-exports-for-ledger \
         --name myExampleLedger
 
-This command produces no output.
 Output::
 
     {

--- a/awscli/examples/qldb/list-journal-s3-exports.rst
+++ b/awscli/examples/qldb/list-journal-s3-exports.rst
@@ -4,7 +4,6 @@ The following ``list-journal-s3-exports`` example lists journal export jobs for 
 
     aws qldb list-journal-s3-exports
 
-This command produces no output.
 Output::
 
     {


### PR DESCRIPTION
These are nothing but typo fixes and removal of incorrect "This command produces no output." statements.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
