### PR TITLE
Adjust hardcoded polling delay on CloudFormation API

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -203,11 +203,11 @@ class Deployer(object):
             raise RuntimeError("Invalid changeset type {0}"
                                .format(changeset_type))
 
-        # Poll every 5 seconds. Optimizing for the case when the stack has only
-        # minimal changes, such the Code for Lambda Function
+        # Poll every 30 seconds. Polling too frequently risks hitting rate limits
+        # on CloudFormation's DescribeStacks API
         waiter_config = {
-            'Delay': 5,
-            'MaxAttempts': 720,
+            'Delay': 30,
+            'MaxAttempts': 120,
         }
 
         try:

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -436,8 +436,8 @@ class TestDeployer(unittest.TestCase):
             mock_deployer.wait_for_execute(stack_name, changeset_type)
 
         waiter_config = {
-            'Delay': 5,
-            'MaxAttempts': 720,
+            'Delay': 30,
+            'MaxAttempts': 120,
         }
         mock_waiter.wait.assert_called_once_with(StackName=stack_name,
                                                  WaiterConfig=waiter_config)


### PR DESCRIPTION
*Description of changes:*
Adjust the hardcoded delay between calls to CloudFormation's DescribeStacks API back to boto3 defaults to reduce the number of customers running into throttling and having to contact CloudFormation support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
