### PR TITLE
[v2] Allow local installs for botocore

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,0 +1,8 @@
+tox>=2.3.1,<3.0.0
+nose==1.3.7
+mock==1.3.0
+cryptography>=2.8.0,<=2.9.0
+wheel==0.24.0
+ruamel.yaml>=0.15.0,<0.16.0
+jsonschema==2.5.1
+PyInstaller==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,2 @@
-tox>=2.3.1,<3.0.0
-nose==1.3.7
-mock==1.3.0
-cryptography>=2.8.0,<=2.9.0
-wheel==0.24.0
-ruamel.yaml>=0.15.0,<0.16.0
-jsonschema==2.5.1
-PyInstaller==3.5
+-r requirements-common.txt
 https://github.com/boto/botocore/zipball/v2#egg=botocore

--- a/scripts/ci/install-deps
+++ b/scripts/ci/install-deps
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import argparse
+import os
+import sys
+from subprocess import check_call
+import shutil
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+os.chdir(REPO_ROOT)
+
+
+def run(command):
+    return check_call(command, shell=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        '--botocore-path',
+        default='',
+        help=(
+            'The optional location of a local botocore install '
+            'for use in place of github.'
+        )
+    )
+
+    args, unknown = parser.parse_known_args()
+    if args.botocore_path:
+        botocore_path = os.path.abspath(args.botocore_path)
+        run('pip install -r requirements-common.txt')
+        run('pip install %s' % botocore_path)
+    else:
+        run('pip install -r requirements.txt')
+    run('pip install .')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/installers/make-exe
+++ b/scripts/installers/make-exe
@@ -103,7 +103,7 @@ def main():
             'useful for debugging.'
         ),
     )
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
 
     output = os.path.abspath(args.output)
     make_exe(output, cleanup=args.cleanup)

--- a/scripts/installers/make-macpkg
+++ b/scripts/installers/make-macpkg
@@ -105,7 +105,7 @@ def main():
             '"dist/%s" zipfile in the root of the awscli.' % EXE_ZIP_NAME
         )
     )
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
     output = os.path.abspath(args.output)
     src_exe = os.path.abspath(args.src_exe)
     make_pkg(output, src_exe)

--- a/scripts/installers/sign-exe
+++ b/scripts/installers/sign-exe
@@ -63,7 +63,7 @@ def main():
             'is your default private key in gpg.'
         )
     )
-    args = parser.parse_args()
+    args, unknown = parser.parse_known_args()
     sign_exe(args.exe, args.output, args.key_name)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,34 +11,27 @@ commands =
 
 [testenv:exe]
 basepython = python3.7
-deps =
-    -r{toxinidir}/requirements.txt
-    {toxinidir}
 commands =
+    {envpython} {toxinidir}/scripts/ci/install-deps {posargs}
     {envpython} {toxinidir}/scripts/installers/make-exe {posargs}
 
 
 [testenv:macpkg]
 basepython = python3.7
-deps =
-    {[testenv:exe]deps}
 commands =
+    {envpython} {toxinidir}/scripts/ci/install-deps {posargs}
     {envpython} {toxinidir}/scripts/installers/make-macpkg {posargs}
 
 
 [testenv:test-exe]
 basepython = python3.7
-deps =
-    -r{toxinidir}/requirements.txt
-    {toxinidir}
 commands =
+    {envpython} {toxinidir}/scripts/ci/install-deps {posargs}
     {envpython} {toxinidir}/scripts/installers/test-installer --installer-type exe
 
 
 [testenv:sign-exe]
 basepython = python3.7
-deps =
-    -r{toxinidir}/requirements.txt
-    {toxinidir}
 commands =
+    {envpython} {toxinidir}/scripts/ci/install-deps {posargs}
     {envpython} {toxinidir}/scripts/installers/sign-exe {posargs}


### PR DESCRIPTION
This change will allow passing an additional flag (`--botocore-path`) to each tox stage with a local path to botocore. With that, we can enable easier testing with unpublished versions and pin botocore for build consistency between tox stages.