### PR TITLE
[CodeArtifact] Removing blank lines from nuget sources response

### DIFF
--- a/.changes/next-release/enhancement-codeartifact-71102.json
+++ b/.changes/next-release/enhancement-codeartifact-71102.json
@@ -1,0 +1,5 @@
+{
+  "category": "codeartifact", 
+  "type": "enhancement", 
+  "description": "Added login support for NuGet client v4.9.4"
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -158,12 +158,25 @@ class NuGetLogin(BaseLogin):
         #   100. Source Name 100
         #       https://source100.com/index.json
 
+       # Or it can be (blank line after Registered Sources:)
+
+       # Registered Sources:
+
+       #   1.  Source Name 1 [Enabled]
+       #       https://source1.com/index.json
+       #   2.  Source Name 2 [Disabled]
+       #       https://source2.com/index.json
+       # ...
+       #   100. Source Name 100
+       #       https://source100.com/index.json
+
         response = self.subprocess_utils.check_output(
             ['nuget', 'sources', 'list', '-format', 'detailed'],
             stderr=self.subprocess_utils.PIPE
         )
 
         lines = response.decode("utf-8").splitlines()
+        lines = [line for line in lines if line.strip() != '']
 
         source_to_url_dict = {}
         for i in range(1, len(lines), 2):

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -151,26 +151,26 @@ Registered Sources:
         )
 
     def test_login_old_nuget(self):
-	self.subprocess_utils.check_output.return_value = \
-	 	self._NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE
-	self.test_subject.login()
-	self.subprocess_utils.check_output.assert_any_call(
-	 	self.list_operation_command,
-	 	stderr=self.subprocess_utils.PIPE
-	)
-	self.subprocess_utils.check_output.assert_called_with(
-	 	self.add_operation_command,
-	 	stderr=self.subprocess_utils.PIPE
-	)
+        self.subprocess_utils.check_output.return_value = \
+            self._NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_any_call(
+            self.list_operation_command,
+            stderr=self.subprocess_utils.PIPE
+        )
+        self.subprocess_utils.check_output.assert_called_with(
+            self.add_operation_command,
+            stderr=self.subprocess_utils.PIPE
+        )
 
     def test_login_dry_run_old_nuget(self):
-	self.subprocess_utils.check_output.return_value = \
-	 	self._NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE
-	self.test_subject.login(dry_run=True)
-	self.subprocess_utils.check_output.assert_called_once_with(
-	 	['nuget', 'sources', 'list', '-format', 'detailed'],
-	 	stderr=self.subprocess_utils.PIPE
-	)
+        self.subprocess_utils.check_output.return_value = \
+            self._NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE
+        self.test_subject.login(dry_run=True)
+        self.subprocess_utils.check_output.assert_called_once_with(
+            ['nuget', 'sources', 'list', '-format', 'detailed'],
+            stderr=self.subprocess_utils.PIPE
+        )
 
     def test_login_source_name_already_exists(self):
         list_response = 'Registered Sources:\n' \
@@ -185,24 +185,24 @@ Registered Sources:
         )
 
     def test_login_source_url_already_exists_old_nuget(self):
