### PR TITLE
Add CLI binary format parameter

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -132,6 +132,10 @@ class CLIDriver(object):
             'pager',
             self._construct_cli_pager_chain()
         )
+        config_store.set_config_provider(
+            'cli_binary_format',
+            self._construct_cli_binary_format_chain()
+        )
 
     def _construct_cli_region_chain(self):
         providers = [
@@ -184,6 +188,16 @@ class CLIDriver(object):
                 env=os.environ,
             ),
             ConstantProvider(value=default_pager),
+        ]
+        return ChainProvider(providers=providers)
+
+    def _construct_cli_binary_format_chain(self):
+        providers = [
+            ScopedConfigProvider(
+                config_var_name='cli_binary_format',
+                session=self.session,
+            ),
+            ConstantProvider(value='legacy'),
         ]
         return ChainProvider(providers=providers)
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -197,7 +197,7 @@ class CLIDriver(object):
                 config_var_name='cli_binary_format',
                 session=self.session,
             ),
-            ConstantProvider(value='legacy'),
+            ConstantProvider(value='base64'),
         ]
         return ChainProvider(providers=providers)
 

--- a/awscli/customizations/binaryformat.py
+++ b/awscli/customizations/binaryformat.py
@@ -15,6 +15,7 @@ import binascii
 
 from botocore.exceptions import ProfileNotFound
 
+from awscli.compat import six
 from awscli.shorthand import ModelVisitor
 
 
@@ -52,7 +53,7 @@ class InvalidBase64Error(Exception):
 
 class Base64DecodeVisitor(ModelVisitor):
     def _visit_scalar(self, parent, shape, name, value):
-        if shape.type_name != 'blob' or not isinstance(value, str):
+        if shape.type_name != 'blob' or not isinstance(value, six.text_type):
             return
         try:
             parent[name] = base64.b64decode(value)

--- a/awscli/customizations/binaryformat.py
+++ b/awscli/customizations/binaryformat.py
@@ -57,7 +57,7 @@ class Base64DecodeVisitor(ModelVisitor):
             return
         try:
             parent[name] = base64.b64decode(value)
-        except binascii.Error:
+        except (binascii.Error, TypeError):
             raise InvalidBase64Error('Invalid base64: "%s"' % value)
 
 

--- a/awscli/customizations/binaryformat.py
+++ b/awscli/customizations/binaryformat.py
@@ -1,0 +1,74 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import base64
+import binascii
+
+from awscli.shorthand import ModelVisitor
+
+
+def add_binary_formatter(session, parsed_args, **kwargs):
+    binary_format = parsed_args.cli_binary_format
+    if binary_format is None:
+        binary_format = session.get_config_variable('cli_binary_format')
+    BinaryFormatHandler(binary_format).register(session)
+
+
+class Base64DecodeVisitor(ModelVisitor):
+    def _visit_scalar(self, parent, shape, name, value):
+        if shape.type_name != 'blob' or not isinstance(value, str):
+            return
+        try:
+            parent[name] = base64.b64decode(value)
+        except binascii.Error:
+            raise RuntimeError('Invalid base64: "%s"' % value)
+
+
+def base64_decode_input_blobs(params, model, **kwargs):
+    Base64DecodeVisitor().visit(params, model.input_shape)
+
+
+def identity(x):
+    return x
+
+
+def _register_blob_parser(session, blob_parser):
+    factory = session.get_component('response_parser_factory')
+    factory.set_parser_defaults(blob_parser=blob_parser)
+
+
+def register_identity_blob_parser(session):
+    _register_blob_parser(session, identity)
+
+
+class BinaryFormatHandler(object):
+    _BINARY_FORMATS = {
+        'base64': (base64_decode_input_blobs, register_identity_blob_parser),
+        'legacy': (None, register_identity_blob_parser),
+    }
+
+    def __init__(self, binary_format):
+        self._format = binary_format
+
+    def register(self, session):
+        self._register_input_formatter(session)
+        self._register_output_formatter(session)
+
+    def _register_input_formatter(self, session):
+        input_handler = self._BINARY_FORMATS[self._format][0]
+        if input_handler:
+            session.register('provide-client-params', input_handler)
+
+    def _register_output_formatter(self, session):
+        output_handler = self._BINARY_FORMATS[self._format][1]
+        if output_handler:
+            output_handler(session)

--- a/awscli/customizations/binaryformat.py
+++ b/awscli/customizations/binaryformat.py
@@ -64,7 +64,7 @@ class Base64DecodeVisitor(ModelVisitor):
 class BinaryFormatHandler(object):
     _BINARY_FORMATS = {
         'base64': (base64_decode_input_blobs, register_identity_blob_parser),
-        'legacy': (None, register_identity_blob_parser),
+        'raw-in-base64-out': (None, register_identity_blob_parser),
     }
 
     def __init__(self, binary_format):

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -124,7 +124,7 @@ def _generate_policy(params):
     policy = POLICY.format(expires=expires_iso,
                            bucket=params['Bucket'],
                            prefix=params['Prefix'])
-    params['UploadPolicy'] = policy
+    params['UploadPolicy'] = policy.encode('utf-8')
 
 
 def _generate_signature(params):
@@ -132,7 +132,7 @@ def _generate_signature(params):
     policy = params.get('UploadPolicy')
     sak = params.get('_SAK')
     if policy and sak:
-        policy = base64.b64encode(six.b(policy)).decode('utf-8')
+        policy = base64.b64encode(policy).decode('utf-8')
         new_hmac = hmac.new(sak.encode('utf-8'), digestmod=sha1)
         new_hmac.update(six.b(policy))
         ps = base64.encodestring(new_hmac.digest()).strip().decode('utf-8')

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -77,6 +77,4 @@ def add_timestamp_parser(session):
 
 
 def add_scalar_parsers(session, **kwargs):
-    factory = session.get_component('response_parser_factory')
-    factory.set_parser_defaults(blob_parser=identity)
     add_timestamp_parser(session)

--- a/awscli/customizations/timestampformat.py
+++ b/awscli/customizations/timestampformat.py
@@ -31,9 +31,8 @@ from botocore.utils import parse_timestamp
 from botocore.exceptions import ProfileNotFound
 
 
