### PR TITLE
[v2] enable offline builds for deployments

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,5 @@
+# Requirements we need to run our build jobs for the installers.
+# We create the separation for cases where we're doing installation
+# from a local dependency directory instead of requirements.txt.
+cryptography==2.8
+PyInstaller==3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 tox>=2.3.1,<3.0.0
 nose==1.3.7
 mock==1.3.0
-cryptography>=2.8.0,<=2.9.0
 wheel==0.24.0
 ruamel.yaml>=0.15.0,<0.16.0
 jsonschema==2.5.1
-PyInstaller==3.5
+-r requirements-build.txt
 https://github.com/boto/botocore/zipball/v2#egg=botocore

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -1,0 +1,74 @@
+import os
+
+from utils import cd, bin_path, run, virtualenv_enabled
+
+INSTALL_ARGS = "--no-binary :all: --no-build-isolation --no-cache-dir --no-index "
+PINNED_PIP_VERSION = '20.0.2'
+SETUP_DEPS = ("setuptools-", "setuptools_scm", "wheel")
+
+
+class InstallationError(Exception):
+    pass
+
+
+def get_package_tarball(package_dir, package_prefix):
+    package_filenames = sorted(
+        [p for p in os.listdir(package_dir) if p.startswith(package_prefix)]
+    )
+    if len(package_filenames) == 0:
+        raise InstallationError(
+            "Unable to find local package starting with %s prefix." % package_prefix
+        )
+    # We only expect a single package from the downloader
+    return package_filenames[0]
+
+
+def install_local_package(package_dir, package, pip_script="pip"):
+    with cd(package_dir):
+        run(
+            "%s install %s --find-links file://%s %s"
+            % (pip_script, INSTALL_ARGS, package_dir, package)
+        )
+
+
+def find_and_install_tarball(package_dir, package_prefix, pip_script="pip"):
+    tarball = get_package_tarball(package_dir, package_prefix)
+    install_local_package(package_dir, tarball, pip_script)
+
+
+def pip_install_packages(package_dir):
+    package_dir = os.path.abspath(package_dir)
+
+    # Setup pip to support modern setuptools calls
+    pip_script = os.path.join(os.environ["VIRTUAL_ENV"], bin_path(), "pip")
+    local_python = os.path.join(os.environ["VIRTUAL_ENV"], bin_path(), "python")
+
+    # Windows can't replace a running pip.exe, so we need to work around
+    run("%s -m pip install pip==%s" % (local_python, PINNED_PIP_VERSION))
+
+    # Install or update prerequisite build packages
+    setup_requires_dir = os.path.join(package_dir, "setup")
+    install_setup_deps(pip_script, setup_requires_dir)
+
+    find_and_install_tarball(package_dir, "awscli", pip_script)
+
+
+def install_setup_deps(pip_script, setup_package_dir):
+    # These packages need to be installed in this order before we
+    # attempt anything else in order to support PEP517 setup_requires
+    # specifications.
+
+    # We need setuptools >= 37.0.0 for setuptools_scm to work properly
+    for setup_dep in SETUP_DEPS:
+        find_and_install_tarball(setup_package_dir, setup_dep, pip_script)
+
+
+def install_packages(package_dir):
+    """Builds setup environment and installs copies of local packages for CLI"""
+
+    if not virtualenv_enabled():
+        raise InstallationError(
+            "Installation being performed outside of a virtualenv. Please enable before running."
+        )
+    else:
+        pip_install_packages(package_dir)

--- a/scripts/installers/make-exe
+++ b/scripts/installers/make-exe
@@ -13,6 +13,7 @@ from distutils.dir_util import copy_tree
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils import run, tmp_dir
+from install_deps import install_packages
 
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
@@ -103,9 +104,24 @@ def main():
             'useful for debugging.'
         ),
     )
+    parser.add_argument(
+        '--src-dir',
+        default=None,
+        help=(
+            'Source directory for pinned installation dependencies. This '
+            'provides the ability to do offline builds without PyPI.'
+        ),
+    )
     args = parser.parse_args()
 
     output = os.path.abspath(args.output)
+    if args.src_dir:
+        print('Installing dependencies from local directory: %s' % args.src_dir)
+        install_packages(args.src_dir)
+    else:
+        run('pip install -r requirements.txt')
+        run('pip install .')
+
     make_exe(output, cleanup=args.cleanup)
 
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import platform
 import shutil
 import sys
 import subprocess
@@ -47,3 +48,31 @@ def tmp_dir():
         yield dirname
     finally:
         shutil.rmtree(dirname)
+
+
+@contextlib.contextmanager
+def cd(dirname):
+    original = os.getcwd()
+    os.chdir(dirname)
+    try:
+        yield
+    finally:
+        os.chdir(original)
+
+
+def bin_path():
+    """Get the system's binary path, either `bin` on reasonable systems
+    or `Scripts` on Windows.
+    """
+    path = "bin"
+
+    if platform.system() == "Windows":
+        path = "Scripts"
+
+    return path
+
+
+def virtualenv_enabled():
+    # Helper function to see if we need to make
+    # our own virtualenv for installs.
+    return bool(os.environ.get('VIRTUAL_ENV'))

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,7 @@ commands =
 [testenv:exe]
 basepython = python3.7
 deps =
-    -r{toxinidir}/requirements.txt
-    {toxinidir}
+    -r{toxinidir}/requirements-build.txt
 commands =
     {envpython} {toxinidir}/scripts/installers/make-exe {posargs}
 
@@ -37,8 +36,5 @@ commands =
 
 [testenv:sign-exe]
 basepython = python3.7
-deps =
-    -r{toxinidir}/requirements.txt
-    {toxinidir}
 commands =
     {envpython} {toxinidir}/scripts/installers/sign-exe {posargs}


### PR DESCRIPTION
We want to improve build reproducibility for the v2 installer and generate exact artifacts for what was used to create the build. This will allow us to optionally supply a curated set of tarballs/wheels to perform the installs without the need of an active PyPI server or internet connection.

