### PR TITLE
Run tests not in verbose mode

### DIFF
--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -17,4 +17,4 @@ def run(command):
 
 
 run('nosetests --with-coverage --cover-erase --cover-package awscli '
-    '--with-xunit --cover-xml -v unit/ functional/')
+    '--with-xunit --cover-xml unit/ functional/')


### PR DESCRIPTION
There are so many tests that get printed now that we cause the Travis job to error out because the logs are too large.
