### PR TITLE
Support exporting DefinitionS3Location in AWS::StepFunctions::StateMachine

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -331,7 +331,6 @@ class GraphQLSchemaResource(Resource):
     # Necessary to support Definition
     PACKAGE_NULL_PROPERTY = False
 
-
 class AppSyncResolverRequestTemplateResource(Resource):
     RESOURCE_TYPE = "AWS::AppSync::Resolver"
     PROPERTY_NAME = "RequestMappingTemplateS3Location"
@@ -415,6 +414,15 @@ class ServerlessRepoApplicationLicense(Resource):
     RESOURCE_TYPE = "AWS::ServerlessRepo::Application"
     PROPERTY_NAME = "LicenseUrl"
     PACKAGE_NULL_PROPERTY = False
+
+
+class StepFunctionsStateMachineDefinitionResource(ResourceWithS3UrlDict):
+    RESOURCE_TYPE = "AWS::StepFunctions::StateMachine"
+    PROPERTY_NAME = "DefinitionS3Location"
+    BUCKET_NAME_PROPERTY = "Bucket"
+    OBJECT_KEY_PROPERTY = "Key"
+    VERSION_PROPERTY = "Version"
+    PACKAGE_NULL_PROPERTY = True
 
 
 class CloudFormationStackResource(Resource):
@@ -504,6 +512,7 @@ RESOURCES_EXPORT_LIST = [
     ServerlessLayerVersionResource,
     LambdaLayerVersionResource,
     GlueJobCommandScriptLocationResource,
+    StepFunctionsStateMachineDefinitionResource
 ]
 
 METADATA_EXPORT_LIST = [

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -331,6 +331,7 @@ class GraphQLSchemaResource(Resource):
     # Necessary to support Definition
     PACKAGE_NULL_PROPERTY = False
 
+
 class AppSyncResolverRequestTemplateResource(Resource):
     RESOURCE_TYPE = "AWS::AppSync::Resolver"
     PROPERTY_NAME = "RequestMappingTemplateS3Location"
@@ -422,7 +423,7 @@ class StepFunctionsStateMachineDefinitionResource(ResourceWithS3UrlDict):
     BUCKET_NAME_PROPERTY = "Bucket"
     OBJECT_KEY_PROPERTY = "Key"
     VERSION_PROPERTY = "Version"
-    PACKAGE_NULL_PROPERTY = True
+    PACKAGE_NULL_PROPERTY = False
 
 
 class CloudFormationStackResource(Resource):

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -22,6 +22,7 @@ This command can upload local artifacts referenced in the following places:
     - ``SourceBundle`` property for the ``AWS::ElasticBeanstalk::ApplicationVersion`` resource
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
     - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
+    - ``DefinitionS3Location`` property for the ``AWS::StepFunctions::StateMachine`` resource
 
 
 To specify a local artifact in your template, specify a path to a local file or folder,

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -83,7 +83,7 @@ def test_all_resources_export():
             "class": GraphQLSchemaResource,
             "expected_result": uploaded_s3_url
         },
-        
+
         {
             "class": AppSyncResolverRequestTemplateResource,
             "expected_result": uploaded_s3_url

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -27,7 +27,8 @@ from awscli.customizations.cloudformation.artifact_exporter \
     AppSyncResolverResponseTemplateResource, \
     AppSyncFunctionConfigurationRequestTemplateResource, \
     AppSyncFunctionConfigurationResponseTemplateResource, \
-    GlueJobCommandScriptLocationResource
+    GlueJobCommandScriptLocationResource, \
+    StepFunctionsStateMachineDefinitionResource
 
 
 def test_is_s3_url():
@@ -82,7 +83,7 @@ def test_all_resources_export():
             "class": GraphQLSchemaResource,
             "expected_result": uploaded_s3_url
         },
-
+        
         {
             "class": AppSyncResolverRequestTemplateResource,
             "expected_result": uploaded_s3_url
@@ -150,7 +151,13 @@ def test_all_resources_export():
             "expected_result": {
                     "ScriptLocation": uploaded_s3_url
             }
-        }
+        },
+        {
+            "class": StepFunctionsStateMachineDefinitionResource,
+            "expected_result": {
+                "Bucket": "foo", "Key": "bar", "Version": "baz"
+            }
+        },
     ]
 
     with patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts") as upload_local_artifacts_mock:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
AWS StepFunctions just released the new property `DefinitionS3Location` which is similar to [BodyS3Location](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-s3location.html) in AWS::ApiGateway::RestApi.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
