### PR TITLE
Fix and Normalize Example Titles

### DIFF
--- a/awscli/examples/budgets/describe-budgets.rst
+++ b/awscli/examples/budgets/describe-budgets.rst
@@ -1,5 +1,3 @@
-
-
 **To retrieve the budgets associated with an account**
 
 This example retrieves the Cost and Usage budgets for an account.

--- a/awscli/examples/ce/get-dimension-values.rst
+++ b/awscli/examples/ce/get-dimension-values.rst
@@ -1,4 +1,3 @@
-
 **To retrieve the tags for the dimension SERVICE, with a value of "Elastic"**
 
 This example retrieves the tags for the dimension SERVICE, with a value of "Elastic" for January 01 2017 through May 18 2017.

--- a/awscli/examples/ce/get-reservation-coverage.rst
+++ b/awscli/examples/ce/get-reservation-coverage.rst
@@ -1,4 +1,3 @@
-
 **To retrieve the reservation coverage for EC2 t2.nano instances in the us-east-1 region**
 
 This example retrieves the reservation coverage for EC2 t2.nano instances in the us-east-1 region for July-September of 2017.

--- a/awscli/examples/cloudfront/create-distribution.rst
+++ b/awscli/examples/cloudfront/create-distribution.rst
@@ -1,3 +1,5 @@
+**To create a CloudFront Web Distribution**
+
 You can create a CloudFront web distribution for an S3 domain (such as
 my-bucket.s3.amazonaws.com) or for a custom domain (such as example.com).
 The following command shows an example for an S3 domain, and optionally also

--- a/awscli/examples/cloudfront/create-invalidation.rst
+++ b/awscli/examples/cloudfront/create-invalidation.rst
@@ -1,3 +1,5 @@
+**To create an invalidation for a CloudFront distribution**
+
 The following command creates an invalidation for a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD \

--- a/awscli/examples/cloudfront/delete-distribution.rst
+++ b/awscli/examples/cloudfront/delete-distribution.rst
@@ -1,3 +1,5 @@
+**To delete a CloudFront distribution**
+
 The following command deletes a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront delete-distribution --id S11A16G5KZMEQD --if-match 8UBQECEJX24ST

--- a/awscli/examples/cloudfront/get-distribution-config.rst
+++ b/awscli/examples/cloudfront/get-distribution-config.rst
@@ -1,3 +1,5 @@
+**To get information about a Cloudfront distribution config**
+
 The following command gets a distribution config for a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront get-distribution-config --id S11A16G5KZMEQD

--- a/awscli/examples/cloudfront/get-distribution.rst
+++ b/awscli/examples/cloudfront/get-distribution.rst
@@ -1,3 +1,5 @@
+**To get information about a CloudFront distribution**
+
 The following command gets a distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront get-distribution --id S11A16G5KZMEQD

--- a/awscli/examples/cloudfront/get-invalidation.rst
+++ b/awscli/examples/cloudfront/get-invalidation.rst
@@ -1,3 +1,5 @@
+**To get information about an invalidation**
+
 The following command retrieves an invalidation with the ID ``YNY2LI2BVJ4NJU`` for a CloudFront web distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront get-invalidation --id YNY2LI2BVJ4NJU --distribution-id S11A16G5KZMEQD

--- a/awscli/examples/cloudfront/list-distributions.rst
+++ b/awscli/examples/cloudfront/list-distributions.rst
@@ -1,3 +1,5 @@
+**To list CloudFront distributions**
+
 The following command retrieves a list of distributions::
 
   aws cloudfront list-distributions

--- a/awscli/examples/cloudfront/list-invalidations.rst
+++ b/awscli/examples/cloudfront/list-invalidations.rst
@@ -1,3 +1,5 @@
+**To list CloudFront invalidations**
+
 The following command retrieves a list of invalidations for a CloudFront web distribution with the ID ``S11A16G5KZMEQD``::
 
   aws cloudfront list-invalidations --distribution-id S11A16G5KZMEQD

--- a/awscli/examples/cloudfront/update-distribution.rst
+++ b/awscli/examples/cloudfront/update-distribution.rst
@@ -1,3 +1,5 @@
+**To update a CloudFront distribution**
+
 The following command updates the Default Root Object to "index.html"
 for a CloudFront distribution with the ID ``S11A16G5KZMEQD``::
 

--- a/awscli/examples/configservice/start-configuration-recorder.rst
+++ b/awscli/examples/configservice/start-configuration-recorder.rst
@@ -1,4 +1,3 @@
-
 **To start the configuration recorder**
 
 The following command starts the default configuration recorder::

--- a/awscli/examples/cur/describe-report-definitions.rst
+++ b/awscli/examples/cur/describe-report-definitions.rst
@@ -1,4 +1,3 @@
-
 **To retrieve a list of AWS Cost and Usage Reports**
 
 This example describes a list of AWS Cost and Usage Reports owned by an account.

--- a/awscli/examples/cur/put-report-definition.rst
+++ b/awscli/examples/cur/put-report-definition.rst
@@ -1,4 +1,3 @@
-
 **To create an AWS Cost and Usage Reports**
 
 The following ``put-report-definition`` example creates a daily AWS Cost and Usage Report that you can upload into Amazon Redshift or Amazon QuickSight. ::

--- a/awscli/examples/devicefarm/create-device-pool.rst
+++ b/awscli/examples/devicefarm/create-device-pool.rst
@@ -1,4 +1,4 @@
-**Create a device pool**
+**To create a device pool**
 
 The following command creates an Android device pool for a project::
 

