### PR TITLE
[v2] Remove support for plugins for dev preview

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -79,8 +79,7 @@ def main():
 def create_clidriver():
     session = botocore.session.Session()
     _set_user_agent_for_session(session)
-    load_plugins(session.full_config.get('plugins', {}),
-                 event_hooks=session.get_component('event_emitter'))
+    _load_plugins(session)
     driver = CLIDriver(session=session)
     return driver
 
@@ -89,6 +88,18 @@ def _set_user_agent_for_session(session):
     session.user_agent_name = 'aws-cli'
     session.user_agent_version = __version__
     session.user_agent_extra = 'botocore/%s' % botocore_version
+
+
+def _load_plugins(session):
+    if 'plugins' in session.full_config:
+        # V2 currently does not support plugins as external modules cannot
+        # be loaded directly from the v2 executables we generate. We eventually
+        # want to figure out how to support plugins in the future.
+        LOG.debug(
+            '[plugins] section is not currently supported. Not loading '
+            'plugins.'
+        )
+    load_plugins({}, event_hooks=session.get_component('event_emitter'))
 
 
 class CLIDriver(object):

--- a/tests/functional/raise_plugin_error.py
+++ b/tests/functional/raise_plugin_error.py
@@ -1,0 +1,18 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+class PluginsNotSupportedError(Exception):
+    pass
+
+
+def awscli_initialize(event_emitter):
+    raise PluginsNotSupportedError()


### PR DESCRIPTION
This is temporary while we figure out how we want to support plugins for v2 long term. Without removing the plugins section, it is not possible to run the CLI.

Fixes https://github.com/aws/aws-cli/issues/4650

