### PR TITLE
[v2] Implement yaml-stream output format

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -105,6 +105,7 @@ if six.PY3:
 
     from urllib.error import URLError
 
+    imap = map
     raw_input = input
 
     def get_binary_stdin():
@@ -152,10 +153,12 @@ else:
     import collections as collections_abc
     import locale
     import io
+    import itertools
     import urlparse
 
     from urllib2 import URLError
 
+    imap = itertools.imap
     raw_input = raw_input
 
     def get_binary_stdin():

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -25,7 +25,8 @@
                 "json",
                 "text",
                 "table",
-                "yaml"
+                "yaml",
+                "yaml-stream"
             ],
 	        "help": "<p>The formatting style for command output.</p>"
         },

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -182,7 +182,8 @@ class StreamedYAMLFormatter(Formatter):
 
     def _get_response_stream(self, response):
         if is_response_paginated(response):
-            return map(self._get_transformed_response_for_output, response)
+            return compat.imap(
+                self._get_transformed_response_for_output, response)
         else:
             output = self._get_transformed_response_for_output(response)
             if output == {}:

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -35,6 +35,13 @@ class Formatter(object):
     def __init__(self, args):
         self._args = args
 
+    def _get_transformed_response_for_output(self, response):
+        # Performs various transformations to the API response ready to
+        # be outputted such as removing response id's and performing the
+        # query
+        self._remove_request_id(response)
+        return self._apply_query_if_needed(response)
+
     def _remove_request_id(self, response_data):
         # We only want to display the ResponseMetadata (which includes
         # the request id) if there is an error in the response.
@@ -46,6 +53,11 @@ class Formatter(object):
                     request_id = response_data['ResponseMetadata']['RequestId']
                     LOG.debug('RequestId: %s', request_id)
                 del response_data['ResponseMetadata']
+
+    def _apply_query_if_needed(self, response_data):
+        if self._args.query is not None:
+            response_data = self._args.query.search(response_data)
+        return response_data
 
     def _get_default_stream(self):
         return compat.get_stdout_text_writer()
@@ -70,9 +82,8 @@ class FullyBufferedFormatter(Formatter):
             response_data = response.build_full_result()
         else:
             response_data = response
-        self._remove_request_id(response_data)
-        if self._args.query is not None:
-            response_data = self._args.query.search(response_data)
+        response_data = self._get_transformed_response_for_output(
+            response_data)
         try:
             self._format_response(command_name, response_data, stream)
         except IOError as e:
@@ -98,9 +109,8 @@ class JSONFormatter(FullyBufferedFormatter):
             stream.write('\n')
 
 
-class YAMLFormatter(FullyBufferedFormatter):
-    def __init__(self, args):
-        super(YAMLFormatter, self).__init__(args)
+class YAMLDumper(object):
+    def __init__(self):
         self._yaml = YAML(typ='safe')
         # Encoding is set to None because we handle the encoding by
         # wrapping the stream, so there's no need for the yaml library
@@ -108,10 +118,8 @@ class YAMLFormatter(FullyBufferedFormatter):
         self._yaml.encoding = None
         self._yaml.representer.default_flow_style = False
 
-    def _format_response(self, command_name, response, stream):
-        if response == {}:
-            return None
-        if self._is_json_scalar(response) or isinstance(response, datetime):
+    def dump(self, value, stream):
+        if self._is_json_scalar(value) or isinstance(value, datetime):
             # YAML will attempt to disambiguate scalars by ending the stream
             # with an elipsis. While this is technically valid YAML,
             # it's not particularly useful. Unfortunately there's no
@@ -120,15 +128,68 @@ class YAMLFormatter(FullyBufferedFormatter):
             # - the json dumper will complain if you pass them in. datetime
             # values should respect the cli timestamp format, which is
             # impossible to do from the Formatter.
-            json.dump(response, stream, ensure_ascii=False)
+            json.dump(value, stream, ensure_ascii=False)
             stream.write('\n')
         else:
-            self._yaml.dump(response, stream)
+            self._yaml.dump(value, stream)
 
     def _is_json_scalar(self, value):
         if value is None:
             return True
         return isinstance(value, (int, float, bool, compat.six.string_types))
