### PR TITLE
Fix displaying of codeartfact login expiration

### DIFF
--- a/.changes/next-release/bugfix-codeartifactlogin-53280.json
+++ b/.changes/next-release/bugfix-codeartifactlogin-53280.json
@@ -1,0 +1,5 @@
+{
+  "category": "``codeartifact login``", 
+  "type": "bugfix", 
+  "description": "Fix issue with displaying expiration times"
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -7,6 +7,7 @@ import subprocess
 from datetime import datetime
 from dateutil.tz import tzutc
 from dateutil.relativedelta import relativedelta
+from botocore.utils import parse_timestamp
 
 from awscli.compat import urlparse, RawConfigParser, StringIO
 from awscli.customizations import utils as cli_utils
@@ -385,7 +386,7 @@ class CodeArtifactLogin(BasicCommand):
         )
 
         auth_token = auth_token_res['authorizationToken']
-        expiration = auth_token_res['expiration']
+        expiration = parse_timestamp(auth_token_res['expiration'])
         login = self.TOOL_MAP[tool]['login_cls'](
             auth_token, expiration, repository_endpoint, subprocess
         )

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -1,10 +1,12 @@
 import os
 import platform
 import subprocess
+import time
 
 from datetime import datetime
 from dateutil.tz import tzlocal
 from dateutil.relativedelta import relativedelta
+from botocore.utils import parse_timestamp
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, mock
 from awscli.compat import urlparse, StringIO, RawConfigParser
@@ -27,9 +29,9 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
         self.domain_owner = 'domain-owner'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
-        self.expiration = (datetime.now(tzlocal()) + relativedelta(hours=10)
-                           + relativedelta(minutes=9)).replace(microsecond=0)
         self.duration = 3600
+        self.expiration = time.time() + self.duration
+        self.expiration_as_datetime = parse_timestamp(self.expiration)
 
         self.pypi_rc_path_patch = mock.patch(
             'awscli.customizations.codeartifact.login.TwineLogin'
@@ -169,7 +171,7 @@ password: {auth_token}'''
 
     def _assert_expiration_printed_to_stdout(self, stdout):
         self.assertEqual(
-            self.expiration.strftime(
+            self.expiration_as_datetime.strftime(
                 "%Y-%m-%d %H:%M:%S"), stdout.split("at ")[1][0:19]
         )
 


### PR DESCRIPTION
Logic to produce relative expiration time was expecting a datetime when botocore produced an epoch timestamp. Example of it working correctly now:
```
$ aws codeartifact login --tool twine --domain mydomain --repository myrepository
Successfully configured twine to use AWS CodeArtifact repository https://mydomain-012345678912.d.codeartifact.us-west-2.amazonaws.com/pypi/myrepository/ 
Login expires in 12 hours at 2020-07-16 01:42:41-07:00
```

