### PR TITLE
[v2] Add support for AWS_REGION env var in the CLI

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -148,6 +148,10 @@ class CLIDriver(object):
                 session=self.session
             ),
             EnvironmentProvider(
+                name='AWS_REGION',
+                env=os.environ,
+            ),
+            EnvironmentProvider(
                 name='AWS_DEFAULT_REGION',
                 env=os.environ,
             ),

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -770,6 +770,15 @@ class TestHowClientIsCreated(BaseAWSCommandParamsTest):
         self.assertEqual(
             self.create_endpoint.call_args[1]['region_name'], 'us-west-2')
 
+    def test_can_use_new_aws_region_env_var(self):
+        self.environ['AWS_REGION'] = 'us-east-2'
+        self.environ['AWS_DEFAULT_REGION'] = 'us-west-1'
+        self.assert_params_for_cmd(
+            'ec2 describe-instances',
+            expected_rc=0)
+        self.assertEqual(
+            self.create_endpoint.call_args[1]['region_name'], 'us-east-2')
+
     def test_aws_with_verify_false(self):
         self.assert_params_for_cmd(
             'ec2 describe-instances --region us-east-1 --no-verify-ssl',


### PR DESCRIPTION
We use a custom chain provider in the CLI so we need
to copy the config into the CLI.  We should eventually just
move the IMDS provider for region into the botocore v2 branch
so we can remove the custom chain.

### Testing

```
$ AWS_REGION=us-east-2 aws ec2 describe-instances --debug 2>&1 | grep 'Starting new HTTPS'
2020-02-07 13:28:18,841 - MainThread - urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): ec2.us-east-2.amazonaws.com:443
$ AWS_REGION=us-west-2 aws ec2 describe-instances --debug 2>&1 | grep 'Starting new HTTPS'
2020-02-07 13:28:22,588 - MainThread - urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): ec2.us-west-2.amazonaws.com:443
```