### PR TITLE
ensure there's a newline before a new profile

### DIFF
--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -77,7 +77,17 @@ class ConfigFileWriter(object):
             pass
 
     def _write_new_section(self, section_name, new_values, config_filename):
-        with open(config_filename, 'a') as f:
+        with open(config_filename, 'a+') as f:
+            position = f.tell()
+
+            if position > 0:
+                # if our position is zero we don't need to worry
+                # about appending a newline
+                f.seek(position - 1, os.SEEK_SET)
+
+                if f.read() != '\n':
+                    f.write('\n')
+
             f.write('[%s]\n' % section_name)
             contents = []
             self._insert_new_values(line_number=0,

--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -338,6 +338,23 @@ class TestConfigureCommand(unittest.TestCase):
             self.get_config_file_contents(),
         )
 
+    def test_can_handle_missing_newline_at_end_of_file(self):
+        self.set_config_file_contents(
+            '[default]\n'
+            'region = us-west-2'
+        )
+        p = aws('configure set profile.testing.region us-west-2 --profile default',
+                env_vars=self.env_vars)
+
+        self.assertEqual(
+            '[default]\n'
+            'region = us-west-2\n'
+            '[profile testing]\n'
+            'region = us-west-2\n',
+            self.get_config_file_contents(),
+        )
+
+
 
 class TestConfigureHasArgTable(unittest.TestCase):
     def test_configure_command_has_arg_table(self):


### PR DESCRIPTION
Fixes an error that corrupts config files when creating a new profile on a config file that didn't have a newline at the end of the file.

We have some scripts that make changes to our developers' local cli config file. In many cases, these files have been edited, one way or another, outside of `aws configure` and this seems to have resulted in there not being a newline at the end of the file.

The writer code doesn't ensure correctness of the file and when a new profile is passed to it, it blindly appends to the file. Instead of trying to make a larger change ensuring overall correctness of the config file, I tried to keep it minimal and check for this single error case.

*Description of changes:*
before writing a new section, the last character of the file is checked to see if it's a newline. If it's not, a newline is written. The rest of the method is unchanged.