### PR TITLE
Improve config parsing regexp to handle values with square brackets

### DIFF
--- a/.changes/next-release/bugfix-configfile-9352.json
+++ b/.changes/next-release/bugfix-configfile-9352.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "config file",
+  "description": "Improve config parsing to handle values with square brackets. fixes `#5263 <https://github.com/aws/aws-cli/issues/5263>`__"
+}

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -17,7 +17,7 @@ from . import SectionNotFoundError
 
 
 class ConfigFileWriter(object):
-    SECTION_REGEX = re.compile(r'\[(?P<header>[^]]+)\]')
+    SECTION_REGEX = re.compile(r'^\s*\[(?P<header>[^]]+)\]')
     OPTION_REGEX = re.compile(
         r'(?P<option>[^:=][^:=]*)'
         r'\s*(?P<vi>[:=])\s*'

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -50,6 +50,12 @@ class TestConfigFileWriter(unittest.TestCase):
         self.assert_update_config(
             original, {'foo': 'newvalue'}, updated)
 
+    def test_update_value_with_square_brackets(self):
+        original = '[default]\nfoo = old[value]\nbar = 1'
+        updated = '[default]\nfoo = new[value]\nbar = 1'
+        self.assert_update_config(
+            original, {'foo': 'new[value]'}, updated)
+
     def test_update_single_existing_value_no_spaces(self):
         original = '[default]\nfoo=1\nbar=1'
         updated = '[default]\nfoo = newvalue\nbar=1'


### PR DESCRIPTION
Right now config file parser considers any expression in square brackets as a profile name which leads to errors in parsing if value has square brackets in it.

*Issue #, if available:* #5239

*Description of changes:* 
Update config parsing regexp to consider expression as a profile name only if it's in square brackets and in the beginning of the string or has leading spaces only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
