### PR TITLE
Add `--proxy-url` flag to `eks update-kubeconfig`

### DIFF
--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -194,7 +194,7 @@ class TestEKSClient(unittest.TestCase):
         self._session.create_client.return_value = self._mock_client
         self._session.profile = None
 
-        self._client = EKSClient(self._session, "ExampleCluster", None)
+        self._client = EKSClient(self._session, "ExampleCluster", None, None)
 
     def test_get_cluster_description(self):
         self.assertEqual(self._client._get_cluster_description(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a flag to `aws eks update-kubeconfig` in order to support proxy URLs. When supplied, the flag will add the url string, unmodified, as the `proxy-url` attribute of the `cluster` object. The attribute is not added if the flag is not provided. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
