### PR TITLE
Omit ResponseMetadata when Errors is empty

### DIFF
--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -47,7 +47,8 @@ class Formatter(object):
         # the request id) if there is an error in the response.
         # Since all errors have been unified under the Errors key,
         # this should be a reasonable way to filter.
-        if 'Errors' not in response_data:
+        if 'Errors' not in response_data or \
+                len(response_data['Errors']) == 0:
             if 'ResponseMetadata' in response_data:
                 if 'RequestId' in response_data['ResponseMetadata']:
                     request_id = response_data['ResponseMetadata']['RequestId']


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Previously, `ResponseMetadata` would be surfaced for responses containing an empty list of `Errors`. Since that state indicates an absence of problems, it's equivalent to Errors being fully absent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
