### PR TITLE
Add shorthand parser error for duplicate keys set on same object

### DIFF
--- a/.changes/next-release/enhancement-shorthand-94224.json
+++ b/.changes/next-release/enhancement-shorthand-94224.json
@@ -1,0 +1,5 @@
+{
+  "category": "shorthand", 
+  "type": "enhancement", 
+  "description": "The CLI now no longer allows a key to be spcified twice in a shorthand parameter. For example foo=bar,foo=baz would previously be accepted, with only baz being set, and foo=bar silently being ignored. Now an error will be raised pointing out the issue, and suggesting a fix."
+}

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -55,15 +55,8 @@ class _NamedRegex(object):
 
 
 class ShorthandParseError(Exception):
-    def __init__(self, value, expected, actual, index):
-        self.value = value
-        self.expected = expected
-        self.actual = actual
-        self.index = index
-        msg = self._construct_msg()
-        super(ShorthandParseError, self).__init__(msg)
 
-    def _construct_msg(self):
+    def _error_location(self):
         consumed, remaining, num_spaces = self.value, '', self.index
         if '\n' in self.value[:self.index]:
             # If there's newlines in the consumed expression, we want
@@ -83,13 +76,40 @@ class ShorthandParseError(Exception):
             next_newline = self.index + self.value[self.index:].index('\n')
             consumed = self.value[:next_newline]
             remaining = self.value[next_newline:]
+        return '%s\n%s%s' % (consumed, (' ' * num_spaces) + '^', remaining)
+
+
+class ShorthandParseSyntaxError(ShorthandParseError):
+    def __init__(self, value, expected, actual, index):
+        self.value = value
+        self.expected = expected
+        self.actual = actual
+        self.index = index
+        msg = self._construct_msg()
+        super(ShorthandParseSyntaxError, self).__init__(msg)
+
+    def _construct_msg(self):
         msg = (
             "Expected: '%s', received: '%s' for input:\n"
-            "%s\n"
             "%s"
-            "%s"
-        ) % (self.expected, self.actual, consumed,
-             ' ' * num_spaces + '^', remaining)
+        ) % (self.expected, self.actual, self._error_location())
+        return msg
+
+
+class DuplicateKeyInObjectError(ShorthandParseError):
+    def __init__(self, key, value, index):
+        self.key = key
+        self.value = value
+        self.index = index
+        msg = self._construct_msg()
+        super(DuplicateKeyInObjectError, self).__init__(msg)
+
+    def _construct_msg(self):
+        msg = (
+            "Second instance of key \"%s\" encountered for input:\n%s\n"
+            "This is often because there is a preceeding \",\" instead of a "
+            "space."
+        ) % (self.key, self._error_location())
         return msg
 
 
@@ -148,10 +168,20 @@ class ShorthandParser(object):
     def _parameter(self):
         # parameter = keyval *("," keyval)
         params = {}
-        params.update(self._keyval())
+        key, val = self._keyval()
+        params[key] = val
+        last_index = self._index
         while self._index < len(self._input_value):
             self._expect(',', consume_whitespace=True)
-            params.update(self._keyval())
+            key, val = self._keyval()
+            # If a key is already defined, it is likely an incorrectly written
+            # shorthand argument. Raise an error to inform the user.
+            if key in params:
+                raise DuplicateKeyInObjectError(
+                    key, self._input_value, last_index + 1
+                )
+            params[key] = val
+            last_index = self._index
         return params
 
     def _keyval(self):
@@ -159,7 +189,7 @@ class ShorthandParser(object):
         key = self._key()
         self._expect('=', consume_whitespace=True)
         values = self._values()
-        return {key: values}
+        return key, values
 
     def _key(self):
         # key = 1*(alpha / %x30-39 / %x5f / %x2e / %x23)  ; [a-zA-Z0-9\-_.#/]
@@ -210,7 +240,7 @@ class ShorthandParser(object):
                     break
                 self._expect(',', consume_whitespace=True)
                 csv_list.append(current)
-            except ShorthandParseError:
+            except ShorthandParseSyntaxError:
                 # Backtrack to the previous comma.
                 # This can happen when we reach this case:
                 # foo=a,b,c=d,e=f
@@ -312,12 +342,12 @@ class ShorthandParser(object):
         if consume_whitespace:
             self._consume_whitespace()
         if self._index >= len(self._input_value):
-            raise ShorthandParseError(self._input_value, char,
-                                      'EOF', self._index)
+            raise ShorthandParseSyntaxError(self._input_value, char,
+                                            'EOF', self._index)
         actual = self._input_value[self._index]
         if actual != char:
-            raise ShorthandParseError(self._input_value, char,
-                                      actual, self._index)
+            raise ShorthandParseSyntaxError(self._input_value, char,
+                                            actual, self._index)
         self._index += 1
         if consume_whitespace:
             self._consume_whitespace()
@@ -326,8 +356,8 @@ class ShorthandParser(object):
         result = regex.match(self._input_value[self._index:])
         if result is not None:
             return self._consume_matched_regex(result)
-        raise ShorthandParseError(self._input_value, '<%s>' % regex.name,
-                                  '<none>', self._index)
+        raise ShorthandParseSyntaxError(self._input_value, '<%s>' % regex.name,
+                                        '<none>', self._index)
 
     def _consume_matched_regex(self, result):
         start, end = result.span()

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -174,6 +174,10 @@ def test_error_parsing():
     yield (_is_error, "foo={bar=bar")
     yield (_is_error, "foo=bar,")
     yield (_is_error, "foo==bar,\nbar=baz")
+    # Duplicate keys should error otherwise they silently
+    # set only one of the values.
+    yield (_is_error, 'foo=bar,foo=qux')
+
 
 def _is_error(expr):
     try:


### PR DESCRIPTION
Currently it is not an error in the shorthand parser if you specify a
second key/value pair with the same key as a previous one. Only one of
these values will actually be set, depending on the version of python
it could be either the first or second.

This is a disproportionately larger issue than it seems (not a big issue
for JSON) because of unfamiliarity with the shorthand parser
syntax. There are also commonly used ec2 APIs that accept a list of
objects in the form Key=key,Value=value Key=key2,Value=value2. This is
a list of two dictionaries each with two keys Key and Value.

A common issue people run into is to write the previous example as
Key=key,Value=value,Key=key2,Value=value2 separating the list items
with a comma as well as the dictionary entries. This is now one
dictionary with two keys named Key and two keys named
Value. Previously this would be accepted and silently drop the
duplicates. Instead now you will get the following error:
```
Error parsing parameter '--attributes': Second instance of key "Key" encountered for input:
Key=key1,Value=value1,Key=key2,Value=value2
                      ^
This is often because there is a preceding "," instead of a space.
```