### PR TITLE
Making setup.py compatible with pipx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 
 [metadata]
 requires-dist =
-        botocore==2.0.0dev55
+        botocore@https://github.com/boto/botocore/zipball/v2#egg=botocore
         colorama>=0.2.5,<0.4.4
         docutils>=0.10,<0.16
         cryptography>=2.8.0,<=2.9.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 
 
 requires = [
-    'botocore==2.0.0dev55',
+    'botocore@https://github.com/boto/botocore/zipball/v2#egg=botocore',
     'colorama>=0.2.5,<0.4.4',
     'docutils>=0.10,<0.16',
     'cryptography>=2.8.0,<=2.9.0',


### PR DESCRIPTION
*Issue #, if available:*
Install using pipx fails on non existent dependency botocore==2.0.0dev55

*Description of changes:*
The setup.py is now usable with pipx: pipx install --spec git+https://github.com/aws/aws-cli.git@v2 awscli

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
