### PR TITLE
[v2] Add a new dynamodb new-table wizard

### DIFF
--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -120,12 +120,18 @@ class PromptStep(BaseStep):
 
     def __init__(self, prompter):
         self._prompter = prompter
+        self._conversion_funcs = {
+            'int': int,
+            'float': float,
+            'str': str,
+            'bool': lambda x: True if x.lower() == 'true' else False
+        }
 
     def run_step(self, step_definition, parameters):
         choices = self._get_choices(step_definition, parameters)
         response = self._prompter.prompt(step_definition['description'],
                                          choices=choices)
-        return response
+        return self._convert_data_type_if_needed(response, step_definition)
 
     def _get_choices(self, step_definition, parameters):
         choices = step_definition.get('choices')
@@ -135,6 +141,11 @@ class PromptStep(BaseStep):
                 # a variable.
                 return parameters[choices]
             return choices
+
+    def _convert_data_type_if_needed(self, response, step_definition):
+        if 'datatype' not in step_definition:
+            return response
+        return self._conversion_funcs[step_definition['datatype']](response)
 
 
 class YesNoPrompt(PromptStep):

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -17,7 +17,6 @@ import os
 from botocore import xform_name
 
 
-
 class Runner(object):
     def __init__(self, planner, executor):
         self._planner = planner
@@ -98,16 +97,26 @@ class Planner(object):
 
 
 class BaseStep(object):
+    # Subclasses must implement this.  This defines the name you'd
+    # use for the `type` in a wizard definition.
+    NAME = ''
+
     def run_step(self, step_definition, parameters):
         raise NotImplementedError("run_step")
 
 
 class StaticStep(BaseStep):
+
+    NAME = 'static'
+
     def run_step(self, step_definition, parameters):
         return step_definition['value']
 
 
 class PromptStep(BaseStep):
+
+    NAME = 'prompt'
+
     def __init__(self, prompter):
         self._prompter = prompter
 
