### PR TITLE
Pop AWS_REGION from env vars in config test

### DIFF
--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -57,6 +57,7 @@ class TestConfigureCommand(unittest.TestCase):
             'aws_secret_access_key=12345\n'
             'region=us-west-2\n'
         )
+        self.env_vars.pop('AWS_REGION', None)
         self.env_vars.pop('AWS_DEFAULT_REGION', None)
         self.env_vars.pop('AWS_ACCESS_KEY_ID', None)
         self.env_vars.pop('AWS_SECRET_ACCESS_KEY', None)


### PR DESCRIPTION
We have to make sure we remove all env vars related to
configuring a region in this test.  We're verifying that we're
pulling the region from the config file when no env vars for
region exist.