### PR TITLE
Sync v2 with develop

### DIFF
--- a/.changes/1.17.1.json
+++ b/.changes/1.17.1.json
@@ -1,0 +1,17 @@
+[
+  {
+    "category": "``ec2``", 
+    "description": "Update ec2 command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``backup``", 
+    "description": "Update backup command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``efs``", 
+    "description": "Update efs command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.2.json
+++ b/.changes/1.17.2.json
@@ -1,0 +1,7 @@
+[
+  {
+    "category": "``ec2``", 
+    "description": "Update ec2 command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.3.json
+++ b/.changes/1.17.3.json
@@ -1,0 +1,22 @@
+[
+  {
+    "category": "``ec2``", 
+    "description": "Update ec2 command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``organizations``", 
+    "description": "Update organizations command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``securityhub``", 
+    "description": "Update securityhub command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``ssm``", 
+    "description": "Update ssm command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.4.json
+++ b/.changes/1.17.4.json
@@ -1,0 +1,17 @@
+[
+  {
+    "category": "``ec2``", 
+    "description": "Update ec2 command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``sagemaker``", 
+    "description": "Update sagemaker command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``ds``", 
+    "description": "Update ds command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.5.json
+++ b/.changes/1.17.5.json
@@ -1,0 +1,32 @@
+[
+  {
+    "category": "``batch``", 
+    "description": "Update batch command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``cloudhsmv2``", 
+    "description": "Update cloudhsmv2 command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``mediaconvert``", 
+    "description": "Update mediaconvert command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``neptune``", 
+    "description": "Update neptune command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``redshift``", 
+    "description": "Update redshift command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``ecs``", 
+    "description": "Update ecs command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.6.json
+++ b/.changes/1.17.6.json
@@ -1,0 +1,32 @@
+[
+  {
+    "category": "``ec2``", 
+    "description": "Update ec2 command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``lambda``", 
+    "description": "Update lambda command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``kms``", 
+    "description": "Update kms command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``application-insights``", 
+    "description": "Update application-insights command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``alexaforbusiness``", 
+    "description": "Update alexaforbusiness command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``cloudwatch``", 
+    "description": "Update cloudwatch command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.7.json
+++ b/.changes/1.17.7.json
@@ -1,0 +1,27 @@
+[
+  {
+    "category": "``discovery``", 
+    "description": "Update discovery command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``iotevents``", 
+    "description": "Update iotevents command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``marketplacecommerceanalytics``", 
+    "description": "Update marketplacecommerceanalytics command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``codepipeline``", 
+    "description": "Update codepipeline command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``ec2``", 
+    "description": "Update ec2 command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.8.json
+++ b/.changes/1.17.8.json
@@ -1,0 +1,12 @@
+[
+  {
+    "category": "``rds``", 
+    "description": "Update rds command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``iam``", 
+    "description": "Update iam command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.17.9.json
+++ b/.changes/1.17.9.json
@@ -1,0 +1,27 @@
+[
+  {
+    "category": "``eks``", 
+    "description": "Update eks command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``opsworkscm``", 
+    "description": "Update opsworkscm command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``workspaces``", 
+    "description": "Update workspaces command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``datasync``", 
+    "description": "Update datasync command to latest version", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``ecs``", 
+    "description": "Update ecs command to latest version", 
+    "type": "api-change"
+  }
+]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,86 @@
 CHANGELOG
 =========
 
+1.17.9
+======
+
+* api-change:``eks``: Update eks command to latest version
+* api-change:``opsworkscm``: Update opsworkscm command to latest version
+* api-change:``workspaces``: Update workspaces command to latest version
+* api-change:``datasync``: Update datasync command to latest version
+* api-change:``ecs``: Update ecs command to latest version
+
+
+1.17.8
+======
+
+* api-change:``rds``: Update rds command to latest version
+* api-change:``iam``: Update iam command to latest version
+
+
+1.17.7
+======
+
+* api-change:``discovery``: Update discovery command to latest version
+* api-change:``iotevents``: Update iotevents command to latest version
+* api-change:``marketplacecommerceanalytics``: Update marketplacecommerceanalytics command to latest version
+* api-change:``codepipeline``: Update codepipeline command to latest version
+* api-change:``ec2``: Update ec2 command to latest version
+
+
+1.17.6
+======
+
+* api-change:``ec2``: Update ec2 command to latest version
+* api-change:``lambda``: Update lambda command to latest version
+* api-change:``kms``: Update kms command to latest version
+* api-change:``application-insights``: Update application-insights command to latest version
+* api-change:``alexaforbusiness``: Update alexaforbusiness command to latest version
+* api-change:``cloudwatch``: Update cloudwatch command to latest version
+
+
+1.17.5
+======
+
+* api-change:``batch``: Update batch command to latest version
+* api-change:``cloudhsmv2``: Update cloudhsmv2 command to latest version
+* api-change:``mediaconvert``: Update mediaconvert command to latest version
+* api-change:``neptune``: Update neptune command to latest version
+* api-change:``redshift``: Update redshift command to latest version
+* api-change:``ecs``: Update ecs command to latest version
+
+
+1.17.4
+======
+
+* api-change:``ec2``: Update ec2 command to latest version
+* api-change:``sagemaker``: Update sagemaker command to latest version
+* api-change:``ds``: Update ds command to latest version
+
+
+1.17.3
+======
+
+* api-change:``ec2``: Update ec2 command to latest version
+* api-change:``organizations``: Update organizations command to latest version
+* api-change:``securityhub``: Update securityhub command to latest version
+* api-change:``ssm``: Update ssm command to latest version
+
+
+1.17.2
+======
+
+* api-change:``ec2``: Update ec2 command to latest version
+
+
+1.17.1
+======
+
+* api-change:``ec2``: Update ec2 command to latest version
+* api-change:``backup``: Update backup command to latest version
+* api-change:``efs``: Update efs command to latest version
+
+
 1.17.0
 ======
 

--- a/awscli/examples/alexaforbusiness/create-network-profile.rst
+++ b/awscli/examples/alexaforbusiness/create-network-profile.rst
@@ -1,0 +1,17 @@
+**To create a network profile**
+
+The following ``create-network-profile`` example creates a network profile with the specified details. ::
+
+    aws alexaforbusiness create-network-profile \
+        --network-profile-name Network123 \
+        --ssid Janenetwork \
+        --security-type WPA2_PSK \
+        --current-password 12345
+
+Output::
+
+    {
+        "NetworkProfileArn": "arn:aws:a4b:us-east-1:123456789012:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111/a1b2c3d4-5678-90ab-cdef-EXAMPLE22222"
+    }            
+
+For more information, see `Managing Network Profiles <https://docs.aws.amazon.com/a4b/latest/ag/manage-network-profiles.html>`__ in the *Alexa for Business Administration Guide*.

--- a/awscli/examples/alexaforbusiness/delete-network-profile.rst
+++ b/awscli/examples/alexaforbusiness/delete-network-profile.rst
@@ -1,0 +1,10 @@
+**To delete a network profile**
+
+The following ``delete-network-profile`` example deletes the specified network profile. ::
+
+    aws alexaforbusiness delete-network-profile \
+        --network-profile-arn arn:aws:a4b:us-east-1:123456789012:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111/a1b2c3d4-5678-90ab-cdef-EXAMPLE22222
+
+This command produces no output.         
+
+For more information, see `Managing Network Profiles <https://docs.aws.amazon.com/a4b/latest/ag/manage-network-profiles.html>`__ in the *Alexa for Business Administration Guide*.

--- a/awscli/examples/alexaforbusiness/get-network-profile.rst
+++ b/awscli/examples/alexaforbusiness/get-network-profile.rst
@@ -1,0 +1,20 @@
+**To get network profile details**
+
+The following ``get-network-profile`` example retrieves details of the specified network profile. ::
+
+    aws alexaforbusiness get-network-profile \
+        --network-profile-arn arn:aws:a4b:us-east-1:123456789012:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "NetworkProfile": {
+            "NetworkProfileArn": "arn:aws:a4b:us-east-1:123456789012:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111/a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+            "NetworkProfileName": "Networkprofile",
+            "Ssid": "Janenetwork",
+            "SecurityType": "WPA2_PSK",
+            "CurrentPassword": "12345"
+        }
+    }
+
+For more information, see `Managing Network Profiles <https://docs.aws.amazon.com/a4b/latest/ag/manage-network-profiles.html>`__ in the *Alexa for Business Administration Guide*.

--- a/awscli/examples/alexaforbusiness/search-network-profiles.rst
+++ b/awscli/examples/alexaforbusiness/search-network-profiles.rst
@@ -1,0 +1,34 @@
+**To search network profiles**
+
+The following ``search-network-profiles`` example lists network profiles that meet a set of filter and sort criteria. In this example, all profiles are listed. ::
+
+    aws alexaforbusiness search-network-profiles
+
+Output::
+
+    {
+        "NetworkProfiles": [
+            {
+                "NetworkProfileArn": "arn:aws:a4b:us-east-1:123456789111:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE22222/a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "NetworkProfileName": "Networkprofile1",
+                "Description": "Personal network",
+                "Ssid": "Janenetwork",
+                "SecurityType": "WPA2_PSK"
+            },
+            {
+                "NetworkProfileArn": "arn:aws:a4b:us-east-1:123456789222:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE44444/a1b2c3d4-5678-90ab-cdef-EXAMPLE55555",
+                "NetworkProfileName": "Networkprofile2",
+                "Ssid": "Johnnetwork",
+                "SecurityType": "WPA2_PSK"
+            },
+            {
+                "NetworkProfileArn": "arn:aws:a4b:us-east-1:123456789333:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE66666/a1b2c3d4-5678-90ab-cdef-EXAMPLE77777",
+                "NetworkProfileName": "Networkprofile3",
+                "Ssid": "Carlosnetwork",
+                "SecurityType": "WPA2_PSK"
+            }
+        ],
+        "TotalCount": 3
+    }         
+
+For more information, see `Managing Network Profiles <https://docs.aws.amazon.com/a4b/latest/ag/manage-network-profiles.html>`__ in the *Alexa for Business Administration Guide*.

--- a/awscli/examples/alexaforbusiness/update-network-profile.rst
+++ b/awscli/examples/alexaforbusiness/update-network-profile.rst
@@ -1,0 +1,11 @@
+**To update a network profile**
+
+The following ``update-network-profile`` example updates the specified network profile by using the network profile ARN. ::
+
+    aws alexaforbusiness update-network-profile \
+        --network-profile-arn arn:aws:a4b:us-east-1:123456789012:network-profile/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 \
+        --network-profile-name Networkprofile
+
+This command produces no output.         
+
+For more information, see `Managing Network Profiles <https://docs.aws.amazon.com/a4b/latest/ag/manage-network-profiles.html>`__ in the *Alexa for Business Administration Guide*.

--- a/awscli/examples/apigateway/update-integration.rst
+++ b/awscli/examples/apigateway/update-integration.rst
@@ -2,23 +2,38 @@
 
 Command::
 
-  aws apigateway update-integration --rest-api-id a1b2c3d4e5 --resource-id a1b2c3 --http-method POST --patch-operations op='add',path='/requestTemplates/application~1json'
+    aws apigateway update-integration \
+        --rest-api-id a1b2c3d4e5 \
+        --resource-id a1b2c3 \
+        --http-method POST \
+        --patch-operations "op='add',path='/requestTemplates/application~1json'"
 
 **To update (replace) the 'Content-Type: application/json' Mapping Template configured with a custom template**
 
 Command::
 
-  aws apigateway update-integration --rest-api-id a1b2c3d4e5 --resource-id a1b2c3 --http-method POST --patch-operations op='replace',path='/requestTemplates/application~1json',value='{"example": "json"}'
+    aws apigateway update-integration \
+        --rest-api-id a1b2c3d4e5 \
+        --resource-id a1b2c3 \
+        --http-method POST \
+        --patch-operations "op='replace',path='/requestTemplates/application~1json',value='{"example": "json"}'"
 
 **To update (replace) a custom template associated with 'Content-Type: application/json' with Input Passthrough**
 
 Command::
 
-  aws apigateway update-integration --rest-api-id a1b2c3d4e5 --resource-id a1b2c3 --http-method POST --patch-operations op='replace',path='requestTemplates/application~1json'
+    aws apigateway update-integration \
+        --rest-api-id a1b2c3d4e5 \
+        --resource-id a1b2c3 \
+        --http-method POST \
+        --patch-operations "op='replace',path='requestTemplates/application~1json'"
 
 **To remove the 'Content-Type: application/json' Mapping Template**
 
 Command::
 
-  aws apigateway update-integration --rest-api-id a1b2c3d4e5 --resource-id a1b2c3 --http-method POST --patch-operations op='remove',path='/requestTemplates/application~1json'
-
+    aws apigateway update-integration \
+        --rest-api-id a1b2c3d4e5 \
+        --resource-id a1b2c3 \
+        --http-method POST \
+        --patch-operations "op='remove',path='/requestTemplates/application~1json'"

--- a/awscli/examples/chime/associate-signin-delegate-groups-with-account.rst
+++ b/awscli/examples/chime/associate-signin-delegate-groups-with-account.rst
@@ -1,0 +1,11 @@
+**To associate sign-in delegate groups**
+
+The following ``associate-signin-delegate-groups-with-account`` example associates the specified sign-in delegate group with the specified Amazon Chime account. ::
+
+    aws chime associate-signin-delegate-groups-with-account \
+        --account-id 12a3456b-7c89-012d-3456-78901e23fg45 \
+        --signin-delegate-groups GroupName=my_users
+
+This command produces no output.
+
+For more information, see `Managing User Access and Permissions <https://docs.aws.amazon.com/chime/latest/ag/manage-access.html>`__ in the *Amazon Chime Administration Guide*.

--- a/awscli/examples/chime/create-user.rst
+++ b/awscli/examples/chime/create-user.rst
@@ -1,0 +1,28 @@
+**To create a user profile for a shared device**
+
+The following ``create-user`` example creates a shared device profile for the specified email address. ::
+
+    aws chime create-user \
+        --account-id 12a3456b-7c89-012d-3456-78901e23fg45 \
+        --email roomdevice@example.com \
+        --user-type SharedDevice
+
+Output::
+
+    {
+        "User": {
+            "UserId": "1ab2345c-67de-8901-f23g-45h678901j2k",
+            "AccountId": "12a3456b-7c89-012d-3456-78901e23fg45",
+            "PrimaryEmail": "roomdevice@example.com",
+            "DisplayName": "Room Device",
+            "LicenseType": "Pro",
+            "UserType": "SharedDevice",
+            "UserRegistrationStatus": "Registered",
+            "RegisteredOn": "2020-01-15T22:38:09.806Z",
+            "AlexaForBusinessMetadata": {
+                "IsAlexaForBusinessEnabled": false
+            }
+        }
+    }
+
+For more information, see `Preparing for Setup <https://docs.aws.amazon.com/chime/latest/ag/prepare-setup.html>`__ in the *Amazon Chime Administration Guide*.

--- a/awscli/examples/chime/disassociate-signin-delegate-groups-from-account.rst
+++ b/awscli/examples/chime/disassociate-signin-delegate-groups-from-account.rst
@@ -1,0 +1,11 @@
+**To disassociate sign-in delegate groups**
+
+The following ``disassociate-signin-delegate-groups-from-account`` example disassociates the specified sign-in delegate group from the specified Amazon Chime account. ::
+
+    aws chime disassociate-signin-delegate-groups-from-account \
+        --account-id 12a3456b-7c89-012d-3456-78901e23fg45 \
+        --group-names "my_users"
+
+This command produces no output.
+
+For more information, see `Managing User Access and Permissions <https://docs.aws.amazon.com/chime/latest/ag/manage-access.html>`__ in the *Amazon Chime Administration Guide*.

--- a/awscli/examples/cloudformation/deregister-type.rst
+++ b/awscli/examples/cloudformation/deregister-type.rst
@@ -1,0 +1,12 @@
+**To deregister a type version**
+
+The following ``deregister-type`` example removes the specified type version from active use in the CloudFormation registry, so that it can no longer be used in CloudFormation operations. ::
+
+    aws cloudformation deregister-type \
+        --type RESOURCE \
+        --type-name My::Logs::LogGroup \
+        --version-id 00000002
+
+This command produces no output.
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/describe-type-registration.rst
+++ b/awscli/examples/cloudformation/describe-type-registration.rst
@@ -1,0 +1,17 @@
+**To display type registration information**
+
+The following ``describe-type-registration`` example displays information about the specified type registration, including the type's current status, type, and version. ::
+
+    aws cloudformation describe-type-registration \
+        --registration-token a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+   {
+       "ProgressStatus": "COMPLETE",
+       "TypeArn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-Logs-LogGroup",
+       "Description": "Deployment is currently in DEPLOY_STAGE of status COMPLETED; ",
+       "TypeVersionArn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-Logs-LogGroup/00000001"
+   }
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/describe-type.rst
+++ b/awscli/examples/cloudformation/describe-type.rst
@@ -1,0 +1,25 @@
+**To display type information**
+
+The following ``describe-type`` example displays information for the specified type. ::
+
+    aws cloudformation describe-type \
+        --type-name My::Logs::LogGroup \
+        --type RESOURCE
+
+Output::
+
+    {
+        "SourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs.git",
+        "Description": "Customized resource derived from AWS::Logs::LogGroup",
+        "TimeCreated": "2019-12-03T23:29:33.321Z",
+        "Visibility": "PRIVATE",
+        "TypeName": "My::Logs::LogGroup",
+        "LastUpdated": "2019-12-03T23:29:33.321Z",
+        "DeprecatedStatus": "LIVE",
+        "ProvisioningType": "FULLY_MUTABLE",
+        "Type": "RESOURCE",
+        "Arn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-Logs-LogGroup/00000001",
+        "Schema": "[details omitted]"
+    }
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/detect-stack-set-drift.rst
+++ b/awscli/examples/cloudformation/detect-stack-set-drift.rst
@@ -1,0 +1,14 @@
+**To detect drift on a stack set and all associated stack instances**
+
+The following ``detect-stack-set-drift`` example initiates drift detection operations on the specified stack set, including all the stack instances associated with that stack set, and returns an operation ID that can be used to track the status of the drift operation. ::
+
+    aws cloudformation detect-stack-set-drift \
+        --stack-set-name stack-set-drift-example
+
+Output::
+
+    {
+        "OperationId": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Detecting Unmanaged Configuration Changes in Stack Sets <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/list-type-registrations.rst
+++ b/awscli/examples/cloudformation/list-type-registrations.rst
@@ -1,0 +1,20 @@
+**To list the completed registrations of a type**
+
+The following ``list-type-registrations`` example displays a list of the completed type registrations for the specified type. ::
+
+    aws cloudformation list-type-registrations \
+        --type RESOURCE \
+        --type-name My::Logs::LogGroup \
+        --registration-status-filter COMPLETE
+
+Output::
+
+    {
+        "RegistrationTokenList": [
+            "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+            "a1b2c3d4-5678-90ab-cdef-EXAMPLE33333"
+        ]
+    }
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/list-type-versions.rst
+++ b/awscli/examples/cloudformation/list-type-versions.rst
@@ -1,0 +1,33 @@
+**To list versions of a type**
+
+The following ``list-type-versions`` example displays summary information of each version of the specified type whose status is ``LIVE``. ::
+
+    aws cloudformation list-type-versions \
+        --type RESOURCE \
+        --type-name My::Logs::LogGroup \
+        --deprecated-status LIVE
+
+Output::
+
+    {
+        "TypeVersionSummaries": [
+            {
+                "Description": "Customized resource derived from AWS::Logs::LogGroup",
+                "TimeCreated": "2019-12-03T23:29:33.321Z",
+                "TypeName": "My::Logs::LogGroup",
+                "VersionId": "00000001",
+                "Type": "RESOURCE",
+                "Arn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-Logs-LogGroup/00000001"
+            },
+            {
+                "Description": "Customized resource derived from AWS::Logs::LogGroup",
+                "TimeCreated": "2019-12-04T06:58:14.902Z",
+                "TypeName": "My::Logs::LogGroup",
+                "VersionId": "00000002",
+                "Type": "RESOURCE",
+                "Arn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-Logs-LogGroup/00000002"
+            }
+        ]
+    }
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/list-types.rst
+++ b/awscli/examples/cloudformation/list-types.rst
@@ -1,0 +1,30 @@
+**To list the private resource types in an account**
+
+The following ``list-types`` example displays a list of the private resource types currently registered in the current AWS account. ::
+
+    aws cloudformation list-types
+
+Output::
+
+    {
+        "TypeSummaries": [
+            {
+                "Description": "WordPress blog resource for internal use",
+                "LastUpdated": "2019-12-04T18:28:15.059Z",
+                "TypeName": "My::WordPress::BlogExample",
+                "TypeArn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-WordPress-BlogExample",
+                "DefaultVersionId": "00000005",
+                "Type": "RESOURCE"
+            },
+            {
+                "Description": "Customized resource derived from AWS::Logs::LogGroup",
+                "LastUpdated": "2019-12-04T18:28:15.059Z",
+                "TypeName": "My::Logs::LogGroup",
+                "TypeArn": "arn:aws:cloudformation:us-west-2:123456789012:type/resource/My-Logs-LogGroup",
+                "DefaultVersionId": "00000003",
+                "Type": "RESOURCE"
+            }
+        ]
+    }
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudformation/set-type-default-version.rst
+++ b/awscli/examples/cloudformation/set-type-default-version.rst
@@ -1,0 +1,12 @@
+**To set a type's default version**
+
+The following ``set-type-default-version`` example sets the specified type version to be used as the default for this type. ::
+
+    aws cloudformation set-type-default-version \
+        --type RESOURCE \
+        --type-name My::Logs::LogGroup \
+        --version-id 00000003
+
+This command produces no output.
+
+For more information, see `Using the CloudFormation Registry <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html>`__ in the *AWS CloudFormation Users Guide*.

--- a/awscli/examples/cloudwatch/list-metrics.rst
+++ b/awscli/examples/cloudwatch/list-metrics.rst
@@ -1,93 +1,94 @@
-**To list the metrics for Amazon EC2**
+**To list the metrics for Amazon SNS**
 
-The following example uses the ``list-metrics`` command to list the metrics for Amazon SNS.::
+The following ``list-metrics`` example displays the metrics for Amazon SNS. ::
 
-  aws cloudwatch list-metrics --namespace "AWS/SNS"
+    aws cloudwatch list-metrics \
+        --namespace "AWS/SNS"
 
 Output::
 
-  {
-      "Metrics": [
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "NotifyMe"
-                  }
-              ],
-              "MetricName": "PublishSize"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "CFO"
-                  }
-              ],
-              "MetricName": "PublishSize"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "NotifyMe"
-                  }
-              ],
-              "MetricName": "NumberOfNotificationsFailed"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "NotifyMe"
-                  }
-              ],
-              "MetricName": "NumberOfNotificationsDelivered"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "NotifyMe"
-                  }
-              ],
-              "MetricName": "NumberOfMessagesPublished"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "CFO"
-                  }
-              ],
-              "MetricName": "NumberOfMessagesPublished"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "CFO"
-                  }
-              ],
-              "MetricName": "NumberOfNotificationsDelivered"
-          },
-          {
-              "Namespace": "AWS/SNS",
-              "Dimensions": [
-                  {
-                      "Name": "TopicName",
-                      "Value": "CFO"
-                  }
-              ],
-              "MetricName": "NumberOfNotificationsFailed"
-          }
-      ]
-  }
+    {
+        "Metrics": [
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "NotifyMe"
+                    }
+                ],
+                "MetricName": "PublishSize"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "CFO"
+                    }
+                ],
+                "MetricName": "PublishSize"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "NotifyMe"
+                    }
+                ],
+                "MetricName": "NumberOfNotificationsFailed"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "NotifyMe"
+                    }
+                ],
+                "MetricName": "NumberOfNotificationsDelivered"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "NotifyMe"
+                    }
+                ],
+                "MetricName": "NumberOfMessagesPublished"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "CFO"
+                    }
+                ],
+                "MetricName": "NumberOfMessagesPublished"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "CFO"
+                    }
+                ],
+                "MetricName": "NumberOfNotificationsDelivered"
+            },
+            {
+                "Namespace": "AWS/SNS",
+                "Dimensions": [
+                    {
+                        "Name": "TopicName",
+                        "Value": "CFO"
+                    }
+                ],
+                "MetricName": "NumberOfNotificationsFailed"
+            }
+        ]
+    }
 

