### PR TITLE
[v2] Improve return code convention and consistency

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -14,6 +14,7 @@ import argparse
 import sys
 from awscli.compat import six
 from difflib import get_close_matches
+from gettext import gettext
 
 
 HELP_BLURB = (
@@ -107,6 +108,21 @@ class CLIArgParser(argparse.ArgumentParser):
                         encoded.append(v)
                 setattr(parsed, arg, encoded)
         return parsed, remaining
+
+    def error(self, message):
+        """error(message: string)
+
+        NOTE: This is lifted directly from argparse, the only difference being
+        we use 252 for parsing errors.
+
+        Prints a usage message incorporating the message to stderr and
+        exits.
+        If you override this in a subclass, it should not return -- it
+        should either exit or raise an exception.
+        """
+        self.print_usage(sys.stderr)
+        args = {'prog': self.prog, 'message': message}
+        self.exit(252, gettext('%(prog)s: error: %(message)s\n') % args)
 
 
 class MainArgParser(CLIArgParser):

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -42,6 +42,7 @@ from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.argparser import ArgTableArgParser
 from awscli.argparser import USAGE
+from awscli.argprocess import ParamError, ParamSyntaxError
 from awscli.help import ProviderHelpCommand
 from awscli.help import ServiceHelpCommand
 from awscli.help import OperationHelpCommand
@@ -61,6 +62,10 @@ from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.exceptions import ConfigurationError
 
 
+PARAM_VALIDATION_ERRORS = (
+    ParamError, ParamSyntaxError,
+    ParamValidationError, BotocoreParamValidationError,
+)
 LOG = logging.getLogger('awscli.clidriver')
 LOG_FORMAT = (
     '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
@@ -320,7 +325,7 @@ class CLIDriver(object):
                 'CLI_VERSION', self.session.user_agent(), 'CLI')
             HISTORY_RECORDER.record('CLI_ARGUMENTS', args, 'CLI')
             return command_table[parsed_args.command](remaining, parsed_args)
-        except (BotocoreParamValidationError, ParamValidationError) as e:
+        except PARAM_VALIDATION_ERRORS as e:
             # RC 252 represents that the command failed to parse or failed
             # client side validation at the botocore level.
             LOG.debug("Client side parameter validation failed", exc_info=True)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -22,7 +22,9 @@ from botocore.compat import copy_kwargs, OrderedDict
 from botocore.exceptions import NoCredentialsError
 from botocore.exceptions import NoRegionError
 from botocore.exceptions import ClientError
-from botocore.exceptions import ParamValidationError
+from botocore.exceptions import (
+    ParamValidationError as BotocoreParamValidationError
+)
 from botocore.history import get_global_history_recorder
 from botocore.configprovider import InstanceVarProvider
 from botocore.configprovider import EnvironmentProvider
@@ -55,6 +57,7 @@ from awscli.utils import emit_top_level_args_parsed_event
 from awscli.utils import write_exception
 from awscli.utils import OutputStreamFactory
 from awscli.utils import IMDSRegionProvider
+from awscli.customizations.exceptions import ParamValidationError
 
 
 LOG = logging.getLogger('awscli.clidriver')
@@ -316,7 +319,7 @@ class CLIDriver(object):
                 'CLI_VERSION', self.session.user_agent(), 'CLI')
             HISTORY_RECORDER.record('CLI_ARGUMENTS', args, 'CLI')
             return command_table[parsed_args.command](remaining, parsed_args)
-        except ParamValidationError as e:
+        except (BotocoreParamValidationError, ParamValidationError) as e:
             # RC 252 represents that the command failed to parse or failed
             # client side validation at the botocore level.
             LOG.debug("Client side parameter validation failed", exc_info=True)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -58,6 +58,7 @@ from awscli.utils import write_exception
 from awscli.utils import OutputStreamFactory
 from awscli.utils import IMDSRegionProvider
 from awscli.customizations.exceptions import ParamValidationError
+from awscli.customizations.exceptions import ConfigurationError
 
 
 LOG = logging.getLogger('awscli.clidriver')
@@ -330,9 +331,13 @@ class CLIDriver(object):
             sys.stderr.write(str(e))
             sys.stderr.write("\n")
             return 252
-        except NoRegionError as e:
+        except ConfigurationError as e:
             # RC 253 represents that the command may be syntatically correct
             # but the environment or configuration is incorrect.
+            LOG.debug("Invalid CLI or client configuration", exc_info=True)
+            write_exception(e, outfile=get_stderr_text_writer())
+            return 253
+        except NoRegionError as e:
             msg = ('%s You can also configure your region by running '
                    '"aws configure".' % e)
             self._show_error(msg)

--- a/awscli/constants.py
+++ b/awscli/constants.py
@@ -1,0 +1,17 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+PARAM_VALIDATION_ERROR_RC = 252
+CONFIGURATION_ERROR_RC = 253
+CLIENT_ERROR_RC = 254
+GENERAL_ERROR_RC = 255

--- a/awscli/customizations/arguments.py
+++ b/awscli/customizations/arguments.py
@@ -13,6 +13,7 @@
 import os
 
 from awscli.arguments import CustomArgument
+from awscli.customizations.exceptions import ParamValidationError
 import jmespath
 
 def resolve_given_outfile_path(path):
@@ -21,7 +22,7 @@ def resolve_given_outfile_path(path):
         return
     outfile = os.path.expanduser(os.path.expandvars(path))
     if not os.access(os.path.dirname(os.path.abspath(outfile)), os.W_OK):
-        raise ValueError('Unable to write to file: %s' % outfile)
+        raise ParamValidationError('Unable to write to file: %s' % outfile)
     return outfile
 
 

