### PR TITLE
EKS get-token - Use STS regional endpoint

### DIFF
--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -90,12 +90,10 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --region us-west-2'
         response = self.run_get_token(cmd)
-        # Even though us-west-2 was specified, we should still only be
-        # signing for the global endpoint.
         self.assert_url_correct(
             response,
-            expected_endpoint='sts.amazonaws.com',
-            expected_signing_region='us-east-1'
+            expected_endpoint='sts.us-west-2.amazonaws.com',
+            expected_signing_region='us-west-2'
         )
 
     def test_url_with_arn(self):


### PR DESCRIPTION
This change will make EKS get-token command to generate getCallerIdentity pre-signed URL using the STS regional endpoint.

Currently, this command invokes sts using the global us-east-1 endpoint.
