### PR TITLE
Handle null account fields in configure sso

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -88,6 +88,25 @@ class PTKPrompt(object):
         return response
 
 
+def display_account(account):
+    """Converts an SSO account response into a display string.
+
+    All fields should be present in the API response but we've seen some
+    cases where the account name or email address is not set. Considering
+    we only need the account name and email address for display purposes
+    we should be defensive just in case they don't come back.
+    """
+    if 'accountName' not in account and 'emailAddress' not in account:
+        account_template = '{accountId}'
+    elif 'emailAddress' not in account:
+        account_template = '{accountName} ({accountId})'
+    elif 'accountName' not in account:
+        account_template = '{emailAddress} ({accountId})'
+    else:
+        account_template = '{accountName}, {emailAddress} ({accountId})'
+    return account_template.format(**account)
+
+
 class ConfigureSSOCommand(BasicCommand):
     NAME = 'sso'
     SYNOPSIS = ('aws2 configure sso [--profile profile-name]')
@@ -151,15 +170,12 @@ class ConfigureSSOCommand(BasicCommand):
         uni_print(single_account_msg.format(sso_account_id))
         return sso_account_id
 
-    def _display_account(self, account):
-        return '{accountName}, {emailAddress} ({accountId})'.format(**account)
-
     def _handle_multiple_accounts(self, accounts):
         available_accounts_msg = (
             'There are {} AWS accounts available to you.\n'
         )
         uni_print(available_accounts_msg.format(len(accounts)))
-        selected_account = self._selector(accounts, self._display_account)
+        selected_account = self._selector(accounts, display_account)
         sso_account_id = selected_account['accountId']
         return sso_account_id
 

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -24,6 +24,7 @@ from botocore.stub import Stubber
 from botocore.exceptions import ProfileNotFound
 
 from awscli.testutils import unittest
+from awscli.customizations.configure.sso import display_account
 from awscli.customizations.configure.sso import select_menu
 from awscli.customizations.configure.sso import PTKPrompt
 from awscli.customizations.configure.sso import ConfigureSSOCommand
@@ -394,3 +395,43 @@ class TestConfigureSSOCommand(unittest.TestCase):
             expected_cli_outputs,
         ]
         self.assert_prompt_completions(expected_completions)
+
+
+class TestDisplayAccount(unittest.TestCase):
+    def setUp(self):
+        self.account_id = '1234'
+        self.email_address = 'test@test.com'
+        self.account_name = 'FooBar'
+        self.account = {
+            'accountId': self.account_id,
+            'emailAddress': self.email_address,
+            'accountName': self.account_name,
+        }
+
+    def test_display_account_all_fields(self):
+        account_str = display_account(self.account)
+        self.assertIn(self.account_name, account_str)
+        self.assertIn(self.email_address, account_str)
+        self.assertIn(self.account_id, account_str)
+
+    def test_display_account_missing_email(self):
+        del self.account['emailAddress']
+        account_str = display_account(self.account)
+        self.assertIn(self.account_name, account_str)
+        self.assertNotIn(self.email_address, account_str)
+        self.assertIn(self.account_id, account_str)
+
+    def test_display_account_missing_name(self):
+        del self.account['accountName']
+        account_str = display_account(self.account)
+        self.assertNotIn(self.account_name, account_str)
+        self.assertIn(self.email_address, account_str)
+        self.assertIn(self.account_id, account_str)
+
+    def test_display_account_missing_name_and_email(self):
+        del self.account['accountName']
+        del self.account['emailAddress']
+        account_str = display_account(self.account)
+        self.assertNotIn(self.account_name, account_str)
+        self.assertNotIn(self.email_address, account_str)
+        self.assertIn(self.account_id, account_str)


### PR DESCRIPTION
Fixes #4637 

We need to merge #4636 first or this might fail.