### PR TITLE
Fix positional arg help documentation

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -128,8 +128,10 @@ class CLIDocumentEventHandler(object):
                 [a.cli_name for a in
                  self._arg_groups[argument.group_name]])
             self._documented_arg_groups.append(argument.group_name)
-        else:
+        elif argument.cli_name.startswith('--'):
             option_str = '%s <value>' % argument.cli_name
+        else:
+            option_str = '<%s>' % argument.cli_name
         if not (argument.required
                 or getattr(argument, '_DOCUMENT_AS_REQUIRED', False)):
             option_str = '[%s]' % option_str

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -474,3 +474,10 @@ class TestAliases(BaseAWSHelpOutputTest):
         self.add_alias('my-alias', 'ec2 describe-regions')
         self.driver.main(['help'])
         self.assert_not_contains('my-alias')
+
+
+class TestStreamingOutputHelp(BaseAWSHelpOutputTest):
+    def test_service_help_command_has_note(self):
+        self.driver.main(['s3api', 'get-object', 'help'])
+        self.assert_not_contains('outfile <value>')
+        self.assert_contains('<outfile>')


### PR DESCRIPTION
This updates the synopsis documentation for positional args to look more like positional args and less like `--flag <value>` args. This also more closely matches the styling used for the custom S3 commands.

The CLI argument classes don't all have a notion of a positional arg, but we've followed the convention that a `cli_name` starting with `--` indicates it's a `--flag <value>` style and anywhere that's removed it's intended as a positional arg.

Example before:
```
SYNOPSIS
            select-object-content
          --bucket <value>
          --key <value>
...
          outfile <value>
```
Example after:
```
SYNOPSIS
            select-object-content
          --bucket <value>
          --key <value>
...
          <outfile>
```