### PR TITLE
Pyyaml update

### DIFF
--- a/.changes/next-release/enhancement-PyYAML-42538.json
+++ b/.changes/next-release/enhancement-PyYAML-42538.json
@@ -1,0 +1,5 @@
+{
+  "category": "PyYAML", 
+  "type": "enhancement", 
+  "description": "Increased the uppber bound on the PyYAML dependency to 5.3."
+}

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -24,9 +24,10 @@ from contextlib import contextmanager
 EXTRA_RUNTIME_DEPS = [
     # Use an up to date virtualenv/pip/setuptools on > 2.6.
     ('virtualenv', '16.7.8'),
-    # The following is for python 3.4 compatibility.
+    # The following are for python 3.4 compatibility.
     ('colorama', '0.4.1'),
     ('urllib3', '1.25.7'),
+    ('PyYAML', '5.2'),
 ]
 BUILDTIME_DEPS = [
     ('setuptools-scm', '3.3.3'),

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,9 @@ requires-dist =
         botocore==1.15.10
         docutils>=0.10,<0.16
         rsa>=3.1.2,<=3.5.0
-        PyYAML>=3.10,<5.3
         s3transfer>=0.3.0,<0.4.0
+        PyYAML>=3.10,<5.3; python_version=='3.4'
+        PyYAML>=3.10,<5.4; python_version!='3.4'
         colorama>=0.2.5,<0.4.2; python_version=='3.4'
         colorama>=0.2.5,<0.4.4; python_version!='3.4'
 

--- a/setup.py
+++ b/setup.py
@@ -28,13 +28,14 @@ install_requires = [
     'docutils>=0.10,<0.16',
     'rsa>=3.1.2,<=3.5.0',
     's3transfer>=0.3.0,<0.4.0',
-    'PyYAML>=3.10,<5.3',
 ]
 
 
 if sys.version_info[:2] == (3, 4):
+    install_requires.append('PyYAML>=3.10,<5.3')
     install_requires.append('colorama>=0.2.5,<0.4.2')
 else:
+    install_requires.append('PyYAML>=3.10,<5.4')
     install_requires.append('colorama>=0.2.5,<0.4.4')
 
 


### PR DESCRIPTION
PyYAML dropped support for Python 3.4. So this now is a conditional dependency, and the last 3.4 compatible version (PyYAML 5.2) needs to be pulled into the bundled installer.

closes #4929, #4858 