### PR TITLE
Make macOS PKG installer more flexible

### DIFF
--- a/.changes/next-release/enhancement-Installer-62445.json
+++ b/.changes/next-release/enhancement-Installer-62445.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Installer",
+  "description": "macOS PKG installer now supports custom install locations."
+}

--- a/macpkg/distribution.xml
+++ b/macpkg/distribution.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <installer-gui-script minSpecVersion="1">
+    <pkg-ref id="com.amazon.aws.cli2"/>
     <title>AWS Command Line Interface</title>
     <license file="LICENSE.txt" />
     <readme file="README.html" mimetype="text/html" />
-    <pkg-ref id="com.amazon.aws.cli2"/>
-    <options customize="never" require-scripts="false"/>
+    <domains enable_anywhere="true" enable_currentUserHome="true" enable_localSystem="true" />
+    <options customize="always" require-scripts="false" />
     <choices-outline>
-        <line choice="default">
-            <line choice="com.amazon.aws.cli2"/>
-        </line>
+      <line choice="default"/>
     </choices-outline>
-    <choice id="default"/>
-    <choice id="com.amazon.aws.cli2" visible="false">
+    <choice title="AWS CLI v2" id="default" customLocation="/usr/local">
         <pkg-ref id="com.amazon.aws.cli2"/>
     </choice>
-    <pkg-ref id="com.amazon.aws.cli2" version="0" onConclusion="none">aws-cli.pkg</pkg-ref>
+    <pkg-ref id="com.amazon.aws.cli2">aws-cli.pkg</pkg-ref>
 </installer-gui-script>

--- a/macpkg/scripts/postinstall
+++ b/macpkg/scripts/postinstall
@@ -1,15 +1,28 @@
 #!/usr/bin/env bash
 EXE_NAME="aws"
 COMPLETER_EXE_NAME="aws_completer"
-sudo mkdir -p /usr/local/bin
-# Files created here are not stored in the bill of materials for the pkg.
-# This means we cannot find and remove them during an installation. We add a
-# custom .install-metadata file here which is read and used by our
-# scripts/installers/uninstall-mac-pkg to clean up any extra files created
-# here. If any new files are added, be sure to add them to the .install-metadata
-# file as well.
-sudo echo "/usr/local/aws-cli/.install-metadata" >> /usr/local/aws-cli/.install-metadata
-sudo ln -sf "/usr/local/aws-cli/$EXE_NAME" "/usr/local/bin/$EXE_NAME"
-sudo echo "/usr/local/bin/$EXE_NAME" >> /usr/local/aws-cli/.install-metadata
-sudo ln -sf "/usr/local/aws-cli/$COMPLETER_EXE_NAME" "/usr/local/bin/$COMPLETER_EXE_NAME"
-sudo echo "/usr/local/bin/$COMPLETER_EXE_NAME" >> /usr/local/aws-cli/.install-metadata
+PATH_TO_INSTALL="$2/aws-cli"
+METADATA_PATH="$PATH_TO_INSTALL/.install-metadata"
+SYMLINK_DIR="/usr/local/bin"
+ID=$(id -u)
+
+# Only install symlinks if we are installing with root permissions
+# this means we selected the install for everyone option.
+if [ "$ID" == "0" ]; then
+    echo "Global install detected. Installing symlinks in $SYMLINK_DIR."
+    sudo mkdir -p "$SYMLINK_DIR"
+    sudo echo "$METADATA_PATH" >> "$METADATA_PATH"
+
+    AWS_PATH="$PATH_TO_INSTALL/$EXE_NAME"
+    AWS_LINK="$SYMLINK_DIR/$EXE_NAME"
+    echo "Linking $AWS_LINK -> $AWS_PATH"
+    sudo ln -sf "$AWS_PATH" "$AWS_LINK"
+    sudo echo "$AWS_LINK" >> "$METADATA_PATH"
+
+
+    COMPLETER_PATH="$PATH_TO_INSTALL/$COMPLETER_EXE_NAME"
+    COMPLETER_LINK="$SYMLINK_DIR/$COMPLETER_EXE_NAME"
+    echo "Linking $COMPLETER_LINK -> $COMPLETER_PATH"
+    sudo ln -sf "$COMPLETER_PATH" "$COMPLETER_LINK"
+    sudo echo "$COMPLETER_LINK" >> "$METADATA_PATH"
+fi

