### PR TITLE
Fix dynamodb pagination bug for query and scan

### DIFF
--- a/.changes/next-release/bugfix-dynamodb-60129.json
+++ b/.changes/next-release/bugfix-dynamodb-60129.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "dynamodb",
+  "description": "Fixed an issue that could cause paginated scans and queries to not fetch the complete list of results on tables with a binary primary key."
+}

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -506,7 +506,8 @@ class ServiceOperation(object):
             event,
             call_parameters=call_parameters,
             parsed_args=parsed_args,
-            parsed_globals=parsed_globals
+            parsed_globals=parsed_globals,
+            session=self._session,
         )
         # There are two possible values for override. It can be some type
         # of exception that will be raised if detected or it can represent

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -506,8 +506,7 @@ class ServiceOperation(object):
             event,
             call_parameters=call_parameters,
             parsed_args=parsed_args,
-            parsed_globals=parsed_globals,
-            session=self._session,
+            parsed_globals=parsed_globals
         )
         # There are two possible values for override. It can be some type
         # of exception that will be raised if detected or it can represent

--- a/awscli/customizations/dynamodb.py
+++ b/awscli/customizations/dynamodb.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import base64
+import binascii
+import logging
+
+from awscli.compat import six
+
+logger = logging.getLogger(__name__)
+
+
+def register_dynamodb_paginator_fix(event_emitter):
+    event_emitter.register(
+        'calling-command.dynamodb.*', _maybe_register_pagination_fix
+    )
+
+
+def _maybe_register_pagination_fix(parsed_globals, session, **kwargs):
+    if parsed_globals.paginate:
+        session.register(
+            'after-call.dynamodb.*', parse_last_evaluated_key_binary
+        )
+
+
+def parse_last_evaluated_key_binary(parsed, **kwargs):
+    # Because we disable parsing blobs into a binary type and leave them as
+    # a base64 string if a binary field is present in the continuation token
+    # as is the case with dynamodb the binary will be double encoded. This
+    # ensures that the continuation token is properly converted to binary to
+    # avoid double encoding the contination token.
+    last_evaluated_key = parsed.get('LastEvaluatedKey', None)
+    if last_evaluated_key is None:
+        return
+    for key, val in last_evaluated_key.items():
+        if 'B' in val:
+            try:
+                val['B'] = base64.b64decode(val['B'])
+            except (binascii.Error, TypeError):
+                logger.debug('Failed to base64 decode potential binary')

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -87,6 +87,7 @@ from awscli.customizations.servicecatalog import register_servicecatalog_command
 from awscli.customizations.s3events import register_event_stream_arg
 from awscli.customizations.sessionmanager import register_ssm_session
 from awscli.customizations.sms_voice import register_sms_voice_hide
+from awscli.customizations.dynamodb import register_dynamodb_paginator_fix
 
 
 def awscli_initialize(event_handlers):
@@ -176,3 +177,4 @@ def awscli_initialize(event_handlers):
     dlm_initialize(event_handlers)
     register_ssm_session(event_handlers)
     register_sms_voice_hide(event_handlers)
+    register_dynamodb_paginator_fix(event_handlers)

--- a/tests/functional/dynamodb/test_pagination.py
+++ b/tests/functional/dynamodb/test_pagination.py
@@ -1,0 +1,49 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import json
+
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestPagination(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestPagination, self).setUp()
+        self.first_response = {
+            "Items": [{"Key": {"B": "MjEzNw=="}}],
+            "Count": 1,
+            "ScannedCount": 1,
+            "ConsumedCapacity": 1,
+            "LastEvaluatedKey": {"Key": {"B":"MjEzNw=="}}
+        }
+        self.second_response = {
+            "Items": [],
+            "Count": 0,
+            "ScannedCount": 1,
+            "ConsumedCapacity": 1
+        }
+
+    def test_scan_pagination_binary_last_evaluated_key(self):
+        self.parsed_responses = [self.first_response, self.second_response]
+        self.run_cmd('dynamodb scan --table-name test', expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2)
+        # The start key in the second request should have been parsed to binary
+        sent_start_key = self.operations_called[1][1].get('ExclusiveStartKey')
+        expected_start_key = {"Key": {"B": b'2137'}}
+        self.assertEqual(sent_start_key, expected_start_key)
+
+    def test_pagination_disabled_works(self):
+        self.parsed_responses = [self.first_response]
+        cmd = 'dynamodb scan --table-name table --no-paginate --output json'
+        stdout, _, _ = self.run_cmd(cmd, expected_rc=0)
+        # Ensure the base64 encoded last evaluated key is in stdout
+        self.assertIn('"MjEzNw=="', stdout)

--- a/tests/unit/customizations/test_dynamodb.py
+++ b/tests/unit/customizations/test_dynamodb.py
@@ -32,14 +32,8 @@ class TestParseLastEvaluatedKeyBinary(unittest.TestCase):
     def test_parses_binary_key(self):
         self.assert_parsed_output({'B': 'Zm9v'}, {'B': b'foo'})
 
-    def test_ignores_already_parsed_binary(self):
-        self.assert_parsed_output({'B': b'foo'}, {'B': b'foo'})
-
     def test_ignores_strings(self):
         self.assert_parsed_output({'S': 'Zm9v'}, {'S': 'Zm9v'})
 
     def test_ignores_numbers(self):
         self.assert_parsed_output({'N': 2}, {'N': 2})
-
-    def test_gracefully_handles_invalid_base64(self):
-        self.assert_parsed_output({'B': 'notb64'}, {'B': 'notb64'})

--- a/tests/unit/customizations/test_dynamodb.py
+++ b/tests/unit/customizations/test_dynamodb.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.customizations.dynamodb import parse_last_evaluated_key_binary
+
+
+class TestParseLastEvaluatedKeyBinary(unittest.TestCase):
+    def assert_parsed_output(self, last_key_value, expected_output):
+        parsed = {
+            'LastEvaluatedKey': {
+                'FooKeyName': last_key_value,
+            }
+        }
+        parse_last_evaluated_key_binary(parsed=parsed)
+        self.assertEqual(last_key_value, expected_output)
+
+    def test_ignores_response_without_last_evaluated_key(self):
+        parsed = {'Items': []}
+        parse_last_evaluated_key_binary(parsed=parsed)
+        self.assertEqual(parsed, {'Items': []})
+
+    def test_parses_binary_key(self):
+        self.assert_parsed_output({'B': 'Zm9v'}, {'B': b'foo'})
+
+    def test_ignores_already_parsed_binary(self):
+        self.assert_parsed_output({'B': b'foo'}, {'B': b'foo'})
+
+    def test_ignores_strings(self):
+        self.assert_parsed_output({'S': 'Zm9v'}, {'S': 'Zm9v'})
+
+    def test_ignores_numbers(self):
+        self.assert_parsed_output({'N': 2}, {'N': 2})
+
+    def test_gracefully_handles_invalid_base64(self):
+        self.assert_parsed_output({'B': 'notb64'}, {'B': 'notb64'})


### PR DESCRIPTION
If the last evaluated key returned contained a binary primary key
subsequent requests would incorrectly double encode this field when
providing it as the exclusive start key leading to inconsistent or
incomplete pagination results.