### PR TITLE
Add codeartifact login duration support

### DIFF
--- a/.changes/next-release/enhancement-codeartifactlogin-18597.json
+++ b/.changes/next-release/enhancement-codeartifactlogin-18597.json
@@ -1,0 +1,5 @@
+{
+  "category": "``codeartifact login``", 
+  "type": "enhancement", 
+  "description": "Add expiration duration support"
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -4,15 +4,39 @@ import platform
 import sys
 import subprocess
 
+from datetime import datetime
+from dateutil.tz import tzutc
+from dateutil.relativedelta import relativedelta
+
 from awscli.compat import urlparse, RawConfigParser, StringIO
 from awscli.customizations import utils as cli_utils
 from awscli.customizations.commands import BasicCommand
 
 
+def get_relative_expiration_time(remaining):
+    values = []
+    prev_non_zero_attr = False
+    for attr in ["years", "months", "days", "hours", "minutes"]:
+        value = getattr(remaining, attr)
+        if value > 0:
+            if prev_non_zero_attr:
+                values.append("and")
+            values.append(str(value))
+            values.append(attr[:-1] if value == 1 else attr)
+        if prev_non_zero_attr:
+            break
+        prev_non_zero_attr = value > 0
+
+    message = " ".join(values)
+    return message
+
+
 class BaseLogin(object):
 
-    def __init__(self, auth_token, repository_endpoint, subprocess_utils):
+    def __init__(self, auth_token,
+                 expiration, repository_endpoint, subprocess_utils):
         self.auth_token = auth_token
+        self.expiration = expiration
         self.repository_endpoint = repository_endpoint
         self.subprocess_utils = subprocess_utils
 
@@ -24,6 +48,22 @@ class BaseLogin(object):
             sys.stdout.write(' '.join(command))
             sys.stdout.write(os.linesep)
             sys.stdout.write(os.linesep)
+
+    def _write_success_message(self, tool):
+        # add extra 30 seconds make expiration more reasonable
+        # for some corner case
+        # e.g. 11 hours 59 minutes 31 seconds should output --> 12 hours.
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        expiration_message = get_relative_expiration_time(remaining)
+
+        sys.stdout.write('Successfully configured {} to use '
+                         'AWS CodeArtifact repository {} '
+                         .format(tool, self.repository_endpoint))
+        sys.stdout.write(os.linesep)
+        sys.stdout.write('Login expires in {} at {}'.format(
+            expiration_message, self.expiration))
+        sys.stdout.write(os.linesep)
 
     def _run_commands(self, tool, commands, dry_run=False):
         if dry_run:
@@ -44,10 +84,7 @@ class BaseLogin(object):
                     )
                 raise ex
 
-        sys.stdout.write(
-            'Successfully logged in to codeartifact for %s.' % tool
-        )
-        sys.stdout.write(os.linesep)
+        self._write_success_message(tool)
 
     @classmethod
     def get_commands(cls, endpoint, auth_token, **kwargs):
@@ -135,6 +172,7 @@ password: {auth_token}'''
     def __init__(
         self,
         auth_token,
+        expiration,
         repository_endpoint,
         subprocess_utils,
         pypi_rc_path=None
@@ -143,7 +181,7 @@ password: {auth_token}'''
             pypi_rc_path = self.get_pypi_rc_path()
         self.pypi_rc_path = pypi_rc_path
         super(TwineLogin, self).__init__(
-            auth_token, repository_endpoint, subprocess_utils)
+            auth_token, expiration, repository_endpoint, subprocess_utils)
 
     @classmethod
     def get_commands(cls, endpoint, auth_token, **kwargs):
