### PR TITLE
change ancient issue timeout to one year

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -10,19 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v3
+    - uses: aws-actions/stale-issue-cleanup@v4
       with:
-        # Setting messages to an empty string will cause the automation to skip
-        # that category
-        ancient-issue-message: Greetings! It looks like this issue hasn’t been active in longer than three years. We encourage you to check if this is still an issue in the latest release. Because it has been longer than three years since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment to prevent automatic closure, or if the issue is already closed, please feel free to reopen it.
+        issue-types: issues
+        ancient-issue-message: Greetings! It looks like this issue hasn’t been active in longer than one year. We encourage you to check if this is still an issue in the latest release. Because it has been longer than one year since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment to prevent automatic closure, or if the issue is already closed, please feel free to reopen it.
         stale-issue-message: Greetings! It looks like this issue hasn’t been active in longer than a week. We encourage you to check if this is still an issue in the latest release. Because it has been longer than a week since the last update on this, and in the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or add an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
-        stale-pr-message: Greetings! It looks like this PR hasn’t been active in longer than a week, add a comment or an upvote to prevent automatic closure, or if the issue is already closed, please feel free to open a new one.
 
         # These labels are required
         stale-issue-label: closing-soon
-        exempt-issue-label: auto-label-exempt
-        stale-pr-label: closing-soon
-        exempt-pr-label: pr/needs-review
+        exempt-issue-label: automation-exempt, help wanted, bug, confusing-error
         response-requested-label: response-requested
 
         # Don't set closed-for-staleness label to skip closing very old issues
@@ -32,7 +28,7 @@ jobs:
         # Issue timing
         days-before-stale: 7
         days-before-close: 4
-        days-before-ancient: 1095
+        days-before-ancient: 365
 
         # If you don't want to mark a issue as being ancient based on a
         # threshold of "upvotes", you can set this here. An "upvote" is


### PR DESCRIPTION
*Description of changes:*

To align with SDK and CDK standards, this sets the ancient issue auto-close length to one year (365 days).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
