### PR TITLE
bump version of PyInstaller to 4.0 

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,4 +2,4 @@
 # We create the separation for cases where we're doing installation
 # from a local dependency directory instead of requirements.txt.
 cryptography==2.8
-PyInstaller==3.5
+PyInstaller==4.0


### PR DESCRIPTION
    bump version of PyInstaller to 4.0 to make it compile/install
    smoothly on arm

*Issue #, if available:*

compile error during compile/install

*Description of changes:*

change the version number of pyinstaller

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
