### PR TITLE
[v2] Remove unused py2 code

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -60,14 +60,6 @@ from awscli.plugin import load_plugins
 from awscli.clidriver import CLIDriver
 
 
-# In python 3, order matters when calling assertEqual to
-# compare lists and dictionaries with lists. Therefore,
-# assertItemsEqual needs to be used but it is renamed to
-# assertCountEqual in python 3.
-if six.PY2:
-    unittest.TestCase.assertCountEqual = unittest.TestCase.assertItemsEqual
-
-
 _LOADER = botocore.loaders.Loader()
 INTEG_LOG = logging.getLogger('awscli.tests.integration')
 AWS_CMD = None

--- a/tests/functional/ec2/test_create_tags.py
+++ b/tests/functional/ec2/test_create_tags.py
@@ -29,17 +29,3 @@ class TestCreateTags(BaseAWSCommandParamsTest):
             'Resources': ['i-12345678'],
             'Tags': [{'Key': 'Name', 'Value': 'bar'}]}
         self.assert_params_for_cmd(cmdline, result)
-
-    @unittest.skipIf(
-        six.PY3, 'Unicode cmd line test only is relevant to python2.')
-    def test_create_tag_unicode(self):
-        cmdline = self.prefix
-        cmdline += u' --resources i-12345678 --tags Key=Name,Value=\u6211'
-        encoding = getattr(sys.stdin, 'encoding', 'utf-8')
-        if encoding is None:
-            encoding = 'utf-8'
-        cmdline = cmdline.encode(encoding)
-        result = {
-            'Resources': ['i-12345678'],
-            'Tags': [{'Key': 'Name', 'Value': u'\u6211'}]}
-        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/elasticbeanstalk/test_create_application.py
+++ b/tests/functional/elasticbeanstalk/test_create_application.py
@@ -25,21 +25,3 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
         cmdline += ' --application-name FooBar'
         result = {'ApplicationName': 'FooBar',}
         self.assert_params_for_cmd(cmdline, result)
-
-    @unittest.skipIf(
-        six.PY3, 'Unicode cmd line test only is relevant to python2.')
-    def test_py2_bytestring_unicode(self):
-        # In Python2, sys.argv is a list of bytestrings that are encoded
-        # in whatever encoding the terminal uses.  We have an extra step
-        # where we need to decode the bytestring into unicode.  In
-        # python3, sys.argv is a list of unicode objects so this test
-        # doesn't make sense for python3.
-        cmdline = self.prefix
-        app_name = u'\u2713'
-        cmdline += u' --application-name %s' % app_name
-        encoding = getattr(sys.stdin, 'encoding')
-        if encoding is None:
-            encoding = 'utf-8'
-        cmdline = cmdline.encode(encoding)
-        result = {'ApplicationName': u'\u2713',}
-        self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/customizations/dynamodb/test_types.py
+++ b/tests/unit/customizations/dynamodb/test_types.py
@@ -99,8 +99,6 @@ class TestSerializer(unittest.TestCase):
         self.assertEqual(self.serializer.serialize(bytearray([1])),
                          {'B': b'\x01'})
 
-    @unittest.skipIf(six.PY2,
-                     'This is a test when using python3 version of bytes')
     def test_serialize_bytes(self):
         self.assertEqual(self.serializer.serialize(b'\x01'), {'B': b'\x01'})
 


### PR DESCRIPTION
Most of these changes were isolated to compat, which is now
mostly a module for cross platform compat instead of python version
compatability.

The diff for compat looks off, but all I basically changed was:

```
if six.PY3:
    A
else:
    B
```

to:

```
A
```