### PR TITLE
Document memberless outputs the same as no output

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -487,7 +487,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         doc.style.h2('Output')
         operation_model = help_command.obj
         output_shape = operation_model.output_shape
-        if output_shape is None:
+        if output_shape is None or not output_shape.members:
             doc.write('None')
         else:
             for member_name, member_shape in output_shape.members.items():

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -105,6 +105,29 @@ class TestRecursiveShapes(unittest.TestCase):
             'arg-name', self.help_command, 'process-cli-arg.foo.bar')
         self.assert_proper_indentation()
 
+    def test_handle_no_output_shape(self):
+        operation_model = mock.Mock()
+        operation_model.output_shape = None
+        self.help_command.obj = operation_model
+        self.operation_handler.doc_output(self.help_command, 'event-name')
+        self.assert_rendered_docs_contain('None')
+
+    def test_handle_memberless_output_shape(self):
+        shape_map = {
+            'NoMembers': {
+                'type': 'structure',
+                'members': {}
+            }
+        }
+        shape = StructureShape('NoMembers', shape_map['NoMembers'],
+                               ShapeResolver(shape_map))
+
+        operation_model = mock.Mock()
+        operation_model.output_shape = shape
+        self.help_command.obj = operation_model
+        self.operation_handler.doc_output(self.help_command, 'event-name')
+        self.assert_rendered_docs_contain('None')
+
 
 class TestCLIDocumentEventHandler(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Currently, if an operation has an output shape that has no members we print the output header but nothing in the contents which looks weird. A member-less output shape produces the same output as no output shape. This updates the documentation logic to document them as the same.