### PR TITLE
Clarify use of --zip-file vs --code / --content

### DIFF
--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -25,6 +25,7 @@ ERROR_MSG = (
 
 ZIP_DOCSTRING = (
     '<p>The path to the zip file of the {param_type} you are uploading. '
+    'Specify --zip-file or --{param_type}, but not both. '
     'Example: fileb://{param_type}.zip</p>'
 )
 


### PR DESCRIPTION
Both appear as optional in the synopsis.

*Issue #, if available:*

*Description of changes:* --zip-file and --code / --content appear as optional params. The latter are required by the API, and the former is a customization on the CLI only. Adding note about usage to the customization as it can't be added to the model just for CLI docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
