### PR TITLE
Adding to CloudFormation's URL parameters

### DIFF
--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -57,6 +57,7 @@ PARAMFILE_DISABLED = set([
     'custom.deploy.template-file',
 
     'cloudformation.update-stack.stack-policy-during-update-url',
+    'cloudformation.register-type.schema-handler-package',
     # We will want to change the event name to ``s3`` as opposed to
     # custom in the near future along with ``s3`` to ``s3api``.
     'custom.cp.website-redirect',

--- a/tests/functional/cloudformation/test_register_type.py
+++ b/tests/functional/cloudformation/test_register_type.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestRegisterType(BaseAWSCommandParamsTest):
+
+    prefix = 'cloudformation register-type'
+
+    def test_schema_handler_package_during_register_url(self):
+        cmdline = self.prefix
+        cmdline += ' --type-name test-type-name '
+        cmdline += '--schema-handler-package s3://bucket_name/my-organization-resource_name.zip'
+        result = {
+            'TypeName': 'test-type-name',
+            'SchemaHandlerPackage': 's3://bucket_name/my-organization-resource_name.zip'
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/cloudformation/test_register_type.py
+++ b/tests/functional/cloudformation/test_register_type.py
@@ -20,9 +20,9 @@ class TestRegisterType(BaseAWSCommandParamsTest):
     def test_schema_handler_package_during_register_url(self):
         cmdline = self.prefix
         cmdline += ' --type-name test-type-name '
-        cmdline += '--schema-handler-package s3://bucket_name/my-organization-resource_name.zip'
+        cmdline += '--schema-handler-package s3://bucket-name/my-organization-resource_name.zip'
         result = {
             'TypeName': 'test-type-name',
-            'SchemaHandlerPackage': 's3://bucket_name/my-organization-resource_name.zip'
+            'SchemaHandlerPackage': 's3://bucket-name/my-organization-resource_name.zip'
         }
         self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
Adding to CloudFormation's URL parameters

CloudFormation introduced a new API RegisterType that takes a URL under the parameter SchemaHandlerPackage.  This change ensures that the CLI does not attempt to download the package contents and pass those instead of the URL directly.

*Issue #, if available:*

*Description of changes:*
See body of commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
