### PR TITLE
Add --cli-auto-prompt arg

### DIFF
--- a/awscli/customizations/autoprompt.py
+++ b/awscli/customizations/autoprompt.py
@@ -1,0 +1,230 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import prompt_toolkit
+from prompt_toolkit.completion import WordCompleter
+
+from awscli.paramfile import get_paramfile, LOCAL_PREFIX_MAP
+from awscli.argprocess import ParamError
+from awscli.customizations.arguments import OverrideRequiredArgsArgument
+from awscli.customizations.utils import get_shape_doc_overview
+from awscli.customizations.wizard import selectmenu
+
+
+def register_autoprompt(cli):
+    cli.register('building-argument-table', add_auto_prompt)
+
+
+def add_auto_prompt(session, argument_table, **kwargs):
+    # This argument cannot support operations with streaming output which
+    # is designated by the argument name `outfile`.
+    if 'outfile' not in argument_table:
+        prompter = AutoPrompter()
+        auto_prompt_argument = AutoPromptArgument(session, prompter)
+        auto_prompt_argument.add_to_arg_table(argument_table)
+
+
+class AutoPromptArgument(OverrideRequiredArgsArgument):
+    """This argument is a boolean to let you prompt for args.
+
+    """
+    ARG_DATA = {
+        'name': 'cli-auto-prompt',
+        'action': 'store_true',
+        'help_text': 'Automatically prompt for CLI input parameters.'
+    }
+
+    def __init__(self, session, prompter):
+        super(AutoPromptArgument, self).__init__(session)
+        self._prompter = prompter
+        self._arg_table = {}
+        self._original_required_args = {}
+
+    def _register_argument_action(self):
+        self._session.register(
+            'calling-command.*', self.auto_prompt_arguments)
+        super(AutoPromptArgument, self)._register_argument_action()
+
+    def override_required_args(self, argument_table, args, **kwargs):
+        self._arg_table = argument_table
+        self._original_required_args = {
+            key: value for key, value in argument_table.items()
+            if value.required
+        }
+        super(AutoPromptArgument, self).override_required_args(
+            argument_table, args, **kwargs
+        )
+
+    def auto_prompt_arguments(self, call_parameters, parsed_args,
+                            parsed_globals, event_name, **kwargs):
+
+        # Check if ``--cli-auto-prompt`` was specified in the command line.
+        auto_prompt = getattr(parsed_args, 'cli_auto_prompt', False)
+        if auto_prompt:
+            return self._prompter.prompt_for_values(
+                complete_arg_table=self._arg_table,
+                required_arg_table=self._original_required_args,
+                apicall_parameters=call_parameters,
+                command_name_parts=['aws'] + event_name.split('.')[1:],
+            )
+
+
+class AutoPrompter(object):
+    """Handles the logic for prompting for a set of values.
+
+    This class focuses on prompting for values that's separate from
+    the integration of this functionality into the CLI
+    (e.g. AutoPromptArgument).
+
+    """
+    QUIT_SENTINEL = object()
+    # These are built-in args that we don't
+    # want to prompt the user for.  If they're using
+    # --cli-auto-prompt, it's unlikely they want to use any
+    # of these args.  Ideally there's a more automatic way to
+    # detect this (e.g. some sort of base class), but for now
+    # we're maintaining an explicit list.  We hardly ever had
+    # to these anyways.
+    _BUILT_IN_ARGS_EXCLUDE = [
+        'cli-input-json',
+        'cli-input-yaml',
+        'generate-cli-skeleton',
+        'cli-auto-prompt',
+    ]
+
+    def __init__(self, prompter=None):
+        if prompter is None:
+            prompter = Prompter()
+        self._prompter = prompter
+
+    def prompt_for_values(self, complete_arg_table, required_arg_table,
+                          apicall_parameters, command_name_parts):
+        """Prompt for values for a given CLI command.
+
+        :param complete_arg_table:  The arg table for the command
+        :param required_arg_table: The subset of the arg table for
+            required args.  The prompter ensutres that it prompts for
+            all required args.
+        :param apicall_parameters: The API call parameters to use for the
+            given command.  The values the user enters during the prompting
+            process will be added to this dictionary.
+        :param command_name_parts: A list of strings of the command.
+            This is used to reconstruct the final command if the user
+            wants to print the command, e.g. ``['aws', 'iam', 'create-user']``.
+
+        If the user requests that that the CLI command is printed, the
+        full command will be returned as a string.  Otherwise ``None``
+        is returned.
+
+        """
+        cli_command = command_name_parts[:]
+        for name, value in required_arg_table.items():
+            self._prompt_for_value(
+                value, self._get_doc_from_arg(value),
+                apicall_parameters, cli_command, {}
+            )
+        remaining_args = self._get_remaining_args(complete_arg_table,
+                                                  required_arg_table)
+        if remaining_args:
+            while True:
+                choices = list(remaining_args)
+                choices = [
+                    {'actual_value': key,
+                     'display': self._get_doc_from_arg(value)}
+                    for key, value in remaining_args.items()
+                ]
+                choices.append({'actual_value': self.QUIT_SENTINEL,
+                                'display': '[DONE] Parameter input finished'})
+                choice = self._prompter.select_from_choices(
+                    choices, display_formatter=lambda x: x['display']
+                )
+                if choice['actual_value'] is self.QUIT_SENTINEL:
+                    break
+                arg = remaining_args[choice['actual_value']]
+                self._prompt_for_value(
+                    arg, choice['display'],
+                    apicall_parameters, cli_command,
+                    remaining_args
+                )
+        return self._decide_next_action(cli_command)
+
+    def _decide_next_action(self, cli_command):
+        choice = self._prompter.select_from_choices(
+            [{'actual_value': 'run-command',
+              'display': 'Execute CLI command'},
+             {'actual_value': 'print-only',
+              'display': 'Print CLI command.'}],
+            display_formatter=lambda x: x['display']
+        )['actual_value']
+        if choice == 'print-only':
+            print(' '.join(cli_command))
+            return 0
+
+    def _get_doc_from_arg(self, arg_shape):
+        return '--%s [%s]: %s' % (arg_shape.name,
+                                  arg_shape.cli_type_name,
+                                  get_shape_doc_overview(arg_shape))
+
+    def _get_remaining_args(self, complete_arg_table, required_arg_table):
+        remaining_args = {
+            key: value for key, value in complete_arg_table.items() if
+            key not in required_arg_table and
+            key not in self._BUILT_IN_ARGS_EXCLUDE
+        }
+        return remaining_args
+
+    def _prompt_for_value(self, arg, prompt_display_text,
+                          apicall_parameters, cli_command,
+                          remaining_args):
+        completer = self._try_get_completer(arg)
+        while True:
+            try:
+                v = self._prompter.prompt(
+                    "--%s: " % arg.name,
+                    completer=completer,
+                    bottom_toolbar=prompt_display_text)
+                arg.add_to_params(apicall_parameters, v)
+                cli_command.extend(['--%s' % arg.name, v])
+                remaining_args.pop(arg.name, None)
+                break
+            except Exception as e:
+                print("Error: %s" % e)
+                print("Please re-enter this value.\n")
+
+    def _try_get_completer(self, arg):
+        # Autocomplete enums if they're modeled.
+        model = getattr(arg, 'argument_model', None)
+        if model is not None and getattr(model, 'enum', None) is not None:
+            choices = model.enum
+            completer = WordCompleter(choices)
+            return completer
+
+
+# Note the point of this class isn't really about abstracting away
+# prompt toolkit.  It's mostly so there's a single class that groups all
+# the prompting functionality together.
+class Prompter(object):
+    def __init__(self):
+        pass
+
+    def prompt(self, prompt_text, completer=None, bottom_toolbar=None):
+        value = prompt_toolkit.prompt(
+            prompt_text,
+            completer=completer,
+            bottom_toolbar=bottom_toolbar)
+        return value
+
+    def select_from_choices(self, choices, display_formatter=None):
+        choice = selectmenu.select_menu(
+            choices, display_format=display_formatter
+        )
+        return choice

