### PR TITLE
Add closed issue message github action

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -1,0 +1,16 @@
+name: Closed Issue Message
+on:
+    issues:
+       types: [closed]
+jobs:
+    auto_comment:
+        runs-on: ubuntu-latest
+        steps:
+        - uses: aws-actions/closed-issue-message@v1
+          with:
+            # These inputs are both required
+            repo-token: "${{ secrets.GITHUB_TOKEN }}"
+            message: |
+                     ### ⚠️COMMENT VISIBILITY WARNING⚠️ 
+                     Comments on closed issues are hard for our team to see. 
+                     If you need more assistance, please open a new issue that references this one. If you wish to keep having a conversation with other community members under this issue feel free to do so.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Add a Github Action which sets a default message that will be commented on all issues when they get closed to warn users that comments on closed issues are hard for our team to see.

![comment-example](https://user-images.githubusercontent.com/23043132/94868605-5e12df80-03f8-11eb-9ea7-59572de4e0fa.png)

This is an OSDS effort across all SDKs&Tools repos to address the issue of customers expecting a response from AWS when they comment on closed issues.

By setting this default message we are clarifying expectations and explaining Github's limitation instead of letting users assume we are willfully ignoring them. We are giving clear directives about how to notify us and we're giving customers agency to make their own informed decisions as to whether or not they want to comment on closed issues.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
