### PR TITLE
Add CodeCommit Repository Resource to cloudformation package command

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -506,6 +506,20 @@ class GlueJobCommandScriptLocationResource(Resource):
     PROPERTY_NAME = "Command.ScriptLocation"
 
 
+class CodeCommitRepositoryS3Resource(ResourceWithS3UrlDict):
+    """
+    Represents CodeCommit::Repository resource.
+    """
+    RESOURCE_TYPE = "AWS::CodeCommit::Repository"
+    PROPERTY_NAME = "Code.S3"
+    BUCKET_NAME_PROPERTY = "Bucket"
+    OBJECT_KEY_PROPERTY = "Key"
+    VERSION_PROPERTY = "ObjectVersion"
+    # Don't package the directory if S3 is omitted.
+    PACKAGE_NULL_PROPERTY = False
+    FORCE_ZIP = True
+
+
 RESOURCES_EXPORT_LIST = [
     ServerlessFunctionResource,
     ServerlessApiResource,
@@ -523,7 +537,8 @@ RESOURCES_EXPORT_LIST = [
     LambdaLayerVersionResource,
     GlueJobCommandScriptLocationResource,
     StepFunctionsStateMachineDefinitionResource,
-    ServerlessStateMachineDefinitionResource
+    ServerlessStateMachineDefinitionResource,
+    CodeCommitRepositoryS3Resource
 ]
 
 METADATA_EXPORT_LIST = [

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -29,6 +29,7 @@ This command can upload local artifacts referenced in the following places:
     - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
     - ``DefinitionS3Location`` property for the ``AWS::StepFunctions::StateMachine`` resource
     - ``DefinitionUri`` property for the ``AWS::Serverless::StateMachine`` resource
+    - ``S3`` property for the ``AWS::CodeCommit::Repository`` resource
 
 
 To specify a local artifact in your template, specify a path to a local file or folder,

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -28,7 +28,8 @@ from awscli.customizations.cloudformation.artifact_exporter \
     AppSyncFunctionConfigurationResponseTemplateResource, \
     GlueJobCommandScriptLocationResource, \
     StepFunctionsStateMachineDefinitionResource, \
-    ServerlessStateMachineDefinitionResource
+    ServerlessStateMachineDefinitionResource, \
+    CodeCommitRepositoryS3Resource
 
 
 VALID_CASES = [


### PR DESCRIPTION
This commit enables the `aws cloudformation package` command
to package the `AWS::CodeCommit::Repository` resource type.

*Issue #, if available:*

#4316

*Description of changes:*
This PR enables `aws cloudformation package` to work with the `AWS::CodeCommit::Repository` resource.
Below shows an example of the input and output.
```yaml
# template.yaml
  Repository:
    Type: AWS::CodeCommit::Repository
    Properties:
      RepositoryName: ExampleRepo
      Code: 
        S3: "./templates"
```

```yaml
# packaged.yaml
  Repository:
    Type: AWS::CodeCommit::Repository
    Properties:
      RepositoryName: ExampleRepo
      Code:
        S3:
          Bucket: example-bucket
          Key: example-key/86b2583b377db47d6632369e46588f79
```

*Testing*

I have tested packaging and deploying a template with this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
