### PR TITLE
Fix "aws s3 ls s3:///random_nonsense returns true"

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -475,6 +475,8 @@ class ListCommand(S3Command):
             path = path[5:]
         bucket, key = find_bucket_key(path)
         if not bucket:
+            if key:
+                return 0
             self._list_all_buckets()
         elif parsed_args.dir_op:
             # Then --recursive was specified.


### PR DESCRIPTION
*Issue #, if available:*
#4815

*Description of changes:*
Currently running aws s3 ls s3:///random_nonsense returns all buckets. This change is to validate that the bucket field is not an empty string especially if a key is provided so that it returns false instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
