### PR TITLE
[v2] Small wizard refactorings

### DIFF
--- a/awscli/customizations/wizard/app.py
+++ b/awscli/customizations/wizard/app.py
@@ -13,7 +13,11 @@
 import json
 from collections.abc import MutableMapping
 
+from prompt_toolkit.application import Application
+
 from awscli.customizations.wizard import core
+from awscli.customizations.wizard.ui.style import get_default_style
+from awscli.customizations.wizard.ui.keybindings import get_default_keybindings
 from awscli.utils import json_encoder
 
 
@@ -37,6 +41,24 @@ class WizardAppRunner(object):
         # Propagates any exceptions that got set while in the app
         app.future.result()
         print(app.traverser.get_output())
+
+
+class WizardApp(Application):
+    def __init__(self, layout, values, traverser, executor, style=None,
+                 key_bindings=None, full_screen=True):
+        self.values = values
+        self.traverser = traverser
+        self.executor = executor
+        if style is None:
+            style = get_default_style()
+        if key_bindings is None:
+            key_bindings = get_default_keybindings()
+        self.details_visible = False
+        self.error_bar_visible = None
+        super().__init__(
+            layout=layout, style=style, key_bindings=key_bindings,
+            full_screen=full_screen
+        )
 
 
 class WizardTraverser:

--- a/awscli/customizations/wizard/ui/layout.py
+++ b/awscli/customizations/wizard/ui/layout.py
@@ -46,19 +46,18 @@ class WizardLayoutFactory:
     def create_wizard_layout(self, definition):
         run_wizard_dialog = self._create_run_wizard_dialog(definition)
         error_bar = self._create_error_bar()
-        layout = Layout(
-            container=HSplit(
-                [
-                    self._create_title(definition),
-                    self._create_sections(
-                        definition, run_wizard_dialog, error_bar),
-                    HorizontalLine()
-                ],
-            )
+        container = HSplit(
+            [
+                self._create_title(definition),
+                self._create_sections(
+                    definition, run_wizard_dialog, error_bar),
+                HorizontalLine()
+            ]
         )
-        layout.run_wizard_dialog = run_wizard_dialog
-        layout.error_bar = error_bar
-        return layout
+        return WizardLayout(
+            container=container, run_wizard_dialog=run_wizard_dialog,
+            error_bar=error_bar
+        )
 
     def _create_title(self, definition):
         title = Label(f'{definition["title"]}', style='class:wizard.title')
@@ -113,6 +112,13 @@ class WizardLayoutFactory:
 
     def _create_error_bar(self):
         return WizardErrorBar()
+
+
+class WizardLayout(Layout):
+    def __init__(self, container, run_wizard_dialog, error_bar):
+        self.run_wizard_dialog = run_wizard_dialog
+        self.error_bar = error_bar
+        super().__init__(container)
 
 
 class WizardDetailsPanel:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -358,7 +358,6 @@ class AppCallbackAction:
 class PromptToolkitApplicationStubber:
     def __init__(self, app):
         self._app = app
-        self._app.input = FakeApplicationInput()
         self._queue = []
 
     def add_keypress(self, key, app_assertion=None):
@@ -424,6 +423,7 @@ class PromptToolkitApplicationStubber:
                 app.after_render = prompt_toolkit.utils.Event(app, None)
                 app.exit()
 
+        self._app.input = FakeApplicationInput()
         self._app.after_render = prompt_toolkit.utils.Event(
             self._app, callback)
 


### PR DESCRIPTION
Specifically includes:
* Create explicit class for the `Application` and `Layout` classes. This better defines the public interfaces for those objects.
* Override the built-in exception handler to just exit the application with the captured error on any unhandled errors.