+
+
+class YAMLFormatter(FullyBufferedFormatter):
+    def __init__(self, args, yaml_dumper=None):
+        super(YAMLFormatter, self).__init__(args)
+        self._yaml_dumper = yaml_dumper
+        if yaml_dumper is None:
+            self._yaml_dumper = YAMLDumper()
+
+    def _format_response(self, command_name, response, stream):
+        if response == {}:
+            return None
+        self._yaml_dumper.dump(response, stream)
+
+
+class StreamedYAMLFormatter(Formatter):
+    def __init__(self, args, yaml_dumper=None):
+        super(StreamedYAMLFormatter, self).__init__(args)
+        self._yaml_dumper = yaml_dumper
+        if yaml_dumper is None:
+            self._yaml_dumper = YAMLDumper()
+
+    def __call__(self, command_name, response, stream=None):
+        if stream is None:
+            stream = self._get_default_stream()
+        response_stream = self._get_response_stream(response)
+        for response in response_stream:
+            try:
+                # For YAML it is ambiguous as to whether the output from the
+                # stream is N responses in 1 list or N lists each with 1
+                # response. We go with the latter so we can reuse our YAML
+                # dumper
+                self._yaml_dumper.dump([response], stream)
+            except IOError:
+                # If the reading end of our stdout stream has closed the file
+                # we can just exit.
+                return
+            finally:
+                # flush is needed to avoid the "close failed in file object
+                # destructor" in python2.x. See:
+                # http://bugs.python.org/issue11380).
+                self._flush_stream(stream)
+
+    def _get_response_stream(self, response):
+        if is_response_paginated(response):
+            return map(self._get_transformed_response_for_output, response)
+        else:
+            output = self._get_transformed_response_for_output(response)
+            if output == {}:
+                # The operation did not have an output so return an empty list
+                # as the stream so nothing gets printed out.
+                return []
+            return [output]
 
 
 class TableFormatter(FullyBufferedFormatter):
@@ -305,6 +366,7 @@ CLI_OUTPUT_FORMATS = {
     'text': TextFormatter,
     'table': TableFormatter,
     'yaml': YAMLFormatter,
+    'yaml-stream': StreamedYAMLFormatter,
 }
 
 

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -460,6 +460,13 @@ class TestSelect(BaseSelectTest):
             command, expected, expected_rc=0
         )
 
+    def test_select_does_not_support_yaml_stream(self):
+        cmdline = 'ddb select mytable --output yaml-stream'
+        stdout, _, _ = self.assert_params_for_cmd(
+            cmdline, expected_rc=255,
+            stderr_contains='yaml-stream output format is not supported',
+        )
+
 
 class TestSelectPagination(BaseSelectTest):
     def setUp(self):

--- a/tests/unit/customizations/dynamodb/test_formatter.py
+++ b/tests/unit/customizations/dynamodb/test_formatter.py
@@ -16,12 +16,13 @@ from decimal import Decimal
 import jmespath
 from nose.tools import assert_equal
 
-from awscli.customizations.dynamodb.formatter import DynamoYAMLFormatter
+from awscli.formatter import YAMLFormatter
+from awscli.customizations.dynamodb.formatter import DynamoYAMLDumper
 from awscli.customizations.dynamodb.types import Binary
 from awscli.testutils import capture_output
 
 
