### PR TITLE
Adds missing curly bracket in examples/cloudformation/describe-stacks.rst

### DIFF
--- a/awscli/examples/cloudformation/describe-stacks.rst
+++ b/awscli/examples/cloudformation/describe-stacks.rst
@@ -27,6 +27,7 @@ Output::
               "DisableRollback": false
           }
       ]
+  }
 
 For more information, see `Stacks`_ in the *AWS CloudFormation User Guide*.
 


### PR DESCRIPTION
*Description of changes:*

Added a missing curly bracket in [examples/cloudformation/describe-stacks.rst](https://github.com/aws/aws-cli/blob/4ff0cbacbac69a21d4dd701921fe0759cf7852ed/awscli/examples/cloudformation/describe-stacks.rst)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
