### PR TITLE
Replace tests that rely on unreadable files with mocked timestamp

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -91,18 +91,6 @@ def skip_if_windows(reason):
     return decorator
 
 
-def set_invalid_utime(path):
-    """Helper function to set an invalid last modified time"""
-    try:
-        os.utime(path, (-1, -100000000000))
-    except (OSError, OverflowError):
-        # Some OS's such as Windows throws an error for trying to set a
-        # last modified time of that size. So if an error is thrown, set it
-        # to just a negative time which will trigger the warning as well for
-        # Windows.
-        os.utime(path, (-1, -1))
-
-
 def create_clidriver():
     driver = awscli.clidriver.create_clidriver()
     session = driver.session

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -15,7 +15,7 @@ import mock
 import os
 
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.testutils import capture_input, set_invalid_utime
+from awscli.testutils import capture_input
 from awscli.compat import six
 from tests.functional.s3 import BaseS3TransferCommandTest
 
@@ -668,14 +668,8 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertIn(progress_message, stdout)
 
     def test_cp_with_error_and_warning_permissions(self):
-        command = "s3 cp %s s3://bucket/ --recursive --no-follow-symlinks"
+        command = "s3 cp %s s3://bucket/foo.txt"
         self.parsed_responses = [{
-            'Error': {
-                'Code': 'NoSuchBucket',
-                'Message': 'The specified bucket does not exist',
-                'BucketName': 'bucket'
-            }
-        },{
             'Error': {
                 'Code': 'NoSuchBucket',
                 'Message': 'The specified bucket does not exist',
@@ -685,15 +679,18 @@ class TestCPCommand(BaseCPCommandTest):
         self.http_response.status_code = 404
 
         full_path = self.files.create_file('foo.txt', 'bar')
-        dir_path = os.path.dirname(full_path)
-        self.files.create_file('bar.txt', 'foo')
-        os.chmod(full_path, 0o300)
 
-        stdout, stderr, rc = self.run_cmd(command % dir_path, expected_rc=1)
+        # Patch get_file_stat to return a value indicating that an invalid
+        # timestamp was loaded. It is impossible to set an invalid timestamp
+        # on all OSes so it has to be patched.
+        # TODO: find another method to test this behavior without patching.
+        with mock.patch(
+                'awscli.customizations.s3.filegenerator.get_file_stat',
+                return_value=(None, None)
+        ):
+            _, stderr, rc = self.run_cmd(command % full_path, expected_rc=1)
         self.assertIn('upload failed', stderr)
-        self.assertIn('warning:', stderr)
-        self.assertIn('File/Directory is not readable.', stderr)
-
+        self.assertIn('warning: File has an invalid timestamp.', stderr)
 
 
 class TestStreamingCPCommand(BaseAWSCommandParamsTest):

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import set_invalid_utime
 from mock import patch
 import os
 
@@ -141,7 +140,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
             {"CommonPrefixes": [], "Contents": []},
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
-        # Patch get_file_stat to return a value indicationg that an invalid
+        # Patch get_file_stat to return a value indicating that an invalid
         # timestamp was loaded. It is impossible to set an invalid timestamp
         # on all OSes so it has to be patched.
         # TODO: find another method to test this behavior without patching.


### PR DESCRIPTION
The timestamp tests do not work on all platforms, but the replacement
tests that rely on an unreadable file also do not work in some
environments. This commit reverts back to a timestamp based test, but
rather than relying on the acutal file timestamp we just mock out the
helper method that fetches it. We should replace these in the future
with something more robust that does not rely on a mock.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
