### PR TITLE
Import mock from testutils

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,9 +5,8 @@ import os
 import awscli
 from awscli.clidriver import create_clidriver
 from awscli.compat import collections_abc
-from awscli.testutils import capture_output
+from awscli.testutils import mock, capture_output
 
-import mock
 import botocore.awsrequest
 import botocore.loaders
 import botocore.model


### PR DESCRIPTION
The `testutils` module has special logic to catch import errors of mock. This is helpful when running individual files such as
`integration/test_smoke.py` where `mock` is not necessarily needed but gets imported because it is imported at the root of the tests package.
