### PR TITLE
Update docs to latest max value

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -386,7 +386,7 @@ EXPECTED_SIZE = {'name': 'expected-size',
                      'This argument specifies the expected size of a stream '
                      'in terms of bytes. Note that this argument is needed '
                      'only when a stream is being uploaded to s3 and the size '
-                     'is larger than 5GB.  Failure to include this argument '
+                     'is larger than 50GB.  Failure to include this argument '
                      'under these conditions may result in a failed upload '
                      'due to too many parts in upload.')}
 


### PR DESCRIPTION
The max parts has been 10000 for a while now, see:
https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html

We've correctly accounted for this in s3transfer, we just haven't
updated our docs.