### PR TITLE
Update autoscaling service principle for emr command

### DIFF
--- a/awscli/customizations/emr/constants.py
+++ b/awscli/customizations/emr/constants.py
@@ -20,6 +20,8 @@ ROLE_ARN_PATTERN = "arn:{{region_suffix}}:iam::aws:policy/service-role/{{policy_
 EC2_ROLE_POLICY_NAME = "AmazonElasticMapReduceforEC2Role"
 EMR_ROLE_POLICY_NAME = "AmazonElasticMapReduceRole"
 EMR_AUTOSCALING_ROLE_POLICY_NAME = "AmazonElasticMapReduceforAutoScalingRole"
+EMR_AUTOSCALING_SERVICE_NAME = "application-autoscaling"
+EMR_AUTOSCALING_SERVICE_PRINCIPAL = "application-autoscaling.amazonaws.com"
 
 # Action on failure
 CONTINUE = 'CONTINUE'


### PR DESCRIPTION
Currently the region is appended to autoscaling service principle. Autoscaling no longer requires the region name in service principle except in CN region.
