### PR TITLE
Add support for nested input structures to doc generation

### DIFF
--- a/.changes/next-release/enhancement-docs-89994.json
+++ b/.changes/next-release/enhancement-docs-89994.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "docs",
+  "description": "Improve AWS CLI docs to include documentation strings for parameters in nested input structures"
+}

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -168,7 +168,9 @@ class CLIDocumentEventHandler(object):
             argument.argument_model, argument.cli_type_name)))
         doc.style.indent()
         doc.include_doc_string(argument.documentation)
-        self._document_enums(argument, doc)
+        if hasattr(argument, 'argument_model'):
+            self._document_enums(argument.argument_model, doc)
+            self._document_nested_structure(argument.argument_model, doc)
         doc.style.dedent()
         doc.style.new_paragraph()
 
@@ -186,18 +188,75 @@ class CLIDocumentEventHandler(object):
         )
         doc.write('\n')
 
-    def _document_enums(self, argument, doc):
+    def _document_enums(self, model, doc):
         """Documents top-level parameter enums"""
-        if hasattr(argument, 'argument_model'):
-            model = argument.argument_model
-            if isinstance(model, StringShape):
-                if model.enum:
-                    doc.style.new_paragraph()
-                    doc.write('Possible values:')
-                    doc.style.start_ul()
-                    for enum in model.enum:
-                        doc.style.li('``%s``' % enum)
-                    doc.style.end_ul()
+        if isinstance(model, StringShape):
+            if model.enum:
+                doc.style.new_paragraph()
+                doc.write('Possible values:')
+                doc.style.start_ul()
+                for enum in model.enum:
+                    doc.style.li('``%s``' % enum)
+                doc.style.end_ul()
+
+    def _document_nested_structure(self, model, doc):
+        """Recursively documents parameters in nested structures"""
+        member_type_name = getattr(model, 'type_name', None)
+        if member_type_name == 'structure':
+            for member_name, member_shape in model.members.items():
+                self._doc_member(doc, member_name, member_shape,
+                                 stack=[model.name])
+        elif member_type_name == 'list':
+            self._doc_member(doc, '', model.member, stack=[model.name])
+        elif member_type_name == 'map':
+            key_shape = model.key
+            key_name = key_shape.serialization.get('name', 'key')
+            self._doc_member(doc, key_name, key_shape, stack=[model.name])
+            value_shape = model.value
+            value_name = value_shape.serialization.get('name', 'value')
+            self._doc_member(doc, value_name, value_shape, stack=[model.name])
+
+    def _doc_member(self, doc, member_name, member_shape, stack):
+        if member_shape.name in stack:
+            # Document the recursion once, otherwise just
+            # note the fact that it's recursive and return.
+            if stack.count(member_shape.name) > 1:
+                if member_shape.type_name == 'structure':
+                    doc.write('( ... recursive ... )')
+                return
+        stack.append(member_shape.name)
+        try:
+            self._do_doc_member(doc, member_name,
+                                member_shape, stack)
+        finally:
+            stack.pop()
+
+    def _do_doc_member(self, doc, member_name, member_shape, stack):
+        docs = member_shape.documentation
+        if member_name:
+            doc.write('%s -> (%s)' % (member_name, self._get_argument_type_name(
+                                      member_shape, member_shape.type_name)))
+        else:
+            doc.write('(%s)' % member_shape.type_name)
+        doc.style.indent()
+        doc.style.new_paragraph()
+        doc.include_doc_string(docs)
+        doc.style.new_paragraph()
+        member_type_name = member_shape.type_name
+        if member_type_name == 'structure':
+            for sub_name, sub_shape in member_shape.members.items():
+                self._doc_member(doc, sub_name, sub_shape, stack)
+        elif member_type_name == 'map':
+            key_shape = member_shape.key
+            key_name = key_shape.serialization.get('name', 'key')
+            self._doc_member(doc, key_name, key_shape, stack)
+            value_shape = member_shape.value
+            value_name = value_shape.serialization.get('name', 'value')
+            self._doc_member(doc, value_name, value_shape, stack)
+        elif member_type_name == 'list':
+            self._doc_member(doc, '', member_shape.member, stack)
+        doc.style.dedent()
+        doc.style.new_paragraph()
 
 
 class ProviderDocumentEventHandler(CLIDocumentEventHandler):
@@ -493,49 +552,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             doc.write('None')
         else:
             for member_name, member_shape in output_shape.members.items():
