### PR TITLE
Fix collections.abc imports for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,16 @@ matrix:
   include:
     - python: 2.7
       dist: trusty
-      sudo: false
     - python: 3.4
       dist: trusty
-      sudo: false
     - python: 3.5
       dist: trusty
-      sudo: false
     - python: 3.6
       dist: trusty
-      sudo: false
     - python: 3.7
       dist: xenial
-      sudo: true
     - python: 3.8
       dist: xenial
-      sudo: true
 
 before_install:
   - if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -16,7 +16,7 @@ import json
 import datetime
 import threading
 import logging
-from collections import MutableMapping
+from awscli.compat import collections_abc
 
 from botocore.history import BaseHistoryHandler
 
@@ -119,7 +119,7 @@ class PayloadSerializer(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, datetime.datetime):
             return self._encode_datetime(obj)
-        elif isinstance(obj, MutableMapping):
+        elif isinstance(obj, collections_abc.MutableMapping):
             return self._encode_mutable_mapping(obj)
         elif isinstance(obj, binary_type):
             # In PY3 the bytes type differs from the str type so the default

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,8 @@
-from collections import MutableMapping
-from collections import Mapping
+from awscli.compat import collections_abc
 
 
 # CaseInsensitiveDict from requests that must be serializble.
-class CaseInsensitiveDict(MutableMapping):
+class CaseInsensitiveDict(collections_abc.MutableMapping):
     def __init__(self, data=None, **kwargs):
         self._store = dict()
         if data is None:
@@ -36,7 +35,7 @@ class CaseInsensitiveDict(MutableMapping):
         )
 
     def __eq__(self, other):
-        if isinstance(other, Mapping):
+        if isinstance(other, collections_abc.Mapping):
             other = CaseInsensitiveDict(other)
         else:
             return NotImplemented


### PR DESCRIPTION
*Issue #, if available:* Fixes https://github.com/aws/aws-cli/issues/4853.

*Description of changes:*

This was emitting deprecation warning from Python 3.4 and it will stop working in Python 3.9. Reference: [python/cpython#10596](https://github.com/python/cpython/pull/10596). There is already awscli/compat.py so import ABCs from `collections_abc` that has Python 2 and 3 compatibility.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

And a heads up: you'll need to migrate off of Nose for testing, it's unmaintained and doesn't support Python 3.9: https://github.com/nose-devs/nose/issues/1099. I'd recommend pytest.