### PR TITLE
[v2] Don't pull from s3transfer/botocore from develop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 tox>=2.3.1,<3.0.0
-# botocore and the awscli packages are typically developed
-# in tandem, so we're requiring the latest develop
-# branch of botocore and s3transfer when working on the awscli.
--e git://github.com/boto/botocore.git@develop#egg=botocore
--e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
 nose==1.3.7
 mock==1.3.0
 rsa>=3.1.2,<=3.5.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ requires = ['botocore==1.13.0',
             'colorama>=0.2.5,<=0.3.9',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
-            's3transfer>=0.1.12,<0.2.0',
+            's3transfer>=0.2.0,<0.3.0',
             'ruamel.yaml>=0.15.0,<0.16.0',
             'prompt-toolkit>=2.0.0,<3.0.0',
             ]


### PR DESCRIPTION
Don't pull s3transfer/botocore from develop

Right now we specify the version from both s3transfer as well
as from the requirements.txt file.  Rather than pull from develop
we should just set the version from the setup.py.

I also synced the version of s3transfer to match the latest
minor version range.