### PR TITLE
[v2] Always quote YAML boolean strings for cloudformation package

### DIFF
--- a/.changes/next-release/bugfix-cloudformationpackage-5958.json
+++ b/.changes/next-release/bugfix-cloudformationpackage-5958.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``cloudformation package``",
+  "description": "Preserve quotes for YAML boolean strings. Fixes `#5245 <https://github.com/aws/aws-cli/issues/5245>`__"
+}

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -70,9 +70,9 @@ def _add_yaml_1_1_boolean_resolvers(dumper_cls):
     # that we dump these values with quotes so that CloudFormation treats
     # these values as strings and not booleans.
     boolean_regex = re.compile(
-        '^(?:y|Y|yes|Yes|YES|n|N|no|No|NO|'
-        'true|True|TRUE|false|False|FALSE'
-        '|on|On|ON|off|Off|OFF)$', re.X
+        '^(?:yes|Yes|YES|no|No|NO'
+        '|true|True|TRUE|false|False|FALSE'
+        '|on|On|ON|off|Off|OFF)$'
     )
     boolean_first_chars = list(u'yYnNtTfFoO')
     dumper_cls.add_implicit_resolver_base(

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -62,7 +62,7 @@ def _dict_representer(dumper, data):
     return dumper.represent_dict(data.items())
 
 
-def _add_yaml_1_1_boolean_resolvers(dumper_cls):
+def _add_yaml_1_1_boolean_resolvers(resolver_cls):
     # CloudFormation treats unquoted values that are YAML 1.1 native
     # booleans as booleans, rather than strings. In YAML 1.2, the only
     # boolean values are "true" and "false" so values such as "yes" and "no"
@@ -75,7 +75,7 @@ def _add_yaml_1_1_boolean_resolvers(dumper_cls):
         '|on|On|ON|off|Off|OFF)$'
     )
     boolean_first_chars = list(u'yYnNtTfFoO')
-    dumper_cls.add_implicit_resolver_base(
+    resolver_cls.add_implicit_resolver(
         'tag:yaml.org,2002:bool', boolean_regex, boolean_first_chars)
 
 
@@ -111,6 +111,7 @@ def yaml_parse(yamlstr):
         yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor)
         yaml.SafeLoader.add_multi_constructor(
             "!", intrinsics_multi_constructor)
+        _add_yaml_1_1_boolean_resolvers(yaml.SafeLoader)
         return yaml.safe_load(yamlstr)
 
 

--- a/tests/functional/cloudformation/deploy_templates/booleans/input.yml
+++ b/tests/functional/cloudformation/deploy_templates/booleans/input.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  ResourceWithMixedBooleanValues:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      MfaConfiguration: 'OFF'
+      Policies:
+        PasswordPolicy:
+          RequireLowercase: false
+          RequireNumbers: true
+  YesTester:
+    Type: Custom::YesTester
+    Properties:
+      Input: !Select [0, ["yes", "no"]]

--- a/tests/functional/cloudformation/deploy_templates/booleans/input.yml
+++ b/tests/functional/cloudformation/deploy_templates/booleans/input.yml
@@ -8,6 +8,8 @@ Resources:
         PasswordPolicy:
           RequireLowercase: false
           RequireNumbers: true
+          RequireUppercase: on
+          RequireSymbols: yes
   YesTester:
     Type: Custom::YesTester
     Properties:

--- a/tests/functional/cloudformation/deploy_templates/booleans/output.yml
+++ b/tests/functional/cloudformation/deploy_templates/booleans/output.yml
@@ -8,6 +8,8 @@ Resources:
         PasswordPolicy:
           RequireLowercase: false
           RequireNumbers: true
+          RequireUppercase: true
+          RequireSymbols: true
   YesTester:
     Type: Custom::YesTester
     Properties:

--- a/tests/functional/cloudformation/deploy_templates/booleans/output.yml
+++ b/tests/functional/cloudformation/deploy_templates/booleans/output.yml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  ResourceWithMixedBooleanValues:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      MfaConfiguration: 'OFF'
+      Policies:
+        PasswordPolicy:
+          RequireLowercase: false
+          RequireNumbers: true
+  YesTester:
+    Type: Custom::YesTester
+    Properties:
+      Input:
+        Fn::Select:
+        - 0
+        - - 'yes'
+          - 'no'

--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -81,5 +81,13 @@ def _assert_input_does_match_expected_output(input_template, output_template):
     template = Template(input_template, os.getcwd(), None)
     exported = template.export()
     result = yaml_dump(exported)
+    expected = open(output_template, 'r').read()
 
-    assert result == open(output_template, 'r').read()
+    assert result == expected, (
+        '\nAcutal template:\n'
+        '%s'
+        '\nDiffers from expected template:\n'
+        '%s' % (
+            result, expected
+        )
+    )

--- a/tests/unit/customizations/cloudformation/__init__.py
+++ b/tests/unit/customizations/cloudformation/__init__.py
@@ -10,8 +10,31 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import copy
 
 import six, unittest
+import ruamel.yaml as yaml
 
 if six.PY3:
     unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
+
+
+class BaseYAMLTest(unittest.TestCase):
+    """Base class for preserving ruamel defaults
+
+    Because ruamel mutates module and class state when custom components
+    are added to a loader or a dumper, it will force downstream tests to pick
+    up these customizations and cause unexpected failures. This class is meant
+    to preserve any ruamel defaults to prevent downstream test failures. Note
+    that mutating module and class state is not really a problem though when a
+    CLI command runs because we do not run multiple commands that differ
+    in YAML loading logic in a single process.
+    """
+    def setUp(self):
+        super(BaseYAMLTest, self).setUp()
+        self.original_implicit_resolvers = copy.deepcopy(
+            yaml.resolver.implicit_resolvers)
+
+    def tearDown(self):
+        super(BaseYAMLTest, self).tearDown()
+        yaml.resolver.implicit_resolvers = self.original_implicit_resolvers

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -10,7 +10,7 @@ from nose.tools import assert_true, assert_false, assert_equal
 from contextlib import contextmanager, closing
 from mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
