### PR TITLE
SNS phone number opt-in example must include country code

### DIFF
--- a/awscli/examples/sns/opt-in-phone-number.rst
+++ b/awscli/examples/sns/opt-in-phone-number.rst
@@ -3,6 +3,6 @@
 The following ``opt-in-phone-number`` example opts the specified phone number into receiving SMS messages. ::
 
     aws sns opt-in-phone-number \
-        --phone-number 555-555-0100
+        --phone-number +1-555-555-0100
 
 This command produces no output.


### PR DESCRIPTION
 *Issue #, if available:*
N/A
*Description of changes:*
I made a small tweak to the SNS phone number opt-in example. The phone-number parameter has to include a country code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
