### PR TITLE
Improve kubeconfig handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ nosetests.xml
 .idea*
 src/
 
+# VS Code IDE
+.vscode/*
+
 # CLI docs generation
 doc/source/aws_man_pages.json
 doc/source/reference
@@ -48,3 +51,11 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
+# Python environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -13,7 +13,6 @@
 
 import os
 import yaml
-import logging
 import errno
 from botocore.compat import OrderedDict
 

--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -193,9 +193,9 @@ class KubeconfigWriter(object):
             with os.fdopen(
                     os.open(
                         config.path,
-                        os.O_CREAT | os.O_RDWR | os.O_TRUNC,
+                        os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
                         0o600),
-                    "w+") as stream:
+                    "w") as stream:
                 ordered_yaml_dump(config.content, stream)
         except (IOError, OSError) as e:
             raise KubeconfigInaccessableError(

--- a/tests/functional/eks/test_update_kubeconfig.py
+++ b/tests/functional/eks/test_update_kubeconfig.py
@@ -12,17 +12,12 @@
 # language governing permissions and limitations under the License.
 
 import os
-import sys
+
 import mock
-import glob
-import yaml
-import logging
-import botocore
 import tempfile
 import shutil
 import re
-from argparse import Namespace
-from mock import patch, Mock, MagicMock, call
+from mock import patch, Mock
 
 from botocore.session import get_session
 
@@ -60,14 +55,14 @@ class TestUpdateKubeconfig(unittest.TestCase):
         self.create_client_patch = patch(
             'botocore.session.Session.create_client'
         )
-        
+
         self.mock_create_client = self.create_client_patch.start()
         self.session = get_session()
 
         self.client = Mock()
         self.client.describe_cluster.return_value = describe_cluster_response()
         self.mock_create_client.return_value = self.client
-                
+
         self.command = UpdateKubeconfigCommand(self.session)
         self.maxDiff = None
 
@@ -104,7 +99,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self._temp_directory)
         if files is not None:
             for file in files:
-                shutil.copy2(get_testdata(file), 
+                shutil.copy2(get_testdata(file),
                             self._get_temp_config(file))
         return self._temp_directory
 
@@ -118,7 +113,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         to put in the environment variable
         :type configs: list
         """
-        return build_environment([self._get_temp_config(config) 
+        return build_environment([self._get_temp_config(config)
                                   for config in configs])
 
     def assert_config_state(self, config_name, correct_output_name):
@@ -127,7 +122,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         as the testdata named correct_output_name.
         Should be called after initialize_tempfiles.
 
-        :param config_name: The filename (not the path) of the tempfile 
+        :param config_name: The filename (not the path) of the tempfile
         to compare
         :type config_name: str
 
@@ -191,7 +186,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
                    verbose=False):
         """
         Run update-kubeconfig in a temp directory,
-        This directory will have copies of all testdata files whose names 
+        This directory will have copies of all testdata files whose names
         are listed in configs.
         The KUBECONFIG environment variable will be set to contain the configs
         listed in env_variable_configs (regardless of whether they exist).
@@ -290,11 +285,13 @@ class TestUpdateKubeconfig(unittest.TestCase):
     def test_all_corrupted(self):
         configs = ["invalid_string_cluster_entry",
                    "invalid_string_contexts",
-                   "invalid_text"]
+                   "invalid_text",
+                   "non_parsable_yaml"]
         passed = None
         environment = ["invalid_string_cluster_entry",
                        "invalid_string_contexts",
-                       "invalid_text"]
+                       "invalid_text",
+                       "non_parsable_yaml"]
 
         with self.assertRaises(KubeconfigCorruptedError):
             self.assert_cmd(configs, passed, environment)
@@ -386,7 +383,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         configs = ["valid_old_data"]
         passed = "valid_old_data"
         environment = []
-        
+
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_old_data", "output_combined")
 
@@ -396,7 +393,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         environment = ["valid_old_data",
                        "output_combined",
                        "output_single"]
-        
+
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_old_data", "output_combined")
 
@@ -416,4 +413,3 @@ class TestUpdateKubeconfig(unittest.TestCase):
 
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_changed_ordering", "output_combined_changed_ordering")
-

--- a/tests/functional/eks/testdata/invalid_text
+++ b/tests/functional/eks/testdata/invalid_text
@@ -1,2 +1,2 @@
-This is not a yaml file
-This is a text document which should not be parsed
+This is not a yaml file.
+This is a text document which is parsable as yaml by Python, but should not be processed.

--- a/tests/functional/eks/testdata/non_parsable_yaml
+++ b/tests/functional/eks/testdata/non_parsable_yaml
@@ -1,0 +1,1 @@
+This is invalid: yaml file: cannot be even parsed.

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -13,24 +13,19 @@
 
 import glob
 import os
-import mock
 import tempfile
 import shutil
 from botocore.compat import OrderedDict
 
 from awscli.testutils import unittest, skip_if_windows
-from awscli.customizations.utils import uni_print
 from awscli.customizations.eks.kubeconfig import (KubeconfigError,
-                                                  KubeconfigInaccessableError,
                                                   KubeconfigCorruptedError,
                                                   Kubeconfig,
                                                   KubeconfigValidator,
-                                                  KubeconfigLoader,
                                                   KubeconfigAppender,
                                                   KubeconfigWriter,
                                                   _get_new_kubeconfig_content,
                                                   )
-from awscli.customizations.eks.exceptions import EKSError
 from awscli.customizations.eks.ordered_yaml import ordered_yaml_load
 from tests.functional.eks.test_util import get_testdata
 
@@ -43,7 +38,7 @@ class TestKubeconfig(unittest.TestCase):
 
     def test_no_content(self):
         config = Kubeconfig(self._path, None)
-        self.assertEqual(config.content, 
+        self.assertEqual(config.content,
                          _get_new_kubeconfig_content())
 
     def test_has_cluster(self):
@@ -113,7 +108,7 @@ class TestKubeconfigValidator(unittest.TestCase):
                 content_dict = ordered_yaml_load(stream)
             config = Kubeconfig(None, content_dict)
             self.assertRaises(KubeconfigCorruptedError,
-                              self._validator.validate_config, 
+                              self._validator.validate_config,
                               config)
 
 class TestKubeconfigAppender(unittest.TestCase):
@@ -197,7 +192,7 @@ class TestKubeconfigAppender(unittest.TestCase):
                 ("server", "endpoint")
             ])),
             ("name", "clustername")
-        ])            
+        ])
         correct = OrderedDict([
             ("apiVersion", "v1"),
             ("clusters", [
@@ -220,7 +215,7 @@ class TestKubeconfigAppender(unittest.TestCase):
                                               cluster)
         self.assertDictEqual(updated.content, correct)
 
-    def test_key_not_exist(self): 
+    def test_key_not_exist(self):
         initial = OrderedDict([
             ("apiVersion", "v1"),
             ("contexts", []),
@@ -274,7 +269,7 @@ class TestKubeconfigAppender(unittest.TestCase):
             ])),
             ("name", "clustername")
         ])
-        self.assertRaises(KubeconfigError, 
+        self.assertRaises(KubeconfigError,
                           self._appender.insert_entry,
                           Kubeconfig(None, initial),
                           "kind",

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -14,21 +14,15 @@
 import glob
 import os
 import mock
-import tempfile
-import shutil
-import sys
 import botocore
 from botocore.compat import OrderedDict
 
 from awscli.testutils import unittest
-from awscli.customizations.utils import uni_print
 import awscli.customizations.eks.kubeconfig as kubeconfig
 from awscli.customizations.eks.update_kubeconfig import (KubeconfigSelector,
                                                          EKSClient,
                                                          API_VERSION)
-from awscli.customizations.eks.exceptions import (EKSError,
-                                                  EKSClusterError)
-from awscli.customizations.eks.ordered_yaml import ordered_yaml_load
+from awscli.customizations.eks.exceptions import EKSClusterError
 from tests.functional.eks.test_util import get_testdata
 from tests.functional.eks.test_util import (describe_cluster_response,
                                             describe_cluster_no_status_response,
@@ -64,11 +58,11 @@ class TestKubeconfigSelector(unittest.TestCase):
                            path_in,
                            cluster_name,
                            chosen_path):
-        selector = KubeconfigSelector(env_variable, path_in, 
+        selector = KubeconfigSelector(env_variable, path_in,
                                                     self._validator,
                                                     self._loader)
         self.assertEqual(selector.choose_kubeconfig(cluster_name).path,
-                         chosen_path)  
+                         chosen_path)
 
     def test_parse_env_variable(self):
         paths = [
@@ -85,7 +79,7 @@ class TestKubeconfigSelector(unittest.TestCase):
 
         selector = KubeconfigSelector(env_variable, None, self._validator,
                                                           self._loader)
-        self.assertEqual(selector._paths, [path for path in paths 
+        self.assertEqual(selector._paths, [path for path in paths
                                                 if len(path) > 0])
 
     def test_choose_env_only(self):
@@ -97,9 +91,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("valid_no_user")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                None, 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                None,
+                                EXAMPLE_ARN,
                                 get_testdata("valid_simple"))
 
     def test_choose_existing(self):
@@ -113,9 +107,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("output_single_with_role")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                None, 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                None,
+                                EXAMPLE_ARN,
                                 get_testdata("output_single"))
 
     def test_arg_override(self):
@@ -129,9 +123,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("output_single_with_role")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                get_testdata("output_combined"), 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                get_testdata("output_combined"),
+                                EXAMPLE_ARN,
                                 get_testdata("output_combined"))
 
     def test_first_corrupted(self):
@@ -142,7 +136,7 @@ class TestKubeconfigSelector(unittest.TestCase):
         env_variable = generate_env_variable(paths)
         selector = KubeconfigSelector(env_variable, None, self._validator,
                                                           self._loader)
-        self.assertRaises(kubeconfig.KubeconfigCorruptedError, 
+        self.assertRaises(kubeconfig.KubeconfigCorruptedError,
                           selector.choose_kubeconfig,
                           EXAMPLE_ARN)
 
@@ -152,9 +146,9 @@ class TestKubeconfigSelector(unittest.TestCase):
             get_testdata("valid_no_user")
         ]
         env_variable = generate_env_variable(paths)
-        self.assert_chosen_path(env_variable, 
-                                get_testdata("output_combined"), 
-                                EXAMPLE_ARN, 
+        self.assert_chosen_path(env_variable,
+                                get_testdata("output_combined"),
+                                EXAMPLE_ARN,
                                 get_testdata("output_combined"))
 
 class TestEKSClient(unittest.TestCase):


### PR DESCRIPTION
This PR contains improvements and cherry-picked changes from original PR #5598 which was created to address the issue described in #5617. In the end, the issue was resolved by #5905 and #5981 as described in https://github.com/aws/aws-cli/pull/5598#issuecomment-795599401.

Changes in this PR:
- improve file mode for kubeconfig
- increase test coverage of kubeconfig handling
- fix whitespaces and redundant imports in files related to kubeconfig handling
- add files related to VS Code and Python virtualenv to `.gitignore`
