### PR TITLE
Fix sts parameter example

### DIFF
--- a/awscli/examples/sts/get-session-token.rst
+++ b/awscli/examples/sts/get-session-token.rst
@@ -3,7 +3,7 @@
 The following ``get-session-token`` example retrieves a set of short-term credentials for the IAM identity making the call. The resulting credentials can be used for requests where multi-factor authentication (MFA) is required by policy. The credentials expire 15 minutes after they are generated. ::
 
      aws sts get-session-token \
-         --session-duration 900 \
+         --duration-seconds 900 \
          --serial-number "YourMFADeviceSerialNumber" \
          --token-code 123456
 


### PR DESCRIPTION
duration-seconds is the correct option to use as per https://docs.aws.amazon.com/cli/latest/reference/sts/get-session-token.html
Tested with aws-cli 2.0.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
