### PR TITLE
Bump python-rsa dependency range

### DIFF
--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -28,6 +28,7 @@ EXTRA_RUNTIME_DEPS = [
     ('colorama', '0.4.1'),
     ('urllib3', '1.25.7'),
     ('PyYAML', '5.2'),
+    ('rsa', '4.0'),
 ]
 BUILDTIME_DEPS = [
     ('setuptools-scm', '3.3.3'),

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,12 +6,13 @@ universal = 1
 requires-dist =
         botocore==1.17.18
         docutils>=0.10,<0.16
-        rsa>=3.1.2,<=3.5.0
         s3transfer>=0.3.0,<0.4.0
         PyYAML>=3.10,<5.3; python_version=='3.4'
         PyYAML>=3.10,<5.4; python_version!='3.4'
         colorama>=0.2.5,<0.4.2; python_version=='3.4'
         colorama>=0.2.5,<0.4.4; python_version!='3.4'
+        rsa>=3.1.2,<=4.0.0; python_version=='3.4'
+        rsa>=3.1.2,<=4.5.0; python_version!='3.4'
 
 
 [check-manifest]

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ def find_version(*file_paths):
 install_requires = [
     'botocore==1.17.18',
     'docutils>=0.10,<0.16',
-    'rsa>=3.1.2,<=3.5.0',
     's3transfer>=0.3.0,<0.4.0',
 ]
 
@@ -34,9 +33,11 @@ install_requires = [
 if sys.version_info[:2] == (3, 4):
     install_requires.append('PyYAML>=3.10,<5.3')
     install_requires.append('colorama>=0.2.5,<0.4.2')
+    install_requires.append('rsa>=3.1.2,<=4.0.0')
 else:
     install_requires.append('PyYAML>=3.10,<5.4')
     install_requires.append('colorama>=0.2.5,<0.4.4')
+    install_requires.append('rsa>=3.1.2,<=4.5.0')
 
 
 setup_options = dict(


### PR DESCRIPTION
PythonRSA 4.3 and 4.5 are the same release, they are also the same as
4.0 with some bugfix backports. Python 2 support was removed in 4.1,
but since 4.3/4.5 are just a re-released 4.0, they support python 2.7.

So the version range <=4.5 supports python 2.7 and python 3. However;
Python 3.4 support was also removed in 4.1, and is explicitly called
out as not restored in 4.3/4.5. Which means we need to branch our
dependency on rsa for Python 3.4 to include 4.0, which is the last
version to have Python 3.4 support. rsa 4.0 is also explicitlly pulled
into the bundled installer.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