--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -17,6 +17,7 @@ from contextlib import closing
 from botocore.vendored import six
 
 from awscli.arguments import CustomArgument, CLIArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 
 ERROR_MSG = (
@@ -94,7 +95,7 @@ def _should_contain_zip_content(value):
         with closing(zipfile.ZipFile(fileobj)) as f:
             f.infolist()
     except zipfile.BadZipfile:
-        raise ValueError(ERROR_MSG)
+        raise ParamValidationError(ERROR_MSG)
 
 
 class ZipFileArgument(CustomArgument):
@@ -140,11 +141,12 @@ class ReplacedZipFileArgument(CLIArgument):
             return
         unpacked = self._unpack_argument(value)
         if 'ZipFile' in unpacked:
-            raise ValueError(
+            raise ParamValidationError(
                 "ZipFile cannot be provided "
                 "as part of the %s argument.  "
                 "Please use the '--zip-file' "
-                "option instead to specify a zip file." % self._cli_name)
+                "option instead to specify a zip file." % self._cli_name
+            )
         if parameters.get(self._param_to_replace):
             parameters[self._param_to_replace].update(unpacked)
         else:

--- a/awscli/customizations/cloudsearch.py
+++ b/awscli/customizations/cloudsearch.py
@@ -14,6 +14,7 @@
 import logging
 
 from awscli.customizations.flatten import FlattenArguments, SEP
+from awscli.customizations.exceptions import ParamValidationError
 from botocore.compat import OrderedDict
 
 LOG = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ def index_hydrate(params, container, cli_type, key, value):
         params['IndexField'] = {}
 
     if 'IndexFieldType' not in params['IndexField']:
-        raise RuntimeError('You must pass the --type option.')
+        raise ParamValidationError('You must pass the --type option.')
 
     # Find the type and transform it for the type options field name
     # E.g: int-array => IntArray

--- a/awscli/customizations/cloudsearchdomain.py
+++ b/awscli/customizations/cloudsearchdomain.py
@@ -17,6 +17,7 @@ This module customizes the cloudsearchdomain command:
     * Add validation that --endpoint-url is required.
 
 """
+from awscli.customizations.exceptions import ParamValidationError
 
 def register_cloudsearchdomain(cli):
     cli.register_last('calling-command.cloudsearchdomain',
@@ -25,5 +26,6 @@ def register_cloudsearchdomain(cli):
 
 def validate_endpoint_url(parsed_globals, **kwargs):
     if parsed_globals.endpoint_url is None:
-        return ValueError(
-            "--endpoint-url is required for cloudsearchdomain commands")
+        return ParamValidationError(
+            "--endpoint-url is required for cloudsearchdomain commands"
+        )

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -23,6 +23,7 @@ from botocore.awsrequest import AWSRequest
 from botocore.compat import urlsplit
 from awscli.customizations.commands import BasicCommand
 from awscli.compat import NonTranslatedStdout
+from awscli.customizations.exceptions import ParamValidationError
 
 logger = logging.getLogger('botocore.credentials')
 
@@ -186,6 +187,7 @@ class CodeCommitCommand(BasicCommand):
                    ' for details')
 
     def _run_main(self, args, parsed_globals):
-        raise ValueError('usage: aws [options] codecommit'
-                         ' credential-helper <subcommand> '
-                         '[parameters]\naws: error: too few arguments')
+        raise ParamValidationError(
+            'usage: aws [options] codecommit credential-helper <subcommand> '
+            '[parameters]\naws: error: too few arguments'
+        )

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -23,7 +23,6 @@ from botocore.awsrequest import AWSRequest
 from botocore.compat import urlsplit
 from awscli.customizations.commands import BasicCommand
 from awscli.compat import NonTranslatedStdout
-from awscli.customizations.exceptions import ParamValidationError
 
 logger = logging.getLogger('botocore.credentials')
 
@@ -187,7 +186,4 @@ class CodeCommitCommand(BasicCommand):
                    ' for details')
 
     def _run_main(self, args, parsed_globals):
-        raise ParamValidationError(
-            'usage: aws [options] codecommit credential-helper <subcommand> '
-            '[parameters]\naws: error: too few arguments'
-        )
+        self._raise_usage_error()

--- a/awscli/customizations/codedeploy/deregister.py
+++ b/awscli/customizations/codedeploy/deregister.py
@@ -83,6 +83,8 @@ class Deregister(BasicCommand):
                 'Using AWS CodeDeploy" in the AWS CodeDeploy User '
                 'Guide.\n'.format(e)
             )
+            return 255
+        return 0
 
     def _get_instance_info(self, params):
         sys.stdout.write('Retrieving on-premises instance information... ')

--- a/awscli/customizations/codedeploy/install.py
+++ b/awscli/customizations/codedeploy/install.py
@@ -80,6 +80,8 @@ class Install(BasicCommand):
                 'On-Premises Instances by Using AWS CodeDeploy" in the AWS '
                 'CodeDeploy User Guide.\n'.format(e)
             )
+            return 255
+        return 0
 
     def _validate_override_config(self, params):
         if os.path.isfile(params.system.CONFIG_PATH) and \

--- a/awscli/customizations/codedeploy/locationargs.py
+++ b/awscli/customizations/codedeploy/locationargs.py
@@ -14,6 +14,7 @@
 from awscli.argprocess import unpack_cli_arg
 from awscli.arguments import CustomArgument
 from awscli.arguments import create_argument_model_from_schema
+from awscli.customizations.exceptions import ParamValidationError
 
 S3_LOCATION_ARG_DESCRIPTION = {
     'name': 's3-location',
@@ -140,7 +141,7 @@ class S3LocationArgument(LocationArgument):
         required = ['bucket', 'key', 'bundleType']
         valid = lambda k: value_dict.get(k, False)
         if not all(map(valid, required)):
-            raise RuntimeError(
+            raise ParamValidationError(
                 '--s3-location must specify bucket, key and bundleType.'
             )
         revision = {
@@ -163,7 +164,7 @@ class GitHubLocationArgument(LocationArgument):
         required = ['repository', 'commitId']
         valid = lambda k: value_dict.get(k, False)
         if not all(map(valid, required)):
-            raise RuntimeError(
+            raise ParamValidationError(
                 '--github-location must specify repository and commitId.'
             )
         return {

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -23,6 +23,7 @@ from botocore.exceptions import ClientError
 from awscli.compat import six
 from awscli.customizations.codedeploy.utils import validate_s3_location
 from awscli.customizations.commands import BasicCommand
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.compat import ZIP_COMPRESSION_MODE
 
 
@@ -125,7 +126,7 @@ class Push(BasicCommand):
         validate_s3_location(parsed_args, 's3_location')
         if parsed_args.ignore_hidden_files \
                 and parsed_args.no_ignore_hidden_files:
-            raise RuntimeError(
+            raise ParamValidationError(
                 'You cannot specify both --ignore-hidden-files and '
                 '--no-ignore-hidden-files.'
             )

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -119,6 +119,7 @@ class Push(BasicCommand):
             region_name=parsed_globals.region
         )
         self._push(parsed_args)
+        return 0
 
     def _validate_args(self, parsed_args):
         validate_s3_location(parsed_args, 's3_location')

--- a/awscli/customizations/codedeploy/register.py
+++ b/awscli/customizations/codedeploy/register.py
@@ -112,6 +112,8 @@ class Register(BasicCommand):
                 'Using AWS CodeDeploy" in the AWS CodeDeploy User '
                 'Guide.\n'.format(e)
             )
+            return 255
+        return 0
 
     def _create_iam_user(self, params):
         sys.stdout.write('Creating the IAM user... ')

--- a/awscli/customizations/codedeploy/uninstall.py
+++ b/awscli/customizations/codedeploy/uninstall.py
@@ -47,6 +47,8 @@ class Uninstall(BasicCommand):
                 'Existing On-Premises Instances by Using AWS CodeDeploy" in '
                 'the AWS CodeDeploy User Guide.\n'.format(e)
             )
+            return 255
+        return 0
 
     def _uninstall_agent(self, params):
         sys.stdout.write('Uninstalling the AWS CodeDeploy Agent... ')

--- a/awscli/customizations/codedeploy/utils.py
+++ b/awscli/customizations/codedeploy/utils.py
@@ -17,6 +17,7 @@ import re
 import awscli.compat
 from awscli.compat import urlopen, URLError
 from awscli.customizations.codedeploy.systems import System, Ubuntu, Windows, RHEL
+from awscli.customizations.exceptions import ParamValidationError
 from socket import timeout
 
 
@@ -59,11 +60,15 @@ def validate_region(params, parsed_globals):
 def validate_instance_name(params):
     if params.instance_name:
         if not re.match(INSTANCE_NAME_PATTERN, params.instance_name):
-            raise ValueError('Instance name contains invalid characters.')
+            raise ParamValidationError(
+                'Instance name contains invalid characters.'
+            )
         if params.instance_name.startswith('i-'):
-            raise ValueError('Instance name cannot start with \'i-\'.')
+            raise ParamValidationError(
+                'Instance name cannot start with \'i-\'.'
+            )
         if len(params.instance_name) > MAX_INSTANCE_NAME_LENGTH:
-            raise ValueError(
+            raise ParamValidationError(
                 'Instance name cannot be longer than {0} characters.'.format(
                     MAX_INSTANCE_NAME_LENGTH
                 )
@@ -73,20 +78,20 @@ def validate_instance_name(params):
 def validate_tags(params):
     if params.tags:
         if len(params.tags) > MAX_TAGS_PER_INSTANCE:
-            raise ValueError(
+            raise ParamValidationError(
                 'Instances can only have a maximum of {0} tags.'.format(
                     MAX_TAGS_PER_INSTANCE
                 )
             )
         for tag in params.tags:
             if len(tag['Key']) > MAX_TAG_KEY_LENGTH:
-                raise ValueError(
+                raise ParamValidationError(
                     'Tag Key cannot be longer than {0} characters.'.format(
                         MAX_TAG_KEY_LENGTH
                     )
                 )
             if len(tag['Value']) > MAX_TAG_VALUE_LENGTH:
-                raise ValueError(
+                raise ParamValidationError(
                     'Tag Value cannot be longer than {0} characters.'.format(
                         MAX_TAG_VALUE_LENGTH
                     )
@@ -96,7 +101,7 @@ def validate_tags(params):
 def validate_iam_user_arn(params):
     if params.iam_user_arn and \
             not re.match(IAM_USER_ARN_PATTERN, params.iam_user_arn):
-        raise ValueError('Invalid IAM user ARN.')
+        raise ParamValidationError('Invalid IAM user ARN.')
 
 
 def validate_instance(params):
@@ -129,7 +134,7 @@ def validate_s3_location(params, arg_name):
                 params.bucket = matcher.group(1)
                 params.key = matcher.group(2)
             else:
-                raise ValueError(
+                raise ParamValidationError(
                     '--{0} must specify the Amazon S3 URL format as '
                     's3://<bucket>/<key>.'.format(
                         arg_name.replace('_', '-')

--- a/awscli/customizations/codedeploy/utils.py
+++ b/awscli/customizations/codedeploy/utils.py
@@ -18,6 +18,7 @@ import awscli.compat
 from awscli.compat import urlopen, URLError
 from awscli.customizations.codedeploy.systems import System, Ubuntu, Windows, RHEL
 from awscli.customizations.exceptions import ParamValidationError
+from awscli.customizations.exceptions import ConfigurationError
 from socket import timeout
 
 
@@ -54,7 +55,7 @@ def validate_region(params, parsed_globals):
     else:
         params.region = params.session.get_config_variable('region')
     if not params.region:
-        raise RuntimeError('Region not specified.')
+        raise ConfigurationError('Region not specified.')
 
 
 def validate_instance_name(params):

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -14,6 +14,7 @@ from awscli.clidocs import OperationDocumentEventHandler
 from awscli.clidriver import CLICommand
 from awscli.help import HelpCommand
 from awscli.schema import SchemaTransformer
+from awscli.customizations.exceptions import ParamValidationError
 
 LOG = logging.getLogger(__name__)
 _open = open
@@ -293,6 +294,14 @@ class BasicCommand(CLICommand):
     @lineage.setter
     def lineage(self, value):
         self._lineage = value
+
+    def _raise_usage_error(self):
+        lineage = ' '.join([c.name for c in self.lineage])
+        error_msg = (
+            "usage: aws [options] %s <subcommand> "
+            "[parameters]\naws: error: too few arguments"
+        ) % lineage
+        raise ParamValidationError(error_msg)
 
 
 class BasicHelp(HelpCommand):

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -187,7 +187,11 @@ class BasicCommand(CLICommand):
                 raise ParamValidationError(
                     "Unknown options: %s" % ','.join(remaining)
                 )
-            return self._run_main(parsed_args, parsed_globals)
+            rc = self._run_main(parsed_args, parsed_globals)
+            if rc is None:
+                return 0
+            else:
+                return rc
         else:
             return self.subcommand_table[parsed_args.subcommand](remaining,
                                                                  parsed_globals)

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -184,7 +184,9 @@ class BasicCommand(CLICommand):
             # No subcommand was specified so call the main
             # function for this top level command.
             if remaining:
-                raise ValueError("Unknown options: %s" % ','.join(remaining))
+                raise ParamValidationError(
+                    "Unknown options: %s" % ','.join(remaining)
+                )
             return self._run_main(parsed_args, parsed_globals)
         else:
             return self.subcommand_table[parsed_args.subcommand](remaining,

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -124,6 +124,7 @@ class ConfigureCommand(BasicCommand):
                 section = profile_to_section(profile)
                 new_values['__section__'] = section
             self._config_writer.update_config(new_values, config_filename)
+        return 0
 
     def _write_out_creds_file_values(self, new_values, profile_name):
         # The access_key/secret_key are now *always* written to the shared

--- a/awscli/customizations/configure/importer.py
+++ b/awscli/customizations/configure/importer.py
@@ -91,6 +91,7 @@ class ConfigureImportCommand(BasicCommand):
         self._csv_parser.strict = not parsed_args.skip_invalid
         self._profile_prefix = parsed_args.profile_prefix
         self._import_csv(parsed_args.csv)
+        return 0
 
 
 class CredentialParserError(Exception):

--- a/awscli/customizations/configure/list.py
+++ b/awscli/customizations/configure/list.py
@@ -67,6 +67,7 @@ class ConfigureListCommand(BasicCommand):
 
         region = self._lookup_region()
         self._display_config_value(region, 'region')
+        return 0
 
     def _display_config_value(self, config_value, config_name):
         self._stream.write('%10s %24s %16s    %s\n' % (

--- a/awscli/customizations/configure/listprofiles.py
+++ b/awscli/customizations/configure/listprofiles.py
@@ -35,3 +35,4 @@ class ListProfilesCommand(BasicCommand):
     def _run_main(self, parsed_args, parsed_globals):
         for profile in self._session.available_profiles:
             uni_print('%s\n' % profile, out_file=self._out_stream)
+        return 0

--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -99,3 +99,4 @@ class ConfigureSetCommand(BasicCommand):
             if section_name.startswith('profile '):
                 updated_config['__section__'] = section_name[8:]
         self._config_writer.update_config(updated_config, config_filename)
+        return 0

--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -326,6 +326,7 @@ class ConfigureSSOCommand(BasicCommand):
         uni_print(usage_msg.format(profile_name))
 
         self._write_new_config(profile_name)
+        return 0
 
     def _write_new_config(self, profile):
         config_path = self._session.get_config_variable('config_file')

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -391,8 +391,10 @@ class ListRunsCommand(BasicCommand):
     def _validate_status_choices(self, statuses):
         for status in statuses:
             if status not in self.VALID_STATUS:
-                raise ValueError("Invalid status: %s, must be one of: %s" %
-                                 (status, ', '.join(self.VALID_STATUS)))
+                raise ParamValidationError(
+                    "Invalid status: %s, must be one of: %s" %
+                    (status, ', '.join(self.VALID_STATUS))
+                )
 
     def _list_runs(self, parsed_args, parsed_globals):
         query = QueryArgBuilder().build_query(parsed_args)

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -22,6 +22,7 @@ from awscli.customizations.datapipeline.createdefaultroles \
     import CreateDefaultRoles
 from awscli.customizations.datapipeline.listrunsformatter \
     import ListRunsFormatter
+from awscli.customizations.exceptions import ParamValidationError
 
 
 DEFINITION_HELP_TEXT = """\
@@ -57,7 +58,7 @@ class DocSectionNotFoundError(Exception):
     pass
 
 
-class ParameterDefinitionError(Exception):
+class ParameterDefinitionError(ParamValidationError):
     def __init__(self, msg):
         full_msg = ("Error in parameter: %s\n" % msg)
         super(ParameterDefinitionError, self).__init__(full_msg)
@@ -279,7 +280,7 @@ class ParameterValuesArgument(CustomArgument):
             return
 
         if parameters.get('parameterValues', None) is not None:
-            raise Exception(
+            raise ParamValidationError(
                 "Only parameter-values or parameter-values-uri is allowed"
             )
 
@@ -295,7 +296,7 @@ class ParameterValuesInlineArgument(CustomArgument):
             return
 
         if parameters.get('parameterValues', None) is not None:
-            raise Exception(
+            raise ParamValidationError(
                 "Only parameter-values or parameter-values-uri is allowed"
             )
 

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -358,6 +358,7 @@ class ListRunsCommand(BasicCommand):
         self._set_client(parsed_globals)
         self._parse_type_args(parsed_args)
         self._list_runs(parsed_args, parsed_globals)
+        return 0
 
     def _set_client(self, parsed_globals):
         # This is called from _run_main and is used to ensure that we have

--- a/awscli/customizations/datapipeline/translator.py
+++ b/awscli/customizations/datapipeline/translator.py
@@ -12,9 +12,10 @@
 # language governing permissions and limitations under the License.
 import json
 from awscli.clidriver import CLIOperationCaller
+from awscli.customizations.exceptions import ParamValidationError
 
 
-class PipelineDefinitionError(Exception):
+class PipelineDefinitionError(ParamValidationError):
     def __init__(self, msg, definition):
         full_msg = (
             "Error in pipeline definition: %s\n" % msg)

--- a/awscli/customizations/dlm/createdefaultrole.py
+++ b/awscli/customizations/dlm/createdefaultrole.py
@@ -22,6 +22,7 @@ from awscli.customizations.dlm.constants \
     LIFECYCLE_DEFAULT_ROLE_ASSUME_POLICY, \
     LIFECYCLE_DEFAULT_MANAGED_POLICY_NAME, \
     POLICY_ARN_PATTERN
+from awscli.customizations.exceptions import ConfigurationError
 
 LOG = logging.getLogger(__name__)
 
@@ -123,9 +124,10 @@ class CreateDefaultRole(BasicCommand):
         region = get_region(self._session, parsed_globals)
 
         if region is None:
-            raise ValueError('You must specify a region. '
-                             'You can also configure your region '
-                             'by running "aws configure".')
+            raise ConfigurationError(
+                'You must specify a region. You can also configure your '
+                'region by running "aws configure".'
+            )
 
         managed_policy_arn = get_policy_arn(
             region,

--- a/awscli/customizations/dynamodb/ddb.py
+++ b/awscli/customizations/dynamodb/ddb.py
@@ -14,7 +14,6 @@ from awscli.customizations.commands import BasicCommand
 from awscli.customizations.dynamodb.subcommands import (
     SelectCommand, PutCommand,
 )
-from awscli.customizations.exceptions import ParamValidationError
 
 
 def register_ddb(events):
@@ -36,7 +35,4 @@ class DDB(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ParamValidationError(
-                "usage: aws [options] <command> <subcommand> "
-                "[parameters]\naws: error: too few arguments"
-            )
+            self._raise_usage_error()

--- a/awscli/customizations/dynamodb/ddb.py
+++ b/awscli/customizations/dynamodb/ddb.py
@@ -14,6 +14,7 @@ from awscli.customizations.commands import BasicCommand
 from awscli.customizations.dynamodb.subcommands import (
     SelectCommand, PutCommand,
 )
+from awscli.customizations.exceptions import ParamValidationError
 
 
 def register_ddb(events):
@@ -35,5 +36,7 @@ class DDB(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ValueError("usage: aws [options] <command> <subcommand> "
-                             "[parameters]\naws: error: too few arguments")
+            raise ParamValidationError(
+                "usage: aws [options] <command> <subcommand> "
+                "[parameters]\naws: error: too few arguments"
+            )

--- a/awscli/customizations/dynamodb/exceptions.py
+++ b/awscli/customizations/dynamodb/exceptions.py
@@ -10,27 +10,28 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class DDBError(Exception):
     pass
 
 
-class EmptyExpressionError(DDBError):
+class EmptyExpressionError(DDBError, ParamValidationError):
     def __init__(self):
         super(EmptyExpressionError, self).__init__(
             "Expressions must not be empty"
         )
 
 
-class LexerError(DDBError):
+class LexerError(DDBError, ParamValidationError):
     def __init__(self, expression, position, message):
         underline = ' ' * position + '^'
         error_message = '%s\n%s\n%s' % (message, expression, underline)
         super(LexerError, self).__init__(error_message)
 
 
-class ParserError(DDBError):
+class ParserError(DDBError, ParamValidationError):
     pass
 
 

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -27,6 +27,7 @@ from awscli.customizations.dynamodb.transform import (
 )
 from awscli.customizations.dynamodb.formatter import DynamoYAMLDumper
 from awscli.customizations.paginate import ensure_paging_params_not_set
+from awscli.customizations.exceptions import ParamValidationError
 from .types import Binary
 
 
@@ -94,7 +95,7 @@ class DDBCommand(BasicCommand):
             #  introduce do not play nicely with the pagination interfaces.
             #  For example, botocore cannot serialize our Binary types into
             #  a resume token when --max-items gets set.
-            raise ValueError(
+            raise ParamValidationError(
                 'yaml-stream output format is not supported for ddb commands'
             )
         formatter = YAMLFormatter(parsed_globals, DynamoYAMLDumper())
@@ -276,7 +277,7 @@ class PutCommand(DDBCommand):
             self._batch_write(items, parsed_args)
         else:
             if len(items) > 1:
-                raise ValueError(
+                raise ParamValidationError(
                     '--condition is not supported for multiple items'
                 )
             self._put_item(items, parsed_args)

--- a/awscli/customizations/ec2/addcount.py
+++ b/awscli/customizations/ec2/addcount.py
@@ -93,4 +93,4 @@ class CountArgument(BaseCLIArgument):
         except:
             msg = ('count parameter should be of '
                    'form min[:max] (e.g. 1 or 1:10)')
-            raise ValueError(msg)
+            raise ParamValidationError(msg)

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -20,6 +20,7 @@ import datetime
 from awscli.compat import six
 
 from awscli.arguments import CustomArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 logger = logging.getLogger('ec2bundleinstance')
 
@@ -104,7 +105,7 @@ def _check_args(parsed_args, **kwargs):
                 msg = ('Mixing the --storage option '
                        'with the simple, scalar options is '
                        'not recommended.')
-                raise ValueError(msg)
+                raise ParamValidationError(msg)
 
 POLICY = ('{{"expiration": "{expires}",'
           '"conditions": ['

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -99,8 +99,8 @@ def _check_args(parsed_args, **kwargs):
     logger.debug(parsed_args)
     arg_dict = vars(parsed_args)
     if arg_dict['storage']:
-        for key in ('bucket', 'prefix', 'owner-akid',
-                    'owner-sak', 'policy'):
+        for key in ('bucket', 'prefix', 'owner_akid',
+                    'owner_sak', 'policy'):
             if arg_dict[key]:
                 msg = ('Mixing the --storage option '
                        'with the simple, scalar options is '

--- a/awscli/customizations/ec2/runinstances.py
+++ b/awscli/customizations/ec2/runinstances.py
@@ -23,6 +23,7 @@ This functionality (and much more) is also available using the
 the most commonly used features available more easily.
 """
 from awscli.arguments import CustomArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 # --secondary-private-ip-address
 SECONDARY_PRIVATE_IP_ADDRESSES_DOCS = (
@@ -77,7 +78,7 @@ def _check_args(parsed_args, **kwargs):
                 msg = ('Mixing the --network-interfaces option '
                        'with the simple, scalar options is '
                        'not supported.')
-                raise ValueError(msg)
+                raise ParamValidationError(msg)
 
 
 def _fix_args(params, **kwargs):

--- a/awscli/customizations/ec2/secgroupsimplify.py
+++ b/awscli/customizations/ec2/secgroupsimplify.py
@@ -23,6 +23,7 @@ authorize operations:
 """
 
 from awscli.arguments import CustomArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 
 def _add_params(argument_table, **kwargs):
@@ -64,7 +65,7 @@ def _check_args(parsed_args, **kwargs):
             if arg_dict[key]:
                 msg = ('The --%s option is not compatible '
                        'with the --ip-permissions option ') % key
-                raise ValueError(msg)
+                raise ParamValidationError(msg)
 
 
 def _add_docs(help_command, **kwargs):
@@ -144,12 +145,12 @@ class ProtocolArgument(CustomArgument):
                 if (int_value < 0 or int_value > 255) and int_value != -1:
                     msg = ('protocol numbers must be in the range 0-255 '
                            'or -1 to specify all protocols')
-                    raise ValueError(msg)
+                    raise ParamValidationError(msg)
             except ValueError:
                 if value not in ('tcp', 'udp', 'icmp', 'all'):
                     msg = ('protocol parameter should be one of: '
                            'tcp|udp|icmp|all or any valid protocol number.')
-                    raise ValueError(msg)
+                    raise ParamValidationError(msg)
                 if value == 'all':
                     value = '-1'
             _build_ip_permissions(parameters, 'IpProtocol', value)
@@ -176,7 +177,7 @@ class PortArgument(CustomArgument):
             except ValueError:
                 msg = ('port parameter should be of the '
                        'form <from[-to]> (e.g. 22 or 22-25)')
-                raise ValueError(msg)
+                raise ParamValidationError(msg)
 
 
 class CidrArgument(CustomArgument):

--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -134,6 +134,7 @@ class ECSDeploy(BasicCommand):
             register_task_def_kwargs, ecs_client_wrapper)
 
         self._create_and_wait_for_deployment(codedeploy_client, appspec_obj)
+        return 0
 
     def _create_and_wait_for_deployment(self, client, appspec):
         deployer = CodeDeployer(client, appspec)

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -157,7 +157,7 @@ class UpdateKubeconfigCommand(BasicCommand):
                     new_user_dict,
                     new_cluster_dict
                 ])
-
+        return 0
 
 
 class KubeconfigSelector(object):

--- a/awscli/customizations/emr/applicationutils.py
+++ b/awscli/customizations/emr/applicationutils.py
@@ -14,6 +14,7 @@
 from awscli.customizations.emr import constants
 from awscli.customizations.emr import emrutils
 from awscli.customizations.emr import exceptions
+from awscli.customizations.exceptions import ParamValidationError
 
 
 def build_applications(region,
@@ -60,8 +61,10 @@ def build_applications(region,
                     _build_hbase_install_step(
                         constants.HBASE_PATH_HADOOP1_INSTALL_JAR))
             else:
-                raise ValueError('aws: error: AMI version ' + ami_version +
-                                 'is not compatible with HBase.')
+                raise ParamValidationError(
+                    'aws: error: AMI version %s is not '
+                    'compatible with HBase.' % ami_version
+                )
         elif app_name == constants.IMPALA:
             ba_list.append(
                 _build_impala_install_bootstrap_action(

--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -13,6 +13,7 @@
 
 import re
 
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.emr import applicationutils
 from awscli.customizations.emr import argumentschema
@@ -175,8 +176,10 @@ class CreateCluster(Command):
                     params["Configurations"] = json.loads(
                         parsed_args.configurations)
                 except ValueError:
-                    raise ValueError('aws: error: invalid json argument for '
-                                     'option --configurations')
+                    raise ParamValidationError(
+                        'aws: error: invalid json argument for '
+                        'option --configurations'
+                    )
 
         if (parsed_args.release_label is None and
                 parsed_args.ami_version is not None):
@@ -440,7 +443,7 @@ class CreateCluster(Command):
         bootstrap_actions = []
         if len(cluster_ba_list) + len(parsed_boostrap_actions) \
                 > constants.MAX_BOOTSTRAP_ACTION_NUMBER:
-            raise ValueError('aws: error: maximum number of '
+            raise ParamValidationError('aws: error: maximum number of '
                              'bootstrap actions for a cluster exceeded.')
 
         for ba in parsed_boostrap_actions:

--- a/awscli/customizations/emr/emrutils.py
+++ b/awscli/customizations/emr/emrutils.py
@@ -17,6 +17,7 @@ import os
 
 
 from awscli.clidriver import CLIOperationCaller
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.emr import constants
 from awscli.customizations.emr import exceptions
 from botocore.exceptions import WaiterError, NoCredentialsError
@@ -61,7 +62,7 @@ def apply_boolean_options(
         error_message = \
             'aws: error: cannot use both ' + true_option_name + \
             ' and ' + false_option_name + ' options together.'
-        raise ValueError(error_message)
+        raise ParamValidationError(error_message)
     elif true_option:
         return True
     else:

--- a/awscli/customizations/emr/exceptions.py
+++ b/awscli/customizations/emr/exceptions.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class EmrError(Exception):
@@ -27,7 +28,7 @@ class EmrError(Exception):
         self.kwargs = kwargs
 
 
-class MissingParametersError(EmrError):
+class MissingParametersError(EmrError, ParamValidationError):
 
     """
     One or more required parameters were not supplied.
@@ -43,7 +44,7 @@ class MissingParametersError(EmrError):
            '{object_name}: {missing}.')
 
 
-class EmptyListError(EmrError):
+class EmptyListError(EmrError, ParamValidationError):
 
     """
     The provided list is empty.
@@ -53,7 +54,7 @@ class EmptyListError(EmrError):
     fmt = ('aws: error: The prameter {param} cannot be an empty list.')
 
 
-class MissingRequiredInstanceGroupsError(EmrError):
+class MissingRequiredInstanceGroupsError(EmrError, ParamValidationError):
 
     """
     In create-cluster command, none of --instance-group,
@@ -64,7 +65,7 @@ class MissingRequiredInstanceGroupsError(EmrError):
            'configure instance groups.')
 
 
-class InstanceGroupsValidationError(EmrError):
+class InstanceGroupsValidationError(EmrError, ParamValidationError):
 
     """
     --instance-type and --instance-count are shortcut option
@@ -77,7 +78,7 @@ class InstanceGroupsValidationError(EmrError):
            'shortcut options for --instance-groups.')
 
 
-class InvalidAmiVersionError(EmrError):
+class InvalidAmiVersionError(EmrError, ParamValidationError):
 
     """
     The supplied ami-version is invalid.
@@ -90,7 +91,7 @@ class InvalidAmiVersionError(EmrError):
            'latest/DeveloperGuide/ami-versions-supported.html')
 
 
-class MissingBooleanOptionsError(EmrError):
+class MissingBooleanOptionsError(EmrError, ParamValidationError):
 
     """
     Required boolean options are not supplied.
@@ -102,7 +103,7 @@ class MissingBooleanOptionsError(EmrError):
            '{true_option}|{false_option}.')
 
 
-class UnknownStepTypeError(EmrError):
+class UnknownStepTypeError(EmrError, ParamValidationError):
 
     """
     The provided step type is not supported.
@@ -133,7 +134,7 @@ class ResolveServicePrincipalError(EmrError):
           ' the region or the endpoint.'
 
 
-class LogUriError(EmrError):
+class LogUriError(EmrError, ParamValidationError):
 
     """
     The LogUri is not specified and debugging is enabled for the cluster.
@@ -151,7 +152,7 @@ class MasterDNSNotAvailableError(EmrError):
           ' Please try again after some time.'
 
 
-class WrongPuttyKeyError(EmrError):
+class WrongPuttyKeyError(EmrError, ParamValidationError):
 
     """
     A wrong key has been used with a compatible program.
@@ -181,7 +182,7 @@ class SCPNotFoundError(EmrError):
           'DeveloperGuide/EMR_SetUp_SSH.html. '
 
 
-class SubnetAndAzValidationError(EmrError):
+class SubnetAndAzValidationError(EmrError, ParamValidationError):
 
     """
     SubnetId and AvailabilityZone are mutual exclusive in --ec2-attributes.
@@ -190,7 +191,7 @@ class SubnetAndAzValidationError(EmrError):
            'tyZone (placement) because ec2SubnetId implies a placement.')
 
 
-class RequiredOptionsError(EmrError):
+class RequiredOptionsError(EmrError, ParamValidationError):
 
     """
     Either of option1 or option2 is required.
@@ -199,7 +200,7 @@ class RequiredOptionsError(EmrError):
     fmt = ('aws: error: Either {option1} or {option2} is required.')
 
 
-class MutualExclusiveOptionError(EmrError):
+class MutualExclusiveOptionError(EmrError, ParamValidationError):
 
     """
     The provided option1 and option2 are mutually exclusive.
@@ -217,7 +218,7 @@ class MutualExclusiveOptionError(EmrError):
         Exception.__init__(self, msg)
 
 
-class MissingApplicationsError(EmrError):
+class MissingApplicationsError(EmrError, ParamValidationError):
 
     """
     The application required for a step is not installed when creating a
@@ -242,7 +243,7 @@ class ClusterTerminatedError(EmrError):
     fmt = 'aws: error: Cluster terminating or already terminated.'
 
 
-class ClusterStatesFilterValidationError(EmrError):
+class ClusterStatesFilterValidationError(EmrError, ParamValidationError):
 
     """
     In the list-clusters command, customers can specify only one
@@ -254,7 +255,7 @@ class ClusterStatesFilterValidationError(EmrError):
            'filters: --cluster-states, --active, --terminated, --failed.')
 
 
-class MissingClusterAttributesError(EmrError):
+class MissingClusterAttributesError(EmrError, ParamValidationError):
 
     """
     In the modify-cluster-attributes command, customers need to provide
@@ -267,7 +268,7 @@ class MissingClusterAttributesError(EmrError):
            '--termination-protected|--no-termination-protected.')
 
 
-class InvalidEmrFsArgumentsError(EmrError):
+class InvalidEmrFsArgumentsError(EmrError, ParamValidationError):
 
     """
     The provided EMRFS parameters are invalid as parent feature e.g.,
@@ -281,13 +282,13 @@ class InvalidEmrFsArgumentsError(EmrError):
            ' following parameters are invalid: {invalid}')
 
 
-class DuplicateEmrFsConfigurationError(EmrError):
+class DuplicateEmrFsConfigurationError(EmrError, ParamValidationError):
 
     fmt = ('aws: error: EMRFS should be configured either using '
            '--configuration or --emrfs but not both')
 
 
-class UnknownCseProviderTypeError(EmrError):
+class UnknownCseProviderTypeError(EmrError, ParamValidationError):
 
     """
     The provided EMRFS client-side encryption provider type is not supported.
@@ -298,7 +299,7 @@ class UnknownCseProviderTypeError(EmrError):
            'not supported. You must specify either KMS or Custom')
 
 
-class UnknownEncryptionTypeError(EmrError):
+class UnknownEncryptionTypeError(EmrError, ParamValidationError):
 
     """
     The provided encryption type is not supported.
@@ -309,7 +310,7 @@ class UnknownEncryptionTypeError(EmrError):
            'You must specify either ServerSide or ClientSide')
 
 
-class BothSseAndEncryptionConfiguredError(EmrError):
+class BothSseAndEncryptionConfiguredError(EmrError, ParamValidationError):
 
     """
     Only one of SSE or Encryption can be configured.
@@ -322,7 +323,7 @@ class BothSseAndEncryptionConfiguredError(EmrError):
            'configured for --emrfs. You must specify only one of the two.')
 
 
-class InvalidBooleanConfigError(EmrError):
+class InvalidBooleanConfigError(EmrError, ParamValidationError):
 
     fmt = ("aws: error: {config_value} for {config_key} in the config file is "
            "invalid. The value should be either 'True' or 'False'. Use "
@@ -330,12 +331,12 @@ class InvalidBooleanConfigError(EmrError):
            "command to set a valid value.")
 
 
-class UnsupportedCommandWithReleaseError(EmrError):
+class UnsupportedCommandWithReleaseError(EmrError, ParamValidationError):
 
     fmt = ("aws: error: {command} is not supported with "
            "'{release_label}' release.")
 
-class MissingAutoScalingRoleError(EmrError):
+class MissingAutoScalingRoleError(EmrError, ParamValidationError):
 
     fmt = ("aws: error: Must specify --auto-scaling-role when configuring an "
            "AutoScaling policy for an instance group.")

--- a/awscli/customizations/emr/hbase.py
+++ b/awscli/customizations/emr/hbase.py
@@ -16,6 +16,7 @@ from awscli.customizations.emr import emrutils
 from awscli.customizations.emr import hbaseutils
 from awscli.customizations.emr import helptext
 from awscli.customizations.emr.command import Command
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class RestoreFromHBaseBackup(Command):
@@ -99,7 +100,7 @@ class ScheduleHBaseBackup(Command):
     def _check_type(self, type):
         type = type.lower()
         if type != constants.FULL and type != constants.INCREMENTAL:
-            raise ValueError('aws: error: invalid type. '
+            raise ParamValidationError('aws: error: invalid type. '
                              'type should be either ' +
                              constants.FULL + ' or ' + constants.INCREMENTAL +
                              '.')
@@ -109,10 +110,11 @@ class ScheduleHBaseBackup(Command):
         if (unit != constants.MINUTES and
                 unit != constants.HOURS and
                 unit != constants.DAYS):
-            raise ValueError('aws: error: invalid unit. unit should be one of'
-                             ' the following values: ' + constants.MINUTES +
-                             ', ' + constants.HOURS + ' or ' + constants.DAYS +
-                             '.')
+            raise ParamValidationError(
+                'aws: error: invalid unit. unit should be one of'
+                ' the following values: ' + constants.MINUTES +
+                ', ' + constants.HOURS + ' or ' + constants.DAYS + '.'
+            )
 
     def _build_hbase_schedule_backup_args(self, parsed_args):
         args = [constants.HBASE_MAIN, constants.HBASE_SCHEDULED_BACKUP,
@@ -228,7 +230,7 @@ class DisableHBaseBackups(Command):
             error_message = 'Should specify at least one of --' +\
                             constants.FULL + ' and --' +\
                             constants.INCREMENTAL + '.'
-            raise ValueError(error_message)
+            raise ParamValidationError(error_message)
         if parsed_args.full is True:
             args.append(constants.HBASE_DISABLE_FULL_BACKUP)
         if parsed_args.incremental is True:

--- a/awscli/customizations/emr/installapplications.py
+++ b/awscli/customizations/emr/installapplications.py
@@ -18,6 +18,7 @@ from awscli.customizations.emr import constants
 from awscli.customizations.emr import emrutils
 from awscli.customizations.emr import helptext
 from awscli.customizations.emr.command import Command
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class InstallApplications(Command):
@@ -54,13 +55,13 @@ class InstallApplications(Command):
 
             if app_name in constants.APPLICATIONS:
                 if app_name not in self.supported_apps:
-                    raise ValueError(
+                    raise ParamValidationError(
                         "aws: error: " + app_config['Name'] + " cannot be"
                         " installed on a running cluster. 'Name' should be one"
                         " of the following: " +
                         ', '.join(self.supported_apps))
             else:
-                raise ValueError(
+                raise ParamValidationError(
                     "aws: error: Unknown application: " + app_config['Name'] +
                     ". 'Name' should be one of the following: " +
                     ', '.join(constants.APPLICATIONS))

--- a/awscli/customizations/exceptions.py
+++ b/awscli/customizations/exceptions.py
@@ -1,0 +1,16 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+class ParamValidationError(Exception):
+    pass

--- a/awscli/customizations/exceptions.py
+++ b/awscli/customizations/exceptions.py
@@ -13,4 +13,16 @@
 
 
 class ParamValidationError(Exception):
-    pass
+    """CLI parameter validation failed. Indicates RC 252.
+
+    This exception indicates that the command was either invalid or failed to
+    pass a client side validation on the command syntax or parameters provided.
+    """
+
+
+class ConfigurationError(Exception):
+    """CLI configuration is an invalid state. Indicates RC 253.
+
+    This exception indicates that the command run may be syntactically correct
+    but the CLI's environment or configuration is incorrect, incomplete, etc.
+    """

--- a/awscli/customizations/flatten.py
+++ b/awscli/customizations/flatten.py
@@ -14,6 +14,7 @@
 import logging
 
 from awscli.arguments import CustomArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 LOG = logging.getLogger(__name__)
 
@@ -218,7 +219,9 @@ class FlattenArguments(object):
                         argument = member
                         break
                 else:
-                    raise ValueError('Invalid piece {0}'.format(piece))
+                    raise ParamValidationError(
+                        'Invalid piece {0}'.format(piece)
+                    )
 
         return argument
 

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -19,6 +19,7 @@ from botocore.handlers import disable_signing
 import jmespath
 
 from awscli.compat import urlparse
+from awscli.customizations.exceptions import ParamValidationError
 
 
 def register_parse_global_args(cli):
@@ -52,7 +53,9 @@ def _resolve_query(value):
     try:
         return jmespath.compile(value)
     except Exception as e:
-        raise ValueError("Bad value for --query %s: %s" % (value, str(e)))
+        raise ParamValidationError(
+            "Bad value for --query %s: %s" % (value, str(e))
+        )
 
 
 def _resolve_endpoint_url(value):
@@ -60,9 +63,11 @@ def _resolve_endpoint_url(value):
     # Our http library requires you specify an endpoint url
     # that contains a scheme, so we'll verify that up front.
     if not parsed.scheme:
-        raise ValueError('Bad value for --endpoint-url "%s": scheme is '
-                         'missing.  Must be of the form '
-                         'http://<hostname>/ or https://<hostname>/' % value)
+        raise ParamValidationError(
+            'Bad value for --endpoint-url "%s": scheme is '
+            'missing.  Must be of the form '
+            'http://<hostname>/ or https://<hostname>/' % value
+        )
     return value
 
 

--- a/awscli/customizations/history/__init__.py
+++ b/awscli/customizations/history/__init__.py
@@ -27,6 +27,7 @@ from awscli.customizations.history.db import RecordBuilder
 from awscli.customizations.history.db import DatabaseHistoryHandler
 from awscli.customizations.history.show import ShowCommand
 from awscli.customizations.history.list import ListCommand
+from awscli.customizations.exceptions import ParamValidationError
 
 
 LOG = logging.getLogger(__name__)
@@ -103,5 +104,7 @@ class HistoryCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ValueError("usage: aws [options] <command> <subcommand> "
-                             "[parameters]\naws: error: too few arguments")
+            raise ParamValidationError(
+                "usage: aws [options] <command> <subcommand> "
+                "[parameters]\naws: error: too few arguments"
+            )

--- a/awscli/customizations/history/__init__.py
+++ b/awscli/customizations/history/__init__.py
@@ -27,7 +27,6 @@ from awscli.customizations.history.db import RecordBuilder
 from awscli.customizations.history.db import DatabaseHistoryHandler
 from awscli.customizations.history.show import ShowCommand
 from awscli.customizations.history.list import ListCommand
-from awscli.customizations.exceptions import ParamValidationError
 
 
 LOG = logging.getLogger(__name__)
@@ -104,7 +103,4 @@ class HistoryCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ParamValidationError(
-                "usage: aws [options] <command> <subcommand> "
-                "[parameters]\naws: error: too few arguments"
-            )
+            self._raise_usage_error()

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -22,6 +22,7 @@ from awscli.table import COLORAMA_KWARGS
 from awscli.compat import six
 from awscli.customizations.history.commands import HistorySubcommand
 from awscli.customizations.history.filters import RegexFilter
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class Formatter(object):
@@ -45,7 +46,7 @@ class Formatter(object):
         if self._output is None:
             self._output = sys.stdout
         if include and exclude:
-            raise ValueError(
+            raise ParamValidationError(
                 'Either input or exclude can be provided but not both')
         self._include = include
         self._exclude = exclude
@@ -387,7 +388,7 @@ class ShowCommand(HistorySubcommand):
 
     def _validate_args(self, parsed_args):
         if parsed_args.exclude and parsed_args.include:
-            raise ValueError(
+            raise ParamValidationError(
                 'Either --exclude or --include can be provided but not both')
 
     def _get_formatter(self, parsed_args, parsed_globals, output_stream):

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -146,6 +146,7 @@ class OpsWorksRegister(BasicCommand):
         self.determine_details(args)
         self.create_iam_entities(args)
         self.setup_target_machine(args)
+        return 0
 
     def prevalidate_arguments(self, args):
         """

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -27,6 +27,7 @@ from botocore.exceptions import ClientError
 from awscli.compat import shlex_quote, urlopen, ensure_text_type
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import create_client_from_parsed_globals
+from awscli.customizations.exceptions import ParamValidationError
 
 
 LOG = logging.getLogger(__name__)
@@ -153,36 +154,36 @@ class OpsWorksRegister(BasicCommand):
         Validates command line arguments before doing anything else.
         """
         if not args.target and not args.local:
-            raise ValueError("One of target or --local is required.")
+            raise ParamValidationError("One of target or --local is required.")
         elif args.target and args.local:
-            raise ValueError(
+            raise ParamValidationError(
                 "Arguments target and --local are mutually exclusive.")
 
         if args.local and platform.system() != 'Linux':
-            raise ValueError(
+            raise ParamValidationError(
                 "Non-Linux instances are not supported by AWS OpsWorks.")
 
         if args.ssh and (args.username or args.private_key):
-            raise ValueError(
+            raise ParamValidationError(
                 "Argument --override-ssh cannot be used together with "
                 "--ssh-username or --ssh-private-key.")
 
         if args.infrastructure_class == 'ec2':
             if args.private_ip:
-                raise ValueError(
+                raise ParamValidationError(
                     "--override-private-ip is not supported for EC2.")
             if args.public_ip:
-                raise ValueError(
+                raise ParamValidationError(
                     "--override-public-ip is not supported for EC2.")
 
         if args.infrastructure_class == 'on-premises' and \
                 args.use_instance_profile:
-            raise ValueError(
+            raise ParamValidationError(
                 "--use-instance-profile is only supported for EC2.")
 
         if args.hostname:
             if not HOSTNAME_RE.match(args.hostname):
-                raise ValueError(
+                raise ParamValidationError(
                     "Invalid hostname: '%s'. Hostnames must consist of "
                     "letters, digits and dashes only and must not start or "
                     "end with a dash." % args.hostname)

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -27,10 +27,11 @@ import logging
 from functools import partial
 
 from botocore import xform_name
-from botocore.exceptions import DataNotFoundError, PaginationError
+from botocore.exceptions import DataNotFoundError
 from botocore import model
 
 from awscli.arguments import BaseCLIArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 
 logger = logging.getLogger(__name__)
@@ -233,9 +234,10 @@ def ensure_paging_params_not_set(parsed_args, shadowed_args):
     if len(params_used) > 0:
         converted_params = ', '.join(
             ["--" + p.replace('_', '-') for p in params_used])
-        raise PaginationError(
-            message="Cannot specify --no-paginate along with pagination "
-                    "arguments: %s" % converted_params)
+        raise ParamValidationError(
+            "Cannot specify --no-paginate along with pagination "
+            "arguments: %s" % converted_params
+        )
 
 
 def _remove_existing_paging_arguments(argument_table, pagination_config):

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -17,6 +17,7 @@ from awscli.customizations.s3.subcommands import ListCommand, WebsiteCommand, \
     PresignCommand
 from awscli.customizations.s3.syncstrategy.register import \
     register_sync_strategies
+from awscli.customizations.exceptions import ParamValidationError
 
 
 def awscli_initialize(cli):
@@ -65,5 +66,7 @@ class S3(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ValueError("usage: aws [options] <command> <subcommand> "
-                             "[parameters]\naws: error: too few arguments")
+            raise ParamValidationError(
+                "usage: aws [options] <command> <subcommand> "
+                "[parameters]\naws: error: too few arguments"
+            )

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -17,7 +17,6 @@ from awscli.customizations.s3.subcommands import ListCommand, WebsiteCommand, \
     PresignCommand
 from awscli.customizations.s3.syncstrategy.register import \
     register_sync_strategies
-from awscli.customizations.exceptions import ParamValidationError
 
 
 def awscli_initialize(cli):
@@ -66,7 +65,4 @@ class S3(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ParamValidationError(
-                "usage: aws [options] <command> <subcommand> "
-                "[parameters]\naws: error: too few arguments"
-            )
+            self._raise_usage_error()

--- a/awscli/customizations/s3/syncstrategy/base.py
+++ b/awscli/customizations/s3/syncstrategy/base.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 import logging
 
+from awscli.customizations.exceptions import ParamValidationError
+
 
 LOG = logging.getLogger(__name__)
 
@@ -65,9 +67,11 @@ class BaseSync(object):
 
     def _check_sync_type(self, sync_type):
         if sync_type not in VALID_SYNC_TYPES:
-            raise ValueError("Unknown sync_type: %s.\n"
-                             "Valid options are %s." %
-                             (sync_type, VALID_SYNC_TYPES))
+            raise ParamValidationError(
+                "Unknown sync_type: %s.\n"
+                "Valid options are %s." %
+                (sync_type, VALID_SYNC_TYPES)
+            )
 
     @property
     def sync_type(self):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -24,6 +24,7 @@ from dateutil.tz import tzlocal, tzutc
 
 from awscli.compat import bytes_print
 from awscli.compat import queue
+from awscli.customizations.exceptions import ParamValidationError
 
 LOGGER = logging.getLogger(__name__)
 HUMANIZE_SUFFIXES = ('KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB')
@@ -523,8 +524,9 @@ class RequestParamsMapper(object):
                 try:
                     permission, grantee = grant.split('=', 1)
                 except ValueError:
-                    raise ValueError('grants should be of the form '
-                                     'permission=principal')
+                    raise ParamValidationError(
+                        'grants should be of the form permission=principal'
+                    )
                 request_params[cls._permission_to_param(permission)] = grantee
 
     @classmethod
@@ -537,8 +539,9 @@ class RequestParamsMapper(object):
             return 'GrantReadACP'
         if permission == 'writeacl':
             return 'GrantWriteACP'
-        raise ValueError('permission must be one of: '
-                         'read|readacl|writeacl|full')
+        raise ParamValidationError(
+            'permission must be one of: read|readacl|writeacl|full'
+        )
 
     @classmethod
     def _set_metadata_params(cls, request_params, cli_params):

--- a/awscli/customizations/servicecatalog/exceptions.py
+++ b/awscli/customizations/servicecatalog/exceptions.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class ServiceCatalogCommandError(Exception):
@@ -21,5 +22,8 @@ class ServiceCatalogCommandError(Exception):
         self.kwargs = kwargs
 
 
-class InvalidParametersException(ServiceCatalogCommandError):
+class InvalidParametersException(
+    ServiceCatalogCommandError,
+    ParamValidationError,
+):
     fmt = "An error occurred (InvalidParametersException) : {message}"

--- a/awscli/customizations/servicecatalog/generate.py
+++ b/awscli/customizations/servicecatalog/generate.py
@@ -17,6 +17,7 @@ from awscli.customizations.servicecatalog.generateproduct \
     import GenerateProductCommand
 from awscli.customizations.servicecatalog.generateprovisioningartifact \
     import GenerateProvisioningArtifactCommand
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class GenerateCommand(BasicCommand):
@@ -31,5 +32,7 @@ class GenerateCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ValueError("usage: aws [options] <command> <subcommand> "
-                             "[parameters]\naws: error: too few arguments")
+            raise ParamValidationError(
+                "usage: aws [options] <command> <subcommand> "
+                "[parameters]\naws: error: too few arguments"
+            )

--- a/awscli/customizations/servicecatalog/generate.py
+++ b/awscli/customizations/servicecatalog/generate.py
@@ -17,7 +17,6 @@ from awscli.customizations.servicecatalog.generateproduct \
     import GenerateProductCommand
 from awscli.customizations.servicecatalog.generateprovisioningartifact \
     import GenerateProvisioningArtifactCommand
-from awscli.customizations.exceptions import ParamValidationError
 
 
 class GenerateCommand(BasicCommand):
@@ -32,7 +31,4 @@ class GenerateCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ParamValidationError(
-                "usage: aws [options] <command> <subcommand> "
-                "[parameters]\naws: error: too few arguments"
-            )
+            self._raise_usage_error()

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -13,9 +13,10 @@
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.sso.utils import do_sso_login
 from awscli.customizations.utils import uni_print
+from awscli.customizations.exceptions import ConfigurationError
 
 
-class InvalidSSOConfigError(Exception):
+class InvalidSSOConfigError(ConfigurationError):
     pass
 
 

--- a/awscli/customizations/timestampformat.py
+++ b/awscli/customizations/timestampformat.py
@@ -29,6 +29,7 @@ in the future.
 """
 from botocore.utils import parse_timestamp
 from botocore.exceptions import ProfileNotFound
+from awscli.customizations.exceptions import ConfigurationError
 
 
 def register_timestamp_format(event_handlers):
@@ -70,6 +71,8 @@ def add_timestamp_parser(session, **kwargs):
     elif timestamp_format == 'iso8601':
         timestamp_parser = iso_format
     else:
-        raise ValueError('Unknown cli_timestamp_format value: %s, valid values'
-                         ' are "wire" or "iso8601"' % timestamp_format)
+        raise ConfigurationError(
+            'Unknown cli_timestamp_format value: %s, valid values'
+            ' are "wire" or "iso8601"' % timestamp_format
+        )
     factory.set_parser_defaults(timestamp_parser=timestamp_parser)

--- a/awscli/customizations/toplevelbool.py
+++ b/awscli/customizations/toplevelbool.py
@@ -23,6 +23,7 @@ from functools import partial
 from awscli.argprocess import detect_shape_structure
 from awscli import arguments
 from awscli.customizations.utils import validate_mutually_exclusive_handler
+from awscli.customizations.exceptions import ParamValidationError
 
 
 LOG = logging.getLogger(__name__)
@@ -91,7 +92,7 @@ def validate_boolean_mutex_groups(boolean_pairs, parsed_args, **kwargs):
     for positive, negative in boolean_pairs:
         if getattr(parsed_args, positive.py_name) is not _NOT_SPECIFIED and \
                 getattr(parsed_args, negative.py_name) is not _NOT_SPECIFIED:
-            raise ValueError(
+            raise ParamValidationError(
                 'Cannot specify both the "%s" option and '
                 'the "%s" option.' % (positive.cli_name, negative.cli_name))
 

--- a/awscli/customizations/translate.py
+++ b/awscli/customizations/translate.py
@@ -13,6 +13,7 @@
 import copy
 
 from awscli.arguments import CustomArgument, CLIArgument
+from awscli.customizations.exceptions import ParamValidationError
 
 FILE_DOCSTRING = ('<p>The path to the file of the code you are uploading. '
                   'Example: fileb://data.csv</p>')
@@ -57,10 +58,11 @@ class TerminologyDataArgument(CLIArgument):
             return
         unpacked = self._unpack_argument(value)
         if 'File' in unpacked:
-            raise ValueError("File cannot be provided as part of the "
-                             "'--terminology-data' argument. Please use the "
-                             "'--data-file' option instead to specify a "
-                             "file.")
+            raise ParamValidationError(
+                "File cannot be provided as part of the '--terminology-data' "
+                "argument. Please use the '--data-file' option instead to "
+                "specify a file."
+            )
         if parameters.get('TerminologyData'):
             parameters['TerminologyData'].update(unpacked)
         else:

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -20,6 +20,7 @@ import sys
 import xml
 
 from botocore.exceptions import ClientError
+from awscli.customizations.exceptions import ParamValidationError
 
 
 _SENTENCE_DELIMETERS_REGEX = re.compile(r'[.:]+')
@@ -90,9 +91,11 @@ def validate_mutually_exclusive(parsed_args, *groups):
         if current_group is None:
             current_group = key_group
         elif not key_group == current_group:
-            raise ValueError('The key "%s" cannot be specified when one '
-                             'of the following keys are also specified: '
-                             '%s' % (key, ', '.join(current_group)))
+            raise ParamValidationError(
+                'The key "%s" cannot be specified when one '
+                'of the following keys are also specified: '
+                '%s' % (key, ', '.join(current_group))
+            )
 
 
 def _get_group_for_key(key, groups):

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -68,6 +68,7 @@ class WaitCommand(BasicCommand):
         if parsed_args.subcommand is None:
             raise ValueError("usage: aws [options] <command> <subcommand> "
                              "[parameters]\naws: error: too few arguments")
+        return 0
 
     def _build_subcommand_table(self):
         subcommand_table = super(WaitCommand, self)._build_subcommand_table()

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -14,6 +14,7 @@ from botocore import xform_name
 from botocore.exceptions import DataNotFoundError
 
 from awscli.clidriver import ServiceOperation
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.commands import BasicCommand, BasicHelp, \
     BasicDocHandler
 
@@ -66,8 +67,10 @@ class WaitCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ValueError("usage: aws [options] <command> <subcommand> "
-                             "[parameters]\naws: error: too few arguments")
+            raise ParamValidationError(
+                "usage: aws [options] <command> <subcommand> "
+                "[parameters]\naws: error: too few arguments"
+            )
         return 0
 
     def _build_subcommand_table(self):

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -14,7 +14,6 @@ from botocore import xform_name
 from botocore.exceptions import DataNotFoundError
 
 from awscli.clidriver import ServiceOperation
-from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.commands import BasicCommand, BasicHelp, \
     BasicDocHandler
 
@@ -67,10 +66,7 @@ class WaitCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         if parsed_args.subcommand is None:
-            raise ParamValidationError(
-                "usage: aws [options] <command> <subcommand> "
-                "[parameters]\naws: error: too few arguments"
-            )
+            self._raise_usage_error()
         return 0
 
     def _build_subcommand_table(self):

--- a/awscli/customizations/wizard/commands.py
+++ b/awscli/customizations/wizard/commands.py
@@ -13,7 +13,6 @@
 from awscli.customizations.wizard import devcommands, factory
 from awscli.customizations.wizard.loader import WizardLoader
 from awscli.customizations.commands import BasicCommand, BasicHelp
-from awscli.customizations.exceptions import ParamValidationError
 
 
 def register_wizard_commands(event_handlers):
@@ -88,12 +87,6 @@ class TopLevelWizardCommand(BasicCommand):
         loaded = self._loader.load_wizard(
             self._parent_command, self._wizard_name)
         self._runner.run(loaded)
-
-    def _raise_usage_error(self):
-        raise ParamValidationError(
-            "usage: aws [options] <command> <subcommand> "
-            "[parameters]\naws: error: too few arguments"
-        )
 
     def create_help_command(self):
         return BasicHelp(self._session, self,

--- a/awscli/customizations/wizard/commands.py
+++ b/awscli/customizations/wizard/commands.py
@@ -13,6 +13,7 @@
 from awscli.customizations.wizard import devcommands, factory
 from awscli.customizations.wizard.loader import WizardLoader
 from awscli.customizations.commands import BasicCommand, BasicHelp
+from awscli.customizations.exceptions import ParamValidationError
 
 
 def register_wizard_commands(event_handlers):
@@ -89,8 +90,10 @@ class TopLevelWizardCommand(BasicCommand):
         self._runner.run(loaded)
 
     def _raise_usage_error(self):
-        raise ValueError("usage: aws [options] <command> <subcommand> "
-                            "[parameters]\naws: error: too few arguments")
+        raise ParamValidationError(
+            "usage: aws [options] <command> <subcommand> "
+            "[parameters]\naws: error: too few arguments"
+        )
 
     def create_help_command(self):
         return BasicHelp(self._session, self,

--- a/awscli/topics/return-codes.rst
+++ b/awscli/topics/return-codes.rst
@@ -31,8 +31,22 @@ of a CLI command:
 
 * ``130`` -- The process received a SIGINT (Ctrl-C).
 
-* ``255`` -- Command failed. There were errors thrown by either the CLI or
-  by the service the request was made to.
+* ``252`` -- Command syntax was invalid, an unknown parameter was provided, or
+  a paramter value was incorrect and prevented the command from running.
+
+* ``253`` -- The system environment or configuration was invalid. While the
+  command provided may be syntactically valid, missing configuration or
+  credentials prevented the command from running.
+
+* ``254`` -- The command was succesfully parsed and a request was made to the
+  specified service but the service returned an error. This will generally
+  indicate incorrect API usage or other service specific issues.
+
+* ``255`` -- General catch-all error. The command may have parsed correctly but
+  an unspecified runtime error occured when running the command. Because this
+  is a general error code, an error may change from 255 to a more specific
+  return code. A return code of 255 should not be relied on to determine a
+  specific error case.
 
 
 To determine the return code of a command, run the following right after

--- a/tests/functional/awslambda/test_function.py
+++ b/tests/functional/awslambda/test_function.py
@@ -94,7 +94,7 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline += ' --role myrole --handler myhandler'
         cmdline += ' --code S3Bucket=mybucket,S3Key=mykey,S3ObjectVersion=vs,'
         cmdline += 'ZipFile=foo'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('ZipFile cannot be provided as part of the --code',
                       stderr)
 
@@ -103,7 +103,7 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline += ' --function-name myfunction --runtime myruntime'
         cmdline += ' --role myrole --handler myhandler'
         cmdline += ' --zip-file filename_instead_of_contents.zip'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('must be a zip file with the fileb:// prefix', stderr)
         # Should also give a pointer to fileb:// for them.
         self.assertIn('fileb://', stderr)
@@ -114,7 +114,7 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline += ' --role myrole --handler myhandler'
         # Note file:// instead of fileb://
         cmdline += ' --zip-file file://%s' % self.zip_file
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         # Ensure we mention fileb:// to give the user an idea of
         # where to go next.
         self.assertIn('fileb://', stderr)
@@ -168,7 +168,7 @@ class TestPublishLayerVersion(BaseLambdaTests):
         cmdline += ' --content'
         cmdline += ' S3Bucket=mybucket,S3Key=mykey,S3ObjectVersion=vs,'
         cmdline += 'ZipFile=foo'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('ZipFile cannot be provided as part of the --content',
                       stderr)
 
@@ -176,7 +176,7 @@ class TestPublishLayerVersion(BaseLambdaTests):
         cmdline = self.prefix
         cmdline += ' --layer-name mylayer'
         cmdline += ' --zip-file filename_instead_of_contents.zip'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('must be a zip file with the fileb:// prefix', stderr)
         # Should also give a pointer to fileb:// for them.
         self.assertIn('fileb://', stderr)
@@ -186,7 +186,7 @@ class TestPublishLayerVersion(BaseLambdaTests):
         cmdline += ' --layer-name mylayer'
         # Note file:// instead of fileb://
         cmdline += ' --zip-file file://%s' % self.zip_file
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         # Ensure we mention fileb:// to give the user an idea of
         # where to go next.
         self.assertIn('fileb://', stderr)
@@ -199,7 +199,7 @@ class TestUpdateFunctionCode(BaseLambdaTests):
     def test_not_using_fileb_prefix(self):
         cmdline = self.prefix + ' --function-name foo'
         cmdline += ' --zip-file filename_instead_of_contents.zip'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('must be a zip file with the fileb:// prefix', stderr)
         # Should also give a pointer to fileb:// for them.
         self.assertIn('fileb://', stderr)

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -120,7 +120,7 @@ class TestCreateDistribution(BaseAWSCommandParamsTest):
     def test_both_distribution_config_and_origin_domain_name(self):
         self.assert_params_for_cmd(
             self.prefix + '--distribution-config {} --origin-domain-name a.us',
-            expected_rc=255,
+            expected_rc=252,
             stderr_contains='cannot be specified when one of the following')
 
     def test_no_input(self):

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -124,4 +124,4 @@ class TestCreateDistribution(BaseAWSCommandParamsTest):
             stderr_contains='cannot be specified when one of the following')
 
     def test_no_input(self):
-        self.run_cmd(self.prefix, expected_rc=255)
+        self.run_cmd(self.prefix, expected_rc=252)

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -48,4 +48,4 @@ class TestCreateInvalidation(BaseAWSCommandParamsTest):
         self.run_cmd(cmdline, expected_rc=255)
 
     def test_neither_invalidation_batch_or_paths(self):
-        self.run_cmd(self.prefix, expected_rc=255)
+        self.run_cmd(self.prefix, expected_rc=252)

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -45,7 +45,7 @@ class TestCreateInvalidation(BaseAWSCommandParamsTest):
 
     def test_invalidation_batch_and_paths(self):
         cmdline = self.prefix + '--invalidation-batch {} --paths foo'
-        self.run_cmd(cmdline, expected_rc=255)
+        self.run_cmd(cmdline, expected_rc=252)
 
     def test_neither_invalidation_batch_or_paths(self):
         self.run_cmd(self.prefix, expected_rc=252)

--- a/tests/functional/cloudfront/test_update_distribution.py
+++ b/tests/functional/cloudfront/test_update_distribution.py
@@ -94,7 +94,7 @@ class TestUpdateDistribution(BaseAWSCommandParamsTest):
     def test_both_distribution_config_and_default_root_object(self):
         self.assert_params_for_cmd(
             self.prefix + '--distribution-config {} --default-root-object foo',
-            expected_rc=255,
+            expected_rc=252,
             stderr_contains='cannot be specified when one of the following')
 
     def test_no_input(self):

--- a/tests/functional/cloudfront/test_update_distribution.py
+++ b/tests/functional/cloudfront/test_update_distribution.py
@@ -98,4 +98,4 @@ class TestUpdateDistribution(BaseAWSCommandParamsTest):
             stderr_contains='cannot be specified when one of the following')
 
     def test_no_input(self):
-        self.run_cmd(self.prefix, expected_rc=255)
+        self.run_cmd(self.prefix, expected_rc=252)

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -259,7 +259,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
     def test_ensures_start_time_before_end_time(self):
         stdout, stderr, rc = self.run_cmd(
             ("cloudtrail validate-logs --trail-arn %s --start-time 2015-01-01 "
-             "--end-time 2014-01-01"), 255)
+             "--end-time 2014-01-01"), 252)
         self.assertIn('start-time must occur before end-time', stderr)
 
     def test_fails_when_digest_not_from_same_location_as_json_contents(self):

--- a/tests/functional/configservice/test_put_configuration_recorder.py
+++ b/tests/functional/configservice/test_put_configuration_recorder.py
@@ -28,7 +28,7 @@ class TestPutConfigurationRecorder(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(cmdline, result)
 
     def test_no_configuration_recorder(self):
-        stdout, stderr, rc = self.run_cmd(self.prefix, expected_rc=2)
+        stdout, stderr, rc = self.run_cmd(self.prefix, expected_rc=252)
         self.assertIn(
             'required',
             stderr

--- a/tests/functional/datapipeline/test_list_runs.py
+++ b/tests/functional/datapipeline/test_list_runs.py
@@ -55,7 +55,7 @@ class TestDataPipelineQueryObjects(BaseAWSCommandParamsTest):
             {'pipelineObjects': objects[100:]}
         ]
 
-        self.run_cmd(command, expected_rc=None)
+        self.run_cmd(command, expected_rc=0)
 
         query = {
             'selectors': [{

--- a/tests/functional/ddb/test_ddb.py
+++ b/tests/functional/ddb/test_ddb.py
@@ -15,7 +15,7 @@ from awscli.testutils import BaseAWSCommandParamsTest
 
 class TestDDB(BaseAWSCommandParamsTest):
     def test_no_command_specified(self):
-        _, stderr, _ = self.run_cmd('ddb', expected_rc=255)
+        _, stderr, _ = self.run_cmd('ddb', expected_rc=252)
         expected = (
             "usage: aws [options] <command> <subcommand> "
             "[parameters]\naws: error: too few arguments"

--- a/tests/functional/ddb/test_ddb.py
+++ b/tests/functional/ddb/test_ddb.py
@@ -17,7 +17,7 @@ class TestDDB(BaseAWSCommandParamsTest):
     def test_no_command_specified(self):
         _, stderr, _ = self.run_cmd('ddb', expected_rc=252)
         expected = (
-            "usage: aws [options] <command> <subcommand> "
+            "usage: aws [options] ddb <subcommand> "
             "[parameters]\naws: error: too few arguments"
         )
         self.assertIn(expected, stderr)

--- a/tests/functional/ddb/test_put.py
+++ b/tests/functional/ddb/test_put.py
@@ -159,7 +159,7 @@ class TestPut(BaseAWSCommandParamsTest):
             'ddb', 'put', 'mytable', '[{foo: bar}, {foo: bar}]',
             '--condition', 'attribute_exists(foo)',
         ]
-        _, stderr, _ = self.assert_params_for_cmd(command, expected_rc=255)
+        _, stderr, _ = self.assert_params_for_cmd(command, expected_rc=252)
         self.assertIn('--condition is not supported', stderr)
 
     def test_load_items_from_file(self):

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -463,8 +463,14 @@ class TestSelect(BaseSelectTest):
     def test_select_does_not_support_yaml_stream(self):
         cmdline = 'ddb select mytable --output yaml-stream'
         stdout, _, _ = self.assert_params_for_cmd(
-            cmdline, expected_rc=255,
+            cmdline, expected_rc=252,
             stderr_contains='yaml-stream output format is not supported',
+        )
+
+    def test_select_parsing_error_rc(self):
+        cmdline = 'ddb select mytable --filter a=?!f'
+        stdout, _, _ = self.assert_params_for_cmd(
+            cmdline, expected_rc=252,
         )
 
 

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -523,8 +523,8 @@ class TestSelectPagination(BaseSelectTest):
         command = [
             'ddb', 'select', 'mytable', '--no-paginate', '--max-items', '1'
         ]
-        _, stderr, _ = self.run_cmd(command, expected_rc=255)
-        self.assertIn('Error during pagination', stderr)
+        _, stderr, _ = self.run_cmd(command, expected_rc=252)
+        self.assertIn('Cannot specify --no-paginate along with ', stderr)
 
     def test_max_items(self):
         command = [

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -91,6 +91,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
     def test_both(self):
         captured = cStringIO()
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
-        args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
+        args = ' --instance-id i-12345678 --owner-akid blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()
-        self.assert_params_for_cmd(args_list, expected_rc=255)
+        _, stderr, _ = self.assert_params_for_cmd(args_list, expected_rc=252)
+        self.assertIn('Mixing the --storage option', stderr)

--- a/tests/functional/ec2/test_modify_image_attribute.py
+++ b/tests/functional/ec2/test_modify_image_attribute.py
@@ -47,7 +47,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         cmdline += ' --image-id ami-d00dbeef'
         cmdline += ' --launch-permission THISISNOTJSON'
         # The arg name should be in the error message.
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=252,
                                    stderr_contains='launch-permission')
 
 

--- a/tests/functional/ec2/test_modify_instance_attribute.py
+++ b/tests/functional/ec2/test_modify_instance_attribute.py
@@ -103,7 +103,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         # Can't mix non-value + value version of the arg.
         cmdline += '--no-ebs-optimized '
         cmdline += '--ebs-optimized Value=true'
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=252,
                                     stderr_contains='Cannot specify both')
 
     def test_mix_non_value_bools_not_allowed(self):
@@ -112,7 +112,7 @@ class TestModifyInstanceAttribute(BaseAWSCommandParamsTest):
         # Can't mix non-value + value version of the arg.
         cmdline += '--no-ebs-optimized '
         cmdline += '--ebs-optimized '
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=252,
                                     stderr_contains='Cannot specify both')
 
 

--- a/tests/functional/ec2/test_security_group_operations.py
+++ b/tests/functional/ec2/test_security_group_operations.py
@@ -121,7 +121,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
             '[{"FromPort":8000,"ToPort":9000,"IpProtocol":"tcp",'
             '"IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]')
         args = self.prefix + '--group-name foobar --port 100 --ip-permissions %s' % json
-        self.assert_params_for_cmd(args, expected_rc=255)
+        self.assert_params_for_cmd(args, expected_rc=252)
 
 
 

--- a/tests/functional/iam/test_create_virtual_mfa_device.py
+++ b/tests/functional/iam/test_create_virtual_mfa_device.py
@@ -155,4 +155,4 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             cmdline,
             stderr_contains=self.parsed_response['Error']['Message'],
-            expected_rc=255)
+            expected_rc=254)

--- a/tests/functional/iam/test_create_virtual_mfa_device.py
+++ b/tests/functional/iam/test_create_virtual_mfa_device.py
@@ -112,7 +112,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
         cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
-        self.assert_params_for_cmd(cmdline, expected_rc=255)
+        self.assert_params_for_cmd(cmdline, expected_rc=252)
 
     def test_relative_filename(self):
         outfile = 'filename.png'
@@ -130,7 +130,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
         cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
-        self.assert_params_for_cmd(cmdline, expected_rc=255)
+        self.assert_params_for_cmd(cmdline, expected_rc=252)
 
     def test_bad_response(self):
         # This can happen if you run the create-virtual-mfa-device

--- a/tests/functional/iot/test_outfile.py
+++ b/tests/functional/iot/test_outfile.py
@@ -88,7 +88,7 @@ class TestOutFileQueryArguments(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             cmdline,
             stderr_contains=self.parsed_response['Error']['Message'],
-            expected_rc=255)
+            expected_rc=254)
 
     def test_ensures_file_is_writable_before_sending(self):
         outfile = os.sep.join(['', 'does', 'not', 'exist_', 'file.txt'])

--- a/tests/functional/iot/test_outfile.py
+++ b/tests/functional/iot/test_outfile.py
@@ -99,4 +99,4 @@ class TestOutFileQueryArguments(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             cmdline,
             stderr_contains='Unable to write to file: ',
-            expected_rc=255)
+            expected_rc=252)

--- a/tests/functional/logs/test_get_log_events.py
+++ b/tests/functional/logs/test_get_log_events.py
@@ -26,6 +26,6 @@ class TestGetLogEvents(BaseAWSCommandParamsTest):
         cmdline += ' --log-group-name foo'
         cmdline += ' --log-stream-name bar'
         cmdline += ' --page-size 5'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('Unknown options', stderr)
         self.assertIn('--page-size', stderr)

--- a/tests/functional/rds/test_modify_option_group.py
+++ b/tests/functional/rds/test_modify_option_group.py
@@ -35,7 +35,7 @@ class TestAddOptionGroup(BaseAWSCommandParamsTest):
                 '--options-to-remove foo')
         cmdline = self.prefix + args
         self.assert_params_for_cmd(
-            cmdline, expected_rc=255,
+            cmdline, expected_rc=252,
             stderr_contains='Unknown options: --options-to-remove')
 
 
@@ -56,5 +56,5 @@ class TestRemoveOptionGroup(BaseAWSCommandParamsTest):
                 '--options-to-include {"OptionName":"TDE"}')
         cmdline = self.prefix + args
         self.assert_params_for_cmd(
-            cmdline, expected_rc=255,
+            cmdline, expected_rc=252,
             stderr_contains='Unknown options: --options-to-include')

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -602,7 +602,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_cannot_use_recursive_with_stream(self):
         cmdline = '%s - s3://bucket/key.txt --recursive' % self.prefix
