### PR TITLE
[v2] Add cloudfront completion for 2020-05-21

### DIFF
--- a/awscli/data/cloudfront/2020-05-31/completions-1.json
+++ b/awscli/data/cloudfront/2020-05-31/completions-1.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "resources": {},
+  "operations": {}
+}


### PR DESCRIPTION
CloudFront bumped their API version and so the completion model need to copied to this new API version.
