### PR TITLE
Add support for writing aws_security_token to credentials file

### DIFF
--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -38,7 +38,7 @@ class ConfigureSetCommand(BasicCommand):
     # Any variables specified in this list will be written to
     # the ~/.aws/credentials file instead of ~/.aws/config.
     _WRITE_TO_CREDS_FILE = ['aws_access_key_id', 'aws_secret_access_key',
-                            'aws_session_token']
+                            'aws_session_token', 'aws_security_token']
 
     def __init__(self, session, config_writer=None):
         super(ConfigureSetCommand, self).__init__(session)


### PR DESCRIPTION
*Issue #5084 

*Description of changes:*
Adds `aws_security_token` to the credentials file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
