### PR TITLE
Refactor autoprompt docs getter

### DIFF
--- a/awscli/autocomplete/completer.py
+++ b/awscli/autocomplete/completer.py
@@ -29,6 +29,9 @@ class AutoCompleter(object):
         self._parser = parser
         self._completers = completers
 
+    def parse(self, command_line, index=None):
+        return self._parser.parse(command_line, index)
+
     def autocomplete(self, command_line, index=None):
         """Attempt to find completion suggestions.
 
@@ -39,7 +42,7 @@ class AutoCompleter(object):
         :return: A list of ``CompletionResult`` objects.
 
         """
-        parsed = self._parser.parse(command_line, index)
+        parsed = self.parse(command_line, index)
         for completer in self._completers:
             result = completer.complete(parsed)
             if result is not None:

--- a/awscli/autoprompt/doc.py
+++ b/awscli/autoprompt/doc.py
@@ -13,8 +13,6 @@
 import io
 from docutils.core import publish_string
 
-import awscli
-from awscli.argparser import ArgTableArgParser
 from awscli.bcdoc import docevents, textwriter
 
 
@@ -25,72 +23,6 @@ class DocsGetter:
     service commands and service operations.
 
     """
-    def __init__(self, driver, aws_top_level_docs_getter=None,
-                 service_command_docs_getter=None):
-        self._driver = driver
-        self._service_command_table = self._driver.subcommand_table
-        if aws_top_level_docs_getter is None:
-            aws_top_level_docs_getter = AwsTopLevelDocsGetter(self._driver)
-        self._aws_top_level_docs_getter = aws_top_level_docs_getter
-        if service_command_docs_getter is None:
-            service_command_docs_getter = \
-                ServiceCommandDocsGetter(self._driver)
-        self._service_command_docs_getter = service_command_docs_getter
-
-    @property
-    def aws_top_level_docs_getter(self):
-        return self._aws_top_level_docs_getter
-
-    @property
-    def service_command_docs_getter(self):
-        return self._service_command_docs_getter
-
-    def get_docs(self, command_text):
-        args = command_text.split()
-        if not args:
-            return self._aws_top_level_docs_getter.get_docs(self._driver)
-        args = self._filter_out_options(args)
-        try:
-            if self._is_valid_service(args):
-                return self._service_command_docs_getter.get_docs(args)
-            else:
-                # At this point, one of two things has happened:
-                # 1. An invalid service command has been entered.
-                # 2. The user has cleared the buffer and has started typing
-                #    out a command. The in-process command won't get parsed
-                #    correctly yet (e.g. `aws ec`).
-                return self._aws_top_level_docs_getter.get_docs(self._driver)
-        except:
-            # If there are any errors in the documentation retrieval process,
-            # we pull up the default top-level aws docs. This can happen if
-            # the buffer is cleared and `aws help` is entered.
-            return self._aws_top_level_docs_getter.get_docs(self._driver)
-
-    def _is_valid_service(self, args):
-        self._valid_services = \
-            {name for name, _ in self._service_command_table.items()}
-        service, *_ = args
-        return service in self._valid_services
-
-    def _filter_out_options(self, args):
-        # Because the lowest level of documentation retrieval is at the
-        # service operation level, we can ignore all `--options` in the
-        # passed-in arguments for the purposes of grabbing documentation. This
-        # allows us to bypass the problem of getting parsing errors in
-        # self.get_docs() when there are `--options` that require arguments to
-        # be passed in (e.g. `aws ec2 describe-instances --output`). We also
-        # need to filter out any specified files at the command line, as these
-        # are positional args that don't make sense after `--options` are
-        # removed.
-        file_path_chars = '.:\\/'
-        return [
-            arg for arg in args
-            if not arg.startswith('--')
-            and not any(char in arg for char in file_path_chars)
-        ]
-
-
-class BaseDocsGetter:
     def __init__(self, driver):
         self._driver = driver
         self._cache = {}
@@ -141,78 +73,22 @@ class BaseDocsGetter:
         instance.unregister()
         return content
 
-
-class AwsTopLevelDocsGetter(BaseDocsGetter):
-    """Getter for the top-level `aws` command."""
-    def get_docs(self, driver):
-        if 'aws' not in self._cache:
-            help_command = driver.create_help_command()
-            self._cache['aws'] = self.get_doc_content(help_command)
-        return self._cache['aws']
-
-
-class ServiceCommandDocsGetter(BaseDocsGetter):
-    def __init__(self, driver, service_operation_docs_getter=None):
-        super(ServiceCommandDocsGetter, self).__init__(driver)
-        self._service_command_table = self._driver.subcommand_table
-        if service_operation_docs_getter is None:
-            service_operation_docs_getter = \
-                ServiceOperationDocsGetter(self._driver)
-        self._service_operation_docs_getter = service_operation_docs_getter
-
-    def get_docs(self, args):
-        service_command, remaining = self._get_service_command(args)
-        if not remaining \
-                or not self._is_valid_operation(service_command, remaining):
-            help_command = service_command.create_help_command()
-            if help_command.name not in self._cache:
-                self._cache[help_command.name] = \
-                     self.get_doc_content(help_command)
-            return self._cache[help_command.name]
-        else:
-            return self._service_operation_docs_getter.get_docs(
-                service_command, remaining)
-
-    def _get_service_command(self, args):
-        service_name, remaining = self._get_service_command_name(args)
-        return self._service_command_table[service_name], remaining
-
-    def _get_service_command_name(self, args):
-        parser = self._driver.create_parser(self._service_command_table)
-        parsed_args, remaining = parser.parse_known_args(args)
-        return parsed_args.command, remaining
-
-    def _is_valid_operation(self, service_command, remaining):
-        subcommand_table = service_command.subcommand_table
-        self._valid_operations = {name for name, _ in subcommand_table.items()}
-        operation, *_ = remaining
-        return operation in self._valid_operations
-
-
-class ServiceOperationDocsGetter(BaseDocsGetter):
-    def get_docs(self, service_command, remaining):
-        subcommand_table = service_command.subcommand_table
-        operation_name = self._get_operation_name(service_command, remaining)
-        if (service_command.name, operation_name) not in self._cache:
-            service_operation = subcommand_table[operation_name]
-            help_command = service_operation.create_help_command()
-            self._cache[(service_command.name, operation_name)] = \
-                self.get_doc_content(help_command)
-        return self._cache[(service_command.name, operation_name)]
-
-    def _get_operation_name(self, service_command, remaining):
-        # We need to differentiate between `awscli.clidriver.ServiceCommand`
-        # and `awscli.customizations` objects, as they use different parsers.
-        if isinstance(service_command, awscli.clidriver.ServiceCommand):
-            service_parser = service_command.create_parser()
-            parsed_args, remaining = service_parser.parse_known_args(remaining)
-            operation_name = parsed_args.operation
-        else:
-            service_parser = ArgTableArgParser(
-                service_command.arg_table, service_command.subcommand_table)
-            parsed_args, remaining = service_parser.parse_known_args(remaining)
-            operation_name = parsed_args.subcommand
-        return operation_name
+    def get_docs(self, parsed):
+        lineage = parsed.lineage
+        current_command = parsed.current_command
+        if (tuple(lineage), current_command) not in self._cache:
+            if current_command == 'aws':
+                help_command = self._driver.create_help_command()
+            else:
+                subcommand_table = self._driver.subcommand_table
+                for arg in lineage[1:]:
+                    subcommand = subcommand_table[arg]
+                    subcommand_table = subcommand.subcommand_table
+                command = subcommand_table.get(current_command)
+                help_command = command.create_help_command()
+            docs = self.get_doc_content(help_command)
+            self._cache[(tuple(lineage), current_command)] = docs
+        return self._cache[(tuple(lineage), current_command)]
 
 
 class FileRenderer:

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -131,7 +131,9 @@ class PromptToolkitPrompter:
         app.debug = False
 
     def _update_doc_window_contents(self, *args):
-        content = self._docs_getter.get_docs(self._input_buffer.text)
+        parsed_args = self._completion_source.parse(
+            'aws ' + self._input_buffer.document.text)
+        content = self._docs_getter.get_docs(parsed_args)
         # The only way to "modify" a read-only buffer in prompt_toolkit is to
         # create a new `prompt_toolkit.document.Document`. A 'cursor_position'
         # of 0 allows us to start viewing the documentation from the beginning,

--- a/tests/functional/autoprompt/test_doc.py
+++ b/tests/functional/autoprompt/test_doc.py
@@ -10,130 +10,80 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.clidriver import create_clidriver, ServiceCommand
-from awscli.autoprompt.doc import (
-    AwsTopLevelDocsGetter, DocsGetter, ServiceCommandDocsGetter,
-    ServiceOperationDocsGetter
-)
-from awscli.testutils import unittest
+from awscli.clidriver import create_clidriver
+from awscli.autocomplete import parser
+from awscli.autoprompt.doc import DocsGetter
+from awscli.testutils import unittest, mock
+
+from tests.unit.autocomplete import InMemoryIndex
 
 
 class TestDocsGetter(unittest.TestCase):
     def setUp(self):
         self.driver = create_clidriver()
         self.docs_getter = DocsGetter(self.driver)
+        self.index = InMemoryIndex({
+            'command_names': {
+                '': [('aws', None)],
+                'aws': [('ec2', None)],
+                'aws.ec2': [('describe-instances', None)],
+            },
+            'arg_names': {
+                '': {'aws': ['region']},
+                'aws.ec2': {'describe-instances': []},
+            },
+            'arg_data': {
+                '': {
+                    'aws': {
+                        'region': ('region', 'string', 'aws', '', None, False,
+                                   False),
+                    }
+                },
+                'aws.ec2': {'describe-instances': {}}
+            }
+        })
+        self.parser = parser.CLIParser(self.index)
 
     def test_get_service_command_docs(self):
-        command_text = 'ec2'
-        actual_docs = self.docs_getter.get_docs(command_text)
+        parsed_args = self.parser.parse('aws ec2')
+        actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Elastic Compute Cloud'
         self.assertIn(expected_docs, actual_docs)
 
     def test_get_service_operation_docs(self):
-        command_text = 'ec2 describe-instances'
-        actual_docs = self.docs_getter.get_docs(command_text)
+        parsed_args = self.parser.parse('aws ec2 describe-instances')
+        actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Describes the specified instances'
         self.assertIn(expected_docs, actual_docs)
 
+    def test_get_service_command_docs_with_invalid_service_operation(self):
+        parsed_args = self.parser.parse('aws ec2 fake')
+        actual_docs = self.docs_getter.get_docs(parsed_args)
+        expected_docs = 'Elastic Compute Cloud'
+        self.assertIn(expected_docs, actual_docs)
+
     def test_get_top_level_aws_docs_if_no_command_specified(self):
-        command_text = ''
-        actual_docs = self.docs_getter.get_docs(command_text)
+        parsed_args = self.parser.parse('aws')
+        actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'The AWS Command Line Interface'
         self.assertIn(expected_docs, actual_docs)
 
     def test_get_top_level_aws_docs_if_service_command_is_invalid(self):
-        command_text = 'fake'
-        actual_docs = self.docs_getter.get_docs(command_text)
+        parsed_args = self.parser.parse('aws fake')
+        actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'The AWS Command Line Interface'
         self.assertIn(expected_docs, actual_docs)
 
-    def test_get_service_command_docs_if_service_operation_is_invalid(self):
-        # The service command docs will still be retrieved if the service
-        # operation is invalid. The special case is if the invalid service
-        # operation is entered at the entrypoint. In this case, the top-level
-        # docs will be retrieved instead. However, this logic is handled
-        # outside of the `DocsGetter` class.
-        command_text = 'ec2 fake'
-        actual_docs = self.docs_getter.get_docs(command_text)
-        expected_docs = 'Elastic Compute Cloud'
-        self.assertIn(expected_docs, actual_docs)
-
-
-class TestAwsTopLevelDocsGetter(unittest.TestCase):
-    """In this set of tests, we only compare the beginning of the help docs
-    instead of checking against the entire top-level AWS help docs because the
-    help docs are subject to change in the future. Any updates to the help docs
-    would require these tests to get updated. Checking just the beginning of
-    the help docs should minimize how often these tests need to get updated.
-
-    """
-    def setUp(self):
-        self.driver = create_clidriver()
-        self.docs_getter = AwsTopLevelDocsGetter(self.driver)
-        self.help_docs = 'The AWS Command Line Interface'
-
-    def test_can_get_top_level_aws_help_text(self):
-        docs = self.docs_getter.get_docs(self.driver)
-        self.assertIn(self.help_docs, docs)
-
-
-class TestServiceCommandDocsGetter(unittest.TestCase):
-    """In this set of tests, we only compare the beginning of the help docs
-    instead of checking against the entire top-level AWS help docs because the
-    help docs are subject to change in the future. Any updates to the help docs
-    would require these tests to get updated. Checking just the beginning of
-    the help docs should minimize how often these tests need to get updated.
-
-    """
-    def setUp(self):
-        self.driver = create_clidriver()
-        self.service_command_docs_getter = \
-            ServiceCommandDocsGetter(self.driver)
-
-    def test_can_get_service_command_docs_with_no_service_operation(self):
-        args = ['ec2']
-        actual_docs = self.service_command_docs_getter.get_docs(args)
-        expected_docs = 'Elastic Compute Cloud'
-        self.assertIn(expected_docs, actual_docs)
-
-    def test_can_get_service_command_docs_with_valid_service_operation(self):
-        args = ['ec2', 'describe-instances']
-        actual_docs = self.service_command_docs_getter.get_docs(args)
+    def test_get_service_operation_docs_if_input_is_vanild(self):
+        parsed_args = self.parser.parse('aws ec2 describe-instances fake')
+        actual_docs = self.docs_getter.get_docs(parsed_args)
         expected_docs = 'Describes the specified instances'
         self.assertIn(expected_docs, actual_docs)
 
-    def test_can_get_service_command_docs_with_invalid_service_operation(self):
-        args = ['ec2', 'fake']
-        actual_docs = self.service_command_docs_getter.get_docs(args)
-        expected_docs = 'Elastic Compute Cloud'
-        self.assertIn(expected_docs, actual_docs)
-
-
-class TestServiceOperationDocsGetter(unittest.TestCase):
-    """In this set of tests, we only compare the beginning of the help docs
-    instead of checking against the entire top-level AWS help docs because the
-    help docs are subject to change in the future. Any updates to the help docs
-    would require these tests to get updated. Checking just the beginning of
-    the help docs should minimize how often these tests need to get updated.
-
-    Note: We don't test against invalid service operation names here, as doing
-    so would cause the parser to raise a SystemExit. The responsibility of
-    handling invalid service operation names falls on the
-    ServiceCommandDocsGetter, so we test for invalid service operation names
-    there instead.
-
-    """
-    def setUp(self):
-        self.driver = create_clidriver()
-        self.service_operation_docs_getter = \
-            ServiceOperationDocsGetter(self.driver)
-        self.service_command = ServiceCommand(cli_name='ec2',
-                                              session=self.driver.session,
-                                              service_name='ec2')
-
-    def test_can_get_service_operation_docs(self):
-        remaining = ['describe-instances']
-        actual_docs = self.service_operation_docs_getter.get_docs(
-            self.service_command, remaining)
-        expected_docs = 'Describes the specified instances'
-        self.assertIn(expected_docs, actual_docs)
+    def test_cache_is_used(self):
+        parsed_args = self.parser.parse('aws ec2 describe-instances fake')
+        self.docs_getter.get_doc_content = mock.Mock()
+        self.docs_getter.get_docs(parsed_args)
+        self.assertEqual(self.docs_getter.get_doc_content.call_count, 1)
+        self.docs_getter.get_docs(parsed_args)
+        self.assertEqual(self.docs_getter.get_doc_content.call_count, 1)

--- a/tests/unit/autoprompt/test_doc.py
+++ b/tests/unit/autoprompt/test_doc.py
@@ -14,80 +14,17 @@ import mock
 import textwrap
 
 from awscli.clidriver import create_clidriver
-from awscli.autoprompt.doc import (
-    AwsTopLevelDocsGetter, BaseDocsGetter, DocsGetter,
-    ServiceCommandDocsGetter, ServiceOperationDocsGetter
-)
+from awscli.autoprompt.doc import DocsGetter
 from awscli.testutils import unittest
 
 
 class TestDocsGetter(unittest.TestCase):
     def setUp(self):
         self.driver = create_clidriver()
-        self.aws_top_level_docs_getter = mock.Mock(spec=AwsTopLevelDocsGetter)
-        self.aws_top_level_docs_getter.get_docs = mock.Mock()
-        self.service_command_docs_getter = \
-            mock.Mock(spec=ServiceCommandDocsGetter)
-        self.service_command_docs_getter.get_docs = mock.Mock()
-        self.docs_getter = DocsGetter(
-            driver=self.driver,
-            aws_top_level_docs_getter=self.aws_top_level_docs_getter,
-            service_command_docs_getter=self.service_command_docs_getter)
-
-    def test_delegates_to_top_level_docs_getter_if_empty_command(self):
-        command_text = ''
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.aws_top_level_docs_getter.get_docs.called)
-
-    def test_delegates_to_top_level_docs_getter_if_invalid_command(self):
-        command_text = 'fake'
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.aws_top_level_docs_getter.get_docs.called)
-
-    def test_delegates_to_service_command_docs_getter_if_valid_command(self):
-        command_text = 'ec2'
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.service_command_docs_getter.get_docs.called)
-
-    def test_delegates_to_service_command_docs_getter_if_valid_operation(self):
-        # We delegate to the service command docs getter here, which will then
-        # delegate to the service operation docs getter internally.
-        command_text = 'ec2 describe-instances'
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.service_command_docs_getter.get_docs.called)
-
-    def test_delegates_to_service_operation_getter_if_option_specified(self):
-        # We delegate to the service command docs getter here, which will then
-        # delegate to the service operation docs getter internally.
-        command_text = 'ec2 describe-instances --output'
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.service_command_docs_getter.get_docs.called)
-
-    def test_delegates_to_top_level_docs_getter_if_aws_help_is_entered(self):
-        command_text = 'help'
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.aws_top_level_docs_getter.get_docs.called)
-
-    def test_delegates_to_service_operation_getter_if_file_path_is_specified(self):
-        command_text = 's3 ls file://path/to/file.txt'
-        self.docs_getter.get_docs(command_text)
-        self.assertTrue(
-            self.docs_getter.service_command_docs_getter.get_docs.called)
-
-
-class TestBaseDocsGetter(unittest.TestCase):
-    def setUp(self):
-        self.driver = create_clidriver()
         self.help_command = self.driver.create_help_command()
         self.help_command.doc = mock.Mock()
         self.help_command.doc.getvalue = mock.Mock()
-        self.base_docs_getter = BaseDocsGetter(self.driver)
+        self.base_docs_getter = DocsGetter(self.driver)
 
     def test_get_doc_content(self):
         self.help_command.doc.getvalue.return_value = b'Dummy content.'
@@ -140,104 +77,3 @@ class TestBaseDocsGetter(unittest.TestCase):
         self.help_command.doc.getvalue.return_value = b''
         content = self.base_docs_getter.get_doc_content(self.help_command)
         self.assertEqual(content, '')
-
-
-class TestAwsTopLevelDocsGetter(unittest.TestCase):
-    def setUp(self):
-        self.driver = create_clidriver()
-        self.aws_top_level_docs_getter = AwsTopLevelDocsGetter(self.driver)
-        self.aws_top_level_docs_getter.get_doc_content = mock.Mock()
-
-    def test_base_docs_getter_is_called(self):
-        self.aws_top_level_docs_getter.get_docs(self.driver)
-        self.assertTrue(self.aws_top_level_docs_getter.get_doc_content.called)
-
-    def test_base_docs_getter_use_cache(self):
-        self.aws_top_level_docs_getter.get_docs(self.driver)
-        self.assertEqual(
-            self.aws_top_level_docs_getter.get_doc_content.call_count, 1
-        )
-        self.aws_top_level_docs_getter.get_docs(self.driver)
-        self.assertEqual(
-            self.aws_top_level_docs_getter.get_doc_content.call_count, 1
-        )
-
-
-class TestServiceCommandDocsGetter(unittest.TestCase):
-    def setUp(self):
-        self.driver = create_clidriver()
-        self.service_operation_docs_getter = \
-            mock.Mock(spec=ServiceOperationDocsGetter)
-        self.service_operation_docs_getter.get_docs = mock.Mock()
-        self.service_command_docs_getter = ServiceCommandDocsGetter(
-            self.driver, self.service_operation_docs_getter)
-        self.service_command_docs_getter.get_doc_content = mock.Mock()
-
-    def test_calls_base_docs_getter_if_no_remaining_args(self):
-        args = ['ec2']
-        self.service_command_docs_getter.get_docs(args)
-        self.assertTrue(self.service_command_docs_getter.get_doc_content.called)
-
-    def test_calls_base_docs_getter_if_service_operation_is_invalid(self):
-        args = ['ec2', 'fake']
-        self.service_command_docs_getter.get_docs(args)
-        self.assertTrue(self.service_command_docs_getter.get_doc_content.called)
-
-    def test_calls_service_operation_docs_getter_if_remaining_args_exist(self):
-        args = ['ec2', 'describe-instances']
-        self.service_command_docs_getter.get_docs(args)
-        self.assertTrue(self.service_operation_docs_getter.get_docs.called)
-
-    def test_base_docs_getter_use_cache(self):
-        args = ['ec2']
-        self.service_command_docs_getter.get_docs(args)
-        self.assertEqual(
-            self.service_command_docs_getter.get_doc_content.call_count, 1
-        )
-        self.service_command_docs_getter.get_docs(args)
-        self.assertEqual(
-            self.service_command_docs_getter.get_doc_content.call_count, 1
-        )
-
-
-class TestServiceOperationDocsGetter(unittest.TestCase):
-    def setUp(self):
-        self.driver = create_clidriver()
-        self.service_command_table = self.driver.subcommand_table
-        self.service_operation_docs_getter = \
-            ServiceOperationDocsGetter(self.driver)
-        self.service_operation_docs_getter.get_doc_content = mock.Mock()
-
-    def get_service_command(self, args):
-        parser = self.driver.create_parser(self.service_command_table)
-        parsed_args, remaining = parser.parse_known_args(args)
-        service_name = parsed_args.command
-        return self.service_command_table[service_name], remaining
-
-    def test_calls_base_docs_getter_if_valid_service_operation(self):
-        args = ['ec2', 'describe-instances']
-        self.service_command, remaining = self.get_service_command(args)
-        self.service_operation_docs_getter.get_docs(
-            self.service_command, remaining)
-        self.assertTrue(
-            self.service_operation_docs_getter.get_doc_content.called)
-
-    def test_calls_base_docs_getter_with_custom_service_commands_and_operations(self):
-        args = ['s3', 'ls']
-        self.service_command, remaining = self.get_service_command(args)
-        self.service_operation_docs_getter.get_docs(
-            self.service_command, remaining)
-        self.assertTrue(
-            self.service_operation_docs_getter.get_doc_content.called)
-
-    def test_base_docs_getter_use_cache(self):
-        args = ['ec2', 'describe-instances']
-        self.service_command, remaining = self.get_service_command(args)
-        self.service_operation_docs_getter.get_docs(
-            self.service_command, remaining)
-        self.assertEqual(
-            self.service_operation_docs_getter.get_doc_content.call_count, 1)
-        self.service_operation_docs_getter.get_docs(
-            self.service_command, remaining)
-        self.assertEqual(
-            self.service_operation_docs_getter.get_doc_content.call_count, 1)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor autoprompt docs getter to use CLI parser for parsing args

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
