### PR TITLE
Soft-deprecate `aws ecr get-login`

### DIFF
--- a/awscli/examples/ecr/get-login_description.rst
+++ b/awscli/examples/ecr/get-login_description.rst
@@ -1,3 +1,5 @@
+    **Note:** This command is deprecated. Use ``get-login-password`` instead.
+
 **To log in to an Amazon ECR registry**
 
 This command retrieves a token that is valid for a specified registry for 12


### PR DESCRIPTION
The command `aws ecr get-login-password` is now the preferred method.
This commit "soft-deprecates" the old command by adding a deprecation
notice to the documentation but leaving the command discoverable in
the commands list. It may be fully deprecated in future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.