### PR TITLE
[v2] Introduce pytest into s3 integration test suite 

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 jsonschema==2.5.1
 nose==1.3.7
 mock==1.3.0
+pytest==6.2.1

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -4,17 +4,66 @@
 # binary package not from the CWD.
 
 import os
-from subprocess import check_call
+from subprocess import run, CalledProcessError
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
 os.chdir(os.path.join(REPO_ROOT, 'tests'))
+NOSE_ONLY_TESTS = [
+    'test_smoke.py',
+    os.path.join('customizations', 'test_generatecliskeleton.py'),
+]
 
 
-def run(command):
-    return check_call(command, shell=True)
+class TestFailureException(Exception):
+    pass
 
 
-run('nosetests --with-xunit --cover-erase --with-coverage '
-    '--cover-package awscli --cover-xml -v integration')
+def get_nose_only_integ_tests():
+    return [
+        os.path.join('integration', integ_test)
+        for integ_test in NOSE_ONLY_TESTS
+    ]
+
+
+def run_pytest():
+    tests_to_ignore = get_nose_only_integ_tests()
+    ignore_params = [
+        f'--ignore={test_to_ignore}' for test_to_ignore in tests_to_ignore
+    ]
+    cmd = ['py.test', '-v', 'integration/'] + ignore_params
+    print(f'Running cmd: {cmd}')
+    return run(cmd)
+
+
+def run_nose():
+    test_to_run = get_nose_only_integ_tests()
+    cmd = ['nosetests', '-v'] + test_to_run
+    print(f'Running cmd: {cmd}')
+    return run(cmd)
+
+
+def check_test_results(test_results):
+    errors = []
+    for result in test_results:
+        try:
+            result.check_returncode()
+        except CalledProcessError as e:
+            errors.append(e)
+    if errors:
+        err_msg = "\n".join(str(errors))
+        raise TestFailureException(
+            f'Tests failed with the following exceptions: {err_msg}'
+        )
+
+
+def main():
+    results = []
+    results.append(run_pytest())
+    results.append(run_nose())
+    check_test_results(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/customizations/history/test_show.py
+++ b/tests/integration/customizations/history/test_show.py
@@ -75,7 +75,7 @@ class TestShow(unittest.TestCase):
                 '    "RoleArn": "arn:aws:iam::...:invalid",',
                 '    "SAMLAssertion": "fake-assertion"',
                 '[0] HTTP request sent',
-                'to URL: https://sts.amazonaws.com/',
+                'to URL: https://sts.us-west-2.amazonaws.com/',
                 'with method: POST',
                 'with body: Action=AssumeRoleWithSAML&Version=2011-06-15',
                 '[0] HTTP response received',
@@ -85,7 +85,7 @@ class TestShow(unittest.TestCase):
                 'parsed to: {',
                 '    "Error": {',
                 'AWS CLI command exited',
-                'with return code: 255'
+                'with return code: 254'
             ],
             uncolored_content
         )


### PR DESCRIPTION
This introduces pytest to the v2 integration test suite. To start, I ported over a test class from the s3 integration tests to start a precedence on how pytest style test look in the codebase and updated the `run-integ-tests` script to run tests using pytest. After this PR, I plan to:

* Port the rest of the s3 `test_plugin.py` tests over to pytest style of testing
* Look into porting the other two integration test that are using nose abstractions and thus can't be run on pytest. This seems helpful as it will simplify the `run-integ-tests` script as we will only need one test runner.

I just wanted to get initial feedback on this work before I make too much progress on it. The end goal is to build up the `pytest-integ-v2` branch and then send out a PR that merges that into the `v2` branch once the remaining tasks are done.

