### PR TITLE
Mute warnings for glacier deep archive objects

### DIFF
--- a/.changes/next-release/bugfix-s3-58726.json
+++ b/.changes/next-release/bugfix-s3-58726.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Mute warnings for not restored glacier deep archive objects if --ignore-glacier-warnings option enabled. Fixes `#4039 <https://github.com/aws/aws-cli/issues/4039>`__"
+}

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -80,9 +80,10 @@ class FileInfo(object):
         return True
 
     def _is_glacier_object(self, response_data):
+        glacier_storage_classes = ['GLACIER', 'DEEP_ARCHIVE']
         if response_data:
-            if response_data.get('StorageClass') == 'GLACIER' and \
-                    not self._is_restored(response_data):
+            if response_data.get('StorageClass') in glacier_storage_classes \
+                    and not self._is_restored(response_data):
                 return True
         return False
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -364,6 +364,20 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
         self.assertIn('GLACIER', stderr)
 
+    def test_warns_on_deep_arhive_incompatible_operation(self):
+        self.parsed_responses = [
+            {'ContentLength': '100', 'LastModified': '00:00:00Z',
+             'StorageClass': 'DEEP_ARCHIVE'},
+        ]
+        cmdline = ('%s s3://bucket/key.txt .' % self.prefix)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier
+        # deep archive incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertIn('GLACIER', stderr)
+
     def test_warns_on_glacier_incompatible_operation_for_multipart_file(self):
         self.parsed_responses = [
             {'ContentLength': str(20 * (1024 ** 2)),
@@ -374,6 +388,21 @@ class TestCPCommand(BaseCPCommandTest):
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         # There should not have been a download attempted because the
         # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertIn('GLACIER', stderr)
+
+    def test_warns_on_deep_archive_incompatible_op_for_multipart_file(self):
+        self.parsed_responses = [
+            {'ContentLength': str(20 * (1024 ** 2)),
+             'LastModified': '00:00:00Z',
+             'StorageClass': 'DEEP_ARCHIVE'},
+        ]
+        cmdline = ('%s s3://bucket/key.txt .' % self.prefix)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier
+        # deep archive incompatible.
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
         self.assertIn('GLACIER', stderr)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -393,6 +393,21 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
         self.assertEqual('', stderr)
 
+    def test_turn_off_glacier_warnings_for_deep_archive(self):
+        self.parsed_responses = [
+            {'ContentLength': str(20 * (1024 ** 2)),
+             'LastModified': '00:00:00Z',
+             'StorageClass': 'DEEP_ARCHIVE'},
+        ]
+        cmdline = (
+                '%s s3://bucket/key.txt . --ignore-glacier-warnings' % self.prefix)
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=0)
+        # There should not have been a download attempted because the
+        # operation was skipped because it is glacier incompatible.
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual('', stderr)
+
     def test_cp_with_sse_flag(self):
         full_path = self.files.create_file('foo.txt', 'contents')
         cmdline = (

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -97,16 +97,22 @@ class TestSyncCommand(BaseS3TransferCommandTest):
         self.parsed_responses = [
             {'Contents': [
                 {'Key': 'foo', 'Size': 100,
-                 'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'}]}
+                 'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'},
+                {'Key': 'bar', 'Size': 100,
+                 'LastModified': '00:00:00Z', 'StorageClass': 'DEEP_ARCHIVE'}
+            ]}
         ]
         cmdline = '%s s3://bucket/ %s' % (
             self.prefix, self.files.rootdir)
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         # There should not have been a download attempted because the
-        # operation was skipped because it is glacier incompatible.
+        # operation was skipped because it is glacier and glacier
+        # deep archive incompatible.
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'ListObjectsV2')
         self.assertIn('GLACIER', stderr)
+        self.assertIn('s3://bucket/foo', stderr)
+        self.assertIn('s3://bucket/bar', stderr)
 
     def test_turn_off_glacier_warnings(self):
         self.parsed_responses = [

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -112,7 +112,10 @@ class TestSyncCommand(BaseS3TransferCommandTest):
         self.parsed_responses = [
             {'Contents': [
                 {'Key': 'foo', 'Size': 100,
-                 'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'}]}
+                 'LastModified': '00:00:00Z', 'StorageClass': 'GLACIER'},
+                {'Key': 'bar', 'Size': 100,
+                 'LastModified': '00:00:00Z', 'StorageClass': 'DEEP_ARCHIVE'}
+            ]}
         ]
         cmdline = '%s s3://bucket/ %s --ignore-glacier-warnings' % (
             self.prefix, self.files.rootdir)


### PR DESCRIPTION
*Issue #, if available:*  #4039

*Description of changes:*
 Mute deep glacier archive objects warnings when --ignore-glacier-warnings option enabled

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
