### PR TITLE
Revert "Merge pull request #4831 from aws/dependabot/pip/colorama-gte…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = ['botocore==1.14.10',
                     'rsa>=3.1.2,<=3.5.0',
                     's3transfer>=0.3.0,<0.4.0',
                     'PyYAML>=3.10,<5.3',
-                    'colorama>=0.2.5,<0.4.4']
+                    'colorama>=0.2.5,<0.4.2']
 
 
 setup_options = dict(


### PR DESCRIPTION
…-0.2.5-and-lt-0.4.4"

This reverts commit c29c90ed4745a4adedf51627ae82909da94c3aa3, reversing
changes made to a5882137e8ce93188766f201c75eec317c93c3ca.

They dropped support for python 3.4 and the tests pass if the cfg isn't updated as well.
