### PR TITLE
Add CLIRunner testing abstraction

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import os
 
 import awscli
@@ -63,8 +64,9 @@ class CLIRunner(object):
         rc = driver.main(cmdline)
         self._session_stubber.assert_no_remaining_responses()
         runner_result = CLIRunnerResult(rc)
-        aws_requests = self._session_stubber.received_aws_requests.copy()
-        runner_result.aws_requests = aws_requests
+        runner_result.aws_requests = copy.copy(
+            self._session_stubber.received_aws_requests
+        )
         return runner_result
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,11 +23,13 @@ _LOADER = botocore.loaders.Loader()
 
 class CLIRunner(object):
     """Runs CLI commands in a stubbed environment"""
-    def __init__(self, env=None):
+    def __init__(self, env=None, session_stubber=None):
         if env is None:
             env = self._get_default_env()
         self.env = env
-        self._session_stubber = SessionStubber()
+        if session_stubber is None:
+            session_stubber = SessionStubber()
+        self._session_stubber = session_stubber
 
     def run(self, cmdline):
         with mock.patch('os.environ', self.env):
@@ -127,14 +129,16 @@ class BaseResponse(object):
 
 
 class AWSResponse(BaseResponse):
-    def __init__(self, service_name, operation_name, parsed_response):
+    def __init__(self, service_name, operation_name, parsed_response,
+                 validate=True):
         self._service_name = service_name
         self._operation_name = operation_name
         self._parsed_response = parsed_response
         self._service_model = self._get_service_model()
         self._operation_model = self._service_model.operation_model(
             self._operation_name)
-        self._validate_parsed_response()
+        if validate:
+            self._validate_parsed_response()
 
     def on_http_request_sent(self, request):
         return self._generate_http_response()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,259 @@
+import collections
+import os
+
+import awscli
+from awscli.clidriver import create_clidriver
 from awscli.compat import collections_abc
