### PR TITLE
Fix use of `user-attributes` in cmd `cognito-idp admin-create-user`

### DIFF
--- a/awscli/examples/cognito-idp/admin-create-user.rst
+++ b/awscli/examples/cognito-idp/admin-create-user.rst
@@ -5,7 +5,7 @@ are specified.
 
 Command::
 
-  aws cognito-idp admin-create-user --user-pool-id us-west-2_aaaaaaaaa --username diego@example.com --user-attributes=Name=email,Value=kermit2@somewhere.com,Name=phone_number,Value="+15555551212" --message-action SUPPRESS
+  aws cognito-idp admin-create-user --user-pool-id us-west-2_aaaaaaaaa --username diego@example.com --user-attributes=Name=email,Value=kermit2@somewhere.com Name=phone_number,Value="+15555551212" --message-action SUPPRESS
 
 Output::
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-archives/amazon-cognito-identity-js/issues/532
https://forums.aws.amazon.com/thread.jspa?threadID=311766

*Description of changes:*
The previous version gives an incorrect example use of multiple user attributes. Should be separated with a space, not a comma as options' doc states.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
