### PR TITLE
[v2] Revert yaml comments

### DIFF
--- a/.changes/next-release/bugfix-cloudformation-93359.json
+++ b/.changes/next-release/bugfix-cloudformation-93359.json
@@ -1,0 +1,5 @@
+{
+  "category": "cloudformation",
+  "type": "bugfix",
+  "description": "Revert pr that added support for comments https://github.com/aws/aws-cli/pull/4873. Comment support also changed from using the 'safe' yaml representer to the 'rt' (round trip) yaml representer. In some cases this causes the `package` command to emit yaml that the CloudFormation service cannot parse, resulting in a service error."
+}

--- a/tests/functional/cloudformation/deploy_templates/nested-tag/input.yml
+++ b/tests/functional/cloudformation/deploy_templates/nested-tag/input.yml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+
+Mappings:
+  AccountMap:
+    dev:
+      AccountId: '112233445566'
+    prod:
+      AccountId: '1111222233333'
+
+Parameters:
+  Environment:
+    Type: String
+    Description: The environment name
+    Default: test
+    AllowedValues:
+      - test
+      - prod
+
+Resources:
+  MyLambda:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: no_artifacts
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/java:openjdk-8
+        Type: LINUX_CONTAINER
+      Name: "FOO"
+      Source:
+        Type: CODECOMMIT
+        Location: "https://git-codecommit.us-west-2.amazonaws.com/v1/repos/foo"
+      Policies:
+        - Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action:
+                - sts:AssumeRole
+              Resource:
+                - !Join ['', ['arn:aws:iam::', !FindInMap [AccountMap, test, AccountId], ':role/InvokeLambdaRole']]
+                - !Join ['', ['arn:aws:iam::', !FindInMap [AccountMap, prod, AccountId], ':role/InvokeLambdaRole']]

--- a/tests/functional/cloudformation/deploy_templates/nested-tag/output.yml
+++ b/tests/functional/cloudformation/deploy_templates/nested-tag/output.yml
@@ -1,0 +1,53 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::Serverless-2016-10-31
+Mappings:
+  AccountMap:
+    dev:
+      AccountId: '112233445566'
+    prod:
+      AccountId: '1111222233333'
+Parameters:
+  Environment:
+    Type: String
+    Description: The environment name
+    Default: test
+    AllowedValues:
+    - test
+    - prod
+Resources:
+  MyLambda:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: no_artifacts
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/java:openjdk-8
+        Type: LINUX_CONTAINER
+      Name: FOO
+      Source:
+        Type: CODECOMMIT
+        Location: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/foo
+      Policies:
+      - Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Action:
+          - sts:AssumeRole
+          Resource:
+          - Fn::Join:
+            - ''
+            - - 'arn:aws:iam::'
+              - Fn::FindInMap:
+                - AccountMap
+                - test
+                - AccountId
+              - :role/InvokeLambdaRole
+          - Fn::Join:
+            - ''
+            - - 'arn:aws:iam::'
+              - Fn::FindInMap:
+                - AccountMap
+                - prod
+                - AccountId
+              - :role/InvokeLambdaRole

--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -19,6 +19,8 @@ import zipfile
 
 from unittest import TestCase
 from awscli.customizations.cloudformation.artifact_exporter import make_zip
+from awscli.customizations.cloudformation.yamlhelper import yaml_dump
+from awscli.customizations.cloudformation.artifact_exporter import Template
 from awscli.testutils import skip_if_windows
 
 
@@ -59,3 +61,25 @@ class TestPackageZipFiles(TestCase):
 
         # Its content should be equal the value we wrote.
         self.assertEquals(data.encode("utf-8"), myfile.read())
+
+
+def test_known_templates():
+    test_case_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        'deploy_templates'
+    )
+    for case in os.listdir(test_case_path):
+        case_path = os.path.join(test_case_path, case)
+        yield (
+            _assert_input_does_match_expected_output,
+            os.path.join(case_path, 'input.yml'),
+            os.path.join(case_path, 'output.yml'),
+        )
+
+
+def _assert_input_does_match_expected_output(input_template, output_template):
+    template = Template(input_template, os.getcwd(), None)
+    exported = template.export()
+    result = yaml_dump(exported)
+
+    assert result == open(output_template, 'r').read()