@@ -136,6 +145,9 @@ class YesNoPrompt(PromptStep):
     step.
 
     """
+
+    NAME = 'yesno-prompt'
+
     def run_step(self, step_definition, parameters):
         choices = [
             {'display': 'Yes', 'actual_value': 'yes'},
@@ -151,6 +163,9 @@ class YesNoPrompt(PromptStep):
 
 
 class FilePromptStep(BaseStep):
+
+    NAME = 'fileprompt'
+
     def __init__(self, prompter):
         self._prompter = prompter
 
@@ -161,12 +176,17 @@ class FilePromptStep(BaseStep):
 
 class TemplateStep(BaseStep):
 
+    NAME = 'template'
+
     def run_step(self, step_definition, parameters):
         value = step_definition['value']
         return value.format(**parameters)
 
 
 class APICallStep(BaseStep):
+
+    NAME = 'apicall'
+
     def __init__(self, api_invoker):
         self._api_invoker = api_invoker
 
@@ -182,6 +202,9 @@ class APICallStep(BaseStep):
 
 
 class SharedConfigStep(BaseStep):
+
+    NAME = 'sharedconfig'
+
     def __init__(self, config_api):
         self._config_api = config_api
 
@@ -302,11 +325,19 @@ class Executor(object):
 
 
 class ExecutorStep(object):
+
+    # Subclasses must implement this to specify what name to use
+    # for the `type` in a wizard definition.
+    NAME = ''
+
     def run_step(self, step_definition, parameters):
         raise NotImplementedError("run_step")
 
 
 class APICallExecutorStep(ExecutorStep):
+
+    NAME = 'apicall'
+
     def __init__(self, api_invoker):
         self._api_invoker = api_invoker
 
@@ -324,6 +355,9 @@ class APICallExecutorStep(ExecutorStep):
 
 
 class SharedConfigExecutorStep(ExecutorStep):
+
+    NAME = 'sharedconfig'
+
     def __init__(self, config_api):
         self._config_api = config_api
 

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -127,6 +127,29 @@ class PromptStep(BaseStep):
             return choices
 
 
+class YesNoPrompt(PromptStep):
+    """Shorthand for a yes/no prompt.
+
+    Asking yes/no questions is common enough in wizards that
+    this class provides a shorthand for doing this instead of having
+    to write out the long form version using the general ``prompt``
+    step.
+
+    """
+    def run_step(self, step_definition, parameters):
+        choices = [
+            {'display': 'Yes', 'actual_value': 'yes'},
+            {'display': 'No', 'actual_value': 'no'},
+        ]
+        if step_definition.get('start_value', 'yes') == 'no':
+            # They want the "No" choice to be the starting value so we
+            # need to reverse the choices.
+            choices[:] = choices[::-1]
+        response = self._prompter.prompt(step_definition['question'],
+                                         choices=choices)
+        return response
+
+
 class FilePromptStep(BaseStep):
     def __init__(self, prompter):
         self._prompter = prompter

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -23,7 +23,7 @@ class Runner(object):
         self._executor = executor
 
     def run(self, wizard_spec):
-        params = self._planner.run(wizard_spec['plan'])
+        params = self._planner.plan(wizard_spec['plan'])
         self._executor.run(wizard_spec['execute'], params)
 
 
@@ -37,12 +37,12 @@ class Planner(object):
         # running through the plan steps.
         self._parameters = {}
 
-    def run(self, plan):
+    def plan(self, plan):
         self._parameters.clear()
         steps_iter = self._steps(plan)
         step = next(steps_iter)
         while step is not self._STOP_RUNNING:
-            next_step_name = self._run_step(step)
+            next_step_name = self._run_plan_step(step)
             step = steps_iter.send(next_step_name)
         return self._parameters
 
@@ -69,7 +69,7 @@ class Planner(object):
                 step_index = step_names.index(next_step_name)
                 step_name = next_step_name
 
-    def _run_step(self, step):
+    def _run_plan_step(self, step):
         # Running step consists of first fetching any values
         # based on what's defined in `values`.
         for key, value in step['values'].items():

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -24,7 +24,7 @@ class Runner(object):
 
     def run(self, wizard_spec):
         params = self._planner.plan(wizard_spec['plan'])
-        self._executor.run(wizard_spec['execute'], params)
+        self._executor.execute(wizard_spec['execute'], params)
 
 
 class Planner(object):
@@ -290,14 +290,14 @@ class Executor(object):
     def __init__(self, step_handlers):
         self._step_handlers = step_handlers
 
-    def run(self, step, parameters):
+    def execute(self, step, parameters):
         # We may eventually support jumping around to different step
         # names, but for now, we just iterate through the steps in order.
         for group in step.values():
             for step in group:
-                self._run_step(step, parameters)
+                self._execute_step(step, parameters)
 
-    def _run_step(self, step, parameters):
+    def _execute_step(self, step, parameters):
         if 'condition' in step:
             should_run = self._check_step_condition(step['condition'],
                                                     parameters)

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -10,6 +10,7 @@ def create_default_wizard_runner(session):
         step_handlers={
             'static': core.StaticStep(),
             'prompt': core.PromptStep(ui.UIPrompter()),
+            'yesno-prompt': core.YesNoPrompt(ui.UIPrompter()),
             'fileprompt': core.FilePromptStep(
                 ui.UIFilePrompter(ui.FileCompleter())),
             'template': core.TemplateStep(),

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -8,20 +8,23 @@ def create_default_wizard_runner(session):
                                          config_writer=ConfigFileWriter())
     planner = core.Planner(
         step_handlers={
-            'static': core.StaticStep(),
-            'prompt': core.PromptStep(ui.UIPrompter()),
-            'yesno-prompt': core.YesNoPrompt(ui.UIPrompter()),
-            'fileprompt': core.FilePromptStep(
+            core.StaticStep.NAME: core.StaticStep(),
+            core.PromptStep.NAME: core.PromptStep(ui.UIPrompter()),
+            core.YesNoPrompt.NAME: core.YesNoPrompt(ui.UIPrompter()),
+            core.FilePromptStep.NAME: core.FilePromptStep(
                 ui.UIFilePrompter(ui.FileCompleter())),
-            'template': core.TemplateStep(),
-            'apicall': core.APICallStep(api_invoker=api_invoker),
-            'sharedconfig': core.SharedConfigStep(config_api=shared_config),
+            core.TemplateStep.NAME: core.TemplateStep(),
+            core.APICallStep.NAME: core.APICallStep(api_invoker=api_invoker),
+            core.SharedConfigStep.NAME: core.SharedConfigStep(
+                config_api=shared_config),
         }
     )
     executor = core.Executor(
         step_handlers={
-            'apicall': core.APICallExecutorStep(api_invoker),
-            'sharedconfig': core.SharedConfigExecutorStep(shared_config),
+            core.APICallExecutorStep.NAME: core.APICallExecutorStep(
+                api_invoker),
+            core.SharedConfigExecutorStep.NAME: core.SharedConfigExecutorStep(
+                shared_config),
         }
     )
     runner = core.Runner(planner, executor)

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -25,8 +25,9 @@ def create_default_wizard_runner(session):
                 api_invoker),
             core.SharedConfigExecutorStep.NAME: core.SharedConfigExecutorStep(
                 shared_config),
+            core.DefineVariableStep.NAME: core.DefineVariableStep(),
+            core.MergeDictStep.NAME: core.MergeDictStep(),
         }
     )
     runner = core.Runner(planner, executor)
     return runner
-

--- a/awscli/customizations/wizard/wizards/dynamodb/new-table.yml
+++ b/awscli/customizations/wizard/wizards/dynamodb/new-table.yml
@@ -1,0 +1,158 @@
+version: "0.1"
+title: Create An Amazon DynamoDB Table
+description: This wizard will create a new Amazon DynamoDB Table
+plan:
+  required_values:
+    values:
+      table_name:
+        type: prompt
+        description: Enter the name of the table
+      primary_key_name:
+        type: prompt
+        description: Enter the name of the primary key
+      primary_key_type:
+        type: prompt
+        description: Primary key type
+        choices:
+            - actual_value: S
+              display: String
+            - actual_value: N
+              display: Number
+            - actual_value: B
+              display:  Binary
+      wants_sort_key:
+        type: yesno-prompt
+        question: Add a sort key?
+        start_value: no
+    next_step:
+      switch: wants_sort_key
+      yes: prompt_sort_key
+      no: prompt_capacity
+  prompt_sort_key:
+    values:
+      sort_key_name:
+        type: prompt
+        description: Enter the name of the sort key
+      sort_key_type:
+        type: prompt
+        description: Sort key type
+        choices:
+            - actual_value: S
+              display: String
+            - actual_value: N
+              display: Number
+            - actual_value: B
+              display:  Binary
+  prompt_capacity:
+    values:
+      capacity_mode:
+        type: prompt
+        description: "Select the read/write capacity mode."
+        choices:
+          - actual_value: PROVISIONED
+            display: Provisioned (free-tier eligible)
+          - actual_value: PAY_PER_REQUEST
+            display: On-demand
+    next_step:
+      switch: capacity_mode
+      PAY_PER_REQUEST: prompt_encryption
+      PROVISIONED: prompt_throughput
+  prompt_throughput:
+    values:
+      read_capacity:
+        type: prompt
+        description: Enter read capacity units
+        datatype: int
+      write_capacity:
+        type: prompt
+        description: Enter write capacity units
+        datatype: int
+  prompt_encryption:
+    values:
+      encryption_settings:
+        type: prompt
+        description: "Select Server-side encryption settings for your DynamoDB table"
+        choices:
+          - display: "DEFAULT"
+            actual_value: default
+          - display: "KMS - AWS managed CMK"
+            actual_value: aws_managed_cmk
+          - display: "KMS - Customer managed CMK"
+            actual_value: customer_managed_cmk
+    next_step:
+      switch: encryption_settings
+      customer_managed_cmk: prompt_for_customer_cmk
+      default: DONE
+      aws_managed_cmk: DONE
+  prompt_for_customer_cmk:
+    values:
+      existing_cmks:
+        type: apicall
+        operation: kms.ListAliases
+        params: {}
+        query: "Aliases[?!starts_with(AliasName, `alias/aws`)].{display: AliasName, actual_value: TargetKeyId}"
+      kms_key_id:
+        type: prompt
+        description: Choose a customer managed CMK
+        choices: existing_cmks
+execute:
+  parameter-build:
+    - type: define-variable
+      varname: create_table_params
+      value:
+        TableName: "{table_name}"
+        KeySchema:
+          - AttributeName: "{primary_key_name}"
+            KeyType: HASH
+        AttributeDefinitions:
+          - AttributeName: "{primary_key_name}"
+            AttributeType: "{primary_key_type}"
+        BillingMode: "{capacity_mode}"
+    - type: merge-dict
+      output_var: create_table_params
+      condition:
+        variable: wants_sort_key
+        equals: yes
+      overlays:
+        - "{create_table_params}"
+        - KeySchema:
+            - AttributeName: "{sort_key_name}"
+              KeyType: RANGE
+          AttributeDefinitions:
+            - AttributeName: "{sort_key_name}"
+              AttributeType: "{sort_key_type}"
+    - type: merge-dict
+      output_var: create_table_params
+      condition:
+        variable: capacity_mode
+        equals: PROVISIONED
+      overlays:
+        - "{create_table_params}"
+        - ProvisionedThroughput:
+            ReadCapacityUnits: "{read_capacity}"
+            WriteCapacityUnits: "{write_capacity}"
+    - type: merge-dict
+      output_var: create_table_params
+      condition:
+        variable: encryption_settings
+        equals: aws_managed_cmk
+      overlays:
+        - "{create_table_params}"
+        - SSESpecification:
+            Enabled: true
+            SSEType: KMS
+    - type: merge-dict
+      output_var: create_table_params
+      condition:
+        variable: encryption_settings
+        equals: customer_managed_cmk
+      overlays:
+        - "{create_table_params}"
+        - SSESpecification:
+            Enabled: true
+            SSEType: KMS
+            KMSMasterKeyId: "{kms_key_id}"
+  apicalls:
+    - type: apicall
+      operation: dynamodb.CreateTable
+      params: "{create_table_params}"

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -178,6 +178,46 @@ class TestPlanner(unittest.TestCase):
                                              'actual_value': 'dev'}])],
         )
 
+    def test_can_prompt_with_types(self):
+        loaded = load_wizard("""
+        plan:
+          start:
+            values:
+              name:
+                type: prompt
+                description: Enter a string
+                datatype: str
+              age:
+                type: prompt
+                description: Enter an int
+                datatype: int
+              float:
+                type: prompt
+                description: Enter a float
+                datatype: float
+              trueval:
+                type: prompt
+                description: Enter a true value
+                datatype: bool
+              falseval:
+                type: prompt
+                description: Enter a false value
+                datatype: bool
+        """)
+        # The responses will always return string values.
+        self.responses['Enter a string'] = 'myname'
+        self.responses['Enter an int'] = '100'
+        self.responses['Enter a float'] = '2.0'
+        self.responses['Enter a true value'] = 'true'
+        self.responses['Enter a false value'] = 'false'
+
+        parameters = self.planner.plan(loaded['plan'])
+        self.assertEqual(parameters['name'], 'myname')
+        self.assertEqual(parameters['age'], 100)
+        self.assertEqual(parameters['float'], 2.0)
+        self.assertEqual(parameters['trueval'], True)
+        self.assertEqual(parameters['falseval'], False)
+
     def test_special_step_done_stops_run(self):
         loaded = load_wizard("""
         plan:

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -553,7 +553,7 @@ class TestExecutor(unittest.TestCase):
               params:
                 UserName: admin
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.session.create_client.assert_called_with('iam')
         self.client.create_user.assert_called_with(UserName='admin')
 
