### PR TITLE
[v2] Rename aws2 back to aws

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -111,9 +111,9 @@ def display_account(account):
 
 class ConfigureSSOCommand(BasicCommand):
     NAME = 'sso'
-    SYNOPSIS = ('aws2 configure sso [--profile profile-name]')
+    SYNOPSIS = ('aws configure sso [--profile profile-name]')
     DESCRIPTION = (
-        'The ``aws2 configure sso`` command interactively prompts for the '
+        'The ``aws configure sso`` command interactively prompts for the '
         'configuration values required to create a profile that sources '
         'temporary AWS credentials from AWS Single Sign-On. To keep an '
         'existing value, hit enter when prompted for the value.  When  you  '
@@ -321,7 +321,7 @@ class ConfigureSSOCommand(BasicCommand):
         usage_msg = (
             '\nTo use this profile, specify the profile name using '
             '--profile, as shown:\n\n'
-            'aws2 s3 ls --profile {}\n'
+            'aws s3 ls --profile {}\n'
         )
         uni_print(usage_msg.format(profile_name))
 

--- a/exe/assets/README.md
+++ b/exe/assets/README.md
@@ -9,12 +9,12 @@ incompatible changes introduced to the AWS CLI v2.
 To install the AWS CLI v2, run the `install` script:
 ```
 $ sudo ./install 
-You can now run: /usr/local/bin/aws2 --version
+You can now run: /usr/local/bin/aws --version
 ```
-This will install the AWS CLI v2 at `/usr/local/bin/aws2`.  Assuming
+This will install the AWS CLI v2 at `/usr/local/bin/aws`.  Assuming
 `/usr/local/bin` is on your `PATH`, you can now run:
 ```
-$ aws2 --verison
+$ aws --verison
 ```
 
 
@@ -27,7 +27,7 @@ and `-i` options:
 $ ./install -i ~/.local/aws-cli -b ~/.local/bin
 ``` 
 This will install the AWS CLI v2 in `~/.local/aws-cli` and create
-symlinks for `aws2` and `aws2_completer` in `~/.local/bin`. For more
+symlinks for `aws` and `aws_completer` in `~/.local/bin`. For more
 information about these options, run the `install` script with `-h`:
 ```
 $ ./install -h
@@ -48,8 +48,8 @@ $ sudo ./install --update
 To remove the AWS CLI v2, delete the its installation and symlinks:
 ```
 $ sudo rm -rf /usr/local/aws-cli
-$ sudo rm /usr/local/bin/aws2
-$ sudo rm /usr/local/bin/aws2_completer
+$ sudo rm /usr/local/bin/aws
+$ sudo rm /usr/local/bin/aws_completer
 ```
 Note if you installed the AWS CLI v2 using the `-b` or `-i` options, you will
 need to remove the installation and the symlinks in the directories you

--- a/exe/assets/install
+++ b/exe/assets/install
@@ -70,8 +70,8 @@ set_global_vars() {
   BIN_DIR=${PARSED_BIN_DIR:-/usr/local/bin}
   UPGRADE=${PARSED_UPGRADE:-no}
 
-  EXE_NAME="aws2"
-  COMPLETER_EXE_NAME="aws2_completer"
+  EXE_NAME="aws"
+  COMPLETER_EXE_NAME="aws_completer"
   INSTALLER_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
   INSTALLER_DIST_DIR="$INSTALLER_DIR/dist"
   INSTALLER_EXE="$INSTALLER_DIST_DIR/$EXE_NAME"

--- a/exe/pyinstaller/aws.spec
+++ b/exe/pyinstaller/aws.spec
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
 
 block_cipher = None
-exe_name = 'aws2'
+exe_name = 'aws'
 
 aws_a = Analysis(['../../bin/aws'],
              binaries=[],

--- a/exe/pyinstaller/aws_completer.spec
+++ b/exe/pyinstaller/aws_completer.spec
@@ -1,7 +1,7 @@
 # -*- mode: python -*-
 
 block_cipher = None
-exe_name = "aws2_completer"
+exe_name = "aws_completer"
 
 
 completer_a = Analysis(['../../bin/aws_completer'],

--- a/exe/tests/install.bats
+++ b/exe/tests/install.bats
@@ -64,11 +64,11 @@ assert_expected_installation() {
   assert_expected_symlink "$expected_current_dir" "$expected_install_dir"
 
   # Assert the bin symlinks are correct
-  assert_expected_symlink "$BIN_DIR/aws2" "$expected_current_dir/bin/aws"
-  assert_expected_symlink "$BIN_DIR/aws2_completer" "$expected_current_dir/bin/aws_completer"
+  assert_expected_symlink "$BIN_DIR/aws" "$expected_current_dir/bin/aws"
+  assert_expected_symlink "$BIN_DIR/aws_completer" "$expected_current_dir/bin/aws_completer"
 
   # Assert the executable works with the expected output
-  [ "$("$BIN_DIR/aws2" --version)" = "$(aws_version_output "$expected_installed_version")" ]
+  [ "$("$BIN_DIR/aws" --version)" = "$(aws_version_output "$expected_installed_version")" ]
 }
 
 assert_expected_symlink() {
@@ -97,14 +97,14 @@ assert_expected_symlink() {
 @test "install" {
   run_install --install-dir "$INSTALL_DIR" --bin-dir "$BIN_DIR"
   [ "$status" -eq 0 ]
-  [ "$output" = "You can now run: $BIN_DIR/aws2 --version" ]
+  [ "$output" = "You can now run: $BIN_DIR/aws --version" ]
   assert_expected_installation "$AWS_EXE_VERSION"
 }
 
 @test "using shorthand parameters" {
   run_install -i "$INSTALL_DIR" -b "$BIN_DIR"
   [ "$status" -eq 0 ]
-  [ "$output" = "You can now run: $BIN_DIR/aws2 --version" ]
+  [ "$output" = "You can now run: $BIN_DIR/aws --version" ]
   assert_expected_installation "$AWS_EXE_VERSION"
 }
 

--- a/macpkg/scripts/postinstall
+++ b/macpkg/scripts/postinstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-EXE_NAME="aws2"
-COMPLETER_EXE_NAME="aws2_completer"
+EXE_NAME="aws"
+COMPLETER_EXE_NAME="aws_completer"
 sudo mkdir -p /usr/local/bin
 # Files created here are not stored in the bill of materials for the pkg.
 # This means we cannot find and remove them during an installation. We add a

--- a/scripts/installers/make-macpkg
+++ b/scripts/installers/make-macpkg
@@ -24,7 +24,7 @@ DISTRIBUTION_PATH = os.path.join(PKG_DIR, 'distribution.xml')
 TEMP_PKG_NAME = 'aws-cli.pkg'
 PKG_NAME = 'AWS-CLI-Installer.pkg'
 EXE_ZIP_NAME = 'awscli-exe.zip'
-EXE_NAME = 'aws2'
+EXE_NAME = 'aws'
 
 
 def make_pkg(pkg_name, src_exe):

--- a/scripts/installers/test-installer
+++ b/scripts/installers/test-installer
@@ -18,7 +18,7 @@ SMOKE_TEST_PATH = os.path.join(
     REPO_ROOT, 'tests', 'integration', 'test_smoke.py')
 UNINSTALL_MAC_PKG_PATH = os.path.join(
     SCRIPTS_DIR, 'installers', 'uninstall-mac-pkg')
-EXE_NAME = 'aws2'
+EXE_NAME = 'aws'
 
 
 class InstallerTester(object):


### PR DESCRIPTION
The rationale is that there are relatively few breaking changes in AWS CLI v2 to warrant a new namespace for CLI v2 when it GA's. If a user wants to have the two CLI's side by side, they can always add an alias for one of them.