+from awscli.testutils import capture_output
+
+import mock
+import botocore.awsrequest
+import botocore.loaders
+import botocore.model
+import botocore.serialize
+import botocore.validate
+
+
+# A shared loader to use for classes in this module. This allows us to
+# load models outside of influence of a session and take advantage of
+# caching to speed up tests.
+_LOADER = botocore.loaders.Loader()
+
+
+class CLIRunner(object):
+    """Runs CLI commands in a stubbed environment"""
+    def __init__(self, env=None):
+        if env is None:
+            env = self._get_default_env()
+        self.env = env
+        self._session_stubber = SessionStubber()
+
+    def run(self, cmdline):
+        with mock.patch('os.environ', self.env):
+            with capture_output() as output:
+                runner_result = self._do_run(cmdline)
+                runner_result.stdout = output.stdout.getvalue()
+                runner_result.stderr = output.stderr.getvalue()
+                return runner_result
+
+    def add_response(self, response):
+        self._session_stubber.add_response(response)
+
+    def _get_default_env(self):
+        # awscli/__init__.py injects AWS_DATA_PATH at import time
+        # so that we can find cli.json.  This might be fixed in the
+        # future, but for now we are just replicating the logic in
+        # this abstraction.
+        cli_data_dir = os.path.join(
+            os.path.dirname(os.path.abspath(awscli.__file__)),
+            'data'
+        )
+        return {
+            'AWS_DATA_PATH': cli_data_dir,
+            'AWS_DEFAULT_REGION': 'us-west-2',
+            'AWS_ACCESS_KEY_ID': 'access_key',
+            'AWS_SECRET_ACCESS_KEY': 'secret_key',
+            'AWS_CONFIG_FILE': '',
+            'AWS_SHARED_CREDENTIALS_FILE': '',
+        }
+
+    def _do_run(self, cmdline):
+        driver = create_clidriver()
+        self._session_stubber.register(driver.session)
+        rc = driver.main(cmdline)
+        self._session_stubber.assert_no_remaining_responses()
+        runner_result = CLIRunnerResult(rc)
+        aws_requests = self._session_stubber.received_aws_requests.copy()
+        runner_result.aws_requests = aws_requests
+        return runner_result
+
+
+class SessionStubber(object):
+    def __init__(self):
+        self.received_aws_requests = []
+        self._responses = collections.deque()
+
+    def register(self, session):
+        events = session.get_component('event_emitter')
+        events.register_first(
+            'before-parameter-build.*.*', self._capture_aws_request,
+        )
+        events.register_last(
+            'request-created', self._capture_http_request
+        )
+        events.register_first(
+            'before-send.*.*', self._return_queued_http_response,
+        )
+
+    def add_response(self, response):
+        self._responses.append(response)
+
+    def assert_no_remaining_responses(self):
+        if len(self._responses) != 0:
+            raise AssertionError(
+                "The following queued responses are remaining: %s" %
+                self._responses
+            )
+
+    def _capture_aws_request(self, params, model, context, **kwargs):
+        aws_request = AWSRequest(
+            service_name=model.service_model.service_name,
+            operation_name=model.name,
+            params=params,
+        )
+        self.received_aws_requests.append(aws_request)
+        context['current_aws_request'] = aws_request
+
+    def _capture_http_request(self, request, **kwargs):
+        request.context['current_aws_request'].http_requests.append(
+            HTTPRequest(
+                method=request.method,
+                url=request.url,
+                headers=request.headers,
+                body=request.body,
+            )
+        )
+
+    def _return_queued_http_response(self, request, **kwargs):
+        response = self._responses.popleft()
+        return response.on_http_request_sent(request)
+
+
+class BaseResponse(object):
+    def on_http_request_sent(self, request):
+        raise NotImplementedError('on_http_request_sent')
+
+
+class AWSResponse(BaseResponse):
+    def __init__(self, service_name, operation_name, parsed_response):
+        self._service_name = service_name
+        self._operation_name = operation_name
+        self._parsed_response = parsed_response
+        self._service_model = self._get_service_model()
+        self._operation_model = self._service_model.operation_model(
+            self._operation_name)
+        self._validate_parsed_response()
+
+    def on_http_request_sent(self, request):
+        return self._generate_http_response()
+
+    def __repr__(self):
+        return (
+            'AWSResponse(service_name=%r, operation_name=%r, '
+            'parsed_response=%r)' %
+            (self._service_name, self._operation_name, self._parsed_response)
+        )
+
+    def _get_service_model(self):
+        loaded_service_model = _LOADER.load_service_model(
+            service_name=self._service_name, type_name='service-2'
+        )
+        return botocore.model.ServiceModel(
+            loaded_service_model, service_name=self._service_name)
+
+    def _validate_parsed_response(self):
+        if self._operation_model.output_shape:
+            botocore.validate.validate_parameters(
+                self._parsed_response, self._operation_model.output_shape)
+
+    def _generate_http_response(self):
+        serialized = self._reverse_serialize_parsed_response()
+        return HTTPResponse(
+            headers=serialized['headers'],
+            body=serialized['body']
+        )
+
+    def _reverse_serialize_parsed_response(self):
+        # NOTE: This is fairly hacky, but it gets us a reasonable,
+        # serialized response with a fairly low amount of effort. Basically,
+        # we swap the operation model so that its input shape points to its
+        # output shape so that we can use the serializer to reverse the
+        # parsing logic and generate a raw HTTP response instead of a raw HTTP
+        # request.
+        #
+        # Theoretically this should work for many use cases (e.g. JSON
+        # protocols), but there are definitely edge cases that are not
+        # being handled (e.g. query protocol). Going forward as more tests
+        # adopt this, we **will** have to build up the logic around this.
+        serializer = botocore.serialize.create_serializer(
+            protocol_name=self._service_model.metadata['protocol'],
+            include_validation=False,
+        )
+        self._operation_model.input_shape = self._operation_model.output_shape
+        return serializer.serialize_to_request(
+            self._parsed_response, self._operation_model)
+
+
+class HTTPResponse(BaseResponse):
+    def __init__(self, status_code=200, headers=None, body=b''):
+        self.status_code = status_code
+        if headers is None:
+            headers = {}
+        self.headers = headers
+        self.body = body
+        # Botocore's interface uses content instead of body so just
+        # making the content an alias to the body.
+        self.content = body
+
+    def on_http_request_sent(self, request):
+        return self
+
+
+class CLIRunnerResult(object):
+    def __init__(self, rc, stdout=None, stderr=None):
+        self.rc = rc
+        self.stdout = stdout
+        self.stderr = stderr
+        self.aws_requests = []
+
+
+class AWSRequest(object):
+    def __init__(self, service_name, operation_name, params):
+        self.service_name = service_name
+        self.operation_name = operation_name
+        self.params = params
+        self.http_requests = []
+
+    def __repr__(self):
+        return (
+            'AWSRequest(service_name=%r, operation_name=%r, params=%r)' %
+            (self.service_name, self.operation_name, self.params)
+        )
+
+    def __eq__(self, other):
+        return (
+            self.service_name == other.service_name and
+            self.operation_name == other.operation_name and
+            self.params == other.params
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class HTTPRequest(object):
+    def __init__(self, method, url, headers, body):
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+
+    def __repr__(self):
+        return (
+            'HTTPRequest(method=%r, url=%r, headers=%r, body=%r)' %
+            (self.method, self.url, self.headers, self.body)
+        )
+
+    def __eq__(self, other):
+        return (
+            self.method == other.method and
+            self.url == other.url and
+            self.headers == other.headers and
+            self.body == other.body
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 # CaseInsensitiveDict from requests that must be serializble.

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import platform
 import subprocess
@@ -62,7 +63,7 @@ class TestCodeArtifactLogin(unittest.TestCase):
                 repository=self.repository
             )
 
-        cmdline = self.prefix.copy()
+        cmdline = copy.copy(self.prefix)
         cmdline.extend([
             '--domain', self.domain,
             '--repository', self.repository,

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -8,18 +8,17 @@ from dateutil.tz import tzlocal
 from dateutil.relativedelta import relativedelta
 from botocore.utils import parse_timestamp
 
-from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, mock
+from tests import CLIRunner, AWSRequest, AWSResponse
+from awscli.testutils import unittest, FileCreator, mock
 from awscli.compat import urlparse, StringIO, RawConfigParser
 from awscli.customizations.codeartifact.login import CodeArtifactLogin
 
 
-class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
+class TestCodeArtifactLogin(unittest.TestCase):
 
-    prefix = 'codeartifact login'
+    prefix = ['codeartifact', 'login']
 
     def setUp(self):
-        super(TestCodeArtifactLogin, self).setUp()
-
         self.file_creator = FileCreator()
         self.test_pypi_rc_path = self.file_creator.full_path('pypirc')
         if not os.path.isdir(os.path.dirname(self.test_pypi_rc_path)):
@@ -43,9 +42,9 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
 
         self.subprocess_patch = mock.patch('subprocess.check_call')
         self.subprocess_mock = self.subprocess_patch.start()
+        self.cli_runner = CLIRunner()
 
     def tearDown(self):
-        super(TestCodeArtifactLogin, self).tearDown()
         self.pypi_rc_path_patch.stop()
         self.subprocess_patch.stop()
         self.file_creator.remove_all()
@@ -63,29 +62,42 @@ class TestCodeArtifactLogin(BaseAWSCommandParamsTest):
                 repository=self.repository
             )
 
-        cmdline = self.prefix
-        cmdline += ' --domain %s' % self.domain
-        cmdline += ' --repository %s' % self.repository
-        cmdline += ' --tool %s' % tool
+        cmdline = self.prefix.copy()
+        cmdline.extend([
+            '--domain', self.domain,
+            '--repository', self.repository,
+            '--tool', tool,
+        ])
 
         if include_domain_owner:
-            cmdline += ' --domain-owner %s' % self.domain_owner
+            cmdline.extend(['--domain-owner', self.domain_owner])
 
         if dry_run:
-            cmdline += ' --dry-run'
+            cmdline.append('--dry-run')
 
         if include_duration_seconds:
-            cmdline += ' --duration-seconds %s' % self.duration
+            cmdline.extend(['--duration-seconds', str(self.duration)])
 
         if include_namespace:
-            cmdline += ' --namespace %s' % self.namespace
+            cmdline.extend(['--namespace', self.namespace])
 
-        # Responses from calls to services.
-        self.parsed_responses = [
-            {"authorizationToken": self.auth_token,
-                "expiration": self.expiration},  # GetAuthorizationToken
-            {"repositoryEndpoint": self.endpoint},  # GetRepositoryEndpoint
-        ]
+        self.cli_runner.add_response(
+            AWSResponse(
+                service_name='codeartifact',
+                operation_name='GetAuthorizationToken',
+                parsed_response={
+                    "authorizationToken": self.auth_token,
+                    "expiration": self.expiration_as_datetime
+                }
+            )
+        )
+        self.cli_runner.add_response(
+            AWSResponse(
+                service_name='codeartifact',
+                operation_name='GetRepositoryEndpoint',
+                parsed_response={"repositoryEndpoint": self.endpoint}
+            )
+        )
 
         return cmdline
 
@@ -184,10 +196,9 @@ password: {auth_token}'''
         )
 
     def _assert_operations_called(
-        self, package_format,
-            include_domain_owner=False, include_duration_seconds=False
+        self, package_format, result,
+        include_domain_owner=False, include_duration_seconds=False
     ):
-        self.assertEqual(len(self.operations_called), 2)
 
         get_auth_token_kwargs = {
             'domain': self.domain
@@ -206,19 +217,19 @@ password: {auth_token}'''
             get_auth_token_kwargs['durationSeconds'] = self.duration
 
         self.assertEqual(
-            self.operations_called[0][0].name, 'GetAuthorizationToken'
-        )
-        self.assertEqual(
-            self.operations_called[0][1],
-            get_auth_token_kwargs
-        )
-
-        self.assertEqual(
-            self.operations_called[1][0].name, 'GetRepositoryEndpoint'
-        )
-        self.assertEqual(
-            self.operations_called[1][1],
-            get_repo_endpoint_kwargs
+            result.aws_requests,
+            [
+                AWSRequest(
+                    service_name='codeartifact',
+                    operation_name='GetAuthorizationToken',
+                    params=get_auth_token_kwargs,
+                ),
+                AWSRequest(
+                    service_name='codeartifact',
+                    operation_name='GetRepositoryEndpoint',
+                    params=get_repo_endpoint_kwargs,
+                )
+            ]
         )
 
     def _assert_subprocess_execution(self, commands):
@@ -272,55 +283,61 @@ password: {auth_token}'''
 
     def test_npm_login_without_domain_owner(self):
         cmdline = self._setup_cmd(tool='npm')
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(package_format='npm')
-        self._assert_expiration_printed_to_stdout(stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='npm', result=result)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(self._get_npm_commands())
 
     def test_npm_login_without_domain_owner_dry_run(self):
         cmdline = self._setup_cmd(tool='npm', dry_run=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(package_format='npm')
-        self._assert_dry_run_execution(self._get_npm_commands(), stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='npm', result=result)
+        self._assert_dry_run_execution(self._get_npm_commands(), result.stdout)
 
     def test_npm_login_with_domain_owner(self):
         cmdline = self._setup_cmd(tool='npm', include_domain_owner=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='npm',
+            package_format='npm', result=result,
             include_domain_owner=True, include_duration_seconds=False
         )
-        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(self._get_npm_commands())
 
     def test_npm_login_with_domain_owner_duration(self):
         cmdline = self._setup_cmd(tool='npm', include_domain_owner=True,
                                   include_duration_seconds=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='npm',
+            package_format='npm', result=result,
             include_domain_owner=True, include_duration_seconds=True
         )
-        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(self._get_npm_commands())
 
     def test_npm_login_with_domain_owner_dry_run(self):
         cmdline = self._setup_cmd(
             tool='npm', include_domain_owner=True, dry_run=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='npm', include_domain_owner=True
+            package_format='npm', result=result, include_domain_owner=True
         )
-        self._assert_dry_run_execution(self._get_npm_commands(), stdout)
+        self._assert_dry_run_execution(self._get_npm_commands(), result.stdout)
 
     def test_npm_login_with_namespace(self):
         cmdline = self._setup_cmd(
             tool='npm', include_namespace=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(package_format='npm')
-        self._assert_expiration_printed_to_stdout(stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='npm', result=result)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(
             self._get_npm_commands(scope='@{}'.format(self.namespace))
         )
@@ -329,82 +346,87 @@ password: {auth_token}'''
         cmdline = self._setup_cmd(
             tool='npm', include_namespace=True, dry_run=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(package_format='npm')
-        self._assert_dry_run_execution(self._get_npm_commands(
-            scope='@{}'.format(self.namespace)), stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='npm', result=result)
+        self._assert_dry_run_execution(
+            self._get_npm_commands(scope='@{}'.format(self.namespace)),
+            result.stdout
+        )
 
     def test_pip_login_without_domain_owner(self):
         cmdline = self._setup_cmd(tool='pip')
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(
-            package_format='pypi'
-        )
-        self._assert_expiration_printed_to_stdout(stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='pypi', result=result)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(self._get_pip_commands())
 
     def test_pip_login_without_domain_owner_dry_run(self):
         cmdline = self._setup_cmd(tool='pip', dry_run=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(
-            package_format='pypi'
-        )
-        self._assert_dry_run_execution(self._get_pip_commands(), stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='pypi', result=result)
+        self._assert_dry_run_execution(self._get_pip_commands(), result.stdout)
 
     def test_pip_login_with_domain_owner(self):
         cmdline = self._setup_cmd(tool='pip', include_domain_owner=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='pypi', include_domain_owner=True
+            package_format='pypi', result=result, include_domain_owner=True
         )
-        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(self._get_pip_commands())
 
     def test_pip_login_with_domain_owner_duration(self):
         cmdline = self._setup_cmd(tool='pip', include_domain_owner=True,
                                   include_duration_seconds=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='pypi', include_domain_owner=True,
+            package_format='pypi', result=result, include_domain_owner=True,
             include_duration_seconds=True
         )
-        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         self._assert_subprocess_execution(self._get_pip_commands())
 
     def test_pip_login_with_domain_owner_dry_run(self):
         cmdline = self._setup_cmd(
             tool='pip', include_domain_owner=True, dry_run=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='pypi', include_domain_owner=True
+            package_format='pypi', result=result, include_domain_owner=True
         )
-        self._assert_dry_run_execution(self._get_pip_commands(), stdout)
+        self._assert_dry_run_execution(self._get_pip_commands(), result.stdout)
 
     def test_pip_login_with_namespace(self):
         cmdline = self._setup_cmd(tool='pip', include_namespace=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
-        self._assert_operations_called(
-            package_format='pypi'
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 255)
+        self._assert_operations_called(package_format='pypi', result=result)
+        self.assertIn(
+            'Argument --namespace is not supported for pip', result.stderr
         )
-        self.assertIn('Argument --namespace is not supported for pip', stderr)
 
     def test_pip_login_with_namespace_dry_run(self):
         cmdline = self._setup_cmd(
             tool='pip', include_namespace=True, dry_run=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
-        self._assert_operations_called(
-            package_format='pypi'
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 255)
+        self._assert_operations_called(package_format='pypi', result=result)
+        self.assertIn(
+            'Argument --namespace is not supported for pip', result.stderr
         )
-        self.assertIn('Argument --namespace is not supported for pip', stderr)
 
     def test_twine_login_without_domain_owner(self):
         cmdline = self._setup_cmd(tool='twine')
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(
-            package_format='pypi'
-        )
-        self._assert_expiration_printed_to_stdout(stdout)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='pypi', result=result)
+        self._assert_expiration_printed_to_stdout(result.stdout)
         with open(self.test_pypi_rc_path) as f:
             test_pypi_rc_str = f.read()
 
@@ -418,10 +440,9 @@ password: {auth_token}'''
 
     def test_twine_login_without_domain_owner_dry_run(self):
         cmdline = self._setup_cmd(tool='twine', dry_run=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
-        self._assert_operations_called(
-            package_format='pypi'
-        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='pypi', result=result)
         self.assertFalse(os.path.exists(self.test_pypi_rc_path))
         self._assert_pypi_rc_has_expected_content(
             pypi_rc_str=self._get_twine_commands(),
@@ -433,11 +454,12 @@ password: {auth_token}'''
 
     def test_twine_login_with_domain_owner(self):
         cmdline = self._setup_cmd(tool='twine', include_domain_owner=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='pypi', include_domain_owner=True
+            package_format='pypi', result=result, include_domain_owner=True
         )
-        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_expiration_printed_to_stdout(result.stdout)
 
         with open(self.test_pypi_rc_path) as f:
             test_pypi_rc_str = f.read()
@@ -453,12 +475,13 @@ password: {auth_token}'''
     def test_twine_login_with_domain_owner_duration(self):
         cmdline = self._setup_cmd(tool='twine', include_domain_owner=True,
                                   include_duration_seconds=True)
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='pypi', include_domain_owner=True,
+            package_format='pypi', result=result, include_domain_owner=True,
             include_duration_seconds=True
         )
-        self._assert_expiration_printed_to_stdout(stdout)
+        self._assert_expiration_printed_to_stdout(result.stdout)
 
         with open(self.test_pypi_rc_path) as f:
             test_pypi_rc_str = f.read()
@@ -475,9 +498,10 @@ password: {auth_token}'''
         cmdline = self._setup_cmd(
             tool='twine', include_domain_owner=True, dry_run=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
         self._assert_operations_called(
-            package_format='pypi', include_domain_owner=True
+            package_format='pypi', result=result, include_domain_owner=True
         )
         self.assertFalse(os.path.exists(self.test_pypi_rc_path))
         self._assert_pypi_rc_has_expected_content(
@@ -492,21 +516,21 @@ password: {auth_token}'''
         cmdline = self._setup_cmd(
             tool='twine', include_namespace=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
-        self._assert_operations_called(
-            package_format='pypi'
-        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 255)
+        self._assert_operations_called(package_format='pypi', result=result)
         self.assertIn(
-            'Argument --namespace is not supported for twine', stderr)
+            'Argument --namespace is not supported for twine', result.stderr
+        )
 
     def test_twine_login_with_namespace_dry_run(self):
         cmdline = self._setup_cmd(
             tool='twine', include_namespace=True, dry_run=True
         )
-        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
-        self._assert_operations_called(
-            package_format='pypi',
-        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 255)
+        self._assert_operations_called(package_format='pypi', result=result)
         self.assertFalse(os.path.exists(self.test_pypi_rc_path))
         self.assertIn(
-            'Argument --namespace is not supported for twine', stderr)
+            'Argument --namespace is not supported for twine', result.stderr
+        )


### PR DESCRIPTION
This class allows us to run a CLI command from a testing context without needing to subclass from any particular `TestCase` class from the `testutils` module. In addition, this class gives us the following benefits over the previous `TestCase` abstractions:

* All of the environment/system patching is built into the the `run` method of the abstraction, which makes it more convenient to use and reduces the chance of a bad patch.
* We exercise the full CLI stack down to when `botocore` sends a request to `urllib3`. This allows us to have more confidence that functionality is behaving appropriately.
* We validate parsed responses provided to the runner against its corresponding model.
* There are abstractions for both AWS responses and HTTP responses that can be interleaved during testing.

I also migrated the `codeartifact login` test suite over to use this abstraction to both show how other tests would adopt it and add some additional validation safety that would have prevented issues for the `login` command like this one: https://github.com/aws/aws-cli/pull/5382

