### PR TITLE
Updating rsa pins for bundler script

### DIFF
--- a/scripts/assets/constraints-bundled.txt
+++ b/scripts/assets/constraints-bundled.txt
@@ -1,1 +1,2 @@
 python-dateutil==2.8.0
+rsa==3.4.2

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -28,7 +28,6 @@ EXTRA_RUNTIME_DEPS = [
     ('colorama', '0.4.1'),
     ('urllib3', '1.25.7'),
     ('PyYAML', '5.2'),
-    ('rsa', '4.0'),
 ]
 BUILDTIME_DEPS = [
     ('setuptools-scm', '3.3.3'),


### PR DESCRIPTION
Changing the pins for the copy of rsa included with the bundler. 3.4.2 is the last stable version that works for Python 2.7, 3.4 and 3.5+.