### PR TITLE
feat: sort account list

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -193,6 +193,7 @@ class ConfigureSSOCommand(BasicCommand):
         if len(accounts) == 1:
             sso_account_id = self._handle_single_account(accounts)
         else:
+            accounts = sorted(accounts, key=lambda i: i['accountName'])
             sso_account_id = self._handle_multiple_accounts(accounts)
         uni_print('Using the account ID {}\n'.format(sso_account_id))
         self._new_values['sso_account_id'] = sso_account_id


### PR DESCRIPTION
*Description of changes:*
Return the list of available accounts sorted by name. 

We have many accounts, all following a standard naming pattern. It would be super helpful to have these in alpha order when creating a new profile through interactive CLI. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
