### PR TITLE
[v2] Add support for sections in wizard UI

### DIFF
--- a/awscli/customizations/wizard/app.py
+++ b/awscli/customizations/wizard/app.py
@@ -13,6 +13,7 @@
 from prompt_toolkit.application import Application
 from prompt_toolkit.key_binding import KeyBindings
 
+from awscli.customizations.wizard.core import ConditionEvaluator
 from awscli.customizations.wizard.ui.keybindings import get_default_keybindings
 from awscli.customizations.wizard.ui.layout import WizardLayoutFactory
 from awscli.customizations.wizard.ui.style import get_default_style
@@ -27,4 +28,80 @@ def create_wizard_app(definition):
         full_screen=True,
     )
     app.values = {}
+    app.traverser = WizardTraverser(definition, app.values)
     return app
+
+
+class WizardTraverser:
+    def __init__(self, definition, values):
+        self._definition = definition
+        self._values = values
+        self._prompt_definitions = self._collect_all_prompt_definitions()
+        self._prompt_to_sections = self._map_prompts_to_sections()
+        self._current_prompt = self._get_starting_prompt()
+        self._previous_prompts = []
+        self._visited_sections = [self.get_current_section()]
+
+    def get_current_prompt(self):
+        return self._current_prompt
+
+    def get_current_section(self):
+        return self._prompt_to_sections[self._current_prompt]
+
+    def next_prompt(self):
+        new_prompt = self._get_next_prompt()
+        if new_prompt != self._current_prompt:
+            self._previous_prompts.append(self._current_prompt)
+        if self._prompt_to_sections[new_prompt] != self.get_current_section():
+            self._visited_sections.append(self._prompt_to_sections[new_prompt])
+        self._current_prompt = new_prompt
+        return new_prompt
+
+    def previous_prompt(self):
+        if self._previous_prompts:
+            previous = self._previous_prompts.pop()
+            self._current_prompt = previous
+        return self._current_prompt
+
+    def is_prompt_visible(self, value_name):
+        if self._prompt_to_sections[value_name] != self.get_current_section():
+            return False
+        return self._prompt_meets_condition(value_name)
+
+    def has_visited_section(self, section_name):
+        return section_name in self._visited_sections
+
+    def _collect_all_prompt_definitions(self):
+        value_prompt_definitions = {}
+        for _, section_definition in self._definition['plan'].items():
+            for name, value_definition in section_definition['values'].items():
+                if value_definition['type'] == 'prompt':
+                    value_prompt_definitions[name] = value_definition
+        return value_prompt_definitions
+
+    def _map_prompts_to_sections(self):
+        prompts_to_sections = {}
+        sections = self._definition['plan']
+        for section_name, section_definition in sections.items():
+            for name, value_definition in section_definition['values'].items():
+                prompts_to_sections[name] = section_name
+        return prompts_to_sections
+
+    def _get_starting_prompt(self):
+        return list(self._prompt_definitions)[0]
+
+    def _get_next_prompt(self):
+        prompts = list(self._prompt_definitions)
+        current_pos = prompts.index(self._current_prompt)
+        for prompt in prompts[current_pos+1:]:
+            if self._prompt_meets_condition(prompt):
+                return prompt
+        return self._current_prompt
+
+    def _prompt_meets_condition(self, value_name):
+        value_definition = self._prompt_definitions[value_name]
+        if 'condition' in value_definition:
+            return ConditionEvaluator().evaluate(
+                value_definition['condition'], self._values
+            )
+        return True

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -336,15 +336,18 @@ class Executor(object):
 
     def _execute_step(self, step, parameters):
         if 'condition' in step:
-            should_run = self._check_step_condition(step['condition'],
-                                                    parameters)
+            should_run = ConditionEvaluator().evaluate(
+                step['condition'], parameters
+            )
             if not should_run:
                 return
         step_type = step['type']
         handler = self._step_handlers[step_type]
         handler.run_step(step, parameters)
 
