### PR TITLE
Allow PyYAML 5.4.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ requires-dist =
         botocore==1.20.3
         docutils>=0.10,<0.16
         s3transfer>=0.3.0,<0.4.0
-        PyYAML>=3.10,<5.4
+        PyYAML>=3.10,<5.5
         colorama>=0.2.5,<0.4.4
         rsa>=3.1.2,<=4.5.0
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'botocore==1.20.3',
     'docutils>=0.10,<0.16',
     's3transfer>=0.3.0,<0.4.0',
-    'PyYAML>=3.10,<5.4',
+    'PyYAML>=3.10,<5.5',
     'colorama>=0.2.5,<0.4.4',
     'rsa>=3.1.2,<=4.5.0',
 ]


### PR DESCRIPTION
*Description of changes:*

PyYAML 5.4 was released a couple of days ago with a fix for:

- https://ubuntu.com/security/CVE-2020-14343
- https://github.com/yaml/pyyaml/issues/420
- https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

The changes otherwise appear to be backwards compatible:

- https://github.com/yaml/pyyaml/blob/5.4.1/CHANGES

Being able to use a later version is important for companies that have
automatic dependency scanning for CVEs.

*Issue #, if available:*

N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
