### PR TITLE
Fix windows-latest GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,11 +27,10 @@ jobs:
         pip install codecov
         python scripts/ci/install
         python scripts/ci/install-check
-    - name: Run tests and checks
-      run: |
-        python scripts/ci/run-tests
-        python scripts/ci/run-check
-
+    - name: Run tests
+      run: python scripts/ci/run-tests
+    - name: Run checks
+      run: python scripts/ci/run-check
     - name: codecov
       run: |
         rm tests/coverage.xml

--- a/awscli/autocomplete/db.py
+++ b/awscli/autocomplete/db.py
@@ -17,6 +17,7 @@ BUILTIN_INDEX_FILE = os.path.join(
     'data', 'ac.index'
 )
 
+
 # This is similar to DBConnection in awscli.customization.history.
 # I'd like to reuse code, but we also have the contraint that we don't
 # want to import anything outside of awscli.autocomplete to ensure
@@ -33,9 +34,18 @@ class DatabaseConnection(object):
     @property
     def _connection(self):
         if self._db_conn is None:
-            self._db_conn = sqlite3.connect(
-                self._db_filename, check_same_thread=False,
-                isolation_level=None)
+            kwargs = {
+                'check_same_thread': False,
+                'isolation_level': None
+            }
+            if self._db_filename.startswith('file::memory:'):
+                # This statement was added because old versions of sqlite
+                # don't support 'uri' but we use it for tests and because
+                # in the tests we use only in-memory database we're looking
+                # for 'file::memory:' prefix if we decide to use 'uri' with
+                # sqlite more widely we can ease restrictions to 'file:'
+                kwargs['uri'] = True
+            self._db_conn = sqlite3.connect(self._db_filename, **kwargs)
             self._ensure_database_setup()
         return self._db_conn
 

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -58,8 +58,9 @@ class PromptToolkitPrompter:
 
     """
     def __init__(self, completion_source, driver, completer=None,
-                 factory=None, app=None, cli_parser=None):
+                 factory=None, app=None, cli_parser=None, output=None):
         self._completion_source = completion_source
+        self._output = output
         if completer is None:
             completer = PromptToolkitCompleter(self._completion_source)
         # We wrap our completer with a ThreadedCompleter to make autocompletion
@@ -115,7 +116,7 @@ class PromptToolkitPrompter:
         kb_manager = self._factory.create_key_bindings()
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
-                          erase_when_done=True)
+                          output=self._output, erase_when_done=True)
         self._set_app_defaults(app)
         return app
 

--- a/awscli/customizations/wizard/app.py
+++ b/awscli/customizations/wizard/app.py
@@ -41,7 +41,7 @@ class WizardAppRunner(object):
 
 class WizardApp(Application):
     def __init__(self, layout, values, traverser, executor, style=None,
-                 key_bindings=None, full_screen=True):
+                 key_bindings=None, full_screen=True, output=None):
         self.values = values
         self.traverser = traverser
         self.executor = executor
@@ -53,7 +53,7 @@ class WizardApp(Application):
         self.error_bar_visible = None
         super().__init__(
             layout=layout, style=style, key_bindings=key_bindings,
-            full_screen=full_screen
+            full_screen=full_screen, output=output
         )
 
     def run(self, pre_run=None, **kwargs):

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -59,7 +59,7 @@ def create_default_wizard_v2_runner(session):
     return WizardAppRunner(session=session, app_factory=create_wizard_app)
 
 
-def create_wizard_app(definition, session):
+def create_wizard_app(definition, session, output=None):
     api_invoker = core.APIInvoker(session=session)
     shared_config = core.SharedConfigAPI(session=session,
                                          config_writer=ConfigFileWriter())
@@ -77,5 +77,6 @@ def create_wizard_app(definition, session):
     executor = create_default_executor(api_invoker, shared_config)
     traverser = WizardTraverser(definition, values, executor)
     return WizardApp(
-        layout=layout, values=values, traverser=traverser, executor=executor
+        layout=layout, values=values, traverser=traverser,
+        executor=executor, output=output
     )

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -505,7 +505,8 @@ class FileCreator(object):
         if os.path.exists(self.rootdir):
             shutil.rmtree(self.rootdir)
 
-    def create_file(self, filename, contents, mtime=None, mode='w'):
+    def create_file(self, filename, contents, mtime=None, mode='w',
+                    encoding=None):
         """Creates a file in a tmpdir
 
         ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
