### PR TITLE
Allow virtual style S3 template urls for cloudformation package

### DIFF
--- a/.changes/next-release/bugfix-cloudformation-6207.json
+++ b/.changes/next-release/bugfix-cloudformation-6207.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "cloudformation",
+  "description": "Fixed an issue with ``cloudformation package`` where virtual style S3 URLs were incorrectly validated for a stack resource's template URL."
+}

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -438,8 +438,8 @@ class CloudFormationStackResource(Resource):
         template_path = resource_dict.get(self.PROPERTY_NAME, None)
 
         if template_path is None or is_s3_url(template_path) or \
-                template_path.startswith(self.uploader.s3.meta.endpoint_url) or \
-                template_path.startswith("https://s3.amazonaws.com/"):
+                template_path.startswith("http://") or \
+                template_path.startswith("https://"):
             # Nothing to do
             return
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -723,41 +723,36 @@ class TestArtifactExporter(unittest.TestCase):
             self.s3_uploader_mock.upload_with_dedup.assert_called_once_with(mock.ANY, "template")
             self.s3_uploader_mock.to_path_style_s3_url.assert_called_once_with("world", None)
 
-    def test_export_cloudformation_stack_no_upload_path_is_s3url(self):
+    def _assert_stack_template_url_is_not_changed(self, s3_url):
         stack_resource = CloudFormationStackResource(self.s3_uploader_mock)
         resource_id = "id"
         property_name = stack_resource.PROPERTY_NAME
-        s3_url = "s3://hello/world"
         resource_dict = {property_name: s3_url}
 
         # Case 1: Path is already S3 url
         stack_resource.export(resource_id, resource_dict, "dir")
         self.assertEquals(resource_dict[property_name], s3_url)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+
+    def test_export_cloudformation_stack_no_upload_path_is_s3url(self):
+        s3_url = "s3://hello/world"
+        self._assert_stack_template_url_is_not_changed(s3_url)
 
     def test_export_cloudformation_stack_no_upload_path_is_httpsurl(self):
-        stack_resource = CloudFormationStackResource(self.s3_uploader_mock)
-        resource_id = "id"
-        property_name = stack_resource.PROPERTY_NAME
         s3_url = "https://s3.amazonaws.com/hello/world"
-        resource_dict = {property_name: s3_url}
-
-        # Case 1: Path is already S3 url
-        stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict[property_name], s3_url)
-        self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+        self._assert_stack_template_url_is_not_changed(s3_url)
 
     def test_export_cloudformation_stack_no_upload_path_is_s3_region_httpsurl(self):
-        stack_resource = CloudFormationStackResource(self.s3_uploader_mock)
-        resource_id = "id"
-        property_name = stack_resource.PROPERTY_NAME
-
         s3_url = "https://s3.some-valid-region.amazonaws.com/hello/world"
-        resource_dict = {property_name: s3_url}
+        self._assert_stack_template_url_is_not_changed(s3_url)
 
-        stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict[property_name], s3_url)
-        self.s3_uploader_mock.upload_with_dedup.assert_not_called()
+    def test_export_cloudformation_stack_no_upload_path_is_virtual(self):
+        s3_url = "https://bucket.s3.amazonaws.com/key"
+        self._assert_stack_template_url_is_not_changed(s3_url)
+
+    def test_export_cloudformation_stack_no_upload_path_is_virtual_region(self):
+        s3_url = "https://bucket.s3.some-region.amazonaws.com/key"
+        self._assert_stack_template_url_is_not_changed(s3_url)
 
     def test_export_cloudformation_stack_no_upload_path_is_empty(self):
         stack_resource = CloudFormationStackResource(self.s3_uploader_mock)


### PR DESCRIPTION
If the `TemplateURL` for a stack resource in a template provided to cloudformation package was using S3's virtual addressing scheme it would be treated as a local file path to upload. This was due to some overly aggressive client side validation for what constitutes a 'valid S3 url'. Given that we can't do much if it's already a URL (S3 or not) I've toned down what we look for on the client side, especially given how complex S3 URLs have become recently (e.g. s3 access points). We should just leave determining whether the URL is valid to cloudformation. 
