### PR TITLE
Mark select-object-content outfile as required

### DIFF
--- a/awscli/customizations/s3events.py
+++ b/awscli/customizations/s3events.py
@@ -58,6 +58,7 @@ def replace_event_stream_docs(help_command, **kwargs):
 
 
 class S3SelectStreamOutputArgument(CustomArgument):
+    _DOCUMENT_AS_REQUIRED = True
 
     def __init__(self, stream_key, session, **kwargs):
         super(S3SelectStreamOutputArgument, self).__init__(**kwargs)

--- a/tests/functional/s3api/test_select_object_content.py
+++ b/tests/functional/s3api/test_select_object_content.py
@@ -119,3 +119,5 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
             'Output\n======\n'
             'This command generates no output'
         )
+        self.assert_not_contains('[outfile')
+        self.assert_contains('outfile')


### PR DESCRIPTION
This updates the customization that adds the `outfile` positional parameter to `s3api select-object-content` to be documented as required. The parameter is already required in practice, the rendering in the docs was wrong though.