### PR TITLE
README: Promote aws-cli v2 on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-=======
-aws-cli
-=======
+==========
+aws-cli v1
+==========
 
 .. image:: https://travis-ci.org/aws/aws-cli.svg?branch=develop
    :target: https://travis-ci.org/aws/aws-cli
@@ -9,6 +9,11 @@ aws-cli
 .. image:: https://badges.gitter.im/aws/aws-cli.svg
    :target: https://gitter.im/aws/aws-cli
    :alt: Gitter
+
+.. attention::
+   aws-cli v2 has been released.  But we don't release it on PyPI.
+   Please read `the document <https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html>`__
+   for installing aws-cli v2.
 
 
 This package provides a unified command line interface to Amazon Web Services.


### PR DESCRIPTION
*Description of changes:*  aws-cli v2 is not released on PyPI but many people still use PyPI.
This pull request add note about aws-cli v2 in README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