--- a/macpkg/scripts/preinstall
+++ b/macpkg/scripts/preinstall
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-sudo rm -rf /usr/local/aws-cli

--- a/macpkg/tests/README.rst
+++ b/macpkg/tests/README.rst
@@ -1,0 +1,40 @@
+Overview
+========
+
+This document describes how to test and lint the macpkg generation scripts and
+PKG.
+
+Running the tests
+-----------------
+
+The test suite utilizes `Bats <https://github.com/sstephenson/bats>`_ to run
+the tests. To run the tests, first make sure you first install Bats::
+
+     $ brew install bats
+
+
+And then run Bats from within this ``tests`` directory::
+
+     $ bats .
+
+You can point the tests to a custom installer package location by using the
+environment variable INSTALLER_TO_TEST. For example to test an installer in your
+home directory::
+
+  $ INSTALLER_TO_TEST=~/AWS-CLI-Installer.pkg bats .
+
+
+Linting
+-------
+To help catch potential issues in the shell script and tests, you should also
+lint the scripts. To lint the shell scripts, use
+`ShellCheck <https://github.com/koalaman/shellcheck>`_. It can be installed
+with ``brew``::
+
+     $ brew install shellcheck
+
+
+Then run on the ``scripts/postinstall`` and ``tests/install.bats``
+test files::
+
+   $ shellcheck scripts/postinstall tests/install.bats

--- a/macpkg/tests/choices.xml
+++ b/macpkg/tests/choices.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <dict>
+      <key>choiceAttribute</key>
+      <string>customLocation</string>
+      <key>attributeSetting</key>
+      <string>REPLACEME</string>
+      <key>choiceIdentifier</key>
+      <string>default</string>
+    </dict>
+  </array>
+</plist>

--- a/macpkg/tests/install.bats
+++ b/macpkg/tests/install.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+setup() {
+    if [ -z "$INSTALLER_TO_TEST" ]; then
+	INSTALLER_TO_TEST="../../dist/AWS-CLI-Installer.pkg"
+    fi
+    PKG_PATH="$BATS_TMPDIR/installer.pkg"
+    CHOICE_XML="$BATS_TMPDIR/choices.xml"
+    INSTALL_TARGET="$HOME/.tmp-cli-pkg-test"
+    mkdir -p "$INSTALL_TARGET"
+    copy_pkg
+}
+
+teardown() {
+    rm -rf "$INSTALL_TARGET"
+}
+
+copy_pkg() {
+    cp "$INSTALLER_TO_TEST" "$PKG_PATH"
+}
+
+write_choices() {
+    sed "s+REPLACEME+$1+g" > "$CHOICE_XML" < choices.xml
+}
+
+@test "user install with custom location succeeds" {
+    write_choices "$INSTALL_TARGET"
+    installer -target CurrentUserHomeDirectory -pkg "$PKG_PATH" -applyChoiceChangesXML "$CHOICE_XML"
+    run "$INSTALL_TARGET/aws-cli/aws" "--version"
+    [ "$status"  -eq 0 ]
+}

--- a/scripts/installers/make-macpkg
+++ b/scripts/installers/make-macpkg
@@ -30,7 +30,17 @@ EXE_NAME = 'aws'
 def make_pkg(pkg_name, src_exe):
     with tmp_dir() as workdir:
         extract_zip(src_exe, workdir)
+        stage_files(workdir)
         do_make_pkg(workdir, pkg_name)
+
+
+def stage_files(workdir):
+    # Stage all the distribution files inside a directory named aws-cli
+    stage_dir = os.path.join(workdir, 'stage')
+    os.makedirs(stage_dir)
+    dist_dir = os.path.join(workdir, 'aws', 'dist')
+    cli_dir = os.path.join(stage_dir, 'aws-cli')
+    shutil.move(dist_dir, cli_dir)
 
 
 def do_make_pkg(workdir, pkg_name):
