### PR TITLE
Disable pager in non interactive mode

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -57,7 +57,6 @@ except ImportError:
 
 is_windows = sys.platform == 'win32'
 
-
 if is_windows:
     default_pager = 'more'
 else:

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -253,7 +253,7 @@ def emit_top_level_args_parsed_event(session, args):
 
 def is_a_tty():
     try:
-        return os.isatty(sys.stdout.fileno())
+        return sys.__stdin__.isatty() and sys.stdout.isatty()
     except Exception as e:
         return False
 

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -150,6 +150,7 @@ class TestOutput(BaseAWSCommandParamsTest):
             expected_content=self.expected_content,
         )
 
+    @mock.patch('awscli.clidriver.is_interactive', True)
     def test_aws_pager_env_var_beats_pager_env_var(self):
         self.write_cli_pager_config('configpager')
         self.environ['PAGER'] = 'envpager'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Disable pager if AWS CLI runs in non interactive mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
