### PR TITLE
[v2] Isolate doc generation requirements

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,2 @@
-docutils>=0.10,<0.16
 Sphinx==3.0.2
 sphinx-notfound-page==0.4
--e .


### PR DESCRIPTION
Similar to this PR: https://github.com/aws/aws-cli/pull/5139. This allows us to isolate additional dependencies needed for just documentation generation in the case the CLI is already installed or installed via different mechanism than an editable install.
