### PR TITLE
Example for multiple environment variables in shorthand

### DIFF
--- a/awscli/examples/elasticbeanstalk/update-environment.rst
+++ b/awscli/examples/elasticbeanstalk/update-environment.rst
@@ -35,7 +35,7 @@ The following command sets the value of the "PARAM1" variable in the "my-env" en
 
 The ``option-settings`` parameter takes a namespace in addition to the name and value of the variable. Elastic Beanstalk supports several namespaces for options in addition to environment variables.
 
-**To set multiple environment variables in shorthand form**
+**To set multiple environment variables using shorthand syntax**
 aws elasticbeanstalk update-environment --environment-name my-env --option-settings Namespace=aws:elasticbeanstalk:application:environment,OptionName=PARAM1,Value=ParamValue Namespace=aws:elasticbeanstalk:application:environment,OptionName=PARAM2,Value=Param2Value
 
 **To configure option settings from a file**

--- a/awscli/examples/elasticbeanstalk/update-environment.rst
+++ b/awscli/examples/elasticbeanstalk/update-environment.rst
@@ -35,6 +35,9 @@ The following command sets the value of the "PARAM1" variable in the "my-env" en
 
 The ``option-settings`` parameter takes a namespace in addition to the name and value of the variable. Elastic Beanstalk supports several namespaces for options in addition to environment variables.
 
+**To set multiple environment variables in shorthand form**
+aws elasticbeanstalk update-environment --environment-name my-env --option-settings Namespace=aws:elasticbeanstalk:application:environment,OptionName=PARAM1,Value=ParamValue Namespace=aws:elasticbeanstalk:application:environment,OptionName=PARAM2,Value=Param2Value
+
 **To configure option settings from a file**
 
 The following command configures several options in the ``aws:elb:loadbalancer`` namespace from a file::


### PR DESCRIPTION
When using through CI/CD pipelines, the json option may not be available. It took me the better part of 2 days to discover how to set multiple environment variables in shorthand form so an example here would be very useful for other beginners.

*Issue #, if available:*

*Description of changes:*
Added an example to --option-settings to show how multiple settings can be set using shorthand form.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
