### PR TITLE
Fix bug in output pager

### DIFF
--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -279,8 +279,8 @@ class OutputStreamFactory(object):
         if not preferred_pager:
             preferred_pager = self._get_configured_pager()
         popen_kwargs = self._get_process_pager_kwargs(preferred_pager)
+        process = self._popen(**popen_kwargs)
         try:
-            process = self._popen(**popen_kwargs)
             yield process.stdin
         except IOError:
             # Ignore IOError since this can commonly be raised when a pager

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -142,6 +142,10 @@ class MockProcess(object):
         pass
 
 
+class PopenException(Exception):
+    pass
+
+
 class TestOutputStreamFactory(unittest.TestCase):
     def setUp(self):
         self.session = mock.Mock(session.Session)
@@ -198,6 +202,12 @@ class TestOutputStreamFactory(unittest.TestCase):
             pass
         returned_process = self.popen.return_value
         self.assertTrue(returned_process.communicate.called)
+
+    def test_propagates_exception_from_popen(self):
+        self.popen.side_effect = PopenException
+        with self.assertRaises(PopenException):
+            with self.stream_factory.get_pager_stream():
+                pass
 
     @mock.patch('awscli.utils.get_stdout_text_writer')
     def test_stdout(self, mock_stdout_writer):


### PR DESCRIPTION
Was referencing a variable before declaration, thus swallowing what the actually error might have been.

Fixes https://github.com/aws/aws-cli/issues/4758
