### PR TITLE
[customizations/eks]: Make kubeconfig not world readable

### DIFF
--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -190,9 +190,14 @@ class KubeconfigWriter(object):
                 raise KubeconfigInaccessableError(
                         "Can't create directory for writing: {0}".format(e))
         try:
-            with open(config.path, "w+") as stream:
+            with os.fdopen(
+                    os.open(
+                        config.path,
+                        os.O_CREAT | os.O_RDWR,
+                        0o600),
+                    "w+") as stream:
                 ordered_yaml_dump(config.content, stream)
-        except IOError as e:
+        except (IOError, OSError) as e:
             raise KubeconfigInaccessableError(
                 "Can't open kubeconfig for writing: {0}".format(e))
 

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -66,6 +66,17 @@ class TestKubeconfig(unittest.TestCase):
         config = Kubeconfig(self._path, self._content)
         self.assertFalse(config.has_cluster("clustername"))
 
+class TestKubeconfigWriter(unittest.TestCase):
+
+    def test_not_world_readable(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+        config_path = os.path.join(tmpdir, "config")
+        config = Kubeconfig(config_path, None)
+        KubeconfigWriter().write_kubeconfig(config)
+        stat = os.stat(config_path)
+        self.assertEqual(stat.st_mode & 0o777, 0o600)
+
 class TestKubeconfigValidator(unittest.TestCase):
     def setUp(self):
         self._validator = KubeconfigValidator()


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

EKS never writes credentials to $KUBECONFIG files the aws eks update-kubeconfig command creates, but its possible that a customer could use the same $KUBECONFIG with another provider that does later write credentials into the file. This is a defense-in-depth change that is consistent with the file mode Kubernetes uses https://github.com/kubernetes/kubernetes/blob/v1.20.2/staging/src/k8s.io/client-go/tools/clientcmd/loader.go#L437

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
