### PR TITLE
Fix paramter validation bug for ec2 bundle-instance

### DIFF
--- a/.changes/next-release/bugfix-ec2-90044.json
+++ b/.changes/next-release/bugfix-ec2-90044.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ec2",
+  "description": "Fixed a paramter validation bug for the ec2 bundle-instance parameter --storage."
+}

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -98,8 +98,8 @@ def _check_args(parsed_args, **kwargs):
     logger.debug(parsed_args)
     arg_dict = vars(parsed_args)
     if arg_dict['storage']:
-        for key in ('bucket', 'prefix', 'owner-akid',
-                    'owner-sak', 'policy'):
+        for key in ('bucket', 'prefix', 'owner_akid',
+                    'owner_sak', 'policy'):
             if arg_dict[key]:
                 msg = ('Mixing the --storage option '
                        'with the simple, scalar options is '

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -93,7 +93,12 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
         args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()
-        self.assert_params_for_cmd(args_list, expected_rc=255)
+        _, stderr, _ = self.assert_params_for_cmd(args_list, expected_rc=255)
+        expected_err_msg = (
+            'Mixing the --storage option with the simple, '
+            'scalar options is not recommended'
+        )
+        self.assertIn(expected_err_msg, stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The parameters need to be checked using snake case else we fail for a `KeyError` and the `--storage` parameter cannot be provided at all. This fixes that and strengthens the assertions in the test for this.
