### PR TITLE
add init to ecs customization tests

### DIFF
--- a/tests/functional/ecs/__init__.py
+++ b/tests/functional/ecs/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License'). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the 'license' file accompanying this file. This file is
+# distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/ecs/test_execute_command.py
+++ b/tests/functional/ecs/test_execute_command.py
@@ -25,7 +25,7 @@ class TestExecuteCommand(BaseAWSCommandParamsTest):
         cmdline = 'ecs execute-command --cluster someCluster ' \
                   '--task someTaskId ' \
                   '--interactive --command ls ' \
-                  '--region use-west-2'
+                  '--region us-west-2'
         mock_check_call.return_value = 0
         self.parsed_responses = [{
             "containerName": "someContainerName",
@@ -34,8 +34,50 @@ class TestExecuteCommand(BaseAWSCommandParamsTest):
             "session": {"sessionId": "session-id",
                         "tokenValue": "token-value",
                         "streamUrl": "stream-url"},
-            "clusterArn": "someClusterArn",
+            "clusterArn": "someCluster",
             "interactive": "true"
+        }, {
+            "failures": [],
+            "tasks": [
+                {
+                    "clusterArn": "ecs/someCLuster",
+                    "desiredStatus": "RUNNING",
+                    "createdAt": "1611619514.46",
+                    "taskArn": "someTaskArn",
+                    "containers": [
+                        {
+                            "containerArn": "ecs/someContainerArn",
+                            "taskArn": "ecs/someTaskArn",
+                            "name": "someContainerName",
+                            "managedAgents": [
+                                {
+                                    "reason": "Execute Command Agent started",
+                                    "lastStatus": "RUNNING",
+                                    "lastStartedAt": "1611619528.272",
+                                    "name": "ExecuteCommandAgent"
+                                }
+                            ],
+                            "runtimeId": "someRuntimeId"
+                        },
+                        {
+                            "containerArn": "ecs/dummyContainerArn",
+                            "taskArn": "ecs/someTaskArn",
+                            "name": "dummyContainerName",
+                            "managedAgents": [
+                                {
+                                    "reason": "Execute Command Agent started",
+                                    "lastStatus": "RUNNING",
+                                    "lastStartedAt": "1611619528.272",
+                                    "name": "ExecuteCommandAgent"
+                                }
+                            ],
+                            "runtimeId": "dummyRuntimeId"
+                        }
+                    ],
+                    "lastStatus": "RUNNING",
+                    "enableExecuteCommand": "true"
+                }
+            ]
         }]
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(self.operations_called[0][0].name,
@@ -43,16 +85,9 @@ class TestExecuteCommand(BaseAWSCommandParamsTest):
                          )
         actual_response = json.loads(mock_check_call.call_args[0][0][1])
         self.assertEqual(
-            {
-                "containerName": "someContainerName",
-                "containerArn": "someContainerArn",
-                "taskArn": "someTaskArn",
-                "session": {"sessionId": "session-id",
-                            "tokenValue": "token-value",
-                            "streamUrl": "stream-url"},
-                "clusterArn": "someClusterArn",
-                "interactive": "true"
-            },
+            {"sessionId": "session-id",
+             "tokenValue": "token-value",
+             "streamUrl": "stream-url"},
             actual_response
         )
 
@@ -61,7 +96,7 @@ class TestExecuteCommand(BaseAWSCommandParamsTest):
         cmdline = 'ecs execute-command --cluster someCluster ' \
                   '--task someTaskId ' \
                   '--interactive --command ls ' \
-                  '--region use-west-2'
+                  '--region us-west-2'
         mock_check_call.side_effect = OSError(errno.ENOENT, 'some error')
         self.run_cmd(cmdline, expected_rc=255)
 


### PR DESCRIPTION
*Issue #, if available:*

Related to PR #5964.

*Description of changes:*

Add a `__init__.py` so that the `nose` test suite in the GitHub action runs them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