@@ -224,10 +262,7 @@ password: {auth_token}'''
             with open(self.pypi_rc_path, 'w+') as fp:
                 fp.write(pypi_rc_str)
 
-            sys.stdout.write(
-                'Successfully logged in to codeartifact for twine.'
-            )
-            sys.stdout.write(os.linesep)
+            self._write_success_message('twine')
 
     @classmethod
     def get_pypi_rc_path(cls):
@@ -256,8 +291,8 @@ class CodeArtifactLogin(BasicCommand):
 
     DESCRIPTION = (
         'Sets up the idiomatic tool for your package format to use your '
-        'CodeArtifact repository. Your login information is valid for 22 '
-        'hours after which you must login again.'
+        'CodeArtifact repository. Your login information is valid for up '
+        'to 12 hours after which you must login again.'
     )
 
     ARG_TABLE = [
@@ -276,6 +311,13 @@ class CodeArtifactLogin(BasicCommand):
             'name': 'domain-owner',
             'help_text': 'The AWS account ID that owns your CodeArtifact '
                          'domain',
+            'required': False,
+        },
+        {
+            'name': 'duration-seconds',
+            'cli_type_name': 'integer',
+            'help_text': 'The time, in seconds, that the login information '
+                         'is valid',
             'required': False,
         },
         {
@@ -317,10 +359,13 @@ class CodeArtifactLogin(BasicCommand):
         if parsed_args.domain_owner:
             kwargs['domainOwner'] = parsed_args.domain_owner
 
+        if parsed_args.duration_seconds:
+            kwargs['durationSeconds'] = parsed_args.duration_seconds
+
         get_authorization_token_response = \
             codeartifact_client.get_authorization_token(**kwargs)
 
-        return get_authorization_token_response['authorizationToken']
+        return get_authorization_token_response
 
     def _run_main(self, parsed_args, parsed_globals):
         tool = parsed_args.tool.lower()
@@ -331,7 +376,7 @@ class CodeArtifactLogin(BasicCommand):
             self._session, 'codeartifact', parsed_globals
         )
 
-        auth_token = self._get_authorization_token(
+        auth_token_res = self._get_authorization_token(
             codeartifact_client, parsed_args
         )
 
@@ -339,8 +384,10 @@ class CodeArtifactLogin(BasicCommand):
             codeartifact_client, parsed_args, package_format
         )
 
+        auth_token = auth_token_res['authorizationToken']
+        expiration = auth_token_res['expiration']
         login = self.TOOL_MAP[tool]['login_cls'](
-            auth_token, repository_endpoint, subprocess
+            auth_token, expiration, repository_endpoint, subprocess
         )
 
         login.login(parsed_args.dry_run)

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -1,7 +1,10 @@
 import os
 import platform
-import string
 import subprocess
+
+from datetime import datetime
+from dateutil.tz import tzlocal
+from dateutil.relativedelta import relativedelta
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, mock
 from awscli.compat import urlparse, StringIO, RawConfigParser
@@ -24,6 +27,9 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
         self.domain_owner = 'domain-owner'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(hours=10)
+                           + relativedelta(minutes=9)).replace(microsecond=0)
+        self.duration = 3600
 
         self.pypi_rc_path_patch = mock.patch(
             'awscli.customizations.codeartifact.login.TwineLogin'
@@ -41,7 +47,9 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
         self.subprocess_patch.stop()
         self.file_creator.remove_all()
 
-    def _setup_cmd(self, tool, include_domain_owner=False, dry_run=False):
+    def _setup_cmd(self, tool,
+                   include_domain_owner=False, dry_run=False,
+                   include_duration_seconds=False):
         package_format = CodeArtifactLogin.TOOL_MAP[tool]['package_format']
         self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
             'a2z.com/{format}/{repository}/'.format(
@@ -62,16 +70,21 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
         if dry_run:
             cmdline += ' --dry-run'
 
+        if include_duration_seconds:
+            cmdline += ' --duration-seconds %s' % self.duration
+
         # Responses from calls to services.
         self.parsed_responses = [
-            {"authorizationToken": self.auth_token},  # GetAuthorizationToken
+            {"authorizationToken": self.auth_token,
+                "expiration": self.expiration},  # GetAuthorizationToken
             {"repositoryEndpoint": self.endpoint},  # GetRepositoryEndpoint
         ]
 
         return cmdline
 
     def _get_npm_commands(self):
-        npm_cmd = 'npm.cmd' if platform.system().lower() == 'windows' else 'npm'
+        npm_cmd = 'npm.cmd' \
+            if platform.system().lower() == 'windows' else 'npm'
 
         repo_uri = urlparse.urlsplit(self.endpoint)
         always_auth_config = '//{}{}:always-auth'.format(
@@ -154,8 +167,15 @@ password: {auth_token}'''
 
         return pypi_rc_str
 
+    def _assert_expiration_printed_to_stdout(self, stdout):
+        self.assertEqual(
+            self.expiration.strftime(
+                "%Y-%m-%d %H:%M:%S"), stdout.split("at ")[1][0:19]
+        )
+
     def _assert_operations_called(
-        self, package_format, include_domain_owner=False
+        self, package_format,
+            include_domain_owner=False, include_duration_seconds=False
     ):
         self.assertEqual(len(self.operations_called), 2)
 
@@ -171,6 +191,9 @@ password: {auth_token}'''
         if include_domain_owner:
             get_auth_token_kwargs['domainOwner'] = self.domain_owner
             get_repo_endpoint_kwargs['domainOwner'] = self.domain_owner
+
+        if include_duration_seconds:
+            get_auth_token_kwargs['durationSeconds'] = self.duration
 
         self.assertEqual(
             self.operations_called[0][0].name, 'GetAuthorizationToken'
@@ -241,6 +264,7 @@ password: {auth_token}'''
         cmdline = self._setup_cmd(tool='npm')
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
         self._assert_operations_called(package_format='npm')
