### PR TITLE
Minor Getting Help change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -279,8 +279,8 @@ Overflow <https://stackoverflow.com/>`__ with the tag
 `aws-cli <https://stackoverflow.com/questions/tagged/aws-cli>`__ or on
 the `AWS Discussion Forum for
 CLI <https://forums.aws.amazon.com/forum.jspa?forumID=150>`__. If you
-have a support plan with `AWS Premium
-Support <https://aws.amazon.com/premiumsupport>`__, you can also create
+have a support plan with `AWS Support
+<https://aws.amazon.com/premiumsupport>`__, you can also create
 a new support case.
 
 Please check for open similar


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* Renames AWS Premium Support link to AWS Support. AWS Support is typically called AWS Support, with different levels such as AWS Developer Support, AWS Business Support, and AWS Enterprise Support. While Premium Support is in the URL, it's more proper to refer to the overall group as AWS Support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