@@ -568,7 +568,7 @@ class TestExecutor(unittest.TestCase):
               optional_params:
                 Path: "/foo"
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.session.create_client.assert_called_with('iam')
         self.client.create_user.assert_called_with(
             UserName='admin', Path='/foo')
@@ -585,7 +585,7 @@ class TestExecutor(unittest.TestCase):
                 # Omitted because the value is null.
                 Path: null
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.session.create_client.assert_called_with('iam')
         self.client.create_user.assert_called_with(UserName='admin')
 
@@ -601,7 +601,7 @@ class TestExecutor(unittest.TestCase):
               params:
                 UserName: admin
         """)
-        self.executor.run(loaded['execute'], {'should_invoke': 'no'})
+        self.executor.execute(loaded['execute'], {'should_invoke': 'no'})
         self.assertFalse(self.session.create_client.called)
         self.assertFalse(self.client.create_user.called)
 
@@ -617,7 +617,7 @@ class TestExecutor(unittest.TestCase):
               params:
                 UserName: admin
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.assertTrue(self.session.create_client.called)
         self.assertTrue(self.client.create_user.called)
 
@@ -635,7 +635,7 @@ class TestExecutor(unittest.TestCase):
               params:
                 UserName: admin
         """)
-        self.executor.run(loaded['execute'], {'foo': 'one', 'bar': 'two'})
+        self.executor.execute(loaded['execute'], {'foo': 'one', 'bar': 'two'})
         self.assertTrue(self.session.create_client.called)
         self.assertTrue(self.client.create_user.called)
 
