### PR TITLE
Adding an optional --prefix flag to "aws logs tail" in order to filter by logStreamName

### DIFF
--- a/tests/unit/customizations/logs/test_tail.py
+++ b/tests/unit/customizations/logs/test_tail.py
@@ -337,7 +337,7 @@ class TestFollowLogEventsGenerator(BaseLogEventsGeneratorTest):
 
         # Because there is no token for the last page, it should remove
         # token from the kwargs and update startTime with the max
-        # timestamp from the prvious response events
+        # timestamp from the previous response events
         self.stubber.add_response(
             'filter_log_events',
             service_response={
@@ -432,7 +432,7 @@ class TestFollowLogEventsGenerator(BaseLogEventsGeneratorTest):
         )
         # Add a new page that has no nextToken
         # It should update startTime with the max timestamp
-        # from the prvious response events
+        # from the previous response events
         self.stubber.add_response(
             'filter_log_events',
             service_response={


### PR DESCRIPTION
*Description of changes:*

This minor change adds a `--prefix` flag to the `aws logs tail` subcommand,
in order to provide the ability to only tail logs for a given `logStreamNamePrefix`.

I'm willing to add tests in `tests/unit/customizations/logs/test_tail.py` but I would greatly appreciate some guidance there:
there is currently no tests for the arguments passed to [`filter_log_events`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs.html#CloudWatchLogs.Client.filter_log_events) (namely `logGroupName`, `startTime` & `filterPattern`), hence it seems tricky to test this new feature, as it relies entirely on a functionnality of `CloudWatchLogs.Client`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