-from awscli.testutils import unittest, FileCreator
+from awscli.testutils import FileCreator
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.artifact_exporter \
     import is_s3_url, parse_s3_url, is_local_file, is_local_folder, \
@@ -29,6 +29,7 @@ from awscli.customizations.cloudformation.artifact_exporter \
     AppSyncFunctionConfigurationResponseTemplateResource, \
     GlueJobCommandScriptLocationResource, \
     StepFunctionsStateMachineDefinitionResource
+from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
 def test_is_s3_url():
@@ -213,9 +214,10 @@ def _helper_verify_export_resources(
     assert_equal(result, expected_result)
 
 
-class TestArtifactExporter(unittest.TestCase):
+class TestArtifactExporter(BaseYAMLTest):
 
     def setUp(self):
+        super(TestArtifactExporter, self).setUp()
         self.s3_uploader_mock = Mock()
         self.s3_uploader_mock.s3.meta.endpoint_url = "https://s3.some-valid-region.amazonaws.com"
 

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -16,11 +16,11 @@ import six
 from mock import patch, Mock, MagicMock, call
 import collections
 
-from awscli.testutils import unittest
 from awscli.customizations.cloudformation.deploy import DeployCommand
 from awscli.customizations.cloudformation.deployer import Deployer
 from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 from awscli.customizations.cloudformation import exceptions
+from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
 class FakeArgs(object):
@@ -43,9 +43,10 @@ def get_example_template():
 
 ChangeSetResult = collections.namedtuple("ChangeSetResult", ["changeset_id", "changeset_type"])
 
-class TestDeployCommand(unittest.TestCase):
+class TestDeployCommand(BaseYAMLTest):
 
     def setUp(self):
+        super(TestDeployCommand, self).setUp()
         self.session = mock.Mock()
         self.session.get_scoped_config.return_value = {}
         self.parsed_args = FakeArgs(template_file='./foo',

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -3,14 +3,15 @@ import botocore.session
 
 from mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
-from awscli.testutils import unittest
 from awscli.customizations.cloudformation.deployer import Deployer, ChangeSetResult
 from awscli.customizations.cloudformation import exceptions
+from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
-class TestDeployer(unittest.TestCase):
+class TestDeployer(BaseYAMLTest):
 
     def setUp(self):
+        super(TestDeployer, self).setUp()
         client = botocore.session.get_session().create_client('cloudformation',
                                                               region_name="us-east-1")
         self.stub_client = Stubber(client)

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -17,10 +17,10 @@ import tempfile
 
 from io import StringIO
 from mock import patch, Mock, MagicMock
-from awscli.testutils import unittest, BaseAWSCommandParamsTest
 from awscli.customizations.cloudformation.package import PackageCommand
 from awscli.customizations.cloudformation.artifact_exporter import Template
 from awscli.customizations.cloudformation.yamlhelper import yaml_dump
+from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
 class FakeArgs(object):
@@ -42,9 +42,10 @@ def get_example_template():
     }
 
 
-class TestPackageCommand(unittest.TestCase):
+class TestPackageCommand(BaseYAMLTest):
 
     def setUp(self):
+        super(TestPackageCommand, self).setUp()
         self.session = mock.Mock()
         self.session.get_scoped_config.return_value = {}
         self.parsed_args = FakeArgs(template_file='./foo',

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -184,3 +184,13 @@ class TestYaml(unittest.TestCase):
         )
         actual = yaml_dump(template)
         self.assertEqual(actual, expected)
+
+    def test_yaml_dump_quotes_boolean_strings(self):
+        bools_as_strings = [
+            'Y', 'y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO',
+            'true', 'True', 'TRUE', 'false', 'False', 'FALSE',
+            'on', 'On', 'ON', 'off', 'Off', 'OFF'
+        ]
+        for bool_as_string in bools_as_strings:
+            self.assertEqual(
+                yaml_dump(bool_as_string), "'%s'\n" % bool_as_string)

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -187,7 +187,7 @@ class TestYaml(unittest.TestCase):
 
     def test_yaml_dump_quotes_boolean_strings(self):
         bools_as_strings = [
-            'Y', 'y', 'yes', 'Yes', 'YES', 'n', 'N', 'no', 'No', 'NO',
+            'yes', 'Yes', 'YES', 'no', 'No', 'NO',
             'true', 'True', 'TRUE', 'false', 'False', 'FALSE',
             'on', 'On', 'ON', 'off', 'Off', 'OFF'
         ]

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -17,12 +17,12 @@ from mock import patch, Mock, MagicMock
 from botocore.compat import json
 from botocore.compat import OrderedDict
 
-from awscli.testutils import unittest
 from awscli.customizations.cloudformation.deployer import Deployer
 from awscli.customizations.cloudformation.yamlhelper import yaml_parse, yaml_dump
+from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
-class TestYaml(unittest.TestCase):
+class TestYaml(BaseYAMLTest):
 
     yaml_with_tags = """
     Resource:


### PR DESCRIPTION
CloudFormation treats unquoted values that are YAML 1.1 native booleans as booleans, rather than strings. In YAML 1.2, the only boolean values are "true" and "false" so values such as "yes" and "no" when loaded as strings are not quoted when dumped. This logic ensures that we dump these values with quotes so that CloudFormation treats these values as strings and not booleans.

Fixes: https://github.com/aws/aws-cli/issues/5245
