### PR TITLE
Use service id for botocore events and service name for cli events

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -245,7 +245,7 @@ def _is_complex_shape(model):
 
 class ParamShorthand(object):
 
-    def _uses_old_list_case(self, service_name, operation_name, argument_name):
+    def _uses_old_list_case(self, command_name, operation_name, argument_name):
         """
         Determines whether a given operation for a service needs to use the
         deprecated shorthand parsing case for lists of structures that only have
@@ -267,7 +267,7 @@ class ParamShorthand(object):
                 'register-instances-with-load-balancer': ['instances']
             }
         }
-        cases = cases.get(service_name, {}).get(operation_name, [])
+        cases = cases.get(command_name, {}).get(operation_name, [])
         return argument_name in cases
 
 
@@ -308,18 +308,18 @@ class ParamShorthandParser(ParamShorthand):
         if not self._should_parse_as_shorthand(cli_argument, value):
             return
         else:
-            service_name, operation_name = \
+            command_name, operation_name = \
                 find_service_and_method_in_event_name(event_name)
             return self._parse_as_shorthand(
-                cli_argument, value, service_name, operation_name)
+                cli_argument, value, command_name, operation_name)
 
-    def _parse_as_shorthand(self, cli_argument, value, service_name,
+    def _parse_as_shorthand(self, cli_argument, value, command_name,
                             operation_name):
         try:
             LOG.debug("Parsing param %s as shorthand",
                         cli_argument.cli_name)
             handled_value = self._handle_special_cases(
-                cli_argument, value, service_name, operation_name)
+                cli_argument, value, command_name, operation_name)
             if handled_value is not None:
                 return handled_value
             if isinstance(value, list):
@@ -344,7 +344,7 @@ class ParamShorthandParser(ParamShorthand):
             raise ParamError(cli_argument.cli_name, str(e))
         return parsed
 
-    def _handle_special_cases(self, cli_argument, value, service_name,
+    def _handle_special_cases(self, cli_argument, value, command_name,
                               operation_name):
         # We need to handle a few special cases that the previous
         # parser handled in order to stay backwards compatible.
@@ -352,7 +352,7 @@ class ParamShorthandParser(ParamShorthand):
         if model.type_name == 'list' and \
            model.member.type_name == 'structure' and \
            len(model.member.members) == 1 and \
-           self._uses_old_list_case(service_name, operation_name, cli_argument.name):
+           self._uses_old_list_case(command_name, operation_name, cli_argument.name):
             # First special case is handling a list of structures
             # of a single element such as:
             #
@@ -411,7 +411,7 @@ class ParamShorthandDocGen(ParamShorthand):
             return _is_complex_shape(argument_model)
         return False
 
-    def generate_shorthand_example(self, cli_argument, service_name,
+    def generate_shorthand_example(self, cli_argument, command_name,
                                    operation_name):
         """Generate documentation for a CLI argument.
 
@@ -427,7 +427,7 @@ class ParamShorthandDocGen(ParamShorthand):
 
         """
         docstring = self._handle_special_cases(
-            cli_argument, service_name, operation_name)
+            cli_argument, command_name, operation_name)
         if docstring is self._DONT_DOC:
             return None
         elif docstring:
@@ -445,13 +445,13 @@ class ParamShorthandDocGen(ParamShorthand):
         except TooComplexError:
             return ''
 
-    def _handle_special_cases(self, cli_argument, service_name, operation_name):
+    def _handle_special_cases(self, cli_argument, command_name, operation_name):
         model = cli_argument.argument_model
         if model.type_name == 'list' and \
                 model.member.type_name == 'structure' and \
                 len(model.member.members) == 1 and \
                 self._uses_old_list_case(
-                    service_name, operation_name, cli_argument.name):
+                    command_name, operation_name, cli_argument.name):
             member_name = list(model.member.members)[0]
             # Handle special case where the min/max is exactly one.
             metadata = model.metadata

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -245,7 +245,7 @@ def _is_complex_shape(model):
 
 class ParamShorthand(object):
 
-    def _uses_old_list_case(self, service_id, operation_name, argument_name):
+    def _uses_old_list_case(self, service_name, operation_name, argument_name):
         """
         Determines whether a given operation for a service needs to use the
         deprecated shorthand parsing case for lists of structures that only have
@@ -260,14 +260,14 @@ class ParamShorthand(object):
                 'rebuild-workspaces': ['rebuild-workspace-requests'],
                 'terminate-workspaces': ['terminate-workspace-requests']
             },
-            'elastic-load-balancing': {
+            'elb': {
                 'remove-tags': ['tags'],
                 'describe-instance-health': ['instances'],
                 'deregister-instances-from-load-balancer': ['instances'],
                 'register-instances-with-load-balancer': ['instances']
             }
         }
-        cases = cases.get(service_id, {}).get(operation_name, [])
+        cases = cases.get(service_name, {}).get(operation_name, [])
         return argument_name in cases
 
 
@@ -308,18 +308,18 @@ class ParamShorthandParser(ParamShorthand):
         if not self._should_parse_as_shorthand(cli_argument, value):
             return
         else:
-            service_id, operation_name = \
+            service_name, operation_name = \
                 find_service_and_method_in_event_name(event_name)
             return self._parse_as_shorthand(
-                cli_argument, value, service_id, operation_name)
+                cli_argument, value, service_name, operation_name)
 
