### PR TITLE
Replace pip with python -m pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,27 +41,27 @@ Installation
 
 The easiest way to install aws-cli is to use `pip`_ in a ``virtualenv``::
 
-    $ pip install awscli
+    $ python -m pip install awscli
 
 or, if you are not installing in a ``virtualenv``, to install globally::
 
-    $ sudo pip install awscli
+    $ sudo python -m pip install awscli
 
 or for your user::
 
-    $ pip install --user awscli
+    $ python -m pip install --user awscli
 
 If you have the aws-cli installed and want to upgrade to the latest version
 you can run::
 
-    $ pip install --upgrade awscli
+    $ python -m pip install --upgrade awscli
 
 .. note::
 
     On macOS, if you see an error regarding the version of six that came with
     distutils in El Capitan, use the ``--ignore-installed`` option::
 
-        $ sudo pip install awscli --ignore-installed six
+        $ sudo python -m pip install awscli --ignore-installed six
 
 
 This will install the aws-cli package as well as all dependencies.  You can
@@ -406,22 +406,22 @@ the CLI, you can use the ``requirements.txt`` file included in this repo.
 This file points to the development version of the above packages::
 
     $ cd <path_to_awscli>
-    $ pip install -r requirements.txt
-    $ pip install -e .
+    $ python -m pip install -r requirements.txt
+    $ python -m pip install -e .
 
 However, to keep up to date, you will continually have to run the
-``pip install -r requirements.txt`` file to pull in the latest changes
+``python -m pip install -r requirements.txt`` file to pull in the latest changes
 from the develop branches of botocore, jmespath, etc.
 
-You can optionally clone each of those repositories and run "pip install -e ."
+You can optionally clone each of those repositories and run "python -m pip install -e ."
 for each repository::
 
     $ git clone <jmespath> && cd jmespath/
-    $ pip install -e . && cd ..
+    $ python -m pip install -e . && cd ..
     $ git clone <botocore> && cd botocore/
-    $ pip install -e . && cd ..
+    $ python -m pip install -e . && cd ..
     $ git clone <awscli> && cd aws-cli/
-    $ pip install -e .
+    $ python -m pip install -e .
 
 
 ------------
@@ -440,5 +440,5 @@ help:
 
 
 .. _`Amazon Web Services Security Bulletins website`: https://aws.amazon.com/security/security-bulletins
-.. _pip: http://www.pip-installer.org/en/latest/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _`download the tarball`: https://pypi.org/project/awscli/


### PR DESCRIPTION
*Description of changes:*
Update install instructions to avoid these warnings:
```
WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
