### PR TITLE
[v2] Default command output to a pager

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -58,7 +58,7 @@ is_windows = sys.platform == 'win32'
 if is_windows:
     default_pager = 'more'
 else:
-    default_pager = 'less -R'
+    default_pager = 'less'
 
 
 class StdinMissingError(Exception):

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -17,6 +17,7 @@ import sys
 
 from ruamel.yaml import YAML
 
+from awscli.utils import OutputStreamFactory
 import awscli.customizations.dynamodb.params as parameters
 from awscli.customizations.commands import BasicCommand, CustomArgument
 from awscli.customizations.dynamodb.extractor import AttributeExtractor
@@ -44,6 +45,7 @@ class DDBCommand(BasicCommand):
         self._serializer = TypeSerializer()
         self._deserializer = TypeDeserializer()
         self._extractor = AttributeExtractor()
+        self._output_stream_factory = OutputStreamFactory(self._session)
 
     def _serialize(self, operation_name, data):
         service_model = self._client.meta.service_model
@@ -81,7 +83,8 @@ class DDBCommand(BasicCommand):
         return response
 
     def _dump_yaml(self, operation_name, data, parsed_globals):
-        DynamoYAMLFormatter(parsed_globals)(operation_name, data)
+        with self._output_stream_factory.get_output_stream() as stream:
+            DynamoYAMLFormatter(parsed_globals)(operation_name, data, stream)
 
     def _add_expression_args(self, expression_name, expression, args,
                              substitution_count=0):

--- a/awscli/customizations/history/commands.py
+++ b/awscli/customizations/history/commands.py
@@ -29,7 +29,11 @@ class HistorySubcommand(BasicCommand):
         self._db_reader = db_reader
         self._output_stream_factory = output_stream_factory
         if output_stream_factory is None:
-            self._output_stream_factory = OutputStreamFactory()
+            self._output_stream_factory = \
+                self._get_default_output_stream_factory()
+
+    def _get_default_output_stream_factory(self):
+        return OutputStreamFactory(self._session)
 
     def _connect_to_history_db(self):
         if self._db_reader is None:
@@ -56,8 +60,5 @@ class HistorySubcommand(BasicCommand):
             return False
         return is_a_tty() and not is_windows
 
-    def _get_output_stream(self, preferred_pager=None):
-        if is_a_tty():
-            return self._output_stream_factory.get_pager_stream(
-                preferred_pager)
-        return self._output_stream_factory.get_stdout_stream()
+    def _get_output_stream(self):
+        return self._output_stream_factory.get_output_stream()

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -213,8 +213,6 @@ class DetailedFormatter(Formatter):
         self._write_output(formatted_value)
 
     def _write_output(self, content):
-        if isinstance(content, six.text_type):
-            content = content.encode('utf-8')
         self._output.write(content)
 
     def _format_section_title(self, title, event_record):
@@ -378,9 +376,9 @@ class ShowCommand(HistorySubcommand):
         self._connect_to_history_db()
         try:
             self._validate_args(parsed_args)
-            with self._get_output_stream() as output_stream:
+            with self._output_stream_factory.get_output_stream() as stream:
                 formatter = self._get_formatter(
-                    parsed_args, parsed_globals, output_stream)
+                    parsed_args, parsed_globals, stream)
                 for record in self._get_record_iterator(parsed_args):
                     formatter.display(record)
         finally:

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -89,6 +89,21 @@ def skip_if_windows(reason):
     return decorator
 
 
+def skip_if_not_windows(reason):
+    """Decorator to skip tests should only be ran for windows.
+
+    Example usage:
+
+        @skip_if_not_windows("Not valid")
+        def test_some_windows_stuff(self):
+            self.assertEqual(...)
+
+    """
+    def decorator(func):
+        return unittest.skipIf(platform.system() != 'Windows', reason)(func)
+    return decorator
+
+
 def set_invalid_utime(path):
     """Helper function to set an invalid last modified time"""
     try:

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -89,12 +89,12 @@ def skip_if_windows(reason):
     return decorator
 
 