-    def _check_step_condition(self, condition, parameters):
+
+class ConditionEvaluator:
+    def evaluate(self, condition, parameters):
         statuses = []
         if not isinstance(condition, list):
             condition = [condition]

--- a/awscli/customizations/wizard/ui/keybindings.py
+++ b/awscli/customizations/wizard/ui/keybindings.py
@@ -21,18 +21,21 @@ def get_default_keybindings():
         event.app.exit()
 
     def submit_current_answer(event):
-        current_buffer = event.app.current_buffer
-        event.app.values[current_buffer.name] = current_buffer.text
+        current_prompt = event.app.traverser.get_current_prompt()
+        prompt_buffer = event.app.layout.get_buffer_by_name(current_prompt)
+        event.app.values[current_prompt] = prompt_buffer.text
 
     @kb.add('tab')
     @kb.add('enter')
     def next_prompt(event):
         submit_current_answer(event)
-        event.app.layout.focus_next()
+        next_prompt = event.app.traverser.next_prompt()
+        event.app.layout.focus(next_prompt)
 
     @kb.add('s-tab')
-    def last_prompt(event):
+    def previous_prompt(event):
         submit_current_answer(event)
-        event.app.layout.focus_last()
+        previous_prompt = event.app.traverser.previous_prompt()
+        event.app.layout.focus(previous_prompt)
 
     return kb

--- a/awscli/customizations/wizard/ui/prompt.py
+++ b/awscli/customizations/wizard/ui/prompt.py
@@ -13,7 +13,10 @@
 from prompt_toolkit.application import get_app
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.document import Document
-from prompt_toolkit.layout.containers import Window, VSplit, Dimension
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.layout.containers import (
+    Window, VSplit, Dimension, ConditionalContainer
+)
 from prompt_toolkit.layout.controls import BufferControl
 
 
@@ -24,15 +27,21 @@ class WizardPrompt:
         self.container = self._get_container()
 
     def _get_container(self):
-        return VSplit(
-            [
-                WizardPromptDescription(
-                    self._value_name,
-                    self._value_definition['description']
-                ),
-                WizardPromptAnswer(self._value_name)
-            ]
+        return ConditionalContainer(
+            VSplit(
+                [
+                    WizardPromptDescription(
+                        self._value_name,
+                        self._value_definition['description']
+                    ),
+                    WizardPromptAnswer(self._value_name)
+                ],
+            ),
+            Condition(self._is_visible)
         )
+
+    def _is_visible(self):
+        return get_app().traverser.is_prompt_visible(self._value_name)
 
     def __pt_container__(self):
         return self.container
@@ -60,7 +69,7 @@ class WizardPromptDescription:
         )
 
     def _get_style(self):
-        if get_app().layout.has_focus(self._value_name):
+        if get_app().traverser.get_current_prompt() == self._value_name:
             return 'class:wizard.prompt.description.current'
         else:
             return 'class:wizard.prompt.description'
@@ -84,7 +93,7 @@ class WizardPromptAnswer:
         )
 
     def _get_style(self):
-        if get_app().layout.has_focus(self._value_name):
+        if get_app().traverser.get_current_prompt() == self._value_name:
             return 'class:wizard.prompt.answer.current'
         else:
             return 'class:wizard.prompt.answer'

