### PR TITLE
Add banner to documentation layout from cli v1 to v2 docs

### DIFF
--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -81,6 +81,21 @@
           {%- block sidebar1 %}{{ sidebar() }}{% endblock %}
           {%- block document %}
             <div class="body">
+                <div class="well">
+                    <p>
+                        <strong>Note:</strong>
+                        You are viewing the documentation for an older major version of the AWS CLI (version 1).
+                    </p>
+                    <p>
+                        AWS CLI version 2, the latest major version of AWS CLI, is now stable and recommended for general use.
+                        To view this page for the AWS CLI version 2, click
+                        <a href="https://awscli.amazonaws.com/v2/documentation/api/latest/{{ pagename }}.html">here</a>.
+                        For more information see the AWS CLI version 2
+                        <a href="https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html">installation instructions</a>
+                        and
+                        <a href="https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html">migration guide</a>.
+                    </p>
+                </div>
               {% block body %} {% endblock %}
             </div>
           {%- endblock %}


### PR DESCRIPTION
Add banner to the top of each page of the AWS CLI version 1 documentation with link to AWS CLI v2 documentation, migration guide and installation instructions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
