### PR TITLE
Fixed typo in example page of authorize-security-group-ingress

### DIFF
--- a/awscli/examples/ec2/authorize-security-group-ingress.rst
+++ b/awscli/examples/ec2/authorize-security-group-ingress.rst
@@ -2,7 +2,7 @@
 
 The following example enables inbound traffic on TCP port 22 (SSH). If the command succeeds, no output is returned. ::
 
-    aws ec2 authorize-security-group-ingress \\
+    aws ec2 authorize-security-group-ingress \
         --group-name MySecurityGroup \
         --protocol tcp \
         --port 22 \


### PR DESCRIPTION
*Issue #, if available:*
#5952 

*Description of changes:*
FIexd typo // -> /

`aws ec2 authorize-security-group-ingress \\` -> `aws ec2 authorize-security-group-ingress \`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
