### PR TITLE
sync: document --delete behavior for excluded files

### DIFF
--- a/awscli/customizations/s3/syncstrategy/delete.py
+++ b/awscli/customizations/s3/syncstrategy/delete.py
@@ -21,7 +21,8 @@ LOG = logging.getLogger(__name__)
 DELETE = {'name': 'delete', 'action': 'store_true',
           'help_text': (
               "Files that exist in the destination but not in the source are "
-              "deleted during sync.")}
+              "deleted during sync. Note that files excluded by filters are "
+              "excluded from deletion.")}
 
 
 class DeleteSync(BaseSync):


### PR DESCRIPTION
Running `aws s3 sync --delete ...` will not delete files that are
excluded by filters. For example:

```bash
aws s3 mb s3://sync-delete-exclude
mkdir /tmp/sync-delete-exclude
touch /tmp/sync-delete-exclude/{1,2,3,4}
aws s3 sync /tmp/sync-delete-exclude s3://sync-delete-exclude
# no files will be deleted:
aws s3 sync s3://sync-delete-exclude /tmp/sync-delete-exclude \
  --exclude=3 --exclude=4 --delete --dryrun
```

This is not immediately obvious from the documentation provided, and the
interaction between exclusion filters and the `--delete` strategy flag
should be explicitly stated.

solves the documentation issue with #4923.