### PR TITLE
Fix typo in new_table wizard

### DIFF
--- a/awscli/customizations/wizard/wizards/dynamodb/new-table.yml
+++ b/awscli/customizations/wizard/wizards/dynamodb/new-table.yml
@@ -266,7 +266,7 @@ __OUTPUT__:
     Wizard successfully created DynamoDB Table:
       Table name: {table_name}
       Primary partition key: {primary_key_name} ({primary_key_type})
-      {% if wants_sort_key == yes %}
+      {% if {wants_sort_key} == yes %}
       Primary sort key: {sort_key_name} ({sort_key_type})
       {% endif %}
 


### PR DESCRIPTION
Fix typo in new_table wizard which prevents sort key from showing in output

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
