### PR TITLE
Add support for cf and codepipeline parameters file to cf deploy

### DIFF
--- a/.changes/next-release/feature-cloudformation-43713.json
+++ b/.changes/next-release/feature-cloudformation-43713.json
@@ -1,5 +1,5 @@
 {
-  "type": "feature",
+  "type": "enhancement",
   "category": "``cloudformation``",
-  "description": "CloudFormation ``deploy`` command now supports various JSON file formats as an input for ``--parameter-overrides`` option."
+  "description": "CloudFormation ``deploy`` command now supports various JSON file formats as an input for ``--parameter-overrides`` option `#2828 <https://github.com/aws/aws-cli/issues/2828>`__"
 }

--- a/.changes/next-release/feature-cloudformation-43713.json
+++ b/.changes/next-release/feature-cloudformation-43713.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``cloudformation``",
+  "description": "CloudFormation ``deploy`` command now supports various JSON file formats as an input for ``--parameter-overrides`` option."
+}

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -390,9 +390,20 @@ class DeployCommand(BasicCommand):
         if isinstance(data, dict):
             return data.get('Parameters', None)
 
+    def _parse_input_as_json(self, arg_value):
+        # In case of inline json input it'll be list where json string
+        # will be the first element
+        if arg_value:
+            if isinstance(arg_value, str):
+                return json.loads(arg_value)
+            try:
+                return json.loads(arg_value[0])
+            except json.JSONDecodeError:
+                return None
+
     def parse_parameter_overrides(self, arg_value):
-        if isinstance(arg_value, str):
-            data = json.loads(arg_value)
+        data = self._parse_input_as_json(arg_value)
+        if data is not None:
             parsers = [
                 self._cf_param_parser,
                 self._codepipeline_param_parser,

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -119,7 +119,7 @@ class DeployCommand(BasicCommand):
                 ' existing value. For new stacks, you must specify'
                 ' parameters that don\'t have a default value.'
                 ' Syntax: ParameterKey1=ParameterValue1'
-                ' ParameterKey2=ParameterValue2 ...'
+                ' ParameterKey2=ParameterValue2 ... or JSON file (see Examples)'
             )
         },
         {

--- a/awscli/examples/cloudformation/deploy.rst
+++ b/awscli/examples/cloudformation/deploy.rst
@@ -23,15 +23,17 @@ CloudFormation like format::
     [
        {
             "ParameterKey": "Key1",
-            "ParameterValue": "Value1",
+            "ParameterValue": "Value1"
         },
         {
             "ParameterKey": "Key2",
-            "ParameterValue": "Value2",
-        },
+            "ParameterValue": "Value2"
+        }
     ]
 
-    Note: Only ParameterKey and ParameterValue are expected keys, command will through an exception if receives unexpected keys (e.g. UsePreviousValue or ResolvedValue).
+.. note::
+
+ Only ParameterKey and ParameterValue are expected keys, command will throw an exception if receives unexpected keys (e.g. UsePreviousValue or ResolvedValue).
 
 CodePipeline like format::
 

--- a/awscli/examples/cloudformation/deploy.rst
+++ b/awscli/examples/cloudformation/deploy.rst
@@ -4,3 +4,40 @@ Following command deploys template named ``template.json`` to a stack named
 
     aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides Key1=Value1 Key2=Value2 --tags Key1=Value1 Key2=Value2
 
+or the same command using parameters from JSON file ``parameters.json``::
+
+    aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides file://path_to_parameters/parameters.json --tags Key1=Value1 Key2=Value2
+
+Supported JSON syntax
+~~~~~~~~~~~~~~~~~~~~~
+
+Original format::
+
+    [
+        "Key1=Value1",
+        "Key2=Value2"
+    ]
+
+CloudFormation like format::
+
+    [
+       {
+            "ParameterKey": "Key1",
+            "ParameterValue": "Value1",
+        },
+        {
+            "ParameterKey": "Key2",
+            "ParameterValue": "Value2",
+        },
+    ]
+
+    Note: Only ParameterKey and ParameterValue are expected keys, command will through an exception if receives unexpected keys (e.g. UsePreviousValue or ResolvedValue).
+
+CodePipeline like format::
+
+    [
+        "Parameters": {
+            "Key1": "Value1",
+            "Key2": "Value2"
+        }
+    ]