--- a/awscli/customizations/wizard/ui/section.py
+++ b/awscli/customizations/wizard/ui/section.py
@@ -1,0 +1,88 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from prompt_toolkit.application import get_app
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
+from prompt_toolkit.filters import Condition
+from prompt_toolkit.layout.containers import (
+    Window, HSplit, Dimension, ConditionalContainer, WindowAlign
+)
+from prompt_toolkit.layout.controls import BufferControl
+from prompt_toolkit.widgets import Label, Box
+
+from awscli.customizations.wizard.ui.prompt import WizardPrompt
+
+
+class WizardSectionTab:
+    def __init__(self, section_name, section_definition):
+        self._name = section_name
+        self._definition = section_definition
+        self.container = self._get_container()
+
+    def _get_container(self):
+        content = f"{self._definition['shortname']}"
+        buffer = Buffer(
+            document=Document(content),
+            read_only=True
+        )
+        return Window(
+            content=BufferControl(
+                buffer=buffer, focusable=False
+            ),
+            style=self._get_style,
+            width=Dimension.exact(len(content) + 1),
+            dont_extend_height=True,
+        )
+
+    def _get_style(self):
+        traverser = get_app().traverser
+        if traverser.get_current_section() == self._name:
+            return 'class:wizard.section.tab.current'
+        elif traverser.has_visited_section(self._name):
+            return 'class:wizard.section.tab.visited'
+        return 'class:wizard.section.tab.unvisited'
+
+    def __pt_container__(self):
+        return self.container
+
+
+class WizardSectionBody:
+    def __init__(self, section_name, section_definition):
+        self._name = section_name
+        self._definition = section_definition
+        self.container = self._get_container()
+
+    def _get_container(self):
+        return ConditionalContainer(
+            Box(
+                HSplit(
+                    self._create_prompts_from_section_definition(),
+                    padding=1
+                ),
+                padding_left=2, padding_top=1
+            ),
+            Condition(self._is_current_section)
+        )
+
+    def _is_current_section(self):
+        return get_app().traverser.get_current_section() == self._name
+
+    def _create_prompts_from_section_definition(self):
+        prompts = []
+        for value_name, value_definition in self._definition['values'].items():
+            if value_definition['type'] == 'prompt':
+                prompts.append(WizardPrompt(value_name, value_definition))
+        return prompts
+
+    def __pt_container__(self):
+        return self.container

--- a/awscli/customizations/wizard/ui/style.py
+++ b/awscli/customizations/wizard/ui/style.py
@@ -22,5 +22,9 @@ def get_default_style():
             ('wizard.prompt.description.current', 'white'),
             ('wizard.prompt.answer', ''),
             ('wizard.prompt.answer.current', 'white'),
+            ('wizard.section.tab', 'bold bg:#aaaaaa black'),
+            ('wizard.section.tab.current', 'white'),
+            ('wizard.section.tab.unvisited', '#777777'),
+            ('wizard.section.tab.visited', '')
         ]
     )

--- a/awscli/customizations/wizard/ui/utils.py
+++ b/awscli/customizations/wizard/ui/utils.py
@@ -1,0 +1,43 @@
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from prompt_toolkit.application import get_app
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
+from prompt_toolkit.layout.containers import Window, Dimension
+from prompt_toolkit.layout.controls import BufferControl
+
+
+class Spacer:
+    """Fills empty space in a layout
+
+    It is helpful for extending a particular container with a visual
+    element such as expanding tab column in the wizard app with the
+    color gray.
+    """
+    def __init__(self):
+        self.container = self._get_container()
+
+    def _get_container(self):
+        buffer = Buffer(
+            document=Document(''),
+            read_only=True
+        )
+        return Window(
+            content=BufferControl(
+                buffer=buffer, focusable=False
+            )
+        )
+
+    def __pt_container__(self):
+        return self.container
+

