### PR TITLE
adds `aws ecr get-login-password` customization

### DIFF
--- a/awscli/examples/ecr/get-login-password.rst
+++ b/awscli/examples/ecr/get-login-password.rst
@@ -1,0 +1,16 @@
+**To retrieve a password to your default registry**
+
+This example prints a password that you can use with a container client of your
+choice to log in to your default Amazon ECR registry.
+
+Command::
+
+  aws ecr get-login-password
+
+Output::
+
+  <password>
+
+Usage with Docker::
+
+  aws ecr get-login-password | docker login --username AWS --password-stdin https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com

--- a/awscli/examples/ecr/get-login-password_description.rst
+++ b/awscli/examples/ecr/get-login-password_description.rst
@@ -1,0 +1,15 @@
+**To log in to an Amazon ECR registry**
+
+This command retrieves and prints a password that is valid for a specified
+registry for 12 hours. You can pass the password to the login command of the
+container client of your preference, such as Docker. After you have logged in
+to an Amazon ECR registry with this command, you can use the Docker CLI to push
+and pull images from that registry until the token expires.
+
+.. note::
+
+    This command displays password(s) to stdout with authentication credentials.
+    Your credentials could be visible by other users on your system in a process
+    list display or a command history. If you are not on a secure system, you
+    should consider this risk and login interactively. For more information,
+    see ``get-authorization-token``.

--- a/awscli/examples/ecr/get-login_description.rst
+++ b/awscli/examples/ecr/get-login_description.rst
@@ -9,7 +9,7 @@ token expires.
 
 .. note::
 
-    This command writes displays ``docker login`` commands to stdout with
+    This command displays ``docker login`` commands to stdout with
     authentication credentials. Your credentials could be visible by other
     users on your system in a process list display or a command history. If you
     are not on a secure system, you should consider this risk and login

--- a/tests/functional/ecr/test_get_login_password.py
+++ b/tests/functional/ecr/test_get_login_password.py
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestGetLoginPasswordCommand(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestGetLoginPasswordCommand, self).setUp()
+        self.parsed_responses = [
+            {
+                'authorizationData': [
+                    {
+                        "authorizationToken": "Zm9vOmJhcg==",
+                        "proxyEndpoint": "1235.ecr.us-east-1.io",
+                        "expiresAt": "2015-10-16T00:00:00Z"
+                    }
+                ]
+            },
+        ]
+
+    def test_prints_get_login_command(self):
+        stdout = self.run_cmd("ecr get-login-password")[0]
+        self.assertIn('bar', stdout)
+        self.assertEquals(1, len(self.operations_called))


### PR DESCRIPTION
*Issue #, if available:*
fixes #4867 

*Description of changes:*
as proposed in https://github.com/aws/aws-cli/issues/4867
and previously discussed in
https://github.com/aws/aws-cli/issues/2875#issuecomment-433565983
https://github.com/aws/aws-cli/issues/3687#issue-374397564

this commit adds a new customization command for ECR that only
returns the password to login to a registry. this approach is
composable, is compatible with other container clients, allows
use of functionality like Docker's --password-stdin flag, and
is more resilient to changes in client APIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
