### PR TITLE
Remove SimpleDB from preview

### DIFF
--- a/awscli/customizations/preview.py
+++ b/awscli/customizations/preview.py
@@ -38,7 +38,6 @@ logger = logging.getLogger(__name__)
 
 
 PREVIEW_SERVICES = [
-    'sdb',
 ]
 
 

--- a/tests/functional/test_preview.py
+++ b/tests/functional/test_preview.py
@@ -14,6 +14,10 @@ import mock
 from awscli.compat import six
 
 from awscli.customizations import preview
+
+# For the sake of testing, sdb is in preview
+preview.PREVIEW_SERVICES.append("sdb")
+
 from awscli.testutils import BaseAWSCommandParamsTest
 
 
@@ -29,6 +33,7 @@ class TestPreviewMode(BaseAWSCommandParamsTest):
         # session config, as that's the only way to control
         # preview services.
         self.driver.session._config = self.full_config
+
 
     def tearDown(self):
         super(TestPreviewMode, self).tearDown()


### PR DESCRIPTION
SimpleDB was released in 2008
SimpleDB support was add in aws-cli in 2014

I think 6 years is enough testing for a service - lets see SimpleDB come out of preview :)