@@ -524,7 +525,7 @@ class FileCreator(object):
         full_path = os.path.join(self.rootdir, filename)
         if not os.path.isdir(os.path.dirname(full_path)):
             os.makedirs(os.path.dirname(full_path))
-        with open(full_path, mode) as f:
+        with open(full_path, mode, encoding=encoding) as f:
             f.write(contents)
         current_time = os.path.getmtime(full_path)
         # Subtract a few years off the last modification date.
@@ -533,7 +534,7 @@ class FileCreator(object):
             os.utime(full_path, (mtime, mtime))
         return full_path
 
-    def append_file(self, filename, contents):
+    def append_file(self, filename, contents, encoding=None):
         """Append contents to a file
 
         ``filename`` should be a relative path, e.g. "foo/bar/baz.txt"
@@ -544,7 +545,7 @@ class FileCreator(object):
         full_path = os.path.join(self.rootdir, filename)
         if not os.path.isdir(os.path.dirname(full_path)):
             os.makedirs(os.path.dirname(full_path))
-        with open(full_path, 'a') as f:
+        with open(full_path, 'a', encoding=encoding) as f:
             f.write(contents)
         return full_path
 

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -17,4 +17,4 @@ def run(command):
 
 
 run('nosetests --with-coverage --cover-erase --cover-package awscli '
-    '--with-xunit --cover-xml unit/ functional/')
+    '--traverse-namespace --with-xunit --cover-xml unit/ functional/')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,6 +18,7 @@ import botocore.validate
 
 import prompt_toolkit
 import prompt_toolkit.input
+import prompt_toolkit.output
 import prompt_toolkit.input.defaults
 import prompt_toolkit.keys
 import prompt_toolkit.utils
@@ -337,6 +338,11 @@ class FakeApplicationInput(prompt_toolkit.input.DummyInput):
     @property
     def closed(self):
         return False
+
+
+class FakeApplicationOutput(prompt_toolkit.output.DummyOutput):
+    def fileno(self):
+        return 1
 
 
 @dataclasses.dataclass

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -72,10 +72,14 @@ class TestCLIFollowParamFileDefault(BaseTestCLIFollowParamFile):
 
 class TestCLIUseEncodingFromEnv(BaseTestCLIFollowParamFile):
 
+    def setUp(self):
+        super(TestCLIUseEncodingFromEnv, self).setUp()
+        self.path = self.files.create_file(
+            'foobar.txt', '經理', encoding='utf-8')
+
     def test_does_use_encoding_utf8(self):
         self.environ['AWS_CLI_FILE_ENCODING'] = 'utf-8'
-        path = self.files.create_file('foobar.txt', '經理')
-        param = 'file://%s' % path
+        param = 'file://%s' % self.path
         self.assert_param_expansion_is_correct(
             provided_param=param,
             expected_param='經理'
@@ -83,8 +87,7 @@ class TestCLIUseEncodingFromEnv(BaseTestCLIFollowParamFile):
 
     def test_does_use_encoding_cp1251(self):
         self.environ['AWS_CLI_FILE_ENCODING'] = 'cp1251'
-        path = self.files.create_file('foobar.txt', '經理')
-        param = 'file://%s' % path
+        param = 'file://%s' % self.path
         self.assert_param_expansion_is_correct(
             provided_param=param,
             expected_param='з¶“зђ†'

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -196,6 +196,16 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         super(CommandArchitectureTest, self).tearDown()
         clean_loc_files(self.file_creator)
 
+    def _get_file_path(self, file):
+        try:
+            return os.path.relpath(file)
+        except ValueError:
+            # In some cases (usually it happens inside Windows based GitHub
+            # Action) tests are situated on one volume and temp folder on
+            # another one, in such a case there is no relative path between
+            # them and we use absolute path instead
+            return os.path.abspath(file)
+
     def test_set_client_no_source(self):
         session = Mock()
         cmd_arc = CommandArchitecture(session, 'sync',
@@ -366,7 +376,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         # to be wired correctly for it to work.
         s3_file = 's3://' + self.bucket + '/' + 'text1.txt'
         local_file = self.loc_files[0]
-        rel_local_file = os.path.relpath(local_file)
+        rel_local_file = self._get_file_path(local_file)
         filters = [['--include', '*']]
         params = {'dir_op': False, 'dryrun': True, 'quiet': False,
                   'src': local_file, 'dest': s3_file, 'filters': filters,
@@ -386,7 +396,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
     def test_error_on_same_line_as_status(self):
         s3_file = 's3://' + 'bucket-does-not-exist' + '/' + 'text1.txt'
         local_file = self.loc_files[0]
-        rel_local_file = os.path.relpath(local_file)
+        rel_local_file = self._get_file_path(local_file)
         filters = [['--include', '*']]
         params = {'dir_op': False, 'dryrun': False, 'quiet': False,
                   'src': local_file, 'dest': s3_file, 'filters': filters,
@@ -417,7 +427,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         # to be wired correctly for it to work.
         s3_file = 's3://' + self.bucket + '/' + 'text1.txt'
         local_file = self.loc_files[0]
-        rel_local_file = os.path.relpath(local_file)
+        rel_local_file = self._get_file_path(local_file)
         filters = [['--include', '*']]
         params = {'dir_op': False, 'dryrun': True, 'quiet': False,
                   'src': s3_file, 'dest': local_file, 'filters': filters,
@@ -514,7 +524,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         local_file = self.loc_files[0]
         s3_prefix = 's3://' + self.bucket + '/'
         local_dir = self.loc_files[3]
-        rel_local_file = os.path.relpath(local_file)
+        rel_local_file = self._get_file_path(local_file)
         filters = [['--include', '*']]
         params = {'dir_op': True, 'dryrun': True, 'quiet': False,
                   'src': local_dir, 'dest': s3_prefix, 'filters': filters,

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -21,7 +21,10 @@ from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import walk
 
-from tests import PromptToolkitApplicationStubber as ApplicationStubber
+from tests import (
+    PromptToolkitApplicationStubber as ApplicationStubber,
+    FakeApplicationOutput
+)
 from awscli.customizations.wizard.factory import create_wizard_app
 from awscli.customizations.wizard.app import (
     WizardAppRunner, WizardTraverser, WizardValues
@@ -63,7 +66,8 @@ class BaseWizardApplicationTest(unittest.TestCase):
     def setUp(self):
         self.definition = self.get_definition()
         self.session = mock.Mock(spec=Session)
-        self.app = create_wizard_app(self.definition, self.session)
+        self.app = create_wizard_app(
+            self.definition, self.session, FakeApplicationOutput())
         self.stubbed_app = ApplicationStubber(self.app)
 
     def get_definition(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Split `run-tests` and `run-checks` in two different steps because before tests failed but checks were successful and actions assumed it as a positive result
- Add `--traverse-namespace` to nosetests runner, otherwise on Python 3.8 it didn't run tests except ones in upper level folder
- Add `FakeOutput` to prompt toolkit Application in tests, otherwise it failed on Application creation in tests
- Add `encoding` argument to `create_file` method of `FileCreator` to set it explicitly to `UTF-8` in cli_encoding tests
- ~Swallow `PermissionError` on tempfile clean up in PromptToolkit tests~
- Use abs path instead of relative in `CommandArchitectureTest` in case there is no relative path (tests and file are on different volumes)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