-        _, stderr, _ = self.run_cmd(cmdline, expected_rc=255)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn(
             'Streaming currently is only compatible with non-recursive cp '
             'commands', stderr)

--- a/tests/functional/s3/test_ls_command.py
+++ b/tests/functional/s3/test_ls_command.py
@@ -36,7 +36,7 @@ class TestLSCommand(BaseS3TransferCommandTest):
             stdout, '%s        100 foo/bar.txt\n'%time_local.strftime('%Y-%m-%d %H:%M:%S'))
 
     def test_errors_out_with_extra_arguments(self):
-        stderr = self.run_cmd('s3 ls --extra-argument-foo', expected_rc=255)[1]
+        stderr = self.run_cmd('s3 ls --extra-argument-foo', expected_rc=252)[1]
         self.assertIn('Unknown options', stderr)
         self.assertIn('--extra-argument-foo', stderr)
 

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -44,4 +44,4 @@ class TestMBCommand(BaseAWSCommandParamsTest):
 
     def test_nonzero_exit_if_invalid_path_provided(self):
         command = self.prefix + 'bucket'
-        self.run_cmd(command, expected_rc=255)
+        self.run_cmd(command, expected_rc=252)

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -22,13 +22,13 @@ class TestMvCommand(BaseS3TransferCommandTest):
 
     def test_cant_mv_object_onto_itself(self):
         cmdline = '%s s3://bucket/key s3://bucket/key' % self.prefix
