### PR TITLE
timespec=milliseconds instead of microseconds

### DIFF
--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -134,7 +134,7 @@ def find_service_and_method_in_event_name(event_name):
 def json_encoder(obj):
     """JSON encoder that formats datetimes as ISO8601 format."""
     if isinstance(obj, datetime.datetime):
-        return obj.isoformat()
+        return obj.isoformat(timespec='milliseconds')
     else:
         return obj
 


### PR DESCRIPTION
*Issue #5045*

*Description of changes:*

Timestamps don't need the extra 3 zeros for microseconds. Milliseconds should be enough.
It feels like a regression based on aws-cli V1 8601 timestamp format.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

It's late on a Saturday night and I had trouble installing the deps to build locally so this is an untested DRAFT to point out where I think the change needs to be made.
