### PR TITLE
Fix too open permissions of kubeconfig file created by command aws eks update-kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ nosetests.xml
 .idea*
 src/
 
+# VS Code IDE
+.vscode/*
+
 # CLI docs generation
 doc/source/aws_man_pages.json
 doc/source/reference
@@ -48,3 +51,11 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
+# Python environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/tests/functional/eks/test_update_kubeconfig.py
+++ b/tests/functional/eks/test_update_kubeconfig.py
@@ -12,17 +12,11 @@
 # language governing permissions and limitations under the License.
 
 import os
-import sys
 import mock
-import glob
-import yaml
-import logging
-import botocore
 import tempfile
 import shutil
 import re
-from argparse import Namespace
-from mock import patch, Mock, MagicMock, call
+from mock import patch, Mock
 
 from botocore.session import get_session
 
@@ -31,7 +25,7 @@ from awscli.customizations.eks.update_kubeconfig import UpdateKubeconfigCommand
 from awscli.customizations.eks.exceptions import EKSClusterError
 from awscli.customizations.eks.kubeconfig import (Kubeconfig,
                                                   KubeconfigCorruptedError,
-                                                  KubeconfigInaccessableError)
+                                                  KubeconfigInaccessibleError)
 from tests.functional.eks.test_util import (describe_cluster_response,
                                             describe_cluster_creating_response,
                                             get_testdata)
@@ -60,14 +54,14 @@ class TestUpdateKubeconfig(unittest.TestCase):
         self.create_client_patch = patch(
             'botocore.session.Session.create_client'
         )
-        
+
         self.mock_create_client = self.create_client_patch.start()
         self.session = get_session()
 
         self.client = Mock()
         self.client.describe_cluster.return_value = describe_cluster_response()
         self.mock_create_client.return_value = self.client
-                
+
         self.command = UpdateKubeconfigCommand(self.session)
         self.maxDiff = None
 
@@ -104,7 +98,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self._temp_directory)
         if files is not None:
             for file in files:
-                shutil.copy2(get_testdata(file), 
+                shutil.copy2(get_testdata(file),
                             self._get_temp_config(file))
         return self._temp_directory
 
@@ -118,7 +112,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         to put in the environment variable
         :type configs: list
         """
-        return build_environment([self._get_temp_config(config) 
+        return build_environment([self._get_temp_config(config)
                                   for config in configs])
 
     def assert_config_state(self, config_name, correct_output_name):
@@ -127,7 +121,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         as the testdata named correct_output_name.
         Should be called after initialize_tempfiles.
 
-        :param config_name: The filename (not the path) of the tempfile 
+        :param config_name: The filename (not the path) of the tempfile
         to compare
         :type config_name: str
 
@@ -191,7 +185,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
                    verbose=False):
         """
         Run update-kubeconfig in a temp directory,
-        This directory will have copies of all testdata files whose names 
+        This directory will have copies of all testdata files whose names
         are listed in configs.
         The KUBECONFIG environment variable will be set to contain the configs
         listed in env_variable_configs (regardless of whether they exist).
@@ -379,14 +373,14 @@ class TestUpdateKubeconfig(unittest.TestCase):
         # Default will be the temp directory once _get_temp_config is called
         default = ""
 
-        with self.assertRaises(KubeconfigInaccessableError):
+        with self.assertRaises(KubeconfigInaccessibleError):
             self.assert_cmd(configs, passed, environment, default)
 
     def test_update_existing(self):
         configs = ["valid_old_data"]
         passed = "valid_old_data"
         environment = []
-        
+
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_old_data", "output_combined")
 
@@ -396,7 +390,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         environment = ["valid_old_data",
                        "output_combined",
                        "output_single"]
-        
+
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_old_data", "output_combined")
 
@@ -416,4 +410,3 @@ class TestUpdateKubeconfig(unittest.TestCase):
 
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_changed_ordering", "output_combined_changed_ordering")
-

--- a/tests/functional/eks/test_update_kubeconfig.py
+++ b/tests/functional/eks/test_update_kubeconfig.py
@@ -23,8 +23,7 @@ from botocore.session import get_session
 from awscli.testutils import unittest, capture_output
 from awscli.customizations.eks.update_kubeconfig import UpdateKubeconfigCommand
 from awscli.customizations.eks.exceptions import EKSClusterError
-from awscli.customizations.eks.kubeconfig import (Kubeconfig,
-                                                  KubeconfigCorruptedError,
+from awscli.customizations.eks.kubeconfig import (KubeconfigCorruptedError,
                                                   KubeconfigInaccessibleError)
 from tests.functional.eks.test_util import (describe_cluster_response,
                                             describe_cluster_creating_response,
@@ -284,11 +283,13 @@ class TestUpdateKubeconfig(unittest.TestCase):
     def test_all_corrupted(self):
         configs = ["invalid_string_cluster_entry",
                    "invalid_string_contexts",
-                   "invalid_text"]
+                   "invalid_text",
+                   "non_parsable_yaml"]
         passed = None
         environment = ["invalid_string_cluster_entry",
                        "invalid_string_contexts",
-                       "invalid_text"]
+                       "invalid_text",
+                       "non_parsable_yaml"]
 
         with self.assertRaises(KubeconfigCorruptedError):
             self.assert_cmd(configs, passed, environment)

--- a/tests/functional/eks/testdata/invalid_text
+++ b/tests/functional/eks/testdata/invalid_text
@@ -1,2 +1,2 @@
-This is not a yaml file
-This is a text document which should not be parsed
+This is not a yaml file.
+This is a text document which is parsable as yaml by Python, but should not be processed.

--- a/tests/functional/eks/testdata/non_parsable_yaml
+++ b/tests/functional/eks/testdata/non_parsable_yaml
@@ -1,0 +1,1 @@
+This is invalid: yaml file: cannot be even parsed.

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -12,16 +12,12 @@
 # language governing permissions and limitations under the License.
 
 import glob
-import os
-import mock
-import tempfile
-import shutil
 from botocore.compat import OrderedDict
 
 from awscli.testutils import unittest
 from awscli.customizations.utils import uni_print
 from awscli.customizations.eks.kubeconfig import (KubeconfigError,
-                                                  KubeconfigInaccessableError,
+                                                  KubeconfigInaccessibleError,
                                                   KubeconfigCorruptedError,
                                                   Kubeconfig,
                                                   KubeconfigValidator,
@@ -43,7 +39,7 @@ class TestKubeconfig(unittest.TestCase):
 
     def test_no_content(self):
         config = Kubeconfig(self._path, None)
-        self.assertEqual(config.content, 
+        self.assertEqual(config.content,
                          _get_new_kubeconfig_content())
 
     def test_has_cluster(self):
@@ -89,7 +85,7 @@ class TestKubeconfigValidator(unittest.TestCase):
                 content_dict = ordered_yaml_load(stream)
             config = Kubeconfig(None, content_dict)
             self.assertRaises(KubeconfigCorruptedError,
-                              self._validator.validate_config, 
+                              self._validator.validate_config,
                               config)
 
 class TestKubeconfigAppender(unittest.TestCase):
@@ -173,7 +169,7 @@ class TestKubeconfigAppender(unittest.TestCase):
                 ("server", "endpoint")
             ])),
             ("name", "clustername")
-        ])            
+        ])
         correct = OrderedDict([
             ("apiVersion", "v1"),
             ("clusters", [
@@ -196,7 +192,7 @@ class TestKubeconfigAppender(unittest.TestCase):
                                               cluster)
         self.assertDictEqual(updated.content, correct)
 
-    def test_key_not_exist(self): 
+    def test_key_not_exist(self):
         initial = OrderedDict([
             ("apiVersion", "v1"),
             ("contexts", []),
@@ -250,7 +246,7 @@ class TestKubeconfigAppender(unittest.TestCase):
             ])),
             ("name", "clustername")
         ])
-        self.assertRaises(KubeconfigError, 
+        self.assertRaises(KubeconfigError,
                           self._appender.insert_entry,
                           Kubeconfig(None, initial),
                           "kind",

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -14,14 +14,10 @@
 import glob
 import os
 import mock
-import tempfile
-import shutil
-import sys
 import botocore
 from botocore.compat import OrderedDict
 
 from awscli.testutils import unittest
-from awscli.customizations.utils import uni_print
 import awscli.customizations.eks.kubeconfig as kubeconfig
 from awscli.customizations.eks.update_kubeconfig import (KubeconfigSelector,
                                                          EKSClient,
@@ -64,11 +60,11 @@ class TestKubeconfigSelector(unittest.TestCase):
                            path_in,
                            cluster_name,
                            chosen_path):
-        selector = KubeconfigSelector(env_variable, path_in, 
+        selector = KubeconfigSelector(env_variable, path_in,
                                                     self._validator,
                                                     self._loader)
         self.assertEqual(selector.choose_kubeconfig(cluster_name).path,
-                         chosen_path)  
+                         chosen_path)
 
     def test_parse_env_variable(self):
         paths = [
@@ -85,7 +81,7 @@ class TestKubeconfigSelector(unittest.TestCase):
 
         selector = KubeconfigSelector(env_variable, None, self._validator,
                                                           self._loader)
-        self.assertEqual(selector._paths, [path for path in paths 
+        self.assertEqual(selector._paths, [path for path in paths
                                                 if len(path) > 0])
 
     def test_choose_env_only(self):
@@ -97,9 +93,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("valid_no_user")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                None, 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                None,
+                                EXAMPLE_ARN,
                                 get_testdata("valid_simple"))
 
     def test_choose_existing(self):
@@ -113,9 +109,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("output_single_with_role")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                None, 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                None,
+                                EXAMPLE_ARN,
                                 get_testdata("output_single"))
 
     def test_arg_override(self):
@@ -129,9 +125,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("output_single_with_role")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                get_testdata("output_combined"), 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                get_testdata("output_combined"),
+                                EXAMPLE_ARN,
                                 get_testdata("output_combined"))
 
     def test_first_corrupted(self):
@@ -142,7 +138,7 @@ class TestKubeconfigSelector(unittest.TestCase):
         env_variable = generate_env_variable(paths)
         selector = KubeconfigSelector(env_variable, None, self._validator,
                                                           self._loader)
-        self.assertRaises(kubeconfig.KubeconfigCorruptedError, 
+        self.assertRaises(kubeconfig.KubeconfigCorruptedError,
                           selector.choose_kubeconfig,
                           EXAMPLE_ARN)
 
@@ -152,9 +148,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("valid_no_user")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                get_testdata("output_combined"), 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                get_testdata("output_combined"),
+                                EXAMPLE_ARN,
                                 get_testdata("output_combined"))
 
 class TestEKSClient(unittest.TestCase):


### PR DESCRIPTION
Closes https://github.com/aws/aws-cli/issues/5617

## Description
Since [Helm 3.3.4](https://github.com/helm/helm/releases/tag/v3.3.4) too open permissions for `kubeconfig` (group-readable, world-readable) are reported as warning.

In the case of non-existing `kubeconfig`, command `aws eks update-kubeconfig` creates it with default permissions
(which are often too open and introduces a security risk). Populating `kubeconfig` in this way is quite common in CI/CD pipelines.

This PR fixes it:
- in case of nonexisting `kubeconfig` creates it with `600` permissions
- in case of existing `kubeconfig` updates it and does not change permissions (even if they are too open)

## Behavior

### Before this PR

Example EKS cluster in this case `my-amazing-cluster` has to be created before.

Ensure that `~/.kube/config` **does not exist** and follow instruction.

```bash
aws eks update-kubeconfig --name my-amazing-cluster
```

Check permissions of created file

```bash
ls -l ~/.kube/config
```

```bash
-rw-r--r--  1 jakubwarczarek  staff  2366 Oct  2 17:29 /Users/jakubwarczarek/.kube/config
```

as you can see in this case they are too open.

Let's test with Helm

```bash
helm repo add haproxytech https://haproxytech.github.io/helm-charts
```

```bash
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/jakubwarczarek/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/jakubwarczarek/.kube/config
"haproxytech" has been added to your repositories
```

output of command contains warnings.

### With proposed change

Reproduce everything from above, but with `aws-cli` from this PR.

File permissions of newly created `kubeconfig`

```bash
-rw-------  1 jakubwarczarek  staff  2366 Oct  2 17:38 /Users/jakubwarczarek/.kube/config
```

thus only owner is allowed to read and write (`600`).

Example Helm command from above finishes without warnings about permissions.

## Other changes

- added  files related to VS Code and Python virtualenv to `.gitignore`
- fixed typos, whitespaces, imports in files affected by this change
- increased test coverage as advised by Codecov 