@@ -38,8 +48,7 @@ def do_make_pkg(workdir, pkg_name):
     print(run(
         (
             'pkgbuild --identifier com.amazon.aws.cli2 '
-            '--root ./aws/dist '
-            '--install-location /usr/local/aws-cli/ '
+            '--root ./stage '
             '--scripts %s '
             '--version %s '
             '%s'
@@ -61,7 +70,7 @@ def do_make_pkg(workdir, pkg_name):
 
 
 def get_version(output_dir):
-    exe_dir = os.path.join(output_dir, 'aws', 'dist')
+    exe_dir = os.path.join(output_dir, 'stage', 'aws-cli')
     exe_path = os.path.join(exe_dir, EXE_NAME)
     result = run('%s --version' % exe_path, cwd=exe_dir).strip()
     version = result.split(' ')[0].split('/')[1]


### PR DESCRIPTION
This commit opens up the PKG installer to install the CLI
anywhere. During installation the user will now be prompted to install
in for all users, or just for the current user. Next it will show you a
choices screen with the install location displayed. Clicking on the
location allows you to select the `other...` option which will display a
file picker dialog to choose where the CLI is installed.

There are several caveats that I have not found suitable workarounds
for. First there can only be one global installation of the CLI. If you
do a second global installation in a different location, it will see
that you have a previous one and uninstall it first. If you choose the
same location it will simply overwrite the files.

This does not apply to current user only installations. If you choose
"install for me only" the CLI can be installed multiple times to
different locations. The caveat here is that it cannot be installed
outside the home directory. The installer app will not catch this
misconfiguration, and will throw an error after encountering a
permissions error.

Another thing to keep in mind about user directory installations is they
will not add a symlink to your PATH on your behalf. By default when you
do a global install, the PKG will install a symlink to the aws and
aws_completer binaries located in `/usr/local/bin`. Since a "for me
only" installation does not have permissions to that directory, and we
do not have a good way of guessing where you'd like us to put
symlinks (if any). We opt not to install any. This means if you want aws
on your PATH, you need to set up the symlinks yourself.

To see debug logs for an installation you can press cmd+L in the
installer GUI to open up the log pane. From there you can select
filtering options and save the log file after the installation is
done. The logs will also be written to `/var/log/install.log`.

In order to run an automated installation you can use the `installer`
command line tool. In order to run a global install (for all users of
this computer option in the GUI) invoke with `-target /` and `sudo`.

For example this will run a global install to the default location:
```
$ sudo installer -pkg AWS-CLI-Installer.pkg -target /
```

If you want to install to custom location it gets a little bit
tricker. This is required for a "me only" current user install since
the default location is `/user/local/` which won't work. To customize
the installation choices you need to use the `-applyChoiceChangesXML`
option. Which as the name implies takes an XML input file. Below I have
an example XML file that will change the install location to `~/aws`.

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <array>
    <dict>
      <key>choiceAttribute</key>
      <string>customLocation</string>
      <key>attributeSetting</key>
      <string>/Users/stealthycoin/aws</string>
      <key>choiceIdentifier</key>
      <string>default</string>
    </dict>
  </array>
</plist>
```

It is important to note that the directory `/Users/stealthycoin/aws`
must already exist or the installer will exit with an error about a
malformed input document. Now we can invoke the `installer` command to
do a user only installation with this as the custom location. The main
differences are we do not need sudo to invoke it, and we change our
`-target` to `CurrentUserHomeDirectory`

```
$ installer -target CurrentUserHomeDirectory \
            -pkg AWS-CLI-Installer.pkg \
	    -applyChoiceChangesXML choices.xml
```

This will invoke the installer without elevated privileges, instruct it
you want to do a "me only" installation. And override the location with
our custom location `/Users/stealthycoin/aws`. Once this completes the CLI
should be installed at `/Users/stealthycoin/aws/aws-cli`. This
installation mode will not set up symlinks for you so it will not be
automatically added to your path.