-        stderr = self.run_cmd(cmdline, expected_rc=255)[1]
+        stderr = self.run_cmd(cmdline, expected_rc=252)[1]
         self.assertIn('Cannot mv a file onto itself', stderr)
 
     def test_cant_mv_object_with_implied_name(self):
         # The "key" key name is implied in the dst argument.
         cmdline = '%s s3://bucket/key s3://bucket/' % self.prefix
-        stderr = self.run_cmd(cmdline, expected_rc=255)[1]
+        stderr = self.run_cmd(cmdline, expected_rc=252)[1]
         self.assertIn('Cannot mv a file onto itself', stderr)
 
     def test_website_redirect_ignore_paramfile(self):

--- a/tests/functional/s3/test_rb_command.py
+++ b/tests/functional/s3/test_rb_command.py
@@ -63,11 +63,11 @@ class TestRb(BaseAWSCommandParamsTest):
 
     def test_nonzero_exit_if_uri_scheme_not_provided(self):
         command = self.prefix + 'bucket'
-        self.run_cmd(command, expected_rc=255)
+        self.run_cmd(command, expected_rc=252)
 
     def test_nonzero_exit_if_key_provided(self):
         command = self.prefix + 's3://bucket/key --force'
-        self.run_cmd(command, expected_rc=255)
+        self.run_cmd(command, expected_rc=252)
 
         command = self.prefix + 's3://bucket/key'
