### PR TITLE
Add bundled installer urllib3 dependency for python 3.4

### DIFF
--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -26,6 +26,7 @@ EXTRA_RUNTIME_DEPS = [
     ('virtualenv', '16.7.8'),
     # The following is for python 3.4 compatibility.
     ('colorama', '0.4.1'),
+    ('urllib3', '1.25.7'),
 ]
 BUILDTIME_DEPS = [
     ('setuptools-scm', '3.3.3'),


### PR DESCRIPTION
Related: https://github.com/boto/botocore/pull/1962/