### PR TITLE
Add colorama to make-bundle packages

### DIFF
--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -186,7 +186,7 @@ def main():
         packages=[
             'virtualenv', 'ordereddict', 'simplejson',
             'argparse', 'python-dateutil', 'urllib3',
-            'PyYAML',
+            'PyYAML', 'colorama',
         ]
     )
 


### PR DESCRIPTION
Adds `colorama` to be downloaded as an extra dependency when making the bundled installer.

Fixes #4563 