### PR TITLE
Remove unused variable and fix typos in human_readable_size

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -50,7 +50,7 @@ _S3_ACCESSPOINT_TO_BUCKET_KEY_REGEX = re.compile(
 
 
 def human_readable_size(value):
-    """Convert an size in bytes into a human readable format.
+    """Convert a size in bytes into a human readable format.
 
     For example::
 
@@ -63,11 +63,10 @@ def human_readable_size(value):
         >>> human_readable_size(1024 * 1024)
         '1.0 MiB'
 
-    :param value: The size in bytes
+    :param value: The size in bytes.
     :return: The size in a human readable format based on base-2 units.
 
     """
-    one_decimal_point = '%.1f'
     base = 1024
     bytes_int = float(value)
 


### PR DESCRIPTION
`human_readable_size()` contained a variable that was never used called `one_decimal_point`. This was probably created to replace the string literal in the return statement, but that's not necessary here. 

Also fixed a a typo in the description comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
