### PR TITLE
Fix bug when CLI fails silently on requests exceptions

### DIFF
--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -24,6 +24,7 @@ from awscli.compat import get_stdout_text_writer
 from awscli.compat import get_popen_kwargs_for_pager_cmd
 from botocore.utils import IMDSFetcher
 from botocore.configprovider import BaseProvider
+from botocore.vendored import requests
 
 logger = logging.getLogger(__name__)
 
@@ -284,6 +285,10 @@ class OutputStreamFactory(object):
         process = self._popen(**popen_kwargs)
         try:
             yield process.stdin
+        except requests.exceptions.RequestException:
+            # Because requests.exceptions inherited from IOError
+            # we need to catch them first and raise again
+            raise
         except IOError:
             # Ignore IOError since this can commonly be raised when a pager
             # is closed abruptly and causes a broken pipe.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -19,6 +19,8 @@ import shlex
 
 import botocore
 import botocore.session as session
+from botocore.vendored import requests
+
 from botocore.exceptions import ConnectionClosedError
 from awscli.testutils import unittest, skip_if_windows, mock
 from awscli.compat import is_windows
@@ -234,6 +236,11 @@ class TestOutputStreamFactory(unittest.TestCase):
         with self.assertRaises(PopenException):
             with self.stream_factory.get_pager_stream():
                 pass
+
+    def test_propagates_exception_from_requests(self):
+        with self.assertRaises(requests.exceptions.RequestException):
+            with self.stream_factory.get_pager_stream():
+                raise requests.exceptions.RequestException
 
     @mock.patch('awscli.utils.get_stdout_text_writer')
     def test_stdout(self, mock_stdout_writer):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix bug when CLI fails silently on any exception inherited from `requests.Exception`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