--- a/awscli/examples/devicefarm/create-project.rst
+++ b/awscli/examples/devicefarm/create-project.rst
@@ -1,4 +1,4 @@
-**Create a project**
+**To create a project**
 
 The following command creates a new project named ``my-project``::
 

--- a/awscli/examples/devicefarm/create-upload.rst
+++ b/awscli/examples/devicefarm/create-upload.rst
@@ -1,4 +1,4 @@
-**Create an upload**
+**To create an upload**
 
 The following command creates an upload for an Android app::
 

--- a/awscli/examples/devicefarm/get-upload.rst
+++ b/awscli/examples/devicefarm/get-upload.rst
@@ -1,4 +1,4 @@
-**Viewing an upload**
+**To view an upload**
 
 The following command retrieves information about an upload::
 

--- a/awscli/examples/devicefarm/list-projects.rst
+++ b/awscli/examples/devicefarm/list-projects.rst
@@ -1,4 +1,4 @@
-**Listing projects**
+**To list projects**
 
 The following retrieves a list of projects::
 

--- a/awscli/examples/ecr/get-login_description.rst
+++ b/awscli/examples/ecr/get-login_description.rst
@@ -1,4 +1,4 @@
-Log in to an Amazon ECR registry.
+**To log in to an Amazon ECR registry**
 
 This command retrieves a token that is valid for a specified registry for 12
 hours, and then it prints a ``docker login`` command with that authorization

--- a/awscli/examples/elastictranscoder/create-pipeline.rst
+++ b/awscli/examples/elastictranscoder/create-pipeline.rst
@@ -1,4 +1,3 @@
-
 **To create a pipeline for ElasticTranscoder**
 
 The following ``create-pipeline`` example creates a pipeline for ElasticTranscoder. ::

--- a/awscli/examples/elastictranscoder/create-preset.rst
+++ b/awscli/examples/elastictranscoder/create-preset.rst
@@ -1,4 +1,3 @@
-
 **To create a preset for ElasticTranscoder**
 
 The following ``create-preset`` example creates a preset for ElasticTranscoder. ::

--- a/awscli/examples/elastictranscoder/list-jobs-by-pipeline.rst
+++ b/awscli/examples/elastictranscoder/list-jobs-by-pipeline.rst
@@ -1,4 +1,3 @@
-
 **To retrieve a list of ElasticTranscoder jobs in the specified pipeline**
 
 This example retrieves a list of ElasticTranscoder jobs in the specified pipeline.

--- a/awscli/examples/elastictranscoder/list-jobs-by-status.rst
+++ b/awscli/examples/elastictranscoder/list-jobs-by-status.rst
@@ -1,4 +1,3 @@
-
 **To retrieve a list of ElasticTranscoder jobs with a status of Complete**
 
 This example retrieves a list of ElasticTranscoder jobs with a status of Complete.

--- a/awscli/examples/elastictranscoder/list-pipelines.rst
+++ b/awscli/examples/elastictranscoder/list-pipelines.rst
@@ -1,4 +1,3 @@
-
 **To retrieve a list of ElasticTranscoder pipelines**
 
 This example retrieves a list of ElasticTranscoder pipelines.

--- a/awscli/examples/elastictranscoder/read-job.rst
+++ b/awscli/examples/elastictranscoder/read-job.rst
@@ -1,4 +1,3 @@
-
 **To retrieve an ElasticTranscoder job**
 
 This example retrieves the specified ElasticTranscoder job.

--- a/awscli/examples/elastictranscoder/update-pipeline-notifications.rst
+++ b/awscli/examples/elastictranscoder/update-pipeline-notifications.rst
@@ -1,4 +1,3 @@
-
 **To update the notifications of an ElasticTranscoder pipeline**
 
 This example updates the notifications of the specified ElasticTranscoder pipeline.

--- a/awscli/examples/iotanalytics/create-pipeline.rst
+++ b/awscli/examples/iotanalytics/create-pipeline.rst
@@ -1,4 +1,4 @@
-**title**
+**Create an IoT Analytics Pipeline**
 
 The following ``create-pipeline`` example creates a pipeline. A pipeline consumes messages from a channel and allows you to process the messages before storing them in a data store. You must specify both a channel and a data store activity and, optionally, as many as 23 additional activities in the ``pipelineActivities`` array. ::
 

--- a/awscli/examples/iotanalytics/delete-channel.rst
+++ b/awscli/examples/iotanalytics/delete-channel.rst
@@ -1,4 +1,4 @@
-**title**
+**Delete an IoT Analytics Channel**
 
 The following ``delete-channel`` example deletes the specified channel. ::
 

--- a/awscli/examples/organizations/leave-organization.rst
+++ b/awscli/examples/organizations/leave-organization.rst
@@ -1,4 +1,3 @@
-
 **To leave an organization as a member account**
 
 The following example shows the administrator of a member account requesting to leave the organization it is currently a member of: ::

--- a/awscli/examples/snowball/list-jobs.rst
+++ b/awscli/examples/snowball/list-jobs.rst
@@ -1,4 +1,4 @@
-**title**
+**To list the current Snowball jobs in your account**
 
 The following ``list-jobs`` example displays an array of ``JobListEntry`` objects. In this example, a single job is listed. ::
 


### PR DESCRIPTION
Examples are inconsistent around the different services. This commit
fixes some of the inconsistencies:

* Removed blank lines at the beginning on many examples
* A few examples had placeholder `**title**` which was replaced with an
appropriate title
* Change several example titles to follow the already-prevalent format
of `**To [goal description]**`
* There still exist many inconsistencies which were not resolved

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
