### PR TITLE
Fix typo in modify-fpga-image-attribute example

### DIFF
--- a/awscli/examples/ec2/modify-fpga-image-attribute.rst
+++ b/awscli/examples/ec2/modify-fpga-image-attribute.rst
@@ -4,7 +4,7 @@ This example adds load permissions for account ID ``123456789012`` for the speci
 
 Command::
 
-  aws ec2 modify-fpga-image-attribute --attribute loadPermission --fpga-image-id afi-0d123e123bfc85abc --load-permission Add=[{UserId=123456789012}
+  aws ec2 modify-fpga-image-attribute --attribute loadPermission --fpga-image-id afi-0d123e123bfc85abc --load-permission Add=[{UserId=123456789012}]
 
 Output::
 


### PR DESCRIPTION
*Description of changes:*

Without the closing `]`, the cli can't parse the input



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