-        self.run_cmd(command, expected_rc=255)
+        self.run_cmd(command, expected_rc=252)

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -44,8 +44,8 @@ class TestSyncCommand(BaseS3TransferCommandTest):
 
     def test_no_recursive_option(self):
         cmdline = '. s3://mybucket --recursive'
-        # Return code will be 2 for invalid parameter ``--recursive``
-        self.run_cmd(cmdline, expected_rc=2)
+        # Return code will be 252 for invalid parameter ``--recursive``
+        self.run_cmd(cmdline, expected_rc=252)
 
     def test_sync_from_non_existant_directory(self):
         non_existant_directory = os.path.join(self.files.rootdir, 'fakedir')

--- a/tests/functional/s3api/test_list_objects.py
+++ b/tests/functional/s3api/test_list_objects.py
@@ -86,7 +86,7 @@ class TestListObjects(BaseAWSCommandParamsTest):
         cmdline = self.prefix + ' --bucket mybucket --no-paginate ' \
                                 '--max-items 100'
         self.assert_params_for_cmd(
-            cmdline, expected_rc=255,
-            stderr_contains="Error during pagination: Cannot specify "
+            cmdline, expected_rc=252,
+            stderr_contains="Cannot specify "
                             "--no-paginate along with pagination arguments: "
                             "--max-items")

--- a/tests/functional/s3api/test_select_object_content.py
+++ b/tests/functional/s3api/test_select_object_content.py
@@ -103,7 +103,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(
             cmd=cmdline, params=expected_params,
-            expected_rc=255,
+            expected_rc=254,
             stderr_contains=(
                 'An error occurred (CastFailed) when '
                 'calling the SelectObjectContent operation'),

--- a/tests/functional/servicecatalog/test_generate_createproduct.py
+++ b/tests/functional/servicecatalog/test_generate_createproduct.py
@@ -139,7 +139,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--file-path')
 
     def test_generate_product_missing_bucket_name(self):
@@ -147,7 +147,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--bucket-name')
 
     def test_generate_product_missing_product_type(self):
@@ -155,7 +155,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--product-type')
 
     def test_generate_product_missing_product_name(self):
@@ -163,7 +163,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--product-name')
 
     def test_generate_product_missing_product_owner(self):
@@ -171,7 +171,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--product-owner')
 
     def test_generate_product_missing_provisioning_artifact_name(self):
@@ -179,7 +179,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-name')
 
     def test_generate_product_missing_provisioning_artifact_description(self):
@@ -187,7 +187,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-description')
 
     def test_generate_product_missing_provisioning_artifact_type(self):
@@ -195,7 +195,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-type')
 
     def test_invalid_product_type(self):
@@ -204,7 +204,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
 
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--product-type: Invalid choice')
 
     def test_generate_product_invalid_provisioning_artifact_type(self):
@@ -213,5 +213,5 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
 
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-type: Invalid choice')

--- a/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
+++ b/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
@@ -103,7 +103,7 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-type: Invalid choice')
 
     def test_generate_provisioning_artifact_missing_file_path(self):
@@ -111,7 +111,7 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--file-path')
 
     def test_generate_provisioning_artifact_missing_bucket_name(self):
@@ -119,7 +119,7 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--bucket-name')
 
     def test_generate_provisioning_artifact_missing_pa_name(self):
@@ -127,7 +127,7 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-name')
 
     def test_generate_provisioning_artifact_missing_pa_description(self):
@@ -135,7 +135,7 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-description')
 
     def test_generate_provisioning_artifact_missing_pa_type(self):
@@ -143,5 +143,5 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.cmd_line = self.build_cmd_line()
         self.assert_params_for_cmd(
             self.cmd_line,
-            expected_rc=2,
+            expected_rc=252,
             stderr_contains='--provisioning-artifact-type')

--- a/tests/functional/ses/test_send_email.py
+++ b/tests/functional/ses/test_send_email.py
@@ -130,7 +130,7 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                 ' --destination {"ToAddresses":["fie@baz.com"]}'
                 ' --to fie2@baz.com')
         args_list = (self.prefix + args).split()
-        self.run_cmd(args_list, expected_rc=255)
+        self.run_cmd(args_list, expected_rc=252)
 
     def test_both_message_and_text(self):
         args = (' --message {"Subject":{"Data":"This_is_a_test"},'
@@ -139,4 +139,4 @@ class TestSendEmail(BaseAWSCommandParamsTest):
                 ' --destination {"ToAddresses":["fie@baz.com"]}'
                 ' --text This_is_another_body')
         args_list = (self.prefix + args).split()
-        self.run_cmd(args_list, expected_rc=255)
+        self.run_cmd(args_list, expected_rc=252)

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -118,7 +118,7 @@ class TestLoginCommand(BaseSSOTest):
 
     def test_login_no_sso_configuration(self):
         self.set_config_file_content(content='')
-        _, stderr, _ = self.run_cmd('sso login', expected_rc=255)
+        _, stderr, _ = self.run_cmd('sso login', expected_rc=253)
         self.assertIn(
             'Missing the following required SSO configuration',
             stderr
@@ -130,7 +130,7 @@ class TestLoginCommand(BaseSSOTest):
             'sso_start_url=%s\n' % self.start_url
         )
         self.set_config_file_content(content=content)
-        _, stderr, _ = self.run_cmd('sso login', expected_rc=255)
+        _, stderr, _ = self.run_cmd('sso login', expected_rc=253)
         self.assertIn(
             'Missing the following required SSO configuration',
             stderr

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -141,7 +141,7 @@ class TestCLIInputYAML(BaseCLIInputArgumentTest):
             '--cli-input-json', '{"Bucket":"bucket","Key":"key"}'
         ]
         self.assert_params_for_cmd(
-            command, expected_rc=255,
+            command, expected_rc=252,
             stderr_contains='Only one --cli-input- parameter may be specified.'
         )
 

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -63,7 +63,7 @@ class TestCLIInputJSON(BaseCLIInputArgumentTest):
         cmdline = (
             's3api head-object --cli-input-json {"Key":"foo"}'
         )
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=252,
                                    stderr_contains='Missing')
 
     def test_cli_input_json_has_extra_unknown_args(self):
@@ -73,7 +73,7 @@ class TestCLIInputJSON(BaseCLIInputArgumentTest):
             's3api head-object --cli-input-json '
             '{"Bucket":"bucket","Key":"key","Foo":"bar"}'
         )
-        self.assert_params_for_cmd(cmdline, expected_rc=255,
+        self.assert_params_for_cmd(cmdline, expected_rc=252,
                                    stderr_contains='Unknown')
 
 
@@ -92,14 +92,14 @@ class TestCLIInputYAML(BaseCLIInputArgumentTest):
             's3api', 'list-objects-v2', '--cli-input-yaml',
             'Bucket: test-bucket\nFoo: bar'
         ]
-        self.run_cmd(command, expected_rc=255)
+        self.run_cmd(command, expected_rc=252)
 
     def test_required_params_missing(self):
         command = [
             's3api', 'list-objects-v2', '--cli-input-yaml',
             'EncodingType: url'
         ]
-        self.run_cmd(command, expected_rc=255)
+        self.run_cmd(command, expected_rc=252)
 
     def test_input_yaml_file(self):
         filename = self.files.create_file(

--- a/tests/functional/test_generatecliskeleton.py
+++ b/tests/functional/test_generatecliskeleton.py
@@ -159,7 +159,7 @@ class TestGenerateCliSkeletonOutput(BaseAWSCommandParamsTest):
 
     def test_validates_at_command_line_level(self):
         cmdline = 'ec2 create-vpc --generate-cli-skeleton output'
-        stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('required', stderr)
         self.assertIn('--cidr-block', stderr)
         self.assertEqual('', stdout)
@@ -169,6 +169,6 @@ class TestGenerateCliSkeletonOutput(BaseAWSCommandParamsTest):
         # Note: The for --filters instead of Value the key should be Values
         # which should throw a validation error.
         cmdline += '--filters Name=instance-id,Value=foo'
-        stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, _ = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('Unknown parameter in Filters[0]', stderr)
         self.assertEqual('', stdout)

--- a/tests/functional/translate/test_import_terminology.py
+++ b/tests/functional/translate/test_import_terminology.py
@@ -77,14 +77,14 @@ class TestImortTerminology(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --name myterminology --merge-strategy OVERWRITE'
         cmdline += ' --terminology-data Format=TMX'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=2)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn('--data-file', stderr)
 
     def test_import_terminology_with_no_format(self):
         cmdline = self.prefix
         cmdline += ' --name myterminology --merge-strategy OVERWRITE'
         cmdline += ' --data-file fileb://%s' % self.temp_file
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn(
             'Missing required parameter in TerminologyData: "Format"', stderr
         )

--- a/tests/functional/translate/test_import_terminology.py
+++ b/tests/functional/translate/test_import_terminology.py
@@ -65,7 +65,7 @@ class TestImortTerminology(BaseAWSCommandParamsTest):
         cmdline += ' --name myterminology --merge-strategy OVERWRITE'
         cmdline += ' --terminology-data File=fileb://wrong.csv,Format=TMX'
         cmdline += ' --data-file fileb://right.csv'
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn(
             "File cannot be provided as part of the '--terminology-data' "
             "argument. Please use the '--data-file' option instead to specify "

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -274,7 +274,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
         self.put_object(bucket_name, key_name='key.txt', contents='foo')
         p = aws('s3 mv s3://%s/key.txt s3://%s/key.txt' %
                 (bucket_name, bucket_name))
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 252)
         self.assertIn('Cannot mv a file onto itself', p.stderr)
 
     def test_cant_move_large_file_onto_itself(self):
@@ -288,7 +288,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
                         contents=file_contents)
         p = aws('s3 mv s3://%s/key.txt s3://%s/key.txt' %
                 (bucket_name, bucket_name))
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 252)
         self.assertIn('Cannot mv a file onto itself', p.stderr)
 
 
@@ -1149,7 +1149,7 @@ class TestLs(BaseS3IntegrationTest):
 
     def test_ls_non_existent_bucket(self):
         p = aws('s3 ls s3://foobara99842u4wbts829381')
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 254)
         self.assertIn(
             ('An error occurred (NoSuchBucket) when calling the '
              'ListObjectsV2 operation: The specified bucket does not exist'),

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -141,7 +141,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         p = aws(
             'ec2 describe-instances --filters '
             '\'{"Name": "bad-filter", "Values": ["i-123"]}\'')
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 254)
         self.assertIn("The filter 'bad-filter' is invalid", p.stderr,
                       "stdout: %s, stderr: %s" % (p.stdout, p.stderr))
 
@@ -187,7 +187,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         p = aws('s3api get-object --bucket %s --key foo %s' % (
             bucket_name, os.path.join(d, 'foo')), env_vars=env_vars)
         # Should have credential issues.
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 254)
 
         p = aws('s3api get-object --bucket %s --key foo '
                 '%s --no-sign-request' % (bucket_name, os.path.join(d, 'foo')),
@@ -247,7 +247,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
 
     def test_unknown_argument(self):
         p = aws('ec2 describe-instances --filterss')
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 252)
         self.assertIn('Unknown options: --filterss', p.stderr)
 
     def test_table_output(self):
@@ -278,7 +278,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
 
     def test_leftover_args_in_operation(self):
         p = aws('ec2 describe-instances BADKEY=foo')
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 252)
         self.assertIn("Unknown option", p.stderr, p.stderr)
 
     def test_json_param_parsing(self):
@@ -463,7 +463,7 @@ class TestGlobalArgs(BaseS3CLICommand):
         # private.
         p = aws('s3api head-object --bucket %s --key private --no-sign-request'
                 % bucket_name, env_vars=env)
-        self.assertEqual(p.rc, 255)
+        self.assertEqual(p.rc, 254)
 
     def test_profile_arg_has_precedence_over_env_vars(self):
         # At a high level, we're going to set access_key/secret_key

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -149,8 +149,8 @@ def test_display_error_message():
 
 
 def _run_error_aws_command(command_string):
-    result = _aws(command_string, target_rc=255)
-    assert_equal(result.rc, 255)
+    result = _aws(command_string, target_rc=254)
+    assert_equal(result.rc, 254)
     error_message = re.compile(
         'An error occurred \(.+\) when calling the \w+ operation: \w+')
     match = error_message.search(result.stderr)

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -36,7 +36,7 @@ from awscli.customizations.cloudtrail.validation import DigestError, \
     InvalidDigestFormat, S3ClientProvider
 from botocore.exceptions import ClientError
 from awscli.testutils import unittest
-from awscli.schema import ParameterRequiredError
+from awscli.customizations.exceptions import ParamValidationError
 
 
 START_DATE = parser.parse('20140810T000000Z')
@@ -184,7 +184,7 @@ class TestValidation(unittest.TestCase):
         try:
             parse_date('foo')
             self.fail('Should have failed to parse')
-        except ValueError as e:
+        except ParamValidationError as e:
             self.assertIn('Unable to parse date value: foo', str(e))
 
     def test_parses_dates(self):