-def register_scalar_parser(event_handlers):
-    event_handlers.register_first(
-        'session-initialized', add_scalar_parsers)
+def register_timestamp_format(event_handlers):
+    event_handlers.register_first('session-initialized', add_timestamp_parser)
 
 
 def identity(x):
@@ -44,7 +43,7 @@ def iso_format(value):
     return parse_timestamp(value).isoformat()
 
 
-def add_timestamp_parser(session):
+def add_timestamp_parser(session, **kwargs):
     factory = session.get_component('response_parser_factory')
     default_format = 'iso8601'
     try:
@@ -74,7 +73,3 @@ def add_timestamp_parser(session):
         raise ValueError('Unknown cli_timestamp_format value: %s, valid values'
                          ' are "wire" or "iso8601"' % timestamp_format)
     factory.set_parser_defaults(timestamp_parser=timestamp_parser)
-
-
-def add_scalar_parsers(session, **kwargs):
-    add_timestamp_parser(session)

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -72,7 +72,7 @@
                 "base64",
                 "raw-in-base64-out"
             ],
-            "help": "<p>The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The raw-in-base64-out format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally.</p>"
+            "help": "<p>The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The raw-in-base64-out format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally. When providing contents from a file that map to a binary blob ``fileb://`` will always be treated as binary and use the file contents directly regardless of the ``cli-binary-format`` setting. When using ``file://`` the file contents will need to properly formatted for the configured ``cli-binary-format``.</p>"
         }
     }
 }

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -72,7 +72,7 @@
                 "base64",
                 "legacy"
             ],
-            "help": "<p>The formatting style to be used for binary blobs. If the format is set to legacy, the value passed to the AWS CLI for a blob field will be treated literally for input and binary blobs will be represented as a Base64 encoded string in output. The legacy format is consistent with V1 of the AWS CLI. The base64 format will treat the values passed to the AWS CLI for a blob field as a Base64 encoded string, decoding it into the appropriate binary value for input, and binary blobs will be represented as a Base64 encoded string in output.</p>"
+            "help": "<p>The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The legacy format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally.</p>"
         }
     }
 }

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -66,6 +66,13 @@
             "dest": "connect_timeout",
             "type": "int",
             "help": "<p>The maximum socket connect time in seconds. If the value is set to 0, the socket connect will be blocking and not timeout.</p>"
+        },
+        "cli-binary-format": {
+            "choices": [
+                "base64",
+                "legacy"
+            ],
+            "help": "<p>The formatting style to be used for binary blobs.</p>"
         }
     }
 }

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -72,7 +72,7 @@
                 "base64",
                 "legacy"
             ],
-            "help": "<p>The formatting style to be used for binary blobs.</p>"
+            "help": "<p>The formatting style to be used for binary blobs. If the format is set to legacy, the value passed to the AWS CLI for a blob field will be treated literally for input and binary blobs will be represented as a Base64 encoded string in output. The legacy format is consistent with V1 of the AWS CLI. The base64 format will treat the values passed to the AWS CLI for a blob field as a Base64 encoded string, decoding it into the appropriate binary value for input, and binary blobs will be represented as a Base64 encoded string in output.</p>"
         }
     }
 }

--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -70,9 +70,9 @@
         "cli-binary-format": {
             "choices": [
                 "base64",
-                "legacy"
+                "raw-in-base64-out"
             ],
-            "help": "<p>The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The legacy format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally.</p>"
+            "help": "<p>The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The raw-in-base64-out format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally.</p>"
         }
     }
 }

--- a/awscli/examples/acm-pca/import-certificate-authority-certificate.rst
+++ b/awscli/examples/acm-pca/import-certificate-authority-certificate.rst
@@ -2,4 +2,4 @@
 
 The following ``import-certificate-authority-certificate`` command imports the signed private CA certificate for the CA specified by the ARN into ACM PCA. ::
 
-  aws acm-pca import-certificate-authority-certificate --certificate-authority-arn arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012 --certificate file://C:\ca_cert.pem --certificate-chain file://C:\ca_cert_chain.pem
+  aws acm-pca import-certificate-authority-certificate --certificate-authority-arn arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012 --certificate fileb://C:\ca_cert.pem --certificate-chain fileb://C:\ca_cert_chain.pem

--- a/awscli/examples/acm-pca/issue-certificate.rst
+++ b/awscli/examples/acm-pca/issue-certificate.rst
@@ -2,4 +2,4 @@
 
 The following ``issue-certificate`` command uses the private CA specified by the ARN to issue a private certificate. ::
 
-  aws acm-pca issue-certificate --certificate-authority-arn arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012 --csr file://C:\cert_1.csr --signing-algorithm "SHA256WITHRSA" --validity Value=365,Type="DAYS" --idempotency-token 1234
+  aws acm-pca issue-certificate --certificate-authority-arn arn:aws:acm-pca:us-west-2:123456789012:certificate-authority/12345678-1234-1234-1234-123456789012 --csr fileb://C:\cert_1.csr --signing-algorithm "SHA256WITHRSA" --validity Value=365,Type="DAYS" --idempotency-token 1234

--- a/awscli/examples/apigateway/import-rest-api.rst
+++ b/awscli/examples/apigateway/import-rest-api.rst
@@ -2,4 +2,4 @@
 
 Command::
 
-  aws apigateway import-rest-api --body 'file:///path/to/API_Swagger_template.json'
+  aws apigateway import-rest-api --body 'fileb:///path/to/API_Swagger_template.json'

--- a/awscli/examples/codecommit/put-file.rst
+++ b/awscli/examples/codecommit/put-file.rst
@@ -5,7 +5,7 @@ The following ``put-file`` example adds a file named 'ExampleSolution.py' to a r
     aws codecommit put-file \
         --repository-name MyDemoRepo \
         --branch-name feature-randomizationfeature \
-        --file-content file://MyDirectory/ExampleSolution.py \
+        --file-content fileb://MyDirectory/ExampleSolution.py \
         --file-path /solutions/ExampleSolution.py \
         --parent-commit-id 4c925148EXAMPLE \
         --name "Maria Garcia" \

--- a/awscli/examples/ec2/import-key-pair.rst
+++ b/awscli/examples/ec2/import-key-pair.rst
@@ -19,7 +19,7 @@ This example command imports the specified public key.
 
 Command::
 
