### PR TITLE
S3 cares not for gender.

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -420,7 +420,7 @@ REQUEST_PAYER = {
     'name': 'request-payer', 'choices': ['requester'],
     'nargs': '?', 'const': 'requester',
     'help_text': (
-        'Confirms that the requester knows that she or he will be charged '
+        'Confirms that the requester knows that they will be charged '
         'for the request. Bucket owners need not specify this parameter in '
         'their requests. Documentation on downloading objects from requester '
         'pays buckets can be found at '


### PR DESCRIPTION
Requester doesn't need to be male, female or even human to use this command. Updated to reflect.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