@@ -195,7 +195,7 @@ class TestValidation(unittest.TestCase):
         try:
             assert_cloudtrail_arn_is_valid('foo:bar:baz')
             self.fail('Should have failed')
-        except ValueError as e:
+        except ParamValidationError as e:
             self.assertIn('Invalid trail ARN provided: foo:bar:baz', str(e))
 
     def test_ensures_cloudtrail_arns_are_valid_when_missing_resource(self):
@@ -203,7 +203,7 @@ class TestValidation(unittest.TestCase):
             assert_cloudtrail_arn_is_valid(
                 'arn:aws:cloudtrail:us-east-1:%s:foo' % TEST_ACCOUNT_ID)
             self.fail('Should have failed')
-        except ValueError as e:
+        except ParamValidationError as e:
             self.assertIn('Invalid trail ARN provided', str(e))
 
     def test_allows_valid_arns(self):
@@ -325,7 +325,7 @@ class TestValidation(unittest.TestCase):
                 "Id": TEST_ORGANIZATION_ID,
             }
         }
-        with self.assertRaises(ParameterRequiredError):
+        with self.assertRaises(ParamValidationError):
             create_digest_traverser(
                 trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
                 cloudtrail_client=cloudtrail_client,

--- a/tests/unit/customizations/codedeploy/test_deregister.py
+++ b/tests/unit/customizations/codedeploy/test_deregister.py
@@ -14,6 +14,7 @@
 from argparse import Namespace
 from mock import MagicMock, call
 from awscli.customizations.codedeploy.deregister import Deregister
+from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 
@@ -67,7 +68,8 @@ class TestDeregister(unittest.TestCase):
     def test_deregister_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        error_msg = 'Region not specified.'
+        with self.assertRaisesRegexp(ConfigurationError, error_msg):
             self.deregister._run_main(self.args, self.globals)
 
     def test_deregister_throws_on_invalid_instance_name(self):

--- a/tests/unit/customizations/codedeploy/test_deregister.py
+++ b/tests/unit/customizations/codedeploy/test_deregister.py
@@ -14,6 +14,7 @@
 from argparse import Namespace
 from mock import MagicMock, call
 from awscli.customizations.codedeploy.deregister import Deregister
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 
 
@@ -71,8 +72,8 @@ class TestDeregister(unittest.TestCase):
 
     def test_deregister_throws_on_invalid_instance_name(self):
         self.args.instance_name = 'invalid%@^&%#&'
-        with self.assertRaisesRegexp(
-                ValueError, 'Instance name contains invalid characters.'):
+        with self.assertRaisesRegexp(ParamValidationError,
+                'Instance name contains invalid characters.'):
             self.deregister._run_main(self.args, self.globals)
 
     def test_deregister_creates_clients(self):

--- a/tests/unit/customizations/codedeploy/test_install.py
+++ b/tests/unit/customizations/codedeploy/test_install.py
@@ -16,6 +16,7 @@ import sys
 from argparse import Namespace
 from awscli.customizations.codedeploy.install import Install
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
+from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 from mock import MagicMock, patch, mock_open
@@ -96,7 +97,8 @@ class TestInstall(unittest.TestCase):
     def test_install_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        error_msg = 'Region not specified.'
+        with self.assertRaisesRegexp(ConfigurationError, error_msg):
             self.install._run_main(self.args, self.globals)
 
     def test_install_throws_on_unsupported_system(self):

--- a/tests/unit/customizations/codedeploy/test_install.py
+++ b/tests/unit/customizations/codedeploy/test_install.py
@@ -16,6 +16,7 @@ import sys
 from argparse import Namespace
 from awscli.customizations.codedeploy.install import Install
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 from mock import MagicMock, patch, mock_open
 from socket import timeout
@@ -131,7 +132,7 @@ class TestInstall(unittest.TestCase):
     def test_install_throws_on_invalid_agent_installer(self):
         self.args.agent_installer = 'invalid-s3-location'
         with self.assertRaisesRegexp(
-                ValueError,
+                ParamValidationError,
                 '--agent-installer must specify the Amazon S3 URL format as '
                 's3://<bucket>/<key>.'):
             self.install._run_main(self.args, self.globals)

--- a/tests/unit/customizations/codedeploy/test_locationargs.py
+++ b/tests/unit/customizations/codedeploy/test_locationargs.py
@@ -113,13 +113,13 @@ class TestGetApplicationRevisionLocationArguments(
         cmd = self.prefix + (
             '--s3-location key=k,'
             'bundleType=zip,eTag=1234,version=abcd')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_s3_location_missing_key(self):
         cmd = self.prefix + (
             '--s3-location bucket=b,'
             'bundleType=zip,eTag=1234,version=abcd')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_github_location_with_etag(self):
         cmd = self.prefix + (
@@ -157,11 +157,11 @@ class TestGetApplicationRevisionLocationArguments(
         cmd = self.prefix + (
             '--github-location '
             'commitId=1234')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_github_location_missing_commit_id(self):
         cmd = self.prefix + '--github-location repository=foo/bar'
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
 
 class TestRegisterApplicationRevisionLocationArguments(
@@ -262,13 +262,13 @@ class TestRegisterApplicationRevisionLocationArguments(
         cmd = self.prefix + (
             '--s3-location key=k,'
             'bundleType=zip,eTag=1234,version=abcd')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_s3_location_missing_key(self):
         cmd = self.prefix + (
             '--s3-location bucket=b,'
             'bundleType=zip,eTag=1234,version=abcd')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_github_location_with_etag(self):
         cmd = self.prefix + (
@@ -306,11 +306,11 @@ class TestRegisterApplicationRevisionLocationArguments(
         cmd = self.prefix + (
             '--github-location '
             'commitId=1234')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_github_location_missing_commit_id(self):
         cmd = self.prefix + '--github-location repository=foo/bar'
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
 
 class TestCreateDeploymentLocationArguments(
@@ -418,13 +418,13 @@ class TestCreateDeploymentLocationArguments(
         cmd = self.prefix + (
             '--s3-location key=k,'
             'bundleType=zip,eTag=1234,version=abcd')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_s3_location_missing_key(self):
         cmd = self.prefix + (
             '--s3-location bucket=b,'
             'bundleType=zip,eTag=1234,version=abcd')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_github_location_with_etag(self):
         cmd = self.prefix + (
@@ -464,11 +464,11 @@ class TestCreateDeploymentLocationArguments(
         cmd = self.prefix + (
             '--github-location '
             'commitId=1234')
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
     def test_github_location_missing_commit_id(self):
         cmd = self.prefix + '--github-location repository=foo/bar'
-        self.run_cmd(cmd, 255)
+        self.run_cmd(cmd, 252)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -19,6 +19,7 @@ from six import StringIO
 from botocore.exceptions import ClientError
 
 from awscli.customizations.codedeploy.push import Push
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 from awscli.compat import ZIP_COMPRESSION_MODE
 
@@ -135,7 +136,7 @@ class TestPush(unittest.TestCase):
     def test_validate_args_throws_on_ignore_and_no_ignore_hidden_files(self):
         self.args.ignore_hidden_files = True
         self.args.no_ignore_hidden_files = True
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ParamValidationError):
             self.push._validate_args(self.args)
 
     def test_validate_args_default_description(self):

--- a/tests/unit/customizations/codedeploy/test_register.py
+++ b/tests/unit/customizations/codedeploy/test_register.py
@@ -14,6 +14,7 @@
 from argparse import Namespace
 from awscli.customizations.codedeploy.register import Register
 from awscli.customizations.codedeploy.utils import MAX_TAGS_PER_INSTANCE
+from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 from mock import MagicMock, patch, call, mock_open
@@ -81,7 +82,8 @@ class TestRegister(unittest.TestCase):
     def test_register_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        error_msg = 'Region not specified.'
+        with self.assertRaisesRegexp(ConfigurationError, error_msg):
             self.register._run_main(self.args, self.globals)
 
     def test_register_throws_on_invalid_instance_name(self):

--- a/tests/unit/customizations/codedeploy/test_register.py
+++ b/tests/unit/customizations/codedeploy/test_register.py
@@ -14,6 +14,7 @@
 from argparse import Namespace
 from awscli.customizations.codedeploy.register import Register
 from awscli.customizations.codedeploy.utils import MAX_TAGS_PER_INSTANCE
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 from mock import MagicMock, patch, call, mock_open
 
@@ -85,8 +86,8 @@ class TestRegister(unittest.TestCase):
 
     def test_register_throws_on_invalid_instance_name(self):
         self.args.instance_name = 'invalid%@^&%#&'
-        with self.assertRaisesRegexp(
-                ValueError, 'Instance name contains invalid characters.'):
+        error_msg = 'Instance name contains invalid characters.'
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             self.register._run_main(self.args, self.globals)
 
     def test_register_throws_on_invalid_tags(self):
@@ -94,14 +95,15 @@ class TestRegister(unittest.TestCase):
             {'Key': 'k' + str(x), 'Value': 'v' + str(x)} for x in range(11)
         ]
         with self.assertRaisesRegexp(
-                ValueError,
+                ParamValidationError,
                 'Instances can only have a maximum of {0} tags.'.format(
                     MAX_TAGS_PER_INSTANCE)):
             self.register._run_main(self.args, self.globals)
 
     def test_register_throws_on_invalid_iam_user_arn(self):
         self.args.iam_user_arn = 'invalid%@^&%#&'
-        with self.assertRaisesRegexp(ValueError, 'Invalid IAM user ARN.'):
+        error_msg = 'Invalid IAM user ARN.'
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             self.register._run_main(self.args, self.globals)
 
     def test_register_creates_clients(self):

--- a/tests/unit/customizations/codedeploy/test_uninstall.py
+++ b/tests/unit/customizations/codedeploy/test_uninstall.py
@@ -16,6 +16,7 @@ import sys
 from argparse import Namespace
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
 from awscli.customizations.codedeploy.uninstall import Uninstall
+from awscli.customizations.exceptions import ConfigurationError
 from awscli.testutils import unittest
 from mock import MagicMock, patch
 from socket import timeout
@@ -62,7 +63,8 @@ class TestUninstall(unittest.TestCase):
     def test_uninstall_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        error_msg = 'Region not specified.'
+        with self.assertRaisesRegexp(ConfigurationError, error_msg):
             self.uninstall._run_main(self.args, self.globals)
 
     def test_uninstall_throws_on_unsupported_system(self):

--- a/tests/unit/customizations/codedeploy/test_utils.py
+++ b/tests/unit/customizations/codedeploy/test_utils.py
@@ -22,6 +22,7 @@ from awscli.customizations.codedeploy.utils import \
     validate_iam_user_arn, validate_instance, validate_s3_location, \
     MAX_INSTANCE_NAME_LENGTH, MAX_TAGS_PER_INSTANCE, MAX_TAG_KEY_LENGTH, \
     MAX_TAG_VALUE_LENGTH
+from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 
@@ -75,7 +76,8 @@ class TestUtils(unittest.TestCase):
     def test_validate_region_throws_on_no_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        error_msg = 'Region not specified.'
+        with self.assertRaisesRegexp(ConfigurationError, error_msg):
             validate_region(self.params, self.globals)
 
     def test_validate_instance_name(self):

--- a/tests/unit/customizations/codedeploy/test_utils.py
+++ b/tests/unit/customizations/codedeploy/test_utils.py
@@ -22,6 +22,7 @@ from awscli.customizations.codedeploy.utils import \
     validate_iam_user_arn, validate_instance, validate_s3_location, \
     MAX_INSTANCE_NAME_LENGTH, MAX_TAGS_PER_INSTANCE, MAX_TAG_KEY_LENGTH, \
     MAX_TAG_VALUE_LENGTH
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 
 
@@ -84,14 +85,14 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_instance_name_throws_on_invalid_characters(self):
         self.params.instance_name = '!#$%^&*()<>/?;:[{]}'
-        with self.assertRaisesRegexp(
-                ValueError, 'Instance name contains invalid characters.'):
+        error_msg = 'Instance name contains invalid characters.'
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_instance_name(self.params)
 
     def test_validate_instance_name_throws_on_i_dash(self):
         self.params.instance_name = 'i-instance'
-        with self.assertRaisesRegexp(
-                ValueError, "Instance name cannot start with 'i-'."):
+        error_msg = "Instance name cannot start with 'i-'."
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_instance_name(self.params)
 
     def test_validate_instance_name_throws_on_long_name(self):
@@ -99,20 +100,20 @@ class TestUtils(unittest.TestCase):
             '01234567890123456789012345678901234567890123456789'
             '012345678901234567890123456789012345678901234567891'
         )
-        with self.assertRaisesRegexp(
-                ValueError,
-                'Instance name cannot be longer than {0} characters.'.format(
-                    MAX_INSTANCE_NAME_LENGTH)):
+        error_msg = (
+            'Instance name cannot be longer than {0} characters.'
+        ).format(MAX_INSTANCE_NAME_LENGTH)
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_instance_name(self.params)
 
     def test_validate_tags_throws_on_too_many_tags(self):
         self.params.tags = [
             {'Key': 'k' + str(x), 'Value': 'v' + str(x)} for x in range(11)
         ]
-        with self.assertRaisesRegexp(
-                ValueError,
-                'Instances can only have a maximum of {0} '
-                'tags.'.format(MAX_TAGS_PER_INSTANCE)):
+        error_msg = (
+            'Instances can only have a maximum of {0} tags.'
+        ).format(MAX_TAGS_PER_INSTANCE)
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_tags(self.params)
 
     def test_validate_tags_throws_on_max_key_not_accepted(self):
@@ -123,10 +124,10 @@ class TestUtils(unittest.TestCase):
     def test_validate_tags_throws_on_long_key(self):
         key = 'k' * 129
         self.params.tags = [{'Key': key, 'Value': 'v1'}]
-        with self.assertRaisesRegexp(
-                ValueError,
-                'Tag Key cannot be longer than {0} characters.'.format(
-                    MAX_TAG_KEY_LENGTH)):
+        error_msg = (
+            'Tag Key cannot be longer than {0} characters.'
+        ).format(MAX_TAG_KEY_LENGTH)
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_tags(self.params)
 
     def test_validate_tags_throws_on_max_value_not_accepted(self):
@@ -137,10 +138,10 @@ class TestUtils(unittest.TestCase):
     def test_validate_tags_throws_on_long_value(self):
         value = 'v' * 257
         self.params.tags = [{'Key': 'k1', 'Value': value}]
-        with self.assertRaisesRegexp(
-                ValueError,
-                'Tag Value cannot be longer than {0} characters.'.format(
-                    MAX_TAG_VALUE_LENGTH)):
+        error_msg = (
+            'Tag Value cannot be longer than {0} characters.'
+        ).format(MAX_TAG_VALUE_LENGTH)
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_tags(self.params)
 
     def test_validate_iam_user_arn(self):
@@ -149,7 +150,8 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_iam_user_arn_throws_on_invalid_arn_pattern(self):
         self.params.iam_user_arn = 'invalid-arn-pattern'
-        with self.assertRaisesRegexp(ValueError, 'Invalid IAM user ARN.'):
+        error_msg = 'Invalid IAM user ARN.'
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_iam_user_arn(self.params)
 
     def test_validate_instance_ubuntu(self):
@@ -210,10 +212,11 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_s3_location_throws_on_invalid_location(self):
         self.params.s3_location = 'invalid-s3-location'
-        with self.assertRaisesRegexp(
-                ValueError,
-                '--{0} must specify the Amazon S3 URL format as '
-                's3://<bucket>/<key>.'.format(self.arg_name)):
+        error_msg = (
+            '--{0} must specify the Amazon S3 URL format as '
+            's3://<bucket>/<key>.'
+        ).format(self.arg_name)
+        with self.assertRaisesRegexp(ParamValidationError, error_msg):
             validate_s3_location(self.params, self.arg_name)
 
 

--- a/tests/unit/customizations/datapipeline/test_arg_serialize.py
+++ b/tests/unit/customizations/datapipeline/test_arg_serialize.py
@@ -78,7 +78,7 @@ class TestErrorMessages(BaseAWSCommandParamsTest):
     def test_unknown_status(self):
         self.assert_params_for_cmd(
             self.prefix + ' --pipeline-id foo --status foo',
-            expected_rc=255,
+            expected_rc=252,
             stderr_contains=('Invalid status: foo, must be one of: waiting, '
                              'pending, cancelled, running, finished, '
                              'failed, waiting_for_runner, '

--- a/tests/unit/customizations/emr/__init__.py
+++ b/tests/unit/customizations/emr/__init__.py
@@ -40,8 +40,8 @@ class EMRBaseAWSCommandParamsTest(BaseAWSCommandParamsTest):
         self.patcher_update_config.stop()
 
     def assert_error_msg(self, cmd,
-                         exception_class_name, error_msg_kwargs={}):
+                         exception_class_name, error_msg_kwargs={}, rc=255):
         exception_class = getattr(exceptions, exception_class_name)
         error_msg = "\n%s\n" % exception_class.fmt.format(**error_msg_kwargs)
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, rc)
         self.assertEquals(error_msg, result[1])

--- a/tests/unit/customizations/emr/test_add_instance_groups.py
+++ b/tests/unit/customizations/emr/test_add_instance_groups.py
@@ -216,20 +216,20 @@ class TestAddInstanceGroups(BaseAWSCommandParamsTest):
     def test_instance_groups_missing_instance_group_type_error(self):
         cmd = self.prefix + ' Name=Task,InstanceType=m1.small,' +\
             'InstanceCount=5'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assert_error_message_has_field_name(result[1],
                                                  'InstanceGroupType')
 
     def test_instance_groups_missing_instance_type_error(self):
         cmd = self.prefix + ' Name=Task,InstanceGroupType=Task,' +\
             'InstanceCount=5'
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceType')
 
     def test_instance_groups_missing_instance_count_error(self):
         cmd = self.prefix + ' Name=Task,InstanceGroupType=Task,' +\
             'InstanceType=m1.xlarge'
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceCount')
 
     def test_instance_groups_all_fields(self):
@@ -309,13 +309,13 @@ class TestAddInstanceGroups(BaseAWSCommandParamsTest):
     def test_instance_groups_with_ebs_config_missing_volume_type(self):
         cmd = self.prefix
         cmd += INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_VOLTYPE_ARG
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'VolumeType')
 
     def test_instance_groups_with_ebs_config_missing_size(self):
         cmd = self.prefix
         cmd += INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_SIZE_ARG
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'SizeInGB')
 
     def test_instance_groups_with_ebs_config_missing_volume_spec(self):

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -629,11 +629,11 @@ class TestAddSteps(BaseAWSCommandParamsTest):
             expected_result_release):
         if expected_error_msg:
             grl_patch.return_value = None
-            result = self.run_cmd(cmd, 255)
+            result = self.run_cmd(cmd, 252)
             self.assertEquals(expected_error_msg, result[1])
         if expected_result_release:
             grl_patch.return_value = 'emr-4.0'
-            result = self.run_cmd(cmd, 255)
+            result = self.run_cmd(cmd, 252)
             self.assertEquals(expected_result_release, result[1])
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_config.py
+++ b/tests/unit/customizations/emr/test_config.py
@@ -101,7 +101,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = ("\n%s\n" % InvalidBooleanConfigError.fmt.format(
             config_value='False1', config_key='enable_debugging',
             profile_var_name='default'))
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     @mock.patch.object(CreateCluster, '_run_main_command')

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -662,7 +662,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--auto-terminate '
             '--instance-groups '
             'Name=Master,InstanceCount=1,InstanceType=m1.small')
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceGroupType')
 
     def test_instance_groups_missing_instance_type_error(self):
@@ -674,7 +674,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = (
             '\nThe following required parameters are missing'
             ' for structure:: InstanceType\n')
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceType')
 
     def test_instance_groups_missing_instance_count_error(self):
@@ -683,7 +683,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--auto-terminate '
             '--instance-groups '
             'Name=Master,InstanceGroupType=MASTER,InstanceType=m1.xlarge')
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceCount')
 
     def test_instance_groups_from_json_file(self):
@@ -801,7 +801,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
     # Bootstrap Actions test cases
     def test_bootstrap_actions_missing_path_error(self):
         cmd = DEFAULT_CMD + '--bootstrap-actions Name=ba1,Args=arg1,arg2'
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'Path')
 
     def test_bootstrap_actions_with_all_fields(self):
@@ -1399,13 +1399,13 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
     def test_instance_groups_with_ebs_config_missing_volume_type(self):
         cmd = (self.prefix + '--ami-version 3.1.0 --instance-groups ' +
                CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_VOLTYPE_ARG)
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'VolumeType')
 
     def test_instance_groups_with_ebs_config_missing_size(self):
         cmd = (self.prefix + '--ami-version 3.1.0 --instance-groups ' +
                CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_SIZE_ARG)
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'SizeInGB')
 
     def test_instance_groups_with_ebs_config_missing_volume_spec(self):

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -387,7 +387,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'and --ec2-attributes InstanceProfile options together. Either '
             'choose --use-default-roles or use both --service-role <roleName>'
             ' and --ec2-attributes InstanceProfile=<profileName>.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_mutual_exclusive_use_default_roles_and_instance_profile(self):
@@ -398,7 +398,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'and --service-role options together. Either choose '
             '--use-default-roles or use both --service-role <roleName> '
             'and --ec2-attributes InstanceProfile=<profileName>.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_cluster_name_no_space(self):
@@ -449,7 +449,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --no-auto-terminate and'
             ' --auto-terminate options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_termination_protected(self):
@@ -470,7 +470,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --termination-protected'
             ' and --no-termination-protected options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_visible_to_all_users(self):
@@ -488,7 +488,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --visible-to-all-users and '
             '--no-visible-to-all-users options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_tags(self):
@@ -541,7 +541,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: LogUri not specified. You must specify a logUri'
             ' if you enable debugging when creating a cluster.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_enable_debugging_and_no_enable_debugging(self):
@@ -550,7 +550,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --enable-debugging and '
             '--no-enable-debugging options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_instance_groups_default_name_market(self):
@@ -618,7 +618,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Must specify either --instance-groups or '
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = (
@@ -628,7 +628,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Must specify either --instance-groups or '
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_instance_groups_exclusive_parameter_validation_error(self):
@@ -641,7 +641,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'or --instance-count with --instance-groups, '
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = (
@@ -653,7 +653,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'or --instance-count with --instance-groups, '
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_instance_groups_missing_instance_group_type_error(self):
@@ -769,7 +769,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = (
             '\naws: error: You may not specify both a SubnetId and an Availab'
             'ilityZone (placement) because ec2SubnetId implies a placement.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_ec2_attributes_with_subnet_from_json_file(self):
@@ -822,7 +822,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
 
         expected_error_msg = '\naws: error: maximum number of ' +\
                              'bootstrap actions for a cluster exceeded.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
 
         self.assertEquals(expected_error_msg, result[1])
 
@@ -834,7 +834,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             cmd += ba_cmd
         expected_error_msg = '\naws: error: maximum number of ' +\
                              'bootstrap actions for a cluster exceeded.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_boostrap_actions_with_default_fields(self):
@@ -999,7 +999,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Type=unknown'
         expected_error_msg = (
             '\naws: error: The step type unknown is not supported.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_default_step_type_name_action_on_failure(self):
@@ -1012,7 +1012,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Name=CustomJarMissingJar'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for CustomJARStepConfig: Jar.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_custom_jar_step_with_all_fields(self):
@@ -1048,7 +1048,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Type=Streaming'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for StreamingStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_streaming_jar_with_all_fields(self):
@@ -1075,7 +1075,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--applications Name=Hive --steps Type=Hive'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for HiveStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_hive_step_with_all_fields(self):
@@ -1100,7 +1100,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--applications Name=Pig --steps Type=Pig'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for PigStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_pig_step_with_all_fields(self):
@@ -1127,7 +1127,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--applications Name=Impala --steps Type=Impala'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for ImpalaStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_impala_step_with_all_fields(self):
@@ -1178,21 +1178,21 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Type=Streaming,Args= '
         expect_error_msg = ('\naws: error: The prameter Args cannot '
                             'be an empty list.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = DEFAULT_CMD + '--steps Type=Pig,Args= '
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = DEFAULT_CMD + '--steps Type=Hive,Args= '
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = DEFAULT_CMD + '--steps Args= '
         expect_error_msg = ('\naws: error: The following required parameters '
                             'are missing for CustomJARStepConfig: Jar.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_missing_applications_for_steps(self):
@@ -1218,7 +1218,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Some of the steps require the following'
             ' applications to be installed: Pig, Impala. '
             'Please install the applications using --applications.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
 
         if(result[1] == expected_error_msg1 or
            result[1] == expected_error_msg2):
@@ -1245,7 +1245,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Some of the steps require the following'
             ' applications to be installed: Impala, Hbase. '
             'Please install the applications using --applications.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
 
         if(result[1] == expected_error_msg1 or
            result[1] == expected_error_msg2):
@@ -1362,7 +1362,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: Must specify --auto-scaling-role when'
             ' configuring an AutoScaling policy for an instance group.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_scale_down_behavior(self):
@@ -1630,7 +1630,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You cannot specify both AvailabilityZone'
             ' and AvailabilityZones options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -236,7 +236,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You cannot specify both --ami-version'
             ' and --release-label options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_if_ami_version_or_release_label_is_provided(self):
@@ -244,7 +244,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                DEFAULT_INSTANCE_GROUPS_ARG)
         expected_error_msg = ('\naws: error: Either --ami-version or'
                               ' --release-label is required.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_no_special_steps_added_for_applications(self):
@@ -343,7 +343,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'and --ec2-attributes InstanceProfile options together. Either '
             'choose --use-default-roles or use both --service-role <roleName>'
             ' and --ec2-attributes InstanceProfile=<profileName>.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_mutual_exclusive_use_default_roles_and_instance_profile(self):
@@ -354,7 +354,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'and --service-role options together. Either choose '
             '--use-default-roles or use both --service-role <roleName> '
             'and --ec2-attributes InstanceProfile=<profileName>.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_cluster_name_no_space(self):
@@ -406,7 +406,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --no-auto-terminate and'
             ' --auto-terminate options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_termination_protected(self):
@@ -427,7 +427,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --termination-protected'
             ' and --no-termination-protected options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_visible_to_all_users(self):
@@ -445,7 +445,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --visible-to-all-users and '
             '--no-visible-to-all-users options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_tags(self):
@@ -490,7 +490,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: LogUri not specified. You must specify a logUri'
             ' if you enable debugging when creating a cluster.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_enable_debugging_and_no_enable_debugging(self):
@@ -499,7 +499,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: cannot use both --enable-debugging and '
             '--no-enable-debugging options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_instance_groups_default_name_market(self):
@@ -567,7 +567,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Must specify either --instance-groups or '
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = (
@@ -577,7 +577,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Must specify either --instance-groups or '
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_instance_groups_exclusive_parameter_validation_error(self):
@@ -590,7 +590,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'or --instance-count with --instance-groups, '
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
         cmd = (
@@ -602,7 +602,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'or --instance-count with --instance-groups, '
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_instance_groups_missing_instance_group_type_error(self):
@@ -739,7 +739,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = (
             '\naws: error: You may not specify both a SubnetId and an Availab'
             'ilityZone (placement) because ec2SubnetId implies a placement.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_ec2_attributes_with_subnet_from_json_file(self):
@@ -792,7 +792,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
 
         expected_error_msg = '\naws: error: maximum number of ' +\
                              'bootstrap actions for a cluster exceeded.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
 
         self.assertEquals(expected_error_msg, result[1])
 
@@ -803,7 +803,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             cmd += ba_cmd
         expected_error_msg = '\naws: error: maximum number of ' +\
                              'bootstrap actions for a cluster exceeded.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_boostrap_actions_with_default_fields(self):
@@ -848,7 +848,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Type=unknown'
         expected_error_msg = (
             '\naws: error: The step type unknown is not supported.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_default_step_type_name_action_on_failure(self):
@@ -861,7 +861,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Name=CustomJarMissingJar'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for CustomJARStepConfig: Jar.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_custom_jar_step_with_all_fields(self):
@@ -897,7 +897,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--steps Type=Streaming'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for StreamingStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_streaming_jar_with_all_fields(self):
@@ -925,7 +925,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--applications Name=Hive --steps Type=Hive'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for HiveStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_hive_step_with_all_fields(self):
@@ -951,7 +951,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD + '--applications Name=Pig --steps Type=Pig'
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for PigStepConfig: Args.\n'
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expect_error_msg, result[1])
 
     def test_pig_step_with_all_fields(self):
@@ -1074,9 +1074,9 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: Must specify --auto-scaling-role when'
             ' configuring an AutoScaling policy for an instance group.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
-        
+
     def test_scale_down_behavior(self):
         cmd = (self.prefix + '--release-label emr-4.0.0 --scale-down-behavior TERMINATE_AT_INSTANCE_HOUR '
                              '--instance-groups ' + DEFAULT_INSTANCE_GROUPS_ARG)
@@ -1284,7 +1284,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You cannot specify both --instance-groups'
             ' and --instance-fleets options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_instance_fleets_with_both_subnetid_subnetids_specified(self):
@@ -1294,7 +1294,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You cannot specify both SubnetId'
             ' and SubnetIds options together.\n')
-        result = self.run_cmd(cmd, 255)
+        result = self.run_cmd(cmd, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_create_cluster_with_security_config(self):

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -611,7 +611,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--auto-terminate '
             '--instance-groups '
             'Name=Master,InstanceCount=1,InstanceType=m1.small')
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceGroupType')
 
     def test_instance_groups_missing_instance_type_error(self):
@@ -623,7 +623,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = (
             '\nThe following required parameters are missing'
             ' for structure:: InstanceType\n')
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceType')
 
     def test_instance_groups_missing_instance_count_error(self):
@@ -632,7 +632,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--auto-terminate '
             '--instance-groups '
             'Name=Master,InstanceGroupType=MASTER,InstanceType=m1.xlarge')
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'InstanceCount')
 
     def test_instance_groups_from_json_file(self):
@@ -771,7 +771,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
     # Bootstrap Actions test cases
     def test_bootstrap_actions_missing_path_error(self):
         cmd = DEFAULT_CMD + '--bootstrap-actions Name=ba1,Args=arg1,arg2'
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'Path')
 
     def test_bootstrap_actions_with_all_fields(self):
@@ -1110,13 +1110,13 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
     def test_instance_groups_with_ebs_config_missing_volume_type(self):
         cmd = (self.prefix + '--release-label emr-4.2.0 --instance-groups ' +
                CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_VOLTYPE_ARG)
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'VolumeType')
 
     def test_instance_groups_with_ebs_config_missing_size(self):
         cmd = (self.prefix + '--release-label emr-4.2.0 --instance-groups ' +
                CONSTANTS.INSTANCE_GROUPS_WITH_EBS_VOLUME_MISSING_SIZE_ARG)
-        stderr = self.run_cmd(cmd, 255)[1]
+        stderr = self.run_cmd(cmd, 252)[1]
         self.assert_error_message_has_field_name(stderr, 'SizeInGB')
 
     def test_instance_groups_with_ebs_config_missing_volume_spec(self):

--- a/tests/unit/customizations/emr/test_create_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_create_hbase_backup.py
@@ -60,7 +60,7 @@ class TestCreateHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         expected_error_msg = ("\naws: error: create-hbase-backup"
                               " is not supported with 'emr-4.0' release.\n")
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEqual(result[1], expected_error_msg)
 

--- a/tests/unit/customizations/emr/test_disable_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_disable_hbase_backup.py
@@ -71,7 +71,7 @@ class TestDisableHBaseBackups(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         expected_error_msg = '\nShould specify at least one of --full' +\
                              ' and --incremental.\n'
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEquals(expected_error_msg, result[1])
 
@@ -84,7 +84,7 @@ class TestDisableHBaseBackups(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         expected_error_msg = ("\naws: error: disable-hbase-backups"
                               " is not supported with 'emr-4.0' release.\n")
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEqual(result[1], expected_error_msg)
 

--- a/tests/unit/customizations/emr/test_emrfs_utils.py
+++ b/tests/unit/customizations/emr/test_emrfs_utils.py
@@ -291,7 +291,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             emrfs_option_value='SSE=true,Encryption=ClientSide,'
             'ProviderType=KMS,KMSKeyId=k1',
             exception_class_name='BothSseAndEncryptionConfiguredError',
-            error_msg_kwargs={'sse': 'True', 'encryption': 'ClientSide'}
+            error_msg_kwargs={'sse': 'True', 'encryption': 'ClientSide'},
+            rc=252,
         )
 
     def test_cse_missing_provider_type(self):
@@ -299,7 +300,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             emrfs_option_value='Encryption=ClientSide',
             exception_class_name='MissingParametersError',
             error_msg_kwargs={'object_name': CSE_OPTION_NAME,
-                              'missing': 'ProviderType'}
+                              'missing': 'ProviderType'},
+            rc=252,
         )
 
     def test_cse_kms_missing_key_id(self):
@@ -307,7 +309,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             emrfs_option_value='Encryption=ClientSide,ProviderType=KMS',
             exception_class_name='MissingParametersError',
             error_msg_kwargs={'object_name': CSE_KMS_OPTION_NAME,
-                              'missing': 'KMSKeyId'}
+                              'missing': 'KMSKeyId'},
+            rc=252,
         )
 
     def test_cse_custom_missing_all(self):
@@ -316,7 +319,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             exception_class_name='MissingParametersError',
             error_msg_kwargs={'object_name': CSE_CUSTOM_OPTION_NAME,
                               'missing': 'CustomProviderClass and '
-                              'CustomProviderLocation'}
+                              'CustomProviderLocation'},
+            rc=252,
         )
 
     def test_cse_custom_missing_provider_class(self):
