### PR TITLE
[v2] Support cli_legacy_plugin_path

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -81,7 +81,8 @@ def main():
 def create_clidriver():
     session = botocore.session.Session()
     _set_user_agent_for_session(session)
-    _load_plugins(session)
+    load_plugins(session.full_config.get('plugins', {}),
+                 event_hooks=session.get_component('event_emitter'))
     driver = CLIDriver(session=session)
     return driver
 
@@ -90,18 +91,6 @@ def _set_user_agent_for_session(session):
     session.user_agent_name = 'aws-cli'
     session.user_agent_version = __version__
     session.user_agent_extra = 'botocore/%s' % botocore_version
-
-
-def _load_plugins(session):
-    if 'plugins' in session.full_config:
-        # V2 currently does not support plugins as external modules cannot
-        # be loaded directly from the v2 executables we generate. We eventually
-        # want to figure out how to support plugins in the future.
-        LOG.debug(
-            '[plugins] section is not currently supported. Not loading '
-            'plugins.'
-        )
-    load_plugins({}, event_hooks=session.get_component('event_emitter'))
 
 
 class CLIDriver(object):

--- a/awscli/plugin.py
+++ b/awscli/plugin.py
@@ -55,7 +55,14 @@ def load_plugins(plugin_mapping, event_hooks=None, include_builtins=True):
 
 def _import_plugins(plugin_mapping):
     plugins = []
-    _handle_legacy_plugin_paths(plugin_mapping)
+    plugin_path = plugin_mapping.pop(CLI_LEGACY_PLUGIN_PATH, None)
+    if plugin_path is None:
+        log.debug(
+            "cli_legacy_plugin_path not defined in plugin section. Not "
+            "importing additional plugins."
+        )
+        return plugins
+    _add_plugin_path_to_sys_path(plugin_path)
     for name, path in plugin_mapping.items():
         log.debug("Importing plugin %s: %s", name, path)
         if '.' not in path:
@@ -67,11 +74,8 @@ def _import_plugins(plugin_mapping):
     return plugins
 
 
-def _handle_legacy_plugin_paths(plugin_mapping):
-    if CLI_LEGACY_PLUGIN_PATH not in plugin_mapping:
-        return
-    values = plugin_mapping.pop(CLI_LEGACY_PLUGIN_PATH)
-    for dirname in values.split(os.pathsep):
+def _add_plugin_path_to_sys_path(plugin_path):
+    for dirname in plugin_path.split(os.pathsep):
         log.debug("Adding additional path from cli_legacy_plugin_path "
                   "configuration: %s", dirname)
         sys.path.append(dirname)

