### PR TITLE
Use a consistent max version for PyYAML

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,6 @@ requires-dist =
         docutils>=0.10,<0.16
         rsa>=3.1.2,<=3.5.0
         PyYAML>=3.10,<=3.13; python_version=="2.6" or python_version=="3.3"
-        PyYAML>=3.10,<=5.2;python_version!="2.6" and python_version!="3.3"
+        PyYAML>=3.10,<5.2;python_version!="2.6" and python_version!="3.3"
         s3transfer>=0.2.0,<0.3.0
         argparse>=1.1; python_version=="2.6"


### PR DESCRIPTION
Fixes an inconsistency between setup.py and setup.cfg.
There is no 5.2 yet so this won't cause any issues, but
we should be consistent here.
