### PR TITLE
[v2] Update testing for v2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+jsonschema==2.5.1
+nose==1.3.7
+mock==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 tox>=2.3.1,<3.0.0
-nose==1.3.7
-mock==1.3.0
 wheel==0.24.0
 ruamel.yaml>=0.15.0,<0.16.0
-jsonschema==2.5.1
+-r requirements-test.txt
 -r requirements-build.txt
 https://github.com/boto/botocore/zipball/v2#egg=botocore

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -305,10 +305,8 @@ class TestBasicCommandFunctionality(unittest.TestCase):
 
     def test_error_msg_with_no_region_configured(self):
         environ = os.environ.copy()
-        try:
-            del environ['AWS_DEFAULT_REGION']
-        except KeyError:
-            pass
+        environ.pop('AWS_REGION', None)
+        environ.pop('AWS_DEFAULT_REGION', None)
         environ['AWS_CONFIG_FILE'] = 'nowhere-foo'
         p = aws('ec2 describe-instances', env_vars=environ)
         self.assertIn('must specify a region', p.stderr)

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -121,7 +121,7 @@ def _aws(command_string, max_attempts=1, delay=5, target_rc=0):
     env = None
     if service in REGION_OVERRIDES:
         env = os.environ.copy()
-        env['AWS_DEFAULT_REGION'] = REGION_OVERRIDES[service]
+        env['AWS_REGION'] = REGION_OVERRIDES[service]
 
     for _ in range(max_attempts - 1):
         result = aws(command_string, env_vars=env)


### PR DESCRIPTION
Specifically made the following updates:

* Broke out the testing requirements into its own separate file: `requirements-test.txt`. This allows us to only have to install that file if the CLI is already installed or installed via a different mechanism.

* Fix some of the integration tests. Specifically, we had tests that did not account for the `AWS_REGION` environment variable being set, which would override the region we would set in the integration tests.