@@ -325,7 +329,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             'CustomProviderLocation=my_location',
             exception_class_name='MissingParametersError',
             error_msg_kwargs={'object_name': CSE_CUSTOM_OPTION_NAME,
-                              'missing': 'CustomProviderClass'}
+                              'missing': 'CustomProviderClass'},
+            rc=252,
         )
 
     def test_cse_custom_missing_provider_location(self):
@@ -334,21 +339,24 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             'CustomProviderClass=my_class',
             exception_class_name='MissingParametersError',
             error_msg_kwargs={'object_name': CSE_CUSTOM_OPTION_NAME,
-                              'missing': 'CustomProviderLocation'}
+                              'missing': 'CustomProviderLocation'},
+            rc=252,
         )
 
     def test_valid_encryption(self):
         self._assert_error_msg(
             emrfs_option_value='Encryption=ClientSide1',
             exception_class_name='UnknownEncryptionTypeError',
-            error_msg_kwargs={'encryption': 'ClientSide1'}
+            error_msg_kwargs={'encryption': 'ClientSide1'},
+            rc=252,
         )
 
     def test_valid_cse_provider_type(self):
         self._assert_error_msg(
             emrfs_option_value='Encryption=ClientSide,ProviderType=KMS1',
             exception_class_name='UnknownCseProviderTypeError',
-            error_msg_kwargs={'provider_type': 'KMS1'}
+            error_msg_kwargs={'provider_type': 'KMS1'},
+            rc=252,
         )
 
     def test_valid_consistent_args(self):
@@ -356,7 +364,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             emrfs_option_value='SSE=true,RetryCount=5,RetryPeriod=30',
             exception_class_name='InvalidEmrFsArgumentsError',
             error_msg_kwargs={'invalid': 'RetryCount and RetryPeriod',
-                              'parent_object_name': CONSISTENT_OPTION_NAME}
+                              'parent_object_name': CONSISTENT_OPTION_NAME},
+            rc=252,
         )
 
     def test_valid_cse_kms_args(self):
@@ -364,7 +373,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             emrfs_option_value='Consistent=true,KMSKeyId=k1',
             exception_class_name='InvalidEmrFsArgumentsError',
             error_msg_kwargs={'invalid': 'KMSKeyId',
-                              'parent_object_name': CSE_KMS_OPTION_NAME}
+                              'parent_object_name': CSE_KMS_OPTION_NAME},
+            rc=252,
         )
 
     def test_valid_cse_custom_args(self):
@@ -372,7 +382,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             emrfs_option_value='Consistent=true,CustomProviderLocation=loc',
             exception_class_name='InvalidEmrFsArgumentsError',
             error_msg_kwargs={'invalid': 'CustomProviderLocation',
-                              'parent_object_name': CSE_CUSTOM_OPTION_NAME}
+                              'parent_object_name': CSE_CUSTOM_OPTION_NAME},
+            rc=252,
         )
 
     def test_configurations_and_emrfs(self):
@@ -415,23 +426,23 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
         result['ReleaseLabel'] = 'emr-4.0'
         result['Configurations'] = configurations
 
-        self.assert_error_msg(cmd, 'DuplicateEmrFsConfigurationError')
+        self.assert_error_msg(cmd, 'DuplicateEmrFsConfigurationError', rc=252)
 
     def _assert_error_msg(self, emrfs_option_value,
-                          exception_class_name, error_msg_kwargs):
+                          exception_class_name, error_msg_kwargs, rc=255):
         cmd = "%s --ami-version 3.4 --emrfs %s" \
             % (DEFAULT_CMD, emrfs_option_value)
         self.assert_error_msg(
             cmd,
             exception_class_name=exception_class_name,
-            error_msg_kwargs=error_msg_kwargs)
+            error_msg_kwargs=error_msg_kwargs, rc=rc)
 
         cmd = "%s --release-label emr-4.0 --emrfs %s" \
             % (DEFAULT_CMD, emrfs_option_value)
         self.assert_error_msg(
             cmd,
             exception_class_name=exception_class_name,
-            error_msg_kwargs=error_msg_kwargs)
+            error_msg_kwargs=error_msg_kwargs, rc=rc)
 
     def _assert_bootstrap_actions(self, emrfs_option_value,
                                   expected_emrfs_ba_key_values,

--- a/tests/unit/customizations/emr/test_install_applications.py
+++ b/tests/unit/customizations/emr/test_install_applications.py
@@ -121,7 +121,7 @@ class TestInstallApplications(BaseAWSCommandParamsTest):
 
         expected_error_msg = ("\naws: error: install-applications"
                               " is not supported with 'emr-4.0' release.\n")
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEqual(result[1], expected_error_msg)
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_install_applications.py
+++ b/tests/unit/customizations/emr/test_install_applications.py
@@ -99,7 +99,7 @@ class TestInstallApplications(BaseAWSCommandParamsTest):
         expected_error_msg = "\naws: error: Impala cannot be installed on" +\
             " a running cluster. 'Name' should be one of the following:" +\
             " HIVE, PIG\n"
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEqual(result[1], expected_error_msg)
 
     def test_install_unknown_app_error(self):
@@ -108,7 +108,7 @@ class TestInstallApplications(BaseAWSCommandParamsTest):
         expected_error_msg = "\naws: error: Unknown application: unknown." +\
             " 'Name' should be one of the following: HIVE, PIG, HBASE," +\
             " GANGLIA, IMPALA, SPARK, MAPR, MAPR_M3, MAPR_M5, MAPR_M7\n"
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEqual(result[1], expected_error_msg)
 
     @mock.patch('awscli.customizations.emr.'

--- a/tests/unit/customizations/emr/test_list_clusters.py
+++ b/tests/unit/customizations/emr/test_list_clusters.py
@@ -56,7 +56,7 @@ class TestListClusters(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You can specify only one of the cluster state '
             'filters: --cluster-states, --active, --terminated, --failed.\n')
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEquals(expected_error_msg, result[1])
 
         args = '--cluster-states STARTING RUNNING --terminated'
@@ -64,7 +64,7 @@ class TestListClusters(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You can specify only one of the cluster state '
             'filters: --cluster-states, --active, --terminated, --failed.\n')
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEquals(expected_error_msg, result[1])
 
 

--- a/tests/unit/customizations/emr/test_modify_cluster_attributes.py
+++ b/tests/unit/customizations/emr/test_modify_cluster_attributes.py
@@ -50,7 +50,7 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You cannot specify both --visible-to-all-users '
             'and --no-visible-to-all-users options together.\n')
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_temination_protected_and_no_termination_protected(self):
@@ -60,7 +60,7 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: You cannot specify both --termination-protected '
             'and --no-termination-protected options together.\n')
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEquals(expected_error_msg, result[1])
 
     def test_termination_protected_and_visible_to_all(self):