-  aws ec2 import-key-pair --key-name "my-key" --public-key-material file://~/.ssh/my-key.pub
+  aws ec2 import-key-pair --key-name "my-key" --public-key-material fileb://~/.ssh/my-key.pub
   
 Output::
 

--- a/awscli/examples/ec2/modify-instance-attribute.rst
+++ b/awscli/examples/ec2/modify-instance-attribute.rst
@@ -71,7 +71,7 @@ Now you can reference that file in the CLI command that follows::
 
     aws ec2 modify-instance-attribute \
         --instance-id=i-09b5a14dbca622e76 \
-        --attribute userData --value file://UserData.base64.txt
+        --attribute userData --value fileb://UserData.base64.txt
 
 This command produces no output.
 

--- a/awscli/examples/ecr/upload-layer-part.rst
+++ b/awscli/examples/ecr/upload-layer-part.rst
@@ -7,7 +7,7 @@ This following ``upload-layer-part`` uploads an image layer part to the ``layer-
         --upload-id 6cb64b8a-9378-0e33-2ab1-b780fab8a9e9 \
         --part-first-byte 0 \
         --part-last-byte 8323314 \
-        --layer-part-blob file:///var/lib/docker/image/overlay2/layerdb/sha256/ff986b10a018b48074e6d3a68b39aad8ccc002cdad912d4148c0f92b3729323e/layer.b64
+        --layer-part-blob fileb:///var/lib/docker/image/overlay2/layerdb/sha256/ff986b10a018b48074e6d3a68b39aad8ccc002cdad912d4148c0f92b3729323e/layer.b64
   
 Output::
 

--- a/awscli/examples/iot-data/update-thing-shadow.rst
+++ b/awscli/examples/iot-data/update-thing-shadow.rst
@@ -3,8 +3,9 @@
 The following ``update-thing-shadow`` example modifies the current state of the device shadow for the specified thing and saves it to the file ``output.txt``. ::
 
     aws iot-data update-thing-shadow \
+        --cli-binary-format legacy \
         --thing-name MyRPi \
-        --payload "{"state":{"reported":{"moisture":"okay"}}}" \ 
+        --payload "{"state":{"reported":{"moisture":"okay"}}}" \
         "output.txt"
 
 The command produces no output on the display, but the following shows the contents of ``output.txt``::

--- a/awscli/examples/iot-data/update-thing-shadow.rst
+++ b/awscli/examples/iot-data/update-thing-shadow.rst
@@ -3,9 +3,9 @@
 The following ``update-thing-shadow`` example modifies the current state of the device shadow for the specified thing and saves it to the file ``output.txt``. ::
 
     aws iot-data update-thing-shadow \
-        --cli-binary-format legacy \
+        --cli-binary-format raw-in-base64-out \
         --thing-name MyRPi \
-        --payload "{"state":{"reported":{"moisture":"okay"}}}" \
+        --payload '{"state":{"reported":{"moisture":"okay"}}}' \
         "output.txt"
 
 The command produces no output on the display, but the following shows the contents of ``output.txt``::

--- a/awscli/examples/iotanalytics/run-pipeline-activity.rst
+++ b/awscli/examples/iotanalytics/run-pipeline-activity.rst
@@ -3,6 +3,7 @@
 The following ``run-pipeline-activity`` example simulates the results of running a pipeline activity on a message payload. ::
 
     aws iotanalytics run-pipeline-activity \
+        --cli-binary-format legacy \
         --pipeline-activity file://maths.json \
         --payloads file://payloads.json
 

--- a/awscli/examples/iotanalytics/run-pipeline-activity.rst
+++ b/awscli/examples/iotanalytics/run-pipeline-activity.rst
@@ -3,7 +3,7 @@
 The following ``run-pipeline-activity`` example simulates the results of running a pipeline activity on a message payload. ::
 
     aws iotanalytics run-pipeline-activity \
-        --cli-binary-format legacy \
+        --cli-binary-format raw-in-base64-out \
         --pipeline-activity file://maths.json \
         --payloads file://payloads.json
 

--- a/awscli/examples/lambda/invoke.rst
+++ b/awscli/examples/lambda/invoke.rst
@@ -3,6 +3,7 @@
 The following ``invoke`` example invokes the ``my-function`` function synchronously. ::
 
     aws lambda invoke \
+        --cli-binary-format legacy \
         --function-name my-function \
         --payload '{ "name": "Bob" }' \
         response.json
@@ -21,6 +22,7 @@ For more information, see `Synchronous Invocation <https://docs.aws.amazon.com/l
 The following ``invoke`` example invokes the ``my-function`` function asynchronously. ::
 
     aws lambda invoke \
+        --cli-binary-format legacy \
         --function-name my-function \
         --invocation-type Event \
         --payload '{ "name": "Bob" }' \

--- a/awscli/examples/lambda/invoke.rst
+++ b/awscli/examples/lambda/invoke.rst
@@ -3,7 +3,7 @@
 The following ``invoke`` example invokes the ``my-function`` function synchronously. ::
 
     aws lambda invoke \
-        --cli-binary-format legacy \
+        --cli-binary-format raw-in-base64-out \
         --function-name my-function \
         --payload '{ "name": "Bob" }' \
         response.json
@@ -22,7 +22,7 @@ For more information, see `Synchronous Invocation <https://docs.aws.amazon.com/l
 The following ``invoke`` example invokes the ``my-function`` function asynchronously. ::
 
     aws lambda invoke \
-        --cli-binary-format legacy \
+        --cli-binary-format raw-in-base64-out \
         --function-name my-function \
         --invocation-type Event \
         --payload '{ "name": "Bob" }' \

--- a/awscli/examples/ses/send-raw-email.rst
+++ b/awscli/examples/ses/send-raw-email.rst
@@ -2,7 +2,9 @@
 
 The following example uses the ``send-raw-email`` command to send an email with a TXT attachment::
 
-    aws ses send-raw-email --raw-message file://message.json
+    aws ses send-raw-email \
+    --cli-binary-format legacy \
+    --raw-message file://message.json
 
 Output::
 

--- a/awscli/examples/ses/send-raw-email.rst
+++ b/awscli/examples/ses/send-raw-email.rst
@@ -3,7 +3,7 @@
 The following example uses the ``send-raw-email`` command to send an email with a TXT attachment::
 
     aws ses send-raw-email \
-    --cli-binary-format legacy \
+    --cli-binary-format raw-in-base64-out \
     --raw-message file://message.json
 
 Output::

