### PR TITLE
Fix README rendering on PyPI.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup_options = dict(
     version=find_version("awscli", "__init__.py"),
     description='Universal Command Line Environment for AWS.',
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     author='Amazon Web Services',
     url='http://aws.amazon.com/cli/',
     scripts=['bin/aws', 'bin/aws.cmd',


### PR DESCRIPTION
*Description of changes:*

README markdown is not rendered now on PyPI: https://pypi.org/project/awscli/
Add long_description_content_type to fix the rendering issue.

See https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