-def skip_if_not_windows(reason):
+def if_windows(reason):
     """Decorator to skip tests should only be ran for windows.
 
     Example usage:
 
-        @skip_if_not_windows("Not valid")
+        @if_windows("Only supported on windows")
         def test_some_windows_stuff(self):
             self.assertEqual(...)
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -302,7 +302,7 @@ class OutputStreamFactory(object):
         kwargs = get_popen_kwargs_for_pager_cmd(pager_cmd)
         kwargs['stdin'] = PIPE
         env = self._environ.copy()
-        if pager_cmd.startswith('less') and 'LESS' not in env:
+        if 'LESS' not in env:
             env['LESS'] = self._default_less_flags
         kwargs['env'] = env
         kwargs['universal_newlines'] = True

--- a/tests/functional/history/__init__.py
+++ b/tests/functional/history/__init__.py
@@ -16,7 +16,6 @@ from botocore.history import HistoryRecorder
 
 from awscli.testutils import mock, create_clidriver, FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.compat import BytesIO
 
 
 class BaseHistoryCommandParamsTest(BaseAWSCommandParamsTest):
@@ -34,15 +33,6 @@ class BaseHistoryCommandParamsTest(BaseAWSCommandParamsTest):
         self.environ['AWS_CLI_HISTORY_FILE'] = self.files.create_file(
             'history.db', '')
         self.driver = create_clidriver()
-        # The run_cmd patches stdout with a StringIO object (similar to what
-        # nose does). Therefore it will run into issues when
-        # get_binary_stdout is called because it returns sys.stdout.buffer
-        # for Py3 and StringIO does not have a buffer
-        self.binary_stdout_patch = mock.patch(
-            'awscli.utils.get_binary_stdout')
-        mock_get_binary_stdout = self.binary_stdout_patch.start()
-        self.binary_stdout = BytesIO()
-        mock_get_binary_stdout.return_value = self.binary_stdout
 
     def _make_clean_history_recorder(self):
         # This is to ensure that for each new test run the CLI is using
@@ -80,4 +70,3 @@ class BaseHistoryCommandParamsTest(BaseAWSCommandParamsTest):
         super(BaseHistoryCommandParamsTest, self).tearDown()
         self._cleanup_db_connections()
         self.files.remove_all()
-        self.binary_stdout_patch.stop()

--- a/tests/functional/history/test_list.py
+++ b/tests/functional/history/test_list.py
@@ -31,10 +31,10 @@ class TestListCommand(BaseHistoryCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        self.run_cmd('history show', expected_rc=0)
+        stdout, _, _ = self.run_cmd('history show', expected_rc=0)
         # The history show should not display anything as no history should
         # have been collected
-        self.assertEqual(b'', self.binary_stdout.getvalue())
+        self.assertEqual('', stdout)
 
     def test_show_nothing_when_no_history(self):
         out, err, rc = self.run_cmd('history list', expected_rc=255)
@@ -59,9 +59,10 @@ class TestListCommand(BaseHistoryCommandParamsTest):
         ]
         _, _, rc = self.run_cmd('ec2 describe-regions', expected_rc=0)
         self.history_recorder.record('CLI_RC', rc, 'CLI')
-        self.run_cmd('history list', expected_rc=0)
-        self.assertIn(b'ec2 describe-regions', self.binary_stdout.getvalue())
-        def test_multiple_calls_present(self):
+        stdout, _, _ = self.run_cmd('history list', expected_rc=0)
+        self.assertIn('ec2 describe-regions', stdout)
+
+    def test_multiple_calls_present(self):
             self.parsed_responses = [
                 {
                     "Regions": [
@@ -81,8 +82,6 @@ class TestListCommand(BaseHistoryCommandParamsTest):
             self.history_recorder.record('CLI_RC', rc, 'CLI')
             _, _, rc = self.run_cmd('sts get-caller-identity', expected_rc=0)
             self.history_recorder.record('CLI_RC', rc, 'CLI')
-            self.run_cmd('history list', expected_rc=0)
-            self.assertIn(b'ec2 describe-regions',
-                          self.binary_stdout.getvalue())
-            self.assertIn(b'sts get-caller-identity',
-                          self.binary_stdout.getvalue())
+            stdout, _, _ = self.run_cmd('history list', expected_rc=0)
+            self.assertIn('ec2 describe-instances', stdout)
+            self.assertIn('sts get-caller-identity', stdout)

--- a/tests/functional/history/test_show.py
+++ b/tests/functional/history/test_show.py
@@ -28,15 +28,15 @@ class TestShowCommand(BaseHistoryCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        self.run_cmd('history show', expected_rc=0)
+        stdout, _, _ = self.run_cmd('history show', expected_rc=0)
         # Test that the CLI specific events are present such as arguments
         # entered and version
         #
         # The show command writes the history out as binary to the attached
         # stream so we want to determine if the values are in the binary
         # stdout stream
-        self.assertIn(b'describe-regions', self.binary_stdout.getvalue())
-        self.assertIn(b'version', self.binary_stdout.getvalue())
+        self.assertIn('describe-regions', stdout)
+        self.assertIn('version', stdout)
 
     def test_show_nothing_when_no_history(self):
         self.environ['AWS_CONFIG_FILE'] = ''
@@ -52,10 +52,10 @@ class TestShowCommand(BaseHistoryCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        self.run_cmd('history show', expected_rc=0)
+        stdout, _, _ = self.run_cmd('history show', expected_rc=0)
         # The history show should not display anything as no history should
         # have been collected
-        self.assertEqual(b'', self.binary_stdout.getvalue())
+        self.assertEqual('', stdout)
 
     def test_show_with_include(self):
         self.parsed_responses = [
@@ -69,14 +69,15 @@ class TestShowCommand(BaseHistoryCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        self.run_cmd('history show --include CLI_ARGUMENTS', expected_rc=0)
+        stdout, _, _ = self.run_cmd(
+            'history show --include CLI_ARGUMENTS', expected_rc=0)
         # Make sure the CLI version was not included because of the filter.
         #
         # The show command writes the history out as binary to the attached
         # stream so we want to determine if the values are in the binary
         # stdout stream
-        self.assertIn(b'describe-regions', self.binary_stdout.getvalue())
-        self.assertNotIn(b'version', self.binary_stdout.getvalue())
+        self.assertIn('describe-regions', stdout)
+        self.assertNotIn('version', stdout)
 
     def test_show_with_exclude(self):
         self.parsed_responses = [
@@ -90,12 +91,13 @@ class TestShowCommand(BaseHistoryCommandParamsTest):
             }
         ]
         self.run_cmd('ec2 describe-regions', expected_rc=0)
-        self.run_cmd('history show --exclude CLI_ARGUMENTS', expected_rc=0)
+        stdout, _, _ = self.run_cmd(
+            'history show --exclude CLI_ARGUMENTS', expected_rc=0)
         # Make sure the API call was not included because of the filter,
         # but all other events such as the version are included.
         #
         # The show command writes the history out as binary to the attached
         # stream so we want to determine if the values are in the binary
         # stdout stream
-        self.assertNotIn(b'describe-regions', self.binary_stdout.getvalue())
-        self.assertIn(b'version', self.binary_stdout.getvalue())
+        self.assertNotIn('describe-regions', stdout)
+        self.assertIn('version', stdout)

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-from awscli.testutils import skip_if_windows, skip_if_not_windows
+from awscli.testutils import skip_if_windows, if_windows
 from awscli.testutils import mock, create_clidriver, FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
 
@@ -100,7 +100,7 @@ class TestOutput(BaseAWSCommandParamsTest):
             expected_less_flags='FRX'
         )
 
-    @skip_if_not_windows('more is only used for windows')
+    @if_windows('more is only used for windows')
     def test_outputs_to_more_for_windows(self):
         self.run_cmd(self.cmdline)
         self.assert_content_to_pager(

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -1,0 +1,176 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import json
+
+from awscli.testutils import skip_if_windows, skip_if_not_windows
+from awscli.testutils import mock, create_clidriver, FileCreator
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestOutput(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestOutput, self).setUp()
+        self.files = FileCreator()
+
+        self.patch_popen = mock.patch('awscli.utils.Popen')
+        self.mock_popen = self.patch_popen.start()
+
+        self.patch_tty = mock.patch('awscli.utils.is_a_tty')
+        self.mock_is_a_tty = self.patch_tty.start()
+        self.mock_is_a_tty.return_value = True
+
+        self.cmdline = 'ec2 describe-regions'
+        self.parsed_response = {
+            "Regions": [
+                {
+                        "Endpoint": "ec2.ap-south-1.amazonaws.com",
+                        "RegionName": "ap-south-1"
+                },
+            ]
+        }
+        self.expected_content = self.get_expected_content(self.parsed_response)
+
+    def tearDown(self):
+        super(TestOutput, self).tearDown()
+        self.files.remove_all()
+        self.patch_popen.stop()
+        self.patch_tty.stop()
+
+    def get_expected_content(self, response):
+        content = json.dumps(response, indent=4)
+        content += '\n'
+        return content
+
+    def write_cli_pager_config(self, pager):
+        config_file = self.files.create_file(
+            'config',
+            '[default]\n'
+            'cli_pager = %s\n' % pager
+        )
+        self.environ['AWS_CONFIG_FILE'] = config_file
+        self.driver = create_clidriver()
+
+    def assert_content_to_pager(self, expected_pager, expected_content,
+                                expected_less_flags=None):
+        actual_pager = self.mock_popen.call_args[1]['args']
+        if isinstance(actual_pager, list):
+            actual_pager = ' '.join(actual_pager)
+        self.assertEqual(expected_pager, actual_pager)
+        self.assertEqual(expected_content, self.get_content_sent_to_popen())
+        if expected_less_flags:
+            actual_env = self.mock_popen.call_args[1]['env']
+            self.assertEqual(expected_less_flags, actual_env['LESS'])
+
+    def get_content_sent_to_popen(self):
+        content = ''
+        popen_stdin = self.mock_popen.return_value.stdin
+        for write_call in popen_stdin.write.call_args_list:
+            content += write_call[0][0]
+        return content
+
+    def test_outputs_to_pager(self):
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager=mock.ANY,
+            expected_content=self.expected_content
+        )
+
+    def test_does_not_output_to_pager_if_not_tty(self):
+        self.mock_is_a_tty.return_value = False
+        stdout, _, _ = self.run_cmd(self.cmdline)
+        self.assertFalse(self.mock_popen.called)
+        self.assertEqual(stdout, self.expected_content)
+
+    @skip_if_windows('less is not used for windows')
+    def test_outputs_to_less_non_windows(self):
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='less',
+            expected_content=self.expected_content,
+            expected_less_flags='FRX'
+        )
+
+    @skip_if_not_windows('more is only used for windows')
+    def test_outputs_to_more_for_windows(self):
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='more',
+            expected_content=self.expected_content,
+        )
+
+    def test_respects_aws_pager_env_var(self):
+        self.environ['AWS_PAGER'] = 'mypager'
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='mypager',
+            expected_content=self.expected_content,
+        )
+
+    def test_respects_cli_pager_config_var(self):
+        self.write_cli_pager_config('mypager')
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='mypager',
+            expected_content=self.expected_content,
+        )
+
+    def test_respects_pager_env_var(self):
+        self.environ['PAGER'] = 'mypager'
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='mypager',
+            expected_content=self.expected_content,
+        )
+
+    def test_no_pager_if_configured_to_empty_str(self):
+        self.environ['AWS_PAGER'] = ''
+        stdout, _, _ = self.run_cmd(self.cmdline)
+        self.assertFalse(self.mock_popen.called)
+        self.assertEqual(stdout, self.expected_content)
+
+    def test_aws_pager_env_var_beats_cli_pager_config_var(self):
+        self.environ['AWS_PAGER'] = 'envpager'
+        self.write_cli_pager_config('configpager')
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='envpager',
+            expected_content=self.expected_content,
+        )
+
+    def test_aws_pager_env_var_beats_pager_env_var(self):
+        self.write_cli_pager_config('configpager')
+        self.environ['PAGER'] = 'envpager'
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='configpager',
+            expected_content=self.expected_content,
+        )
+
+    def test_cli_pager_config_var_beats_pager_env_var(self):
+        self.environ['AWS_PAGER'] = 'awspager'
+        self.environ['PAGER'] = 'envpager'
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='awspager',
+            expected_content=self.expected_content,
+        )
+
+    def test_respects_less_env_var(self):
+        self.environ['AWS_PAGER'] = 'less'
+        self.environ['LESS'] = 'S'
+        self.run_cmd(self.cmdline)
+        self.assert_content_to_pager(
+            expected_pager='less',
+            expected_content=self.expected_content,
+            expected_less_flags='S'
+        )

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -17,7 +17,7 @@ import xml.dom.minidom
 from botocore.session import Session
 
 from awscli.compat import ensure_text_type
-from awscli.compat import BytesIO
+from awscli.compat import StringIO
 from awscli.utils import OutputStreamFactory
 from awscli.testutils import unittest, mock, FileCreator
 from awscli.customizations.history.show import ShowCommand
@@ -87,7 +87,7 @@ class TestFormatter(unittest.TestCase):
 
 class TestDetailedFormatter(unittest.TestCase):
     def setUp(self):
-        self.output = BytesIO()
+        self.output = StringIO()
         self.formatter = DetailedFormatter(self.output, colorize=False)
 
     def get_pretty_xml(self, xml_str):
@@ -591,10 +591,7 @@ class TestShowCommand(unittest.TestCase):
         self.output_stream = mock.Mock()
         output_stream_context.__enter__.return_value = self.output_stream
 
-        self.output_stream_factory.get_pager_stream.return_value = \
-            output_stream_context
-
-        self.output_stream_factory.get_stdout_stream.return_value = \
+        self.output_stream_factory.get_output_stream.return_value = \
             output_stream_context
 
         self.db_reader = mock.Mock(DatabaseRecordReader)
@@ -722,7 +719,6 @@ class TestShowCommand(unittest.TestCase):
         self.parsed_args.command_id = 'latest'
 
         self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
-        call = self.output_stream_factory.get_pager_stream.call_args
         self.assertEqual(
             self.formatter.call_args,
             mock.call(
@@ -741,8 +737,6 @@ class TestShowCommand(unittest.TestCase):
         self.parsed_args.command_id = 'latest'
 
         self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
-        self.assertTrue(
-            self.output_stream_factory.get_stdout_stream.called)
         self.assertEqual(
             self.formatter.call_args,
             mock.call(

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -103,7 +103,8 @@ GET_DATA = {
 GET_VARIABLE = {
     'provider': 'aws',
     'output': 'json',
-    'api_versions': {}
+    'api_versions': {},
+    'pager': 'less'
 }
 
 
@@ -263,6 +264,9 @@ class FakeSession(object):
             self.profile = value
         else:
             self.session_vars[name] = value
+
+    def get_scoped_config(self):
+        return GET_VARIABLE.copy()
 
 
 class FakeCommand(BasicCommand):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -167,7 +167,7 @@ class TestOutputStreamFactory(unittest.TestCase):
     def assert_popen_call(self, expected_pager_cmd, **override_args):
         popen_kwargs = {
             'stdin': subprocess.PIPE,
-            'env': self.environ,
+            'env': mock.ANY,
             'universal_newlines': True
         }
         if is_windows:
@@ -235,11 +235,11 @@ class TestOutputStreamFactory(unittest.TestCase):
         with self.stream_factory.get_output_stream():
             self.assertTrue(mock_stdout_writer.called)
 
-    def test_adds_default_less_env_vars_if_pager_is_less(self):
-        self.set_session_pager('less')
+    def test_adds_default_less_env_vars(self):
+        self.set_session_pager('myless')
         with self.stream_factory.get_output_stream():
             self.assert_popen_call(
-                expected_pager_cmd='less',
+                expected_pager_cmd='myless',
                 env={'LESS': 'FRX'}
             )
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,11 +15,13 @@ import platform
 import subprocess
 import json
 import os
+import shlex
 
 import botocore
 import botocore.session as session
 from botocore.exceptions import ConnectionClosedError
 from awscli.testutils import unittest, skip_if_windows, mock
+from awscli.compat import is_windows
 from awscli.utils import (split_on_commas, ignore_ctrl_c,
                           find_service_and_method_in_event_name,
                           OutputStreamFactory)
@@ -142,62 +144,65 @@ class MockProcess(object):
 
 class TestOutputStreamFactory(unittest.TestCase):
     def setUp(self):
+        self.session = mock.Mock(session.Session)
         self.popen = mock.Mock(subprocess.Popen)
-        self.stream_factory = OutputStreamFactory(self.popen)
+        self.environ = {}
+        self.stream_factory = OutputStreamFactory(
+            session=self.session, popen=self.popen,
+            environ=self.environ,
+        )
+        self.pager = 'mypager --option'
+        self.set_session_pager(self.pager)
+        self.patch_tty = mock.patch('awscli.utils.is_a_tty')
+        self.mock_is_a_tty = self.patch_tty.start()
+        self.mock_is_a_tty.return_value = True
 
-    @mock.patch('awscli.utils.get_popen_kwargs_for_pager_cmd')
-    def test_pager(self, mock_get_popen_pager):
-        mock_get_popen_pager.return_value = {
-                'args': ['mypager', '--option']
+    def tearDown(self):
+        self.patch_tty.stop()
+
+    def set_session_pager(self, pager):
+        self.session.get_component.return_value.\
+            get_config_variable.return_value = pager
+
+    def assert_popen_call(self, expected_pager_cmd, **override_args):
+        popen_kwargs = {
+            'stdin': subprocess.PIPE,
+            'env': self.environ,
+            'universal_newlines': True
         }
+        if is_windows:
+            popen_kwargs['args'] = expected_pager_cmd
+            popen_kwargs['shell'] = True
+        else:
+            popen_kwargs['args'] = shlex.split(expected_pager_cmd)
+        popen_kwargs.update(override_args)
+        self.popen.assert_called_with(**popen_kwargs)
+
+    def test_pager(self):
+        self.set_session_pager('mypager --option')
         with self.stream_factory.get_pager_stream():
-            mock_get_popen_pager.assert_called_with(None)
-            self.assertEqual(
-                self.popen.call_args_list,
-                [mock.call(
-                    args=['mypager', '--option'],
-                    stdin=subprocess.PIPE)]
+            self.assert_popen_call(
+                expected_pager_cmd='mypager --option'
             )
 
-    @mock.patch('awscli.utils.get_popen_kwargs_for_pager_cmd')
-    def test_env_configured_pager(self, mock_get_popen_pager):
-        mock_get_popen_pager.return_value = {
-            'args': ['mypager', '--option']
-        }
+    def test_explicit_pager(self):
+        self.set_session_pager('sessionpager --option')
         with self.stream_factory.get_pager_stream('mypager --option'):
-            mock_get_popen_pager.assert_called_with('mypager --option')
-            self.assertEqual(
-                self.popen.call_args_list,
-                [mock.call(
-                    args=['mypager', '--option'],
-                    stdin=subprocess.PIPE)]
-            )
-
-    @mock.patch('awscli.utils.get_popen_kwargs_for_pager_cmd')
-    def test_pager_using_shell(self, mock_get_popen_pager):
-        mock_get_popen_pager.return_value = {
-            'args': 'mypager --option', 'shell': True
-        }
-        with self.stream_factory.get_pager_stream():
-            mock_get_popen_pager.assert_called_with(None)
-            self.assertEqual(
-                self.popen.call_args_list,
-                [mock.call(
-                    args='mypager --option',
-                    stdin=subprocess.PIPE,
-                    shell=True)]
+            self.assert_popen_call(
+                expected_pager_cmd='mypager --option'
             )
 
     def test_exit_of_context_manager_for_pager(self):
+        self.set_session_pager('mypager --option')
         with self.stream_factory.get_pager_stream():
             pass
         returned_process = self.popen.return_value
         self.assertTrue(returned_process.communicate.called)
 
-    @mock.patch('awscli.utils.get_binary_stdout')
-    def test_stdout(self, mock_binary_out):
+    @mock.patch('awscli.utils.get_stdout_text_writer')
+    def test_stdout(self, mock_stdout_writer):
         with self.stream_factory.get_stdout_stream():
-            self.assertTrue(mock_binary_out.called)
+            self.assertTrue(mock_stdout_writer.called)
 
     def test_can_silence_io_error_from_pager(self):
         self.popen.return_value = MockProcess()
@@ -211,6 +216,51 @@ class TestOutputStreamFactory(unittest.TestCase):
         except IOError:
             self.fail('Should not raise IOError')
 
+    def test_get_output_stream(self):
+        self.set_session_pager('mypager --option')
+        with self.stream_factory.get_output_stream():
+            self.assert_popen_call(
+                expected_pager_cmd='mypager --option'
+            )
+
+    @mock.patch('awscli.utils.get_stdout_text_writer')
+    def test_use_stdout_if_not_tty(self, mock_stdout_writer):
+        self.mock_is_a_tty.return_value = False
+        with self.stream_factory.get_output_stream():
+            self.assertTrue(mock_stdout_writer.called)
+
+    @mock.patch('awscli.utils.get_stdout_text_writer')
+    def test_use_stdout_if_pager_set_to_empty_string(self, mock_stdout_writer):
+        self.set_session_pager('')
+        with self.stream_factory.get_output_stream():
+            self.assertTrue(mock_stdout_writer.called)
+
+    def test_adds_default_less_env_vars_if_pager_is_less(self):
+        self.set_session_pager('less')
+        with self.stream_factory.get_output_stream():
+            self.assert_popen_call(
+                expected_pager_cmd='less',
+                env={'LESS': 'FRX'}
+            )
+
+    def test_does_not_clobber_less_env_var_if_in_env_vars(self):
+        self.set_session_pager('less')
+        self.environ['LESS'] = 'S'
+        with self.stream_factory.get_output_stream():
+            self.assert_popen_call(
+                expected_pager_cmd='less',
+                env={'LESS': 'S'}
+            )
+
+    def test_set_less_flags_through_constructor(self):
+        self.set_session_pager('less')
+        stream_factory = OutputStreamFactory(
+            self.session, self.popen, self.environ, default_less_flags='ABC')
+        with stream_factory.get_output_stream():
+            self.assert_popen_call(
+                expected_pager_cmd='less',
+                env={'LESS': 'ABC'}
+            )
 
 class TestInstanceMetadataRegionFetcher(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This introduces logic that takes the response from the CLI and output it directly to a pager (think `git diff`). This makes it much easier to consume/navigate a response from the service if it is really large. In terms of behavior, it closely follows the behavior of `git`'s pager (except for using `more` on Windows):

* By default if on Linux/MacOS, use `less` as the pager and set the `LESS` environment variable to `FRX` in order to set the appropriate flags. For Windows, `more` is used with no additional environment variables.

* You can override the default pager with the following configuration options. These are in order of precedence:
  * `AWS_PAGER` environment variable
  * `cli_pager` shared config variable
  * `PAGER` environment variable

* If you set any of the configuration options to an empty string (e.g. `AWS_PAGER=""`). The CLI will not send the output to a pager.

*  You can also set flags when specifying the pager and those will combine with any env vars we set (e.g. `AWS_PAGER="less -S"` will essentially make it `less -FRXS`). The combining flags behavior is builtin into `less`. You can also negate flags we set by specifying it on the command line: (e.g. `AWS_PAGER="less -+F"` will deactivate the quit if one screen behavior)

* If you set the `LESS` env var, we will not clobber it with ours (e.g. `FRX`). 