### PR TITLE
help config-vars: render groff tables

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -109,7 +109,7 @@ class PosixHelpRenderer(PagingHelpRenderer):
         man_contents = publish_string(contents, writer=manpage.Writer())
         if not self._exists_on_path('groff'):
             raise ExecutableNotFoundError('groff')
-        cmdline = ['groff', '-m', 'man', '-T', 'ascii']
+        cmdline = ['groff', '-m', 'man', '-T', 'ascii', '-t']
         LOG.debug("Running command: %s", cmdline)
         p3 = self._popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         groff_output = p3.communicate(input=man_contents)[0]


### PR DESCRIPTION
Fix missing `-t` flag to groff(1), to ask it to pre-process with tbl(1), which handles tables.  Needed for `aws help config-vars` at the very least.