### PR TITLE
Refresh bundled installer to work with modern pip/venv

### DIFF
--- a/scripts/assets/constraints-bundled.txt
+++ b/scripts/assets/constraints-bundled.txt
@@ -1,0 +1,1 @@
+python-dateutil==2.8.0

--- a/scripts/install
+++ b/scripts/install
@@ -19,6 +19,19 @@ PACKAGES_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'packages')
 INSTALL_DIR = os.path.expanduser(os.path.join(
     '~', '.local', 'lib', 'aws'))
+IS_PY26 = sys.version_info[:2] == (2, 6)
+IS_PY3 = sys.version_info[0] == 3
+if IS_PY26:
+    # --no-build-isolation isn't available in the pip
+    # version we use in py26.
+    INSTALL_ARGS = (
+        '--no-binary :all: --no-cache-dir '
+        '--no-index '
+    )
+else:
+    INSTALL_ARGS = (
+        '--no-binary :all: --no-build-isolation --no-cache-dir --no-index '
+    )
 
 
 class BadRCError(Exception):
@@ -66,14 +79,21 @@ def bin_path():
 def create_install_structure(working_dir, install_dir):
     if not os.path.isdir(install_dir):
         os.makedirs(install_dir)
-    _create_virtualenv(location=install_dir, working_dir=working_dir)
+    create_virtualenv(location=install_dir, working_dir=working_dir)
 
 
-def _create_virtualenv(location, working_dir):
+def _create_virtualenv_internal(location, working_dir):
+    # On py3 we use the built in venv to create our virtualenv.
+    # There's a bug with sys.executable on external virtualenv
+    # that causes installation failures.
+    run('%s -m venv %s' % (sys.executable, location))
+
+
+def _create_virtualenv_external(location, working_dir):
     # working_dir is used (generally somewhere in /tmp) so that we
     # don't modify the install/packages directories.
     with cd(PACKAGES_DIR):
-        venv = [p for p in os.listdir('.') if p.startswith('virtualenv')][0]
+        venv = _get_venv_package_tarball('.')
         compressed = tarfile.open(venv)
         compressed.extractall(path=working_dir)
         compressed.close()
@@ -85,6 +105,24 @@ def _create_virtualenv(location, working_dir):
                  '--python %s %s') % (sys.executable,
                                       sys.executable,
                                       location))
+
+
+def _get_package_tarball(package_dir, package_prefix):
+    package_filenames = sorted([p for p in os.listdir(package_dir)
+                                if p.startswith(package_prefix)])
+    # Given we're droping py26 support soon we don't have to make this
+    # super sophisticated.  If we're on py26 we use the earliest version of
+    # this package, otherwise we use the most recent version.
+    # When we drop py26 support there will only be a single version of
+    # each package so we can change this back to return package_filenames[0].
+    if IS_PY26:
+        return package_filenames[0]
+    else:
+        return package_filenames[-1]
+
+
+def _get_venv_package_tarball(package_dir):
+    return _get_package_tarball(package_dir, 'virtualenv')
 
 
 def create_working_dir():
@@ -104,19 +142,31 @@ def pip_install_packages(install_dir):
     cli_tarball = cli_tarball[0]
     pip_script = os.path.join(install_dir, bin_path(), 'pip')
 
-    # Some packages declare `setup_requires`, which is a list of dependencies
-    # to be used at setup time. These need to be installed before anything
-    # else, and pip doesn't manage them.
     setup_requires_dir = os.path.join(PACKAGES_DIR, 'setup')
     with cd(setup_requires_dir):
-        for package in os.listdir(setup_requires_dir):
-            run('%s install --no-cache-dir --no-index --find-links file://%s %s' % (
-                pip_script, setup_requires_dir, package
-            ))
+        _install_setup_deps(pip_script, '.')
 
     with cd(PACKAGES_DIR):
-        run('%s install --no-cache-dir --no-index --find-links file://%s %s' % (
-            pip_script, PACKAGES_DIR, cli_tarball))
+        run('%s install %s --find-links file://%s %s' % (
+                pip_script, INSTALL_ARGS, PACKAGES_DIR, cli_tarball))
+
+
+def _install_setup_deps(pip_script, setup_package_dir):
+    # Some packages declare `setup_requires`, which is a list of dependencies
+    # to be used at setup time. These need to be installed before anything
+    # else, and pip doesn't manage them.  We have to manage this ourselves
+    # so for now we're explicitly installing the one setup_requires package
+    # we need.  This comes from python-dateutils.
+    setuptools_scm_tarball = _get_package_tarball(
+        setup_package_dir, 'setuptools_scm')
+    run('%s install --no-binary :all: --no-cache-dir --no-index '
+        '--find-links file://%s %s' % (
+            pip_script, setup_package_dir, setuptools_scm_tarball))
+    wheel_tarball = _get_package_tarball(
+        setup_package_dir, 'wheel')
+    run('%s install --no-binary :all: --no-cache-dir --no-index '
+        '--find-links file://%s %s' % (
+            pip_script, setup_package_dir, wheel_tarball))
 
 
 def create_symlink(real_location, symlink_name):
