### PR TITLE
[v2] Allow referencing of wizard choices from a variable

### DIFF
--- a/awscli/customizations/wizard/app.py
+++ b/awscli/customizations/wizard/app.py
@@ -187,8 +187,7 @@ class WizardValues(MutableMapping):
                 retrieval_step = self._value_retrieval_steps[
                     value_definition['type']
                 ]
-                self._values[key] = retrieval_step.run_step(
-                    value_definition, self)
+                return retrieval_step.run_step(value_definition, self)
         return self._values[key]
 
     def __setitem__(self, key, value):

--- a/awscli/customizations/wizard/devcommands.py
+++ b/awscli/customizations/wizard/devcommands.py
@@ -23,6 +23,7 @@ def register_dev_commands(event_handlers):
 def create_default_wizard_dev_runner(session):
     return WizardDevRunner(
         wizard_loader=WizardLoader(),
+        session=session,
     )
 
 
@@ -33,13 +34,14 @@ class WizardLoader(object):
 
 
 class WizardDevRunner(object):
-    def __init__(self, wizard_loader):
+    def __init__(self, wizard_loader, session):
         self._wizard_loader = wizard_loader
+        self._session = session
 
     def run_wizard(self, wizard_contents):
         """Run a single wizard given the contents as a string."""
         loaded = self._wizard_loader.load(wizard_contents)
-        app = create_wizard_app(loaded)
+        app = create_wizard_app(loaded, self._session)
         app.run()
         print(f'Collected values: {app.values}')
 

--- a/awscli/customizations/wizard/ui/selectmenu.py
+++ b/awscli/customizations/wizard/ui/selectmenu.py
@@ -196,13 +196,18 @@ class CollapsableSelectionMenuControl(SelectionMenuControl):
         if not selection_capture_buffer:
             selection_capture_buffer = Buffer()
         self.buffer = selection_capture_buffer
+        self._has_ever_entered_select_menu = False
 
     def create_content(self, width, height):
         if get_app().layout.has_focus(self):
+            self._has_ever_entered_select_menu = True
             return super().create_content(width, height)
         else:
             def get_line(i):
-                return [('', self._get_items()[self._selection])]
+                content = ''
+                if self._has_ever_entered_select_menu:
+                    content = self._get_items()[self._selection]
+                return [('', content)]
 
             return UIContent(get_line=get_line, line_count=1)
 

--- a/awscli/customizations/wizard/wizards/iam/_new-role-wip.yml
+++ b/awscli/customizations/wizard/wizards/iam/_new-role-wip.yml
@@ -57,6 +57,7 @@ plan:
         params:
           Scope: AWS
         query: "sort_by(Policies[].{display: PolicyName, actual_value: Arn}, &display)"
+        cache: true
       policy_arn:
         type: prompt
         description: Choose a policy to attach

--- a/awscli/customizations/wizard/wizards/iam/_new-role-wip.yml
+++ b/awscli/customizations/wizard/wizards/iam/_new-role-wip.yml
@@ -59,10 +59,8 @@ plan:
         query: "sort_by(Policies[].{display: PolicyName, actual_value: Arn}, &display)"
       policy_arn:
         type: prompt
-        description: Choose a policy to attach to your new role
-        # TODO: Uncomment this choices once we implement pulling choices
-        # from variables.
-        # choices: existing_policies
+        description: Choose a policy to attach
+        choices: existing_policies
   ask_profile_config:
     shortname: CLI config
     description: Determine CLI configuration
@@ -87,9 +85,7 @@ plan:
       source_profile:
         type: prompt
         description: Name of the source profile
-        # TODO: Uncomment this choices once we implement pulling choices
-        # from variables.
-        # choices: existing_profiles
+        choices: existing_profiles
         condition:
           variable: wants_config_profile
           equals: yes

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -325,13 +325,7 @@ class TestApiCallWizardApplication(BaseWizardApplicationTest):
             ]
         }
         self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(
-            choose_policy='policy1_arn',
-            existing_policies=[
-                {'actual_value': 'policy1_arn', 'display': 'policy1'},
-                {'actual_value': 'policy2_arn', 'display': 'policy2'}
-            ]
-        )
+        self.add_app_values_assertion(choose_policy='policy1_arn')
         self.stubbed_app.run()
 
 
@@ -360,10 +354,7 @@ class TestSharedConfigWizardApplication(BaseWizardApplicationTest):
     def test_uses_choices_from_api_call(self):
         self.session.available_profiles = ['profile1', 'profile2']
         self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(
-            choose_profile='profile1',
-            existing_profiles=['profile1', 'profile2']
-        )
+        self.add_app_values_assertion(choose_profile='profile1')
         self.stubbed_app.run()
 
 
@@ -776,13 +767,6 @@ class TestWizardValues(unittest.TestCase):
         self.handler.run_step.return_value = 'from_handler'
         values = self.get_wizard_values({'use_handler': self.handler})
         self.assertEqual(values['handler_value'], 'from_handler')
-
-    def test_get_with_handler_caches_result(self):
-        self.handler.run_step.return_value = 'from_handler'
-        values = self.get_wizard_values({'use_handler': self.handler})
-        self.assertEqual(values['handler_value'], 'from_handler')
-        self.assertEqual(values['handler_value'], 'from_handler')
-        self.assertEqual(self.handler.run_step.call_count, 1)
 
     def test_manual_set_overrides_delegation_handler(self):
         self.handler.run_step.return_value = 'from_handler'

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -247,6 +247,41 @@ class TestChoicesWizardApplication(BaseWizardApplicationTest):
         self.stubbed_app.run()
 
 
+class TestMixedPromptTypeWizardApplication(BaseWizardApplicationTest):
+    def get_definition(self):
+        return {
+            'title': 'Wizard with both buffer inputs and select inputs',
+            'plan': {
+                'section': {
+                    'shortname': 'Section',
+                    'values': {
+                        'buffer_input_prompt': {
+                            'description': 'Type answer',
+                            'type': 'prompt',
+                        },
+                        'select_prompt': {
+                            'description': 'Select answer',
+                            'type': 'prompt',
+                            'choices': [
+                                'select_answer_1',
+                                'select_answer_2'
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_can_answer_buffer_prompt_followed_by_select_prompt(self):
+        self.add_answer_submission('buffer_answer')
+        self.stubbed_app.add_keypress(Keys.Enter)
+        self.add_app_values_assertion(
+            buffer_input_prompt='buffer_answer',
+            select_prompt='select_answer_1'
+        )
+        self.stubbed_app.run()
+
+
 class TestApiCallWizardApplication(BaseWizardApplicationTest):
     def get_definition(self):
         return {


### PR DESCRIPTION
Values in the wizard planning stage can now be retrieved outside of a prompting stage such as making API calls and listing profiles. In addition, this change allows choices to reference both a variable and the value of choices can be a list of strings. To try out the updated, just run the same command from the previous PR's:
```
~/GitHub/aws-cli/awscli/customizations/wizard/wizards/iam$ aws cli-dev wizard-dev --run-wizard file://_new-role-wip.yml
```
