### PR TITLE
Add a newline between AWS profiles

### DIFF
--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -68,7 +68,7 @@ class ConfigFileWriter(object):
             self._write_new_section(section_name, new_values, config_filename)
 
     def _create_file(self, config_filename):
-        # Create the file as well as the parent dir if needed.
+        """Create the file as well as the parent dir if needed."""
         dirname = os.path.split(config_filename)[0]
         if not os.path.isdir(dirname):
             os.makedirs(dirname)
@@ -78,6 +78,8 @@ class ConfigFileWriter(object):
 
     def _write_new_section(self, section_name, new_values, config_filename):
         with open(config_filename, 'a') as f:
+            if f.tell() != 0:
+                f.write('\n')
             f.write('[%s]\n' % section_name)
             contents = []
             self._insert_new_values(line_number=0,

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -131,7 +131,7 @@ class TestConfigFileWriter(unittest.TestCase):
         self.assert_update_config(
             '\n',
             {'foo': 'value'},
-            '\n[default]\nfoo = value\n')
+            '\n\n[default]\nfoo = value\n')
 
     def test_section_does_not_exist(self):
         original_contents = (
@@ -152,7 +152,7 @@ class TestConfigFileWriter(unittest.TestCase):
         self.assert_update_config(
             original_contents,
             {'foo': 'value'},
-            original_contents + appended_contents)
+            original_contents + '\n' + appended_contents)
 
     def test_config_file_does_not_exist(self):
         self.writer.update_config({'foo': 'value'}, self.config_filename)


### PR DESCRIPTION
*Description of changes:*
`aws configure --profile <new_profile_name> ...` does not add spaces between different profile names which makes it hard to read if multiple profiles exist on file. Adding a newline between section makes the file more readable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