@@ -150,12 +200,19 @@ def main():
         create_install_structure(working_dir, opts.install_dir)
         pip_install_packages(opts.install_dir)
         real_location = os.path.join(opts.install_dir, bin_path(), 'aws')
-        if opts.bin_location and create_symlink(real_location, opts.bin_location):
+        if opts.bin_location and create_symlink(real_location,
+                                                opts.bin_location):
             print("You can now run: %s --version" % opts.bin_location)
         else:
             print("You can now run: %s --version" % real_location)
     finally:
         shutil.rmtree(working_dir)
+
+
+if IS_PY3:
+    create_virtualenv = _create_virtualenv_internal
+else:
+    create_virtualenv = _create_virtualenv_external
 
 
 if __name__ == '__main__':

--- a/scripts/install
+++ b/scripts/install
@@ -20,7 +20,7 @@ PACKAGES_DIR = os.path.join(
 INSTALL_DIR = os.path.expanduser(os.path.join(
     '~', '.local', 'lib', 'aws'))
 IS_PY26 = sys.version_info[:2] == (2, 6)
-IS_PY3 = sys.version_info[0] == 3
+IS_PY37 = sys.version_info[:2] == (3, 7)
 if IS_PY26:
     # --no-build-isolation isn't available in the pip
     # version we use in py26.
@@ -58,8 +58,9 @@ def run(cmd):
                          stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
+        output = (stdout + stderr).decode("utf-8")
         raise BadRCError("Bad rc (%s) for cmd '%s': %s" % (
-            p.returncode, cmd, stdout + stderr))
+            p.returncode, cmd, output))
     return stdout
 
 
@@ -209,7 +210,7 @@ def main():
         shutil.rmtree(working_dir)
 
 
-if IS_PY3:
+if IS_PY37:
     create_virtualenv = _create_virtualenv_internal
 else:
     create_virtualenv = _create_virtualenv_external

--- a/scripts/install
+++ b/scripts/install
@@ -14,14 +14,17 @@ import tempfile
 
 from contextlib import contextmanager
 
-
 PACKAGES_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'packages')
 INSTALL_DIR = os.path.expanduser(os.path.join(
     '~', '.local', 'lib', 'aws'))
+# There's a few things we need to care about when handling
+# multiple versions of python.  For older versions of python
+# (2.6 and 3.3) we need to use older virtualenv and older packages.
 IS_PY26 = sys.version_info[:2] == (2, 6)
-IS_PY37 = sys.version_info[:2] == (3, 7)
-if IS_PY26:
+IS_PY33 = sys.version_info[:2] == (3, 3)
+GTE_PY37 = sys.version_info[:2] >= (3, 7)
+if IS_PY26 or IS_PY33:
     # --no-build-isolation isn't available in the pip
     # version we use in py26.
     INSTALL_ARGS = (
@@ -116,7 +119,7 @@ def _get_package_tarball(package_dir, package_prefix):
     # this package, otherwise we use the most recent version.
     # When we drop py26 support there will only be a single version of
     # each package so we can change this back to return package_filenames[0].
-    if IS_PY26:
+    if IS_PY26 or IS_PY33:
         return package_filenames[0]
     else:
         return package_filenames[-1]
@@ -210,7 +213,7 @@ def main():
         shutil.rmtree(working_dir)
 
 
-if IS_PY37:
+if GTE_PY37:
     create_virtualenv = _create_virtualenv_internal
 else:
     create_virtualenv = _create_virtualenv_external

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -43,7 +43,14 @@ BUILDTIME_DEPS = [
     ('setuptools-scm', '1.15.7'),
     ('wheel', '0.29.0')
 ]
-PIP_DOWNLOAD__ARGS = '--no-binary :all:'
+PIP_DOWNLOAD_ARGS = '--no-binary :all:'
+# The constraints file is used to lock the version of dateutils needed
+# to be 2.8.0 until we can drop py26/py33 support.  This lets us put
+# botocore's version range on dateutils to be <3.0.
+CONSTRAINTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'assets', 'constraints-bundled.txt'
+)
 
 
 class BadRCError(Exception):
