### PR TITLE
Remove duplicate global params note

### DIFF
--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -237,3 +237,6 @@ class WaiterCommandDocHandler(BasicDocHandler):
 
     def doc_option(self, arg_name, help_command, **kwargs):
         pass
+
+    def doc_options_end(self, help_command, **kwargs):
+        pass


### PR DESCRIPTION
For the top level waiter command (such as `aws ec2 wait`) the global parameters note was rendered twice:
```
NAME
       wait -

DESCRIPTION
       Wait  until  a particular condition is satisfied. Each subcommand polls
       an API until the listed requirement is met.

       See 'aws help' for descriptions of global parameters.

       See 'aws help' for descriptions of global parameters.
```

You can also see this on the HTML docs:
https://docs.aws.amazon.com/cli/latest/reference/rds/wait/index.html

For the top level command the `OPTIONS` section is skipped, this updates the waiter doc class to also skip the options end section which is where the duplicate note was coming from.
This change does not affect the individual wait commands, only the top level wait help.
