### PR TITLE
add back pyyaml dependency on python 3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ if sys.version_info[:2] == (2, 6):
     # Colorama removed support for EOL pythons.
     install_requires.append('colorama>=0.2.5,<0.3.9')
 elif sys.version_info[:2] == (3, 3):
+    install_requires.append('PyYAML>=3.10,<=5.2')
     # Colorama removed support for EOL pythons.
     install_requires.append('colorama>=0.2.5,<0.3.9')
 else:


### PR DESCRIPTION
looks like a logic mistake in https://github.com/aws/aws-cli/commit/b9a62ad07789bad35b6a0c114c451084c3de8efc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
