### PR TITLE
[v2] Update build status badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 aws-cli
 =======
 
-.. image:: https://travis-ci.org/aws/aws-cli.svg?branch=v2
-   :target: https://travis-ci.org/aws/aws-cli
+.. image:: https://github.com/aws/aws-cli/actions/workflows/run-tests.yml/badge.svg?branch=v2
+   :target: https://github.com/aws/aws-cli/actions/workflows/run-tests.yml
    :alt: Build Status
 
 .. image:: https://badges.gitter.im/aws/aws-cli.svg


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Builds are not run using Travis anymore. This updates to show the status of tests running against the v2 branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
