### PR TITLE
Add paramfile exception for apigatewayv2 integration-uri

### DIFF
--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 PARAMFILE_DISABLED = set([
     'api-gateway.put-integration.uri',
     'api-gateway.create-integration.integration-uri',
+    'api-gateway.update-integration.integration-uri',
     'api-gateway.create-api.target',
     'api-gateway.update-api.target',
     'appstream.create-stack.redirect-url',


### PR DESCRIPTION
This was added for the create-integration call but not for the
update-integration call. This PR brings them into sync.