--- a/tests/functional/ddb/test_put.py
+++ b/tests/functional/ddb/test_put.py
@@ -25,22 +25,10 @@ class TestPut(BaseAWSCommandParamsTest):
         super(TestPut, self).setUp()
         self.parsed_response = {}
         self.tempdir = tempfile.mkdtemp()
-        self.original_tag_handlers = yaml.YAML(typ='safe').constructor\
-            .yaml_constructors.copy()
 
     def tearDown(self):
         super(TestPut, self).tearDown()
         shutil.rmtree(self.tempdir)
-        # This line looks wrong, right?  Well... the "yaml_constructors"
-        # is actually a class attribute that's shared across *all* of the
-        # yaml.YAML() instances.  Because the ddb customization registers
-        # a custom handler for the binary and float types, this will break
-        # other code (and tests) that rely on the default behavior.  So
-        # to fix this, we put back the original tag handlers that we saved
-        # in self.original_tag_handlers to ensure we handle binary and
-        # float types correctly.
-        yaml.YAML(typ='safe').constructor.yaml_constructors.update(
-            self.original_tag_handlers)
 
     def assert_yaml_response_equal(self, response, expected):
         with self.assertRaises(ValueError):

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -24,8 +24,6 @@ from awscli.customizations.cloudformation.yamlhelper import yaml_parse, yaml_dum
 
 class TestYaml(unittest.TestCase):
 
-    maxDiff = None
-
     yaml_with_tags = """
     Resource:
         Key1: !Ref Something
@@ -158,18 +156,19 @@ class TestYaml(unittest.TestCase):
             <<: *base
         """
         output = yaml_parse(test_yaml)
+        self.assertTrue(isinstance(output, OrderedDict))
         self.assertEqual(output.get('test').get('property'), 'value')
 
     def test_unroll_yaml_anchors(self):
-        properties = OrderedDict([
-            ("Foo", "bar"),
-            ("Spam", "eggs"),
-        ])
+        properties = {
+            "Foo": "bar",
+            "Spam": "eggs",
+        }
         template = {
-            "Resources": OrderedDict([
-                ("Resource1", {"Properties": properties}),
-                ("Resource2", {"Properties": properties}),
-            ])
+            "Resources": {
+                "Resource1": {"Properties": properties},
+                "Resource2": {"Properties": properties}
+            }
         }
 
         expected = (
@@ -185,15 +184,3 @@ class TestYaml(unittest.TestCase):
         )
         actual = yaml_dump(template)
         self.assertEqual(actual, expected)
-
-    def test_can_roundtrip_comments(self):
-        test_yaml = (
-            'foo:\n # This is a comment'
-            '  # So is this.\n'
-            '  bar: baz\n'
-            '  baz: qux  # Another comment\n'
-            'list: [1, 2, 3] # List comment\n'
-        )
-        parsed = yaml_parse(test_yaml)
-        round_tripped = yaml_dump(parsed)
-        self.assertEqual(test_yaml, round_tripped)


### PR DESCRIPTION
Previously we merged a change to switch ruamel to use its `rt` (round trip) yaml representer instead of the `safe` one. The change enabled ruamel to parse comments from yaml documents and put them back in the emitted document approximately where they were before. As the name implies the `rt`represented also tries to keep the source and destination documents as close to the same as possible in formatting and style. This has introduced edge cases where ruamel will generate templates that CloudFormation cannot parse. One example [here](https://github.com/aws/aws-cli/issues/4955). There are multiple issues in that one example, both the expanded `Fn::FindInMap` inside of a json style list, and the unquoted `:role/InvokeLambdaRole` cause CloudFormation to return a parse error.

Because of this we are reverting back to use the `safe` representer, which outputs yaml in a consistent format, which CloudFormation can parse. Adding comment support is something we would like to add back in the future.