### PR TITLE
Fix bug when shorthand prompting not autocomplete in maps

### DIFF
--- a/awscli/autocomplete/local/basic.py
+++ b/awscli/autocomplete/local/basic.py
@@ -446,7 +446,7 @@ class ShorthandCompleter(BaseCompleter):
 
     def _get_prompt_for_map(self, arg_model, parsed_input):
         last_key, last_value = self._get_last_key_value(parsed_input)
-        if last_value:
+        if last_value is not None:
             return self._get_completion(arg_model.value, last_value)
         return self._get_completion(arg_model.key, last_key)
 

--- a/tests/functional/autocomplete/test_completer.py
+++ b/tests/functional/autocomplete/test_completer.py
@@ -85,6 +85,8 @@ class TestShorthandCompleter(unittest.TestCase):
             self.assertTrue(all([suggest in expected_suggestions
                                  for suggest in displayed_suggestions]),
                             command_line)
+            self.assertEqual(len(expected_suggestions),
+                             len(displayed_suggestions), command_line)
 
     def test_return_none_if_it_does_not_have_shorthand_input(self):
         self.assert_command_generates_suggestions(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix shorthand prompting bug when autoprompt doesn't suggest anything  for map shape
`string -> structure` on such input

`key={`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
