### PR TITLE
Support export ModulePackage in AWS::CloudFormation::ModuleVersion

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -497,6 +497,15 @@ class GlueJobCommandScriptLocationResource(Resource):
     PROPERTY_NAME = "Command.ScriptLocation"
 
 
+class CloudFormationModuleVersionResource(Resource):
+    """
+    Represents CloudFormation::ModuleVersion resource.
+    """
+    RESOURCE_TYPE = "AWS::CloudFormation::ModuleVersion"
+    PROPERTY_NAME = "ModulePackage"
+    FORCE_ZIP = True
+
+
 RESOURCES_EXPORT_LIST = [
     ServerlessFunctionResource,
     ServerlessApiResource,
@@ -513,7 +522,8 @@ RESOURCES_EXPORT_LIST = [
     ServerlessLayerVersionResource,
     LambdaLayerVersionResource,
     GlueJobCommandScriptLocationResource,
-    StepFunctionsStateMachineDefinitionResource
+    StepFunctionsStateMachineDefinitionResource,
+    CloudFormationModuleVersionResource
 ]
 
 METADATA_EXPORT_LIST = [

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -21,6 +21,7 @@ This command can upload local artifacts referenced in the following places:
     - ``Location`` parameter for the ``AWS::Include`` transform
     - ``SourceBundle`` property for the ``AWS::ElasticBeanstalk::ApplicationVersion`` resource
     - ``TemplateURL`` property for the ``AWS::CloudFormation::Stack`` resource
+    - ``ModulePackage`` property for the ``AWS::CloudFormation::ModuleVersion`` resource
     - ``Command.ScriptLocation`` property for the ``AWS::Glue::Job`` resource
     - ``DefinitionS3Location`` property for the ``AWS::StepFunctions::StateMachine`` resource
 


### PR DESCRIPTION
*Issue #, if available:*
#6043 

*Description of changes:*
AWS CloudFormation released registry modules, that can be created from a CloudFormation Template, and include a `ModulePackage` property, similar to `AWS::Serverless::Function`'s `CodeUri` et. al.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
