### PR TITLE
Don't display (AWS Secret Access Key) on cli

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -19,6 +19,7 @@ import platform
 import zipfile
 import signal
 import contextlib
+import getpass
 
 from botocore.compat import six
 #import botocore.compat
@@ -229,7 +230,10 @@ def compat_input(prompt):
     """
     sys.stdout.write(prompt)
     sys.stdout.flush()
-    return raw_input()
+    if "AWS Secret Access Key" in prompt: 
+        return getpass.getpass('')
+    else:
+        return raw_input()
 
 
 def compat_shell_quote(s, platform=None):

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -19,7 +19,7 @@ import platform
 import zipfile
 import signal
 import contextlib
-from getpass import getpass
+import getpass
 
 from botocore.compat import six
 #import botocore.compat

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -19,7 +19,7 @@ import platform
 import zipfile
 import signal
 import contextlib
-import getpass
+from getpass import getpass
 
 from botocore.compat import six
 #import botocore.compat


### PR DESCRIPTION
It's better to don't display `AWS Secret Access Key` on the screen when running `aws configure`:
```
AWS Access Key ID [****************Rt71]: adqQEWQEFDFASDA1121
AWS Secret Access Key [****************Ym4F]: 344523DSAFGDE12EERdfsHG76%6bvvc!dDFDF
```
Here is the output of CLI:
```
AWS Access Key ID [****************Rt71]: adqQEWQEFDFASDA1121
AWS Secret Access Key [****************Ym4F]: 
```


