### PR TITLE
Fix emr list-clusters documentation

### DIFF
--- a/awscli/customizations/emr/helptext.py
+++ b/awscli/customizations/emr/helptext.py
@@ -419,9 +419,9 @@ LIST_CLUSTERS_CREATED_AFTER = (
     ' <code>--created-after 2017-07-04T00:01:30.</p>')
 
 LIST_CLUSTERS_CREATED_BEFORE = (
-    '<p>List only those clusters created after the date and time'
+    '<p>List only those clusters created before the date and time'
     ' specified in the format yyyy-mm-ddThh:mm:ss. For example,'
-    ' <code>--created-after 2017-07-04T00:01:30.</p>')
+    ' <code>--created-before 2017-07-04T00:01:30.</p>')
 
 EMR_MANAGED_MASTER_SECURITY_GROUP = (
     '<p>The identifier of the Amazon EC2 security group '


### PR DESCRIPTION
The documentation for emr list-clusters --created-before had the same help text as --created-after. Changed references from after to before. Fixes issue #5566.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
