### PR TITLE
Upgrade dependabot configs from v1 to v2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: python
-    directory: /
-    update_schedule: daily
-    allowed_updates:
-      - match:
-          dependency_name: colorama

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - depenency-name: "colorama"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change upgrades the dependabot configs from version 1 to version 2 syntax. 

The config change I believe is functionally equivalent. The difference should only be in the syntax and where the config is located.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
