### PR TITLE
Add scope/namespace option to CodeArtifact login

### DIFF
--- a/.changes/next-release/enhancement-codeartifactlogin-29592.json
+++ b/.changes/next-release/enhancement-codeartifactlogin-29592.json
@@ -1,0 +1,5 @@
+{
+  "category": "``codeartifact login``", 
+  "type": "enhancement", 
+  "description": "Add support for ``--namespace`` parameter `#5291 <https://github.com/aws/aws-cli/issues/5291>`__"
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -3,6 +3,7 @@ import os
 import platform
 import sys
 import subprocess
+import re
 
 from datetime import datetime
 from dateutil.tz import tzutc
@@ -34,12 +35,13 @@ def get_relative_expiration_time(remaining):
 
 class BaseLogin(object):
 
-    def __init__(self, auth_token,
-                 expiration, repository_endpoint, subprocess_utils):
+    def __init__(self, auth_token, expiration,
+                 repository_endpoint, subprocess_utils, namespace=None):
         self.auth_token = auth_token
         self.expiration = expiration
         self.repository_endpoint = repository_endpoint
         self.subprocess_utils = subprocess_utils
+        self.namespace = namespace
 
     def login(self, dry_run=False):
         raise NotImplementedError('login()')
@@ -99,18 +101,47 @@ class NpmLogin(BaseLogin):
     NPM_CMD = 'npm.cmd' if platform.system().lower() == 'windows' else 'npm'
 
     def login(self, dry_run=False):
+        scope = self.get_scope(
+            self.namespace
+        )
         commands = self.get_commands(
-            self.repository_endpoint, self.auth_token
+            self.repository_endpoint, self.auth_token, scope=scope
         )
         self._run_commands('npm', commands, dry_run)
 
     @classmethod
+    def get_scope(cls, namespace):
+        # Regex for valid scope name
+        valid_scope_name = re.compile('^(@[a-z0-9-~][a-z0-9-._~]*)')
+
+        if namespace is None:
+            return namespace
+
+        # Add @ prefix to scope if it doesn't exist
+        if namespace.startswith('@'):
+            scope = namespace
+        else:
+            scope = '@{}'.format(namespace)
+
+        if not valid_scope_name.match(scope):
+            raise ValueError(
+                'Invalid scope name, scope must contain URL-safe '
+                'characters, no leading dots or underscores'
+            )
+
+        return scope
+
+    @classmethod
     def get_commands(cls, endpoint, auth_token, **kwargs):
         commands = []
+        scope = kwargs.get('scope')
+
+        # prepend scope if it exists
+        registry = '{}:registry'.format(scope) if scope else 'registry'
 
         # set up the codeartifact repository as the npm registry.
         commands.append(
-            [cls.NPM_CMD, 'config', 'set', 'registry', endpoint]
+            [cls.NPM_CMD, 'config', 'set', registry, endpoint]
         )
 
         repo_uri = urlparse.urlsplit(endpoint)
@@ -276,15 +307,18 @@ class CodeArtifactLogin(BasicCommand):
     TOOL_MAP = {
         'npm': {
             'package_format': 'npm',
-            'login_cls': NpmLogin
+            'login_cls': NpmLogin,
+            'namespace_support': True,
         },
         'pip': {
             'package_format': 'pypi',
-            'login_cls': PipLogin
+            'login_cls': PipLogin,
+            'namespace_support': False,
         },
         'twine': {
             'package_format': 'pypi',
-            'login_cls': TwineLogin
+            'login_cls': TwineLogin,
+            'namespace_support': False,
         }
     }
 
@@ -315,6 +349,11 @@ class CodeArtifactLogin(BasicCommand):
             'required': False,
         },
         {
+            'name': 'namespace',
+            'help_text': 'Associates a namespace with your repository tool',
+            'required': False,
+        },
+        {
             'name': 'duration-seconds',
             'cli_type_name': 'integer',
             'help_text': 'The time, in seconds, that the login information '
@@ -336,6 +375,16 @@ class CodeArtifactLogin(BasicCommand):
             'default': False
         },
     ]
+
+    def _get_namespace(self, tool, parsed_args):
+        namespace_compatible = self.TOOL_MAP[tool]['namespace_support']
+
+        if not namespace_compatible and parsed_args.namespace:
+            raise ValueError(
+                'Argument --namespace is not supported for {}'.format(tool)
+            )
+        else:
+            return parsed_args.namespace
 
     def _get_repository_endpoint(
         self, codeartifact_client, parsed_args, package_format
@@ -385,10 +434,12 @@ class CodeArtifactLogin(BasicCommand):
             codeartifact_client, parsed_args, package_format
         )
 
+        namespace = self._get_namespace(tool, parsed_args)
+
         auth_token = auth_token_res['authorizationToken']
         expiration = parse_timestamp(auth_token_res['expiration'])
         login = self.TOOL_MAP[tool]['login_cls'](
-            auth_token, expiration, repository_endpoint, subprocess
+            auth_token, expiration, repository_endpoint, subprocess, namespace
         )
 
         login.login(parsed_args.dry_run)

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -29,6 +29,7 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
         self.domain_owner = 'domain-owner'
         self.repository = 'repository'
         self.auth_token = 'auth-token'
