### PR TITLE
Add AWS::CloudFormation::Stackset resource to cloudformation package command

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -497,6 +497,15 @@ class GlueJobCommandScriptLocationResource(Resource):
     PROPERTY_NAME = "Command.ScriptLocation"
 
 
+class CloudFormationStacksetResource(CloudFormationStackResource):
+    """
+    Represents CloudFormation::Stackset Resource that can refer to a
+    stack template via TemplateURL property.
+    """
+
+    RESOURCE_TYPE = "AWS::CloudFormation::StackSet"
+    PROPERTY_NAME = "TemplateURL"
+
 RESOURCES_EXPORT_LIST = [
     ServerlessFunctionResource,
     ServerlessApiResource,
@@ -509,6 +518,7 @@ RESOURCES_EXPORT_LIST = [
     LambdaFunctionResource,
     ElasticBeanstalkApplicationVersion,
     CloudFormationStackResource,
+    CloudFormationStacksetResource,
     ServerlessApplicationResource,
     ServerlessLayerVersionResource,
     LambdaLayerVersionResource,

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -26,6 +26,7 @@ This command can upload local artifacts referenced in the following places:
     - ``Location`` parameter for the ``AWS::Include`` transform
     - ``SourceBundle`` property for the ``AWS::ElasticBeanstalk::ApplicationVersion`` resource
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
+    - ``TemplateURL`` property for the ``AWS::CloudFormation::Stackset`` resource
     - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
     - ``DefinitionS3Location`` property for the ``AWS::StepFunctions::StateMachine`` resource
 

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -27,7 +27,8 @@ from awscli.customizations.cloudformation.artifact_exporter \
     AppSyncFunctionConfigurationRequestTemplateResource, \
     AppSyncFunctionConfigurationResponseTemplateResource, \
     GlueJobCommandScriptLocationResource, \
-    StepFunctionsStateMachineDefinitionResource
+    StepFunctionsStateMachineDefinitionResource, \
+    CloudFormationStacksetResource
 
 
 VALID_CASES = [
@@ -730,6 +731,37 @@ class TestArtifactExporter(unittest.TestCase):
             stack_resource.export(resource_id, resource_dict, parent_dir)
 
             self.assertEqual(resource_dict[property_name], result_path_style_s3_url)
+
+            TemplateMock.assert_called_once_with(template_path, parent_dir, self.s3_uploader_mock)
+            template_instance_mock.export.assert_called_once_with()
+            self.s3_uploader_mock.upload_with_dedup.assert_called_once_with(mock.ANY, "template")
+            self.s3_uploader_mock.to_path_style_s3_url.assert_called_once_with("world", None)
+
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.Template")
+    def test_export_cloudformation_stackset(self, TemplateMock):
+        stackset_resource = CloudFormationStacksetResource(self.s3_uploader_mock)
+
+        resource_id = "id"
+        property_name = stackset_resource.PROPERTY_NAME
+        exported_template_dict = {"foo": "bar"}
+        result_s3_url = "s3://hello/world"
+        result_path_style_s3_url = "http://s3.amazonws.com/hello/world"
+
+        template_instance_mock = mock.Mock()
+        TemplateMock.return_value = template_instance_mock
+        template_instance_mock.export.return_value = exported_template_dict
+
+        self.s3_uploader_mock.upload_with_dedup.return_value = result_s3_url
+        self.s3_uploader_mock.to_path_style_s3_url.return_value = result_path_style_s3_url
+
+        with tempfile.NamedTemporaryFile() as handle:
+            template_path = handle.name
+            resource_dict = {property_name: template_path}
+            parent_dir = tempfile.gettempdir()
+
+            stackset_resource.export(resource_id, resource_dict, parent_dir)
+
+            self.assertEquals(resource_dict[property_name], result_path_style_s3_url)
 
             TemplateMock.assert_called_once_with(template_path, parent_dir, self.s3_uploader_mock)
             template_instance_mock.export.assert_called_once_with()


### PR DESCRIPTION
*Issue #, if available:*
#5590 

*Description of changes:*
This PR enables the `aws cloudformation package` command to package the `AWS::CloudFormation::Stackset` resource.

It defines the `CloudFormationStacksetResource` class in `artifact_exporter.py`. This is an extension of the `CloudFormationStackResource` class.

I have also updated the docs.

Before this is merged, I debated whether a test should be added to `tests/unit/customizations/cloudformation/test_artifact_exporter.py`. 
I would appreciate some guidance on whether this is necessary. 


Here is an example snippet of the template, and output after the packaging command
```yaml
# template.yaml
MainStackSet:
    Type: AWS::CloudFormation::StackSet
    Properties:
      StackSetName: example-stackset
      PermissionModel: SELF_MANAGED
      TemplateURL: ./main.yaml
      Capabilities:
          - CAPABILITY_IAM
      StackInstancesGroup: 
        - Regions:
            - us-east-1
          DeploymentTargets:
            Accounts:
              - !Ref AWS::AccountId
```

```yaml
#packaged.yaml
MainStackSet:
    Type: AWS::CloudFormation::StackSet
    Properties:
      StackSetName: example-stackset
      PermissionModel: SELF_MANAGED
      TemplateURL: https://s3.eu-west-2.amazonaws.com/example-bucket/stackset-test/9a8c1dca11fcd0938d8eb3b6850e9d9c.template
      Capabilities:
      - CAPABILITY_IAM
      StackInstancesGroup:
      - Regions:
        - us-east-1
        DeploymentTargets:
          Accounts:
          - Ref: AWS::AccountId
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
