### PR TITLE
Fix py26 py33 deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ requires-dist =
         colorama>=0.2.5,<0.4.2; python_version!="2.6" and python_version!="3.3"
         docutils>=0.10,<0.16
         rsa>=3.1.2,<=3.5.0
-        PyYAML>=3.10,<=3.13; python_version=="2.6"
-        PyYAML>=3.10,<=5.2;python_version!="2.6"
+        PyYAML>=3.10,<=3.13; python_version=="2.6" or python_version=="3.3"
+        PyYAML>=3.10,<=5.2;python_version!="2.6" and python_version!="3.3"
         s3transfer>=0.2.0,<0.3.0
         argparse>=1.1; python_version=="2.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 1
 [metadata]
 requires-dist =
         botocore==1.12.247
-        colorama>=0.2.5,<0.3.9; python_version=="2.6" or python_version=="3.3"
+        colorama>=0.2.5,<=0.3.9; python_version=="2.6" or python_version=="3.3"
         colorama>=0.2.5,<0.4.2; python_version!="2.6" and python_version!="3.3"
         docutils>=0.10,<0.16
         rsa>=3.1.2,<=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ if sys.version_info[:2] == (2, 6):
     install_requires.append('PyYAML>=3.10,<=3.13')
 
     # Colorama removed support for EOL pythons.
-    install_requires.append('colorama>=0.2.5,<0.3.9')
+    install_requires.append('colorama>=0.2.5,<=0.3.9')
 elif sys.version_info[:2] == (3, 3):
     install_requires.append('PyYAML>=3.10,<=5.2')
     # Colorama removed support for EOL pythons.
-    install_requires.append('colorama>=0.2.5,<0.3.9')
+    install_requires.append('colorama>=0.2.5,<=0.3.9')
 else:
     install_requires.append('PyYAML>=3.10,<=5.2')
     install_requires.append('colorama>=0.2.5,<0.4.2')

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,11 @@ if sys.version_info[:2] == (2, 6):
     # Colorama removed support for EOL pythons.
     install_requires.append('colorama>=0.2.5,<=0.3.9')
 elif sys.version_info[:2] == (3, 3):
-    install_requires.append('PyYAML>=3.10,<=5.2')
+    install_requires.append('PyYAML>=3.10,<=3.13')
     # Colorama removed support for EOL pythons.
     install_requires.append('colorama>=0.2.5,<=0.3.9')
 else:
-    install_requires.append('PyYAML>=3.10,<=5.2')
+    install_requires.append('PyYAML>=3.10,<5.2')
     install_requires.append('colorama>=0.2.5,<0.4.2')
 
 


### PR DESCRIPTION
* The colorama version range was wrong.  We include 0.3.9 in the bundled installer but had a range of `<0.3.9`.
* The PyYAML range was wrong.  The 3.x versions were the last to support py2.6/py3.3

Fixes #4577.


## Testing

Generated a bundled installer and tested we could install it on all our supported versions.


```
$ ./test-all-versions.sh

Python 2.6.9
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-2.6.9/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-2.6.9/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/2.6.9 Darwin/18.7.0 botocore/1.12.247


Python 2.7.14
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-2.7.14/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-2.7.14/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/2.7.14 Darwin/18.7.0 botocore/1.12.247


Python 3.3.6
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-3.3.6/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-3.3.6/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/3.3.6 Darwin/18.7.0 botocore/1.12.247


Python 3.4.6
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-3.4.6/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-3.4.6/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/3.4.6 Darwin/18.7.0 botocore/1.12.247


Python 3.5.3
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-3.5.3/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-3.5.3/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/3.5.3 Darwin/18.7.0 botocore/1.12.247


Python 3.6.8
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-3.6.8/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-3.6.8/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/3.6.8 Darwin/18.7.0 botocore/1.12.247

Python 3.7.3
Running cmd: /Users/jamessar/.pythonz/pythons/CPython-3.7.3/bin/python virtualenv.py --no-download --python /Users/jamessar/.pythonz/pythons/CPython-3.7.3/bin/python /tmp/verify/here
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages/setup setuptools_scm-1.15.7.tar.gz
Running cmd: /tmp/verify/here/bin/pip install --no-cache-dir --no-index --find-links file:///private/tmp/verify/awscli-bundle/packages awscli-1.16.257.tar.gz
You can now run: /tmp/verify/here/bin/aws --version
aws-cli/1.16.257 Python/3.7.3 Darwin/18.7.0 botocore/1.12.247

```