### PR TITLE
[v2] Add support for AWS_CLI_FILE_ENCODING environment variable to cloudformation and eks customizations

### DIFF
--- a/.changes/next-release/bugfix-locale-28959.json
+++ b/.changes/next-release/bugfix-locale-28959.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "locale",
+  "description": "Add support for AWS_CLI_FILE_ENCODING environment variable to cloudformation and eks customizations"
+}

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -23,6 +23,7 @@ from botocore.utils import set_value_from_jmespath
 
 from awscli.compat import urlparse
 from contextlib import contextmanager
+from awscli.compat import compat_open
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.yamlhelper import yaml_dump, \
     yaml_parse
@@ -571,7 +572,7 @@ class Template(object):
         abs_template_path = make_abs_path(parent_dir, template_path)
         template_dir = os.path.dirname(abs_template_path)
 
-        with open(abs_template_path, "r") as handle:
+        with compat_open(abs_template_path, "r") as handle:
             template_str = handle.read()
 
         self.template_dict = yaml_parse(template_str)

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -17,6 +17,7 @@ import logging
 
 from botocore.client import Config
 
+from awscli.compat import compat_open
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.deployer import Deployer
 from awscli.customizations.s3uploader import S3Uploader
@@ -250,7 +251,7 @@ class DeployCommand(BasicCommand):
                     template_path=template_path)
 
         # Parse parameters
-        with open(template_path, "r") as handle:
+        with compat_open(template_path, "r") as handle:
             template_str = handle.read()
 
         stack_name = parsed_args.stack_name

--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -17,6 +17,7 @@ import os
 import ruamel.yaml as yaml
 from botocore.compat import OrderedDict
 
+from awscli.compat import compat_open
 from awscli.customizations.eks.exceptions import EKSError
 from awscli.customizations.eks.ordered_yaml import (
     ordered_yaml_load,
@@ -153,7 +154,7 @@ class KubeconfigLoader(object):
         :rtype: Kubeconfig
         """
         try:
-            with open(path, "r") as stream:
+            with compat_open(path, "r") as stream:
                 loaded_content = ordered_yaml_load(stream)
         except IOError as e:
             if e.errno == errno.ENOENT:
@@ -192,7 +193,7 @@ class KubeconfigWriter(object):
                 raise KubeconfigInaccessableError(
                         "Can't create directory for writing: {0}".format(e))
         try:
-            with open(config.path, "w+") as stream:
+            with compat_open(config.path, "w+") as stream:
                 ordered_yaml_dump(config.content, stream)
         except IOError as e:
             raise KubeconfigInaccessableError(

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -918,7 +918,8 @@ class TestArtifactExporter(BaseYAMLTest):
 
         # Patch the file open method to return template string
         with patch(
-                "awscli.customizations.cloudformation.artifact_exporter.open",
+                "awscli.customizations.cloudformation."
+                "artifact_exporter.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
 
             template_exporter = Template(
@@ -983,7 +984,8 @@ class TestArtifactExporter(BaseYAMLTest):
 
         # Patch the file open method to return template string
         with patch(
-                "awscli.customizations.cloudformation.artifact_exporter.open",
+                "awscli.customizations.cloudformation."
+                "artifact_exporter.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
 
             template_exporter = Template(
@@ -1044,7 +1046,8 @@ class TestArtifactExporter(BaseYAMLTest):
         yaml_parse_mock.return_value = template_dict
 
         with patch(
-                "awscli.customizations.cloudformation.artifact_exporter.open",
+                "awscli.customizations.cloudformation."
+                "artifact_exporter.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
             with patch.dict(GLOBAL_EXPORT_DICT, {"Fn::Transform": include_transform_export_handler_mock}):
                 template_exporter = Template(

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -90,7 +90,7 @@ class TestDeployCommand(BaseYAMLTest):
             open_mock = mock.mock_open()
             # Patch the file open method to return template string
             with patch(
-                    "awscli.customizations.cloudformation.deploy.open",
+                    "awscli.customizations.cloudformation.deploy.compat_open",
                     open_mock(read_data=template_str)) as open_mock:
 
                 fake_template = get_example_template()
@@ -108,7 +108,6 @@ class TestDeployCommand(BaseYAMLTest):
                 result = self.deploy_command._run_main(self.parsed_args,
                                               parsed_globals=self.parsed_globals)
                 self.assertEquals(0, result)
-
                 open_mock.assert_called_once_with(file_path, "r")
 
                 self.deploy_command.deploy.assert_called_once_with(
@@ -162,7 +161,7 @@ class TestDeployCommand(BaseYAMLTest):
         open_mock = mock.mock_open()
 
         with patch(
-                "awscli.customizations.cloudformation.deploy.open",
+                "awscli.customizations.cloudformation.deploy.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
             with self.assertRaises(exceptions.DeployBucketRequiredError):
                 result = self.deploy_command._run_main(self.parsed_args,
@@ -187,7 +186,7 @@ class TestDeployCommand(BaseYAMLTest):
         open_mock = mock.mock_open()
 
         with patch(
-                "awscli.customizations.cloudformation.deploy.open",
+                "awscli.customizations.cloudformation.deploy.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
 
             self.parsed_args.s3_bucket = bucket_name


### PR DESCRIPTION
*Issue #, if available:* #5086

*Description of changes:*
Add support for AWS_CLI_FILE_ENCODING environment variable to cloudformation and eks customizations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
