### PR TITLE
Use shorthand syntax for instance type

### DIFF
--- a/awscli/examples/ec2/modify-instance-attribute.rst
+++ b/awscli/examples/ec2/modify-instance-attribute.rst
@@ -4,7 +4,7 @@ The following ``modify-instance-attribute`` example modifies the instance type o
 
     aws ec2 modify-instance-attribute \
         --instance-id i-1234567890abcdef0 \
-        --instance-type "{\"Value\": \"m1.small\"}"
+        --instance-type "m1.small"
 
 This command produces no output.
 


### PR DESCRIPTION
Possibly related to #484 

Simplify the [documentation for modify-instance-attribute](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/modify-instance-attribute.html) by using shorthand syntax.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