-                self._doc_member_for_output(doc, member_name, member_shape, stack=[])
-
-    def _doc_member_for_output(self, doc, member_name, member_shape, stack):
-        if member_shape.name in stack:
-            # Document the recursion once, otherwise just
-            # note the fact that it's recursive and return.
-            if stack.count(member_shape.name) > 1:
-                if member_shape.type_name == 'structure':
-                    doc.write('( ... recursive ... )')
-                return
-        stack.append(member_shape.name)
-        try:
-            self._do_doc_member_for_output(doc, member_name,
-                                           member_shape, stack)
-        finally:
-            stack.pop()
-
-    def _do_doc_member_for_output(self, doc, member_name, member_shape, stack):
-        docs = member_shape.documentation
-        if member_name:
-            doc.write('%s -> (%s)' % (member_name, self._get_argument_type_name(
-                                      member_shape, member_shape.type_name)))
-        else:
-            doc.write('(%s)' % member_shape.type_name)
-        doc.style.indent()
-        doc.style.new_paragraph()
-        doc.include_doc_string(docs)
-        doc.style.new_paragraph()
-        member_type_name = member_shape.type_name
-        if member_type_name == 'structure':
-            for sub_name, sub_shape in member_shape.members.items():
-                self._doc_member_for_output(doc, sub_name, sub_shape, stack)
-        elif member_type_name == 'map':
-            key_shape = member_shape.key
-            key_name = key_shape.serialization.get('name', 'key')
-            self._doc_member_for_output(doc, key_name, key_shape, stack)
-            value_shape = member_shape.value
-            value_name = value_shape.serialization.get('name', 'value')
-            self._doc_member_for_output(doc, value_name, value_shape, stack)
-        elif member_type_name == 'list':
-            self._doc_member_for_output(doc, '', member_shape.member, stack)
-        doc.style.dedent()
-        doc.style.new_paragraph()
+                self._doc_member(doc, member_name, member_shape, stack=[])
 
     def doc_options_end(self, help_command, **kwargs):
         self._add_top_level_args_reference(help_command)

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -13,7 +13,8 @@
 import json
 
 import mock
-from botocore.model import ShapeResolver, StructureShape, StringShape
+from botocore.model import ShapeResolver, StructureShape, StringShape, \
+    ListShape, MapShape
 from botocore.docs.bcdoc.restdoc import ReSTDocument
 
 from awscli.testutils import unittest, FileCreator
@@ -54,7 +55,7 @@ class TestRecursiveShapes(unittest.TestCase):
                 'type': 'structure',
                 'members': {
                     'A': {'shape': 'NonRecursive'},
-                    'B':  {'shape': 'RecursiveStruct'},
+                    'B': {'shape': 'RecursiveStruct'},
                 }
             },
             'NonRecursive': {'type': 'string'}
@@ -73,7 +74,7 @@ class TestRecursiveShapes(unittest.TestCase):
                 'type': 'structure',
                 'members': {
                     'A': {'shape': 'NonRecursive'},
-                    'B':  {'shape': 'RecursiveStruct'},
+                    'B': {'shape': 'RecursiveStruct'},
                 }
             },
             'NonRecursive': {'type': 'string'}
@@ -149,6 +150,19 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         help_command.obj = operation_model
         return help_command
 
+    def get_help_docs_for_argument(self, shape):
+        arg_table = {'arg-name': mock.Mock(argument_model=shape)}
+        help_command = mock.Mock()
+        help_command.doc = ReSTDocument()
+        help_command.event_class = 'custom'
+        help_command.arg_table = arg_table
+        operation_model = mock.Mock()
+        operation_model.service_model.operation_names = []
+        help_command.obj = operation_model
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_option('arg-name', help_command)
+        return help_command.doc.getvalue().decode('utf-8')
+
     def test_breadcrumbs_man(self):
         # Create an arbitrary help command class. This was chosen
         # because it is fairly easy to instantiate.
@@ -223,17 +237,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
             'locationName': 'X-Amz-Header-Name'
         }
         shape = StringShape('JSONValueArg', shape)
-        arg_table = {'arg-name': mock.Mock(argument_model=shape)}
-        help_command = mock.Mock()
-        help_command.doc = ReSTDocument()
-        help_command.event_class = 'custom'
-        help_command.arg_table = arg_table
-        operation_model = mock.Mock()
-        operation_model.service_model.operation_names = []
-        help_command.obj = operation_model
-        operation_handler = OperationDocumentEventHandler(help_command)
-        operation_handler.doc_option('arg-name', help_command)
-        rendered = help_command.doc.getvalue().decode('utf-8')
+        rendered = self.get_help_docs_for_argument(shape)
         self.assertIn('(JSON)', rendered)
 
     def test_documents_enum_values(self):