@@ -653,7 +653,7 @@ class TestExecutor(unittest.TestCase):
               params:
                 UserName: admin
         """)
-        self.executor.run(loaded['execute'], {'foo': 'one', 'bar': 'NOTTWO'})
+        self.executor.execute(loaded['execute'], {'foo': 'one', 'bar': 'NOTTWO'})
         self.assertFalse(self.session.create_client.called)
 
     def test_can_recursively_template_variables_in_params(self):
@@ -674,7 +674,7 @@ class TestExecutor(unittest.TestCase):
                     - Bar: "{foo}"
                     - Baz: "{foo}"
         """)
-        self.executor.run(loaded['execute'], {'foo': 'FOOVALUE'})
+        self.executor.execute(loaded['execute'], {'foo': 'FOOVALUE'})
         self.session.create_client.assert_called_with('iam')
         expected_params = {
             'UserName': 'FOOVALUE',
@@ -706,7 +706,7 @@ class TestExecutor(unittest.TestCase):
         self.client.create_role.return_value = {
             'Role': {'Arn': 'my-role-arn'},
         }
-        self.executor.run(loaded['execute'], params)
+        self.executor.execute(loaded['execute'], params)
         self.client.create_role.assert_called_with(RoleName='admin')
         # We should have added 'role_arn' to the params dict and also
         # applied the jmespath query to the response before storing the
@@ -730,7 +730,7 @@ class TestExecutor(unittest.TestCase):
               params:
                 RoleName: admin
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.session.create_client.assert_called_with('iam')
         self.assertEqual(
             self.client.method_calls,
@@ -749,7 +749,7 @@ class TestExecutor(unittest.TestCase):
                 region: us-west-2
                 output: json
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.config_api.set_values.assert_called_with(
              {'region': 'us-west-2', 'output': 'json'},
             profile='mydevprofile',
@@ -765,7 +765,7 @@ class TestExecutor(unittest.TestCase):
                 region: us-west-2
                 output: json
         """)
-        self.executor.run(loaded['execute'], {})
+        self.executor.execute(loaded['execute'], {})
         self.config_api.set_values.assert_called_with(
             {'region': 'us-west-2', 'output': 'json'}, profile=None
         )
@@ -780,7 +780,7 @@ class TestExecutor(unittest.TestCase):
                 region: "{foo}"
         """)
         variables = {'foo': 'bar'}
-        self.executor.run(loaded['execute'], variables)
+        self.executor.execute(loaded['execute'], variables)
         self.config_api.set_values.assert_called_with(
             {'region': 'bar'}, profile=None)
 
@@ -838,7 +838,7 @@ class TestRunner(unittest.TestCase):
         self.runner.run(wizard_spec=loaded)
 
         self.planner.plan.assert_called_with(loaded['plan'])
-        self.executor.run.assert_called_with(loaded['execute'], params)
+        self.executor.execute.assert_called_with(loaded['execute'], params)
 
 
 class TestAPIInvoker(unittest.TestCase):

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -65,7 +65,7 @@ class TestPlanner(unittest.TestCase):
         """)
 
         self.responses['Enter user name'] = 'admin'
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['name'], 'admin')
 
     def test_can_prompt_for_multiple_values_in_order(self):
@@ -83,7 +83,7 @@ class TestPlanner(unittest.TestCase):
         self.responses['Enter user name'] = 'myname'
         self.responses['Enter group name'] = 'wheel'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['name'], 'myname')
         self.assertEqual(parameters['group'], 'wheel')
         # We should also have prompted in the order that the keys
@@ -115,7 +115,7 @@ class TestPlanner(unittest.TestCase):
         self.responses['Should we stop'] = 'no'
         self.responses['Enter user name'] = 'admin'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['should_stop'], 'no')
         self.assertEqual(parameters['name'], 'admin')
         self.assertEqual(
@@ -144,7 +144,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Should we stop'] = 'yes'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['should_stop'], 'yes')
         self.assertNotIn('name', parameters)
         self.assertEqual(
@@ -168,7 +168,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Enter user name'] = 'admin'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['name'], 'admin')
         self.assertEqual(
             self.prompter.recorded_prompts,
@@ -196,7 +196,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Foo'] = 'foo-value'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], 'foo-value')
         self.assertNotIn('bar', parameters)
         self.assertEqual(
@@ -219,7 +219,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Foo'] = 'foo-value'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], 'foo-value')
         self.assertEqual(parameters['bar'], 'template-foo-value')
         self.assertEqual(
@@ -252,7 +252,7 @@ class TestPlanner(unittest.TestCase):
                 'apicall': api_step,
             },
         )
-        parameters = planner.run(loaded['plan'])
+        parameters = planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], {'Policies': ['foo']})
 
     def test_can_run_apicall_step_with_query(self):
@@ -281,7 +281,7 @@ class TestPlanner(unittest.TestCase):
                 'apicall': api_step,
             },
         )
-        parameters = planner.run(loaded['plan'])
+        parameters = planner.plan(loaded['plan'])
         # Note this value is the result is applying the
         # Polices[].Name jmespath query to the response.
         self.assertEqual(parameters['foo'], ['one', 'two'])
@@ -295,7 +295,7 @@ class TestPlanner(unittest.TestCase):
                 type: static
                 value: myvalue
         """)
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], 'myvalue')
 
     def test_can_use_static_value_as_non_string_type(self):
