### PR TITLE
Fix typo in ecr example command

### DIFF
--- a/awscli/examples/ecr/set-repository-policy.rst
+++ b/awscli/examples/ecr/set-repository-policy.rst
@@ -1,6 +1,6 @@
 **To set the repository policy for a repository**
 
-The following ``set-repository-polixy`` example attaches a repository policy contained in a file to the ``cluster-autoscaler`` repository. ::
+The following ``set-repository-policy`` example attaches a repository policy contained in a file to the ``cluster-autoscaler`` repository. ::
 
     aws ecr set-repository-policy \
         --repository-name cluster-autoscaler \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The word "policy" was misspelled in the example command for setting an ECR policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
