### PR TITLE
Update eks get-token to use client interface

### DIFF
--- a/.changes/next-release/enhancement-eksgettoken-48847.json
+++ b/.changes/next-release/enhancement-eksgettoken-48847.json
@@ -1,0 +1,5 @@
+{
+  "category": "``eks get-token``", 
+  "type": "enhancement", 
+  "description": "Refactor ``get-token`` implementation and add support for non-aws partitions and regions."
+}

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -1,0 +1,145 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import base64
+from datetime import datetime
+import json
+
+from awscli.testutils import mock
+from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.compat import urlparse
+
+
+class TestGetTokenCommand(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestGetTokenCommand, self).setUp()
+        self.cluster_name = 'MyCluster'
+        self.role_arn = 'arn:aws:iam::012345678910:role/RoleArn'
+        self.access_key = 'ABCDEFGHIJKLMNOPQRST'
+        self.secret_key = 'TSRQPONMLKJUHGFEDCBA'
+        self.session_token = 'TOKENTOKENTOKENTOKEN'
+        self.environ['AWS_ACCESS_KEY_ID'] = self.access_key
+        self.environ['AWS_SECRET_ACCESS_KEY'] = self.secret_key
+        self.expected_token_prefix = 'k8s-aws-v1.'
+
+    def run_get_token(self, cmd):
+        response, _, _ = self.run_cmd(cmd)
+        return json.loads(response)
+
+    def assert_url_correct(self, response,
+                           expected_endpoint='sts.amazonaws.com',
+                           expected_signing_region='us-east-1',
+                           has_session_token=False):
+        url = self._get_url(response)
+        url_components = urlparse.urlparse(url)
+        self.assertEqual(url_components.netloc, expected_endpoint)
+        parsed_qs = urlparse.parse_qs(url_components.query)
+        self.assertIn(
+            expected_signing_region, parsed_qs['X-Amz-Credential'][0])
+        if has_session_token:
+            self.assertEqual(
+                [self.session_token], parsed_qs['X-Amz-Security-Token'])
+        else:
+            self.assertNotIn('X-Amz-Security-Token', parsed_qs)
+
+        self.assertIn(self.access_key, parsed_qs['X-Amz-Credential'][0])
+        self.assertIn('x-k8s-aws-id', parsed_qs['X-Amz-SignedHeaders'][0])
+
+    def _get_url(self, response):
+        token = response['status']['token']
+        b64_token = token[len(self.expected_token_prefix):].encode()
+        missing_padding = len(b64_token) % 4
+        if missing_padding:
+            b64_token += b'=' * (4 - missing_padding)
+        return base64.urlsafe_b64decode(b64_token).decode()
+
+
+    @mock.patch('awscli.customizations.eks.get_token.datetime')
+    def test_get_token(self, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        response = self.run_get_token(cmd)
+        self.assertEqual(
+            response,
+            {
+                "kind": "ExecCredential",
+                "apiVersion": "client.authentication.k8s.io/v1alpha1",
+                "spec": {},
+                "status": {
+                    "expirationTimestamp": "2019-10-23T23:14:00Z",
+                    "token": mock.ANY,  # This is asserted in later cases
+                },
+            }
+        )
+
+    def test_url(self):
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        response = self.run_get_token(cmd)
+        self.assert_url_correct(response)
+
+    def test_url_with_region(self):
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --region us-west-2'
+        response = self.run_get_token(cmd)
+        # Even though us-west-2 was specified, we should still only be
+        # signing for the global endpoint.
+        self.assert_url_correct(
+            response,
+            expected_endpoint='sts.amazonaws.com',
+            expected_signing_region='us-east-1'
+        )
+
+    def test_url_with_arn(self):
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --role-arn %s' % self.role_arn
+        self.parsed_responses = [
+            {
+                "Credentials": {
+                    "AccessKeyId": self.access_key,
+                    "SecretAccessKey": self.secret_key,
+                    "SessionToken": self.session_token,
+                },
+            }
+        ]
+        response = self.run_get_token(cmd)
+        assume_role_call = self.operations_called[0]
+        self.assertEqual(assume_role_call[0].name, 'AssumeRole')
+        self.assertEqual(
+            assume_role_call[1],
+            {
+                'RoleArn': self.role_arn,
+                'RoleSessionName': 'EKSGetTokenAuth'
+            }
+        )
+        self.assert_url_correct(
+            response, has_session_token=True)
+
+    def test_token_has_no_padding(self):
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        num_rounds = 100
+        # It is difficult to patch everything out to get an exact
+        # reproduceable token. So to make sure there is no padding, we
+        # run the command N times and make sure there is no padding in the
+        # generated token.
+        for _ in range(num_rounds):
+            response = self.run_get_token(cmd)
+            self.assertNotIn('=', response['status']['token'])
+
+    def test_url_different_partition(self):
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --region cn-north-1'
+        response = self.run_get_token(cmd)
+        self.assert_url_correct(
+            response,
+            expected_endpoint='sts.cn-north-1.amazonaws.com.cn',
+            expected_signing_region='cn-north-1'
+        )

--- a/tests/unit/customizations/eks/test_get_token.py
+++ b/tests/unit/customizations/eks/test_get_token.py
@@ -25,102 +25,26 @@ from awscli.customizations.eks.get_token import (
 )
 
 
-REGION = 'us-west-2'
-SIGN_REGION = 'us-east-1'
-CLUSTER_NAME = 'MyCluster'
-TOKEN_PREFIX = "k8s-aws-v1."
-
-CREDENTIALS   = 'ABCDEFGHIJKLMNOPQRST'
-SECRET_KEY    = 'TSRQPONMLKJUHGFEDCBA'
-SESSION_TOKEN = 'TOKENTOKENTOKENTOKEN'
-
-class TestTokenGenerator(unittest.TestCase):
-    def assert_url_correct(self, url, is_session):
-        url_no_signature = url[0:-64]
-
-        if is_session:
-            self.assertIn("X-Amz-Security-Token=" + SESSION_TOKEN + "&", url_no_signature)
-        else:
-            self.assertNotIn("X-Amz-Security-Token=" + SESSION_TOKEN + "&", url_no_signature)
-
-        self.assertIn("X-Amz-Credential=" + CREDENTIALS + "%2F", url_no_signature)
-        self.assertIn("%3Bx-k8s-aws-id&", url_no_signature)
-
+class BaseTokenTest(unittest.TestCase):
     def setUp(self):
-        session = botocore.session.get_session()
-        session.set_credentials(CREDENTIALS, SECRET_KEY)
-        self._session = session
+        self._session = botocore.session.get_session()
+        self._access_key = 'ABCDEFGHIJKLMNOPQRST'
+        self._secret_key = 'TSRQPONMLKJUHGFEDCBA'
+        self._region = 'us-west-2'
+        self._cluster_name = 'MyCluster'
+        self._session.set_credentials(self._access_key, self._secret_key)
+        self._sts_client = self._session.create_client('sts', self._region)
 
-        self.mock_sts_client = mock.Mock()
-        self.mock_sts_client.assume_role.return_value = {
-            "Credentials": {
-                "AccessKeyId": CREDENTIALS,
-                "SecretAccessKey": SECRET_KEY,
-                "SessionToken": SESSION_TOKEN,
-            },
-        }
 
-        self.maxDiff = None
-
-    def test_url(self):
-        generator = TokenGenerator(self._session)
-        url = generator._get_presigned_url(CLUSTER_NAME, None, REGION)
-        self.assert_url_correct(url, False)
-
-    def test_url_no_region(self):
-        self._session.set_config_variable('region', 'us-east-1')
-        generator = TokenGenerator(self._session)
-        url = generator._get_presigned_url(CLUSTER_NAME, None, None)
-        self.assert_url_correct(url, False)
-
-    @patch.object(botocore.session.Session, 'create_client')
-    def test_url_with_role(self, mock_create_client):
-        mock_create_client.return_value = self.mock_sts_client
-        generator = TokenGenerator(self._session)
-        url = generator._get_presigned_url(CLUSTER_NAME, "arn:aws:iam::012345678910:role/RoleArn", REGION)
-        self.assert_url_correct(url, True)
-
-    def test_token_no_role(self):
-        generator = TokenGenerator(self._session)
-        token = generator.get_token(CLUSTER_NAME, None, REGION)
-        prefix = token[:len(TOKEN_PREFIX)]
-        self.assertEqual(prefix, TOKEN_PREFIX)
-        token_no_prefix = token[len(TOKEN_PREFIX):]
-
-        decrypted_token = base64.urlsafe_b64decode(
-            token_no_prefix.encode()
-        ).decode()
-        self.assert_url_correct(decrypted_token, False)
-
+class TestTokenGenerator(BaseTokenTest):
     @patch.object(TokenGenerator, '_get_presigned_url', return_value='aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8=')
     def test_token_no_padding(self, mock_presigned_url):
-        generator = TokenGenerator(self._session)
-        tok = generator.get_token(CLUSTER_NAME, None, REGION)
+        generator = TokenGenerator(self._sts_client)
+        tok = generator.get_token(self._cluster_name)
         self.assertTrue('=' not in tok)
 
-    @patch.object(botocore.session.Session, 'create_client')
-    def test_token_sess(self, mock_create_client):
-        mock_create_client.return_value = self.mock_sts_client
 
-        generator = TokenGenerator(self._session)
-        token = generator.get_token(CLUSTER_NAME, "arn:aws:iam::012345678910:role/RoleArn", REGION)
-        prefix = token[:len(TOKEN_PREFIX)]
-        self.assertEqual(prefix, TOKEN_PREFIX)
-        token_no_prefix = token[len(TOKEN_PREFIX):]
-
-        decrypted_token = base64.urlsafe_b64decode(
-            token_no_prefix.encode()
-        ).decode()
-        self.assert_url_correct(decrypted_token, True)
-
-class TestGetTokenCommand(unittest.TestCase):
-
-    def setUp(self):
-        session = botocore.session.get_session()
-        session.set_credentials(CREDENTIALS, SECRET_KEY)
-        self._session = session
-        self.maxDiff = None
-
+class TestGetTokenCommand(BaseTokenTest):
     def test_get_expiration_time(self):
         cmd = GetTokenCommand(self._session)
         timestamp = cmd.get_expiration_time()
@@ -128,29 +52,3 @@ class TestGetTokenCommand(unittest.TestCase):
             datetime.strptime(timestamp, '%Y-%m-%dT%H:%M:%SZ')
         except ValueError:
             raise ValueError("Incorrect data format, should be %Y-%m-%dT%H:%M:%SZ")
-
-    @patch.object(GetTokenCommand, 'get_expiration_time', return_value='2019-06-21T22:07:54Z')
-    def test_run_main(self, mock_expiration_time):
-        mock_token_generator = mock.Mock()
-        fake_token = 'k8s-aws-v1.aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8='
-        mock_token_generator.get_token.return_value = fake_token
-
-        mock_args = mock.Mock()
-        mock_args.cluster_name = "my-cluster"
-        mock_args.role_arn = None
-
-        mock_globals = mock.Mock()
-        mock_globals.region = 'us-west-2'
-
-        expected_stdout = json.dumps({
-            "kind": "ExecCredential",
-            "apiVersion": "client.authentication.k8s.io/v1alpha1", "spec": {},
-            "status": {
-                "expirationTimestamp": "2019-06-21T22:07:54Z",
-                "token": fake_token,
-            },
-        }) +'\n'
-        cmd = GetTokenCommand(self._session)
-        with capture_output() as captured:
-            cmd._run_main(mock_args, mock_globals, mock_token_generator)
-            self.assertEqual(expected_stdout, captured.stdout.getvalue())


### PR DESCRIPTION
It ensures that we are not using any internals of botocore by using public interfaces. Also since we are using the client now, much of this was able to be refactored to functional testing.