### PR TITLE
Add support for AWS::Synthetics::Canary.Code to aws cloudformation package

### DIFF
--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -30,6 +30,7 @@ This command can upload local artifacts referenced in the following places:
     - ``DefinitionS3Location`` property for the ``AWS::StepFunctions::StateMachine`` resource
     - ``DefinitionUri`` property for the ``AWS::Serverless::StateMachine`` resource
     - ``S3`` property for the ``AWS::CodeCommit::Repository`` resource
+    - ``Code.Script`` property for the ``AWS::Synthetics::Canary`` resource
 
 
 To specify a local artifact in your template, specify a path to a local file or folder,


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/5230

*Description of changes:*

Adds support to `aws cloudformation package` for `AWS::Synthetics::Canary` by introducing a new class `ResourceWithS3UrlProperties` that performs mostly the same function as `ResourceWithS3UrlDict` but has the additional feature that it preserves existing properties.

This is required because, unlike `AWS::Lambda::Function`, the Canary resource defines the `Handler` and S3 location properties within the same dict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Example input:

```yaml
MyCanary:                                                                                                                                               
  Type: "AWS::Synthetics::Canary"                                                                                                                       
  Properties:                                                                                                                                           
    ArtifactS3Location: s3://abucket/                                                                                                           
    Code:                                                                                                                                               
      Handler: foo.handler                                                                                                                              
      Script: foo.py                                                                                                                                    
    ExecutionRoleArn: !GetAtt MyRole.Arn                                                                                                                
    Name: CanaryName                                                                                                                               
    RuntimeVersion: syn-1.0                                                                                                                             
    Schedule:                                                                                                                                           
      Expression: rate(1 minute)                                                                                                                        
    StartCanaryAfterCreation: false
```

Example output:

```yaml
MyCanary:                                                                                                                                               
  Type: "AWS::Synthetics::Canary"                                                                                                                       
  Properties:                                                                                                                                           
    ArtifactS3Location: s3://abucket/                                                                                                           
    Code:                                                                                                                                               
      Handler: foo.handler           # Note that the Handler property has been preserved                                                                                                                    
      S3Bucket: anotherbucket
      S3Key: 0123456789abcdef                                                                                                                           
    ExecutionRoleArn: !GetAtt MyRole.Arn                                                                                                                
    Name: CanaryName                                                                                                                               
    RuntimeVersion: syn-1.0                                                                                                                             
    Schedule:                                                                                                                                           
      Expression: rate(1 minute)                                                                                                                        
    StartCanaryAfterCreation: false
```