### PR TITLE
Pass O_TRUNC when rewriting kubeconfig

### DIFF
--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -193,7 +193,7 @@ class KubeconfigWriter(object):
             with os.fdopen(
                     os.open(
                         config.path,
-                        os.O_CREAT | os.O_RDWR,
+                        os.O_CREAT | os.O_RDWR | os.O_TRUNC,
                         0o600),
                     "w+") as stream:
                 ordered_yaml_dump(config.content, stream)

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -79,6 +79,16 @@ class TestKubeconfigWriter(unittest.TestCase):
         stat = os.stat(config_path)
         self.assertEqual(stat.st_mode & 0o777, 0o600)
 
+    def test_truncates(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmpdir)
+        config_path = os.path.join(tmpdir, "config")
+        with open(config_path, "w+") as f:
+            f.write("#" * 100)
+        KubeconfigWriter().write_kubeconfig(Kubeconfig(config_path, {}))
+        empty_stat = os.stat(config_path)
+        self.assertLessEqual(empty_stat.st_size, 4, "file should be '{}[newline]', 3/4 bytes long ")
+
 
 class TestKubeconfigValidator(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:*
The symptoms I'm seeing are the same as in #5854, but I think it was introduced by #5905, so... probably none.
[Edit:] Added after the PR: #5986 

*Description of changes:*
Updating `~/.kube/config` with commands like `aws eks --region ap-northeast-1 update-kubeconfig --name foobar` may produce invalid YAML due to an improperly truncated config file, e.g.:
```yaml
- name: zing
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      args: [] # zing
      env:
      - name: AWS_STS_REGIONAL_ENDPOINTS
        value: regional
      provideClusterInfo: false
e: AWS_STS_REGIONAL_ENDPOINTS
        value: regional
      provideClusterInfo: false
```
or
```yaml
- name: zing
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1alpha1
      args: [] # zing
      command: aws
      env:
      - name: AWS_STS_REGIONAL_ENDPOINTS
        value: regional
ional
```
This PR fixes that.

Note: It is possible that another instance of this behavior is at [`configure/writer.py`](https://github.com/aws/aws-cli/blob/19acfed0a6978d717845a0e134e080997bffaa1d/awscli/customizations/configure/writer.py#L76), but I have little idea what the intention of that file is and leave investigating it to someone else.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
