### PR TITLE
Wheels are only universal if they support Python 2 & 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[wheel]
-universal = 1
-
-
 [metadata]
 requires-dist =
         botocore==2.0.0dev97


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

Remove the `universal` flag from section `wheel` in `setup.cfg`, because wheels are only universal if they support both Python 2 and 3.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
