### PR TITLE
Remove duplicate see help link for global params in waiter docs

### DIFF
--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -235,5 +235,8 @@ class WaiterCommandDocHandler(BasicDocHandler):
     def doc_options_start(self, help_command, **kwargs):
         pass
 
+    def doc_options_end(self, help_command, **kwargs):
+        pass
+
     def doc_option(self, arg_name, help_command, **kwargs):
         pass

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -80,6 +80,11 @@ class TestHelpOutput(BaseAWSHelpOutputTest):
         self.assert_contains('Launches the specified number of instances')
         self.assert_contains('``--count`` (string)')
 
+    def test_waiter_does_not_have_duplicate_global_params_link(self):
+        self.driver.main(['ec2', 'wait', 'help'])
+        self.assert_contains_with_count(
+            'for descriptions of global parameters', 1)
+
     def test_custom_service_help_output(self):
         self.driver.main(['s3', 'help'])
         self.assert_contains('.. _cli:aws s3:')


### PR DESCRIPTION
The waiter help documentation does not include an options section, but
the handler for generating it does not override and suppress the
option_end documentation event. The default handler is used instead
and emits a global parameters link, the same as the previous
description section. This results in the waiter docs having two links
to the global parameters help page at the end of the description
section.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
