### PR TITLE
Correct link to Sphinx

### DIFF
--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -118,7 +118,7 @@
 
   {%- block footer_wrapper %}
   <div class="footer container">
-    &copy; Copyright {{ copyright }}. Created using <a href="http://sphinx.pocoo.org/">Sphinx</a>.
+    &copy; Copyright {{ copyright }}. Created using <a href="http://www.sphinx-doc.org/">Sphinx</a>.
   </div>
   {%- endblock %}
 


### PR DESCRIPTION
Currently this leads to a 404 page: http://sphinx.pocoo.org/
I believe it should be http://www.sphinx-doc.org/ according to http://www.pocoo.org/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
