### PR TITLE
[v2] Add support for building windows executables

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ wheel==0.24.0
 ruamel.yaml>=0.15.0,<0.16.0
 PyYAML>=3.10,<=3.13
 jsonschema==2.5.1
-PyInstaller==3.4
+PyInstaller==3.5

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ skipsdist = True
 
 [testenv]
 commands =
-    {toxinidir}/scripts/ci/install
-    {toxinidir}/scripts/ci/run-tests
+    {envpython} {toxinidir}/scripts/ci/install
+    {envpython} {toxinidir}/scripts/ci/run-tests
 
 
 [testenv:exe]
@@ -15,7 +15,7 @@ deps =
     -r{toxinidir}/requirements.txt
     {toxinidir}
 commands =
-    {toxinidir}/scripts/installers/make-exe {posargs}
+    {envpython} {toxinidir}/scripts/installers/make-exe {posargs}
 
 
 [testenv:macpkg]
@@ -24,7 +24,7 @@ deps =
     {[testenv:exe]deps}
 commands =
     {[testenv:exe]commands}
-    {toxinidir}/scripts/installers/make-macpkg
+    {envpython} {toxinidir}/scripts/installers/make-macpkg
 
 
 [testenv:test-exe]
@@ -33,7 +33,7 @@ deps =
     -r{toxinidir}/requirements.txt
     {toxinidir}
 commands =
-    {toxinidir}/scripts/installers/test-installer --installer-type exe
+    {envpython} {toxinidir}/scripts/installers/test-installer --installer-type exe
 
 
 [testenv:sign-exe]
@@ -42,4 +42,4 @@ deps =
     -r{toxinidir}/requirements.txt
     {toxinidir}
 commands =
-    {toxinidir}/scripts/installers/sign-exe {posargs}
+    {envpython} {toxinidir}/scripts/installers/sign-exe {posargs}


### PR DESCRIPTION
* Upgrade to pyinstaller 3.5.  There was a bug in 3.4 that didn't
  build properly on windows when using a virtualenv.
* Explicitly use python when invoking scripts.  We can't rely on
  the shebang on windows.

Other than that everything else just works.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
