### PR TITLE
Use 'alias' as kube-context username when arg is passed

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -116,6 +116,7 @@ class UpdateKubeconfigCommand(BasicCommand):
         client = EKSClient(self._session,
                            parsed_args.name,
                            parsed_args.role_arn,
+                           parsed_args.alias,
                            parsed_globals)
         new_cluster_dict = client.get_cluster_entry()
         new_user_dict = client.get_user_entry()
@@ -230,10 +231,11 @@ class KubeconfigSelector(object):
 
 
 class EKSClient(object):
-    def __init__(self, session, cluster_name, role_arn, parsed_globals=None):
+    def __init__(self, session, cluster_name, role_arn, alias, parsed_globals=None):
         self._session = session
         self._cluster_name = cluster_name
         self._role_arn = role_arn
+        self._alias = alias
         self._cluster_description = None
         self._globals = parsed_globals
 
@@ -293,7 +295,7 @@ class EKSClient(object):
         region = self._get_cluster_description().get("arn").split(":")[3]
 
         generated_user = OrderedDict([
-            ("name", self._get_cluster_description().get("arn", "")),
+            ("name", self._alias if self._alias is not None else self._get_cluster_description().get("arn", "")),
             ("user", OrderedDict([
                 ("exec", OrderedDict([
                     ("apiVersion", API_VERSION),

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -194,7 +194,7 @@ class TestEKSClient(unittest.TestCase):
         self._session.create_client.return_value = self._mock_client
         self._session.profile = None
 
-        self._client = EKSClient(self._session, "ExampleCluster", None)
+        self._client = EKSClient(self._session, "ExampleCluster", None, None)
 
     def test_get_cluster_description(self):
         self.assertEqual(self._client._get_cluster_description(),


### PR DESCRIPTION
*Issue #, if available:* #4079

*Description of changes:*
We have a similar issue to #4079, whereby admin users want to perform tests on eks clusters with both developer-like and admin permissions. We use alias's as our way to distinguish between contexts. 

With current setup, the following two commands executed one after the other would overwrite the user entry since its sharing the same user-name (i.e. the cluster ARN is always the user-name):
`aws eks update-kubeconfig --name mycluster --role-arn arn:aws:iam::123456789123:role/k8s-admin --alias mycluster-admin`
`aws eks update-kubeconfig --name mycluster --role-arn arn:aws:iam::123456789123:role/k8s-dev --alias mycluster-dev`

I feel like an easy win would be to use the `--alias` name as the user-name for the context, since the alias is anyway being used as the kube-context name. With this change if the `alias` arg isn't passed, the user-name would continue to be named as before, i.e. cluster-ARN.

@swetashre, since the issue is assigned to you, I was wondering what you think of this approach? 

Thanks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
