### PR TITLE
Update requires-dist to new syntax for setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 
 [metadata]
-requires-dist =
+requires_dist =
         botocore==1.20.21
         docutils>=0.10,<0.16
         s3transfer>=0.3.0,<0.4.0


### PR DESCRIPTION
Updating setup.cfg metadata key `requires_dist` to expected format of setuptools.
