### PR TITLE
Fix some SyntaxWarnings from python 3.8

### DIFF
--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -539,8 +539,8 @@ class CreateCluster(Command):
                                                 parsed_args, parsed_configs):
         if parsed_args.use_default_roles:
             configurations = [x for x in configurations
-                              if x.name is not 'service_role' and
-                              x.name is not 'instance_profile']
+                              if x.name != 'service_role' and
+                              x.name != 'instance_profile']
         return configurations
 
     def _handle_emrfs_parameters(self, cluster, emrfs_args, release_label):

--- a/awscli/customizations/emr/emrutils.py
+++ b/awscli/customizations/emr/emrutils.py
@@ -240,7 +240,7 @@ def join(values, separator=',', lastSeparator='and'):
     values = [str(x) for x in values]
     if len(values) < 1:
         return ""
-    elif len(values) is 1:
+    elif len(values) == 1:
         return values[0]
     else:
         separator = '%s ' % separator


### PR DESCRIPTION
Comparisons to literals should be done with "==" or "!=" and not "is" "is not".

This fixes some SyntaxWarnings that python 3.8 is raising now.

Fix #4673
