### PR TITLE
Add permissions to compat_open function

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -21,6 +21,7 @@ import signal
 import contextlib
 import collections.abc as collections_abc
 import locale
+from functools import partial
 import urllib.parse as urlparse
 from urllib.error import URLError
 
@@ -128,7 +129,7 @@ def getpreferredencoding(*args, **kwargs):
     )
 
 
-def compat_open(filename, mode='r', encoding=None):
+def compat_open(filename, mode='r', encoding=None, access_permissions=None):
     """Back-port open() that accepts an encoding argument.
 
     In python3 this uses the built in open() and in python2 this
@@ -139,9 +140,13 @@ def compat_open(filename, mode='r', encoding=None):
     encoding.
 
     """
+    opener = os.open
+    if access_permissions is not None:
+        opener = partial(os.open, mode=access_permissions)
     if 'b' not in mode:
         encoding = getpreferredencoding()
-    return open(filename, mode, encoding=encoding)
+    return open(filename, mode, encoding=encoding, opener=opener)
+
 
 def bytes_print(statement, stdout=None):
     """

--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -193,7 +193,8 @@ class KubeconfigWriter(object):
                 raise KubeconfigInaccessableError(
                         "Can't create directory for writing: {0}".format(e))
         try:
-            with compat_open(config.path, "w+") as stream:
+            with compat_open(
+                    config.path, "w+", access_permissions=0o600) as stream:
                 ordered_yaml_dump(config.content, stream)
         except IOError as e:
             raise KubeconfigInaccessableError(


### PR DESCRIPTION
*Issue #, if available:*
Add optional `access_permissions` argument to `compat_open` function to let create files with more strict permissions.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
