### PR TITLE
use safe loader wrapper to isolate use.

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -80,6 +80,12 @@ def _dict_constructor(loader, node):
     return OrderedDict(loader.construct_pairs(node))
 
 
+class SafeLoaderWrapper(yaml.SafeLoader):
+    """Isolated safe loader to allow for customizations without global changes.
+    """
+
+    pass
+
 def yaml_parse(yamlstr):
     """Parse a yaml string"""
     try:
@@ -88,10 +94,11 @@ def yaml_parse(yamlstr):
         # json parser.
         return json.loads(yamlstr, object_pairs_hook=OrderedDict)
     except ValueError:
-        yaml.SafeLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor)
-        yaml.SafeLoader.add_multi_constructor(
-            "!", intrinsics_multi_constructor)
-        return yaml.safe_load(yamlstr)
+        loader = SafeLoaderWrapper
+        loader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, 
+                               _dict_constructor)
+        loader.add_multi_constructor("!", intrinsics_multi_constructor)
+        return yaml.load(yamlstr, loader)
 
 
 class FlattenAliasDumper(yaml.SafeDumper):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This addresses the underlying cause of tests for the ECS customization failing. The cloudformation customization is changing global options for PyYAML's safe loader. A solution for this is provided here:

https://github.com/yaml/pyyaml/issues/221

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