@@ -307,7 +307,7 @@ class TestPlanner(unittest.TestCase):
                 type: static
                 value: [1, 2, 3]
         """)
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], [1, 2, 3])
 
     def test_choices_can_be_variable_reference(self):
@@ -329,7 +329,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Enter user name'] = 'admin'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['name'], 'admin')
         self.assertEqual(
             self.prompter.recorded_prompts,
@@ -355,7 +355,7 @@ class TestPlanner(unittest.TestCase):
                 'fileprompt': core.FilePromptStep(prompter=prompter),
             },
         )
-        parameters = planner.run(loaded['plan'])
+        parameters = planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'],
                          os.path.abspath('myfile.txt'))
 
@@ -370,7 +370,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Do you want to use the defaults?'] = 'yes'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['wants_defaults'], 'yes')
         self.assertEqual(
             self.prompter.recorded_prompts,
@@ -392,7 +392,7 @@ class TestPlanner(unittest.TestCase):
         """)
         self.responses['Do you want to use the defaults?'] = 'no'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(
             self.prompter.recorded_prompts[0][2],
             # The default is No so it should be presented first.
@@ -437,7 +437,7 @@ class TestPlanner(unittest.TestCase):
         self.responses['step_c'] = 'three'
         self.responses['step_b'] = 'four'
 
-        parameters = self.planner.run(loaded['plan'])
+        parameters = self.planner.plan(loaded['plan'])
         self.assertEqual(parameters['first'], 'one')
         self.assertEqual(parameters['second'], 'two')
         self.assertEqual(parameters['third'], 'three')
@@ -472,7 +472,7 @@ class TestPlanner(unittest.TestCase):
                 type: customstep
                 foo: myreturnvalue
         """)
-        parameters = custom_planner.run(loaded['plan'])
+        parameters = custom_planner.plan(loaded['plan'])
         self.assertEqual(parameters['name'], 'myreturnvalue')
 
     def test_can_load_profiles(self):
@@ -494,7 +494,7 @@ class TestPlanner(unittest.TestCase):
                 'sharedconfig': sharedconfig,
             },
         )
-        parameters = planner.run(loaded['plan'])
+        parameters = planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], ['profile1', 'profile2'])
 
     def test_can_read_config_profile_data(self):
@@ -519,7 +519,7 @@ class TestPlanner(unittest.TestCase):
                 'sharedconfig': sharedconfig,
             },
         )
-        parameters = planner.run(loaded['plan'])
+        parameters = planner.plan(loaded['plan'])
         self.assertEqual(parameters['foo'], 'us-west-2')
         config_api.get_value.assert_called_with(profile='devprofile',
                                                 value='region')
@@ -834,10 +834,10 @@ class TestRunner(unittest.TestCase):
                 UserName: admin
         """)
         params = {'foo': 'bar'}
