### PR TITLE
describe-instance-status example - correct option

### DIFF
--- a/awscli/examples/ec2/describe-instance-status.rst
+++ b/awscli/examples/ec2/describe-instance-status.rst
@@ -4,7 +4,7 @@ This example describes the current status of the specified instance.
 
 Command::
 
-  aws ec2 describe-instance-status --instance-id i-1234567890abcdef0
+  aws ec2 describe-instance-status --instance-ids i-1234567890abcdef0
 
 Output::
 


### PR DESCRIPTION
_re-submission of #5044 against the `develop` branch_
*Description of changes:*

Proposing changing the option for passing instance IDs to what's listed in the [documentation]:(https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instance-status.html#options)
![image](https://user-images.githubusercontent.com/416477/76132716-227e7700-5fc9-11ea-8a85-82f46c8c5e87.png)
```diff
- instance-id
+ instance-ids
```
Although both options work in my testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
