### PR TITLE
[v2] Add standard mode retry to v2 changelog

### DIFF
--- a/.changes/2.0.0.json
+++ b/.changes/2.0.0.json
@@ -90,6 +90,11 @@
     "type": "breaking-change"
   },
   {
+    "category": "retries",
+    "description": "Add support for standard mode retries, which lowers the maximum attempts to 3, includes a consistent set of errors to retry, and implements retry quotas which limit the number of unsuccessful retries an SDK can make. See `boto/botocore#1952 <https://github.com/boto/botocore/pull/1952>`__.",
+    "type": "breaking-change"
+  },
+  {
     "category": "autocomplete",
     "description": "Improved command and parameter autocompletion, including support for service side resource ID autocompletion. See `#3725 <https://github.com/aws/aws-cli/issues/3725>`__.",
     "type": "feature"


### PR DESCRIPTION
This is a backfill.  This was part of the 2.0.0 release but didn't make
it on the v2 changelog.
