### PR TITLE
Strip whitespace in aws configure sso prompts

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -82,6 +82,8 @@ class PTKPrompt(object):
             completer=completer,
             complete_while_typing=True,
         )
+        # Strip any extra white space
+        response = response.strip()
         if not response:
             # If the user hits enter, we return the current/default value
             response = current_value

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -80,6 +80,11 @@ class TestPTKPrompt(unittest.TestCase):
         self.prompter.get_value('', '', validator=validator)
         self.assert_expected_validator(validator)
 
+    def test_strips_extra_whitespace(self):
+        self.mock_prompter.return_value = '  no_whitespace \t  '
+        response = self.prompter.get_value('default_value', 'Prompt Text')
+        self.assertEqual(response, 'no_whitespace')
+
 
 class TestStartUrlValidator(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -49,8 +49,13 @@ class TestPTKPrompt(unittest.TestCase):
         self.assertEqual(response, 'default_value')
 
     def assert_expected_completions(self, completions):
+        # The order of the completion list can vary becuase it comes from the
+        # dict's keys. Asserting that each expected completion is in the list
         _, kwargs = self.mock_prompter.call_args_list[0]
-        self.assertEqual(kwargs['completer'].words, completions)
+        completer = kwargs['completer']
+        self.assertEqual(len(completions), len(completer.words))
+        for completion in completions:
+            self.assertIn(completion, completer.words)
 
     def assert_expected_meta_dict(self, meta_dict):
         _, kwargs = self.mock_prompter.call_args_list[0]


### PR DESCRIPTION
This adds additional logic to strip any extra white space we get from prompts while running `aws configure sso` to help protect against copy paste errors.
