### PR TITLE
Update rsa pin to < 4.8

### DIFF
--- a/scripts/assets/constraints-bundled.txt
+++ b/scripts/assets/constraints-bundled.txt
@@ -1,2 +1,1 @@
-python-dateutil==2.8.0
 rsa==3.4.2

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -30,6 +30,13 @@ BUILDTIME_DEPS = [
     ('wheel', '0.33.6'),
 ]
 PIP_DOWNLOAD_ARGS = '--no-binary :all:'
+# The constraints file is used to lock the version of rsa needed
+# to be 3.4.2 until we can drop py27 support. This lets us ensure
+# we're distributing a copy that works on all supported platforms.
+CONSTRAINTS_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    'assets', 'constraints-bundled.txt'
+)
 
 
 class BadRCError(Exception):
@@ -81,8 +88,8 @@ def download_cli_deps(scratch_dir):
     awscli_dir = os.path.dirname(
         os.path.dirname(os.path.abspath(__file__)))
     with cd(scratch_dir):
-        run('pip download %s %s' % (
-            PIP_DOWNLOAD_ARGS, awscli_dir))
+        run('pip download -c %s %s %s' % (
+            CONSTRAINTS_FILE, PIP_DOWNLOAD_ARGS, awscli_dir))
 
 
 def _remove_cli_zip(scratch_dir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,8 @@ requires-dist =
         s3transfer>=0.3.0,<0.4.0
         PyYAML>=3.10,<5.4
         colorama>=0.2.5,<0.4.4
-        rsa>=3.1.2,<=4.5.0
-
+        rsa>=3.1.2,<=4.5.0; python_version=='2.7'
+        rsa>=3.1.2,<4.8; python_version>='3.6'
 
 [check-manifest]
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,13 @@ install_requires = [
     's3transfer>=0.3.0,<0.4.0',
     'PyYAML>=3.10,<5.4',
     'colorama>=0.2.5,<0.4.4',
-    'rsa>=3.1.2,<=4.5.0',
 ]
+
+if sys.version_info[:2] == (2, 7):
+    # Last version of rsa supporting Python 2.7
+    install_requires.append('rsa>=3.1.2,<=4.5.0')
+else:
+    install_requires.append('rsa>=3.1.2,<4.8')
 
 
 setup_options = dict(


### PR DESCRIPTION
This addresses #5352 and ups our allowed versions for rsa to current release 4.7.1 for Python 3.6 and later. Python 2.7 is no longer supported by RSA and will remain pinned at 4.5.0. The CLI is not impacted by the recent [CVE-2020-25658](https://nvd.nist.gov/vuln/detail/CVE-2020-25658) but any other usage of rsa-4.5.0 in an environment with Python 2.7 may be subject to exploit.

We _strongly_ encourage anyone still using the CLI on Python 2.7 to update promptly. We'd recommend [upgrading to the CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) which will provide isolated copies of all of it's dependencies ensuring better system security going forward. 
