### PR TITLE
[V2] Update --cli-auto-prompt wording

### DIFF
--- a/awscli/customizations/autoprompt.py
+++ b/awscli/customizations/autoprompt.py
@@ -158,9 +158,9 @@ class AutoPrompter(object):
     def _decide_next_action(self, cli_command):
         choice = self._prompter.select_from_choices(
             [{'actual_value': 'run-command',
-              'display': 'Execute CLI command'},
+              'display': 'Run CLI command'},
              {'actual_value': 'print-only',
-              'display': 'Print CLI command.'}],
+              'display': 'Display CLI command'}],
             display_formatter=lambda x: x['display']
         )['actual_value']
         if choice == 'print-only':

--- a/tests/unit/customizations/test_autoprompt.py
+++ b/tests/unit/customizations/test_autoprompt.py
@@ -93,7 +93,7 @@ class TestAutoPrompter(unittest.TestCase):
         self.command_name_parts = []
         self.prompter.select_from_choices.return_value = {
             'actual_value': 'print-only',
-            'display': 'Print CLI command.'
+            'display': 'Display CLI command'
         }
 
     def prompt_for_values(self):
@@ -135,7 +135,7 @@ class TestAutoPrompter(unittest.TestCase):
             # User selects they're done entering params.
             {'actual_value': self.auto_prompter.QUIT_SENTINEL, 'display': ''},
             # User selects they want to print the params.
-            {'actual_value': 'print-only', 'display': 'Print CLI command.'}
+            {'actual_value': 'print-only', 'display': 'Display CLI command'}
         ]
         self.prompter.prompt.side_effect = ['my-value-1', 'my-value-2']
         self.prompt_for_values()


### PR DESCRIPTION
This updates some of the prompts when using the `--cli-auto-prompt` flag to be consistent with other wording/formatting.