+        self.namespace = 'namespace'
         self.duration = 3600
         self.expiration = time.time() + self.duration
         self.expiration_as_datetime = parse_timestamp(self.expiration)
@@ -51,7 +52,8 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
 
     def _setup_cmd(self, tool,
                    include_domain_owner=False, dry_run=False,
-                   include_duration_seconds=False):
+                   include_duration_seconds=False,
+                   include_namespace=False):
         package_format = CodeArtifactLogin.TOOL_MAP[tool]['package_format']
         self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
             'a2z.com/{format}/{repository}/'.format(
@@ -75,6 +77,9 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
         if include_duration_seconds:
             cmdline += ' --duration-seconds %s' % self.duration
 
+        if include_namespace:
+            cmdline += ' --namespace %s' % self.namespace
+
         # Responses from calls to services.
         self.parsed_responses = [
             {"authorizationToken": self.auth_token,
@@ -84,7 +89,7 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
 
         return cmdline
 
-    def _get_npm_commands(self):
+    def _get_npm_commands(self, **kwargs):
         npm_cmd = 'npm.cmd' \
             if platform.system().lower() == 'windows' else 'npm'
 
@@ -96,9 +101,12 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
             repo_uri.netloc, repo_uri.path
         )
 
+        scope = kwargs.get('scope')
+        registry = '{}:registry'.format(scope) if scope else 'registry'
+
         commands = []
         commands.append(
-            [npm_cmd, 'config', 'set', 'registry', self.endpoint]
+            [npm_cmd, 'config', 'set', registry, self.endpoint]
         )
         commands.append(
             [npm_cmd, 'config', 'set', always_auth_config, 'true']
@@ -306,6 +314,26 @@ password: {auth_token}'''
         )
         self._assert_dry_run_execution(self._get_npm_commands(), stdout)
 
+    def test_npm_login_with_namespace(self):
+        cmdline = self._setup_cmd(
+            tool='npm', include_namespace=True
+        )
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        self._assert_operations_called(package_format='npm')
+        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_subprocess_execution(
+            self._get_npm_commands(scope='@{}'.format(self.namespace))
+        )
+
+    def test_npm_login_with_namespace_dry_run(self):
+        cmdline = self._setup_cmd(
+            tool='npm', include_namespace=True, dry_run=True
+        )
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        self._assert_operations_called(package_format='npm')
+        self._assert_dry_run_execution(self._get_npm_commands(
+            scope='@{}'.format(self.namespace)), stdout)
+
     def test_pip_login_without_domain_owner(self):
         cmdline = self._setup_cmd(tool='pip')
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
@@ -352,6 +380,23 @@ password: {auth_token}'''
             package_format='pypi', include_domain_owner=True
         )
         self._assert_dry_run_execution(self._get_pip_commands(), stdout)
+
+    def test_pip_login_with_namespace(self):
+        cmdline = self._setup_cmd(tool='pip', include_namespace=True)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        self._assert_operations_called(
+            package_format='pypi'
+        )
+        self.assertIn('Argument --namespace is not supported for pip', stderr)
+
+    def test_pip_login_with_namespace_dry_run(self):
+        cmdline = self._setup_cmd(
+            tool='pip', include_namespace=True, dry_run=True)
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        self._assert_operations_called(
+            package_format='pypi'
+        )
+        self.assertIn('Argument --namespace is not supported for pip', stderr)
 
     def test_twine_login_without_domain_owner(self):
         cmdline = self._setup_cmd(tool='twine')
@@ -442,3 +487,26 @@ password: {auth_token}'''
             username='aws',
             password=self.auth_token
         )
+
+    def test_twine_login_with_namespace(self):
+        cmdline = self._setup_cmd(
+            tool='twine', include_namespace=True
+        )
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        self._assert_operations_called(
+            package_format='pypi'
+        )
+        self.assertIn(
+            'Argument --namespace is not supported for twine', stderr)
+
+    def test_twine_login_with_namespace_dry_run(self):
+        cmdline = self._setup_cmd(
+            tool='twine', include_namespace=True, dry_run=True
+        )
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
+        self._assert_operations_called(
+            package_format='pypi',
+        )
+        self.assertFalse(os.path.exists(self.test_pypi_rc_path))
+        self.assertIn(
+            'Argument --namespace is not supported for twine', stderr)


### PR DESCRIPTION
Resolves #5291 

*Description of changes:*

This change adds the ability to pass in a scope/namespace to CodeArtifact login.
The primary arg is `namespace` to remain generalized across different CodeArtifact
tools (ie: npm scope, maven groupid).

This change also includes:

- Throw error if namespace or scope are used for configuring pip
- Throw error if namespace or scope are used for configuring twine
- Throw error if namespace and scope are used at the same time
- Accept npm namespace value with or without "@" prefix for scope
- Add "@" prefix to npm scope if user has not passed it
- Validation on scope name to adhere with npm rules


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