--- a/exe/pyinstaller/hook-awscli.py
+++ b/exe/pyinstaller/hook-awscli.py
@@ -11,6 +11,10 @@ hiddenimports = [
     'pipes',
     'colorama',
     'awscli.handlers',
+    # NOTE: This can be removed once this hidden import issue related to
+    # setuptools and PyInstaller is resolved:
+    # https://github.com/pypa/setuptools/issues/1963
+    'pkg_resources.py2_warn'
 ]
 
 imports_for_legacy_plugins = (

--- a/exe/pyinstaller/hook-awscli.py
+++ b/exe/pyinstaller/hook-awscli.py
@@ -1,7 +1,23 @@
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils import hooks
 
-hiddenimports = ['docutils', 'urllib', 'httplib', 'html.parser',
-                 'configparser', 'xml.etree', 'pipes', 'colorama',
-                 'awscli.handlers']
-datas = collect_data_files('awscli')
 
+hiddenimports = [
+    'docutils',
+    'urllib',
+    'httplib',
+    'html.parser',
+    'configparser',
+    'xml.etree',
+    'pipes',
+    'colorama',
+    'awscli.handlers',
+]
+
+imports_for_legacy_plugins = (
+    hooks.collect_submodules('http') +
+    hooks.collect_submodules('logging')
+)
+
+hiddenimports += imports_for_legacy_plugins
+
+datas = hooks.collect_data_files('awscli')

--- a/tests/functional/add_awscli_cmd_plugin.py
+++ b/tests/functional/add_awscli_cmd_plugin.py
@@ -14,10 +14,10 @@ from awscli.customizations.commands import BasicCommand
 
 
 def awscli_initialize(event_emitter):
-    event_emitter.register('building-command-table.main', add_plugin_test_cmd)
+    event_emitter.register('building-command-table.main', add_plugin_cmd)
 
 
-def add_plugin_test_cmd(command_table, session, **kwargs):
+def add_plugin_cmd(command_table, session, **kwargs):
     command_table['plugin-test-cmd'] = PluginTestCommand(session)
 
 

--- a/tests/functional/add_awscli_test_cmd_plugin.py
+++ b/tests/functional/add_awscli_test_cmd_plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -10,9 +10,17 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-class PluginsNotSupportedError(Exception):
-    pass
+from awscli.customizations.commands import BasicCommand
 
 
 def awscli_initialize(event_emitter):
-    raise PluginsNotSupportedError()
+    event_emitter.register('building-command-table.main', add_plugin_test_cmd)
+
+
+def add_plugin_test_cmd(command_table, session, **kwargs):
+    command_table['plugin-test-cmd'] = PluginTestCommand(session)
+
+
+class PluginTestCommand(BasicCommand):
+    def _run_main(self, parsed_args, parsed_globals):
+        return 0

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -10,11 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
 import re
+import shutil
 import functools
 
 from tests import RawResponse
-from tests.functional.raise_plugin_error import PluginsNotSupportedError
 
 import mock
 
@@ -79,29 +80,61 @@ class TestSession(BaseCLIDriverTest):
 class TestPlugins(BaseCLIDriverTest):
     def setUp(self):
         super(TestPlugins, self).setUp()
-        self._raise_plugin_error_module = '.'.join(
-            ['tests', 'functional', 'raise_plugin_error']
-        )
         self.files = FileCreator()
+        self.plugins_site_packages = os.path.join(
+            self.files.rootdir, 'site-packages'
+        )
+        self.plugin_module_name = 'add_awscli_test_cmd_plugin'
+        self.plugin_filename = os.path.join(
+            os.path.dirname(__file__), self.plugin_module_name) + '.py'
+        self.setup_plugin_site_packages()
+
+    def setup_plugin_site_packages(self):
+        os.makedirs(self.plugins_site_packages)
+        shutil.copy(self.plugin_filename, self.plugins_site_packages)
 
     def tearDown(self):
         super(TestPlugins, self).setUp()
         self.files.remove_all()
 
-    def create_config_with_plugin(self, plugin_module):
-        config_contents = (
-            '[plugins]\n'
-            'myplugin = %s\n' % plugin_module
-        )
+    def assert_plugin_loaded(self, clidriver):
+        self.assertIn('plugin-test-cmd', clidriver.subcommand_table)
+
+    def assert_plugin_not_loaded(self, clidriver):
+        self.assertNotIn('plugin-test-cmd', clidriver.subcommand_table)
+
+    def create_config(self, config_contents):
         config_file = self.files.create_file('config', config_contents)
         self.environ['AWS_CONFIG_FILE'] = config_file
 
-    def test_plugins_are_not_loaded(self):
-        self.create_config_with_plugin(self._raise_plugin_error_module)
-        try:
-            create_clidriver()
-        except PluginsNotSupportedError:
-            self.fail(
-                'plugin %s should not have been loaded' %
-                self._raise_plugin_error_module
-            )
+    def test_plugins_loaded_from_specified_path(self):
+        self.create_config(
+            '[plugins]\n'
+            'cli_legacy_plugin_path = %s\n'
+            'myplugin = %s\n' % (
+                self.plugins_site_packages, self.plugin_module_name)
+        )
+        clidriver = create_clidriver()
+        self.assert_plugin_loaded(clidriver)
+
+    def test_plugins_are_not_loaded_when_path_specified(self):
+        self.create_config(
+            '[plugins]\n'
+            'myplugin = %s\n' % self.plugin_module_name
+        )
+        clidriver = create_clidriver()
+        self.assert_plugin_not_loaded(clidriver)
+
+    def test_looks_in_all_specified_paths(self):
+        nonexistent_dir = os.path.join(
+            self.files.rootdir, 'no-exist'
+        )
+        plugin_path = os.pathsep.join(
+            [nonexistent_dir, self.plugins_site_packages])
+        self.create_config(
+            '[plugins]\n'
+            'cli_legacy_plugin_path = %s\n'
+            'myplugin = %s\n' % (plugin_path, self.plugin_module_name)
+        )
+        clidriver = create_clidriver()
+        self.assert_plugin_loaded(clidriver)

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -84,7 +84,7 @@ class TestPlugins(BaseCLIDriverTest):
         self.plugins_site_packages = os.path.join(
             self.files.rootdir, 'site-packages'
         )
-        self.plugin_module_name = 'add_awscli_test_cmd_plugin'
+        self.plugin_module_name = 'add_awscli_cmd_plugin'
         self.plugin_filename = os.path.join(
             os.path.dirname(__file__), self.plugin_module_name) + '.py'
         self.setup_plugin_site_packages()
@@ -94,7 +94,7 @@ class TestPlugins(BaseCLIDriverTest):
         shutil.copy(self.plugin_filename, self.plugins_site_packages)
 
     def tearDown(self):
-        super(TestPlugins, self).setUp()
+        super(TestPlugins, self).tearDown()
         self.files.remove_all()
 
     def assert_plugin_loaded(self, clidriver):


### PR DESCRIPTION
This allows users to use v1 plugins when migrating to v2. To do this you need to specify a `cli_legacy_plugin_path` in the `plugins` section of the config file:
```
[plugins]
cli_legacy_plugin_path=/Users/kyleknap/.pyenv/versions/cli-plugins/lib/python3.7/site-packages/
endpoint = awscli_plugin_endpoint
```
There are a few caveats though in using this:

* V1 plugins will not be automatically supported in v2. You must specify the `cli_legacy_plugin_path` path.
* This purpose of this functionality is merely to ease migrating to v2. Once v2 has a better plugin story, it is expected CLI plugins start to use the new interface and support for plugins using the `cli_legacy_plugin_path` will be limited.
* The plugin will rely on the Python runtime bundled into the CLI executable. So the plugin needs to be relying on that Python version. Furthermore, there is no guarantee that a particular plugin will continue to work if a plugin updated its dependencies or if a user updated their version of the CLI.