--- a/awscli/customizations/wizard/wizards/iam/_new-role-wip.yml
+++ b/awscli/customizations/wizard/wizards/iam/_new-role-wip.yml
@@ -1,0 +1,93 @@
+version: "0.2"
+title: Create An IAM Role and Policy
+description: This wizard will create a new IAM role for you
+plan:
+  ask_role_name:
+    shortname: Intro
+    description: Provide role name and description
+    values:
+      role_name:
+        type: prompt
+        description: Role name
+      role_description:
+        type: prompt
+        description: Role description
+  decide_role_type:
+    shortname: Trusted Entity
+    description: Select the trusted entity for the role
+    values:
+      # This will prompt the user using the 'description' value.
+      # The value the user enters is saved under the global variable
+      # 'name'.
+      role_type:
+        type: prompt
+        description: Select type of trusted entity
+        choices:
+          # There's also Web Identity and SAML but we're skipping that.
+          - display: AWS Service
+            actual_value: aws_service
+          - display: Another AWS Account
+            actual_value: aws_account
+      service_name:
+        type: prompt
+        description: Choose the service that will use this role
+        condition:
+          variable: role_type
+          equals: aws_service
+        choices:
+          - display: Amazon EC2
+            actual_value: ec2
+          - display: AWS Lambda
+            actual_value: lambda
+      account_id:
+        type: prompt
+        description: Enter the Account ID that can use this role
+        condition:
+          variable: role_type
+          equals: aws_account
+  ask_role_permissions:
+    shortname: Permissions
+    description: Attach permissions policies
+    # The console by default asks you to pick an existing policy
+    # to attach to.  We'll just go with that behavior for now.
+    values:
+      existing_policies:
+        type: apicall
+        operation: iam.ListPolicies
+        params:
+          Scope: AWS
+        query: "sort_by(Policies[].{display: PolicyName, actual_value: Arn}, &display)"
+      policy_arn:
+        type: prompt
+        description: Choose a policy to attach to your new role
+        choices: existing_policies
+  ask_profile_config:
+    shortname: CLI config
+    description: Determine CLI configuration
+    values:
+      wants_config_profile:
+        type: prompt
+        description: Do you want to create a new CLI profile with this role?
+        choices:
+          - display: Yes
+            actual_value: yes
+          - display: No
+            actual_value: no
+      new_profile_name:
+        type: prompt
+        description: Enter the name of the new profile
+        condition:
+          variable: wants_config_profile
+          equals: yes
+      existing_profiles:
+        type: sharedconfig
+        operation: ListProfiles
+      source_profile:
+        type: prompt
+        description: Name of the source profile
+        choices: existing_profiles
+        condition:
+          variable: wants_config_profile
+          equals: yes
+execute:
+

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -16,14 +16,55 @@ from prompt_toolkit.keys import Keys
 
 from tests import PromptToolkitApplicationStubber as ApplicationStubber
 from awscli.customizations.wizard.app import create_wizard_app
+from awscli.customizations.wizard.app import WizardTraverser
 
 
-class TestWizardApplication(unittest.TestCase):
+class BaseWizardApplicationTest(unittest.TestCase):
     def setUp(self):
