### PR TITLE
Add AWS::Serverless::StateMachine resource to cloudformation package command

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -426,6 +426,15 @@ class StepFunctionsStateMachineDefinitionResource(ResourceWithS3UrlDict):
     PACKAGE_NULL_PROPERTY = False
 
 
+class ServerlessStateMachineDefinitionResource(ResourceWithS3UrlDict):
+    RESOURCE_TYPE = "AWS::Serverless::StateMachine"
+    PROPERTY_NAME = "DefinitionUri"
+    BUCKET_NAME_PROPERTY = "Bucket"
+    OBJECT_KEY_PROPERTY = "Key"
+    VERSION_PROPERTY = "Version"
+    PACKAGE_NULL_PROPERTY = False
+
+
 class CloudFormationStackResource(Resource):
     """
     Represents CloudFormation::Stack resource that can refer to a nested
@@ -513,7 +522,8 @@ RESOURCES_EXPORT_LIST = [
     ServerlessLayerVersionResource,
     LambdaLayerVersionResource,
     GlueJobCommandScriptLocationResource,
-    StepFunctionsStateMachineDefinitionResource
+    StepFunctionsStateMachineDefinitionResource,
+    ServerlessStateMachineDefinitionResource
 ]
 
 METADATA_EXPORT_LIST = [

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -28,6 +28,7 @@ This command can upload local artifacts referenced in the following places:
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
     - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
     - ``DefinitionS3Location`` property for the ``AWS::StepFunctions::StateMachine`` resource
+    - ``DefinitionUri`` property for the ``AWS::Serverless::StateMachine`` resource
 
 
 To specify a local artifact in your template, specify a path to a local file or folder,

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -27,7 +27,8 @@ from awscli.customizations.cloudformation.artifact_exporter \
     AppSyncFunctionConfigurationRequestTemplateResource, \
     AppSyncFunctionConfigurationResponseTemplateResource, \
     GlueJobCommandScriptLocationResource, \
-    StepFunctionsStateMachineDefinitionResource
+    StepFunctionsStateMachineDefinitionResource, \
+    ServerlessStateMachineDefinitionResource
 
 
 VALID_CASES = [
@@ -155,6 +156,12 @@ RESOURCE_EXPORT_TEST_CASES = [
     },
     {
         "class": StepFunctionsStateMachineDefinitionResource,
+        "expected_result": {
+            "Bucket": "foo", "Key": "bar", "Version": "baz"
+        }
+    },
+    {
+        "class": ServerlessStateMachineDefinitionResource,
         "expected_result": {
             "Bucket": "foo", "Key": "bar", "Version": "baz"
         }


### PR DESCRIPTION
*Issue #:* #5480 

*Description of changes:*

AWS SAM [added support for AWS Step Functions](https://aws.amazon.com/about-aws/whats-new/2020/05/aws-sam-adds-support-for-aws-step-functions/). One of the properties is `DefinitionUri`, which is not currently exported as an artifact when calling `aws cloudformation package`.

This is based on PR #5222.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
