### PR TITLE
Added warning about writing to StdErr from custom credential provider

### DIFF
--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -351,6 +351,9 @@ Sourcing Credentials From External Processes
     credential providers should be preferred if at all possible. If using
     this option, you should make sure that the config file is as locked down
     as possible using security best practices for your operating system.
+    Ensure that your custom credential tool does not write any secret 
+    information to StdErr because the SDKs and CLI can capture and log such 
+    information, potentially exposing it to unauthorized users.
 
 If you have a method of sourcing credentials that isn't built in to the AWS
 CLI, you can integrate it by using ``credential_process`` in the config file.


### PR DESCRIPTION
Per request from Amazon security support, I added a warning to the topic about Custom Credential providers for the customer to ensure that they don't write to StdErr from the custom tool to avoid the chance that the CLI or SDK could capture and log (and thus compromise) information there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
