### PR TITLE
[v2] Cloudformation default no fail

### DIFF
--- a/.changes/next-release/enhancment-cloudformation-66951.json
+++ b/.changes/next-release/enhancment-cloudformation-66951.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancment",
+  "category": "cloudformation",
+  "description": "Changes the default of cloudformation deploy to not fail on an empty changeset."
+}

--- a/.changes/next-release/enhancment-cloudformation-66951.json
+++ b/.changes/next-release/enhancment-cloudformation-66951.json
@@ -1,5 +1,0 @@
-{
-  "type": "enhancment",
-  "category": "cloudformation",
-  "description": "Changes the default of cloudformation deploy to not fail on an empty changeset."
-}

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -198,11 +198,11 @@ class DeployCommand(BasicCommand):
             'action': 'store_true',
             'group_name': 'fail-on-empty-changeset',
             'dest': 'fail_on_empty_changeset',
-            'default': True,
+            'default': False,
             'help_text': (
                 'Specify if the CLI should return a non-zero exit code if '
                 'there are no changes to be made to the stack. The default '
-                'behavior is to return a non-zero exit code.'
+                'behavior is to return a zero exit code.'
             )
         },
         {
@@ -211,7 +211,7 @@ class DeployCommand(BasicCommand):
             'action': 'store_false',
             'group_name': 'fail-on-empty-changeset',
             'dest': 'fail_on_empty_changeset',
-            'default': True,
+            'default': False,
             'help_text': (
                 'Causes the CLI to return an exit code of 0 if there are no '
                 'changes to be made to the stack.'
@@ -297,7 +297,7 @@ class DeployCommand(BasicCommand):
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
                notification_arns, s3_uploader, tags,
-               fail_on_empty_changeset=True):
+               fail_on_empty_changeset=False):
         try:
             result = deployer.create_and_wait_for_changeset(
                 stack_name=stack_name,
@@ -382,6 +382,3 @@ class DeployCommand(BasicCommand):
             result[key_value_pair[0]] = key_value_pair[1]
 
         return result
-
-
-

--- a/tests/functional/cloudformation/test_deploy.py
+++ b/tests/functional/cloudformation/test_deploy.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import FileCreator
+
+
+class TestDeployCommand(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestDeployCommand, self).setUp()
+        self.files = FileCreator()
+        self.parsed_responses = [
+            # First it checks to see if a stack with that name exists. So
+            # we fake a response indicating that the stack exists and is in
+            # an OK state.
+            {'Stacks': {'StackName': 'Stack',
+                        'StackStatus': 'UPDATE_COMPLETE'}},
+            # Now it creates a changeset, so we fake a response with an ID.
+            {'Id': 'FakeChangeSetId'},
+            # This fakes a failed response from the waiter because the
+            # changeset was empty.
+            {
+                'StackName': 'Stack',
+                'Status': 'FAILED',
+                'StatusReason': (
+                    'The submitted information didn\'t contain changes. '
+                    'Submit different information to create a change set.'
+                ),
+                'ExecutionStatus': 'UNAVAILABLE'
+            },
+        ]
+        # The template is inspected before we make any of the calls so it
+        # needs to have valid JSON content.
+        path = self.files.create_file('template.json', '{}')
+        self.command = (
+            'cloudformation deploy --template-file %s '
+            '--stack-name Stack'
+        ) % path
+
+    def tearDown(self):
+        self.files.remove_all()
+        super(TestDeployCommand, self).tearDown()
+
+    def test_does_return_zero_exit_code_on_empty_changeset_by_default(self):
+        self.run_cmd(self.command, expected_rc=0)
+
+    def test_does_return_zero_exit_code_on_empty_changeset(self):
+        self.command += ' --no-fail-on-empty-changeset'
+        self.run_cmd(self.command, expected_rc=0)
+
+    def test_does_return_non_zero_exit_code_on_empty_changeset(self):
+        self.command += ' --fail-on-empty-changeset'
+        self.run_cmd(self.command, expected_rc=255)

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -344,7 +344,7 @@ class TestDeployCommand(unittest.TestCase):
             self.deploy_command.deploy(
                 self.deployer, stack_name, template, parameters, capabilities,
                 execute_changeset, role_arn, notification_arns,
-                None, tags)
+                None, tags, fail_on_empty_changeset=True)
 
     def test_deploy_does_not_raise_exception_on_empty_changeset(self):
         stack_name = "stack_name"
@@ -363,6 +363,24 @@ class TestDeployCommand(unittest.TestCase):
             execute_changeset, role_arn, notification_arns,
             s3_uploader=None, tags=[],
             fail_on_empty_changeset=False
+        )
+
+    def test_deploy_empty_changeset_does_not_raise_exception_by_default(self):
+        stack_name = "stack_name"
+        parameters = ["a", "b"]
+        template = "cloudformation template"
+        capabilities = ["foo", "bar"]
+        execute_changeset = True
+        role_arn = "arn:aws:iam::1234567890:role"
+        notification_arns = ["arn:aws:sns:region:1234567890:notify"]
+
+        empty_changeset = exceptions.ChangeEmptyError(stack_name=stack_name)
+        changeset_func = self.deployer.create_and_wait_for_changeset
+        changeset_func.side_effect = empty_changeset
+        self.deploy_command.deploy(
+            self.deployer, stack_name, template, parameters, capabilities,
+            execute_changeset, role_arn, notification_arns,
+            s3_uploader=None, tags=[]
         )
 
     def test_parse_key_value_arg_success(self):


### PR DESCRIPTION
Update cloudformation deploy default to not fail on empty changeset

Existing Tests were updated to be explicit about what their changeset
failure argument was and an additional test was added for the default case.