--- a/awscli/examples/cognito-idp/admin-create-user.rst
+++ b/awscli/examples/cognito-idp/admin-create-user.rst
@@ -1,35 +1,35 @@
 **To create a user**
 
-This example creates username diego@example.com. An email address and phone number
-are specified. 
+The following ``admin-create-user`` example creates a user with the specified settings email address and phone number. ::
 
-Command::
-
-  aws cognito-idp admin-create-user --user-pool-id us-west-2_aaaaaaaaa --username diego@example.com --user-attributes=Name=email,Value=kermit2@somewhere.com,Name=phone_number,Value="+15555551212" --message-action SUPPRESS
+    aws cognito-idp admin-create-user \
+        --user-pool-id us-west-2_aaaaaaaaa \
+        --username diego@example.com \
+        --user-attributes Name=email,Value=kermit2@somewhere.com Name=phone_number,Value="+15555551212" \
+        --message-action SUPPRESS
 
 Output::
 
-  {
-    "User": {
-        "Username": "7325c1de-b05b-4f84-b321-9adc6e61f4a2",
-        "Enabled": true,
-        "UserStatus": "FORCE_CHANGE_PASSWORD",
-        "UserCreateDate": 1548099495.428,
-        "UserLastModifiedDate": 1548099495.428,
-        "Attributes": [
-            {
-                "Name": "sub",
-                "Value": "7325c1de-b05b-4f84-b321-9adc6e61f4a2"
-            },
-            {
-                "Name": "phone_number",
-                "Value": "+15555551212"
-            },
-            {
-                "Name": "email",
-                "Value": "diego@example.com"
-            }
-        ]
+    {
+        "User": {
+            "Username": "7325c1de-b05b-4f84-b321-9adc6e61f4a2",
+            "Enabled": true,
+            "UserStatus": "FORCE_CHANGE_PASSWORD",
+            "UserCreateDate": 1548099495.428,
+            "UserLastModifiedDate": 1548099495.428,
+            "Attributes": [
+                {
+                    "Name": "sub",
+                    "Value": "7325c1de-b05b-4f84-b321-9adc6e61f4a2"
+                },
+                {
+                    "Name": "phone_number",
+                    "Value": "+15555551212"
+                },
+                {
+                    "Name": "email",
+                    "Value": "diego@example.com"
+                }
+            ]
+        }
     }
-  }
-  

--- a/awscli/examples/cognito-idp/delete-user-pool-domain.rst
+++ b/awscli/examples/cognito-idp/delete-user-pool-domain.rst
@@ -2,6 +2,6 @@
 
 The following ``delete-user-pool-domain`` example deletes a user pool domain named ``my-domain`` ::
 
-    aws cognito-idp delete-user-pool \
+    aws cognito-idp delete-user-pool-domain \
         --user-pool-id us-west-2_aaaaaaaaa \
         --domain my-domain

--- a/awscli/examples/dax/describe-parameter-groups.rst
+++ b/awscli/examples/dax/describe-parameter-groups.rst
@@ -1,0 +1,18 @@
+**To describe the parameter groups defined in DAX**
+
+The following ``describe-parameter-groups`` example retrieves details about the parameter groups that are defined in DAX. ::
+
+    aws dax describe-parameter-groups
+
+Output::
+
+    {
+        "ParameterGroups": [
+            {
+                "ParameterGroupName": "default.dax1.0",
+                "Description": "Default parameter group for dax1.0"
+            }
+        ]
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.cluster-management.html>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/dax/describe-parameters.rst
+++ b/awscli/examples/dax/describe-parameters.rst
@@ -1,0 +1,39 @@
+**To describe the parameters defined in a DAX parameter group**
+
+The following ``describe-parameters`` example retrieves details about the parameters that are defined in the specified DAX parameter group. ::
+
+    aws dax describe-parameters \
+        --parameter-group-name default.dax1.0
+
+Output::
+
+    {
+        "Parameters": [
+            {
+                "ParameterName": "query-ttl-millis",
+                "ParameterType": "DEFAULT",
+                "ParameterValue": "300000",
+                "NodeTypeSpecificValues": [],
+                "Description": "Duration in milliseconds for queries to remain cached",
+                "Source": "user",
+                "DataType": "integer",
+                "AllowedValues": "0-",
+                "IsModifiable": "TRUE",
+                "ChangeType": "IMMEDIATE"
+            },
+            {
+                "ParameterName": "record-ttl-millis",
+                "ParameterType": "DEFAULT",
+                "ParameterValue": "300000",
+                "NodeTypeSpecificValues": [],
+                "Description": "Duration in milliseconds for records to remain valid in cache (Default: 0 = infinite)",
+                "Source": "user",
+                "DataType": "integer",
+                "AllowedValues": "0-",
+                "IsModifiable": "TRUE",
+                "ChangeType": "IMMEDIATE"
+            }
+        ]
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.cluster-management.html>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/dax/describe-subnet-groups.rst
+++ b/awscli/examples/dax/describe-subnet-groups.rst
@@ -1,0 +1,37 @@
+**To describe subnet groups defined in DAX**
+
+The following ``describe-subnet-groups`` example retrieves details for the subnet groups defined in DAX. ::
+
+    aws dax describe-subnet-groups
+
+Output::
+
+    {
+        "SubnetGroups": [
+            {
+                "SubnetGroupName": "default",
+                "Description": "Default CacheSubnetGroup",
+                "VpcId": "vpc-ee70a196",
+                "Subnets": [
+                    {
+                        "SubnetIdentifier": "subnet-874953af",
+                        "SubnetAvailabilityZone": "us-west-2d"
+                    },
+                    {
+                        "SubnetIdentifier": "subnet-bd3d1fc4",
+                        "SubnetAvailabilityZone": "us-west-2a"
+                    },
+                    {
+                        "SubnetIdentifier": "subnet-72c2ff28",
+                        "SubnetAvailabilityZone": "us-west-2c"
+                    },
+                    {
+                        "SubnetIdentifier": "subnet-09e6aa42",
+                        "SubnetAvailabilityZone": "us-west-2b"
+                    }
+                ]
+            }
+        ]
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.concepts.cluster.html#DAX.concepts.cluster.security>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/dax/increase-replication-factor.rst
+++ b/awscli/examples/dax/increase-replication-factor.rst
@@ -1,0 +1,64 @@
+**To increase the replication factor for a DAX cluster**
+
+The following ``increase-replication-factor`` example increases the specified DAX cluster's replication factor to 3. ::
+
+    aws dax increase-replication-factor \
+        --cluster-name daxcluster \
+        --new-replication-factor 3
+
+Output::
+
+    {
+        "Cluster": {
+            "ClusterName": "daxcluster",
+            "ClusterArn": "arn:aws:dax:us-west-2:123456789012:cache/daxcluster",
+            "TotalNodes": 3,
+            "ActiveNodes": 1,
+            "NodeType": "dax.r4.large",
+            "Status": "modifying",
+            "ClusterDiscoveryEndpoint": {
+                "Address": "daxcluster.ey3o9d.clustercfg.dax.usw2.cache.amazonaws.com",
+                "Port": 8111
+            },
+            "Nodes": [
+                {
+                    "NodeId": "daxcluster-a",
+                    "Endpoint": {
+                        "Address": "daxcluster-a.ey3o9d.0001.dax.usw2.cache.amazonaws.com",
+                        "Port": 8111
+                    },
+                    "NodeCreateTime": 1576625059.509,
+                    "AvailabilityZone": "us-west-2c",
+                    "NodeStatus": "available",
+                    "ParameterGroupStatus": "in-sync"
+                },
+                {
+                    "NodeId": "daxcluster-b",
+                    "NodeStatus": "creating"
+                },
+                {
+                    "NodeId": "daxcluster-c",
+                    "NodeStatus": "creating"
+                }
+            ],
+            "PreferredMaintenanceWindow": "thu:13:00-thu:14:00",
+            "SubnetGroup": "default",
+            "SecurityGroups": [
+                {
+                    "SecurityGroupIdentifier": "sg-1af6e36e",
+                    "Status": "active"
+                }
+            ],
+            "IamRoleArn": "arn:aws:iam::123456789012:role/DAXServiceRoleForDynamoDBAccess",
+            "ParameterGroup": {
+                "ParameterGroupName": "default.dax1.0",
+                "ParameterApplyStatus": "in-sync",
+                "NodeIdsToReboot": []
+            },
+            "SSEDescription": {
+                "Status": "ENABLED"
+            }
+        }
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.cluster-management.html#DAX.cluster-management.custom-settings>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/dax/list-tags.rst
+++ b/awscli/examples/dax/list-tags.rst
@@ -1,0 +1,19 @@
+**To list tags on a DAX resource**
+
+The following ``list-tags`` example lists the tag keys and values attached to the specified DAX cluster. ::
+
+    aws dax list-tags \
+        --resource-name arn:aws:dax:us-west-2:123456789012:cache/daxcluster 
+
+Output::
+
+    {
+        "Tags": [
+            {
+                "Key": "ClusterUsage",
+                "Value": "prod"
+            }
+        ]
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.cluster-management.html#DAX.management.tagging>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/dax/tag-resource.rst
+++ b/awscli/examples/dax/tag-resource.rst
@@ -1,0 +1,20 @@
+**To tag a DAX resource**
+
+The following ``tag-resource`` example attaches the specified tag key name and associated value to the specified DAX cluster to describe the cluster usage. ::
+
+    aws dax tag-resource \
+        --resource-name arn:aws:dax:us-west-2:123456789012:cache/daxcluster \
+        --tags="Key=ClusterUsage,Value=prod"
+
+Output::
+
+    {
+        "Tags": [
+            {
+                "Key": "ClusterUsage",
+                "Value": "prod"
+            }
+        ]
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.cluster-management.html#DAX.management.tagging>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/dax/untag-resource.rst
+++ b/awscli/examples/dax/untag-resource.rst
@@ -1,0 +1,15 @@
+**To remove tags from a DAX resource**
+
+The following ``untag-resource`` example removes the tag with the specified key name from a DAX cluster. ::
+
+    aws dax untag-resource  \
+        --resource-name arn:aws:dax:us-west-2:123456789012:cache/daxcluster \
+        --tag-keys="ClusterUsage"
+
+Output::
+
+    {
+        "Tags": []
+    }
+
+For more information, see `Managing DAX Clusters <https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DAX.cluster-management.html#DAX.management.tagging>`__ in the *Amazon DynamoDB Developer Guide*.

--- a/awscli/examples/ec2/create-launch-template.rst
+++ b/awscli/examples/ec2/create-launch-template.rst
@@ -1,29 +1,36 @@
-**To create a launch template**
+**Example 1: To create a launch template**
 
-This example creates a launch template that specifies the subnet in which to launch the instance (``subnet-7b16de0c``), assigns a public IP address and an IPv6 address to the instance, and creates a tag for the instance (``purpose=webserver``). ::
+The following ``create-launch-template`` example creates a launch template that specifies the subnet in which to launch the instance , assigns a public IP address and an IPv6 address to the instance, and creates a tag for the instance. ::
 
-  aws ec2 create-launch-template --launch-template-name TemplateForWebServer --version-description WebVersion1 --launch-template-data '{"NetworkInterfaces":[{"AssociatePublicIpAddress":true,"DeviceIndex":0,"Ipv6AddressCount":1,"SubnetId":"subnet-7b16de0c"}],"ImageId":"ami-8c1be5f6","InstanceType":"t2.small","TagSpecifications":[{"ResourceType":"instance","Tags":[{"Key":"purpose","Value":"webserver"}]}]}'
+    aws ec2 create-launch-template \
+        --launch-template-name TemplateForWebServer \
+        --version-description WebVersion1 \
+        --launch-template-data '{"NetworkInterfaces":[{"AssociatePublicIpAddress":true,"DeviceIndex":0,"Ipv6AddressCount":1,"SubnetId":"subnet-7b16de0c"}],"ImageId":"ami-8c1be5f6","InstanceType":"t2.small","TagSpecifications":[{"ResourceType":"instance","Tags":[{"Key":"purpose","Value":"webserver"}]}]}'
 
 Output::
 
-  {
-      "LaunchTemplate": {
-          "LatestVersionNumber": 1, 
-          "LaunchTemplateId": "lt-01238c059e3466abc", 
-          "LaunchTemplateName": "TemplateForWebServer", 
-          "DefaultVersionNumber": 1, 
-          "CreatedBy": "arn:aws:iam::123456789012:user/Bob", 
-          "CreateTime": "2019-01-27T09:13:24.000Z"
-      }
-  }
+    {
+        "LaunchTemplate": {
+            "LatestVersionNumber": 1, 
+            "LaunchTemplateId": "lt-01238c059e3466abc", 
+            "LaunchTemplateName": "TemplateForWebServer", 
+            "DefaultVersionNumber": 1, 
+            "CreatedBy": "arn:aws:iam::123456789012:user/Bob", 
+            "CreateTime": "2019-01-27T09:13:24.000Z"
+        }
+    }
 
 For more information, see `Launching an Instance from a Launch Template`_ in the *Amazon Elastic Compute Cloud User Guide*.
+For information about quoting JSON-formatted parameters, see `Quoting Strings`_ in the *AWS Command Line Interface User Guide*.
 
-**To create a launch template for Amazon EC2 Auto Scaling**
+**Example 2: To create a launch template for Amazon EC2 Auto Scaling**
 
-This example creates a launch template named TemplateForAutoScaling with multiple tags and a block device mapping to specify an additional EBS volume when an instance launches. Specify a value for ``Groups`` that corresponds to security groups for the VPC that your Auto Scaling group will launch instances into. Specify the VPC and subnets as properties of the Auto Scaling group. ::
+The following ``create-launch-template`` example creates a launch template with multiple tags and a block device mapping to specify an additional EBS volume when an instance launches. Specify a value for ``Groups`` that corresponds to security groups for the VPC that your Auto Scaling group will launch instances into. Specify the VPC and subnets as properties of the Auto Scaling group. ::
 
-  aws ec2 create-launch-template --launch-template-name TemplateForAutoScaling --version-description AutoScalingVersion1 --launch-template-data '{"NetworkInterfaces":[{"DeviceIndex":0,"AssociatePublicIpAddress":true,"Groups":["sg-7c227019,sg-903004f8"],"DeleteOnTermination":true}],"ImageId":"ami-b42209de","InstanceType":"m4.large","TagSpecifications":[{"ResourceType":"instance","Tags":[{"Key":"environment","Value":"production"},{"Key":"purpose","Value":"webserver"}]},{"ResourceType":"volume","Tags":[{"Key":"environment","Value":"production"},{"Key":"cost-center","Value":"cc123"}]}],"BlockDeviceMappings":[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":100}}]}' --region us-east-1 
+    aws ec2 create-launch-template \
+        --launch-template-name TemplateForAutoScaling \
+        --version-description AutoScalingVersion1 \
+        --launch-template-data '{"NetworkInterfaces":[{"DeviceIndex":0,"AssociatePublicIpAddress":true,"Groups":["sg-7c227019,sg-903004f8"],"DeleteOnTermination":true}],"ImageId":"ami-b42209de","InstanceType":"m4.large","TagSpecifications":[{"ResourceType":"instance","Tags":[{"Key":"environment","Value":"production"},{"Key":"purpose","Value":"webserver"}]},{"ResourceType":"volume","Tags":[{"Key":"environment","Value":"production"},{"Key":"cost-center","Value":"cc123"}]}],"BlockDeviceMappings":[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":100}}]}' --region us-east-1 
 
 Output::
 
@@ -39,11 +46,63 @@ Output::
   }
 
 For more information, see `Creating a Launch Template for an Auto Scaling Group`_ in the *Amazon EC2 Auto Scaling User Guide*.
-
 For information about quoting JSON-formatted parameters, see `Quoting Strings`_ in the *AWS Command Line Interface User Guide*.
 
+**Example 3: To create a launch template that specifies encryption of EBS volumes**
+
+The following ``create-launch-template`` example creates a launch template that includes encrypted EBS volumes created from an unencrypted snapshot. It also tags the volumes during creation. If encryption by default is disabled, you must specify the ``"Encrypted"`` option as shown in the following example. If you use the ``"KmsKeyId"`` option to specify a customer managed CMK, you also must specify the ``"Encrypted"`` option even if encryption by default is enabled. ::
+
+  aws ec2 create-launch-template \
+    --launch-template-name TemplateForEncryption \
+    --launch-template-data file://config.json
+
+Contents of ``config.json``::
+
+    {
+        "BlockDeviceMappings":[
+            {
+                "DeviceName":"/dev/sda1",
+                "Ebs":{
+                    "VolumeType":"gp2",
+                    "DeleteOnTermination":true,
+                    "SnapshotId":"snap-066877671789bd71b",
+                    "Encrypted":true,
+                    "KmsKeyId":"arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef"
+                }
+            }
+        ],
+        "ImageId":"ami-00068cd7555f543d5",
+        "InstanceType":"c5.large",
+        "TagSpecifications":[
+            {
+                "ResourceType":"volume",
+                "Tags":[
+                    {
+                        "Key":"encrypted",
+                        "Value":"yes"
+                    }
+                ]
+            }
+        ]
+    }
+
+Output::
+
+    {
+        "LaunchTemplate": {
+            "LatestVersionNumber": 1,
+            "LaunchTemplateId": "lt-0d5bd51bcf8530abc",
+            "LaunchTemplateName": "TemplateForEncryption",
+            "DefaultVersionNumber": 1,
+            "CreatedBy": "arn:aws:iam::123456789012:user/Bob",
+            "CreateTime": "2020-01-07T19:08:36.000Z"
+        }
+    }
+
+For more information, see `Restoring an Amazon EBS Volume from a Snapshot`_ and `Encryption by Default`_ in the *Amazon Elastic Compute Cloud User Guide*.
+
 .. _`Launching an Instance from a Launch Template`: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html
-
 .. _`Creating a Launch Template for an Auto Scaling Group`: https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-launch-template.html
-
 .. _`Quoting Strings`: https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters.html#quoting-strings
+.. _`Restoring an Amazon EBS Volume from a Snapshot`: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-restoring-volume.html
+.. _`Encryption by Default`: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html#encryption-by-default

--- a/awscli/examples/ec2/describe-ipv6-pools.rst
+++ b/awscli/examples/ec2/describe-ipv6-pools.rst
@@ -1,0 +1,26 @@
+**To describe your IPv6 address pools**
+
+The following ``describe-ipv6-pools`` example displays details for all of your IPv6 address pools. ::
+
+    aws ec2 describe-ipv6-pools
+
+Output::
+
+    {
+        "Ipv6Pools": [
+            {
+                "PoolId": "ipv6pool-ec2-012345abc12345abc",
+                "PoolCidrBlocks": [
+                    {
+                        "Cidr": "2001:db8:123::/48"
+                    }
+                ],
+                "Tags": [
+                    {
+                        "Key": "pool-1",
+                        "Value": "public"
+                    }
+                ]
+            }
+        ]
+    }

--- a/awscli/examples/ec2/get-associated-ipv6-pool-cidrs.rst
+++ b/awscli/examples/ec2/get-associated-ipv6-pool-cidrs.rst
@@ -1,0 +1,17 @@
+**To get the associations for an IPv6 address pool**
+
+The following ``get-associated-ipv6-pool-cidrs`` example gets the associations for the specified IPv6 address pool. ::
+
+    aws ec2 get-associated-ipv6-pool-cidrs \
+        --pool-id ipv6pool-ec2-012345abc12345abc
+
+Output::
+
+    {
+        "Ipv6CidrAssociations": [
+            {
+                "Ipv6Cidr": "2001:db8:1234:1a00::/56",
+                "AssociatedResource": "vpc-111111222222333ab"
+            }
+        ]
+    }

--- a/awscli/examples/ec2/run-instances.rst
+++ b/awscli/examples/ec2/run-instances.rst
@@ -365,7 +365,7 @@ The following ``run-instances`` example launches a ``c3.large`` instance with ``
         --key-name MyKeyPair \
         --metadata-options "HttpEndpoint=enabled,HttpTokens=required"
 
-For more information, see 'Configuring the Instance Metadata Service <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#configuring-instance-metadata-service>'__ in the *Amazon Elastic Compute Cloud User Guide for Linux Instances*.
+For more information, see `Configuring the Instance Metadata Service <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#configuring-instance-metadata-service>`__ in the *Amazon Elastic Compute Cloud User Guide for Linux Instances*.
 
 **Example 12: To turn off access to instance metadata on a new instance**
 
@@ -379,7 +379,7 @@ The following ``run-instances`` example launches a ``c3.large`` instance with ``
         --key-name MyKeyPair \
         --metadata-options "HttpEndpoint=disabled"
 
-For more information, see 'Configuring the Instance Metadata Service <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#configuring-instance-metadata-service>'__ in the *Amazon Elastic Compute Cloud User Guide for Linux Instances*.
+For more information, see `Configuring the Instance Metadata Service <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#configuring-instance-metadata-service>`__ in the *Amazon Elastic Compute Cloud User Guide for Linux Instances*.
 
 **Example 13: To specify the PUT response hop limit on a new instance**
 
@@ -395,4 +395,4 @@ The following ``run-instances`` example launches a ``c3.large`` instance with ``
         --key-name MyKeyPair \
         --metadata-options "HttpEndpoint=enabled,HttpTokens=required,HttpPutResponseHopLimit=3"
 
-For more information, see 'Configuring the Instance Metadata Service <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#configuring-instance-metadata-service>'__ in the *Amazon Elastic Compute Cloud User Guide for Linux Instances*.
+For more information, see `Configuring the Instance Metadata Service <https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#configuring-instance-metadata-service>`__ in the *Amazon Elastic Compute Cloud User Guide for Linux Instances*.

--- a/awscli/examples/ecr/create-repository.rst
+++ b/awscli/examples/ecr/create-repository.rst
@@ -1,18 +1,62 @@
-**To create a repository**
+**Example 1: To create a repository**
 
-This example creates a repository called ``nginx-web-app`` inside the
-``project-a`` namespace in the default registry for an account.
+The following ``create-repository`` example creates a repository inside the specified namespace in the default registry for an account. ::
 
-Command::
-
-  aws ecr create-repository --repository-name project-a/nginx-web-app
+    aws ecr create-repository \
+        --repository-name project-a/nginx-web-app
 
 Output::
 
-  {
-      "repository": {
-          "registryId": "<aws_account_id>",
-          "repositoryName": "project-a/nginx-web-app",
-          "repositoryArn": "arn:aws:ecr:us-west-2:<aws_account_id>:repository/project-a/nginx-web-app"
-      }
-  }
+    {
+        "repository": {
+            "registryId": "123456789012",
+            "repositoryName": "sample-repo",
+            "repositoryArn": "arn:aws:ecr:us-west-2:123456789012:repository/project-a/nginx-web-app"
+        }
+    }
+
+For more information, see `Creating a Repository <https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html>`__ in the *Amazon ECR User Guide*.
+
+**Example 2: To create a repository configured with image tag immutability**
+
+The following ``create-repository`` example creates a repository configured for tag immutability in the default registry for an account. ::
+
+    aws ecr create-repository \
+        --repository-name sample-repo \
+        --image-tag-mutability IMMUTABLE
+
+Output::
+
+    {
+        "repository": {
+            "registryId": "123456789012",
+            "repositoryName": "sample-repo",
+            "repositoryArn": "arn:aws:ecr:us-west-2:123456789012:repository/sample-repo",
+            "imageTagMutability": "IMMUTABLE"
+        }
+    }
+
+For more information, see `Image Tag Mutability <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html>`__ in the *Amazon ECR User Guide*.
+
+**Example 3: To create a repository configured with a scanning configuration**
+
+The following ``create-repository`` example creates a repository configured to perform a vulnerability scan on image push in the default registry for an account. ::
+
+    aws ecr create-repository \
+        --repository-name sample-repo \
+        --image-scanning-configuration scanOnPush=true
+
+Output::
+
+    {
+        "repository": {
+            "registryId": "123456789012",
+            "repositoryName": "sample-repo",
+            "repositoryArn": "arn:aws:ecr:us-west-2:123456789012:repository/sample-repo",
+            "imageScanningConfiguration": {
+                "scanOnPush": true
+            }
+        }
+    }
+
+For more information, see `Image Scanning <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/delete-repository.rst
+++ b/awscli/examples/ecr/delete-repository.rst
@@ -1,19 +1,19 @@
 **To delete a repository**
 
-This example command force deletes a repository named ``ubuntu`` in the default
-registry for an account. The ``--force`` flag is required if the repository
-contains images.
+The following ``delete-repository`` example command force deletes the specified repository in the default registry for an account. The ``--force`` flag is required if the repository contains images. ::
 
-Command::
-
-  aws ecr delete-repository --force --repository-name ubuntu
+    aws ecr delete-repository \
+        --repository-name ubuntu \
+        --force
 
 Output::
 
-  {
-      "repository": {
-          "registryId": "<aws_account_id>",
-          "repositoryName": "ubuntu",
-          "repositoryArn": "arn:aws:ecr:us-west-2:<aws_account_id>:repository/ubuntu"
-      }
-  }
+    {
+        "repository": {
+            "registryId": "123456789012",
+            "repositoryName": "ubuntu",
+            "repositoryArn": "arn:aws:ecr:us-west-2:123456789012:repository/ubuntu"
+        }
+    }
+
+For more information, see `Deleting a Repository <https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-delete.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/describe-image-scan-findings.rst
+++ b/awscli/examples/ecr/describe-image-scan-findings.rst
@@ -1,0 +1,56 @@
+**To describe the scan findings for an image**
+
+The following ``describe-image-scan-findings`` example returns the image scan findings for an image using the image digest in the specified repository in the default registry for an account. ::
+
+    aws ecr describe-image-scan-findings \
+        --repository-name sample-repo \
+        --image-id imageDigest=sha256:74b2c688c700ec95a93e478cdb959737c148df3fbf5ea706abe0318726e885e6
+
+Output::
+
+    {
+        "imageScanFindings": {
+          "findings": [
+              {
+                  "name": "CVE-2019-5188",
+                  "description": "A code execution vulnerability exists in the directory rehashing functionality of E2fsprogs e2fsck 1.45.4. A specially crafted ext4 directory can cause an out-of-bounds write on the stack, resulting in code execution. An attacker can corrupt a partition to trigger this vulnerability.",
+                  "uri": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188",
+                  "severity": "MEDIUM",
+                  "attributes": [
+                      {
+                          "key": "package_version",
+                          "value": "1.44.1-1ubuntu1.1"
+                      },
+                      {
+                          "key": "package_name",
+                          "value": "e2fsprogs"
+                      },
+                      {
+                          "key": "CVSS2_VECTOR",
+                          "value": "AV:L/AC:L/Au:N/C:P/I:P/A:P"
+                      },
+                      {
+                          "key": "CVSS2_SCORE",
+                          "value": "4.6"
+                      }
+                  ]
+              }
+          ],
+          "imageScanCompletedAt": 1579839105.0,
+          "vulnerabilitySourceUpdatedAt": 1579811117.0,
+          "findingSeverityCounts": {
+              "MEDIUM": 1
+          }
+      },
+      "registryId": "123456789012",
+      "repositoryName": "sample-repo",
+      "imageId": {
+          "imageDigest": "sha256:74b2c688c700ec95a93e478cdb959737c148df3fbf5ea706abe0318726e885e6"
+      },
+      "imageScanStatus": {
+          "status": "COMPLETE",
+          "description": "The scan was completed successfully."
+      }
+    }
+
+For more information, see `Image Scanning <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/get-authorization-token.rst
+++ b/awscli/examples/ecr/get-authorization-token.rst
@@ -1,58 +1,17 @@
 **To get an authorization token for your default registry**
 
-This example command gets an authorization token for your default registry.
+The following ``get-authorization-token`` example command gets an authorization token for your default registry. ::
 
-Command::
-
-  aws ecr get-authorization-token
+    aws ecr get-authorization-token
 
 Output::
 
-  {
-      "authorizationData": [
-          {
-              "authorizationToken": "QVdTOkN...",
-              "expiresAt": 1448875853.241,
-              "proxyEndpoint": "https://<aws_account_id>.dkr.ecr.us-west-2.amazonaws.com"
-          }
-      ]
-  }
-
-
-**To get the decoded password for your default registry**
-
-This example command gets an authorization token for your default registry and
-returns the decoded password for you to use in a ``docker login`` command.
-
-.. note::
-
-    Mac OSX users should use the ``-D`` option to ``base64`` to decode the
-    token data.
-
-Command::
-
-  aws ecr get-authorization-token --output text \
-  --query 'authorizationData[].authorizationToken' \
-  | base64 -D | cut -d: -f2
-
-
-**To `docker login` with your decoded password**
-
-This example command uses your decoded password to add authentication
-information to your Docker installation by using the ``docker login`` command.
-The user name is ``AWS``, and you can use any email you want (Amazon ECR does
-nothing with this information, but ``docker login`` required the email field).
-
-.. note::
-
-    The final argument is the ``proxyEndpoint`` returned from
-    ``get-authorization-token`` without the ``https://`` prefix.
-
-Command::
-
-  docker login -u AWS -p <my_decoded_password> -e <any_email_address> <aws_account_id>.dkr.ecr.us-west-2.amazonaws.com
-
-Output::
-
-  WARNING: login credentials saved in $HOME/.docker/config.json
-  Login Succeeded
+    {
+        "authorizationData": [
+            {
+                "authorizationToken": "QVdTOkN...",
+                "expiresAt": 1448875853.241,
+                "proxyEndpoint": "https://123456789012.dkr.ecr.us-west-2.amazonaws.com"
+            }
+        ]
+    }

--- a/awscli/examples/ecr/get-lifecycle-policy-preview.rst
+++ b/awscli/examples/ecr/get-lifecycle-policy-preview.rst
@@ -1,6 +1,8 @@
 **To retrieve details for a lifecycle policy preview**
 
-The following ``get-lifecycle-policy-preview`` example retrieves the result of a lifecycle policy preview for a repository called ``project-a/amazon-ecs-sample`` in the default registry for an account. ::
+The following ``get-lifecycle-policy-preview`` example retrieves the result of a lifecycle policy preview for the specified repository in the default registry for an account.
+
+Command::
 
     aws ecr get-lifecycle-policy-preview \
         --repository-name "project-a/amazon-ecs-sample"
@@ -8,7 +10,7 @@ The following ``get-lifecycle-policy-preview`` example retrieves the result of a
 Output::
 
     {
-        "registryId": "<aws_account_id>",
+        "registryId": "012345678910",
         "repositoryName": "project-a/amazon-ecs-sample",
         "lifecyclePolicyText": "{\n    \"rules\": [\n        {\n            \"rulePriority\": 1,\n            \"description\": \"Expire images older than 14 days\",\n            \"selection\": {\n                \"tagStatus\": \"untagged\",\n                \"countType\": \"sinceImagePushed\",\n                \"countUnit\": \"days\",\n                \"countNumber\": 14\n            },\n            \"action\": {\n                \"type\": \"expire\"\n            }\n        }\n    ]\n}\n",
         "status": "COMPLETE",
@@ -17,3 +19,5 @@ Output::
             "expiringImageTotalCount": 0
         }
     }
+
+For more information, see `Lifecycle Policies <https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/get-lifecycle-policy.rst
+++ b/awscli/examples/ecr/get-lifecycle-policy.rst
@@ -1,16 +1,17 @@
 **To retrieve a lifecycle policy**
 
-This example retrieves the lifecycle policy for a repository called ``project-a/amazon-ecs-sample`` in the default registry for an account.
+The following ``get-lifecycle-policy`` example displays details of the lifecycle policy for the specified repository in the default registry for the account. ::
 
-Command::
-
-  aws ecr get-lifecycle-policy --repository-name "project-a/amazon-ecs-sample"
+    aws ecr get-lifecycle-policy \
+        --repository-name "project-a/amazon-ecs-sample"
 
 Output::
 
-   {
-       "registryId": "<aws_account_id>",
-       "repositoryName": "project-a/amazon-ecs-sample",
-       "lifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire images older than 14 days\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":14},\"action\":{\"type\":\"expire\"}}]}",
-       "lastEvaluatedAt": 1504295007.0
-   }
+    {
+         "registryId": "123456789012",
+         "repositoryName": "project-a/amazon-ecs-sample",
+         "lifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire images older than 14 days\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":14},\"action\":{\"type\":\"expire\"}}]}",
+         "lastEvaluatedAt": 1504295007.0
+    }
+
+For more information, see `Lifecycle Policies <https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/get-login-password.rst
+++ b/awscli/examples/ecr/get-login-password.rst
@@ -1,0 +1,16 @@
+**To retrieve a password to your default registry**
+
+This example prints a password that you can use with a container client of your
+choice to log in to your default Amazon ECR registry.
+
+Command::
+
+  aws ecr get-login-password
+
+Output::
+
+  <password>
+
+Usage with Docker::
+
+  aws ecr get-login-password | docker login --username AWS --password-stdin https://<aws_account_id>.dkr.ecr.<region>.amazonaws.com

--- a/awscli/examples/ecr/get-login-password_description.rst
+++ b/awscli/examples/ecr/get-login-password_description.rst
@@ -1,0 +1,15 @@
+**To log in to an Amazon ECR registry**
+
+This command retrieves and prints a password that is valid for a specified
+registry for 12 hours. You can pass the password to the login command of the
+container client of your preference, such as Docker. After you have logged in
+to an Amazon ECR registry with this command, you can use the Docker CLI to push
+and pull images from that registry until the token expires.
+
+.. note::
+
+    This command displays password(s) to stdout with authentication credentials.
+    Your credentials could be visible by other users on your system in a process
+    list display or a command history. If you are not on a secure system, you
+    should consider this risk and login interactively. For more information,
+    see ``get-authorization-token``.

--- a/awscli/examples/ecr/get-login_description.rst
+++ b/awscli/examples/ecr/get-login_description.rst
@@ -1,3 +1,5 @@
+    **Note:** This command is deprecated. Use ``get-login-password`` instead.
+
 **To log in to an Amazon ECR registry**
 
 This command retrieves a token that is valid for a specified registry for 12
@@ -9,7 +11,7 @@ token expires.
 
 .. note::
 
-    This command writes displays ``docker login`` commands to stdout with
+    This command displays ``docker login`` commands to stdout with
     authentication credentials. Your credentials could be visible by other
     users on your system in a process list display or a command history. If you
     are not on a secure system, you should consider this risk and login

--- a/awscli/examples/ecr/put-image-scanning-configuration.rst
+++ b/awscli/examples/ecr/put-image-scanning-configuration.rst
@@ -1,0 +1,19 @@
+**To update the image scanning configuration for a repository**
+
+The following ``put-image-scanning-configuration`` example updates the image scanning configuration for the specified repository. ::
+
+    aws ecr put-image-scanning-configuration \
+        --repository-name sample-repo \
+        --image-scanning-configuration scanOnPush=true
+
+Output::
+
+    {
+       "registryId": "012345678910",
+       "repositoryName": "sample-repo",
+       "imageScanningConfiguration": {
+         "scanOnPush": true
+       }
+    }
+
+For more information, see `Image Scanning <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/put-image-tag-mutability.rst
+++ b/awscli/examples/ecr/put-image-tag-mutability.rst
@@ -1,15 +1,17 @@
-**To make a repository's image tags immutable**
+**To update the image tag mutability setting for a repository**
 
-The following ``put-image-tag-mutability`` example sets immutable image tags on the ``hello-world`` repository. ::
+The following ``put-image-tag-mutability`` example configures the specified repository for tag immutability. This prevents all image tags within the repository from being overwritten. ::
 
     aws ecr put-image-tag-mutability \
-        --repository-name hello-world \
+        --repository-name hello-repository \
         --image-tag-mutability IMMUTABLE
 
 Output::
 
     {
-        "registryId": "012345678910",
-        "repositoryName": "hello-world",
-        "imageTagMutability": "IMMUTABLE"
+       "registryId": "012345678910",
+       "repositoryName": "sample-repo",
+       "imageTagMutability": "IMMUTABLE"
     }
+
+For more information, see `Image Tag Mutability <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/put-lifecycle-policy.rst
+++ b/awscli/examples/ecr/put-lifecycle-policy.rst
@@ -1,15 +1,14 @@
 **To create a lifecycle policy**
 
-This example creates a lifecycle policy defined by ``policy.json` for a repository called
-``project-a/amazon-ecs-sample`` in the default registry for an account.
+The following ``put-lifecycle-policy`` example creates a lifecycle policy for the specified repository in the default registry for an account. ::
 
-Command::
+    aws ecr put-lifecycle-policy \
+        --repository-name "project-a/amazon-ecs-sample" \
+        --lifecycle-policy-text "file://policy.json"
 
-  aws ecr put-lifecycle-policy --repository-name "project-a/amazon-ecs-sample" --lifecycle-policy-text "file://policy.json"
+Contents of ``policy.json``::
 
-JSON file format::
-
-   {
+    {
        "rules": [
            {
                "rulePriority": 1,
@@ -25,12 +24,14 @@ JSON file format::
                }
            }
        ]
-   }
+    }
 
 Output::
 
-  {
-    "registryId": "<aws_account_id>",
-    "repositoryName": "project-a/amazon-ecs-sample",
-    "lifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire images older than 14 days\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":14},\"action\":{\"type\":\"expire\"}}]}"
-   }
+    {
+       "registryId": "<aws_account_id>",
+       "repositoryName": "project-a/amazon-ecs-sample",
+       "lifecyclePolicyText": "{\"rules\":[{\"rulePriority\":1,\"description\":\"Expire images older than 14 days\",\"selection\":{\"tagStatus\":\"untagged\",\"countType\":\"sinceImagePushed\",\"countUnit\":\"days\",\"countNumber\":14},\"action\":{\"type\":\"expire\"}}]}"
+    }
+
+For more information, see `Lifecycle Policies <https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/start-image-scan.rst
+++ b/awscli/examples/ecr/start-image-scan.rst
@@ -1,0 +1,22 @@
+**To start an image vulnerability scan**
+
+The following ``start-image-scan`` example starts an image scan for and specified by the image digest in the `specified` repository. ::
+
+    aws ecr start-image-scan \
+        --repository-name sample-repo \
+        --image-id imageDigest=sha256:74b2c688c700ec95a93e478cdb959737c148df3fbf5ea706abe0318726e885e6
+
+Output::
+
+    {
+       "registryId": "012345678910",
+       "repositoryName": "sample-repo",
+       "imageId": {
+           "imageDigest": "sha256:74b2c688c700ec95a93e478cdb959737c148df3fbf5ea706abe0318726e885e6"
+       },
+       "imageScanStatus": {
+           "status": "IN_PROGRESS"
+       }
+    }
+
+For more information, see `Image Scanning <https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html>`__ in the *Amazon ECR User Guide*.

--- a/awscli/examples/ecr/start-lifecycle-policy-preview.rst
+++ b/awscli/examples/ecr/start-lifecycle-policy-preview.rst
@@ -1,15 +1,14 @@
 **To create a lifecycle policy preview**
 
-This example creates a lifecycle policy preview defined by ``policy.json` for a repository called
-``project-a/amazon-ecs-sample`` in the default registry for an account.
+The following ``start-lifecycle-policy-preview`` example creates a lifecycle policy preview defined by a JSON file for the specified repository. ::
 
-Command::
+    aws ecr start-lifecycle-policy-preview \
+        --repository-name "project-a/amazon-ecs-sample" \
+        --lifecycle-policy-text "file://policy.json"
 
-  aws ecr start-lifecycle-policy-preview --repository-name "project-a/amazon-ecs-sample" --lifecycle-policy-text "file://policy.json"
+Contents of ``policy.json``::
 
-JSON file format::
-
-   {
+    {
        "rules": [
            {
                "rulePriority": 1,
@@ -25,13 +24,13 @@ JSON file format::
                }
            }
        ]
-   }
+    }
 
 Output::
 
-   {
-       "registryId": "<aws_account_id>",
+    {
+       "registryId": "012345678910",
        "repositoryName": "project-a/amazon-ecs-sample",
        "lifecyclePolicyText": "{\n    \"rules\": [\n        {\n            \"rulePriority\": 1,\n            \"description\": \"Expire images older than 14 days\",\n            \"selection\": {\n                \"tagStatus\": \"untagged\",\n                \"countType\": \"sinceImagePushed\",\n                \"countUnit\": \"days\",\n                \"countNumber\": 14\n            },\n            \"action\": {\n                \"type\": \"expire\"\n            }\n        }\n    ]\n}\n",
        "status": "IN_PROGRESS"
-  }
+    }

--- a/awscli/examples/gamelift/create-build.rst
+++ b/awscli/examples/gamelift/create-build.rst
@@ -1,0 +1,70 @@
+**Example1: To create a game build from files in an S3 bucket**
+
+The following ``create-build`` example creates a custom game build resource. It uses zipped files that are stored in an S3 location in an AWS account that you control. This example assumes that you've already created an IAM role that gives Amazon GameLift permission to access the S3 location. Since the request does not specify an operating system, the new build resource defaults to WINDOWS_2012. ::
+
+    aws gamelift create-build \
+        --storage-location file://storage-loc.json \ 
+        --name MegaFrogRaceServer.NA \
+        --build-version 12345.678
+
+Contents of ``storage-loc.json``::
+
+    {
+        "Bucket":"MegaFrogRaceServer_NA_build_files"
+        "Key":"MegaFrogRaceServer_build_123.zip"
+        "RoleArn":"arn:aws:iam::123456789012:role/gamelift"
+    }
+
+Output:: 
+
+    {
+        "Build": {
+            "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "CreationTime": 1496708916.18, 
+            "Name": "MegaFrogRaceServer.NA", 
+            "OperatingSystem": "WINDOWS_2012", 
+            "SizeOnDisk": 479303, 
+            "Status": "INITIALIZED", 
+            "Version": "12345.678"
+        },
+        "StorageLocation": {
+            "Bucket": "MegaFrogRaceServer_NA_build_files", 
+            "Key": "MegaFrogRaceServer_build_123.zip"
+        }
+    }
+
+**Example2: To create a game build resource for manually uploading files to GameLift**
+
+The following ``create-build`` example creates a new build resource. It also gets a storage location and temporary credentials that allow you to manually upload your game build to the GameLift location in Amazon S3. Once you've successfully uploaded your build, the GameLift service validates the build and updates the new build's status. ::
+
+    aws gamelift create-build \
+        --name MegaFrogRaceServer.NA \
+        --build-version 12345.678 \
+        --operating-system AMAZON_LINUX
+
+Output::
+
+    {
+        "Build": {
+            "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111", 
+            "CreationTime": 1496708916.18, 
+            "Name": "MegaFrogRaceServer.NA", 
+            "OperatingSystem": "AMAZON_LINUX", 
+            "SizeOnDisk": 0, 
+            "Status": "INITIALIZED", 
+            "Version": "12345.678"
+        }, 
+        "StorageLocation": {
+            "Bucket": "gamelift-builds-us-west-2", 
+            "Key": "123456789012/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+        }, 
+        "UploadCredentials": {
+            "AccessKeyId": "AKIAIOSFODNN7EXAMPLE", 
+            "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", 
+            "SessionToken": "AgoGb3JpZ2luENz...EXAMPLETOKEN=="
+        }
+    }
+
+For more information, see `Upload a Custom Server Build to GameLift <https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/create-fleet.rst
+++ b/awscli/examples/gamelift/create-fleet.rst
@@ -3,9 +3,9 @@
 The following ``create-fleet`` example creates a minimally configured fleet of on-demand Linux instances to host a custom server build. You can complete the configuration by using ``update-fleet``. ::
 
     aws gamelift create-fleet \
-        --name MegaFrogRace.NA.v2 \
+        --name MegaFrogRaceServer.NA.v2 \
         --description 'Hosts for v2 North America' \
-        --build-id build-1111aaaa-22bb-33cc-44dd-5555eeee66ff  \
+        --build-id build-1111aaaa-22bb-33cc-44dd-5555eeee66ff \
         --certificate-configuration 'CertificateType=GENERATED' \
         --ec2-instance-type c4.large \
         --fleet-type ON_DEMAND \
@@ -17,7 +17,7 @@ Output::
         "FleetAttributes": {
             "BuildId": "build-1111aaaa-22bb-33cc-44dd-5555eeee66ff", 
             "CertificateConfiguration": { 
-              "CertificateType": "GENERATED"
+                "CertificateType": "GENERATED"
             },
             "CreationTime": 1496365885.44, 
             "Description": "Hosts for v2 North America",
@@ -45,7 +45,7 @@ The following ``create-fleet`` example creates a minimally configured fleet of s
         --certificate-configuration 'CertificateType=GENERATED' \
         --ec2-instance-type c4.large \
         --fleet-type SPOT \
-        --runtime-configuration 'ServerProcesses=[{LaunchPath==C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe,ConcurrentExecutions=1}]'
+        --runtime-configuration 'ServerProcesses=[{LaunchPath=C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe,ConcurrentExecutions=1}]'
 
 Output::
 
@@ -53,7 +53,7 @@ Output::
         "FleetAttributes": {
             "BuildId": "build-2222aaaa-33bb-44cc-55dd-6666eeee77ff", 
             "CertificateConfiguration": { 
-              "CertificateType": "GENERATED"
+                "CertificateType": "GENERATED"
             },
             "CreationTime": 1496365885.44, 
             "Description": "Hosts for v2 North America",
@@ -69,6 +69,7 @@ Output::
             "Status": "NEW"
         }
     }
+
 
 **Example 3: To create a fully configured fleet**
 
@@ -89,20 +90,20 @@ The following ``create-fleet`` example creates a fleet of Spot Windows instances
 
 Contents of ``runtime-config.json``::
 
-    GameSessionActivationTimeoutSeconds=300,
-    MaxConcurrentGameSessionActivations=2,
-    ServerProcesses=[
-        {LaunchPath=C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe,Parameters=-debug,ConcurrentExecutions=1},
-        {LaunchPath=C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe,ConcurrentExecutions=1}]
+  GameSessionActivationTimeoutSeconds=300,
+   MaxConcurrentGameSessionActivations=2,
+   ServerProcesses=[
+     {LaunchPath=C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe,Parameters=-debug,ConcurrentExecutions=1},
+     {LaunchPath=C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe,ConcurrentExecutions=1}]
 
 Output::
 
     {
         "FleetAttributes": {
-            "InstanceRoleArn": "arn:aws:iam::123456789012:role/GameLiftS3Access",
+            "InstanceRoleArn": "arn:aws:iam::444455556666:role/GameLiftS3Access",
             "Status": "NEW",
             "InstanceType": "c4.large",
-            "FleetArn": "arn:aws:gamelift:us-west-2:123456789012:fleet/fleet-2222bbbb-33cc-44dd-55ee-6666ffff77aa",
+            "FleetArn": "arn:aws:gamelift:us-west-2:444455556666:fleet/fleet-2222bbbb-33cc-44dd-55ee-6666ffff77aa",
             "FleetId": "fleet-2222bbbb-33cc-44dd-55ee-6666ffff77aa",
             "Description": "Hosts for v2 North America",
             "FleetType": "SPOT",
@@ -124,7 +125,7 @@ Output::
 
 **Example 4: To create a Realtime Servers fleet**
 
-The following ``create-fleet`` example creates a fleet of Spot instances with a Realtime configuration script that has been uploaded to Amazon GameLift. All Realtime servers are deployed onto Linux machines. For the purposes of this example, assume that the uploaded Realtime script includes multiple script files, with the Init() function located in the script file called "MainScript.js". As shown, this file is identified as the launch script in the runtime configuration. ::
+The following ``create-fleet`` example creates a fleet of Spot instances with a Realtime configuration script that has been uploaded to Amazon GameLift. All Realtime servers are deployed onto Linux machines. For the purposes of this example, assume that the uploaded Realtime script includes multiple script files, with the ``Init()`` function located in the script file called ``MainScript.js``. As shown, this file is identified as the launch script in the runtime configuration. ::
 
     aws gamelift create-fleet \
         --name MegaFrogRace.NA.realtime \
@@ -132,8 +133,7 @@ The following ``create-fleet`` example creates a fleet of Spot instances with a 
         --script-id script-1111aaaa-22bb-33cc-44dd-5555eeee66ff \
         --ec2-instance-type c4.large \
         --fleet-type SPOT \
-        --certificate-configuration 'CertificateType=GENERATED' \
-        --runtime-configuration 'ServerProcesses=[{LaunchPath=/local/game/MainScript.js,Parameters=+map Winter444,ConcurrentExecutions=5}]'
+        --certificate-configuration 'CertificateType=GENERATED' --runtime-configuration 'ServerProcesses=[{LaunchPath=/local/game/MainScript.js,Parameters=+map Winter444,ConcurrentExecutions=5}]'
 
 Output::
 
@@ -149,7 +149,7 @@ Output::
             },
             "Name": "MegaFrogRace.NA.realtime",
             "ScriptId": "script-1111aaaa-22bb-33cc-44dd-5555eeee66ff",
-            "FleetArn": "arn:aws:gamelift:us-west-2:123456789012:fleet/fleet-2222bbbb-33cc-44dd-55ee-6666ffff77aa",
+            "FleetArn": "arn:aws:gamelift:us-west-2:444455556666:fleet/fleet-2222bbbb-33cc-44dd-55ee-6666ffff77aa",
             "FleetType": "SPOT",
             "MetricGroups": [
                 "default"

--- a/awscli/examples/gamelift/create-game-session-queue.rst
+++ b/awscli/examples/gamelift/create-game-session-queue.rst
@@ -1,0 +1,86 @@
+**Example1: To set up an ordered game session queue**
+
+The following ``create-game-session-queue`` example creates a new game session queue with destinations in two regions. It also configures the queue so that game session requests time out after waiting 10 minutes for placement. Since no latency policies are defined, GameLift attempts to place all game sessions with the first destination listed. ::
+
+    aws gamelift create-game-session-queue \
+        --name MegaFrogRaceServer-NA \
+        --destinations file://destinations.json \
+        --timeout-in-seconds 600
+
+Contents of ``destinations.json``::
+
+    {
+        "Destinations": [ 
+            {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111" },
+            {"DestinationArn": "arn:aws:gamelift:us-west-1::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222" }
+        ]
+    }
+
+Output::
+
+    {
+        "GameSessionQueues": [
+	    {
+                "Name": "MegaFrogRaceServer-NA",
+                "GameSessionQueueArn": "arn:aws:gamelift:us-west-2:123456789012:gamesessionqueue/MegaFrogRaceServer-NA",
+                "TimeoutInSeconds": 600,
+                "Destinations": [
+                    {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"},
+                    {"DestinationArn": "arn:aws:gamelift:us-west-1::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222"}
+                ]
+            }
+        ]
+    }
+
+**Example2: To set up a game session queue with player latency policies**
+
+The following ``create-game-session-queue`` example creates a new game session queue with two player latency policies. The first policy sets a 100ms latency cap that is enforced during the first minute of a game session placement attempt. The second policy raises the latency cap to 200ms until the placement request times out at 3 minutes. ::
+
+    aws gamelift create-game-session-queue \
+        --name MegaFrogRaceServer-NA \
+        --destinations file://destinations.json \
+        --player-latency-policies file://latency-policies.json \
+        --timeout-in-seconds 180
+
+Contents of ``destinations.json``::
+
+    {
+        "Destinations": [ 
+            { "DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111" },
+            { "DestinationArn": "arn:aws:gamelift:us-east-1::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222" }
+        ]
+    }
+
+Contents of ``latency-policies.json``::
+
+    {
+        "PlayerLatencyPolicies": [ 
+            {"MaximumIndividualPlayerLatencyMilliseconds": 200},
+            {"MaximumIndividualPlayerLatencyMilliseconds": 100, "PolicyDurationSeconds": 60}
+        ]
+    }
+
+Output::
+
+    {
+        "GameSessionQueue": {
+            "Name": "MegaFrogRaceServer-NA",
+            "GameSessionQueueArn": "arn:aws:gamelift:us-west-2:111122223333:gamesessionqueue/MegaFrogRaceServer-NA",
+            "TimeoutInSeconds": 600,
+            "PlayerLatencyPolicies": [
+                {
+                    "MaximumIndividualPlayerLatencyMilliseconds": 100, 
+                    "PolicyDurationSeconds": 60
+                }, 
+                {
+                    "MaximumIndividualPlayerLatencyMilliseconds": 200
+                }
+            ]
+            "Destinations": [
+                {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"},
+                {"DestinationArn": "arn:aws:gamelift:us-east-1::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222"}
+            ],
+        }
+    }
+
+For more information, see `Create a Queue <https://docs.aws.amazon.com/gamelift/latest/developerguide/queues-creating.html#queues-creating-cli>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/delete-build.rst
+++ b/awscli/examples/gamelift/delete-build.rst
@@ -1,0 +1,8 @@
+**To delete a custom game build**
+
+The following ``delete-build`` example removes a build from your Amazon GameLift account. After the build is deleted, you cannot use it to create new fleets. This operation cannot be undone. ::
+
+    aws gamelift delete-build \
+       --build-id build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+This command produces no output.

--- a/awscli/examples/gamelift/delete-fleet.rst
+++ b/awscli/examples/gamelift/delete-fleet.rst
@@ -1,0 +1,10 @@
+**To delete a fleet that is no longer in use**
+
+The following ``delete-fleet`` example removes a fleet that has been scaled down to zero instances. If the fleet capacity is greater than zero, the request fails with an HTTP 400 error. ::
+
+    aws gamelift delete-fleet \
+       --fleet-id fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+This command produces no output.
+
+For more information, see `Manage GameLift Fleets <https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-editing.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/delete-game-session-queue.rst
+++ b/awscli/examples/gamelift/delete-game-session-queue.rst
@@ -1,0 +1,8 @@
+**To delete a game session queue**
+
+The following ``delete-game-session-queue`` example deletes a specified game session queue. ::
+
+    aws gamelift delete-game-session-queue \
+        --name MegaFrogRace-NA 
+
+This command produces no output.

--- a/awscli/examples/gamelift/describe-build.rst
+++ b/awscli/examples/gamelift/describe-build.rst
@@ -1,0 +1,23 @@
+**To get information on a custom game build**
+
+The following ``describe-build`` example retrieves properties for a game server build resource. ::
+
+    aws gamelift describe-build \
+        --build-id build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "Build": {
+            "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111", 
+            "CreationTime": 1496708916.18, 
+            "Name": "My_Game_Server_Build_One", 
+            "OperatingSystem": "AMAZON_LINUX", 
+            "SizeOnDisk": 1304924, 
+            "Status": "READY", 
+            "Version": "12345.678"
+        }
+    }
+
+For more information, see `Upload a Custom Server Build to GameLift <https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html#gamelift-build-cli-uploading-builds>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-ec2-instance-limits.rst
+++ b/awscli/examples/gamelift/describe-ec2-instance-limits.rst
@@ -1,0 +1,20 @@
+**To retrieve service limits for an EC2 instance type**
+
+The following ``describe-ec2-instance-limits`` example displays the maximum allowed instances and current instances in use for the specified EC2 instance type in the current Region. The result indicates that only five of the allowed twenty instances are being used. ::
+
+    aws gamelift describe-ec2-instance-limits \
+        --ec2-instance-type m5.large
+
+Output:: 
+
+    {
+        "EC2InstanceLimits": [
+            {
+                "EC2InstanceType": ""m5.large",
+                "CurrentInstances": 5,
+                "InstanceLimit": 20
+            }
+        ]
+    }
+
+For more information, see `Choose Computing Resources <https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-ec2-instances.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-fleet-attributes.rst
+++ b/awscli/examples/gamelift/describe-fleet-attributes.rst
@@ -1,0 +1,102 @@
+**Example1: To view attributes for a list of fleets**
+
+The following ``describe-fleet-attributes`` example retrieves fleet attributes for two specified fleets. As shown, the requested fleets are deployed with the same build, one for On-Demand instances and one for Spot instances, with some minor configuration differences. ::
+
+    aws gamelift describe-fleet-attributes \
+        --fleet-ids arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222
+
+Output::
+
+    {
+        "FleetAttributes": [
+            {
+                "FleetId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "FleetArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "FleetType": "ON_DEMAND",
+                "InstanceType": "c4.large",
+                "Description": "On-demand hosts for v2 North America",
+                "Name": "MegaFrogRaceServer.NA.v2-od",
+                "CreationTime": 1568836191.995,
+                "Status": "ACTIVE",
+                "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "ServerLaunchPath": "C:\\game\\MegaFrogRace_Server.exe",
+                "ServerLaunchParameters": "+gamelift_start_server",
+                "NewGameSessionProtectionPolicy": "NoProtection",
+                "OperatingSystem": "WINDOWS_2012",
+                "MetricGroups": [
+                    "default"
+                ],
+                "CertificateConfiguration": {
+                    "CertificateType": "DISABLED"
+                }
+            },
+            {
+                "FleetId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "FleetArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "FleetType": "SPOT",
+                "InstanceType": "c4.large",
+                "Description": "On-demand hosts for v2 North America",
+                "Name": "MegaFrogRaceServer.NA.v2-spot",
+                "CreationTime": 1568838275.379,
+                "Status": "ACTIVATING",
+                "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "ServerLaunchPath": "C:\\game\\MegaFrogRace_Server.exe",
+                "NewGameSessionProtectionPolicy": "NoProtection",
+                "OperatingSystem": "WINDOWS_2012",
+                    "MetricGroups": [
+                    "default"
+                ],
+                "CertificateConfiguration": {
+                    "CertificateType": "GENERATED"
+                }
+            }
+        ]
+    }
+
+**Example2: To request attributes for all fleets**
+
+The following ``describe-fleet-attributes`` returns fleet attributes for all fleets with any status. This example illustrates the use of pagination parameters to return one fleet at a time. ::
+
+    aws gamelift describe-fleet-attributes \
+        --limit 1 
+
+Output::
+
+    {
+        "FleetAttributes": [
+            {
+                "FleetId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "FleetArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "FleetType": "SPOT",
+                "InstanceType": "c4.large",
+                "Description": "On-demand hosts for v2 North America",
+                "Name": "MegaFrogRaceServer.NA.v2-spot",
+                "CreationTime": 1568838275.379,
+                "Status": "ACTIVATING",
+                "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+                "ServerLaunchPath": "C:\\game\\MegaFrogRace_Server.exe",
+                "NewGameSessionProtectionPolicy": "NoProtection",
+                "OperatingSystem": "WINDOWS_2012",
+                "MetricGroups": [
+                    "default"
+                ],
+                "CertificateConfiguration": {
+                    "CertificateType": "GENERATED"
+                }
+            }
+        ],
+        "NextToken": "eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjEXAMPLE2"
+    }
+
+The output includes a ``NextToken`` value that you can use when you call the command a second time. Pass the value to the ``--next-token`` parameter to specify where to pick up the output. The following command returns the second result in the output. ::
+ 
+    aws gamelift describe-fleet-attributes \
+        --limit 1 \
+        --next-token eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjEXAMPLE1
+
+Repeat until the response doesn't include a ``NextToken`` value.
+
+For more information, see `Setting Up GameLift Fleets <https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-intro.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-fleet-capacity.rst
+++ b/awscli/examples/gamelift/describe-fleet-capacity.rst
@@ -1,0 +1,42 @@
+**To view capacity status for a list of fleets**
+
+The following ``describe-fleet-capacity`` example retrieves current capacity for two specified fleets. ::
+
+    aws gamelift describe-fleet-capacity \
+        --fleet-ids arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222
+
+Output::
+
+    {
+        "FleetCapacity": [
+            {
+                "FleetId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "InstanceType": "c5.large",
+                "InstanceCounts": {
+                    "DESIRED": 10,
+                    "MINIMUM": 1,
+                    "MAXIMUM": 20,
+                    "PENDING": 0,
+                    "ACTIVE": 10,
+                    "IDLE": 3,
+                    "TERMINATING": 0
+                }
+            },
+            {
+                "FleetId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "InstanceType": "c5.large",
+                "InstanceCounts": {
+                    "DESIRED": 13,
+                    "MINIMUM": 1,
+                    "MAXIMUM": 20,
+                    "PENDING": 0,
+                    "ACTIVE": 15,
+                    "IDLE": 2,
+                    "TERMINATING": 2
+                }
+            }
+
+        ]
+    }
+
+For more information, see `GameLift Metrics for Fleets <https://docs.aws.amazon.com/gamelift/latest/developerguide/monitoring-cloudwatch.html#gamelift-metrics-fleet>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-fleet-events.rst
+++ b/awscli/examples/gamelift/describe-fleet-events.rst
@@ -1,0 +1,55 @@
+**To request events for a specified time span**
+
+The following ``describe-fleet-events`` example diplays details of all fleet-related events that occurred during the specified time span. ::
+
+    aws gamelift describe-fleet-events \
+        --fleet-id arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 \
+        --start-time 1579647600 \
+        --end-time 1579649400 \
+        --limit 5
+
+Output:: 
+
+    {
+        "Events": [
+            {
+                "EventId": "a37b6892-5d07-4d3b-8b47-80244ecf66b9",
+                "ResourceId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "EventCode": "FLEET_STATE_ACTIVE",
+                "Message": "Fleet fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 changed state to ACTIVE",
+                "EventTime": 1579649342.191
+            },
+            {
+                "EventId": "67da4ec9-92a3-4d95-886a-5d6772c24063",
+                "ResourceId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "EventCode": "FLEET_STATE_ACTIVATING",
+                "Message": "Fleet fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 changed state to ACTIVATING",
+                "EventTime": 1579649321.427
+            },
+            {
+                "EventId": "23813a46-a9e6-4a53-8847-f12e6a8381ac",
+                "ResourceId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "EventCode": "FLEET_STATE_BUILDING",
+                "Message": "Fleet fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 changed state to BUILDING",
+                "EventTime": 1579649321.243
+            },
+            {
+                "EventId": "3bf217d0-1d44-42f9-9202-433ed475d2e8",
+                "ResourceId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "EventCode": "FLEET_STATE_VALIDATING",
+                "Message": "Fleet fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 changed state to VALIDATING",
+                "EventTime": 1579649197.449
+            },
+            {
+                "EventId": "2ecd0130-5986-44eb-99a7-62df27741084",
+                "ResourceId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "EventCode": "FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND",
+                "Message": "Failed to find a valid path",
+                "EventTime": 1569319075.839,
+                "PreSignedLogUrl": "https://gamelift-event-logs-prod-us-west-2.s3.us-west-2.amazonaws.com/logs/fleet-83422059-8329-42a2-a4d6-c4444386a6f8/events/2ecd0130-5986-44eb-99a7-62df27741084/FLEET_VALIDATION_LAUNCH_PATH_NOT_FOUND.txt?X-Amz-Security-Token=IQoJb3JpZ2luX2VjEB8aCXVzLXdlc3QtMiJHMEUCIHV5K%2FLPx8h310D%2FAvx0%2FZxsDy5XA3cJOwPdu3T0eBa%2FAiEA1yovokcZYy%2FV4CWW6l26aFyiSHO%2Bxz%2FBMAhEHYHMQNcqkQMImP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw3NDEwNjE1OTIxNzEiDI8rsZtzLzlwEDQhXSrlAtl5Ae%2Fgo6FCIzqXPbXfBOnSvFYqeDlriZarEpKqKrUt8mXQv9iqHResqCph9AKo49lwgSYTT2QoSxnrD7%2FUgv%2BZm2pVuczvuKtUA0fcx6s0GxpjIAzdIE%2F5P%2FB7B9M%2BVZ%2F9KF82hbJi0HTE6Y7BjKsEgFCvk4UXILhfjtan9iQl8%2F21ZTurAcJbm7Y5tuLF9SWSK3%2BEa7VXOcCK4D4O1sMjmdRm0q0CKZ%2FIaXoHkNvg0RVTa0hIqdvpaDQlsSBNdqTXbjHTu6fETE9Y9Ky%2BiJK5KiUG%2F59GjCpDcvS1FqKeLUEmKT7wysGmvjMc2n%2Fr%2F9VxQfte7w9srXwlLAQuwhiXAAyI5ICMZ5JvzjzQwTqD4CHTVKUUDwL%2BRZzbuuqkJObZml02CkRGp%2B74RTAzLbWptVqZTIfzctiCTmWxb%2FmKyELRYsVLrwNJ%2BGJ7%2BCrN0RC%2FjlgfLYIZyeAqjPgAu5HjgX%2BM7jCo9M7wBTrnAXKOFQuf9dvA84SuwXOJFp17LYGjrHMKv0qC3GfbTMrZ6kzeNV9awKCpXB2Gnx9z2KvIlJdqirWVpvHVGwKCmJBCesDzjJHrae3neogI1uW%2F9C6%2B4jIZPME3jXmZcEHqqw5uvAVF7aeIavtUZU8pxpDIWT0YE4p3Kriy2AA7ziCRKtVfjV839InyLk8LUjsioWK2qlpg2HXKFLpAXw1QsQyxYmFMB9sGKOUlbL7Jdkk%2BYUq8%2FDTlLxqj1S%2FiO4TI0Wo7ilAo%2FKKWWF4guuNDexj8EOOynSp1yImB%2BZf2Fua3O44W4eEXAMPLE33333&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20170621T231808Z&X-Amz-SignedHeaders=host&X-Amz-Expires=900&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20170621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Signature=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            }
+        ],
+        "NextToken": "eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjEXAMPLE2"
+    }
+
+For more information, see `Debug GameLift Fleet Issues <https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-creating-debug.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-fleet-port-settings.rst
+++ b/awscli/examples/gamelift/describe-fleet-port-settings.rst
@@ -1,0 +1,27 @@
+**To view inbound connection permissions for a fleet**
+
+The following ``describe-fleet-port-settings`` example retrieves connection settings for a specified fleet. ::
+
+    aws gamelift describe-fleet-port-settings \
+        --fleet-id arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "InboundPermissions": [
+            {
+                "FromPort": 33400,
+                "ToPort": 33500,
+                "IpRange": "0.0.0.0/0",
+                "Protocol": "UDP"
+            },
+            {
+                "FromPort": 1900,
+                "ToPort": 2000,
+                "IpRange": "0.0.0.0/0",
+                "Protocol": "TCP"
+            }
+        ]
+    }
+
+For more information, see `Setting Up GameLift Fleets <https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-intro.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-fleet-utilization.rst
+++ b/awscli/examples/gamelift/describe-fleet-utilization.rst
@@ -1,0 +1,61 @@
+**Example1: To view usage data for a list of fleets**
+
+The following ``describe-fleet-utilization`` example retrieves current usage information for one specified fleet. ::
+
+    aws gamelift describe-fleet-utilization \
+        --fleet-ids arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "FleetUtilization": [
+            {
+            "FleetId": "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "ActiveServerProcessCount": 100,
+            "ActiveGameSessionCount": 62,
+            "CurrentPlayerSessionCount": 329,
+            "MaximumPlayerSessionCount": 1000
+            }
+        ]
+    }
+
+**Example2: To request usage data for all fleets**
+
+The following ``describe-fleet-utilization`` returns fleet usage data for all fleets with any status. This example uses pagination parameters to return data for two fleets at a time. ::
+
+    aws gamelift describe-fleet-utilization \
+        --limit 2 
+
+Output::
+
+    {
+        "FleetUtilization": [
+            {
+                "FleetId": "fleet-1111aaaa-22bb-33cc-44dd-5555eeee66ff",
+                "ActiveServerProcessCount": 100,
+                "ActiveGameSessionCount": 13,
+                "CurrentPlayerSessionCount": 98,
+                "MaximumPlayerSessionCount": 1000
+            },
+            {
+                "FleetId": "fleet-2222bbbb-33cc-44dd-55ee-6666ffff77aa",
+                "ActiveServerProcessCount": 100,
+                "ActiveGameSessionCount": 62,
+                "CurrentPlayerSessionCount": 329,
+                "MaximumPlayerSessionCount": 1000
+            }
+        ],
+        "NextToken": "eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjEXAMPLE2"
+    }
+
+Call the command a second time, passing the ``NextToken`` value as the argument to the ``--next-token`` parameter to see the next two results. ::
+
+    aws gamelift describe-fleet-utilization \
+        --limit 2 \
+        --next-token eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjEXAMPLE2
+
+Repeat until the response no longer includes a ``NextToken`` value in the output.
+
+For more information, see `GameLift Metrics for Fleets <https://docs.aws.amazon.com/gamelift/latest/developerguide/monitoring-cloudwatch.html#gamelift-metrics-fleet>`__ in the *Amazon GameLift Developer Guide*.
+
+

--- a/awscli/examples/gamelift/describe-game-session-queues.rst
+++ b/awscli/examples/gamelift/describe-game-session-queues.rst
@@ -1,0 +1,36 @@
+**To view game session queues**
+
+The following ``describe-game-session-queues`` example retrieves properties for two specified queues. ::
+
+    aws gamelift describe-game-session-queues \
+        --names MegaFrogRace-NA MegaFrogRace-EU
+
+Output::
+
+    {
+        "GameSessionQueues": [
+            {
+                "Destinations": [
+                    {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"},
+                    {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222"}
+                ],
+                "Name": "MegaFrogRace-NA",
+                "TimeoutInSeconds": 600,
+                "GameSessionQueueArn": "arn:aws:gamelift:us-west-2::gamesessionqueue/MegaFrogRace-NA",
+                "PlayerLatencyPolicies": [
+                    {"MaximumIndividualPlayerLatencyMilliseconds": 200}, 
+                    {"MaximumIndividualPlayerLatencyMilliseconds": 100, "PolicyDurationSeconds": 60}
+                ]
+            },
+            {
+                "Destinations": [
+                    {"DestinationArn": "arn:aws:gamelift:eu-west-3::fleet/fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222"}
+                ],
+                "Name": "MegaFrogRace-EU",
+                "TimeoutInSeconds": 600,
+                "GameSessionQueueArn": "arn:aws:gamelift:us-west-2::gamesessionqueue/MegaFrogRace-EU"
+            }
+        ]
+    }
+
+For more information, see `Using Multi-Region Queues <https://docs.aws.amazon.com/gamelift/latest/developerguide/queues-intro.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/describe-runtime-configuration.rst
+++ b/awscli/examples/gamelift/describe-runtime-configuration.rst
@@ -1,0 +1,29 @@
+**To request the runtime configuration for a fleet**
+
+The following ``describe-runtime-configuration`` example retrieves details about the current runtime configuration for a specified fleet. ::
+
+    aws gamelift describe-runtime-configuration \
+        --fleet-id fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output:: 
+
+    {
+        "RuntimeConfiguration": {
+            "ServerProcesses": [
+                {
+                    "LaunchPath": "C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe",
+                    "Parameters": "+gamelift_start_server",
+                    "ConcurrentExecutions": 3
+                },
+                {
+                    "LaunchPath": "C:\game\Bin64.Release.Dedicated\MegaFrogRace_Server.exe",
+                    "Parameters": "+gamelift_start_server +debug",
+                    "ConcurrentExecutions": 1
+                }
+            ],
+            "MaxConcurrentGameSessionActivations": 2147483647,
+            "GameSessionActivationTimeoutSeconds": 300
+        }
+    }
+
+For more information, see `Run Multiple Processes on a Fleet <https://docs.aws.amazon.com/gamelift/latest/developerguide/fleets-multiprocess.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/list-builds.rst
+++ b/awscli/examples/gamelift/list-builds.rst
@@ -1,0 +1,67 @@
+**Example1: To get a list of custom game builds**
+
+The following ``list-builds`` example retrieves properties for all game server builds in the current Region. The sample request illustrates how to use the pagination parameters, ``Limit`` and ``NextToken``, to retrieve the results in sequential sets. The first command retrieves the first two builds. Because there are more than two available, the response includes a ``NextToken`` to indicate that more results are available. ::
+
+    aws gamelift list-builds \
+        --limit 2
+
+Output::
+
+    {
+        "Builds": [
+            {
+                "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111", 
+                "CreationTime": 1495664528.723, 
+                "Name": "My_Game_Server_Build_One", 
+                "OperatingSystem": "WINDOWS_2012", 
+                "SizeOnDisk": 8567781, 
+                "Status": "READY", 
+                "Version": "12345.678"
+            }, 
+            {
+                "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222", 
+                "CreationTime": 1495528748.555, 
+                "Name": "My_Game_Server_Build_Two", 
+                "OperatingSystem": "AMAZON_LINUX_2",
+                "SizeOnDisk": 8567781,
+                "Status": "FAILED", 
+                "Version": "23456.789"
+            }
+        ], 
+        "NextToken": "eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjJEXAMPLE="
+    }
+
+You can then call the command again with the ``--next-token`` parameter as follows to see the next two builds. ::
+
+    aws gamelift list-builds \
+        --limit 2
+        --next-token eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjJEXAMPLE=
+
+Repeat until the response doesn't include a ``NextToken`` value.
+
+**Example2: To get a list of custom game builds in failure status**
+
+The following ``list-builds`` example retrieves properties for all game server builds in the current region that currently have status FAILED. ::
+
+    aws gamelift list-builds \
+        --status FAILED
+
+Output::
+
+    {
+        "Builds": [
+            {
+                "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222", 
+                "CreationTime": 1495528748.555, 
+                "Name": "My_Game_Server_Build_Two", 
+                "OperatingSystem": "AMAZON_LINUX_2",
+                "SizeOnDisk": 8567781,
+                "Status": "FAILED", 
+                "Version": "23456.789"
+            }
+        ]
+    }
+

--- a/awscli/examples/gamelift/list-fleets.rst
+++ b/awscli/examples/gamelift/list-fleets.rst
@@ -1,0 +1,39 @@
+**Example1: To get a list of all fleets in a Region**
+
+The following ``list-fleets`` example displays the fleet IDs of all fleets in the current Region. This example uses pagination parameters to retrieve two fleet IDs at a time. The response includes a ``next-token`` attribute, which indicates that there are more results to retrieve. ::
+
+    aws gamelift list-fleets \
+        --limit 2
+
+Output::
+
+    {
+        "FleetIds": [
+            "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222"
+        ],
+        "NextToken": "eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC01NWYxZTZmMS1jY2FlLTQ3YTctOWI5ZS1iYjFkYTQwMjJEXAMPLE="
+    }
+
+You can pass the ``NextToken`` value from the previous response in the next command, as shown here to get the next two results. ::
+
+    aws gamelift list-fleets \
+        --limit 2 \
+        --next-token eyJhd3NBY2NvdW50SWQiOnsicyI6IjMwMjc3NjAxNjM5OCJ9LCJidWlsZElkIjp7InMiOiJidWlsZC00NDRlZjQxZS1hM2I1LTQ2NDYtODJmMy0zYzI4ZTgxNjVjEXAMPLE=
+
+**Example2: To get a list of all fleets in a Region with a specific build or script**
+
+The following ``list-builds`` example retrieves the IDs of fleets that are deployed with the specified game build. If you're working with Realtime Servers, you can provide a script ID in place of a build ID. Because this example does not specify the limit parameter, the results can include up to 16 fleet IDs. ::
+
+    aws gamelift list-fleets \
+        --build-id build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "FleetIds": [
+            "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+            "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE33333",
+            "fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE44444"
+        ]
+    }

--- a/awscli/examples/gamelift/request-upload-credentials.rst
+++ b/awscli/examples/gamelift/request-upload-credentials.rst
@@ -1,0 +1,22 @@
+**To refresh access credentials for uploading a build**
+
+The following ``create-build`` example obtains new, valid access credentials for uploading a GameLift build file to an Amazon S3 location. Credentials have a limited life span. You get the build ID from the response to the original ``CreateBuild`` request. ::
+
+    aws gamelift request-upload-credentials \
+        --build-id build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output:: 
+
+    {
+        "StorageLocation": {
+            "Bucket": "gamelift-builds-us-west-2", 
+            "Key": "123456789012/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+        }, 
+        "UploadCredentials": {
+            "AccessKeyId": "AKIAIOSFODNN7EXAMPLE", 
+            "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", 
+            "SessionToken": "AgoGb3JpZ2luENz...EXAMPLETOKEN=="
+        }
+    }
+
+For more information, see `Upload a Custom Server Build to GameLift <https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/start-fleet-actions.rst
+++ b/awscli/examples/gamelift/start-fleet-actions.rst
@@ -1,0 +1,9 @@
+**To restart fleet automatic scaling activity**
+
+The following ``start-fleet-actions`` example resumes the use of all scaling policies that are defined for the specified fleet but were stopped by calling``stop-fleet-actions``. After starting, the scaling policies immediately begin tracking their respective metrics. ::
+
+    aws gamelift start-fleet-actions \
+        --fleet-id fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 \ 
+        --actions AUTO_SCALING
+
+This command produces no output.

--- a/awscli/examples/gamelift/stop-fleet-actions.rst
+++ b/awscli/examples/gamelift/stop-fleet-actions.rst
@@ -1,0 +1,10 @@
+**To stop a fleet's automatic scaling activity**
+
+The following ``stop-fleet-actions`` example stops the use of all scaling policies that are defined for the specified fleet. After the policies are suspended, fleet capacity remains at the same active instance count unless you adjust it manually.  ::
+
+    aws gamelift start-fleet-actions \
+        --fleet-id fleet-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 \ 
+        --actions AUTO_SCALING
+
+This command produces no output.
+

--- a/awscli/examples/gamelift/update-build.rst
+++ b/awscli/examples/gamelift/update-build.rst
@@ -1,0 +1,25 @@
+**To update a custom game build**
+
+The following ``update-build`` example changes the name and version information that is associated with a specified build resource. The returned build object verifies that the changes were made successfully. ::
+
+    aws gamelift update-build \
+        --build-id build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111 \
+        --name MegaFrogRaceServer.NA.east \
+        --build-version 12345.east
+
+Output::
+
+    {
+        "Build": {
+            "BuildArn": "arn:aws:gamelift:us-west-2::build/build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "BuildId": "build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111", 
+            "CreationTime": 1496708916.18,
+            "Name": "MegaFrogRaceServer.NA.east",
+            "OperatingSystem": "AMAZON_LINUX_2",
+            "SizeOnDisk": 1304924, 
+            "Status": "READY", 
+            "Version": "12345.east"
+        }
+    }
+
+For more information, see `Update Your Build Files <https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html#gamelift-build-cli-uploading-update-build-files>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/update-game-session-queue.rst
+++ b/awscli/examples/gamelift/update-game-session-queue.rst
@@ -1,0 +1,50 @@
+**To update a game session queue configuration**
+
+The following ``update-game-session-queue`` example adds a new destination and updates the player latency policies for an existing game session queue. ::
+
+    aws gamelift update-game-session-queue \
+        --name MegaFrogRace-NA \
+        --destinations file://destinations.json \
+        --player-latency-policies file://latency-policies.json
+
+Contents of ``destinations.json``::
+
+    {
+        "Destinations": [ 
+            {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"},
+            {"DestinationArn": "arn:aws:gamelift:us-east-1::fleet/fleet-5c6d3c4d-5e6f-7a8b-9c0d-1e2f3a4b5a2b"},
+            {"DestinationArn": "arn:aws:gamelift:us-east-1::alias/alias-11aa22bb-3c4d-5e6f-000a-1111aaaa22bb"}
+        ]
+    }
+
+Contents of ``latency-policies.json``::
+
+    {
+        "PlayerLatencyPolicies": [ 
+            {"MaximumIndividualPlayerLatencyMilliseconds": 200},
+            {"MaximumIndividualPlayerLatencyMilliseconds": 150, "PolicyDurationSeconds": 120},
+            {"MaximumIndividualPlayerLatencyMilliseconds": 100, "PolicyDurationSeconds": 120}
+        ]
+    }
+
+Output::
+
+    {
+        "GameSessionQueue": {
+            "Destinations": [
+                {"DestinationArn": "arn:aws:gamelift:us-west-2::fleet/fleet-1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"},
+                {"DestinationArn": "arn:aws:gamelift:us-east-1::fleet/fleet-5c6d3c4d-5e6f-7a8b-9c0d-1e2f3a4b5a2b"}, 
+                {"DestinationArn": "arn:aws:gamelift:us-east-1::alias/alias-11aa22bb-3c4d-5e6f-000a-1111aaaa22bb"}
+            ],
+            "GameSessionQueueArn": "arn:aws:gamelift:us-west-2:111122223333:gamesessionqueue/MegaFrogRace-NA",
+            "Name": "MegaFrogRace-NA",
+            "TimeoutInSeconds": 600,
+            "PlayerLatencyPolicies": [
+                {"MaximumIndividualPlayerLatencyMilliseconds": 200}, 
+                {"MaximumIndividualPlayerLatencyMilliseconds": 150, "PolicyDurationSeconds": 120},
+                {"MaximumIndividualPlayerLatencyMilliseconds": 100, "PolicyDurationSeconds": 120}
+            ]
+        }
+    }
+
+For more information, see `Using Multi-Region Queues <https://docs.aws.amazon.com/gamelift/latest/developerguide/queues-intro.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/gamelift/upload-build.rst
+++ b/awscli/examples/gamelift/upload-build.rst
@@ -1,0 +1,41 @@
+**Example1: To upload a Linux game server build**
+
+The following ``upload-build`` example uploads Linux game server build files from a file directory to the GameLift service and creates a build resource. ::
+
+    aws gamelift upload-build \
+        --name MegaFrogRaceServer.NA \
+        --build-version 2.0.1 \
+        --build-root ~/MegaFrogRace_Server/release-na \
+        --operating-system AMAZON_LINUX_2
+
+Output::
+
+    Uploading ~/MegaFrogRace_Server/release-na:  16.0 KiB / 74.6 KiB (21.45%)
+    Uploading ~/MegaFrogRace_Server/release-na:  32.0 KiB / 74.6 KiB (42.89%)
+    Uploading ~/MegaFrogRace_Server/release-na:  48.0 KiB / 74.6 KiB (64.34%)
+    Uploading ~/MegaFrogRace_Server/release-na:  64.0 KiB / 74.6 KiB (85.79%)
+    Uploading ~/MegaFrogRace_Server/release-na:  74.6 KiB / 74.6 KiB (100.00%)
+    Successfully uploaded ~/MegaFrogRace_Server/release-na to AWS GameLift
+    Build ID: build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+**Example2: To upload a Windows game server build**
+
+The following ``upload-build`` example uploads Windows game server build files from a directory to the GameLift service and creates a build record. ::
+
+    aws gamelift upload-build \
+        --name MegaFrogRaceServer.NA \
+        --build-version 2.0.1 \
+        --build-root C:\MegaFrogRace_Server\release-na \
+        --operating-system WINDOWS_2012
+
+Output::
+
+    Uploading C:\MegaFrogRace_Server\release-na:  16.0 KiB / 74.6 KiB (21.45%)
+    Uploading C:\MegaFrogRace_Server\release-na:  32.0 KiB / 74.6 KiB (42.89%)
+    Uploading C:\MegaFrogRace_Server\release-na:  48.0 KiB / 74.6 KiB (64.34%)
+    Uploading C:\MegaFrogRace_Server\release-na:  64.0 KiB / 74.6 KiB (85.79%)
+    Uploading C:\MegaFrogRace_Server\release-na:  74.6 KiB / 74.6 KiB (100.00%)
+    Successfully uploaded C:\MegaFrogRace_Server\release-na to AWS GameLift
+    Build ID: build-a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+For more information, see `Upload a Custom Server Build to GameLift <https://docs.aws.amazon.com/gamelift/latest/developerguide/gamelift-build-cli-uploading.html>`__ in the *Amazon GameLift Developer Guide*.

--- a/awscli/examples/greengrass/list-bulk-deployment-detailed-reports.rst
+++ b/awscli/examples/greengrass/list-bulk-deployment-detailed-reports.rst
@@ -1,0 +1,32 @@
+**To list information about individual deployments in a bulk deployment**
+
+The following ``list-bulk-deployment-detailed-reports`` example displays information about the individual deployments in a bulk deployment operation, including status. ::
+
+    aws greengrass list-bulk-deployment-detailed-reports \
+        --bulk-deployment-id 42ce9c42-489b-4ed4-b905-8996aa50ef9d
+
+Output::
+
+    {
+        "Deployments": [
+            {
+                "DeploymentType": "NewDeployment",
+                "DeploymentStatus": "Success",
+                "DeploymentId": "123456789012:a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "DeploymentArn": "arn:aws:greengrass:us-west-2:123456789012:/greengrass/groups/a1b2c3d4-5678-90ab-cdef-EXAMPLE33333/deployments/123456789012:123456789012:a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "GroupArn": "arn:aws:greengrass:us-west-2:123456789012:/greengrass/groups/a1b2c3d4-5678-90ab-cdef-EXAMPLE33333/versions/123456789012:a1b2c3d4-5678-90ab-cdef-EXAMPLE44444",
+                "CreatedAt": "2020-01-21T21:34:16.501Z"
+            },
+            {
+                "DeploymentType": "NewDeployment",
+                "DeploymentStatus": "InProgress",
+                "DeploymentId": "123456789012:a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "DeploymentArn": "arn:aws:greengrass:us-west-2:123456789012:/greengrass/groups/a1b2c3d4-5678-90ab-cdef-EXAMPLE55555/deployments/123456789012:123456789012:a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+                "GroupArn": "arn:aws:greengrass:us-west-2:123456789012:/greengrass/groups/a1b2c3d4-5678-90ab-cdef-EXAMPLE55555/versions/a1b2c3d4-5678-90ab-cdef-EXAMPLE66666",
+                "CreatedAt": "2020-01-21T21:34:16.486Z"
+            },
+            ...
+        ]
+    }
+
+For more information, see `Create Bulk Deployments for Groups <https://docs.aws.amazon.com/greengrass/latest/developerguide/bulk-deploy-cli.html>`__ in the *AWS IoT Greengrass Developer Guide*.

--- a/awscli/examples/iot/create-domain-configuration.rst
+++ b/awscli/examples/iot/create-domain-configuration.rst
@@ -1,0 +1,16 @@
+**To create a domain configuration**
+
+The following ``create-domain-configuration`` example creates an AWS-managed domain configuration with a service type of ``DATA``. ::
+
+    aws iot create-domain-configuration \
+        --domain-configuration-name "additionalDataDomain" \
+        --service-type "DATA"
+
+Output::
+
+    {
+        "domainConfigurationName": "additionalDataDomain",
+        "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/additionalDataDomain/dikMh"
+    }
+
+For more information, see `Configurable Endpoints <https://docs.aws.amazon.com/iot/latest/developerguide/iot-custom-endpoints-configurable-aws.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/iot/delete-domain-configuration.rst
+++ b/awscli/examples/iot/delete-domain-configuration.rst
@@ -1,0 +1,11 @@
+**To delete a domain configuration**
+
+The following ``delete-domain-configuration`` example deletes a domain configuration named ``additionalDataDomain`` from your AWS account. ::
+
+    aws iot update-domain-configuration \
+        --domain-configuration-name "additionalDataDomain" \
+        --domain-configuration-status "DISABLED"
+
+This command produces no output.
+
+For more information, see `Configurable Endpoints <https://docs.aws.amazon.com/iot/latest/developerguide/iot-custom-endpoints-configurable-aws.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/iot/describe-domain-configuration.rst
+++ b/awscli/examples/iot/describe-domain-configuration.rst
@@ -1,0 +1,20 @@
+**To describe a domain configuration**
+
+The following ``describe-domain-configuration`` example displays details about the specified domain configuration. ::
+
+    aws iot describe-domain-configuration \
+        --domain-configuration-name "additionalDataDomain"
+
+Output::
+
+    {    
+        "domainConfigurationName": "additionalDataDomain",   
+        "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/additionalDataDomain/dikMh",   
+        "domainName": "d01645582h24k4we2vblw-ats.iot.us-west-2.amazonaws.com",   
+        "serverCertificates": [],   
+        "domainConfigurationStatus": "ENABLED",  
+        "serviceType": "DATA",  
+        "domainType": "AWS_MANAGED"
+    }
+
+For more information, see `Configurable Endpoints <https://docs.aws.amazon.com/iot/latest/developerguide/iot-custom-endpoints-configurable-aws.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/iot/get-cardinality.rst
+++ b/awscli/examples/iot/get-cardinality.rst
@@ -1,0 +1,42 @@
+**To return the approximate count of unique values that match the query**
+
+You can use the following setup script to create 10 things representing 10 temperature sensors. Each new thing has 3 attributes. ::
+
+    # Bash script. If in other shells, type `bash` before running
+    Temperatures=(70 71 72 73 74 75 47 97 98 99)
+    Racks=(Rack1 Rack1 Rack2 Rack2 Rack3 Rack4 Rack5 Rack6 Rack6 Rack6)
+    IsNormal=(true true true true true true false false false false)
+    for ((i=0; i<10 ; i++))
+    do
+      thing=$(aws iot create-thing --thing-name "TempSensor$i" --attribute-payload attributes="{temperature=${Temperatures[i]},rackId=${Racks[i]},stateNormal=${IsNormal[i]}}")
+      aws iot describe-thing --thing-name "TempSensor$i"
+    done
+
+Example output of the setup script::
+
+    {
+        "version": 1, 
+        "thingName": "TempSensor0", 
+        "defaultClientId": "TempSensor0", 
+        "attributes": {
+            "rackId": "Rack1", 
+            "stateNormal": "true", 
+            "temperature": "70"
+        }, 
+        "thingArn": "arn:aws:iot:us-east-1:123456789012:thing/TempSensor0", 
+        "thingId": "example1-90ab-cdef-fedc-ba987example"
+    }
+
+The following ``get-cardinality`` example queries the 10 sensors created by the setup script and returns the number of racks that have temperature sensors reporting abnormal temperature values. If the temperature value is below 60 or above 80, the temperature sensor is in an abnormal state. ::
+
+    aws iot get-cardinality \
+        --aggregation-field "attributes.rackId" \
+        --query-string "thingName:TempSensor* AND attributes.stateNormal:false"
+
+Output::
+
+    {
+        "cardinality": 2
+    }
+
+For more information, see `Querying for Aggregate Data<https://docs.aws.amazon.com/iot/latest/developerguide/index-aggregate.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/iot/get-percentiles.rst
+++ b/awscli/examples/iot/get-percentiles.rst
@@ -1,0 +1,60 @@
+**To group the aggregated values that match the query into percentile groupings**
+
+You can use the following setup script to create 10 things representing 10 temperature sensors. Each new thing has 1 attribute. ::
+
+    # Bash script. If in other shells, type `bash` before running
+    Temperatures=(70 71 72 73 74 75 47 97 98 99)
+    for ((i=0; i<10 ; i++))
+    do
+        thing=$(aws iot create-thing --thing-name "TempSensor$i" --attribute-payload attributes="{temperature=${Temperatures[i]}}")
+        aws iot describe-thing --thing-name "TempSensor$i"
+    done
+
+Example output of the setup script::
+
+    {
+        "version": 1, 
+        "thingName": "TempSensor0", 
+        "defaultClientId": "TempSensor0", 
+        "attributes": {
+            "temperature": "70"
+        }, 
+        "thingArn": "arn:aws:iot:us-east-1:123456789012:thing/TempSensor0", 
+        "thingId": "example1-90ab-cdef-fedc-ba987example"
+    }
+
+The following ``get-percentiles`` example queries the 10 sensors created by the setup script and returns a value for each percentile group specified. The percentile group "10" contains the aggregated field value that occurs in approximately 10 percent of the values that match the query. In the following output, {"percent": 10.0, "value": 67.7} means approximately 10.0% of the temperature values are below 67.7. ::
+
+    aws iot get-percentiles \
+        --aggregation-field "attributes.temperature" \
+        --query-string "thingName:TempSensor*" \
+        --percents 10 25 50 75 90
+
+Output::
+
+    {
+        "percentiles": [
+            {
+                "percent": 10.0, 
+                "value": 67.7
+            }, 
+            {
+                "percent": 25.0, 
+                "value": 71.25
+            }, 
+            {
+                "percent": 50.0, 
+                "value": 73.5
+            }, 
+            {
+                "percent": 75.0, 
+                "value": 91.5
+            }, 
+            {
+                "percent": 90.0, 
+                "value": 98.1
+            }
+        ]
+    }
+
+For more information, see `Querying for Aggregate Data <https://docs.aws.amazon.com/iot/latest/developerguide/index-aggregate.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/iot/list-domain-configurations.rst
+++ b/awscli/examples/iot/list-domain-configurations.rst
@@ -1,0 +1,37 @@
+**To list domain configurations**
+
+The following ``list-domain-configurations`` example lists the domain configurations in your AWS account that have the specified service type. ::
+
+    aws iot list-domain-configurations \
+        --service-type "DATA"
+
+Output::
+
+    {
+        "domainConfigurations": 
+        [       
+            {                 
+                "domainConfigurationName": "additionalDataDomain",              
+                "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/additionalDataDomain/dikMh",          
+                "serviceType": "DATA"         
+            },
+                
+            {               
+                "domainConfigurationName": "iot:Jobs",           
+                "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/iot:Jobs",               
+                "serviceType": "JOBS"          
+            },          
+            {               
+                "domainConfigurationName": "iot:Data-ATS",              
+                "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/iot:Data-ATS",                
+                "serviceType": "DATA"           
+            },          
+            {               
+                "domainConfigurationName": "iot:CredentialProvider",               
+                "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/iot:CredentialProvider",               
+                "serviceType": "CREDENTIAL_PROVIDER"           
+            }    
+        ]
+    }
+
+For more information, see `Configurable Endpoints <https://docs.aws.amazon.com/iot/latest/developerguide/iot-custom-endpoints-configurable-aws.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/iot/update-domain-configuration.rst
+++ b/awscli/examples/iot/update-domain-configuration.rst
@@ -1,0 +1,16 @@
+**To update a domain configuration**
+
+The following ``update-domain-configuration`` example disables the specified domain configuration. ::
+
+    aws iot update-domain-configuration \
+        --domain-configuration-name "additionalDataDomain" \
+        --domain-configuration-status "DISABLED"
+
+Output::
+
+    {
+        "domainConfigurationName": "additionalDataDomain",
+        "domainConfigurationArn": "arn:aws:iot:us-west-2:123456789012:domainconfiguration/additionalDataDomain/dikMh"
+    }
+
+For more information, see `Configurable Endpoints <https://docs.aws.amazon.com/iot/latest/developerguide/iot-custom-endpoints-configurable-aws.html>`__ in the *AWS IoT Developer Guide*.

--- a/awscli/examples/shield/associate-drt-log-bucket.rst
+++ b/awscli/examples/shield/associate-drt-log-bucket.rst
@@ -1,0 +1,10 @@
+**To authorize the DRT to access an Amazon S3 bucket**
+
+The following ``associate-drt-log-bucket`` example creates an association between the DRT and the specified S3 bucket. This permits the DRT to access the bucket on behalf of the account.::
+
+    aws shield associate-drt-log-bucket \
+        --log-bucket flow-logs-for-website-lb
+
+This command produces no output.
+
+For more information, see `Authorize the DDoS Response Team <https://docs.aws.amazon.com/waf/latest/developerguide/authorize-DRT.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/associate-drt-role.rst
+++ b/awscli/examples/shield/associate-drt-role.rst
@@ -1,0 +1,10 @@
+**To authorize the DRT to mitigate potential attacks on your behalf**
+
+The following ``associate-drt-role`` example creates an association between the DRT and the specified role. The DRT can use the role to access and manage the account. ::
+
+    aws shield associate-drt-role \
+        --role-arn arn:aws:iam::123456789012:role/service-role/DrtRole
+
+This command produces no output.
+
+For more information, see `Authorize the DDoS Response Team <https://docs.aws.amazon.com/waf/latest/developerguide/authorize-DRT.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/create-protection.rst
+++ b/awscli/examples/shield/create-protection.rst
@@ -1,0 +1,15 @@
+**To enable AWS Shield Advanced protection for a single AWS resource**
+
+The following ``create-protection`` example enables Shield Advanced protection for the specified AWS CloudFront distribution. ::
+
+    aws shield create-protection \
+        --name "Protection for CloudFront distribution" \
+        --resource-arn arn:aws:cloudfront::123456789012:distribution/E198WC25FXOWY8
+
+Output::
+
+    {
+        "ProtectionId": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111"
+    }
+
+For more information, see `Specify Your Resources to Protect <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-choose-resources.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/create-subscription.rst
+++ b/awscli/examples/shield/create-subscription.rst
@@ -1,0 +1,9 @@
+**To enable AWS Shield Advanced protection for an account**
+
+The following ``create-subscription`` example enables Shield Advanced protection for the account. ::
+
+    aws shield create-subscription
+
+This command produces no output.
+        
+For more information, see `Getting Started with AWS Shield Advanced <https://docs.aws.amazon.com/waf/latest/developerguide/getting-started-ddos.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/delete-protection.rst
+++ b/awscli/examples/shield/delete-protection.rst
@@ -1,0 +1,10 @@
+**To remove AWS Shield Advanced protection from an AWS resource**
+
+The following ``delete-protection`` example removes the specified AWS Shield Advanced protection. ::
+
+    aws shield delete-protection \
+        --protection-id a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+This command produces no output.
+        
+For more information, see `Removing AWS Shield Advanced from an AWS Resource <https://docs.aws.amazon.com/waf/latest/developerguide/remove-protection.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/describe-attack.rst
+++ b/awscli/examples/shield/describe-attack.rst
@@ -1,0 +1,228 @@
+**To retrieve a detailed description of an attack**
+
+The following ``describe-attack`` example displays details about the DDoS attack with the specified attack ID. You can obtain attack IDs by running the ``list-attacks`` command. ::
+
+    aws shield describe-attack --attack-id a1b2c3d4-5678-90ab-cdef-EXAMPLE22222
+
+Output::
+
+    {
+        "Attack": {
+            "AttackId": "a1b2c3d4-5678-90ab-cdef-EXAMPLE22222",
+            "ResourceArn": "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/testElb",
+            "SubResources": [
+                {
+                    "Type": "IP",
+                    "Id": "192.0.2.2",
+                    "AttackVectors": [
+                        {
+                            "VectorType": "SYN_FLOOD",
+                            "VectorCounters": [
+                                {
+                                    "Name": "SYN_FLOOD_BPS",
+                                    "Max": 982184.0,
+                                    "Average": 982184.0,
+                                    "Sum": 11786208.0,
+                                    "N": 12,
+                                    "Unit": "BPS"
+                                }
+                            ]
+                        }
+                    ],
+                    "Counters": []
+                },
+                {
+                    "Type": "IP",
+                    "Id": "192.0.2.3",
+                    "AttackVectors": [
+                        {
+                            "VectorType": "SYN_FLOOD",
+                            "VectorCounters": [
+                                {
+                                    "Name": "SYN_FLOOD_BPS",
+                                    "Max": 982184.0,
+                                    "Average": 982184.0,
+                                    "Sum": 9821840.0,
+                                    "N": 10,
+                                    "Unit": "BPS"
+                                }
+                            ]
+                        }
+                    ],
+                    "Counters": []
+                },
+                {
+                    "Type": "IP",
+                    "Id": "192.0.2.4",
+                    "AttackVectors": [
+                        {
+                            "VectorType": "SYN_FLOOD",
+                            "VectorCounters": [
+                                {
+                                    "Name": "SYN_FLOOD_BPS",
+                                    "Max": 982184.0,
+                                    "Average": 982184.0,
+                                    "Sum": 7857472.0,
+                                    "N": 8,
+                                    "Unit": "BPS"
+                                }
+                            ]
+                        }
+                    ],
+                    "Counters": []
+                },
+                {
+                    "Type": "IP",
+                    "Id": "192.0.2.5",
+                    "AttackVectors": [
+                        {
+                            "VectorType": "SYN_FLOOD",
+                            "VectorCounters": [
+                                {
+                                    "Name": "SYN_FLOOD_BPS",
+                                    "Max": 982184.0,
+                                    "Average": 982184.0,
+                                    "Sum": 1964368.0,
+                                    "N": 2,
+                                    "Unit": "BPS"
+                                }
+                            ]
+                        }
+                    ],
+                    "Counters": []
+                },
+                {
+                    "Type": "IP",
+                    "Id": "2001:DB8::bcde:4321:8765:0:0",
+                    "AttackVectors": [
+                        {
+                            "VectorType": "SYN_FLOOD",
+                            "VectorCounters": [
+                                {
+                                    "Name": "SYN_FLOOD_BPS",
+                                    "Max": 982184.0,
+                                    "Average": 982184.0,
+                                    "Sum": 1964368.0,
+                                    "N": 2,
+                                    "Unit": "BPS"
+                                }
+                            ]
+                        }
+                    ],
+                    "Counters": []
+                },
+                {
+                    "Type": "IP",
+                    "Id": "192.0.2.6",
+                    "AttackVectors": [
+                        {
+                            "VectorType": "SYN_FLOOD",
+                            "VectorCounters": [
+                                {
+                                    "Name": "SYN_FLOOD_BPS",
+                                    "Max": 982184.0,
+                                    "Average": 982184.0,
+                                    "Sum": 1964368.0,
+                                    "N": 2,
+                                    "Unit": "BPS"
+                                }
+                            ]
+                        }
+                    ],
+                    "Counters": []
+                }
+            ],
+            "StartTime": 1576024927.457,
+            "EndTime": 1576025647.457,
+            "AttackCounters": [],
+            "AttackProperties": [
+                {
+                    "AttackLayer": "NETWORK",
+                    "AttackPropertyIdentifier": "SOURCE_IP_ADDRESS",
+                    "TopContributors": [
+                        {
+                            "Name": "198.51.100.5",
+                            "Value": 2024475682
+                        },
+                        {
+                            "Name": "198.51.100.8",
+                            "Value": 1311380863
+                        },
+                        {
+                            "Name": "203.0.113.4",
+                            "Value": 900599855
+                        },
+                        {
+                            "Name": "198.51.100.4",
+                            "Value": 769417366
+                        },
+                        {
+                            "Name": "203.1.113.13",
+                            "Value": 757992847
+                        }
+                    ],
+                    "Unit": "BYTES",
+                    "Total": 92773354841
+                },
+                {
+                    "AttackLayer": "NETWORK",
+                    "AttackPropertyIdentifier": "SOURCE_COUNTRY",
+                    "TopContributors": [
+                        {
+                            "Name": "United States",
+                            "Value": 80938161764
+                        },
+                        {
+                            "Name": "Brazil",
+                            "Value": 9929864330
+                        },
+                        {
+                            "Name": "Netherlands",
+                            "Value": 1635009446
+                        },
+                        {
+                            "Name": "Mexico",
+                            "Value": 144832971
+                        },
+                        {
+                            "Name": "Japan",
+                            "Value": 45369000
+                        }
+                    ],
+                    "Unit": "BYTES",
+                    "Total": 92773354841
+                },
+                {
+                    "AttackLayer": "NETWORK",
+                    "AttackPropertyIdentifier": "SOURCE_ASN",
+                    "TopContributors": [
+                        {
+                            "Name": "12345",
+                            "Value": 74953625841
+                        },
+                        {
+                            "Name": "12346",
+                            "Value": 4440087595
+                        },
+                        {
+                            "Name": "12347",
+                            "Value": 1635009446
+                        },
+                        {
+                            "Name": "12348",
+                            "Value": 1221230000
+                        },
+                        {
+                            "Name": "12349",
+                            "Value": 1199425294
+                        }
+                    ],
+                    "Unit": "BYTES",
+                    "Total": 92755479921
+                }
+            ],
+            "Mitigations": []
+        }
+    }
+
+For more information, see `Reviewing DDoS Incidents <https://docs.aws.amazon.com/waf/latest/developerguide/using-ddos-reports.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/describe-drt-access.rst
+++ b/awscli/examples/shield/describe-drt-access.rst
@@ -1,0 +1,16 @@
+**To retrieve a description of the authorizations the DRT has to mitigate attacks on your behalf**
+
+The following ``describe-drt-access`` example retrieves the role and S3 bucket authorizations that the DRT has, which allow it to respond to potential attacks on your behalf. ::
+
+    aws shield describe-drt-access
+
+Output::
+
+    {
+        "RoleArn": "arn:aws:iam::123456789012:role/service-role/DrtRole",
+        "LogBucketList": [
+            "flow-logs-for-website-lb"
+        ]
+    }
+
+For more information, see `Authorize the DDoS Response Team <https://docs.aws.amazon.com/waf/latest/developerguide/authorize-DRT.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/describe-emergency-contact-settings.rst
+++ b/awscli/examples/shield/describe-emergency-contact-settings.rst
@@ -1,0 +1,20 @@
+**To retrieve emergency e-mail addresses that you have on file with the DRT**
+
+The following ``describe-emergency-contact-settings`` example retrieves the e-mail addresses that are on file with the DRT for the account. These are the addresses the DRT should contact when it's responding to a suspected attack. ::
+
+    aws shield describe-emergency-contact-settings
+
+Output::
+
+    {
+        "EmergencyContactList": [
+            {
+                "EmailAddress": "ops@example.com"
+            },
+            {
+                "EmailAddress": "ddos-notifications@example.com"
+           }
+        ]
+    }
+
+For more information, see `How AWS Shield Works<https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/describe-protection.rst
+++ b/awscli/examples/shield/describe-protection.rst
@@ -1,0 +1,18 @@
+**To retrieve the details for an AWS Shield Advanced protection**
+
+The following ``describe-protection`` example displays details about the Shield Advanced protection with the specified ID. You can obtain protection IDs by running the ``list-protections`` command. ::
+
+    aws shield describe-protection \
+        --protection-id a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
+
+Output::
+
+    {
+        "Protection": {
+            "Id": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+            "Name": "1.2.3.4",
+            "ResourceArn": "arn:aws:ec2:us-west-2:123456789012:eip-allocation/eipalloc-0ac1537af40742a6d"
+        }
+    }
+
+For more information, see `Specify Your Resources to Protect <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-choose-resources.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/describe-subscription.rst
+++ b/awscli/examples/shield/describe-subscription.rst
@@ -1,0 +1,40 @@
+**To retrieve the details of the AWS Shield Advanced protection for the account**
+
+The following ``describe-subscription`` example displays details about the Shield Advanced protection provided for the account.::
+
+    aws shield describe-subscription
+
+Output::
+
+    {
+        "Subscription": {
+            "StartTime": 1534368978.0,
+            "EndTime": 1597613778.0,
+            "TimeCommitmentInSeconds": 63244800,
+            "AutoRenew": "ENABLED",
+            "Limits": [
+                {
+                    "Type": "GLOBAL_ACCELERATOR",
+                    "Max": 1000
+                },
+                {
+                    "Type": "ROUTE53_HOSTED_ZONE",
+                    "Max": 1000
+                },
+                {
+                    "Type": "CF_DISTRIBUTION",
+                    "Max": 1000
+                },
+                {
+                    "Type": "ELB_LOAD_BALANCER",
+                    "Max": 1000
+                },
+                {
+                    "Type": "EC2_ELASTIC_IP_ALLOCATION",
+                    "Max": 1000
+                }
+            ]
+        }
+    }
+
+For more information, see `How AWS Shield Works <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/disassociate-drt-log-bucket.rst
+++ b/awscli/examples/shield/disassociate-drt-log-bucket.rst
@@ -1,0 +1,10 @@
+**To remove the authorization for DRT to access an Amazon S3 bucket on your behalf**
+
+The following ``disassociate-drt-log-bucket`` example removes the association between the DRT and the specified S3 bucket. After this command completes, the DRT can no longer access the bucket on behalf of the account. ::
+
+    aws shield disassociate-drt-log-bucket \
+        --log-bucket flow-logs-for-website-lb
+
+This command produces no output.
+
+For more information, see `Authorize the DDoS Response Team <https://docs.aws.amazon.com/waf/latest/developerguide/authorize-DRT.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/disassociate-drt-role.rst
+++ b/awscli/examples/shield/disassociate-drt-role.rst
@@ -1,0 +1,9 @@
+**To remove the authorization for DRT to mitigate potential attacks on your behalf**
+
+The following ``disassociate-drt-role`` example removes the association between the DRT and the account. After this call, the DRT can no longer access or manage your account. ::
+
+    aws shield disassociate-drt-role 
+
+This command produces no output.
+ 
+For more information, see `Authorize the DDoS Response Team <https://docs.aws.amazon.com/waf/latest/developerguide/authorize-DRT.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/get-subscription-state.rst
+++ b/awscli/examples/shield/get-subscription-state.rst
@@ -1,0 +1,13 @@
+**To retrieve the current state of the account's AWS Shield Advanced subscription**
+
+The following ``get-subscription-state`` example retrieves the state of the Shield Advanced protection for the account. ::
+
+    aws shield get-subscription-state
+
+Output::
+
+    {
+        "SubscriptionState": "ACTIVE"
+    }
+
+For more information, see `How AWS Shield Works <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/list-attacks.rst
+++ b/awscli/examples/shield/list-attacks.rst
@@ -1,0 +1,27 @@
+**To retrieve attack summaries from AWS Shield Advanced**
+
+The following ``list-attacks`` example retrieves summaries of attacks for the specified AWS CloudFront distribution during the specified time period. The response includes attack IDs that you can provide to the ``describe-attack`` command for detailed information on an attack. ::
+
+    aws shield list-attacks \
+        --resource-arns arn:aws:cloudfront::12345678910:distribution/E1PXMP22ZVFAOR \
+        --start-time FromInclusive=1529280000,ToExclusive=1529300000
+
+Output::
+
+    {
+        "AttackSummaries": [
+            {
+                "AttackId": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "ResourceArn": "arn:aws:cloudfront::123456789012:distribution/E1PXMP22ZVFAOR",
+                "StartTime": 1529280000.0,
+                "EndTime": 1529449200.0,
+                "AttackVectors": [
+                    {
+                        "VectorType": "SYN_FLOOD"
+                    }
+                ]
+            }
+        ]
+    }
+
+For more information, see `Reviewing DDoS Incidents <https://docs.aws.amazon.com/waf/latest/developerguide/using-ddos-reports.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/list-protections.rst
+++ b/awscli/examples/shield/list-protections.rst
@@ -1,0 +1,19 @@
+**To retrieve protection summaries from AWS Shield Advanced**
+
+The following ``list-protections`` example retrieves summaries of the protections that are enabled for the account. ::
+
+    aws shield list-protections
+
+Output::
+
+    {
+        "Protections": [
+            {
+                "Id": "a1b2c3d4-5678-90ab-cdef-EXAMPLE11111",
+                "Name": "Protection for CloudFront distribution",
+                "ResourceArn": "arn:aws:cloudfront::123456789012:distribution/E198WC25FXOWY8"
+            }
+        ]
+    }
+        
+For more information, see `Specify Your Resources to Protect <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-choose-resources.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/update-emergency-contact-settings.rst
+++ b/awscli/examples/shield/update-emergency-contact-settings.rst
@@ -1,0 +1,10 @@
+**To define the emergency e-mail addresses that are on file with the DRT**
+
+The following ``update-emergency-contact-settings`` example defines two e-mail addresses that the DRT should contact when it's responding to a suspected attack. ::
+
+    aws shield update-emergency-contact-settings \
+	    --emergency-contact-list EmailAddress=ops@example.com EmailAddress=ddos-notifications@example.com
+
+This command produces no output.  
+        
+For more information, see `How AWS Shield Works <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/shield/update-subscription.rst
+++ b/awscli/examples/shield/update-subscription.rst
@@ -1,0 +1,10 @@
+**To modify the account's AWS Shield Advanced subscription**
+
+The following ``update-subscription`` example enables auto-renewal of the AWS Shield Advanced subscription for the account. ::
+
+    aws shield update-subscription \
+        --auto-renew ENABLED
+
+This command produces no output.
+       
+For more information, see `How AWS Shield Works <https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html>`__ in the *AWS Shield Advanced Developer Guide*.

--- a/awscli/examples/workspaces/describe-tags.rst
+++ b/awscli/examples/workspaces/describe-tags.rst
@@ -1,0 +1,17 @@
+**To describe the tags for a WorkSpace**
+
+The following ``describe-tags`` example lists the tag key names and their values for the specified WorkSpace. ::
+
+    aws workspaces describe-tags \
+        --resource-id ws-12345678
+
+Output::
+
+    {
+        "TagList": [
+            {
+                "Key": "username",
+                "Value": "jane1234"
+            }
+        ]
+    }

--- a/awscli/examples/workspaces/migrate-workspace.rst
+++ b/awscli/examples/workspaces/migrate-workspace.rst
@@ -1,0 +1,15 @@
+**To migrate a WorkSpace**
+
+The following ``migrate-workspace`` example migrates the specified WorkSpace to the ``Standard with Windows 10 (English)`` public bundle type. ::
+
+    aws workspaces migrate-workspace \
+        --source-workspace-id ws-12345678 \
+        --bundle-id wsb-8vbljg4r6
+
+Output::
+
+    {
+        "SourceWorkspaceId": "ws-12345678",
+        "TargetWorkspaceId": "ws-87654321"
+    }
+

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ def find_version(*file_paths):
 
 
 requires = ['botocore==2.0.0dev2',
-            'colorama>=0.2.5,<=0.3.9',
-            'docutils>=0.10',
+            'colorama>=0.2.5,<=0.4.2',
+            'docutils>=0.10,<0.16',
             'cryptography>=2.8.0,<=2.9.0',
             's3transfer>=0.3.0,<0.4.0',
             'ruamel.yaml>=0.15.0,<0.16.0',

--- a/tests/functional/ecr/test_get_login_password.py
+++ b/tests/functional/ecr/test_get_login_password.py
@@ -1,0 +1,35 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestGetLoginPasswordCommand(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestGetLoginPasswordCommand, self).setUp()
+        self.parsed_responses = [
+            {
+                'authorizationData': [
+                    {
+                        "authorizationToken": "Zm9vOmJhcg==",
+                        "proxyEndpoint": "1235.ecr.us-east-1.io",
+                        "expiresAt": "2015-10-16T00:00:00Z"
+                    }
+                ]
+            },
+        ]
+
+    def test_prints_get_login_command(self):
+        stdout = self.run_cmd("ecr get-login-password")[0]
+        self.assertIn('bar', stdout)
+        self.assertEquals(1, len(self.operations_called))


### PR DESCRIPTION
For the ECR `get-login` command, this will be removed in a subsequent PR. Also note there were changes in the `setup.py`, but not the `setup.cfg` because it looks like the previous changes to our dependencies were merged to the `setup.cfg` but not the `setup.py` in the previous sync. For `docutils` and `colorama` we probably can remove the ceiling or pin to the latest, but I'd like to that in a separate PR so just wanted to keep it in sync with v1 for now.
