### PR TITLE
Added example for passing JSON string as Input parameter

### DIFF
--- a/awscli/examples/events/put-targets.rst
+++ b/awscli/examples/events/put-targets.rst
@@ -4,7 +4,7 @@ This example adds a Lambda function as the target of a rule::
 
   aws events put-targets --rule DailyLambdaFunction --targets "Id"="1","Arn"="arn:aws:lambda:us-east-1:123456789012:function:MyFunctionName" 
 
-This example adds a Lambda function as the target of a rule and passes JSON payload to Input parameter::
+This example adds a Lambda function as the target of a rule and passes JSON string as Input parameter::
 
   aws events put-targets --rule DailyLambdaFunction --targets "Id"="1","Arn"="arn:aws:lambda:us-east-1:123456789012:function:MyFunctionName","Input"='"{\"Org\":\"AWS\"}"'
 

--- a/awscli/examples/events/put-targets.rst
+++ b/awscli/examples/events/put-targets.rst
@@ -4,6 +4,10 @@ This example adds a Lambda function as the target of a rule::
 
   aws events put-targets --rule DailyLambdaFunction --targets "Id"="1","Arn"="arn:aws:lambda:us-east-1:123456789012:function:MyFunctionName" 
 
+This example adds a Lambda function as the target of a rule and passes JSON payload to Input parameter::
+
+  aws events put-targets --rule DailyLambdaFunction --targets "Id"="1","Arn"="arn:aws:lambda:us-east-1:123456789012:function:MyFunctionName","Input"='"{\"Org\":\"AWS\"}"'
+
 This example sets an Amazon Kinesis stream as the target, so that events caught by this rule are relayed to the stream::
 
   aws events put-targets --rule EC2InstanceStateChanges --targets "Id"="1","Arn"="arn:aws:kinesis:us-east-1:123456789012:stream/MyStream","RoleArn"="arn:aws:iam::123456789012:role/MyRoleForThisRule"


### PR DESCRIPTION
*Issue #, if available: Many AWS users unable to figure out the syntax to pass JSON string to Input parameter.

*Description of changes:*
Added new example on how to pass JSON string as Input, when target is lambda function


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
