### PR TITLE
feat: Add Support for creating user entries with alias flag

### DIFF
--- a/.changes/next-release/enhancement-eks-48703.json
+++ b/.changes/next-release/enhancement-eks-48703.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "eks",
+  "description": "Add user-alias argument to update-kubeconfig command. Implements `#5164 <https://github.com/aws/aws-cli/issues/5164>`__"
+}

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -96,6 +96,12 @@ class UpdateKubeconfigCommand(BasicCommand):
             'help_text': ("Alias for the cluster context name. "
                           "Defaults to match cluster ARN."),
             'required': False
+        },
+        {
+            'name': 'user-alias',
+            'help_text': ("Alias for the generated user name. "
+                          "Defaults to match cluster ARN."),
+            'required': False
         }
     ]
 
@@ -117,7 +123,7 @@ class UpdateKubeconfigCommand(BasicCommand):
                            parsed_args.role_arn,
                            parsed_globals)
         new_cluster_dict = client.get_cluster_entry()
-        new_user_dict = client.get_user_entry()
+        new_user_dict = client.get_user_entry(user_alias=parsed_args.user_alias)
 
         config_selector = KubeconfigSelector(
             os.environ.get("KUBECONFIG", ""),
@@ -283,7 +289,7 @@ class EKSClient(object):
             ("name", arn)
         ])
 
-    def get_user_entry(self):
+    def get_user_entry(self, user_alias=None):
         """
         Return a user entry generated using
         the previously obtained description.
@@ -301,7 +307,7 @@ class EKSClient(object):
             cluster_identification_value = cluster_description.get("id")
 
         generated_user = OrderedDict([
-            ("name", self._get_cluster_description().get("arn", "")),
+            ("name", user_alias or self._get_cluster_description().get("arn", "")),
             ("user", OrderedDict([
                 ("exec", OrderedDict([
                     ("apiVersion", API_VERSION),

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -307,3 +307,20 @@ class TestEKSClient(unittest.TestCase):
             name="ExampleCluster"
         )
         self._session.create_client.assert_called_once_with("eks")
+
+    def test_create_user_with_alias(self):
+        self._correct_user_entry["name"] = "alias"
+        self.assertEqual(self._client.get_user_entry(user_alias="alias"),
+                         self._correct_user_entry)
+        self._mock_client.describe_cluster.assert_called_once_with(
+            name="ExampleCluster"
+        )
+        self._session.create_client.assert_called_once_with("eks")
+
+    def test_create_user_without_alias(self):
+        self.assertEqual(self._client.get_user_entry(),
+                         self._correct_user_entry)
+        self._mock_client.describe_cluster.assert_called_once_with(
+            name="ExampleCluster"
+        )
+        self._session.create_client.assert_called_once_with("eks")


### PR DESCRIPTION
*Issue #, if available: Fixes #5164

*Description of changes: Added support for creating user name in kube-config with alias (simliar to the way context works with alias)
Added appropriate testing for user name creation with and without alias flag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