--- a/tests/functional/cloudformation/test_deploy.py
+++ b/tests/functional/cloudformation/test_deploy.py
@@ -60,3 +60,122 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
     def test_does_return_non_zero_exit_code_on_empty_changeset(self):
         self.command += ' --fail-on-empty-changeset'
         self.run_cmd(self.command, expected_rc=255)
+
+
+class TestDeployCommandParameterOverrides(TestDeployCommand):
+    def setUp(self):
+        super(TestDeployCommandParameterOverrides, self).setUp()
+        template = '''{
+          "AWSTemplateFormatVersion": "2010-09-09",
+          "Parameters": {
+            "Key1": {
+              "Type": "String"
+            },
+            "Key2": {
+              "Type": "String"
+            }
+          }
+        }'''
+        path = self.files.create_file('template.json', template)
+        self.command = (
+            'cloudformation deploy --template-file %s '
+            '--stack-name Stack '
+        ) % path
+
+    def _assert_parameters_parsed(self):
+        self.assertEqual(
+            self.operations_called[1][1]['Parameters'],
+            [
+                {'ParameterKey': 'Key1', 'ParameterValue': 'Value1'},
+                {'ParameterKey': 'Key2', 'ParameterValue': 'Value2'}
+            ]
+        )
+
+    def test_parameter_overrides_shorthand(self):
+        self.command += ' --parameter-overrides Key1=Value1 Key2=Value2'
+        self.run_cmd(self.command)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_inline_original_json(self):
+        original_like_json = '["Key1=Value1","Key2=Value2"]'
+        path = self.files.create_file('param.json', original_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        self.run_cmd(self.command)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_inline_cf_like_json(self):
+        cf_like_json = ('[{"ParameterKey":"Key1",'
+                        '"ParameterValue":"Value1"},'
+                        '{"ParameterKey":"Key2",'
+                        '"ParameterValue":"Value2"}]')
+        self.command += ' --parameter-overrides %s' % cf_like_json
+        self.run_cmd(self.command)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_cf_like_json_file(self):
+        cf_like_json = '''
+            [
+                {"ParameterKey": "Key1", "ParameterValue": "Value1"},
+                {"ParameterKey": "Key2", "ParameterValue": "Value2"}
+            ]
+        '''
+        path = self.files.create_file('param.json', cf_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        self.run_cmd(self.command)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_invalid_cf_like_json_file(self):
+        cf_like_json = '''
+            [
+                {"ParameterKey": "Key1",
+                 "ParameterValue": "Value1",
+                 "RedundantKey": "RedundantValue"
+                 },
+                {"ParameterKey": "Key2", "ParameterValue": "Value2"}
+            ]
+        '''
+        path = self.files.create_file('param.json', cf_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        _, err, _ = self.run_cmd(self.command, expected_rc=252)
+        self.assertTrue('CloudFormation like parameter JSON should have format'
+                        in err)
+
+    def test_parameter_overrides_from_inline_codepipeline_like_json(self):
+        codepipeline_like_json = ('{"Parameters":{"Key1":"Value1",'
+                                  '"Key2":"Value2"}}')
+        self.command += ' --parameter-overrides %s' % codepipeline_like_json
+        self.run_cmd(self.command)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_codepipeline_like_json_file(self):
+        codepipeline_like_json = '''
+            {
+                "Parameters":
+                {"Key1": "Value1",
+                 "Key2": "Value2"}
+            }
+        '''
+        path = self.files.create_file('param.json', codepipeline_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        self.run_cmd(self.command)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_original_json_file(self):
+        original_like_json = '''
+            [
+                "Key1=Value1",
+                "Key2=Value2"
+            ]
+        '''
+        path = self.files.create_file('param.json', original_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        self.run_cmd(self.command, expected_rc=0)
+        self._assert_parameters_parsed()
+
+    def test_parameter_overrides_from_random_invalid_json(self):
+        cf_like_json = '{"SomeKey":[{"RedundantKey": "RedundantValue"}]}'
+        path = self.files.create_file('param.json', cf_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        _, err, _ = self.run_cmd(self.command, expected_rc=255)
+        self.assertTrue("['SomeKey'] value passed to --parameter-overrides"
+                        in err)

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -473,6 +473,18 @@ class TestDeployCommand(BaseYAMLTest):
         result = self.deploy_command.parse_parameter_overrides(data)
         self.assertEqual(result, output)
 
+    def test_parse_parameter_override_with_inline_json(self):
+        data = [json.dumps([
+            'Key1=Value1',
+            'Key2=[1,2,3]',
+            'Key3={"a":"val", "b": 2}'
+        ])]
+        output = {"Key1": "Value1",
+                  "Key2": '[1,2,3]',
+                  "Key3": '{"a":"val", "b": 2}'}
+        result = self.deploy_command.parse_parameter_overrides(data)
+        self.assertEqual(result, output)
+
     def test_parse_parameter_override_with_deploy_data_format(self):
         """
         Tests that we can parse parameter arguments in

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import json
+
 import mock
 import tempfile
 import six
@@ -20,6 +22,7 @@ from awscli.customizations.cloudformation.deploy import DeployCommand
 from awscli.customizations.cloudformation.deployer import Deployer
 from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 from awscli.customizations.cloudformation import exceptions
+from awscli.customizations.exceptions import ParamValidationError
 from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
@@ -399,6 +402,93 @@ class TestDeployCommand(BaseYAMLTest):
         # Empty input should return empty output
         result = self.deploy_command.parse_key_value_arg([], argname)
         self.assertEqual(result, {})
+
+    def test_parse_parameter_override_with_cf_data_format(self):
+        """
+        Tests that we can parse parameter arguments from file in
+        CloudFormation parameters file format
+        :return:
+        """
+        data = json.dumps([
+            {'ParameterKey': 'Key1',
+             'ParameterValue': 'Value1'},
+            {'ParameterKey': 'Key2',
+             'ParameterValue': '[1,2,3]'},
+            {'ParameterKey': 'Key3',
+             'ParameterValue': '{"a":"val", "b": 2}'}
+        ])
+        output = {"Key1": "Value1",
+                  "Key2": '[1,2,3]',
+                  "Key3": '{"a":"val", "b": 2}'}
+        result = self.deploy_command.parse_parameter_overrides(data)
+        self.assertEqual(result, output)
+
+    def test_validate_parameter_override_with_cf_data_format(self):
+        """
+        Tests that we through exception if have redundant keys in json
+        CloudFormation parameters file format
+        :return:
+        """
+        data = json.dumps([
+            {'ParameterKey': 'Key1',
+             'ParameterValue': 'Value1',
+             'RedundantKey': 'foo'}
+        ])
+        with self.assertRaises(ParamValidationError):
+            self.deploy_command.parse_parameter_overrides(data)
+
+    def test_parse_parameter_override_with_codepipeline_data_format(self):
+        """
+        Tests that we can parse parameter arguments from file in
+        CodePipeline parameters file format
+        :return:
+        """
+        data = json.dumps({
+            'Parameters': {
+                "Key1": "Value1",
+                "Key2": '[1,2,3]',
+                "Key3": '{"a":"val", "b": 2}'
+            }
+        })
+        output = {"Key1": "Value1",
+                  "Key2": '[1,2,3]',
+                  "Key3": '{"a":"val", "b": 2}'}
+        result = self.deploy_command.parse_parameter_overrides(data)
+        self.assertEqual(result, output)
+
+    def test_parse_parameter_override_with_deploy_data_format_from_file(self):
+        """
+        Tests that we can parse parameter arguments from file in
+        deploy command parameters file format
+        :return:
+        """
+        data = json.dumps([
+            'Key1=Value1',
+            'Key2=[1,2,3]',
+            'Key3={"a":"val", "b": 2}'
+        ])
+        output = {"Key1": "Value1",
+                  "Key2": '[1,2,3]',
+                  "Key3": '{"a":"val", "b": 2}'}
+        result = self.deploy_command.parse_parameter_overrides(data)
+        self.assertEqual(result, output)
+
+    def test_parse_parameter_override_with_deploy_data_format(self):
+        """
+        Tests that we can parse parameter arguments in
+        deploy command parameters command line format
+        :return:
+        """
+        data = [
+            'Key1=Value1',
+            'Key2=[1,2,3]',
+            'Key3={"a":"val", "b": 2}'
+        ]
+        output = {"Key1": "Value1",
+                  "Key2": '[1,2,3]',
+                  "Key3": '{"a":"val", "b": 2}'}
+        result = self.deploy_command.parse_parameter_overrides(data)
+        self.assertEqual(result, output)
 
     def test_parse_key_value_arg_invalid_input(self):
         # non-list input


### PR DESCRIPTION
Add support for cf and codepipeline parameters file to cf deploy command

*Issue #, if available:*  #2828

*Description of changes:*

### Current state:

The current format for “*—parameter-overrides*“ option is

`ParameterKey1=ParameterValue1 ParameterKey2=ParameterKey2 `

or JSON format

```
  [
    "ParameterKey1=ParameterValue1",
    "ParameterKey2=ParameterKey2"
  ]
```

### Proposed improvements:

Keep the shorthand format without changing but update the file parser to accept data in “CloudFromation format” and “CodePipeline format”, it means such JSON formats will be valid as well


* **“CloudFromation format”**

```
[
   {
        "ParameterKey": "ParameterKey1",
        "ParameterValue": "ParameterValue1",
    },
    {
        "ParameterKey": "ParameterKey2",
        "ParameterValue": "ParameterValue2",
    },
...
]
```

* **“CodePipeline format”**

```
[
    "Parameters": {
        "ParameterKey1": "ParameterValue1",
        "ParameterKey2": "ParameterValue2"`
    }

...
]
```

***Note: ***the logic of the “*—parameter-overrides*“ option won’t be changed, it means that it will expect only parameter’s keys and values and throw ValidationError if get unexpected keys (e. g. ***UsePreviousValue*** or ***ResolvedValue **which exist in CloudFormation format)*.. If parameter not set will be used previous value if stack is updated or default value for stack creation.



## Examples

Following command deploys template named ``template.json`` to a stack named ``my-new-stack``:


```
aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides BucketName=MyBucket Tag1value=awesomeBucket
```

```
template.json{
  "AWSTemplateFormatVersion": "2010-09-09",
  "Description": "AWS CloudFormation Sample S3 bucket Template.",
  "Parameters": {
    "BucketName": {
      "Description": "Name of s3 Bucket",
      "Type": "String"
    },
    "Tag1value": {
      "Description": "Tag1 value",
      "Default": "value1",
      "Type": "String"
    },
    "Tag2value": {
      "Description": "Tag2 value",
      "Default": "value2",
      "Type": "String"
    }
  },
  "Resources": {
    "s3bucket": {
      "Type": "AWS::S3::Bucket",
      "Properties": {
        "BucketName": {"Ref": "BucketName"},
        "Tags": [
          {
            "Key": "Tag1",
            "Value": {"Ref": "Tag1value"}
          },
          {
            "Key": "Tag2",
            "Value": {"Ref": "Tag2value"}
          }
        ]
      }
    }
  }
}
```


You can do the same with inline json 


```
aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides '["BucketName=MyBucket", "Tag1value=awesomeBucket"]'
```


Or you can do the same using JSON file

```
aws cloudformation deploy --template-file /path_to_template/template.json --stack-name my-new-stack --parameter-overrides file://parameter.json 

parameter.json in CloudFormation format
[
   {
        "ParameterKey": "BucketName",
        "ParameterValue": "MyBucket",
    },
    {
        "ParameterKey": "Tag1value",
        "ParameterValue": "awesomeBucket",
    },
]

parameter.json in CodePipeline format
[
    "Parameters": {
        "BucketName": "MyBucket",
        "Tag1value": "awesomeBucket"
    }
]

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