-    def _parse_as_shorthand(self, cli_argument, value, service_id,
+    def _parse_as_shorthand(self, cli_argument, value, service_name,
                             operation_name):
         try:
             LOG.debug("Parsing param %s as shorthand",
                         cli_argument.cli_name)
             handled_value = self._handle_special_cases(
-                cli_argument, value, service_id, operation_name)
+                cli_argument, value, service_name, operation_name)
             if handled_value is not None:
                 return handled_value
             if isinstance(value, list):
@@ -344,7 +344,7 @@ class ParamShorthandParser(ParamShorthand):
             raise ParamError(cli_argument.cli_name, str(e))
         return parsed
 
-    def _handle_special_cases(self, cli_argument, value, service_id,
+    def _handle_special_cases(self, cli_argument, value, service_name,
                               operation_name):
         # We need to handle a few special cases that the previous
         # parser handled in order to stay backwards compatible.
@@ -352,7 +352,7 @@ class ParamShorthandParser(ParamShorthand):
         if model.type_name == 'list' and \
            model.member.type_name == 'structure' and \
            len(model.member.members) == 1 and \
-           self._uses_old_list_case(service_id, operation_name, cli_argument.name):
+           self._uses_old_list_case(service_name, operation_name, cli_argument.name):
             # First special case is handling a list of structures
             # of a single element such as:
             #
@@ -411,7 +411,7 @@ class ParamShorthandDocGen(ParamShorthand):
             return _is_complex_shape(argument_model)
         return False
 
-    def generate_shorthand_example(self, cli_argument, service_id,
+    def generate_shorthand_example(self, cli_argument, service_name,
                                    operation_name):
         """Generate documentation for a CLI argument.
 
@@ -427,7 +427,7 @@ class ParamShorthandDocGen(ParamShorthand):
 
         """
         docstring = self._handle_special_cases(
-            cli_argument, service_id, operation_name)
+            cli_argument, service_name, operation_name)
         if docstring is self._DONT_DOC:
             return None
         elif docstring:
@@ -445,13 +445,13 @@ class ParamShorthandDocGen(ParamShorthand):
         except TooComplexError:
             return ''
 
-    def _handle_special_cases(self, cli_argument, service_id, operation_name):
+    def _handle_special_cases(self, cli_argument, service_name, operation_name):
         model = cli_argument.argument_model
         if model.type_name == 'list' and \
                 model.member.type_name == 'structure' and \
                 len(model.member.members) == 1 and \
                 self._uses_old_list_case(
-                    service_id, operation_name, cli_argument.name):
+                    service_name, operation_name, cli_argument.name):
             member_name = list(model.member.members)[0]
             # Handle special case where the min/max is exactly one.
             metadata = model.metadata

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -71,8 +71,9 @@ def register_customizations(cli):
     cli.register(
         'building-argument-table.datapipeline.activate-pipeline',
         activate_pipeline_definition)
+    # botocore level events use service id, not service name
     cli.register(
-        'after-call.datapipeline.GetPipelineDefinition',
+        'after-call.data-pipeline.GetPipelineDefinition',
         translate_definition)
     cli.register(
         'building-command-table.datapipeline',

--- a/awscli/customizations/ec2/decryptpassword.py
+++ b/awscli/customizations/ec2/decryptpassword.py
@@ -89,7 +89,8 @@ class LaunchKeyArgument(BaseCLIArgument):
                 self._key_path = path
                 endpoint_prefix = \
                     self._operation_model.service_model.endpoint_prefix
-                event = 'after-call.%s.%s' % (endpoint_prefix,
+                service_id = self._operation_model.service_model.service_id
+                event = 'after-call.%s.%s' % (service_id.hyphenize(),
                                               self._operation_model.name)
                 self._session.register(event, self._decrypt_password_data)
             else:

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -251,8 +251,9 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_list_structure_scalars(self):
         p = self.get_param_model(
             'elb.RegisterInstancesWithLoadBalancer.Instances')
-        event_name = ('process-cli-arg.elastic-load-balancing'
-                      '.register-instances-with-load-balancer')
+        event_name = (
+            'process-cli-arg.elb.register-instances-with-load-balancer'
+        )
         # Because this is a list type param, we'll use nargs
         # with argparse which means the value will be presented
         # to us as a list.
@@ -512,12 +513,11 @@ class TestDocGen(BaseArgProcessTest):
         self.shorthand_documenter = ParamShorthandDocGen()
         self.service_name = 'foo'
         self.operation_name = 'bar'
-        self.service_id = 'baz'
 
     def get_generated_example_for(self, argument):
         # Returns a string containing the generated documentation.
         return self.shorthand_documenter.generate_shorthand_example(
-            argument, self.service_id, self.operation_name)
+            argument, self.service_name, self.operation_name)
 
     def assert_generated_example_is(self, argument, expected_docs):
         generated_docs = self.get_generated_example_for(argument)
@@ -537,7 +537,6 @@ class TestDocGen(BaseArgProcessTest):
 
     def test_gen_list_scalar_docs(self):
         self.service_name = 'elb'
-        self.service_id = 'elastic-load-balancing'
         self.operation_name = 'register-instances-with-load-balancer'
         argument = self.get_param_model(
             'elb.RegisterInstancesWithLoadBalancer.Instances')


### PR DESCRIPTION
This depends and builds upon https://github.com/boto/botocore/pull/1948

This updates some of the code using botocore's event handlers to now expect botocore client events to strictly be the service ID instead of conflating service name, service ID, and endpoint prefix. This partially reverts some of the changes made in #3521. 

The convention going forward is that CLI specific events will emit and register based on the CLI's command name (generally the service name but not always such as `s3` vs `s3api`). Events at the botocore level for a particular client will always use the service ID. 