+        self._assert_expiration_printed_to_stdout(stdout)
         self._assert_subprocess_execution(self._get_npm_commands())
 
     def test_npm_login_without_domain_owner_dry_run(self):
@@ -253,8 +277,21 @@ password: {auth_token}'''
         cmdline = self._setup_cmd(tool='npm', include_domain_owner=True)
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
         self._assert_operations_called(
-            package_format='npm', include_domain_owner=True
+            package_format='npm',
+            include_domain_owner=True, include_duration_seconds=False
         )
+        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_subprocess_execution(self._get_npm_commands())
+
+    def test_npm_login_with_domain_owner_duration(self):
+        cmdline = self._setup_cmd(tool='npm', include_domain_owner=True,
+                                  include_duration_seconds=True)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        self._assert_operations_called(
+            package_format='npm',
+            include_domain_owner=True, include_duration_seconds=True
+        )
+        self._assert_expiration_printed_to_stdout(stdout)
         self._assert_subprocess_execution(self._get_npm_commands())
 
     def test_npm_login_with_domain_owner_dry_run(self):
@@ -273,6 +310,7 @@ password: {auth_token}'''
         self._assert_operations_called(
             package_format='pypi'
         )
+        self._assert_expiration_printed_to_stdout(stdout)
         self._assert_subprocess_execution(self._get_pip_commands())
 
     def test_pip_login_without_domain_owner_dry_run(self):
@@ -289,9 +327,21 @@ password: {auth_token}'''
         self._assert_operations_called(
             package_format='pypi', include_domain_owner=True
         )
+        self._assert_expiration_printed_to_stdout(stdout)
         self._assert_subprocess_execution(self._get_pip_commands())
 
-    def test_pip_login_with_domain_owner(self):
+    def test_pip_login_with_domain_owner_duration(self):
+        cmdline = self._setup_cmd(tool='pip', include_domain_owner=True,
+                                  include_duration_seconds=True)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        self._assert_operations_called(
+            package_format='pypi', include_domain_owner=True,
+            include_duration_seconds=True
+        )
+        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_subprocess_execution(self._get_pip_commands())
+
+    def test_pip_login_with_domain_owner_dry_run(self):
         cmdline = self._setup_cmd(
             tool='pip', include_domain_owner=True, dry_run=True
         )
@@ -307,7 +357,7 @@ password: {auth_token}'''
         self._assert_operations_called(
             package_format='pypi'
         )
-
+        self._assert_expiration_printed_to_stdout(stdout)
         with open(self.test_pypi_rc_path) as f:
             test_pypi_rc_str = f.read()
 