@@ -87,7 +94,7 @@ def download_package_tarballs(dirname, packages):
     with cd(dirname):
         for package, package_version in packages:
             run('%s -m pip download %s==%s %s' % (
-                sys.executable, package, package_version, PIP_DOWNLOAD__ARGS
+                sys.executable, package, package_version, PIP_DOWNLOAD_ARGS
             ))
 
 
@@ -95,7 +102,8 @@ def download_cli_deps(scratch_dir):
     awscli_dir = os.path.dirname(
         os.path.dirname(os.path.abspath(__file__)))
     with cd(scratch_dir):
-        run('pip download %s %s' % (PIP_DOWNLOAD__ARGS, awscli_dir))
+        run('pip download -c %s %s %s' % (
+            CONSTRAINTS_FILE, PIP_DOWNLOAD_ARGS, awscli_dir))
 
 
 def _remove_cli_zip(scratch_dir):

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -14,33 +14,36 @@ ecosystem.
 """
 import os
 import sys
-import time
 import subprocess
 import shutil
 import tempfile
 import zipfile
 from contextlib import contextmanager
-# These are package versions that are needed to boostrap
-# the installation process.  It is *not* the deps required
-# by awscli/botocore.
-PACKAGE_VERSION = {
-    'virtualenv': '15.1.0',
-    # These packages are included because they are required for
-    # python2.6, but our normal dependency downloading via pip
-    # only works if you use python2.6.  To fix this issue, we're
-    # explicitly saying that we need to download these packages
-    # even if pip doesn't think we need them.  That way we can
-    # run make-bundle in python versions besides 2.6.
-    'PyYAML': '3.13',
-    'ordereddict': '1.1',
-    'simplejson': '3.3.0',
-    'argparse': '1.2.1',
-    'python-dateutil': '2.6.1',
-    'setuptools-scm': '1.15.7',
-    'urllib3': '1.22',
-    'colorama': '0.3.9.',
-}
-INSTALL_ARGS = '--allow-all-external --no-use-wheel'
+
+
+EXTRA_RUNTIME_DEPS = [
+    # Use an up to date virtualenv/pip/setuptools on > 2.6.
+    ('virtualenv', '16.7.8'),
+    # Everything below is for py26 deps.  We can remove this once
+    # we drop py26.
+    ('virtualenv', '15.2.0'),
+    ('PyYAML', '3.13'),
+    ('ordereddict', '1.1'),
+    ('simplejson', '3.3.0'),
+    ('argparse', '1.2.1'),
+    ('python-dateutil', '2.6.1'),
+    ('urllib3', '1.22'),
+    ('colorama', '0.3.9'),
+]
+BUILDTIME_DEPS = [
+    ('setuptools-scm', '3.3.3'),
+    ('wheel', '0.33.6'),
+    # We have to use an older version2 for py26.  We can remove
+    # this when we drop py26 support.
+    ('setuptools-scm', '1.15.7'),
+    ('wheel', '0.29.0')
+]
+PIP_DOWNLOAD__ARGS = '--no-binary :all:'
 
 
 class BadRCError(Exception):
@@ -82,35 +85,17 @@ def create_scratch_dir():
 
 def download_package_tarballs(dirname, packages):
     with cd(dirname):
-        for package in packages:
-            run('%s -m pip install -d . %s==%s %s' % (
-                sys.executable, package, PACKAGE_VERSION[package], INSTALL_ARGS
+        for package, package_version in packages:
+            run('%s -m pip download %s==%s %s' % (
+                sys.executable, package, package_version, PIP_DOWNLOAD__ARGS
             ))
 
 
 def download_cli_deps(scratch_dir):
-    # As far as i can tell this is a bug in pip.
-    # Running 'pip intall -d . ~/clidir' does not work.
-    # Running 'pip install -d foo ~/clidir' results
-    # in python consuming 100% CPU.
-    # This problem is surprisingly hard, specifically that
-    # of downloading all the dependent python packages of
-    # the awscli as tarballs.
-    # So here's what we do.
-    # Step one create a virtualenv.
-    venv_dir = tempfile.mkdtemp()
-    try:
-        run('%s -m virtualenv --no-download  %s' % (sys.executable, venv_dir))
-        pip = os.path.join(venv_dir, 'bin', 'pip')
-        assert os.path.isfile(pip)
-        awscli_dir = os.path.dirname(
-            os.path.dirname(os.path.abspath(__file__)))
-        with cd(scratch_dir):
-            run('%s install %s -d . -e %s' % (pip, INSTALL_ARGS, awscli_dir))
-        # Remove the awscli package, we'll create our own sdist.
-        _remove_cli_zip(scratch_dir)
-    finally:
-        shutil.rmtree(venv_dir)
+    awscli_dir = os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__)))
+    with cd(scratch_dir):
+        run('pip download %s %s' % (PIP_DOWNLOAD__ARGS, awscli_dir))
 
 
 def _remove_cli_zip(scratch_dir):
@@ -183,11 +168,7 @@ def main():
     print("Bundle dir at: %s" % scratch_dir)
     download_package_tarballs(
         package_dir,
-        packages=[
-            'virtualenv', 'ordereddict', 'simplejson',
-            'argparse', 'python-dateutil', 'urllib3',
-            'PyYAML', 'colorama',
-        ]
+        packages=EXTRA_RUNTIME_DEPS,
     )
 
     # Some packages require setup time dependencies, and so we will need to
@@ -198,7 +179,7 @@ def main():
     setup_dir = os.path.join(package_dir, 'setup')
     download_package_tarballs(
         setup_dir,
-        packages=['setuptools-scm']
+        packages=BUILDTIME_DEPS,
     )
     download_cli_deps(package_dir)
     add_cli_sdist(package_dir)


### PR DESCRIPTION
This updates the bundled installer generation to use modern versions of
virtualenv, and as a result, modern versions of pip, setuptools, etc.

Some of these changes may seem unnecessary, but here's why I had
to make all these changes.

The motivation for this change was that we couldn't upgrade our version
of dateutils in botocore because it used new functionality in its
build/install process that required a modern version of setuptools.  The
version we pull in comes from our virtualenv which is a fairly old
version.  So the first thing we had to do was upgrade our version of
virtualenv we use in the bundled installer.

That's where it all begins.

First there's py26 issues, specifically that newer virtualenvs (>=16)
don't support python2.6.  So we have to branch and decide which version
of virtualenv to use based on our python version.  That's not really a
problem because new versions of dateutils don't support py26 anyways so
it doesn't change anything for py26.  We just need to add more branching
to the bundled installer.

Next we have the fact that because we're pulling in a new virtualenv
for > py26, we pull in a new pip.  A new, major version of pip, that is
not backwards compatible with the version we were previously using.
Some of the arguments have been removed.  So we have to update how we're
calling pip.

Next up we have the fact that dateutils uses pep517 as part of its build
process, which is fairly new.  This introduces a few wrinkles for us.
First, it utilizes "isolated builds", which should contain "only the
standard library and any explicitly requested build-dependencies."
Normally this is a good thing, but it's problematic for us because this
is an offline installer and we don't want pip creating a new build
environment for us and downloading dependencies from pypi.  So we have to
disable that feature (that's the `--no-build-isolation`).  Fortunately,
all of dateutils build deps we already have installed in our main
installation venv we create so we're all all set there.

As part of dateutils build process, pip shells out to other processes to
invoke various hooks.  It uses the same virtualenv by using
`sys.executable` when it invokes its python hooks.  Except that there
appears to be a bug, only for py37 as far as I can tell, where
`sys.executable` is wrong and instead of pointing to the virtualenv
python, it instead points to the system python.  As you might expect,
this causes the build/install to fail.  I've filed an issue on the
virtualenv repo to see what they think about it.

Turns out, using the built in `venv` module works as expected, in that
`sys.executable` is correctly set.  But of course `venv` is only
available in py33+.  Which brings us to our next change, conditionally
use `python -m venv` on py3, otherwise fall back to one of the versions
of external `virtualenv` on py26/py27.

This brings us to our final change, `python -m venv` does not install
wheel whereas `virtualenv` does install wheel.  So we need to install
wheel, conditionally, based on python version.

Going forward, there's a few things we should consider:

* py26 is being dropped real soon so a good chunk of this code can be
  removed.
* Once we can ensure we're using a modern version of pip after dropping
  py26, we should try switching to wheels instead of sdists where
  possible.  If a package has a py2/py3 compatible pure python wheel,
  (python-dateutil) we should use that instead of the sdist.  That
  way we can avoid all these build issues and just use the pre-built
  wheel.  I opted not to do that here because I'm sure there's some
  gotcha that I'm not considering.

Verified I could generate a bundled installer that works on py26/py27/py37.
Also bumped the version of dateutils in botocore and verified I could generate
a bundled installer with v2.8.1 through our release process.
I'll send a follow up PR to botocore that bumps the max dateutils version.