--- a/awscli/customizations/autoprompt.py
+++ b/awscli/customizations/autoprompt.py
@@ -13,8 +13,6 @@
 import prompt_toolkit
 from prompt_toolkit.completion import WordCompleter
 
-from awscli.paramfile import get_paramfile, LOCAL_PREFIX_MAP
-from awscli.argprocess import ParamError
 from awscli.customizations.arguments import OverrideRequiredArgsArgument
 from awscli.customizations.utils import get_shape_doc_overview
 from awscli.customizations.wizard import selectmenu
@@ -65,7 +63,7 @@ class AutoPromptArgument(OverrideRequiredArgsArgument):
         )
 
     def auto_prompt_arguments(self, call_parameters, parsed_args,
-                            parsed_globals, event_name, **kwargs):
+                              parsed_globals, event_name, **kwargs):
 
         # Check if ``--cli-auto-prompt`` was specified in the command line.
         auto_prompt = getattr(parsed_args, 'cli_auto_prompt', False)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -89,6 +89,7 @@ from awscli.customizations.logs import register_logs_commands
 from awscli.customizations.devcommands import register_dev_commands
 from awscli.customizations.wizard.commands import register_wizard_commands
 from awscli.customizations.sms_voice import register_sms_voice_hide
+from awscli.customizations.autoprompt import register_autoprompt
 
 
 def awscli_initialize(event_handlers):
