### PR TITLE
Stringify values from JSON for deploy parameter-overrides

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -442,7 +442,8 @@ class DeployCommand(BasicCommand):
             ]
             for parser in parsers:
                 if parser.can_parse(data):
-                    return parser.parse(data)
+                    return {key: str(value)
+                            for key, value in parser.parse(data).items()}
             raise ParamValidationError(
                 'JSON passed to --parameter-overrides must be one of '
                 'the formats: ["Key1=Value1","Key2=Value2", ...] , '

--- a/tests/functional/cloudformation/test_deploy.py
+++ b/tests/functional/cloudformation/test_deploy.py
@@ -146,6 +146,24 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
         self.run_cmd(self.command)
         self._assert_parameters_parsed()
 
+    def test_parameter_overrides_from_json_file_with_nonstring_params(self):
+        codepipeline_like_json = {
+            'Parameters': {
+                'Key1': True,
+                'Key2': 1
+            }
+        }
+        path = self.create_json_file('param.json', codepipeline_like_json)
+        self.command += ' --parameter-overrides file://%s' % path
+        self.run_cmd(self.command)
+        self.assertEqual(
+            self.operations_called[1][1]['Parameters'],
+            [
+                {'ParameterKey': 'Key1', 'ParameterValue': 'True'},
+                {'ParameterKey': 'Key2', 'ParameterValue': '1'}
+            ]
+        )
+
     def test_parameter_overrides_from_original_json_file(self):
         original_like_json = ['Key1=Value1', 'Key2=Value2']
         path = self.create_json_file('param.json', original_like_json)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When values in JSON aren't strings they are sent to the service as they are but service expects for strings only.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
