### PR TITLE
Fix issue with parsing a trailing empty line in codecommit helper

### DIFF
--- a/.changes/next-release/bugfix-codecommit-56815.json
+++ b/.changes/next-release/bugfix-codecommit-56815.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "codecommit",
+  "description": "Fix codecommit credential-helper input parsing to allow a trailing newline."
+}

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -122,8 +122,10 @@ class CodeCommitGetCommand(BasicCommand):
     def read_git_parameters(self):
         parsed = {}
         for line in sys.stdin:
-            key, value = line.strip().split('=', 1)
-            parsed[key] = value
+            line = line.strip()
+            if line:
+                key, value = line.split('=', 1)
+                parsed[key] = value
         return parsed
 
     def extract_url(self, parameters):

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -32,6 +32,14 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
                           'host=git-codecommit.us-east-1.amazonaws.com\n'
                           'path=/v1/repos/myrepo')
 
+    PROTOCOL_HOST_PATH_TRAILING_NEWLINE = ('protocol=https\n'
+                                           'host=git-codecommit.us-east-1.amazonaws.com\n'
+                                           'path=/v1/repos/myrepo\n')
+
+    PROTOCOL_HOST_PATH_BLANK_LINE = ('protocol=https\n'
+                                     'host=git-codecommit.us-east-1.amazonaws.com\n'
+                                     'path=/v1/repos/myrepo\n\n')
+
     FIPS_PROTOCOL_HOST_PATH = ('protocol=https\n'
                                'host=git-codecommit-fips.us-east-1.amazonaws.com\n'
                                'path=/v1/repos/myrepo')
@@ -76,6 +84,24 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
     def test_generate_credentials(self, stdout_mock):
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_TRAILING_NEWLINE))
+    def test_generate_credentials_trailing_newline(self, stdout_mock):
+        self.get_command = CodeCommitGetCommand(self.session)
+        self.get_command._run_main(self.args, self.globals)
+        output = stdout_mock.getvalue().strip()
+        self.assertRegexpMatches(
+            output, 'username={0}\npassword=.+'.format('access'))
+
+    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_BLANK_LINE))
+    def test_generate_credentials_blank_line(self, stdout_mock):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()


### PR DESCRIPTION
The spec for the IO format
https://git-scm.com/docs/git-credential#IOFMT allows for a trailing
newline character. Previously the codecommit credential helper would
crash if presented with input that ended in a blank line. Some third
party github libraries emit this format, causing them to be
incompatible with the CLI, but still spec-compliant.

