### PR TITLE
authorize-security-group-ingress.html examples example code update

### DIFF
--- a/awscli/examples/ec2/authorize-security-group-ingress.rst
+++ b/awscli/examples/ec2/authorize-security-group-ingress.rst
@@ -2,7 +2,7 @@
 
 The following example enables inbound traffic on TCP port 22 (SSH). If the command succeeds, no output is returned. ::
 
-    aws ec2 authorize-security-group-ingress \\
+    aws ec2 authorize-security-group-ingress \
         --group-name MySecurityGroup \
         --protocol tcp \
         --port 22 \


### PR DESCRIPTION
The first example within https://docs.aws.amazon.com/cli/latest/reference/ec2/authorize-security-group-ingress.html#examples has double '\' which results in error "Unknown option: \" 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