-	non_default_source_name = 'Source Name'
-	list_response = 'Registered Sources:\n' \
-	             '\n' \
-	             '  1. ' + non_default_source_name + ' [ENABLED]\n' \
-	             '      ' + self.nuget_index_url
-	self.subprocess_utils.check_output.return_value = \
-	 	list_response.encode('utf-8')
-	self.test_subject.login()
-	self.subprocess_utils.check_output.assert_called_with(
-	 	[
-	     'nuget', 'sources', 'update',
-	     '-name', non_default_source_name,
-	     '-source', self.nuget_index_url,
-	     '-username', 'aws',
-	     '-password', self.auth_token
-	 	],
-	 	stderr=self.subprocess_utils.PIPE
-	)
+        non_default_source_name = 'Source Name'
+        list_response = 'Registered Sources:\n' \
+                        '\n' \
+                        '  1. ' + non_default_source_name + ' [ENABLED]\n' \
+                                                            '      ' + self.nuget_index_url
+        self.subprocess_utils.check_output.return_value = \
+            list_response.encode('utf-8')
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_called_with(
+            [
+                'nuget', 'sources', 'update',
+                '-name', non_default_source_name,
+                '-source', self.nuget_index_url,
+                '-username', 'aws',
+                '-password', self.auth_token
+            ],
+            stderr=self.subprocess_utils.PIPE
+        )
 
     def test_login_source_url_already_exists(self):
         non_default_source_name = 'Source Name'

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -74,6 +74,14 @@ Registered Sources:
   2. Ab[.d7  $#!],   [Disabled]
      https://source2.com/index.json"""
 
+    _NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE = b"""\
+                Registered Sources:
+
+                  1. Source Name 1 [Enabled]
+                     https://source1.com/index.json
+                  2. Ab[.d7  $#!],   [Disabled]
+                     https://source2.com/index.json"""
+
     def setUp(self):
         self.domain = 'domain'
         self.domain_owner = 'domain-owner'
@@ -142,6 +150,28 @@ Registered Sources:
             stderr=self.subprocess_utils.PIPE
         )
 
+    def test_login_old_nuget(self):
+	self.subprocess_utils.check_output.return_value = \
+	 	self._NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE
+	self.test_subject.login()
+	self.subprocess_utils.check_output.assert_any_call(
+	 	self.list_operation_command,
+	 	stderr=self.subprocess_utils.PIPE
+	)
+	self.subprocess_utils.check_output.assert_called_with(
+	 	self.add_operation_command,
+	 	stderr=self.subprocess_utils.PIPE
+	)
+
+    def test_login_dry_run_old_nuget(self):
+	self.subprocess_utils.check_output.return_value = \
+	 	self._NUGET_SOURCES_LIST_RESPONSE_WITH_SPACE
+	self.test_subject.login(dry_run=True)
+	self.subprocess_utils.check_output.assert_called_once_with(
+	 	['nuget', 'sources', 'list', '-format', 'detailed'],
+	 	stderr=self.subprocess_utils.PIPE
+	)
+
     def test_login_source_name_already_exists(self):
         list_response = 'Registered Sources:\n' \
                         '  1.  ' + self.source_name + ' [ENABLED]\n' \
@@ -153,6 +183,26 @@ Registered Sources:
             self.update_operation_command,
             stderr=self.subprocess_utils.PIPE
         )
+
+    def test_login_source_url_already_exists_old_nuget(self):
+	non_default_source_name = 'Source Name'
+	list_response = 'Registered Sources:\n' \
+	             '\n' \
+	             '  1. ' + non_default_source_name + ' [ENABLED]\n' \
+	             '      ' + self.nuget_index_url
+	self.subprocess_utils.check_output.return_value = \
+	 	list_response.encode('utf-8')
+	self.test_subject.login()
+	self.subprocess_utils.check_output.assert_called_with(
+	 	[
+	     'nuget', 'sources', 'update',
+	     '-name', non_default_source_name,
+	     '-source', self.nuget_index_url,
+	     '-username', 'aws',
+	     '-password', self.auth_token
+	 	],
+	 	stderr=self.subprocess_utils.PIPE
+	)
 
     def test_login_source_url_already_exists(self):
         non_default_source_name = 'Source Name'


### PR DESCRIPTION
*Issue #, if available:*
The `nuget sources list -format detailed` command lists slightly different output for nuget client version `4.9.4` and `5.8.0`. There is a blank space after Registered sources. This code changes removes the blank lines from the output.

*Description of changes:*
Removing the blank lines from nuget sources response
### Testing
```
C:\Users\sankalbh\AWSCLIDev>nosetests tests\unit\customizations\codeartifact
...........................................
----------------------------------------------------------------------
Ran 43 tests in 0.038s

OK

C:\Users\sankalbh\AWSCLIDev>nosetests tests\functional\codeartifact\test_codeartifact_login.py
.............................
----------------------------------------------------------------------
Ran 29 tests in 8.195s

OK
```
Manually tested `aws codeartifact login --tool nuget ...` command with nuget version 4.9.4 and 5.8.0. 

Tested the add and update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
