### PR TITLE
Update emr ebs-root-volume-size help text to match docs

### DIFF
--- a/awscli/customizations/emr/helptext.py
+++ b/awscli/customizations/emr/helptext.py
@@ -334,7 +334,7 @@ INSTALL_APPLICATIONS = (
     '<code>Name</code> and <code>Args</code>.</p>')
 
 EBS_ROOT_VOLUME_SIZE = (
-    '<p>Applies only to Amazon EMR release version 4.0 and earlier. Specifies the size,'
+    '<p>This option is available only with Amazon EMR version 4.x and later. Specifies the size,'
     ' in GiB, of the EBS root device volume of the Amazon Linux AMI'
     ' that is used for each EC2 instance in the cluster. </p>')
 


### PR DESCRIPTION
update ebs-root-volume-size text to match https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-custom-ami-boot-volume-size.html

*Issue #, if available:*

https://github.com/aws/aws-cli/issues/5033

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