@@ -340,6 +390,28 @@ password: {auth_token}'''
         self._assert_operations_called(
             package_format='pypi', include_domain_owner=True
         )
+        self._assert_expiration_printed_to_stdout(stdout)
+
+        with open(self.test_pypi_rc_path) as f:
+            test_pypi_rc_str = f.read()
+
+        self._assert_pypi_rc_has_expected_content(
+            pypi_rc_str=test_pypi_rc_str,
+            server='codeartifact',
+            repo_url=self.endpoint,
+            username='aws',
+            password=self.auth_token
+        )
+
+    def test_twine_login_with_domain_owner_duration(self):
+        cmdline = self._setup_cmd(tool='twine', include_domain_owner=True,
+                                  include_duration_seconds=True)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        self._assert_operations_called(
+            package_format='pypi', include_domain_owner=True,
+            include_duration_seconds=True
+        )
+        self._assert_expiration_printed_to_stdout(stdout)
 
         with open(self.test_pypi_rc_path) as f:
             test_pypi_rc_str = f.read()

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -1,15 +1,16 @@
 import errno
 import os
-import platform
-import string
-import subprocess
+
+from datetime import datetime
+from dateutil.tz import tzlocal, tzutc
+from dateutil.relativedelta import relativedelta
 
 from awscli.testutils import unittest, mock, FileCreator
 from awscli.compat import urlparse, RawConfigParser, StringIO
-from awscli.customizations.codeartifact.login import BaseLogin
-from awscli.customizations.codeartifact.login import NpmLogin
-from awscli.customizations.codeartifact.login import PipLogin
-from awscli.customizations.codeartifact.login import TwineLogin
+from awscli.customizations.codeartifact.login import (
+    BaseLogin, NpmLogin, PipLogin, TwineLogin,
+    get_relative_expiration_time
+)
 
 
 class TestBaseLogin(unittest.TestCase):
@@ -19,6 +20,8 @@ class TestBaseLogin(unittest.TestCase):
         self.package_format = 'npm'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(hours=10)
+                           + relativedelta(minutes=9)).replace(microsecond=0)
         self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
             'a2z.com/{format}/{repository}/'.format(
                 domain=self.domain,
@@ -30,7 +33,8 @@ class TestBaseLogin(unittest.TestCase):
         self.subprocess_utils = mock.Mock()
 
         self.test_subject = BaseLogin(
-            self.auth_token, self.endpoint, self.subprocess_utils
+            self.auth_token, self.expiration,
+            self.endpoint, self.subprocess_utils
         )
 
     def test_login(self):
@@ -70,6 +74,8 @@ class TestNpmLogin(unittest.TestCase):
         self.package_format = 'npm'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(hours=10)
+                           + relativedelta(minutes=9)).replace(microsecond=0)
         self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
             'a2z.com/{format}/{repository}/'.format(
                 domain=self.domain,
@@ -99,7 +105,8 @@ class TestNpmLogin(unittest.TestCase):
         self.subprocess_utils = mock.Mock()
 
         self.test_subject = NpmLogin(
-            self.auth_token, self.endpoint, self.subprocess_utils
+            self.auth_token, self.expiration,
+            self.endpoint, self.subprocess_utils
         )
 
     def test_login(self):
@@ -136,6 +143,8 @@ class TestPipLogin(unittest.TestCase):
         self.package_format = 'pip'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(years=1)
+                           + relativedelta(months=9)).replace(microsecond=0)
         self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
             'a2z.com/{format}/{repository}/'.format(
                 domain=self.domain,
@@ -155,7 +164,8 @@ class TestPipLogin(unittest.TestCase):
         self.subprocess_utils = mock.Mock()
 
         self.test_subject = PipLogin(
-            self.auth_token, self.endpoint, self.subprocess_utils
+            self.auth_token, self.expiration,
+            self.endpoint, self.subprocess_utils
         )
 
     def test_get_commands(self):
@@ -191,6 +201,8 @@ class TestTwineLogin(unittest.TestCase):
         self.package_format = 'pip'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(years=1)
+                           + relativedelta(months=9)).replace(microsecond=0)
         self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
             'a2z.com/{format}/{repository}/'.format(
                 domain=self.domain,
@@ -209,6 +221,7 @@ class TestTwineLogin(unittest.TestCase):
 
         self.test_subject = TwineLogin(
             self.auth_token,
+            self.expiration,
             self.endpoint,
             self.subprocess_utils,
             self.test_pypi_rc_path
@@ -392,3 +405,108 @@ password: JgCXIr5xGG
         # We should just leave the pypirc untouched when it's invalid.
         with open(self.test_pypi_rc_path) as f:
             self.assertEqual(f.read(), original_content)
+
+
+class TestRelativeExpirationTime(unittest.TestCase):
+
+    def test_with_years_months_days(self):
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(years=1)
+                           + relativedelta(months=9) + relativedelta(days=11))\
+            .replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 year and 9 months')
+
+    def test_with_years_months(self):
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(years=1)
+                           + relativedelta(months=9)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 year and 8 months')
+
+    def test_with_years_month(self):
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(years=3)
+                           + relativedelta(months=1)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '3 years')
+
+    def test_with_years_days(self):
+        self.expiration = (datetime.now(tzlocal())
+                           + relativedelta(years=1)
+                           + relativedelta(days=9)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 year')
+
+    def test_with_year(self):
+        self.expiration = (datetime.now(tzlocal())
+                           + relativedelta(years=1)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '11 months and 30 days')
+
+    def test_with_years(self):
+        self.expiration = (datetime.now(tzlocal())
+                           + relativedelta(years=2)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 year and 11 months')
+
+    def test_with_years_days_hours_minutes(self):
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(years=2)
+                           + relativedelta(days=7) + relativedelta(hours=11) +
+                           relativedelta(minutes=44)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '2 years')
+
+    def test_with_days_minutes(self):
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(days=1) +
+                           relativedelta(minutes=44)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 day')
+
+    def test_with_day(self):
+        self.expiration = (datetime.now(tzlocal())
+                           + relativedelta(days=1)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 day')
+
+    def test_with_hour(self):
+        self.expiration = (datetime.now(tzlocal())
+                           + relativedelta(hours=1)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 hour')
+
+    def test_with_minutes_seconds(self):
+        self.expiration = (
+                datetime.now(tzlocal()) + relativedelta(minutes=59)
+                + relativedelta(seconds=50)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '1 hour')
+
+    def test_with_full_time(self):
+        self.expiration = (datetime.now(tzlocal())
+                           + relativedelta(years=2) + relativedelta(months=3)
+                           + relativedelta(days=7) + relativedelta(hours=11) +
+                           relativedelta(minutes=44)).replace(microsecond=0)
+        remaining = relativedelta(
+            self.expiration, datetime.now(tzutc())) + relativedelta(seconds=30)
+        message = get_relative_expiration_time(remaining)
+        self.assertEqual(message, '2 years and 3 months')


### PR DESCRIPTION
You can specify `--duration-seconds` to specify how long you can be logged in for and the output also includes the expiry time.
