### PR TITLE
Update customization to not use pyyaml

### DIFF
--- a/awscli/customizations/ecs/filehelpers.py
+++ b/awscli/customizations/ecs/filehelpers.py
@@ -10,9 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
 import json
-import yaml
+import ruamel.yaml as yaml
 
 from awscli.customizations.ecs import exceptions
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ mock==1.3.0
 cryptography>=2.8.0,<=2.9.0
 wheel==0.24.0
 ruamel.yaml>=0.15.0,<0.16.0
-# TODO: Remove this once we update all customizations to not rely on pyyaml.
-PyYAML>=3.10,<5.2
 jsonschema==2.5.1
 PyInstaller==3.5
 https://github.com/boto/botocore/zipball/v2#egg=botocore

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ requires-dist =
         colorama>=0.2.5,<0.4.2
         docutils>=0.10,<0.16
         cryptography>=2.8.0,<=2.9.0
-        PyYAML>=3.10,<5.2
         ruamel.yaml>=0.15.0,<0.16.0
         s3transfer>=0.3.0,<0.4.0
         prompt-toolkit>=2.0.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ requires = ['botocore==2.0.0dev2',
             'docutils>=0.10',
             'cryptography>=2.8.0,<=2.9.0',
             's3transfer>=0.3.0,<0.4.0',
-            'PyYAML>=3.10,<5.2',
             'ruamel.yaml>=0.15.0,<0.16.0',
             'prompt-toolkit>=2.0.0,<3.0.0',
             ]


### PR DESCRIPTION
This lets us remove pyyaml entirely as a dep.

Testing:

* Created a fresh virtualenv.
* Installed deps
* Verified pyyaml isn't installed.
* Verified tests pass.