### PR TITLE
Add CodeArtifact login support for .NET CLI

### DIFF
--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -10,7 +10,7 @@ from dateutil.tz import tzutc
 from dateutil.relativedelta import relativedelta
 from botocore.utils import parse_timestamp
 
-from awscli.compat import urlparse, RawConfigParser, StringIO
+from awscli.compat import is_windows, urlparse, RawConfigParser, StringIO
 from awscli.customizations import utils as cli_utils
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import uni_print
@@ -98,17 +98,16 @@ class BaseLogin(object):
         raise NotImplementedError('get_commands()')
 
 
-class NuGetLogin(BaseLogin):
+class NuGetBaseLogin(BaseLogin):
     _NUGET_INDEX_URL_FMT = '{endpoint}v3/index.json'
 
     # When adding new sources we can specify that we added the source to the
     # user level NuGet.Config file. However, when updating an existing source
     # we cannot be specific about which level NuGet.Config file was updated
     # because it is possible that the existing source was not in the user
-    # level NuGet.Config. The 'nuget sources list' command returns all
-    # configured sources from all NuGet.Config levels. The 'nuget sources
-    # update' command updates the source in whichever NuGet.Config file the
-    # source was found.
+    # level NuGet.Config. The source listing command returns all configured
+    # sources from all NuGet.Config levels. The update command updates the
+    # source in whichever NuGet.Config file the source was found.
     _SOURCE_ADDED_MESSAGE = 'Added source %s to the user level NuGet.Config\n'
     _SOURCE_UPDATED_MESSAGE = 'Updated source %s in the NuGet.Config\n'
 
@@ -118,7 +117,7 @@ class NuGetLogin(BaseLogin):
         except OSError as ex:
             if ex.errno == errno.ENOENT:
                 raise ValueError(
-                    self._TOOL_NOT_FOUND_MESSAGE % 'nuget'
+                    self._TOOL_NOT_FOUND_MESSAGE % self._get_tool_name()
                 )
             raise ex
 
@@ -130,12 +129,12 @@ class NuGetLogin(BaseLogin):
         )
 
         if already_exists:
-            command = self._get_command(
+            command = self._get_configure_command(
                 'update', nuget_index_url, source_name
             )
             source_configured_message = self._SOURCE_UPDATED_MESSAGE
         else:
-            command = self._get_command('add', nuget_index_url, source_name)
+            command = self._get_configure_command('add', nuget_index_url, source_name)
             source_configured_message = self._SOURCE_ADDED_MESSAGE
 
         if dry_run:
@@ -157,7 +156,7 @@ class NuGetLogin(BaseLogin):
         self._write_success_message('nuget')
 
     def _get_source_to_url_dict(self):
-        # The response from 'nuget sources list' takes the following form:
+        # The response from listing sources takes the following form:
         #
         # Registered Sources:
         #   1.  Source Name 1 [Enabled]
@@ -181,7 +180,7 @@ class NuGetLogin(BaseLogin):
        #       https://source100.com/index.json
 
         response = self.subprocess_utils.check_output(
-            ['nuget', 'sources', 'list', '-format', 'detailed'],
+            self._get_list_command(),
             stderr=self.subprocess_utils.PIPE
         )
 
@@ -231,7 +230,25 @@ class NuGetLogin(BaseLogin):
         # NuGet.Config file, use the default source name.
         return default_name, False
 
-    def _get_command(self, operation, nuget_index_url, source_name):
+    def _get_tool_name(self):
+        raise NotImplementedError('_get_tool_name()')
+
+    def _get_list_command(self):
+        raise NotImplementedError('_get_list_command()')
+
+    def _get_configure_command(self, operation, nuget_index_url, source_name):
+        raise NotImplementedError('_get_configure_command()')
+
+
+class NuGetLogin(NuGetBaseLogin):
+
+    def _get_tool_name(self):
+        return 'nuget'
+
+    def _get_list_command(self):
+        return ['nuget', 'sources', 'list', '-format', 'detailed']
+
+    def _get_configure_command(self, operation, nuget_index_url, source_name):
         return [
             'nuget', 'sources', operation,
             '-name', source_name,
@@ -239,6 +256,36 @@ class NuGetLogin(BaseLogin):
             '-username', 'aws',
             '-password', self.auth_token
         ]
+
+
+class DotNetLogin(NuGetBaseLogin):
+
+    def _get_tool_name(self):
+        return 'dotnet'
+
+    def _get_list_command(self):
+        return ['dotnet', 'nuget', 'list', 'source', '--format', 'detailed']
+
+    def _get_configure_command(self, operation, nuget_index_url, source_name):
+        command = ['dotnet', 'nuget', operation, 'source']
+
+        if operation == 'add':
+            command.append(nuget_index_url)
+            command += ['--name', source_name]
+        else:
+            command.append(source_name)
+            command += ['--source', nuget_index_url]
+
+        command += [
+            '--username', 'aws',
+            '--password', self.auth_token
+        ]
+
+        # Encryption is not supported on non-Windows platforms.
+        if not is_windows:
+            command.append('--store-password-in-clear-text')
+
+        return command
 
 
 class NpmLogin(BaseLogin):
@@ -458,6 +505,11 @@ class CodeArtifactLogin(BasicCommand):
         'nuget': {
             'package_format': 'nuget',
             'login_cls': NuGetLogin,
+            'namespace_support': False,
+        },
+        'dotnet': {
+            'package_format': 'nuget',
+            'login_cls': DotNetLogin,
             'namespace_support': False,
         },
         'npm': {

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -123,6 +123,22 @@ class TestCodeArtifactLogin(unittest.TestCase):
         )
         return commands
 
+    def _get_dotnet_commands(self):
+        nuget_index_url = self.nuget_index_url_fmt.format(
+            endpoint=self.endpoint
+        )
+
+        commands = []
+        commands.append(
+            [
+                'dotnet', 'nuget', 'add', 'source', nuget_index_url,
+                '--name', self.nuget_source_name,
+                '--username', 'aws',
+                '--password', self.auth_token
+            ]
+        )
+        return commands
+
     def _get_npm_commands(self, **kwargs):
         npm_cmd = 'npm.cmd' \
             if platform.system().lower() == 'windows' else 'npm'
@@ -428,6 +444,131 @@ password: {auth_token}'''
         )
         self._assert_dry_run_execution(
             self._get_nuget_commands(),
+            result.stdout
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_without_domain_owner_without_duration_seconds(self):
+        cmdline = self._setup_cmd(tool='dotnet')
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='nuget', result=result)
+        self._assert_expiration_printed_to_stdout(result.stdout)
+        self._assert_subprocess_check_output_execution(
+            self._get_dotnet_commands()
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_with_domain_owner_without_duration_seconds(self):
+        cmdline = self._setup_cmd(tool='dotnet', include_domain_owner=True)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(
+            package_format='nuget',
+            include_domain_owner=True,
+            result=result
+        )
+        self._assert_expiration_printed_to_stdout(result.stdout)
+        self._assert_subprocess_check_output_execution(
+            self._get_dotnet_commands()
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_without_domain_owner_with_duration_seconds(self):
+        cmdline = self._setup_cmd(tool='dotnet', include_duration_seconds=True)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(
+            package_format='nuget',
+            include_duration_seconds=True,
+            result=result
+        )
+        self._assert_expiration_printed_to_stdout(result.stdout)
+        self._assert_subprocess_check_output_execution(
+            self._get_dotnet_commands()
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_with_domain_owner_duration_sections(self):
+        cmdline = self._setup_cmd(
+            tool='dotnet',
+            include_domain_owner=True,
+            include_duration_seconds=True
+        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(
+            package_format='nuget',
+            include_domain_owner=True,
+            include_duration_seconds=True,
+            result=result
+        )
+        self._assert_expiration_printed_to_stdout(result.stdout)
+        self._assert_subprocess_check_output_execution(
+            self._get_dotnet_commands()
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_without_domain_owner_dry_run(self):
+        cmdline = self._setup_cmd(tool='dotnet', dry_run=True)
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(package_format='nuget', result=result)
+        self._assert_dry_run_execution(
+            self._get_dotnet_commands(),
+            result.stdout
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_with_domain_owner_dry_run(self):
+        cmdline = self._setup_cmd(
+            tool='dotnet', include_domain_owner=True, dry_run=True
+        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(
+            package_format='nuget',
+            include_domain_owner=True,
+            result=result
+        )
+        self._assert_dry_run_execution(
+            self._get_dotnet_commands(),
+            result.stdout
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_with_duration_seconds_dry_run(self):
+        cmdline = self._setup_cmd(
+            tool='dotnet', include_duration_seconds=True, dry_run=True
+        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(
+            package_format='nuget',
+            include_duration_seconds=True,
+            result=result
+        )
+        self._assert_dry_run_execution(
+            self._get_dotnet_commands(),
+            result.stdout
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_dotnet_login_with_domain_owner_duration_seconds_dry_run(self):
+        cmdline = self._setup_cmd(
+            tool='dotnet', include_domain_owner=True,
+            include_duration_seconds=True, dry_run=True
+        )
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_operations_called(
+            package_format='nuget',
+            include_domain_owner=True,
+            include_duration_seconds=True,
+            result=result
+        )
+        self._assert_dry_run_execution(
+            self._get_dotnet_commands(),
             result.stdout
         )
 

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -8,7 +8,7 @@ from dateutil.relativedelta import relativedelta
 from awscli.testutils import unittest, mock, FileCreator
 from awscli.compat import urlparse, RawConfigParser, StringIO
 from awscli.customizations.codeartifact.login import (
-    BaseLogin, NuGetLogin, NpmLogin, PipLogin, TwineLogin,
+    BaseLogin, NuGetLogin, DotNetLogin, NpmLogin, PipLogin, TwineLogin,
     get_relative_expiration_time
 )
 
@@ -230,6 +230,164 @@ Registered Sources:
         with self.assertRaisesRegexp(
                 ValueError,
                 'nuget was not found. Please verify installation.'):
+            self.test_subject.login()
+
+
+class TestDotNetLogin(unittest.TestCase):
+    _NUGET_INDEX_URL_FMT = NuGetLogin._NUGET_INDEX_URL_FMT
+    _NUGET_SOURCES_LIST_RESPONSE = b"""\
+Registered Sources:
+  1. Source Name 1 [Enabled]
+     https://source1.com/index.json
+  2. Ab[.d7  $#!],   [Disabled]
+     https://source2.com/index.json"""
+
+    def setUp(self):
+        self.domain = 'domain'
+        self.domain_owner = 'domain-owner'
+        self.package_format = 'nuget'
+        self.repository = 'repository'
+        self.auth_token = 'auth-token'
+        self.expiration = (datetime.now(tzlocal()) + relativedelta(hours=10)
+                           + relativedelta(minutes=9)).replace(microsecond=0)
+        self.endpoint = 'https://{domain}-{domainOwner}.codeartifact.aws.' \
+            'a2z.com/{format}/{repository}/'.format(
+                domain=self.domain,
+                domainOwner=self.domain_owner,
+                format=self.package_format,
+                repository=self.repository
+            )
+
+        self.nuget_index_url = self._NUGET_INDEX_URL_FMT.format(
+            endpoint=self.endpoint,
+        )
+        self.source_name = self.domain + '/' + self.repository
+        self.list_operation_command = [
+            'dotnet', 'nuget', 'list', 'source', '--format', 'detailed'
+        ]
+        self.add_operation_command_windows = [
+            'dotnet', 'nuget', 'add', 'source', self.nuget_index_url,
+            '--name', self.source_name,
+            '--username', 'aws',
+            '--password', self.auth_token
+        ]
+        self.add_operation_command_non_windows = [
+            'dotnet', 'nuget', 'add', 'source', self.nuget_index_url,
+            '--name', self.source_name,
+            '--username', 'aws',
+            '--password', self.auth_token,
+            '--store-password-in-clear-text'
+        ]
+        self.update_operation_command_windows = [
+            'dotnet', 'nuget', 'update', 'source', self.source_name,
+            '--source', self.nuget_index_url,
+            '--username', 'aws',
+            '--password', self.auth_token
+        ]
+        self.update_operation_command_non_windows = [
+            'dotnet', 'nuget', 'update', 'source', self.source_name,
+            '--source', self.nuget_index_url,
+            '--username', 'aws',
+            '--password', self.auth_token,
+            '--store-password-in-clear-text'
+        ]
+
+        self.subprocess_utils = mock.Mock()
+
+        self.test_subject = DotNetLogin(
+            self.auth_token, self.expiration, self.endpoint,
+            self.domain, self.repository, self.subprocess_utils
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', False)
+    def test_login(self):
+        self.subprocess_utils.check_output.return_value = \
+            self._NUGET_SOURCES_LIST_RESPONSE
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_any_call(
+            self.list_operation_command,
+            stderr=self.subprocess_utils.PIPE
+        )
+        self.subprocess_utils.check_output.assert_called_with(
+            self.add_operation_command_non_windows,
+            stderr=self.subprocess_utils.PIPE
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_login_on_windows(self):
+        self.subprocess_utils.check_output.return_value = \
+            self._NUGET_SOURCES_LIST_RESPONSE
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_any_call(
+            self.list_operation_command,
+            stderr=self.subprocess_utils.PIPE
+        )
+        self.subprocess_utils.check_output.assert_called_with(
+            self.add_operation_command_windows,
+            stderr=self.subprocess_utils.PIPE
+        )
+
+    def test_login_dry_run(self):
+        self.subprocess_utils.check_output.return_value = \
+            self._NUGET_SOURCES_LIST_RESPONSE
+        self.test_subject.login(dry_run=True)
+        self.subprocess_utils.check_output.assert_called_once_with(
+            self.list_operation_command,
+            stderr=self.subprocess_utils.PIPE
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', False)
+    def test_login_source_name_already_exists(self):
+        list_response = 'Registered Sources:\n' \
+                        '  1.  ' + self.source_name + ' [ENABLED]\n' \
+                        '      https://source.com/index.json'
+        self.subprocess_utils.check_output.return_value = \
+            list_response.encode('utf-8')
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_called_with(
+            self.update_operation_command_non_windows,
+            stderr=self.subprocess_utils.PIPE
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_login_source_name_already_exists_on_windows(self):
+        list_response = 'Registered Sources:\n' \
+                        '  1.  ' + self.source_name + ' [ENABLED]\n' \
+                        '      https://source.com/index.json'
+        self.subprocess_utils.check_output.return_value = \
+            list_response.encode('utf-8')
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_called_with(
+            self.update_operation_command_windows,
+            stderr=self.subprocess_utils.PIPE
+        )
+
+    @mock.patch('awscli.customizations.codeartifact.login.is_windows', True)
+    def test_login_source_url_already_exists(self):
+        non_default_source_name = 'Source Name'
+        list_response = 'Registered Sources:\n' \
+                        '  1. ' + non_default_source_name + ' [ENABLED]\n' \
+                        '      ' + self.nuget_index_url
+        self.subprocess_utils.check_output.return_value = \
+            list_response.encode('utf-8')
+        self.test_subject.login()
+        self.subprocess_utils.check_output.assert_called_with(
+            [
+                'dotnet', 'nuget', 'update', 'source', non_default_source_name,
+                '--source', self.nuget_index_url,
+                '--username', 'aws',
+                '--password', self.auth_token
+            ],
+            stderr=self.subprocess_utils.PIPE
+        )
+
+    def test_login_dotnet_not_installed(self):
+        self.subprocess_utils.check_output.side_effect = OSError(
+            errno.ENOENT, 'not found error'
+        )
+        with self.assertRaisesRegexp(
+                ValueError,
+                'dotnet was not found. Please verify installation.'):
             self.test_subject.login()
 
 


### PR DESCRIPTION
Add CodeArtifact login support for the .NET CLI (https://docs.microsoft.com/en-us/dotnet/core/tools/).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
