### PR TITLE
acm import-certificates broken on invalid base64 padding

### DIFF
--- a/awscli/customizations/binaryformat.py
+++ b/awscli/customizations/binaryformat.py
@@ -56,7 +56,7 @@ class Base64DecodeVisitor(ModelVisitor):
         if shape.type_name != 'blob' or not isinstance(value, six.text_type):
             return
         try:
-            parent[name] = base64.b64decode(value)
+            parent[name] = base64.b64decode(value+"===" )
         except (binascii.Error, TypeError):
             raise InvalidBase64Error('Invalid base64: "%s"' % value)
 


### PR DESCRIPTION
Based on base64.b64decode issue https://gist.github.com/perrygeo/ee7c65bb1541ff6ac770

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
