### PR TITLE
Python 3.4/3.5 deprecation changes

### DIFF
--- a/.changes/next-release/feature-Python-36604.json
+++ b/.changes/next-release/feature-Python-36604.json
@@ -1,0 +1,5 @@
+{
+  "category": "Python", 
+  "type": "feature", 
+  "description": "Dropped support for Python 3.4 and 3.5"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,13 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.6, 3.7, 3.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        include:
-          # Python 3.4 is not available on mac and windows so it needs to to
-          # be manually added to the matrix for linux.
-          - python-version: 3.4
-            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -33,18 +33,16 @@ Requirements
 The aws-cli package works on Python versions:
 
 -  2.7.x and greater
--  3.4.x and greater
--  3.5.x and greater
 -  3.6.x and greater
 -  3.7.x and greater
 -  3.8.x and greater
 
-On 10/09/2019 support for Python 2.6 and Python 3.3 was deprecated and
-support was dropped on 01/10/2020. To avoid disruption, customers using
-the AWS CLI on Python 2.6 or 3.3 will need to upgrade their version of
-Python or pin the version of the AWS CLI in use prior to 01/10/2020. For
-more information, see this `blog
-post <https://aws.amazon.com/blogs/developer/deprecation-of-python-2-6-and-python-3-3-in-botocore-boto3-and-the-aws-cli/>`__.
+On 10/29/2020 support for Python 3.4 and Python 3.5 was deprecated and
+support was dropped on 02/01/2021. Customers using the AWS CLI on
+Python 3.4 or 3.5 will need to upgrade their version of Python to
+continue receiving feature and security updates. For more information,
+see this `blog
+post <https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
 *Attention!*
 

--- a/scripts/install
+++ b/scripts/install
@@ -22,8 +22,10 @@ INSTALL_DIR = os.path.expanduser(os.path.join(
     '~', '.local', 'lib', 'aws'))
 GTE_PY37 = sys.version_info[:2] >= (3, 7)
 UNSUPPORTED_PYTHON = (
-    (sys.version_info[0] == 2 and sys.version_info[:2] <= (2, 6)) or
-    (sys.version_info[0] == 3 and sys.version_info[:2] <= (3, 3))
+    (2,6),
+    (3,3),
+    (3,4),
+    (3,5),
 )
 INSTALL_ARGS = (
     '--no-binary :all: --no-build-isolation --no-cache-dir --no-index '
@@ -47,12 +49,6 @@ class PythonDeprecationWarning(Warning):
 
 
 def _build_deprecations():
-    py_34_35_params = {
-        'date': 'February 1, 2021',
-        'blog_link': 'https://aws.amazon.com/blogs/developer/announcing-the-'
-                     'end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-'
-                     'for-python-and-aws-cli-v1/'
-    }
     py_27_params = {
         'date': 'July 15, 2021',
         'blog_link': 'https://aws.amazon.com/blogs/developer/announcing-end-'
@@ -60,8 +56,6 @@ def _build_deprecations():
                      'aws-cli-v1/'
     }
     return {
-        (3,4): py_34_35_params,
-        (3,5): py_34_35_params,
         (2,7): py_27_params
     }
 
@@ -215,7 +209,7 @@ def main():
                       "If you do not provide this argument you will have to "
                       "add INSTALL_DIR/bin to your PATH.")
     py_version = sys.version_info[:2]
-    if UNSUPPORTED_PYTHON:
+    if py_version in UNSUPPORTED_PYTHON:
         unsupported_python_msg = (
             "Unsupported Python version detected: Python %s.%s\n"
             "To continue using this installer you must use Python 2.7, "

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -24,23 +24,12 @@ from contextlib import contextmanager
 EXTRA_RUNTIME_DEPS = [
     # Use an up to date virtualenv/pip/setuptools on > 2.6.
     ('virtualenv', '16.7.8'),
-    # The following are for python 3.4 compatibility.
-    ('colorama', '0.4.1'),
-    ('urllib3', '1.25.7'),
-    ('PyYAML', '5.2'),
 ]
 BUILDTIME_DEPS = [
     ('setuptools-scm', '3.3.3'),
     ('wheel', '0.33.6'),
 ]
 PIP_DOWNLOAD_ARGS = '--no-binary :all:'
-# The constraints file is used to lock the version of dateutils needed
-# to be 2.8.0 until we can drop py26/py33 support.  This lets us put
-# botocore's version range on dateutils to be <3.0.
-CONSTRAINTS_FILE = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    'assets', 'constraints-bundled.txt'
-)
 
 
 class BadRCError(Exception):
@@ -92,8 +81,8 @@ def download_cli_deps(scratch_dir):
     awscli_dir = os.path.dirname(
         os.path.dirname(os.path.abspath(__file__)))
     with cd(scratch_dir):
-        run('pip download -c %s %s %s' % (
-            CONSTRAINTS_FILE, PIP_DOWNLOAD_ARGS, awscli_dir))
+        run('pip download %s %s' % (
+            PIP_DOWNLOAD_ARGS, awscli_dir))
 
 
 def _remove_cli_zip(scratch_dir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,9 @@ requires-dist =
         botocore==1.19.57
         docutils>=0.10,<0.16
         s3transfer>=0.3.0,<0.4.0
-        PyYAML>=3.10,<5.3; python_version=='3.4'
-        PyYAML>=3.10,<5.4; python_version!='3.4'
-        colorama>=0.2.5,<0.4.2; python_version=='3.4'
-        colorama>=0.2.5,<0.4.4; python_version!='3.4'
-        rsa>=3.1.2,<=4.0.0; python_version=='3.4'
-        rsa>=3.1.2,<=4.5.0; python_version!='3.4'
+        PyYAML>=3.10,<5.4
+        colorama>=0.2.5,<0.4.4
+        rsa>=3.1.2,<=4.5.0
 
 
 [check-manifest]

--- a/setup.py
+++ b/setup.py
@@ -27,17 +27,10 @@ install_requires = [
     'botocore==1.19.57',
     'docutils>=0.10,<0.16',
     's3transfer>=0.3.0,<0.4.0',
+    'PyYAML>=3.10,<5.4',
+    'colorama>=0.2.5,<0.4.4',
+    'rsa>=3.1.2,<=4.5.0',
 ]
-
-
-if sys.version_info[:2] == (3, 4):
-    install_requires.append('PyYAML>=3.10,<5.3')
-    install_requires.append('colorama>=0.2.5,<0.4.2')
-    install_requires.append('rsa>=3.1.2,<=4.0.0')
-else:
-    install_requires.append('PyYAML>=3.10,<5.4')
-    install_requires.append('colorama>=0.2.5,<0.4.4')
-    install_requires.append('rsa>=3.1.2,<=4.5.0')
 
 
 setup_options = dict(
@@ -58,6 +51,7 @@ setup_options = dict(
     install_requires=install_requires,
     extras_require={},
     license="Apache License 2.0",
+    python_requires=">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -68,8 +62,6 @@ setup_options = dict(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37,py38
+envlist = py27,py36,py37,py38
 
 skipsdist = True
 


### PR DESCRIPTION
This is a draft PR with the list of possible cleanup changes we can make with the deprecation of Python 3.4 and 3.5 on Feb 1, 2021. This should cover the full scope of 3.4/3.5 specific code but not all of these are strictly required. Looking for feedback before we merge.

### Changes
- [x] Add `python_requires` to setup.py to inform pip of compatibility
- [x] Updated trove classifiers
- [x] Removed versions from GHA CI
- [x] Removed version from tox.ini
- [x] Updated Readme with latest deprecation info
- [x] Moved 3.4/3.5 to "Unsupported" in install script for bundled installer
- [x] Removed Python 2.6/3.3/3.4 specific requirements from bundler script
- [x] Removed Python 3.4 specific dependencies from setup.* files