### PR TITLE
codecommit: Remove unused import of fileinput

### DIFF
--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -15,7 +15,6 @@ import os
 import re
 import sys
 import logging
-import fileinput
 import datetime
 
 from botocore.auth import SigV4Auth


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Remove unused import of `fileinput`

The code commit customization used to `import fileinput` but never uses it
this caused an issue when used in yocto ditributions which may not install
all python built in modules.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
