### PR TITLE
Fix issue in validate logs command when s3 bucket is specified

### DIFF
--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -134,12 +134,15 @@ def create_digest_traverser(cloudtrail_client, organization_client,
                     "trail: '--account-id'")
             organization_id = organization_client.describe_organization()[
                 'Organization']['Id']
-        if not account_id:
-            account_id = get_account_id_from_arn(trail_arn)
+
     # Determine the region from the ARN (e.g., arn:aws:cloudtrail:REGION:...)
     trail_region = trail_arn.split(':')[3]
     # Determine the name from the ARN (the last part after "/")
     trail_name = trail_arn.split('/')[-1]
+    # If account id is not specified parse it from trail ARN
+    if not account_id:
+        account_id = get_account_id_from_arn(trail_arn)
+
     digest_provider = DigestProvider(
         account_id=account_id, trail_name=trail_name,
         s3_client_provider=s3_client_provider,

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -265,6 +265,21 @@ class TestValidation(unittest.TestCase):
         digest_provider = traverser.digest_provider
         self.assertEqual('us-east-1', digest_provider.trail_home_region)
         self.assertEqual('foo', digest_provider.trail_name)
+        self.assertEqual(TEST_ACCOUNT_ID, digest_provider.account_id)
+
+    def test_creates_traverser_and_gets_trail_by_arn_s3_bucket_specified(self):
+        cloudtrail_client = Mock()
+        traverser = create_digest_traverser(
+            trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+            cloudtrail_client=cloudtrail_client,
+            organization_client=Mock(),
+            s3_client_provider=Mock(),
+            bucket="bucket")
+        self.assertEqual('bucket', traverser.starting_bucket)
+        digest_provider = traverser.digest_provider
+        self.assertEqual('us-east-1', digest_provider.trail_home_region)
+        self.assertEqual('foo', digest_provider.trail_name)
+        self.assertEqual(TEST_ACCOUNT_ID, digest_provider.account_id)
 
     def test_creates_traverser_and_gets_organization_id(self):
         cloudtrail_client = Mock()


### PR DESCRIPTION
When the S3 bucket is specified and account id is not specified in the
CLI params, the account id is not being parsed from the trail ARN.
This is causing the account id to be set as None causing an Exception.
