### PR TITLE
Include PyYAML in setup.py as well as requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ rsa>=3.1.2,<=3.5.0
 wheel==0.24.0
 ruamel.yaml>=0.15.0,<0.16.0
 # TODO: Remove this once we update all customizations to not rely on pyyaml.
-PyYAML>=3.10,<=3.13
+PyYAML>=3.10,<5.2
 jsonschema==2.5.1
 PyInstaller==3.5
 https://github.com/boto/botocore/zipball/v2#egg=botocore

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ requires-dist =
         colorama>=0.2.5,<0.4.2
         docutils>=0.10,<0.16
         rsa>=3.1.2,<=3.5.0
+        PyYAML>=3.10,<5.2
         ruamel.yaml>=0.15.0,<0.16.0
         s3transfer>=0.2.0,<0.3.0
         prompt-toolkit>=2.0.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ requires = ['botocore==2.0.0dev0',
             'docutils>=0.10',
             'rsa>=3.1.2,<=3.5.0',
             's3transfer>=0.2.0,<0.3.0',
+            'PyYAML>=3.10,<5.2',
             'ruamel.yaml>=0.15.0,<0.16.0',
             'prompt-toolkit>=2.0.0,<3.0.0',
             ]


### PR DESCRIPTION
This syncs our PyYAML dependency with what is in v1 develop and also includes it in our `setup.py`. This was removed but is still used in some customization logic, so it needs to be in `setup.py` still.