### PR TITLE
[v2] Add environment variable to set encoding used for text files.

### DIFF
--- a/.changes/next-release/feature-encoding-19887.json
+++ b/.changes/next-release/feature-encoding-19887.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "encoding",
+  "description": "Add environment variable to set encoding used for text files. fixes `#5086 <https://github.com/aws/aws-cli/issues/5086>`__"
+}

--- a/.changes/next-release/feature-encoding-19887.json
+++ b/.changes/next-release/feature-encoding-19887.json
@@ -1,5 +1,5 @@
 {
-  "type": "feature",
+  "type": "enhancement",
   "category": "encoding",
   "description": "Add environment variable to set encoding used for text files. fixes `#5086 <https://github.com/aws/aws-cli/issues/5086>`__"
 }

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -116,6 +116,18 @@ def get_binary_stdout():
 def _get_text_writer(stream, errors):
     return stream
 
+
+def getpreferredencoding(*args, **kwargs):
+    """Use AWS_CLI_ENCODING environment variable value as encoding,
+    if it's not set use locale.getpreferredencoding()
+    to find the preferred encoding.
+    """
+    return os.environ.get(
+        'AWS_CLI_ENCODING',
+        locale.getpreferredencoding(*args, **kwargs)
+    )
+
+
 def compat_open(filename, mode='r', encoding=None):
     """Back-port open() that accepts an encoding argument.
 
@@ -123,12 +135,12 @@ def compat_open(filename, mode='r', encoding=None):
     uses the io.open() function.
 
     If the file is not being opened in binary mode, then we'll
-    use locale.getpreferredencoding() to find the preferred
+    use getpreferredencoding() to find the preferred
     encoding.
 
     """
     if 'b' not in mode:
-        encoding = locale.getpreferredencoding()
+        encoding = getpreferredencoding()
     return open(filename, mode, encoding=encoding)
 
 def bytes_print(statement, stdout=None):

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -118,12 +118,12 @@ def _get_text_writer(stream, errors):
 
 
 def getpreferredencoding(*args, **kwargs):
-    """Use AWS_CLI_ENCODING environment variable value as encoding,
+    """Use AWS_CLI_FILE_ENCODING environment variable value as encoding,
     if it's not set use locale.getpreferredencoding()
     to find the preferred encoding.
     """
     return os.environ.get(
-        'AWS_CLI_ENCODING',
+        'AWS_CLI_FILE_ENCODING',
         locale.getpreferredencoding(*args, **kwargs)
     )
 

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -471,6 +471,11 @@ One option for UNIX systems is the ``LC_ALL`` environment variable. Setting
 ``LC_ALL=en_US.UTF-8``, for instance, would give you a United States English
 locale which is compatible with unicode.
 
+To set encoding used for text files different from the locale, you can use
+``AWS_CLI_ENCODING`` environment variable. For example, if you use Windows with
+default encoding ``CP1252``, setting ``AWS_CLI_ENCODING=UTF-8`` would make CLI
+ignore locale encoding and open text files using ``UTF-8``.
+
 
 Plugins
 =======

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -472,9 +472,9 @@ One option for UNIX systems is the ``LC_ALL`` environment variable. Setting
 locale which is compatible with unicode.
 
 To set encoding used for text files different from the locale, you can use
-``AWS_CLI_ENCODING`` environment variable. For example, if you use Windows with
-default encoding ``CP1252``, setting ``AWS_CLI_ENCODING=UTF-8`` would make CLI
-ignore locale encoding and open text files using ``UTF-8``.
+``AWS_CLI_FILE_ENCODING`` environment variable. For example, if you use Windows
+with default encoding ``CP1252``, setting ``AWS_CLI_FILE_ENCODING=UTF-8`` would
+make CLI ignore locale encoding and open text files using ``UTF-8``.
 
 
 Plugins

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
+import os
 
 from mock import patch, ANY
 
@@ -66,4 +67,25 @@ class TestCLIFollowParamFileDefault(BaseTestCLIFollowParamFile):
         self.assert_param_expansion_is_correct(
             provided_param=param,
             expected_param=b'file content'
+        )
+
+
+class TestCLIUseEncodingFromEnv(BaseTestCLIFollowParamFile):
+
+    def test_does_use_encoding_utf8(self):
+        self.environ['AWS_CLI_FILE_ENCODING'] = 'utf-8'
+        path = self.files.create_file('foobar.txt', '經理')
+        param = 'file://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param='經理'
+        )
+
+    def test_does_use_encoding_cp1251(self):
+        self.environ['AWS_CLI_FILE_ENCODING'] = 'cp1251'
+        path = self.files.create_file('foobar.txt', '經理')
+        param = 'file://%s' % path
+        self.assert_param_expansion_is_correct(
+            provided_param=param,
+            expected_param='з¶“зђ†'
         )

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -143,7 +143,7 @@ class TestIgnoreUserSignals(unittest.TestCase):
 
 class TestGetPreferredEncoding(unittest.TestCase):
 
-    @mock.patch.dict(os.environ, {'AWS_CLI_ENCODING': 'cp1252'})
+    @mock.patch.dict(os.environ, {'AWS_CLI_FILE_ENCODING': 'cp1252'})
     def test_getpreferredencoding_with_env_var(self):
         encoding = getpreferredencoding()
         self.assertEqual(encoding, 'cp1252')

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import locale
 import os
 import signal
 
@@ -19,6 +20,7 @@ from botocore.compat import six
 from awscli.compat import ensure_text_type
 from awscli.compat import compat_shell_quote
 from awscli.compat import get_popen_kwargs_for_pager_cmd
+from awscli.compat import getpreferredencoding
 from awscli.compat import ignore_user_entered_signals
 from awscli.testutils import mock, unittest, skip_if_windows
 
@@ -137,3 +139,15 @@ class TestIgnoreUserSignals(unittest.TestCase):
         with ignore_user_entered_signals():
             self.assertEqual(signal.getsignal(signal.SIGTSTP), signal.SIG_IGN)
             os.kill(os.getpid(), signal.SIGTSTP)
+
+
+class TestGetPreferredEncoding(unittest.TestCase):
+
+    @mock.patch.dict(os.environ, {'AWS_CLI_ENCODING': 'cp1252'})
+    def test_getpreferredencoding_with_env_var(self):
+        encoding = getpreferredencoding()
+        self.assertEqual(encoding, 'cp1252')
+
+    def test_getpreferredencoding_wo_env_var(self):
+        encoding = getpreferredencoding()
+        self.assertEqual(encoding, locale.getpreferredencoding())


### PR DESCRIPTION
*Issue #, if available:* 
5086

*Description of changes:* 
Add ``AWS_CLI_ENCODING`` environment variable to set encoding used for text files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
