### PR TITLE
Allow to name the session name when importing STSClientFactory

### DIFF
--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -111,12 +111,12 @@ class STSClientFactory(object):
     def __init__(self, session):
         self._session = session
 
-    def get_sts_client(self, region_name=None, role_arn=None):
+    def get_sts_client(self, region_name=None, role_arn=None, role_session_name='EKSGetTokenAuth'):
         client_kwargs = {
             'region_name': region_name
         }
         if role_arn is not None:
-            creds = self._get_role_credentials(region_name, role_arn)
+            creds = self._get_role_credentials(region_name, role_arn, role_session_name)
             client_kwargs['aws_access_key_id'] = creds['AccessKeyId']
             client_kwargs['aws_secret_access_key'] = creds['SecretAccessKey']
             client_kwargs['aws_session_token'] = creds['SessionToken']
@@ -124,11 +124,11 @@ class STSClientFactory(object):
         self._register_cluster_name_handlers(sts)
         return sts
 
-    def _get_role_credentials(self, region_name, role_arn):
+    def _get_role_credentials(self, region_name, role_arn, role_session_name):
         sts = self._session.create_client('sts', region_name)
         return sts.assume_role(
             RoleArn=role_arn,
-            RoleSessionName='EKSGetTokenAuth'
+            RoleSessionName=role_session_name
         )['Credentials']
 
     def _register_cluster_name_handlers(self, sts_client):


### PR DESCRIPTION
As the AWS EKS token mechanism is not implemented in boto3 / botocore directly (as it's actually a presigned URL workflow) some people want to import STSClientFactory as part of their own code.

```from awscli.customizations.eks.get_token import TokenGenerator, STSClientFactory```

For auditing purposes it's nice to have the possibility to submit a RoleSessionName other than EKSTokenAuth.

I'm not sure if this functionality is relevant for pure CLI use cases so I did not implement it.

*Description of changes:*

Added parameter to private method and set the previous hardcoded value as default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
