### PR TITLE
Fix s3 cp example for grants to specific users

### DIFF
--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -140,10 +140,10 @@ Output::
 
 **Granting permissions for an S3 object**
 
-The following ``cp`` command illustrates the use of the ``--grants`` option to grant read access to all users and full
-control to a specific user identified by their URI::
+The following ``cp`` command illustrates the use of the ``--grants`` option to grant read access to all users identified
+by URI and full control to a specific user identified by their Canonical ID::
 
-  aws s3 cp file.txt s3://mybucket/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=uri=79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
+  aws s3 cp file.txt s3://mybucket/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
 
 Output::
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The example for `aws s3 cp --grants` is incorrectly specifying `uri` as the Grantee_Type for the "specific user" part of the example, it should be `id` instead as the Grantee_Id in that part of the example is a Canonical ID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