-def test_dynamo_formatter():
+def test_yaml_formatter_with_dynamo_dumper():
     cases = [
         {
             'given': {'mykey': Decimal('1')},
@@ -60,7 +61,8 @@ def assert_format(given, expected, query=None):
     compiled_query = None
     if query is not None:
         compiled_query = jmespath.compile(query)
-    formatter = DynamoYAMLFormatter(Namespace(query=compiled_query))
+    formatter = YAMLFormatter(
+        Namespace(query=compiled_query), DynamoYAMLDumper())
     with capture_output() as output:
         formatter('fake-command-name', given)
     assert_equal(output.stdout.getvalue(), expected)

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,0 +1,136 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from argparse import Namespace
+
+from botocore.paginate import PageIterator
+
+from awscli.testutils import unittest, mock
+from awscli.compat import StringIO
+from awscli.formatter import YAMLDumper, StreamedYAMLFormatter
+
+
+class FakePageIterator(PageIterator):
+    def __init__(self, responses):
+        self._responses = responses
+
+    def __iter__(self):
+        for response in self._responses:
+            yield response
+
+
+class TestYAMLDumper(unittest.TestCase):
+    def setUp(self):
+        self.dumper = YAMLDumper()
+        self.output = StringIO()
+
+    def test_dump_int(self):
+        self.dumper.dump(1, self.output)
+        self.assertEqual(self.output.getvalue(), '1\n')
+
+    def test_dump_float(self):
+        self.dumper.dump(1.2, self.output)
+        self.assertEqual(self.output.getvalue(), '1.2\n')
+
+    def test_dump_bool(self):
+        self.dumper.dump(True, self.output)
+        self.assertEqual(self.output.getvalue(), 'true\n')
+
+    def test_dump_str(self):
+        self.dumper.dump('foo', self.output)
+        self.assertEqual(self.output.getvalue(), '"foo"\n')
+
+    def test_dump_structure(self):
+        self.dumper.dump({'key': 'val'}, self.output)
+        self.assertEqual(self.output.getvalue(), 'key: val\n')
+
+    def test_dump_list(self):
+        self.dumper.dump(['val1', 'val2'], self.output)
+        self.assertEqual(self.output.getvalue(), '- val1\n- val2\n')
+
+
+class TestStreamedYAMLFormatter(unittest.TestCase):
+    def setUp(self):
+        self.args = Namespace(query=None)
+        self.formatter = StreamedYAMLFormatter(self.args)
+        self.output = StringIO()
+
+    def test_format_single_response(self):
+        response = {
+            'TableNames': [
+                'MyTable'
+            ]
+        }
+        self.formatter('list-tables', response, self.output)
+        self.assertEqual(
+            self.output.getvalue(),
+            '- TableNames:\n'
+            '  - MyTable\n'
+        )
+
+    def test_format_paginated_response(self):
+        response = FakePageIterator([
+            {
+                'TableNames': [
+                    'MyTable'
+                ]
+            },
+            {
+                'TableNames': [
+                    'MyTable2'
+                ]
+            },
+        ])
+        self.formatter('list-tables', response, self.output)
+        self.assertEqual(
+            self.output.getvalue(),
+            '- TableNames:\n'
+            '  - MyTable\n'
+            '- TableNames:\n'
+            '  - MyTable2\n'
+        )
+
+    def test_flushes_after_io_error(self):
+        io_error_dumper = mock.Mock(YAMLDumper)
+        mock_output = mock.Mock()
+        io_error_dumper.dump.side_effect = IOError()
+        response = {
+            'TableNames': [
+                'MyTable'
+            ]
+        }
+        formatter = StreamedYAMLFormatter(self.args, io_error_dumper)
+        formatter('list-tables', response, mock_output)
+        self.assertTrue(mock_output.flush.called)
+
+    def test_stops_paginating_after_io_error(self):
+        io_error_dumper = mock.Mock(YAMLDumper)
+        mock_output = mock.Mock()
+        io_error_dumper.dump.side_effect = IOError()
+        response = FakePageIterator([
+            {
+                'TableNames': [
+                    'MyTable'
+                ]
+            },
+            {
+                'TableNames': [
+                    'MyTable2'
+                ]
+            },
+        ])
+        formatter = StreamedYAMLFormatter(self.args, io_error_dumper)
+        formatter('list-tables', response, mock_output)
+        # The dumper should have only been called once as the io error is
+        # immediately raised and we should not have kept paginating.
+        self.assertTrue(len(io_error_dumper.dump.call_args_list), 1)
+        self.assertTrue(mock_output.flush.called)


### PR DESCRIPTION
This adds a new output format `yaml-stream`. This format will print out each response in a large yaml list as they are outputted. In general if a command has an output, it will be encapsulated in a list and each response will be outputted as they are received in the case for pagination. So for example:

If I get a single response, it will look like this:
```
$ aws dynamodb list-tables --output yaml-stream --no-paginate
- TableNames:
  - ChaliceChatTable
  - Forum
```

Then a paginated response will look like this:
```
$ aws dynamodb list-tables --output yaml-stream --page-size 1
- LastEvaluatedTableName: ChaliceChatTable
  TableNames:
  - ChaliceChatTable
- LastEvaluatedTableName: Forum
  TableNames:
  - Forum
```
This output format pairs nicely with outputting to a pager because you can start looking over the responses coming back as the CLI is receiving them instead of having to wait for the entire pagination process to complete to see results.