### PR TITLE
[v2] Update to PyInstaller 4.2

### DIFF
--- a/.changes/next-release/enhancement-Python-69854.json
+++ b/.changes/next-release/enhancement-Python-69854.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Update embedded Python version to 3.8.8 for standalone artifacts"
+}

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,4 +2,4 @@
 # We create the separation for cases where we're doing installation
 # from a local dependency directory instead of requirements.txt.
 cryptography==2.8
-PyInstaller==3.5
+PyInstaller==4.2


### PR DESCRIPTION
This allows us to build exe's for Python 3.8
