### PR TITLE
CHANGELOG: 1.17.10 mentions new 'aws ecr get-login-password'

### DIFF
--- a/.changes/1.17.10.json
+++ b/.changes/1.17.10.json
@@ -33,5 +33,10 @@
     "category": "``iot``", 
     "description": "Update iot command to latest version", 
     "type": "api-change"
+  },
+  {
+    "category": "``ecr``",
+    "description": "Add ``get-login-password``, alternative to ``get-login`` (`#4874 <https://github.com/aws/aws-cli/issues/4874>`__)",
+    "type": "enhancement"
   }
 ]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -191,6 +191,7 @@ CHANGELOG
 * api-change:``storagegateway``: Update storagegateway command to latest version
 * api-change:``cloudfront``: Update cloudfront command to latest version
 * api-change:``iot``: Update iot command to latest version
+* api-change:``ecr``: Add get-login-password, alternative to get-login
 
 
 1.17.9

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -191,7 +191,7 @@ CHANGELOG
 * api-change:``storagegateway``: Update storagegateway command to latest version
 * api-change:``cloudfront``: Update cloudfront command to latest version
 * api-change:``iot``: Update iot command to latest version
-* api-change:``ecr``: Add get-login-password, alternative to get-login
+* enhancement:``ecr``: Add ``get-login-password``, alternative to ``get-login`` (`#4874 <https://github.com/aws/aws-cli/issues/4874>`__)
 
 
 1.17.9


### PR DESCRIPTION
The [v2.0.0 changelog entry](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst#200) includes:

> Removed support for the `ecr get-login` command in favor of `ecr get-login-password`

... however the new `get-login-password` isn't mentioned anywhere in CHANGELOG.rst.

The `get-login-password` command was introduced in #4874 in commit 00cfc2cb3739379ebd5fdb49cac8ef96b04f57a0 which merged in d1f7339b4 and was first tagged in 1.17.10:

```
$ git tag --contains 00cfc2cb | sort --version-sort | head -n1
1.17.10
```

---

This pull request updates the 1.17.10 changelog entry to mention this added `get-login-password` command.

This is important because awscli v2 completely drops the previous `get-login` command, and many downstream consumers/maintainers will be trying to understand the window of cross-compatibility where awscli supported both commands.

(Unfortunately, `get-login-password` only landed in 1.17.0 on 2020-02-05, and `get-login` was dropped as of v2.0.0 on 2020-02-11, so there's only six version-days of cross-compatibility. I understand the v2 release represents breaking changes and v1 is still being maintained for now, but it still puts dependent tooling like https://github.com/buildkite-plugins/ecr-buildkite-plugin in an awkward position of trying to detect and support both.)

Related context:

* `get-login-password` proposed in https://github.com/aws/aws-cli/issues/4867
* `get-login-password` implemented in https://github.com/aws/aws-cli/pull/4874
* `get-login` removed in https://github.com/aws/aws-cli/pull/4886
* Example of a dependent project version-pinning to v1 due to this change: https://github.com/buildkite/elastic-ci-stack-for-aws/pull/670

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