@@ -242,20 +246,100 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
             'enum': ['FOO', 'BAZ']
         }
         shape = StringShape('EnumArg', shape)
-        arg_table = {'arg-name': mock.Mock(argument_model=shape)}
-        help_command = mock.Mock()
-        help_command.doc = ReSTDocument()
-        help_command.event_class = 'custom'
-        help_command.arg_table = arg_table
-        operation_model = mock.Mock()
-        operation_model.service_model.operation_names = []
-        help_command.obj = operation_model
-        operation_handler = OperationDocumentEventHandler(help_command)
-        operation_handler.doc_option('arg-name', help_command)
-        rendered = help_command.doc.getvalue().decode('utf-8')
+        rendered = self.get_help_docs_for_argument(shape)
         self.assertIn('Possible values', rendered)
         self.assertIn('FOO', rendered)
         self.assertIn('BAZ', rendered)
+
+    def test_documents_recursive_input(self):
+        shape_map = {
+            'RecursiveStruct': {
+                'type': 'structure',
+                'members': {
+                    'A': {'shape': 'NonRecursive'},
+                    'B': {'shape': 'RecursiveStruct'},
+                }
+            },
+            'NonRecursive': {'type': 'string'}
+        }
+        shape = StructureShape('RecursiveStruct',
+                               shape_map['RecursiveStruct'],
+                               ShapeResolver(shape_map))
+        rendered = self.get_help_docs_for_argument(shape)
+        self.assertIn('( ... recursive ... )', rendered)
+
+    def test_documents_nested_structure(self):
+        shape_map = {
+            'UpperStructure': {
+                'type': 'structure',
+                'members': {
+                    'A': {'shape': 'NestedStruct'},
+                    'B': {'shape': 'NestedStruct'},
+                }
+            },
+            'NestedStruct': {
+                'type': 'structure',
+                'members': {
+                    'Nested_A': {'shape': 'Line'},
+                    'Nested_B': {'shape': 'Line'},
+                }
+            },
+            'Line': {'type': 'string'}
+        }
+        shape = StructureShape('UpperStructure',
+                               shape_map['UpperStructure'],
+                               ShapeResolver(shape_map))
+        rendered = self.get_help_docs_for_argument(shape)
+        self.assertEqual(rendered.count('A -> (structure)'), 1)
+        self.assertEqual(rendered.count('B -> (structure)'), 1)
+        self.assertEqual(rendered.count('Nested_A -> (string)'), 2)
+        self.assertEqual(rendered.count('Nested_B -> (string)'), 2)
+
+    def test_documents_nested_list(self):
+        shape_map = {
+            'UpperList': {
+                'type': 'list',
+                'member': {'shape': 'NestedStruct'},
+            },
+            'NestedStruct': {
+                'type': 'structure',
+                'members': {
+                    'Nested_A': {'shape': 'Line'},
+                    'Nested_B': {'shape': 'Line'},
+                }
+            },
+            'Line': {'type': 'string'}
+        }
+        shape = ListShape('UpperList', shape_map['UpperList'],
+                          ShapeResolver(shape_map))
+        rendered = self.get_help_docs_for_argument(shape)
+        self.assertEqual(rendered.count('(structure)'), 1)
+        self.assertEqual(rendered.count('Nested_A -> (string)'), 1)
+        self.assertEqual(rendered.count('Nested_B -> (string)'), 1)
+
+    def test_documents_nested_map(self):
+        shape_map = {
+            'UpperMap': {
+                'type': 'map',
+                'key': {'shape': 'NestedStruct'},
+                'value': {'shape': 'NestedStruct'},
+            },
+            'NestedStruct': {
+                'type': 'structure',
+                'members': {
+                    'Nested_A': {'shape': 'Line'},
+                    'Nested_B': {'shape': 'Line'},
+                }
+            },
+            'Line': {'type': 'string'}
+        }
+        shape = MapShape('UpperMap', shape_map['UpperMap'],
+                         ShapeResolver(shape_map))
+        rendered = self.get_help_docs_for_argument(shape)
+        self.assertEqual(rendered.count('key -> (structure)'), 1)
+        self.assertEqual(rendered.count('value -> (structure)'), 1)
+        self.assertEqual(rendered.count('Nested_A -> (string)'), 2)
+        self.assertEqual(rendered.count('Nested_B -> (string)'), 2)
 
     def test_description_only_for_crosslink_manpage(self):
         help_command = self.create_help_command()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Improve AWS CLI docs to include documentation strings for parameters in nested input structures

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