--- a/awscli/examples/ssm/register-task-with-maintenance-window.rst
+++ b/awscli/examples/ssm/register-task-with-maintenance-window.rst
@@ -4,7 +4,7 @@ This example registers an Automation task with a Maintenance Window that is targ
 
 Command::
 
-   aws ssm register-task-with-maintenance-window --window-id "mw-082dcd7649dee04e4" --targets Key=InstanceIds,Values=i-12345201220f8cd0d --task-arn AWS-RestartEC2Instance --service-role-arn arn:aws:iam::111222333444:role/SSM --task-type AUTOMATION --task-invocation-parameters "{\"Automation\":{\"DocumentVersion\":\"\$LATEST\",\"Parameters\":{\"InstanceId\":[\"{{TARGET_ID}}\"]}}}" --priority 0 --max-concurrency 1 --max-errors 1 --name "AutomationExample" --description "Restarting EC2 Instance for maintenance"
+   aws ssm register-task-with-maintenance-window --cli-binary-format legacy --window-id "mw-082dcd7649dee04e4" --targets Key=InstanceIds,Values=i-12345201220f8cd0d --task-arn AWS-RestartEC2Instance --service-role-arn arn:aws:iam::111222333444:role/SSM --task-type AUTOMATION --task-invocation-parameters "{\"Automation\":{\"DocumentVersion\":\"\$LATEST\",\"Parameters\":{\"InstanceId\":[\"{{TARGET_ID}}\"]}}}" --priority 0 --max-concurrency 1 --max-errors 1 --name "AutomationExample" --description "Restarting EC2 Instance for maintenance"
   
 Output::
 

--- a/awscli/examples/ssm/register-task-with-maintenance-window.rst
+++ b/awscli/examples/ssm/register-task-with-maintenance-window.rst
@@ -4,7 +4,7 @@ This example registers an Automation task with a Maintenance Window that is targ
 
 Command::
 
-   aws ssm register-task-with-maintenance-window --cli-binary-format legacy --window-id "mw-082dcd7649dee04e4" --targets Key=InstanceIds,Values=i-12345201220f8cd0d --task-arn AWS-RestartEC2Instance --service-role-arn arn:aws:iam::111222333444:role/SSM --task-type AUTOMATION --task-invocation-parameters "{\"Automation\":{\"DocumentVersion\":\"\$LATEST\",\"Parameters\":{\"InstanceId\":[\"{{TARGET_ID}}\"]}}}" --priority 0 --max-concurrency 1 --max-errors 1 --name "AutomationExample" --description "Restarting EC2 Instance for maintenance"
+   aws ssm register-task-with-maintenance-window --cli-binary-format raw-in-base64-out --window-id "mw-082dcd7649dee04e4" --targets Key=InstanceIds,Values=i-12345201220f8cd0d --task-arn AWS-RestartEC2Instance --service-role-arn arn:aws:iam::111222333444:role/SSM --task-type AUTOMATION --task-invocation-parameters "{\"Automation\":{\"DocumentVersion\":\"\$LATEST\",\"Parameters\":{\"InstanceId\":[\"{{TARGET_ID}}\"]}}}" --priority 0 --max-concurrency 1 --max-errors 1 --name "AutomationExample" --description "Restarting EC2 Instance for maintenance"
   
 Output::
 

--- a/awscli/examples/waf-regional/update-byte-match-set.rst
+++ b/awscli/examples/waf-regional/update-byte-match-set.rst
@@ -3,7 +3,7 @@
 The following ``update-byte-match-set`` command  deletes a ``ByteMatchTuple`` object (filter) in a ``ByteMatchSet``. Because the ``updates`` value has embedded double quotes, you must surround the value with single quotes. ::
 
     aws waf-regional update-byte-match-set \
-        --cli-binary-format legacy \
+        --cli-binary-format raw-in-base64-out \
         --byte-match-set-id a123fae4-b567-8e90-1234-5ab67ac8ca90 \
         --change-token 12cs345-67cd-890b-1cd2-c3a4567d89f1 \
         --updates 'Action="DELETE",ByteMatchTuple={FieldToMatch={Type="HEADER",Data="referer"},TargetString="badrefer1",TextTransformation="NONE",PositionalConstraint="CONTAINS"}'

--- a/awscli/examples/waf-regional/update-byte-match-set.rst
+++ b/awscli/examples/waf-regional/update-byte-match-set.rst
@@ -3,6 +3,7 @@
 The following ``update-byte-match-set`` command  deletes a ``ByteMatchTuple`` object (filter) in a ``ByteMatchSet``. Because the ``updates`` value has embedded double quotes, you must surround the value with single quotes. ::
 
     aws waf-regional update-byte-match-set \
+        --cli-binary-format legacy \
         --byte-match-set-id a123fae4-b567-8e90-1234-5ab67ac8ca90 \
         --change-token 12cs345-67cd-890b-1cd2-c3a4567d89f1 \
         --updates 'Action="DELETE",ByteMatchTuple={FieldToMatch={Type="HEADER",Data="referer"},TargetString="badrefer1",TextTransformation="NONE",PositionalConstraint="CONTAINS"}'

--- a/awscli/examples/waf/update-byte-match-set.rst
+++ b/awscli/examples/waf/update-byte-match-set.rst
@@ -2,7 +2,7 @@
 
 The following ``update-byte-match-set`` command  deletes a ByteMatchTuple object (filter) in a ByteMatchSet::
 
- aws waf update-byte-match-set --cli-binary-format legacy --byte-match-set-id a123fae4-b567-8e90-1234-5ab67ac8ca90 --change-token 12cs345-67cd-890b-1cd2-c3a4567d89f1 --updates Action="DELETE",ByteMatchTuple={FieldToMatch={Type="HEADER",Data="referer"},TargetString="badrefer1",TextTransformation="NONE",PositionalConstraint="CONTAINS"}
+ aws waf update-byte-match-set --cli-binary-format raw-in-base64-out --byte-match-set-id a123fae4-b567-8e90-1234-5ab67ac8ca90 --change-token 12cs345-67cd-890b-1cd2-c3a4567d89f1 --updates Action="DELETE",ByteMatchTuple={FieldToMatch={Type="HEADER",Data="referer"},TargetString="badrefer1",TextTransformation="NONE",PositionalConstraint="CONTAINS"}
 
 
 

