### PR TITLE
Removed redundant parser assignment

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -143,7 +143,6 @@ class CLIDriver(object):
         return commands
 
     def _add_aliases(self, command_table, parser):
-        parser = self._create_parser(command_table)
         injector = AliasCommandInjector(
             self.session, self.alias_loader)
         injector.inject_aliases(command_table, parser)


### PR DESCRIPTION
`parser` is passed as a parameter when `_add_aliases()` is called in `main()`. However, `parser` is then re-declared on line 145 to the very same thing it is assigned before `_add_aliases()` is called (line 203).

This PR removes the redundant assignment of `parser`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
