### PR TITLE
[v2] Fix issue with opening browser on moder linux distros

### DIFF
--- a/.changes/next-release/bugfix-SSO-65835.json
+++ b/.changes/next-release/bugfix-SSO-65835.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SSO",
+  "description": "Fix issue where browser would not open in modern linux distros (`#4839 <https://github.com/aws/aws-cli/issues/4839>`__)"
+}

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -18,6 +18,7 @@ from botocore.utils import SSOTokenFetcher
 from botocore.credentials import JSONFileCache
 
 from awscli.customizations.utils import uni_print
+from awscli.utils import original_ld_library_path
 from awscli.customizations.assumerole import CACHE_DIR as AWS_CREDS_CACHE_DIR
 
 LOG = logging.getLogger(__name__)
@@ -32,7 +33,9 @@ def do_sso_login(session, sso_region, start_url, token_cache=None,
     if token_cache is None:
         token_cache = JSONFileCache(SSO_TOKEN_DIR)
     if on_pending_authorization is None:
-        on_pending_authorization = OpenBrowserHandler()
+        on_pending_authorization = OpenBrowserHandler(
+            open_browser=open_browser_with_original_ld_path
+        )
     token_fetcher = SSOTokenFetcher(
         sso_region=sso_region,
         client_creator=session.create_client,
@@ -43,6 +46,11 @@ def do_sso_login(session, sso_region, start_url, token_cache=None,
         start_url=start_url,
         force_refresh=force_refresh
     )
+
+
+def open_browser_with_original_ld_path(url):
+    with original_ld_library_path():
+        webbrowser.open_new_tab(url)
 
 
 class OpenBrowserHandler(object):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,6 +27,7 @@ from awscli.utils import (split_on_commas, ignore_ctrl_c,
                           OutputStreamFactory)
 from awscli.utils import InstanceMetadataRegionFetcher
 from awscli.utils import IMDSRegionProvider
+from awscli.utils import original_ld_library_path
 from tests import RawResponse
 
 
@@ -112,6 +113,31 @@ class TestIgnoreCtrlC(unittest.TestCase):
             # And if we actually try to sigint ourselves, an exception
             # should not propogate.
             os.kill(os.getpid(), signal.SIGINT)
+
+
+class TestOriginalLDLibraryPath(unittest.TestCase):
+    def test_swaps_original_ld_library_path(self):
+        env = {'LD_LIBRARY_PATH_ORIG': '/my/original',
+               'LD_LIBRARY_PATH': '/pyinstallers/version'}
+        with original_ld_library_path(env):
+            self.assertEqual(env['LD_LIBRARY_PATH'],
+                             '/my/original')
+        self.assertEqual(env['LD_LIBRARY_PATH'],
+                            '/pyinstallers/version')
+
+    def test_no_ld_library_path_original(self):
+        env = {'LD_LIBRARY_PATH': '/pyinstallers/version'}
+        with original_ld_library_path(env):
+            self.assertIsNone(env.get('LD_LIBRARY_PATH'))
+        self.assertEqual(env['LD_LIBRARY_PATH'],
+                            '/pyinstallers/version')
+
+    def test_no_ld_library_path(self):
+        env = {'OTHER_VALUE': 'foo'}
+        with original_ld_library_path(env):
+            self.assertIsNone(env.get('LD_LIBRARY_PATH'))
+            self.assertEqual(env, {'OTHER_VALUE': 'foo'})
+        self.assertEqual(env, {'OTHER_VALUE': 'foo'})
 
 
 class TestFindServiceAndOperationNameFromEvent(unittest.TestCase):


### PR DESCRIPTION
Don't use pyinstaller ld path for sso login

This ensures that the browser, launched as a subprocess, will load with the system libraries and not try to use any of the bundled libs that come from the pyinstaller exe.

As part of this change I added a commit that implements a context manager for swapping out the `LD_LIBRARY_PATH`.   For more info see:  https://pyinstaller.readthedocs.io/en/stable/runtime-information.html

I audited the rest of the places we use a subprocess (including transitive usage) and my initial testing shows that the `webbrowser` was the only place affected by this.  We should probably just swap out all of our usage of subprocess with one that swaps out `LD_LIBRARY_PATH` but that's more of a "best-practice"/future-proofing thing than it is fixing an actual issue.

Fixes https://github.com/aws/aws-cli/issues/4839

I tested this out on the same distro reported in #4839, Fedora 31.  I noticed that it took a long time to open a browser (the gif is sped up) but I can't tell if that's just xfce/firefox being slow or if it's related to me testing this in vmware.

![sso-fedora31](https://user-images.githubusercontent.com/368057/74569348-1144cc00-4f2f-11ea-9df8-76993149e206.gif)

