### PR TITLE
[v2] Sensible Pager provider chain.

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -190,12 +190,7 @@ class CLIDriver(object):
             ScopedConfigProvider(
                 config_var_name='cli_pager',
                 session=self.session,
-            ),
-            EnvironmentProvider(
-                name='PAGER',
-                env=os.environ,
-            ),
-            ConstantProvider(value=default_pager),
+            )
         ]
         return ChainProvider(providers=providers)
 

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -14,8 +14,6 @@ import json
 
 import ruamel.yaml as yaml
 
-
-from awscli.testutils import skip_if_windows, if_windows
 from awscli.testutils import mock, create_clidriver, FileCreator
 from awscli.testutils import BaseAWSCommandParamsTest
 
@@ -81,35 +79,11 @@ class TestOutput(BaseAWSCommandParamsTest):
             content += write_call[0][0]
         return content
 
-    def test_outputs_to_pager(self):
-        self.run_cmd(self.cmdline)
-        self.assert_content_to_pager(
-            expected_pager=mock.ANY,
-            expected_content=self.expected_content
-        )
-
     def test_does_not_output_to_pager_if_not_tty(self):
         self.mock_is_a_tty.return_value = False
         stdout, _, _ = self.run_cmd(self.cmdline)
         self.assertFalse(self.mock_popen.called)
         self.assertEqual(stdout, self.expected_content)
-
-    @skip_if_windows('less is not used for windows')
-    def test_outputs_to_less_non_windows(self):
-        self.run_cmd(self.cmdline)
-        self.assert_content_to_pager(
-            expected_pager='less',
-            expected_content=self.expected_content,
-            expected_less_flags='FRX'
-        )
-
-    @if_windows('more is only used for windows')
-    def test_outputs_to_more_for_windows(self):
-        self.run_cmd(self.cmdline)
-        self.assert_content_to_pager(
-            expected_pager='more',
-            expected_content=self.expected_content,
-        )
 
     def test_respects_aws_pager_env_var(self):
         self.environ['AWS_PAGER'] = 'mypager'
@@ -121,14 +95,6 @@ class TestOutput(BaseAWSCommandParamsTest):
 
     def test_respects_cli_pager_config_var(self):
         self.write_cli_pager_config('mypager')
-        self.run_cmd(self.cmdline)
-        self.assert_content_to_pager(
-            expected_pager='mypager',
-            expected_content=self.expected_content,
-        )
-
-    def test_respects_pager_env_var(self):
-        self.environ['PAGER'] = 'mypager'
         self.run_cmd(self.cmdline)
         self.assert_content_to_pager(
             expected_pager='mypager',


### PR DESCRIPTION
https://github.com/aws/aws-cli/pull/4702#issuecomment-658574750

*Description of changes:*

In PR #4702, command output directly to a pager was added. One of the provider mechanisms in that PR was (and is) the `PAGER` env var., with a fallback of _using the default pager_.  The provider chain reads like so:
- Value of `AWS_PAGER` environment variable.
- Value of `cli_pager` config option
- Value of `PAGER` environment variable.
- _The default pager detected for the OS_

This is a show stopper in one-liners and similar on-the-fly automation efforts, because it interrupts the logic flow and forces a human to exit from the pager at each iteration. The post-merge feedback on the original PR is very vocal. Additional pain and feedback from users (and AWS customers by extension) in #5102 and #5343.

This PR removes the `PAGER` environment variable and the default-pager from the evaluation logic, leaving the `AWS_PAGER` environment variable, and the config option itself. This allows users to be explicit on their desired behavior, while not ripping the feature out entirely. Win win. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
