### PR TITLE
Change pip requirements to pull via HTTPS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ tox>=2.3.1,<3.0.0
 # botocore and the awscli packages are typically developed
 # in tandem, so we're requiring the latest develop
 # branch of botocore and s3transfer when working on the awscli.
--e git://github.com/boto/botocore.git@develop#egg=botocore
--e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
+-e git+https://github.com/boto/botocore.git@develop#egg=botocore
+-e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer
 nose==1.3.7
 mock==1.3.0
 # TODO: this can now be bumped


### PR DESCRIPTION
This changes requirements.txt so that `pip install -r requirements.txt`
will pull all its dependencies via HTTPS rather than SSH.

This will allow users behind a restrictive enterprise proxy to get started
without having to change aws-cli before even being able to start working with it.

*Issue #5087 

*Description of changes:*

* Changed the URL pattern in requirements.txt