### PR TITLE
Fix s3 bug when request payer not passed to subcommands

### DIFF
--- a/.changes/next-release/bugfix-s3-99894.json
+++ b/.changes/next-release/bugfix-s3-99894.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Fix `s3 cp` bug when request-payer parameter wasn't passed to subcommands"
+}

--- a/awscli/customizations/s3/subscribers.py
+++ b/awscli/customizations/s3/subscribers.py
@@ -313,10 +313,15 @@ class SetTagsSubscriber(OnDoneFilteredSubscriber):
                 future.set_exception(e)
 
     def _put_object_tagging(self, bucket, key, tag_set):
+        extra_args = {}
+        utils.RequestParamsMapper.map_put_object_tagging_params(
+            extra_args, self._cli_params
+        )
         self._client.put_object_tagging(
             Bucket=bucket,
             Key=key,
-            Tagging={'TagSet': tag_set}
+            Tagging={'TagSet': tag_set},
+            **extra_args
         )
 
     def _delete_object(self, bucket, key):
@@ -333,8 +338,12 @@ class SetTagsSubscriber(OnDoneFilteredSubscriber):
         return copy_source['Bucket'], copy_source['Key']
 
     def _get_tags(self, bucket, key):
+        extra_args = {}
+        utils.RequestParamsMapper.map_get_object_tagging_params(
+            extra_args, self._cli_params
+        )
         get_tags_response = self._client.get_object_tagging(
-            Bucket=bucket, Key=key)
+            Bucket=bucket, Key=key, **extra_args)
         return get_tags_response['TagSet']
 
     def _fits_in_tagging_header(self, tagging_header):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -442,6 +442,16 @@ class RequestParamsMapper(object):
         cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
+    def map_get_object_tagging_params(cls, request_params, cli_params):
+        """Map CLI params to GetObjectTagging request params"""
+        cls._set_request_payer_param(request_params, cli_params)
+
+    @classmethod
+    def map_put_object_tagging_params(cls, request_params, cli_params):
+        """Map CLI params to PutObjectTagging request params"""
+        cls._set_request_payer_param(request_params, cli_params)
+
+    @classmethod
     def map_copy_object_params(cls, request_params, cli_params):
         """Map CLI params to CopyObject request params"""
         cls._set_general_object_params(request_params, cli_params)

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -258,3 +258,10 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
         self.http_responses = [
             AWSResponse(None, code, {}, None) for code in status_codes
         ]
+
+    def mp_copy_responses(self):
+        return [
+            self.create_mpu_response('upload_id'),
+            self.upload_part_copy_response(),
+            self.complete_mpu_response(),
+        ]

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -506,6 +506,18 @@ class TestRequestParamsMapperRequestPayer(unittest.TestCase):
             params, self.cli_params)
         self.assertEqual(params, {'RequestPayer': 'requester'})
 
+    def test_map_get_object_tagging_params(self):
+        params = {}
+        RequestParamsMapper.map_get_object_tagging_params(
+            params, self.cli_params)
+        self.assertEqual(params, {'RequestPayer': 'requester'})
+
+    def test_map_put_object_tagging_params(self):
+        params = {}
+        RequestParamsMapper.map_put_object_tagging_params(
+            params, self.cli_params)
+        self.assertEqual(params, {'RequestPayer': 'requester'})
+
 
 class TestBytesPrint(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix `s3 cp` bug when `request-payer` parameter wasn't passed to subcommands

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
