### PR TITLE
Remove old S3 authenticaton

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -650,8 +650,8 @@ class PresignCommand(S3Command):
     DESCRIPTION = (
         "Generate a pre-signed URL for an Amazon S3 object. This allows "
         "anyone who receives the pre-signed URL to retrieve the S3 object "
-        "with an HTTP GET request. For sigv4 requests the region needs to be "
-        "configured explicitly."
+        "with an HTTP GET request. All presigned URL's now use sigv4 "
+        "so the region needs to be configured explicitly."
     )
     USAGE = "<S3Uri>"
     ARG_TABLE = [{'name': 'path',

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -88,9 +88,16 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
                 'hostname': 'bucket.s3.amazonaws.com',
                 'path': '/key',
                 'query_params': {
-                    'AWSAccessKeyId': 'access_key',
-                    'Expires': str(FROZEN_TIMESTAMP + DEFAULT_EXPIRES),
-                    'Signature': '2m9M0eLB%2BqI0nUpkyTskKmHd0Ig%3D',
+                    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+                    'X-Amz-Credential': (
+                        'access_key%2F20160818%2Fus-east-1'
+                        '%2Fs3%2Faws4_request'),
+                    'X-Amz-Date': '20160818T143303Z',
+                    'X-Amz-Expires': '3600',
+                    'X-Amz-Signature': (
+                        'd28b6c4a54f31196a6d49335556736a3fc29f036018c8e'
+                        '50775887299092d1a0'),
+                    'X-Amz-SignedHeaders': 'host',
                 }
             }
         )
@@ -104,9 +111,16 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
                 'hostname': 's3.amazonaws.com',
                 'path': '/bucket.dots/key',
                 'query_params': {
-                    'AWSAccessKeyId': 'access_key',
-                    'Expires': str(FROZEN_TIMESTAMP + DEFAULT_EXPIRES),
-                    'Signature': '0IiC2vxub438EVcKfEFEMHuoHRw%3D',
+                    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+                    'X-Amz-Credential': (
+                        'access_key%2F20160818%2Fus-east-1'
+                        '%2Fs3%2Faws4_request'),
+                    'X-Amz-Date': '20160818T143303Z',
+                    'X-Amz-Expires': '3600',
+                    'X-Amz-Signature': (
+                        '8bbbd5a0d492b74048ba0b057b7d012bda6d21ecac3ef'
+                        '005dbcc34a2744922cc'),
+                    'X-Amz-SignedHeaders': 'host',
                 }
             }
         )
@@ -121,9 +135,16 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
                 'hostname': 'bucket.s3.amazonaws.com',
                 'path': '/key',
                 'query_params': {
-                    'AWSAccessKeyId': 'access_key',
-                    'Expires': str(FROZEN_TIMESTAMP + expires_in),
-                    'Signature': 'WZEMcfBNlzfTZBq3bOvYef1cfoU%3D',
+                    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+                    'X-Amz-Credential': (
+                        'access_key%2F20160818%2Fus-east-1'
+                        '%2Fs3%2Faws4_request'),
+                    'X-Amz-Date': '20160818T143303Z',
+                    'X-Amz-Expires': '{}'.format(expires_in),
+                    'X-Amz-Signature': (
+                        '58972912303cabb8ce4c9f49cb65e9ef61e72cfded805e'
+                        '87d8004592f5d4cf79'),
+                    'X-Amz-SignedHeaders': 'host',
                 }
             }
         )
@@ -162,9 +183,16 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
                 'hostname': 'bucket.s3.amazonaws.com',
                 'path': '/key',
                 'query_params': {
-                    'AWSAccessKeyId': 'access_key',
-                    'Expires': str(FROZEN_TIMESTAMP + DEFAULT_EXPIRES),
-                    'Signature': '2m9M0eLB%2BqI0nUpkyTskKmHd0Ig%3D',
+                    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+                    'X-Amz-Credential': (
+                        'access_key%2F20160818%2Fus-east-1'
+                        '%2Fs3%2Faws4_request'),
+                    'X-Amz-Date': '20160818T143303Z',
+                    'X-Amz-Expires': '3600',
+                    'X-Amz-Signature': (
+                        'd28b6c4a54f31196a6d49335556736a3fc29f036018c8e'
+                        '50775887299092d1a0'),
+                    'X-Amz-SignedHeaders': 'host',
                 }
             }
         )
@@ -179,9 +207,16 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
                 'hostname': 's3.amazonaws.com',
                 'path': '/bucket/key',
                 'query_params': {
-                    'AWSAccessKeyId': 'access_key',
-                    'Expires': str(FROZEN_TIMESTAMP + DEFAULT_EXPIRES),
-                    'Signature': '2m9M0eLB%2BqI0nUpkyTskKmHd0Ig%3D',
+                    'X-Amz-Algorithm': 'AWS4-HMAC-SHA256',
+                    'X-Amz-Credential': (
+                        'access_key%2F20160818%2Fus-east-1'
+                        '%2Fs3%2Faws4_request'),
+                    'X-Amz-Date': '20160818T143303Z',
+                    'X-Amz-Expires': '3600',
+                    'X-Amz-Signature': (
+                        'd20178280d7521b384730c678549f6344401ae040bec55'
+                        '9ad06020854c6c718f'),
+                    'X-Amz-SignedHeaders': 'host',
                 }
             }
         )


### PR DESCRIPTION
Updating to support https://github.com/boto/botocore/pull/1912 which removes_ old s3 authorization.  This PR won't build clean until that PR is merged.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