-        self.definition = {
+        self.definition = self.get_definition()
+        self.app = create_wizard_app(self.definition)
+        self.stubbed_app = ApplicationStubber(self.app)
+
+    def get_definition(self):
+        return {
             'title': 'Wizard title',
+            'plan': {}
+        }
+
+    def add_answer_submission(self, answer):
+        self.stubbed_app.add_text_to_current_buffer(answer)
+        self.stubbed_app.add_keypress(Keys.Enter)
+
+    def add_app_values_assertion(self, **expected_values):
+        self.stubbed_app.add_app_assertion(
+            lambda app: self.assertEqual(app.values, expected_values)
+        )
+
+    def add_prompt_is_visible_assertion(self, name):
+        self.stubbed_app.add_app_assertion(
+            lambda app: self.assertIn(name, self.get_visible_buffers(app))
+        )
+
+    def add_prompt_is_not_visible_assertion(self, name):
+        self.stubbed_app.add_app_assertion(
+            lambda app: self.assertNotIn(name, self.get_visible_buffers(app))
+        )
+
+    def get_visible_buffers(self, app):
+        return [
+            window.content.buffer.name
+            for window in app.layout.visible_windows
+            if hasattr(window.content, 'buffer')
+        ]
+
+
+class TestBasicWizardApplication(BaseWizardApplicationTest):
+    def get_definition(self):
+        return {
+            'title': 'Basic Wizard',
             'plan': {
-                'first_step': {
+                'first_section': {
+                    'shortname': 'First',
                     'values': {
                         'prompt1': {
                             'description': 'Description of first prompt',
@@ -33,21 +74,19 @@ class TestWizardApplication(unittest.TestCase):
                             'description': 'Description of second prompt',
                             'type': 'prompt'
                         },
-                        'prompt3': {
-                            'description': 'Description of third prompt',
+                    }
+                },
+                'second_section': {
+                    'shortname': 'Second',
+                    'values': {
+                        'second_section_prompt': {
+                            'description': 'Description of prompt',
                             'type': 'prompt'
-                        }
+                        },
                     }
                 }
             }
         }
-        self.app = create_wizard_app(self.definition)
-        self.stubbed_app = ApplicationStubber(self.app)
-
-    def add_app_values_assertion(self, **expected_values):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(app.values, expected_values)
-        )
 
     def test_can_answer_single_prompt(self):
         self.stubbed_app.add_text_to_current_buffer('val1')
@@ -70,12 +109,379 @@ class TestWizardApplication(unittest.TestCase):
         self.stubbed_app.run()
 
     def test_can_use_shift_tab_to_toggle_backwards_and_change_answer(self):
-        self.stubbed_app.add_text_to_current_buffer('orig1')
-        self.stubbed_app.add_keypress(Keys.Enter)
+        self.add_answer_submission('orig1')
         self.stubbed_app.add_keypress(Keys.BackTab)
-        self.stubbed_app.add_text_to_current_buffer('override1')
-        self.stubbed_app.add_keypress(Keys.Enter)
+        self.add_answer_submission('override1')
         self.add_app_values_assertion(prompt1='override1', prompt2='')
         self.stubbed_app.run()
 
+    def test_can_answer_prompts_across_sections(self):
+        self.add_answer_submission('val1')
+        self.add_answer_submission('val2')
+        self.add_answer_submission('second_section_val1')
+        self.add_app_values_assertion(
+            prompt1='val1', prompt2='val2',
+            second_section_prompt='second_section_val1'
+        )
+        self.stubbed_app.run()
 
+    def test_can_move_back_to_a_prompt_in_previous_section(self):
+        self.add_answer_submission('val1')
+        self.add_answer_submission('val2')
+        self.add_answer_submission('second_section_val1')
+        self.stubbed_app.add_keypress(Keys.BackTab)
+        self.add_answer_submission('override2')
+        self.add_app_values_assertion(
+            prompt1='val1', prompt2='override2',
+            second_section_prompt='second_section_val1'
+        )
+        self.stubbed_app.run()
+
+    def test_prompts_are_not_visible_across_sections(self):
+        self.add_prompt_is_visible_assertion('prompt1')
+        self.add_prompt_is_visible_assertion('prompt2')
+        self.add_prompt_is_not_visible_assertion('second_section_prompt')
+
+        self.add_answer_submission('val1')
+        self.add_answer_submission('val2')
+
+        self.add_prompt_is_not_visible_assertion('prompt1')
+        self.add_prompt_is_not_visible_assertion('prompt2')
+        self.add_prompt_is_visible_assertion('second_section_prompt')
+        self.stubbed_app.run()
+
+
+class TestConditionalWizardApplication(BaseWizardApplicationTest):
+    def get_definition(self):
+        return {
+            'title': 'Conditional wizard',
+            'plan': {
+                'section': {
+                    'shortname': 'Section',
+                    'values': {
+                        'before_conditional': {
+                            'description': 'Description of first prompt',
+                            'type': 'prompt'
+                        },
+                        'conditional': {
+                            'description': 'Description of second prompt',
+                            'type': 'prompt',
+                            'condition': {
+                                'variable': 'before_conditional',
+                                'equals': 'condition-met'
+                            }
+                        },
+                        'after_conditional': {
+                            'description': 'Description of second prompt',
+                            'type': 'prompt',
+                        },
+                    }
+                },
+            }
+        }
+
+    def test_conditional_prompt_is_skipped_when_condition_not_met(self):
+        self.add_prompt_is_not_visible_assertion('conditional')
+        self.add_answer_submission('condition-not-met')
+        self.add_prompt_is_not_visible_assertion('conditional')
+        self.add_answer_submission('after-conditional-val')
+        self.add_app_values_assertion(
+            before_conditional='condition-not-met',
+            after_conditional='after-conditional-val',
+        )
+        self.stubbed_app.run()
+
+    def test_conditional_prompt_appears_when_condition_met(self):
+        self.add_prompt_is_not_visible_assertion('conditional')
+        self.add_answer_submission('condition-met')
+        self.add_prompt_is_visible_assertion('conditional')
+        self.add_answer_submission('val-at-conditional')
+        self.add_app_values_assertion(
+            before_conditional='condition-met',
+            conditional='val-at-conditional',
+        )
+        self.stubbed_app.run()
+
+
+class TestWizardTraverser(unittest.TestCase):
+    def setUp(self):
+        self.simple_definition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                        'second_prompt': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+
+    def create_traverser(self, definition, values=None):
+        if values is None:
+            values = {}
+        return WizardTraverser(definition, values)
+
+    def create_definition(self, sections):
+        return {
+            'plan': sections
+        }
+
+    def create_prompt_definition(self, description=None, condition=None):
+        prompt = {
+            'type': 'prompt'
+        }
+        if not description:
+            description = 'A sample description'
+        prompt['description'] = description
+        if condition:
+            prompt['condition'] = condition
+        return prompt
+
+    def test_get_current_prompt(self):
+        traverser = self.create_traverser(self.simple_definition)
+        self.assertEqual(traverser.get_current_prompt(), 'first_prompt')
+
+    def test_get_current_section(self):
+        traverser = self.create_traverser(self.simple_definition)
+        self.assertEqual(traverser.get_current_section(), 'first_section')
+
+    def test_next_prompt(self):
+        traverser = self.create_traverser(self.simple_definition)
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'second_prompt')
+        self.assertEqual(traverser.get_current_section(), 'first_section')
+
+    def test_next_prompt_condition_not_met(self):
+        definition_with_condition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                        'conditional': self.create_prompt_definition(
+                            condition={
+                                'variable': 'first_prompt',
+                                'equals': 'condition-met'
+                            }
+                        ),
+                        'after_conditional': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(
+            definition_with_condition,
+            values={
+                'first_prompt': 'condition-not-met'
+            }
+        )
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'after_conditional')
+
+    def test_next_prompt_condition_met(self):
+        definition_with_condition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                        'conditional': self.create_prompt_definition(
+                            condition={
+                                'variable': 'first_prompt',
+                                'equals': 'condition-met'
+                            }
+                        ),
+                        'after_conditional': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(
+            definition_with_condition,
+            values={
+                'first_prompt': 'condition-met'
+            }
+        )
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'conditional')
+
+    def test_next_prompt_moves_to_next_section_when_no_more_prompts(self):
+        definition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                    }
+                },
+                'second_section': {
+                    'values': {
+                        'second_prompt': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(definition)
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'second_prompt')
+        self.assertEqual(traverser.get_current_section(), 'second_section')
+
+    def test_next_prompt_returns_same_prompt_at_end_of_wizard(self):
+        definition = self.create_definition(
+            sections={
+                'only_section': {
+                    'values': {
+                        'only_prompt': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(definition)
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'only_prompt')
+
+    def test_previous_prompt(self):
+        traverser = self.create_traverser(self.simple_definition)
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'second_prompt')
+        self.assertEqual(traverser.get_current_section(), 'first_section')
+
+        previous_prompt = traverser.previous_prompt()
+        self.assertEqual(previous_prompt, 'first_prompt')
+        self.assertEqual(traverser.get_current_section(), 'first_section')
+
+    def test_previous_prompt_can_move_back_sections(self):
+        definition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                    }
+                },
+                'second_section': {
+                    'values': {
+                        'second_prompt': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(definition)
+        next_prompt = traverser.next_prompt()
+        self.assertEqual(next_prompt, 'second_prompt')
+        self.assertEqual(traverser.get_current_section(), 'second_section')
+
+        previous_prompt = traverser.previous_prompt()
+        self.assertEqual(previous_prompt, 'first_prompt')
+        self.assertEqual(traverser.get_current_section(), 'first_section')
+
+    def test_previous_prompt_returns_same_prompt_at_start_of_wizard(self):
+        traverser = self.create_traverser(self.simple_definition)
+        previous_prompt = traverser.previous_prompt()
+        self.assertEqual(previous_prompt, 'first_prompt')
+        self.assertEqual(traverser.get_current_section(), 'first_section')
+
+    def test_prompt_is_visible_when_no_condition(self):
+        traverser = self.create_traverser(self.simple_definition)
+        self.assertTrue(traverser.is_prompt_visible('second_prompt'))
+
+    def test_prompt_is_visible_when_condition_met(self):
+        definition_with_condition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                        'conditional': self.create_prompt_definition(
+                            condition={
+                                'variable': 'first_prompt',
+                                'equals': 'condition-met'
+                            }
+                        ),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(
+            definition_with_condition,
+            values={
+                'first_prompt': 'condition-not-met'
+            }
+        )
+        self.assertFalse(traverser.is_prompt_visible('conditional'))
+
+    def test_prompt_is_not_visible_when_condition_not_met(self):
+        definition_with_condition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                        'conditional': self.create_prompt_definition(
+                            condition={
+                                'variable': 'first_prompt',
+                                'equals': 'condition-met'
+                            }
+                        ),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(
+            definition_with_condition,
+            values={
+                'first_prompt': 'condition-met'
+            }
+        )
+        self.assertTrue(traverser.is_prompt_visible('conditional'))
+
+    def test_prompt_is_not_visible_when_not_on_current_section(self):
+        definition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                    }
+                },
+                'second_section': {
+                    'values': {
+                        'second_prompt': self.create_prompt_definition(),
+                    }
+                }
+            }
+        )
+        traverser = self.create_traverser(definition)
+        self.assertFalse(traverser.is_prompt_visible('second_prompt'))
+
+    def test_has_visited_section(self):
+        definition = self.create_definition(
+            sections={
+                'first_section': {
+                    'values': {
+                        'first_prompt': self.create_prompt_definition(),
+                    }
+                },
+                'second_section': {
+                    'values': {
+                        'second_prompt': self.create_prompt_definition(),
+                    }
+                },
+                'third_section': {
+                    'values': {
+                        'third_prompt': self.create_prompt_definition(),
+                    }
+                },
+            }
+        )
+        # Start at the first section
+        traverser = self.create_traverser(definition)
+        self.assertTrue(traverser.has_visited_section('first_section'))
+        self.assertFalse(traverser.has_visited_section('second_section'))
+        self.assertFalse(traverser.has_visited_section('third_section'))
+
+        # Move to the second section
+        traverser.next_prompt()
+        self.assertTrue(traverser.has_visited_section('first_section'))
+        self.assertTrue(traverser.has_visited_section('second_section'))
+        self.assertFalse(traverser.has_visited_section('third_section'))
+
+        # Go back to the first section. Note the second section should still
+        # count as visited.
+        traverser.previous_prompt()
+        self.assertTrue(traverser.has_visited_section('first_section'))
+        self.assertTrue(traverser.has_visited_section('second_section'))
+        self.assertFalse(traverser.has_visited_section('third_section'))


### PR DESCRIPTION
This makes it so that the UI will only display prompts related to a particular section. This is useful as it:

1. Makes the prompts less cluttered and easier to follow
2. Makes more space available for building wizards as we are no longer restricted to all prompts to a single terminal screen.

In making sections, this also introduced a wizard traverser that:
* Keeps track of the current prompt in the wizard
* Determines what the next prompt is
* Keeps track of what the previous prompts are in order to back
* Determines what prompts should be visible to the user

In order to try out the new UI, you can run the `_new-role-wip.yml` wizard:
```
~/GitHub/aws-cli/awscli/customizations/wizard/wizards/iam$ aws cli-dev wizard-dev --run-wizard file://_new-role-wip.yml
```
This `_new-role-wip` wizard is just a copy of the `new-role` wizard that will be used for testing updates to the UI with the goal of it eventually becoming the `new-role` once this is all fully integrated.