--- a/awscli/examples/waf/update-byte-match-set.rst
+++ b/awscli/examples/waf/update-byte-match-set.rst
@@ -2,7 +2,7 @@
 
 The following ``update-byte-match-set`` command  deletes a ByteMatchTuple object (filter) in a ByteMatchSet::
 
- aws waf update-byte-match-set --byte-match-set-id a123fae4-b567-8e90-1234-5ab67ac8ca90 --change-token 12cs345-67cd-890b-1cd2-c3a4567d89f1 --updates Action="DELETE",ByteMatchTuple={FieldToMatch={Type="HEADER",Data="referer"},TargetString="badrefer1",TextTransformation="NONE",PositionalConstraint="CONTAINS"}
+ aws waf update-byte-match-set --cli-binary-format legacy --byte-match-set-id a123fae4-b567-8e90-1234-5ab67ac8ca90 --change-token 12cs345-67cd-890b-1cd2-c3a4567d89f1 --updates Action="DELETE",ByteMatchTuple={FieldToMatch={Type="HEADER",Data="referer"},TargetString="badrefer1",TextTransformation="NONE",PositionalConstraint="CONTAINS"}
 
 
 

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -90,10 +90,12 @@ from awscli.customizations.devcommands import register_dev_commands
 from awscli.customizations.wizard.commands import register_wizard_commands
 from awscli.customizations.sms_voice import register_sms_voice_hide
 from awscli.customizations.autoprompt import register_autoprompt
+from awscli.customizations.binaryformat import add_binary_formatter
 
 
 def awscli_initialize(event_handlers):
     event_handlers.register('session-initialized', register_uri_param_handler)
+    event_handlers.register('session-initialized', add_binary_formatter)
     param_shorthand = ParamShorthandParser()
     event_handlers.register('process-cli-arg', param_shorthand)
     # The s3 error mesage needs to registered before the

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -74,7 +74,7 @@ from awscli.customizations.route53 import register_create_hosted_zone_doc_fix
 from awscli.customizations.s3.s3 import s3_plugin_initialize
 from awscli.customizations.s3endpoint import register_s3_endpoint
 from awscli.customizations.s3errormsg import register_s3_error_msg
-from awscli.customizations.scalarparse import register_scalar_parser
+from awscli.customizations.timestampformat import register_timestamp_format
 from awscli.customizations.sessendemail import register_ses_send_email
 from awscli.customizations.sso import register_sso_commands
 from awscli.customizations.streamingoutputarg import add_streaming_output_arg
@@ -152,7 +152,7 @@ def awscli_initialize(event_handlers):
     register_subscribe(event_handlers)
     register_get_status(event_handlers)
     register_rename_config(event_handlers)
-    register_scalar_parser(event_handlers)
+    register_timestamp_format(event_handlers)
     opsworks_init(event_handlers)
     register_lambda_create_function(event_handlers)
     register_fix_kms_create_grant_docs(event_handlers)

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -106,6 +106,11 @@ The valid values of the ``cli_binary_format`` configuration variable are:
 * raw-in-base64-out - Binary values are provided are treated literally.
   Consistent with AWS CLI V1.
 
+When providing contents from a file that map to a binary blob ``fileb://`` will
+always be treated as binary and use the file contents directly regardless of
+the ``cli_binary_format`` setting. When using ``file://`` the file contents
+will need to properly formatted for the configured ``cli_binary_format``.
+
 The default value is ``iso8601``.
 
 ``cli_follow_urlparam`` controls whether or not the CLI will attempt to follow

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -60,25 +60,27 @@ General Options
 
 The AWS CLI has a few general options:
 
-==================== =========== ===================== ===================== ============================
-Variable             Option      Config Entry          Environment Variable  Description
-==================== =========== ===================== ===================== ============================
-profile              --profile   N/A                   AWS_PROFILE           Default profile name
--------------------- ----------- --------------------- --------------------- ----------------------------
-region               --region    region                AWS_DEFAULT_REGION    Default AWS Region
--------------------- ----------- --------------------- --------------------- ----------------------------
-output               --output    output                AWS_DEFAULT_OUTPUT    Default output style
--------------------- ----------- --------------------- --------------------- ----------------------------
-cli_timestamp_format N/A         cli_timestamp_format  N/A                   Output format of timestamps
--------------------- ----------- --------------------- --------------------- ----------------------------
-cli_follow_urlparam  N/A         cli_follow_urlparam   N/A                   Fetch URL url parameters
--------------------- ----------- --------------------- --------------------- ----------------------------
-ca_bundle            --ca-bundle ca_bundle             AWS_CA_BUNDLE         CA Certificate Bundle
--------------------- ----------- --------------------- --------------------- ----------------------------
-parameter_validation N/A         parameter_validation  N/A                   Toggles parameter validation
--------------------- ----------- --------------------- --------------------- ----------------------------
-tcp_keepalive        N/A         tcp_keepalive         N/A                   Toggles TCP Keep-Alive
-==================== =========== ===================== ===================== ============================
+==================== =================== ===================== ===================== ============================
+Variable             Option               Config Entry          Environment Variable  Description
+==================== =================== ===================== ===================== ============================
+profile              --profile           N/A                   AWS_PROFILE           Default profile name
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+region               --region            region                AWS_DEFAULT_REGION    Default AWS Region
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+output               --output            output                AWS_DEFAULT_OUTPUT    Default output style
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+cli_timestamp_format N/A                 cli_timestamp_format  N/A                   Output format of timestamps
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+cli_binary_format    --cli-binary-format cli_binary_format     N/A                   Binary input & output format
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+cli_follow_urlparam  N/A                 cli_follow_urlparam   N/A                   Fetch URL url parameters
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+ca_bundle            --ca-bundle         ca_bundle             AWS_CA_BUNDLE         CA Certificate Bundle
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+parameter_validation N/A                 parameter_validation  N/A                   Toggles parameter validation
+-------------------- ------------------- --------------------- --------------------- ----------------------------
+tcp_keepalive        N/A                 tcp_keepalive         N/A                   Toggles TCP Keep-Alive
+==================== =================== ===================== ===================== ============================
 
 The third column, Config Entry, is the value you would specify in the AWS CLI
 config file.  By default, this location is ``~/.aws/config``.  If you need to