@@ -98,7 +98,7 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
             '\naws: error: Must specify one of the following boolean options: '
             '--visible-to-all-users|--no-visible-to-all-users, '
             '--termination-protected|--no-termination-protected.\n')
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
         self.assertEquals(expected_error_msg, result[1])
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
@@ -61,7 +61,7 @@ class TestRestoreFromHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         expected_error_msg = ("\naws: error: restore-from-hbase-backup"
                               " is not supported with 'emr-4.0' release.\n")
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEqual(result[1], expected_error_msg)
 

--- a/tests/unit/customizations/emr/test_schedule_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_schedule_hbase_backup.py
@@ -93,7 +93,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         expected_error_msg = '\naws: error: invalid type. type should be' +\
                              ' either full or incremental.\n'
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEquals(expected_error_msg, result[1])
 
@@ -104,7 +104,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         expected_error_msg = '\naws: error: invalid unit. unit should be' +\
                              ' one of the following values: minutes,' +\
                              ' hours or days.\n'
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEquals(expected_error_msg, result[1])
 
@@ -140,7 +140,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         expected_error_msg = ("\naws: error: schedule-hbase-backup"
                               " is not supported with 'emr-4.0' release.\n")
-        result = self.run_cmd(cmdline, 255)
+        result = self.run_cmd(cmdline, 252)
 
         self.assertEqual(result[1], expected_error_msg)
 

--- a/tests/unit/customizations/history/test_history.py
+++ b/tests/unit/customizations/history/test_history.py
@@ -23,6 +23,7 @@ from awscli.customizations.history import attach_history_handler
 from awscli.customizations.history import add_history_commands
 from awscli.customizations.history import HistoryCommand
 from awscli.customizations.history.db import DatabaseHistoryHandler
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class TestAttachHistoryHandler(unittest.TestCase):
@@ -167,5 +168,5 @@ class TestHistoryCommand(unittest.TestCase):
         parsed_args = argparse.Namespace()
         parsed_args.subcommand = None
         parsed_globals = argparse.Namespace()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             history_command._run_main(parsed_args, parsed_globals)

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -24,6 +24,7 @@ from awscli.customizations.history.show import ShowCommand
 from awscli.customizations.history.show import Formatter
 from awscli.customizations.history.show import DetailedFormatter
 from awscli.customizations.history.db import DatabaseRecordReader
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class FakeError(Exception):
@@ -81,7 +82,7 @@ class TestFormatter(unittest.TestCase):
             formatter.history, [other_event_record])
 
     def test_raises_error_when_both_include_and_exclude(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             Formatter(include=['one_event'], exclude=['other_event'])
 
 
@@ -706,7 +707,7 @@ class TestShowCommand(unittest.TestCase):
     def test_raises_error_when_both_include_and_exclude(self):
         self.parsed_args.include = ['API_CALL']
         self.parsed_args.exclude = ['CLI_RC']
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
 
     @mock.patch('awscli.customizations.history.commands.is_windows', False)

--- a/tests/unit/customizations/s3/syncstrategy/test_base.py
+++ b/tests/unit/customizations/s3/syncstrategy/test_base.py
@@ -18,6 +18,7 @@ from awscli.customizations.s3.filegenerator import FileStat
 from awscli.customizations.s3.syncstrategy.base import BaseSync, \
     SizeAndLastModifiedSync, MissingFileSync, NeverSync
 from awscli.testutils import unittest
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class TestBaseSync(unittest.TestCase):
@@ -32,7 +33,7 @@ class TestBaseSync(unittest.TestCase):
             self.assertEqual(strategy.sync_type, sync_type)
 
         # Check for invalid ``sync_type`` options.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             BaseSync('wrong_sync_type')
 
     def test_register_strategy(self):

--- a/tests/unit/customizations/s3/test_s3.py
+++ b/tests/unit/customizations/s3/test_s3.py
@@ -51,7 +51,7 @@ class CreateTablesTest(unittest.TestCase):
 
 class TestS3(BaseAWSCommandParamsTest):
     def test_too_few_args(self):
-        stderr = self.run_cmd('s3', expected_rc=255)[1]
+        stderr = self.run_cmd('s3', expected_rc=252)[1]
         self.assertIn(("usage: aws [options] <command> "
                        "<subcommand> [parameters]"), stderr)
         self.assertIn('too few arguments', stderr)

--- a/tests/unit/customizations/s3/test_s3.py
+++ b/tests/unit/customizations/s3/test_s3.py
@@ -52,7 +52,7 @@ class CreateTablesTest(unittest.TestCase):
 class TestS3(BaseAWSCommandParamsTest):
     def test_too_few_args(self):
         stderr = self.run_cmd('s3', expected_rc=252)[1]
-        self.assertIn(("usage: aws [options] <command> "
+        self.assertIn(("usage: aws [options] s3 "
                        "<subcommand> [parameters]"), stderr)
         self.assertIn('too few arguments', stderr)
 

--- a/tests/unit/customizations/servicecatalog/test_generate.py
+++ b/tests/unit/customizations/servicecatalog/test_generate.py
@@ -14,6 +14,7 @@
 from argparse import Namespace
 
 from awscli.customizations.servicecatalog import GenerateCommand
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 
 
@@ -27,7 +28,7 @@ class TestGenerateCommand(unittest.TestCase):
         arguments.subcommand = None
 
         # Act+Assert
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.cmd._run_main(arguments, None)
 
     def test_with_subcommand(self):

--- a/tests/unit/customizations/test_arguments.py
+++ b/tests/unit/customizations/test_arguments.py
@@ -19,6 +19,7 @@ from awscli.customizations.arguments import StatefulArgument
 from awscli.customizations.arguments import QueryOutFileArgument
 from awscli.customizations.arguments import resolve_given_outfile_path
 from awscli.customizations.arguments import is_parsed_result_successful
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class TestOverrideRequiredArgsArgument(unittest.TestCase):
@@ -78,7 +79,7 @@ class TestArgumentHelpers(unittest.TestCase):
 
     def test_raises_when_cannot_write_to_file(self):
         filename = os.sep.join(['_path', 'not', '_exist_', 'file.xyz'])
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             resolve_given_outfile_path(filename)
 
     def test_checks_if_valid_result(self):

--- a/tests/unit/customizations/test_cloudsearchdomain.py
+++ b/tests/unit/customizations/test_cloudsearchdomain.py
@@ -14,6 +14,7 @@ from awscli.testutils import unittest
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.help import PagingHelpRenderer
 from awscli.customizations.cloudsearchdomain import validate_endpoint_url
+from awscli.customizations.exceptions import ParamValidationError
 
 import mock
 
@@ -40,7 +41,7 @@ class TestSearchCommand(BaseAWSCommandParamsTest):
     def test_endpoint_is_required(self):
         cmd = self.prefix.split()
         cmd += ['--search-query', 'foo']
-        stderr = self.run_cmd(cmd, expected_rc=255)[1]
+        stderr = self.run_cmd(cmd, expected_rc=252)[1]
         self.assertIn('--endpoint-url is required', stderr)
 
     def test_endpoint_not_required_for_help(self):
@@ -60,8 +61,8 @@ class TestCloudsearchDomainHandler(unittest.TestCase):
         parsed_globals = mock.Mock()
         parsed_globals.endpoint_url = None
         # Method should return instantiated exception.
-        self.assertTrue(isinstance(validate_endpoint_url(parsed_globals),
-                                   ValueError))
+        err = validate_endpoint_url(parsed_globals)
+        self.assertTrue(isinstance(err, ParamValidationError))
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -21,6 +21,7 @@ from botocore.credentials import Credentials
 from awscli.customizations.codecommit import CodeCommitGetCommand
 from awscli.customizations.codecommit import CodeCommitCommand
 from awscli.testutils import unittest, StringIOWithFileNo
+from awscli.customizations.exceptions import ParamValidationError
 
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
@@ -154,9 +155,9 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         output = stdout_mock.getvalue().strip()
         self.assertEquals('', output)
 
-    def test_raises_value_error_when_not_provided_any_subcommands(self):
+    def test_raises_validation_error_when_not_provided_any_subcommands(self):
         self.get_command = CodeCommitCommand(self.session)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.get_command._run_main(self.args, self.globals)
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -19,6 +19,7 @@ from awscli.compat import six
 import mock
 
 from awscli.customizations import globalargs
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class FakeParsedArgs(object):
@@ -65,7 +66,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
     def test_parse_query_error_message(self):
         # Invalid jmespath expression.
         parsed_args = FakeParsedArgs(query='foo.bar.')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             globalargs.resolve_types(parsed_args)
             globalargs.resolve_types('query')
 
@@ -185,9 +186,9 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         self.assertFalse(session.register.called)
 
     def test_invalid_endpoint_url(self):
-        # Invalid jmespath expression.
+        # Invalid endpoint URL
         parsed_args = FakeParsedArgs(endpoint_url='missing-scheme.com')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             globalargs.resolve_types(parsed_args)
 
     def test_valid_endpoint_url(self):

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -20,6 +20,7 @@ from botocore.exceptions import ClientError
 
 from awscli.customizations import opsworks
 from awscli.testutils import unittest
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class TestOpsWorksBase(unittest.TestCase):
@@ -122,13 +123,13 @@ class TestOpsWorksRegister(TestOpsWorksBase):
             self._build_args(
                 infrastructure_class="on-premises",
                 hostname="AlsoAGoodHostname456", local=True))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     infrastructure_class="on-premises",
                     hostname="-bad-hostname",
                     local=True))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     infrastructure_class="on-premises",
@@ -140,11 +141,11 @@ class TestOpsWorksRegister(TestOpsWorksBase):
         """Shouldn't allow local and remote mode at the same time."""
 
         mock_platform.system.return_value = "Linux"
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(self._build_args(
                 infrastructure_class="on-premises",
                 hostname=None, target=None, local=False))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(self._build_args(
                 infrastructure_class="on-premises",
                 hostname=None, target="HOSTNAME", local=True))
@@ -155,11 +156,11 @@ class TestOpsWorksRegister(TestOpsWorksBase):
             infrastructure_class="on-premises",
             hostname=None, target=None, local=True))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(self._build_args(
                 infrastructure_class="ec2",
                 hostname=None, target=None, local=False))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(self._build_args(
                 infrastructure_class="ec2",
                 hostname=None, target="HOSTNAME", local=True))
@@ -177,7 +178,7 @@ class TestOpsWorksRegister(TestOpsWorksBase):
         mock_platform.system.return_value = "Linux"
         self.register.prevalidate_arguments(self._build_args(
             infrastructure_class="on-premises", target=None, local=True))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             mock_platform.system.return_value = "Windows"
             self.register.prevalidate_arguments(self._build_args(
                 infrastructure_class="on-premises", target=None, local=True))
@@ -192,17 +193,17 @@ class TestOpsWorksRegister(TestOpsWorksBase):
             self._build_args(
                 username="root", private_key="id_rsa",
                 infrastructure_class="ec2", target="1.2.3.4"))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     ssh="telnet", username="root", infrastructure_class="ec2",
                     target="1.2.3.4"))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     ssh="telnet", private_key="id_rsa",
                     infrastructure_class="ec2", target="1.2.3.4"))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     ssh="telnet", username="root", private_key="id_rsa",
@@ -736,11 +737,11 @@ class TestOpsWorksRegisterEc2(TestOpsWorksBase):
     def test_prevalidate_arguments_no_ips_for_ec2(self):
         """Shouldn't allow overriding IP addresses for EC2."""
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     target="target", private_ip="private-ip"))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(target="target", public_ip="public-ip"))
 
@@ -1139,7 +1140,7 @@ class TestOpsWorksRegisterOnPremises(TestOpsWorksBase):
     def test_prevalidate_arguments_no_instance_profile(self):
         """Shouldn't allow using an instance profile on-premises."""
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.register.prevalidate_arguments(
                 self._build_args(
                     target="target", use_instance_profile=True))

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
 
-from botocore.exceptions import DataNotFoundError, PaginationError
+from botocore.exceptions import DataNotFoundError
 from botocore.model import OperationModel
 from awscli.help import OperationHelpCommand, OperationDocumentEventHandler
 
@@ -20,6 +20,7 @@ import mock
 from mock import Mock, patch
 
 from awscli.customizations import paginate
+from awscli.customizations.exceptions import ParamValidationError
 
 
 class TestPaginateBase(unittest.TestCase):
@@ -344,7 +345,7 @@ class TestEnsurePagingParamsNotSet(TestPaginateBase):
     def test_pagination_params_raise_error_with_no_paginate(self):
         self.parsed_args.max_items = 100
 
-        with self.assertRaises(PaginationError):
+        with self.assertRaises(ParamValidationError):
             paginate.ensure_paging_params_not_set(self.parsed_args, {})
 
     def test_can_handle_missing_page_size(self):

--- a/tests/unit/customizations/test_timestampformat.py
+++ b/tests/unit/customizations/test_timestampformat.py
@@ -15,6 +15,7 @@ from botocore.session import Session
 from mock import Mock, call
 
 from awscli.customizations import timestampformat
+from awscli.customizations.exceptions import ConfigurationError
 from awscli.testutils import unittest
 
 
@@ -62,7 +63,7 @@ class TestScalarParse(unittest.TestCase):
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'foobar'}
         session.get_component.return_value
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ConfigurationError):
             timestampformat.add_timestamp_parser(session)
 
     def test_choose_timestamp_parser_profile_not_found(self):

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ClientError
 from botocore.model import Shape
 
 from awscli.customizations import utils
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
 from awscli.testutils import BaseAWSHelpOutputTest
 
@@ -81,7 +82,7 @@ class TestValidateMututuallyExclusiveGroups(unittest.TestCase):
         utils.validate_mutually_exclusive(parsed, ['foo'], ['bar'])
         # But if we specify both foo and bar then we get an error.
         parsed = FakeParsedArgs(foo='one', bar='two')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             utils.validate_mutually_exclusive(parsed, ['foo'], ['bar'])
 
     def test_multiple_groups(self):
@@ -92,7 +93,7 @@ class TestValidateMututuallyExclusiveGroups(unittest.TestCase):
         utils.validate_mutually_exclusive(parsed, *groups)
         # But this is bad.
         parsed = FakeParsedArgs(foo='one', bar=None, qux='three')
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             utils.validate_mutually_exclusive(parsed, *groups)
 
 

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -17,6 +17,7 @@ from botocore.exceptions import DataNotFoundError
 
 from awscli.testutils import unittest, BaseAWSHelpOutputTest, \
     BaseAWSCommandParamsTest
+from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.waiters import add_waiters, WaitCommand, \
     get_waiter_model_from_service_model, WaiterStateCommand, WaiterCaller, \
     WaiterStateDocBuilder, WaiterStateCommandBuilder
@@ -121,7 +122,7 @@ class TestWaitCommand(unittest.TestCase):
     def test_run_main_error(self):
         self.parsed_args = mock.Mock()
         self.parsed_args.subcommand = None
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ParamValidationError):
             self.cmd._run_main(self.parsed_args, None)
 
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -650,7 +650,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         rc = driver.main(
             'ec2 foo --bar {"Name":"test",Count:4}'.split())
 
-        self.assertEqual(rc, 255)
+        self.assertEqual(rc, 252)
 
     def test_empty_params_gracefully_handled(self):
         # Simulates the equivalent in bash: --identifies ""
@@ -662,7 +662,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         driver = create_clidriver()
         rc = driver.main('ec2 describe-instances '
                          '--filters file://does/not/exist.json'.split())
-        self.assertEqual(rc, 255)
+        self.assertEqual(rc, 252)
         error_msg = self.stderr.getvalue()
         self.assertIn("Error parsing parameter '--filters': "
                       "Unable to load paramfile file://does/not/exist.json",

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -515,9 +515,9 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
 
     def test_event_emission_for_top_level_params(self):
         driver = create_clidriver()
-        # --unknown-foo is an known arg, so we expect a 255 rc.
+        # --unknown-foo is an unknown arg, so we expect a 252 rc.
         rc = driver.main('ec2 describe-instances --unknown-arg foo'.split())
-        self.assertEqual(rc, 255)
+        self.assertEqual(rc, 252)
         self.assertIn('Unknown options: --unknown-arg', self.stderr.getvalue())
 
         # The argument table is memoized in the CLIDriver object. So
@@ -632,13 +632,13 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         rc = driver.main(
             'ec2 foo --bar Count=4'.split())
 
-        self.assertEqual(rc, 255)
+        self.assertEqual(rc, 252)
 
         # Test extra unknown shorthand item
         rc = driver.main(
             'ec2 foo --bar Name=test,Unknown='.split())
 
-        self.assertEqual(rc, 255)
+        self.assertEqual(rc, 252)
 
         # Test long form JSON
         rc = driver.main(


### PR DESCRIPTION
This is a sweeping audit of mostly the customization commands in the AWS CLI to introduce a more nuanced return code convention and applying that convention consistently. This aims to have a little more granularity in the RCs used to convey broad categories of errors and to help distinguish between client side and server side errors.

The convention is:

* 0 Success
* 1 - 127 Reserved for custom commands to express granular exceptions
* 130 - Keyboard interrupt (Ctrl-C)
* 252 Client side failure to parse the command / make the request (Failing argparse, unknown parameter, failing botocore parameter validation, etc).
* 253 Configuration error. This indicates that the command invoked may not necessarily be wrong but the environment/configuration is invalid (No region, no credentials, etc).
* 254 Client error. This indicates there was a successful request/response with the service but the request failed. Indicates that the root issue is likely specific to the service
* 255 Catch all error. 255 specifically as a return code should not be relied on and a particular exception can move from 255 to a specific RC such as the above.
