### PR TITLE
[v2] Fix log tail bug when it doesn't pick up new log streams during polling

### DIFF
--- a/.changes/next-release/bugfix-logstail-46066.json
+++ b/.changes/next-release/bugfix-logstail-46066.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``logs tail``",
+  "description": "Fix bug when we're using --follow parameter. It wasn't picking newly created streams during polling."
+}

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from _collections import  defaultdict
 from datetime import datetime, timedelta
 import re
 import time
@@ -294,20 +295,31 @@ class FollowLogEventsGenerator(BaseLogEventsGenerator):
             return
 
     def _do_filter_log_events(self, filter_logs_events_kwargs):
-        last_event_ids = []
+        event_ids_per_timestamp = defaultdict(set)
         while True:
             response = self._client.filter_log_events(
                 **filter_logs_events_kwargs)
             for event in response['events']:
                 # For the case where we've hit the last page, we will be
-                # reusing the most recent nextToken to continue polling. This
-                # means it is possible that duplicate log events from the last
-                # page are returned back which we do not want to yield again.
+                # reusing the newest timestamp of the received events to keep polling.
+                # This means it is possible that duplicate log events with same timestamp
+                # are returned back which we do not want to yield again.
                 # We only want to yield log events that we have not seen.
-                if event['eventId'] not in last_event_ids:
+                if event['eventId'] not in event_ids_per_timestamp[event['timestamp']]:
+                    event_ids_per_timestamp[event['timestamp']].add(event['eventId'])
                     yield event
-            last_event_ids = [event['eventId'] for event in response['events']]
+            if event_ids_per_timestamp.keys():
+                # Store ids of the events with the newest timestamp only
+                newest_timestamp = max(event_ids_per_timestamp.keys())
+                event_ids_per_timestamp = defaultdict(
+                    set, {newest_timestamp: event_ids_per_timestamp[newest_timestamp]}
+                )
             if 'nextToken' in response:
                 filter_logs_events_kwargs['nextToken'] = response['nextToken']
             else:
+                # Remove nextToken and update startTime for the next request
+                # with the timestamp of the newest event
+                if event_ids_per_timestamp.keys():
+                    filter_logs_events_kwargs['startTime'] = max(event_ids_per_timestamp.keys())
+                filter_logs_events_kwargs.pop('nextToken', None)
                 self._sleep(self._TIME_TO_SLEEP)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix bug when we're using `logs tail` with `--follow` parameter. It wasn't picking newly created streams during polling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