@@ -96,6 +98,12 @@ The valid values of the ``cli_timestamp_format`` configuration variable are:
 
 * wire - Display the timestamp exactly as received from the HTTP response.
 * iso8601 - Reformat timestamp using iso8601 in the UTC timezone.
+
+``cli_binary_format`` controls the format of binary values in input and output.
+The valid values of the ``cli_binary_format`` configuration variable are:
+
+* base64 - Binary values are provided as Base64 encoded strings. The default.
+* legacy - Binary values are provided are treated literally. Consistent with AWS CLI V1.
 
 The default value is ``iso8601``.
 

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -103,7 +103,8 @@ The valid values of the ``cli_timestamp_format`` configuration variable are:
 The valid values of the ``cli_binary_format`` configuration variable are:
 
 * base64 - Binary values are provided as Base64 encoded strings. The default.
-* legacy - Binary values are provided are treated literally. Consistent with AWS CLI V1.
+* raw-in-base64-out - Binary values are provided are treated literally.
+  Consistent with AWS CLI V1.
 
 The default value is ``iso8601``.
 

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -27,9 +27,9 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
     prefix = 'ec2 bundle-instance'
 
     POLICY = (
-        '{"expiration": "2013-08-10T00:00:00.000000Z",'
-        '"conditions": [{"bucket": "mybucket"},{"acl": '
-        '"ec2-bundle-read"},["starts-with", "$key", "foobar"]]}')
+        b'{"expiration": "2013-08-10T00:00:00.000000Z",'
+        b'"conditions": [{"bucket": "mybucket"},{"acl": '
+        b'"ec2-bundle-read"},["starts-with", "$key", "foobar"]]}')
     POLICY_SIGNATURE = 'ynxybUMv9YuGbPl7HZ8AFJW/2t0='
 
     def setUp(self):
@@ -74,7 +74,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-        args += ' --bucket mybucket --prefix foobar --policy %s' % policy
+        args += ' --bucket mybucket --prefix foobar --policy %s' % base64policy
         args_list = (self.prefix + args).split()
         result =  {'InstanceId': 'i-12345678',
                    'Storage': {
@@ -82,7 +82,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
                            'Bucket': 'mybucket',
                            'Prefix': 'foobar',
                            'AWSAccessKeyId': 'AKIAIOSFODNN7EXAMPLE',
-                           'UploadPolicy': '{"notarealpolicy":true}',
+                           'UploadPolicy': b'{"notarealpolicy":true}',
                            'UploadPolicySignature': policy_signature}
                        }
                    }
@@ -94,7 +94,3 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()
         self.assert_params_for_cmd(args_list, expected_rc=255)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/functional/firehose/test_put_record_batch.py
+++ b/tests/functional/firehose/test_put_record_batch.py
@@ -19,9 +19,9 @@ class TestPutRecordBatch(BaseAWSCommandParamsTest):
 
     def test_shorthand(self):
         command = self.prefix + ' --delivery-stream-name foo'
-        command += ' --records foo bar'
+        command += ' --records Zm9v YmFy'
         params = {
             'DeliveryStreamName': 'foo',
-            'Records': [{'Data': 'foo'}, {'Data': 'bar'}]
+            'Records': [{'Data': b'foo'}, {'Data': b'bar'}]
         }
         self.assert_params_for_cmd(command, params)

--- a/tests/functional/rekognition/test_image_parameters.py
+++ b/tests/functional/rekognition/test_image_parameters.py
@@ -47,11 +47,11 @@ class TestCompareFaces(BaseRekognitionTest):
 
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
-        cmdline += ' --source-image Bytes=foo'
-        cmdline += ' --target-image Bytes=bar'
+        cmdline += ' --source-image Bytes=Zm9v'
+        cmdline += ' --target-image Bytes=YmFy'
         result = {
-            'SourceImage': {'Bytes': 'foo'},
-            'TargetImage': {'Bytes': 'bar'},
+            'SourceImage': {'Bytes': b'foo'},
+            'TargetImage': {'Bytes': b'bar'},
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -70,9 +70,9 @@ class TestDetectFaces(BaseRekognitionTest):
 
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -91,9 +91,9 @@ class TestDetectLabels(BaseRekognitionTest):
 
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -112,9 +112,9 @@ class TestDetectModerationLabels(BaseRekognitionTest):
 
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -133,9 +133,9 @@ class TestDetectText(BaseRekognitionTest):
 
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -157,10 +157,10 @@ class TestIndexFaces(BaseRekognitionTest):
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
         cmdline += ' --collection-id foobar'
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
             'CollectionId': 'foobar',
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -179,9 +179,9 @@ class TestRecognizeCelebrities(BaseRekognitionTest):
 
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)
 
@@ -203,9 +203,9 @@ class TestSearchFacesByImage(BaseRekognitionTest):
     def test_image_bytes_still_works(self):
         cmdline = self.prefix
         cmdline += ' --collection-id foobar'
-        cmdline += ' --image Bytes=foobar'
+        cmdline += ' --image Bytes=Zm9vYmFy'
         result = {
             'CollectionId': 'foobar',
-            'Image': {'Bytes': 'foobar'}
+            'Image': {'Bytes': b'foobar'}
         }
         self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -144,3 +144,26 @@ class TestCLIInputYAML(BaseCLIInputArgumentTest):
             command, expected_rc=255,
             stderr_contains='Only one --cli-input- parameter may be specified.'
         )
+
+class TestBinaryInput(BaseCLIInputArgumentTest):
+    def test_converts_base64_to_binary_in_base64_mode(self):
+        command = [
+            'kms', 'encrypt', '--cli-binary-format', 'base64',
+            '--key-id', 'test', '--plaintext', 'Zm9v'
+        ]
+        params = {
+            'KeyId': 'test',
+            'Plaintext': b'foo',
+        }
+        self.assert_params_for_cmd(command, params)
+
+    def test_preserved_input_value_in_legacy_mode(self):
+        command = [
+            'kms', 'encrypt', '--cli-binary-format', 'legacy',
+            '--key-id', 'test', '--plaintext', 'Zm9v'
+        ]
+        params = {
+            'KeyId': 'test',
+            'Plaintext': 'Zm9v',
+        }
+        self.assert_params_for_cmd(command, params)

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -157,9 +157,9 @@ class TestBinaryInput(BaseCLIInputArgumentTest):
         }
         self.assert_params_for_cmd(command, params)
 
