### PR TITLE
Preserve comments in yaml for cloudformation commands

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -60,7 +60,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
 
 
 def _dict_representer(dumper, data):
-    return dumper.represent_dict(data.items())
+    return dumper.represent_dict(data)
 
 
 def yaml_dump(dict_to_dump):

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -24,6 +24,8 @@ from awscli.customizations.cloudformation.yamlhelper import yaml_parse, yaml_dum
 
 class TestYaml(unittest.TestCase):
 
+    maxDiff = None
+
     yaml_with_tags = """
     Resource:
         Key1: !Ref Something

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -186,3 +186,15 @@ class TestYaml(unittest.TestCase):
         )
         actual = yaml_dump(template)
         self.assertEqual(actual, expected)
+
+    def test_can_roundtrip_comments(self):
+        test_yaml = (
+            'foo:\n # This is a comment'
+            '  # So is this.\n'
+            '  bar: baz\n'
+            '  baz: qux  # Another comment\n'
+            'list: [1, 2, 3] # List comment\n'
+        )
+        parsed = yaml_parse(test_yaml)
+        round_tripped = yaml_dump(parsed)
+        self.assertEqual(test_yaml, round_tripped)

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -158,19 +158,18 @@ class TestYaml(unittest.TestCase):
             <<: *base
         """
         output = yaml_parse(test_yaml)
-        self.assertTrue(isinstance(output, OrderedDict))
         self.assertEqual(output.get('test').get('property'), 'value')
 
     def test_unroll_yaml_anchors(self):
-        properties = {
-            "Foo": "bar",
-            "Spam": "eggs",
-        }
+        properties = OrderedDict([
+            ("Foo", "bar"),
+            ("Spam", "eggs"),
+        ])
         template = {
-            "Resources": {
-                "Resource1": {"Properties": properties},
-                "Resource2": {"Properties": properties}
-            }
+            "Resources": OrderedDict([
+                ("Resource1", {"Properties": properties}),
+                ("Resource2", {"Properties": properties}),
+            ])
         }
 
         expected = (


### PR DESCRIPTION
Switch from safe to rt yaml loader

This allows us to preserve mapping order (which we were
already handling) as well as comments.

rt is a subclass of safe, from the docs:

https://yaml.readthedocs.io/en/latest/api.html

> The default loader (typ='rt') is a direct derivative of the safe loader,
without the methods to construct arbitrary Python objects that make the
unsafe loader unsafe, but with the changes needed for round-trip
preservation of comments, etc.. For trusted Python classes a constructor
can of course be added to the round-trip or safe-loader, but this has to
be done explicitly (add_constructor).

Closes #2757
