### PR TITLE
missing comma on example

### DIFF
--- a/awscli/examples/emr/create-cluster-examples.rst
+++ b/awscli/examples/emr/create-cluster-examples.rst
@@ -202,7 +202,7 @@ Contents of ``ec2_attributes.json``::
             "InstanceProfile":"myRole",
             "EmrManagedMasterSecurityGroup": "sg-master1",
             "EmrManagedSlaveSecurityGroup": "sg-slave1",
-            "ServiceAccessSecurityGroup": "sg-service-access"
+            "ServiceAccessSecurityGroup": "sg-service-access",
             "AdditionalMasterSecurityGroups": ["sg-addMaster1","sg-addMaster2","sg-addMaster3","sg-addMaster4"],
             "AdditionalSlaveSecurityGroups": ["sg-addSlave1","sg-addSlave2","sg-addSlave3","sg-addSlave4"]
         }


### PR DESCRIPTION
Added missing comma to the end of a line in ec2_attributes.json under example 11

appended missing comma to line 205

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