-    def test_preserved_input_value_in_legacy_mode(self):
+    def test_preserved_input_value_in_raw_in_base64_out_mode(self):
         command = [
-            'kms', 'encrypt', '--cli-binary-format', 'legacy',
+            'kms', 'encrypt', '--cli-binary-format', 'raw-in-base64-out',
             '--key-id', 'test', '--plaintext', 'Zm9v'
         ]
         params = {

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -38,7 +38,7 @@ from awscli.testutils import aws as _aws
 from awscli.testutils import BaseS3CLICommand
 from awscli.testutils import random_chars, random_bucket_name
 from awscli.customizations.s3.transferconfig import DEFAULTS
-from awscli.customizations.scalarparse import add_scalar_parsers, identity
+from awscli.customizations.timestampformat import add_timestamp_parser, identity
 
 
 # Using the same log name as testutils.py
@@ -547,7 +547,7 @@ class TestCp(BaseS3IntegrationTest):
     def test_copy_metadata(self):
         # Copy the same style of parsing as the CLI session. This is needed
         # For comparing expires timestamp.
-        add_scalar_parsers(self.session)
+        add_timestamp_parser(self.session)
         bucket_name = _SHARED_BUCKET
         key = random_chars(6)
         filename = self.files.create_file(key, contents='')

--- a/tests/unit/customizations/test_binaryformat.py
+++ b/tests/unit/customizations/test_binaryformat.py
@@ -116,13 +116,13 @@ class TestAddBinaryFormatter(unittest.TestCase):
         )
 
     def test_legacy_handlers_added(self):
-        self.parsed_args.cli_binary_format = 'legacy'
+        self.parsed_args.cli_binary_format = 'raw-in-base64-out'
         add_binary_formatter(self.mock_session, self.parsed_args)
         self._assert_legacy_handlers_added()
 
     def test_legacy_handlers_added_via_profile(self):
         self.parsed_args.cli_binary_format = None
-        self.mock_session.get_config_variable.return_value = 'legacy'
+        self.mock_session.get_config_variable.return_value = 'raw-in-base64-out'
         add_binary_formatter(self.mock_session, self.parsed_args)
         self._assert_legacy_handlers_added()
 

--- a/tests/unit/customizations/test_binaryformat.py
+++ b/tests/unit/customizations/test_binaryformat.py
@@ -1,0 +1,116 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest, mock
+from awscli.customizations.binaryformat import identity
+from awscli.customizations.binaryformat import base64_decode_input_blobs
+from awscli.customizations.binaryformat import Base64DecodeVisitor
+from awscli.customizations.binaryformat import add_binary_formatter
+
+from botocore import model
+from botocore.session import Session
+
+
+class TestBase64DecodeVisitor(unittest.TestCase):
+    def construct_model(self, members):
+        model_builder = model.DenormalizedStructureBuilder()
+        return model_builder.with_members(members).build_model()
+
+    def assert_decoded_params(self, members, params, expected_params):
+        shape = self.construct_model(members)
+        base64_decode_visitor = Base64DecodeVisitor()
+        base64_decode_visitor.visit(params, shape)
+        self.assertEqual(params, expected_params)
+
+    def test_can_convert_top_level_blob(self):
+        members = {'B': {'type': 'blob'}}
+        params = {'B': 'Zm9v'}
+        expected_params = {'B': b'foo'}
+        self.assert_decoded_params(members, params, expected_params)
+
+    def test_can_convert_nested_blob(self):
+        members = {
+            'Nested': {
+                'type': 'structure',
+                'members': {
+                    'B': {'type': 'blob'},
+                }
+            }
+        }
+        params = {
+            'Nested': {'B': 'Zm9v'}
+        }
+        expected_params = {
+            'Nested': {'B': b'foo'}
+        }
+        self.assert_decoded_params(members, params, expected_params)
+
+    def test_can_convert_list_of_blob(self):
+        members = {
+            'BS': {
+                'type': 'list',
+                'member': {'type': 'blob'},
+            }
+        }
+        params = {
+            'BS': ['Zm9v', '']
+        }
+        expected_params = {
+            'BS': [b'foo', b'']
+        }
+        self.assert_decoded_params(members, params, expected_params)
+
+    def test_can_convert_map_to_blob(self):
+        members = {
+            'StoB': {
+                'type': 'map',
+                'key': {'type': 'string'},
+                'value': {'type': 'blob'},
+            }
+        }
+        params = {
+            'StoB': {'a': 'Zm9v', 'b': ''}
+        }
+        expected_params = {
+            'StoB': {'a': b'foo', 'b': b''}
+        }
+        self.assert_decoded_params(members, params, expected_params)
+
+
+class TestAddBinaryFormatter(unittest.TestCase):
+    def setUp(self):
+        self.parsed_args = mock.Mock()
+        self.mock_factory = mock.Mock()
+        self.mock_session = mock.Mock(spec=Session)
+        self.mock_session.get_component.return_value = self.mock_factory
+
+    def test_legacy_handlers_added(self):
+        self.parsed_args.cli_binary_format = 'legacy'
+        add_binary_formatter(self.mock_session, self.parsed_args)
+        # Legacy format does not register a handler to transform input
+        self.assertEqual(self.mock_session.register.call_count, 0)
+        # Legacy format parses blobs with an identity function
+        self.mock_factory.set_parser_defaults.assert_called_with(
+            blob_parser=identity
+        )
+
+    def test_base64_handlers_added(self):
+        self.parsed_args.cli_binary_format = 'base64'
+        add_binary_formatter(self.mock_session, self.parsed_args)
+        self.assertEqual(self.mock_session.register.call_count, 1)
+        self.mock_session.register.assert_called_with(
+            'provide-client-params', base64_decode_input_blobs,
+        )
+        # base64 format parses blobs with an identity function
+        self.mock_factory.set_parser_defaults.assert_called_with(
+            blob_parser=identity
+        )

--- a/tests/unit/customizations/test_binaryformat.py
+++ b/tests/unit/customizations/test_binaryformat.py
@@ -33,7 +33,7 @@ class TestBase64DecodeVisitor(unittest.TestCase):
 
     def test_can_convert_top_level_blob(self):
         members = {'B': {'type': 'blob'}}