@@ -180,3 +181,4 @@ def awscli_initialize(event_handlers):
     register_wizard_commands(event_handlers)
     register_sms_voice_hide(event_handlers)
     register_sso_commands(event_handlers)
+    register_autoprompt(event_handlers)

--- a/tests/unit/customizations/test_autoprompt.py
+++ b/tests/unit/customizations/test_autoprompt.py
@@ -1,0 +1,175 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import mock
+import os
+import shutil
+import tempfile
+
+from botocore import model
+
+from awscli.testutils import unittest
+from awscli.argprocess import ParamError
+from awscli.customizations import autoprompt
+
+
+class TestCLIAutoPrompt(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock()
+        self.prompter = mock.Mock(spec=autoprompt.AutoPrompter)
+        self.argument = autoprompt.AutoPromptArgument(self.session,
+                                                      self.prompter)
+
+    def tearDown(self):
+        pass
+
+    def create_args(self, cli_auto_prompt=True):
+        parsed_args = mock.Mock()
+        parsed_args.cli_auto_prompt = cli_auto_prompt
+        return parsed_args
+
+    def test_add_arg_if_outfile_not_in_argtable(self):
+        arg_table = {}
+        autoprompt.add_auto_prompt(self.session, arg_table)
+        self.assertIn('cli-auto-prompt', arg_table)
+        self.assertIsInstance(arg_table['cli-auto-prompt'],
+                              autoprompt.AutoPromptArgument)
+
+    def test_register_argument_action(self):
+        self.session.register.assert_any_call(
+            'calling-command.*', self.argument.auto_prompt_arguments
+        )
+
+    def test_auto_prompter_not_called_if_arg_not_provided(self):
+        args = self.create_args(cli_auto_prompt=False)
+        self.argument.auto_prompt_arguments(
+            call_parameters={},
+            parsed_args=args,
+            parsed_globals=None,
+            event_name='calling-command.iam.create-user'
+        )
+        self.assertFalse(self.prompter.prompt_for_values.called)
+
+    def test_add_to_call_parameters_no_file(self):
+        parsed_args = self.create_args(cli_auto_prompt=True)
+        call_parameters = {}
+        self.argument.auto_prompt_arguments(
+            call_parameters={},
+            parsed_args=parsed_args,
+            parsed_globals=None,
+            event_name='calling-command.iam.create-user'
+        )
+        self.assertTrue(self.prompter.prompt_for_values.called)
+
+
+class FakeArg(object):
+    def __init__(self, name, cli_type_name='string', arg_model=None):
+        self.name = name
+        self.cli_type_name = cli_type_name
+        self.argument_model = arg_model
+
+    @property
+    def documentation(self):
+        return 'Documentation for %s' % self.name
+
+    def add_to_params(self, call_parameters, value):
+        # Our fake instance don't need to map to api call params,
+        # so we just use the arg name as they into the api call params.
+        call_parameters[self.name] = value
+
+
+class TestAutoPrompter(unittest.TestCase):
+    def setUp(self):
+        self.prompter = mock.Mock(spec=autoprompt.Prompter)
+        self.auto_prompter = autoprompt.AutoPrompter(prompter=self.prompter)
+        self.complete_arg_table = {}
+        self.required_arg_table = {}
+        self.apicall_parameters = {}
+        self.command_name_parts = []
+        self.prompter.select_from_choices.return_value = {
+            'actual_value': 'print-only',
+            'display': 'Print CLI command.'
+        }
+
+    def prompt_for_values(self):
+        self.auto_prompter.prompt_for_values(
+            self.complete_arg_table,
+            self.required_arg_table,
+            self.apicall_parameters,
+            self.command_name_parts
+        )
+
+    def add_required_arg(self, arg):
+        self.required_arg_table[arg.name] = arg
+        self.complete_arg_table[arg.name] = arg
+
+    def add_optional_arg(self, arg):
+        self.complete_arg_table[arg.name] = arg
+
+    def test_always_prompts_all_required_args(self):
+        self.add_required_arg(FakeArg('my-arg-1'))
+        self.add_required_arg(FakeArg('my-arg-2'))
+        self.prompter.prompt.side_effect = ['my-value-1', 'my-value-2']
+        result = self.prompt_for_values()
+        # The prompter should have said the appropriate apicall_parameters
+        # based on the return values from the prompt.
+        self.assertEqual(self.apicall_parameters, {'my-arg-1': 'my-value-1',
+                                                   'my-arg-2': 'my-value-2'})
+
+    def test_can_prompt_optional_args(self):
+        # We have two optional args we'll ask the user about.
+        self.add_optional_arg(FakeArg('optional-1'))
+        self.add_optional_arg(FakeArg('optional-2'))
+        # The user will select the first arg.
+        self.prompter.select_from_choices.side_effect = [
+            # User selects they want to input optional-1
+            {'actual_value': 'optional-1', 'display': 'Option 1'},
+            # User selects they want to input optional-1
+            {'actual_value': 'optional-2', 'display': 'Option 2'},
+            # User selects they're done entering params.
+            {'actual_value': self.auto_prompter.QUIT_SENTINEL, 'display': ''},
+            # User selects they want to print the params.
+            {'actual_value': 'print-only', 'display': 'Print CLI command.'}
+        ]
+        self.prompter.prompt.side_effect = ['my-value-1', 'my-value-2']
+        result = self.prompt_for_values()
+        self.assertEqual(self.apicall_parameters,
+                         {'optional-1': 'my-value-1',
+                          'optional-2': 'my-value-2'})
+
+    def test_loops_until_no_exception_on_error(self):
+        self.add_required_arg(FakeArg('my-arg-1'))
+        self.prompter.prompt.side_effect = [
+            # User enters a bad value, so we'll reprompt.
+            ValueError("Bad value"),
+            # User enters a good value.
+            'my-value-1',
+        ]
+        result = self.prompt_for_values()
+        # The good value should make it to the api call params.
+        self.assertEqual(self.apicall_parameters, {'my-arg-1': 'my-value-1'})
+
+    def test_model_with_enum_offers_completer(self):
+        arg = FakeArg('my-arg-1')
+        arg.argument_model = model.StringShape(
+            'MyArg1',
+            {'type': 'string', 'enum': ['choice1', 'choice2']}
+        )
+        self.add_required_arg(arg)
+        self.prompter.prompt.return_value = 'my-value-1'
+        result = self.prompt_for_values()
+        self.assertEqual(self.apicall_parameters, {'my-arg-1': 'my-value-1'})
+        # Because the shape has an enum, we should have used that for the
+        # word completer in the prompt.
+        completer_arg = self.prompter.prompt.call_args[1].get('completer')
+        self.assertIsNotNone(completer_arg)
+        self.assertEqual(completer_arg.words, ['choice1', 'choice2'])

--- a/tests/unit/customizations/test_autoprompt.py
+++ b/tests/unit/customizations/test_autoprompt.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import mock
+from collections import OrderedDict
 
 from botocore import model
 
@@ -86,8 +87,8 @@ class TestAutoPrompter(unittest.TestCase):
     def setUp(self):
         self.prompter = mock.Mock(spec=autoprompt.Prompter)
         self.auto_prompter = autoprompt.AutoPrompter(prompter=self.prompter)
-        self.complete_arg_table = {}
-        self.required_arg_table = {}
+        self.complete_arg_table = OrderedDict({})
+        self.required_arg_table = OrderedDict({})
         self.apicall_parameters = {}
         self.command_name_parts = []
         self.prompter.select_from_choices.return_value = {

--- a/tests/unit/customizations/test_autoprompt.py
+++ b/tests/unit/customizations/test_autoprompt.py
@@ -11,14 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import mock
-import os
-import shutil
-import tempfile
 
 from botocore import model
 
 from awscli.testutils import unittest
-from awscli.argprocess import ParamError
 from awscli.customizations import autoprompt
 
 
@@ -61,7 +57,6 @@ class TestCLIAutoPrompt(unittest.TestCase):
 
     def test_add_to_call_parameters_no_file(self):
         parsed_args = self.create_args(cli_auto_prompt=True)
-        call_parameters = {}
         self.argument.auto_prompt_arguments(
             call_parameters={},
             parsed_args=parsed_args,
@@ -101,7 +96,7 @@ class TestAutoPrompter(unittest.TestCase):
         }
 
     def prompt_for_values(self):
-        self.auto_prompter.prompt_for_values(
+        return self.auto_prompter.prompt_for_values(
             self.complete_arg_table,
             self.required_arg_table,
             self.apicall_parameters,
@@ -120,6 +115,7 @@ class TestAutoPrompter(unittest.TestCase):
         self.add_required_arg(FakeArg('my-arg-2'))
         self.prompter.prompt.side_effect = ['my-value-1', 'my-value-2']
         result = self.prompt_for_values()
+        self.assertEqual(result, 0)
         # The prompter should have said the appropriate apicall_parameters
         # based on the return values from the prompt.
         self.assertEqual(self.apicall_parameters, {'my-arg-1': 'my-value-1',
@@ -141,7 +137,7 @@ class TestAutoPrompter(unittest.TestCase):
             {'actual_value': 'print-only', 'display': 'Print CLI command.'}
         ]
         self.prompter.prompt.side_effect = ['my-value-1', 'my-value-2']
-        result = self.prompt_for_values()
+        self.prompt_for_values()
         self.assertEqual(self.apicall_parameters,
                          {'optional-1': 'my-value-1',
                           'optional-2': 'my-value-2'})
@@ -154,7 +150,7 @@ class TestAutoPrompter(unittest.TestCase):
             # User enters a good value.
             'my-value-1',
         ]
-        result = self.prompt_for_values()
+        self.prompt_for_values()
         # The good value should make it to the api call params.
         self.assertEqual(self.apicall_parameters, {'my-arg-1': 'my-value-1'})
 
@@ -166,7 +162,7 @@ class TestAutoPrompter(unittest.TestCase):
         )
         self.add_required_arg(arg)
         self.prompter.prompt.return_value = 'my-value-1'
-        result = self.prompt_for_values()
+        self.prompt_for_values()
         self.assertEqual(self.apicall_parameters, {'my-arg-1': 'my-value-1'})
         # Because the shape has an enum, we should have used that for the
         # word completer in the prompt.


### PR DESCRIPTION
This arg is similar to `cli-input-json`, except instead
of specifying params in a json/yaml file, we'll instead
interactively prompt you for values.