### PR TITLE
Fix timestamp related s3 tests failing on MacOS

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -97,6 +97,22 @@ def skip_if_windows(reason):
     return decorator
 
 
+def skip_if_macos(reason):
+    """Decorator to skip tests that should not be run on MacOS.
+
+    Example usage:
+
+        @skip_if_macos("Not valid")
+        def test_some_non_macos_stuff(self):
+            self.assertEqual(...)
+
+    """
+    def decorator(func):
+        return unittest.skipIf(
+            platform.system() in ['Darwin'], reason)(func)
+    return decorator
+
+
 def set_invalid_utime(path):
     """Helper function to set an invalid last modified time"""
     try:

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -16,6 +16,7 @@ import os
 
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import capture_input, set_invalid_utime
+from awscli.testutils import skip_if_windows, skip_if_macos
 from awscli.compat import six
 from tests.functional.s3 import BaseS3TransferCommandTest
 
@@ -615,7 +616,29 @@ class TestCPCommand(BaseCPCommandTest):
         progress_message = 'Completed 10 Bytes'
         self.assertIn(progress_message, stdout)
 
-    def test_cp_with_error_and_warning(self):
+
+    @skip_if_windows("Unreadable file is hard to make on windows")
+    def test_cp_with_error_and_warning_unreadable_file(self):
+        command = "s3 cp --recursive %s s3://bucket/"
+        self.parsed_responses = [{
+            'Error': {
+                'Code': 'NoSuchBucket',
+                'Message': 'The specified bucket does not exist',
+                'BucketName': 'bucket'
+            }
+        }]
+        self.http_response.status_code = 404
+
+        unreadable_path = self.files.create_file('foo.txt', 'foo')
+        self.files.create_file('bar.txt', 'bar')
+        os.chmod(unreadable_path, 0o222)
+        _, stderr, rc = self.run_cmd(command % self.files.rootdir, expected_rc=1)
+        self.assertIn('upload failed', stderr)
+        self.assertIn('warning: Skipping file', stderr)
+        self.assertIn('File/Directory is not readable.', stderr)
+
+    @skip_if_macos("On MacOS we cannot create an invalid timestamp.")
+    def test_cp_with_error_and_warning_invalid_timestamp(self):
         command = "s3 cp %s s3://bucket/foo.txt"
         self.parsed_responses = [{
             'Error': {

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import set_invalid_utime
+from awscli.testutils import set_invalid_utime, skip_if_macos
 from mock import patch
 import os
 
@@ -123,6 +123,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
         self.assertEqual(self.operations_called[0][0].name, 'ListObjectsV2')
         self.assertEqual('', stderr)
 
+    @skip_if_macos("Timestamps can't be invalid on macos")
     def test_warning_on_invalid_timestamp(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
 


### PR DESCRIPTION
On MacOS the file timestamp can no longer be invalid. This means our
tests that were checking for a warning by setting an invalid timestamp
no longer emit such a warning on newer Macs.

In one test it was specifically for invalid timestamps. This one is now
skipped on MacOS since it is not a valid case to check for anymore.

The other was a test to see if an error and a warning can be emitted at
the same time. It was using an invalid timestamp incidentally to emit a
warning. This test is run the same way on windows, and now skipped on
posix systems. The test was duplicated for posix systems and uses an
unreadable file to generate the warning.