-        params = {'B': 'Zm9vAGJheg=='}
+        params = {'B': u'Zm9vAGJheg=='}
         expected_params = {'B': b'foo\x00baz'}
         self.assert_decoded_params(members, params, expected_params)
 
@@ -47,7 +47,7 @@ class TestBase64DecodeVisitor(unittest.TestCase):
             }
         }
         params = {
-            'Nested': {'B': 'Zm9v'}
+            'Nested': {'B': u'Zm9v'}
         }
         expected_params = {
             'Nested': {'B': b'foo'}
@@ -62,7 +62,7 @@ class TestBase64DecodeVisitor(unittest.TestCase):
             }
         }
         params = {
-            'BS': ['Zm9v', '']
+            'BS': [u'Zm9v', u'']
         }
         expected_params = {
             'BS': [b'foo', b'']
@@ -78,7 +78,7 @@ class TestBase64DecodeVisitor(unittest.TestCase):
             }
         }
         params = {
-            'StoB': {'a': 'Zm9v', 'b': ''}
+            'StoB': {'a': u'Zm9v', 'b': u''}
         }
         expected_params = {
             'StoB': {'a': b'foo', 'b': b''}

--- a/tests/unit/customizations/test_binaryformat.py
+++ b/tests/unit/customizations/test_binaryformat.py
@@ -33,8 +33,8 @@ class TestBase64DecodeVisitor(unittest.TestCase):
 
     def test_can_convert_top_level_blob(self):
         members = {'B': {'type': 'blob'}}
-        params = {'B': 'Zm9v'}
-        expected_params = {'B': b'foo'}
+        params = {'B': 'Zm9vAGJheg=='}
+        expected_params = {'B': b'foo\x00baz'}
         self.assert_decoded_params(members, params, expected_params)
 
     def test_can_convert_nested_blob(self):

--- a/tests/unit/customizations/test_scalarparse.py
+++ b/tests/unit/customizations/test_scalarparse.py
@@ -36,10 +36,8 @@ class TestScalarParse(unittest.TestCase):
         scalarparse.add_scalar_parsers(session)
         session.get_component.assert_called_with('response_parser_factory')
         factory = session.get_component.return_value
-        expected = [call(blob_parser=scalarparse.identity),
-                    call(timestamp_parser=scalarparse.identity)]
-        self.assertEqual(factory.set_parser_defaults.mock_calls,
-                         expected)
+        expected = [call(timestamp_parser=scalarparse.identity)]
+        self.assertEqual(factory.set_parser_defaults.mock_calls, expected)
 
     def test_choose_none_timestamp_formatter(self):
         session = Mock(spec=Session)

--- a/tests/unit/customizations/test_timestampformat.py
+++ b/tests/unit/customizations/test_timestampformat.py
@@ -14,29 +14,29 @@ from botocore.exceptions import ProfileNotFound
 from botocore.session import Session
 from mock import Mock, call
 
-from awscli.customizations import scalarparse
+from awscli.customizations import timestampformat
 from awscli.testutils import unittest
 
 
 class TestScalarParse(unittest.TestCase):
-    def test_register_scalar_parser(self):
+    def test_register_timestamp_format(self):
         event_handers = Mock()
-        scalarparse.register_scalar_parser(event_handers)
+        timestampformat.register_timestamp_format(event_handers)
         event_handers.register_first.assert_called_with(
-            'session-initialized', scalarparse.add_scalar_parsers)
+            'session-initialized', timestampformat.add_timestamp_parser)
 
     def test_identity(self):
-        self.assertEqual(scalarparse.identity('foo'), 'foo')
-        self.assertEqual(scalarparse.identity(10), 10)
+        self.assertEqual(timestampformat.identity('foo'), 'foo')
+        self.assertEqual(timestampformat.identity(10), 10)
 
     def test_scalar_parsers_set(self):
         session = Mock()
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'wire'}
-        scalarparse.add_scalar_parsers(session)
+        timestampformat.add_timestamp_parser(session)
         session.get_component.assert_called_with('response_parser_factory')
         factory = session.get_component.return_value
-        expected = [call(timestamp_parser=scalarparse.identity)]
+        expected = [call(timestamp_parser=timestampformat.identity)]
         self.assertEqual(factory.set_parser_defaults.mock_calls, expected)
 
     def test_choose_none_timestamp_formatter(self):
@@ -44,18 +44,18 @@ class TestScalarParse(unittest.TestCase):
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'wire'}
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        timestampformat.add_timestamp_parser(session)
         factory.set_parser_defaults.assert_called_with(
-            timestamp_parser=scalarparse.identity)
+            timestamp_parser=timestampformat.identity)
 
     def test_choose_iso_timestamp_formatter(self):
         session = Mock(spec=Session)
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'iso8601'}
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        timestampformat.add_timestamp_parser(session)
         factory.set_parser_defaults.assert_called_with(
-            timestamp_parser=scalarparse.iso_format)
+            timestamp_parser=timestampformat.iso_format)
 
     def test_choose_invalid_timestamp_formatter(self):
         session = Mock(spec=Session)
@@ -63,12 +63,12 @@ class TestScalarParse(unittest.TestCase):
                                                   'foobar'}
         session.get_component.return_value
         with self.assertRaises(ValueError):
-            scalarparse.add_scalar_parsers(session)
+            timestampformat.add_timestamp_parser(session)
 
     def test_choose_timestamp_parser_profile_not_found(self):
         session = Mock(spec=Session)
         session.get_scoped_config.side_effect = ProfileNotFound(profile='foo')
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        timestampformat.add_timestamp_parser(session)
         factory.set_parser_defaults.assert_called_with(
-            timestamp_parser=scalarparse.iso_format)
+            timestamp_parser=timestampformat.iso_format)


### PR DESCRIPTION
This adds a new parameter / configuration to modify how the CLI interprets binary values passed as a command line argument and how binary values are represented in the output. The new argument is `--cli-binary-format` and can currently be set to `base64` to consistently treat binary input as a base64 encoded string for input and represented as a base64 encoded string in output. Additionally, this can be set to `legacy` to maintain the same behavior that the V1 of the CLI had which would treat strings literally which can be useful for some commands.

The motivation for this change is that treating parameters that map to binary blobs in the request literally significantly restricts what binary values can be provided and also does not allow for binary values present in responses to be provided as input to subsequent commands without additional processing.