### PR TITLE
Return UTF-8 as preferred encoding when using the "POSIX" locale

### DIFF
--- a/.changes/next-release/bugfix-locale-96830.json
+++ b/.changes/next-release/bugfix-locale-96830.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``locale``",
+  "description": "Fix when UTF-8 isn't preferred encoding with locale equals to \"POSIX\" or \"C\""
+}

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -123,10 +123,16 @@ def getpreferredencoding(*args, **kwargs):
     if it's not set use locale.getpreferredencoding()
     to find the preferred encoding.
     """
-    return os.environ.get(
-        'AWS_CLI_FILE_ENCODING',
-        locale.getpreferredencoding(*args, **kwargs)
-    )
+    if 'AWS_CLI_FILE_ENCODING' in os.environ:
+        return os.environ['AWS_CLI_FILE_ENCODING']
+    # in Python 3.8 PyConfig API has been changed but pyInstaller only
+    # partially supports these changes, one thing it doesn't support is
+    # auto-conversion POSIX locale to UTF-8 which is part of PEP-540
+    # so we have to implement this conversion on our side
+    lc_type = locale.setlocale(locale.LC_CTYPE)
+    if lc_type in ('C', 'POSIX'):
+        return 'UTF-8'
+    return locale.getpreferredencoding(*args, **kwargs)
 
 
 def compat_open(filename, mode='r', encoding=None, access_permissions=None):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -149,9 +149,19 @@ class TestGetPreferredEncoding(unittest.TestCase):
         encoding = getpreferredencoding()
         self.assertEqual(encoding, 'cp1252')
 
-    def test_getpreferredencoding_wo_env_var(self):
+    @mock.patch('locale.setlocale', side_effect=['POSIX', 'C'])
+    def test_getpreferredencoding_wo_env_var_with_ctype_posix(self, *args):
         encoding = getpreferredencoding()
-        self.assertEqual(encoding, locale.getpreferredencoding())
+        self.assertEqual(encoding, 'UTF-8')
+        encoding = getpreferredencoding()
+        self.assertEqual(encoding, 'UTF-8')
+
+    @mock.patch('locale.setlocale', return_value='English_United States.1252')
+    @mock.patch('locale.getpreferredencoding')
+    def test_runs_locale_getpreferredencoding_wo_env_var_and_posix(
+            self, getprefedencoding, *args):
+        getpreferredencoding()
+        getprefedencoding.assert_called_once_with()
 
 
 class TestCompatOpenWithAccessPermissions(unittest.TestCase):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
All the logic was replicated from Python `sys.flags.utf8_mode` setting implementation 

https://github.com/python/cpython/blob/4b9aad49992a825d8c76e428ed1aca81dd3878b2/Python/preconfig.c#L648

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
