### PR TITLE
Fix issue 3131: checksum on folder content rather than zip file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ mock==1.3.0
 # remove this upper bound on the wheel version once 2.6 support
 # is dropped from aws-cli
 wheel>0.24.0,<0.30.0
+checksumdir>=1.1.7


### PR DESCRIPTION
*Issue #3131 *

*Description of changes:*
Currently aws cloudformation package generates a zip archive containing the entire function code and dependencies and, after creating the zip archive computes the checksum of the zip and uses this value for the artifact name.
This implies that, when using dependencies into build, each time you build your code dependencies get downloaded and included in the zip file, the checksum computed on the zip file changes every time as the checksum of the zip includes file extended attributes (mtime and ctime) and dependencies files are always freshly installed.
The resulting checksum is different and the resulting cloudformation template contains a new artifact url and causes the function to be re-deployed even if there is no actual change in any of the code or dependencies file.

The changes computes the checksum on the entire folder content **before** creating the zip, this implies that the checksum represents the actual content of each function including dependencies.
Therefore this changes allows to trigger a function deployment only when there is an actual change in the code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