-        self.planner.run.return_value = params
+        self.planner.plan.return_value = params
         self.runner.run(wizard_spec=loaded)
 
-        self.planner.run.assert_called_with(loaded['plan'])
+        self.planner.plan.assert_called_with(loaded['plan'])
         self.executor.run.assert_called_with(loaded['execute'], params)
 
 


### PR DESCRIPTION
Add a new dynamodb new-table wizard

There's a few things missing compared to the console version:

* No support for adding GSIs.  This needs a couple of additional
  parts added to the wizard core runner to fully support this (loops/conditions).
* No support for autoscaling.  This involves role management
  and autoscaling policy so it's fairly involved to get all the
  details right
* No support for creating cloudwatch alarms.  The default settings
  will create alarms on RCU/WCU if they reach an 80% threshold

In addition, I refactored a few of the internals and had to add
a few more steps in the planner/executor to support this new wizard.

The high level change needed was support for manipulating the
request parameters needed for an API call.  Based on optional
values provided during the prompting process, we needed to
be able to modify top level keys.  For example, based on whether
you want a sort key, we have to modify the top level
`AttributeDefinitions` key.

Quick note on the GSI, it's *almost* doable, the issue is
that if you're configuring a GSI you may optionally need
to provide the provisioned throughput based on if you're
using on-demand billing or not.  I think we either need
the ability to conditionally prompt for values *or* the
ability to iterate through a list and prompt for values.
