### PR TITLE
Fix bug in validate log command of CloudTrail

### DIFF
--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -126,7 +126,7 @@ def create_digest_traverser(cloudtrail_client, organization_client,
         LOG.debug('Loaded trail info: %s', trail_info)
         bucket = trail_info['S3BucketName']
         prefix = trail_info.get('S3KeyPrefix', None)
-        is_org_trail = trail_info['IsOrganizationTrail']
+        is_org_trail = trail_info.get('IsOrganizationTrail')
         if is_org_trail:
             if not account_id:
                 raise ParameterRequiredError(

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -267,6 +267,24 @@ class TestValidation(unittest.TestCase):
         self.assertEqual('foo', digest_provider.trail_name)
         self.assertEqual(TEST_ACCOUNT_ID, digest_provider.account_id)
 
+    def test_create_traverser_organizational_trail_not_launched(self):
+        cloudtrail_client = Mock()
+        cloudtrail_client.describe_trails.return_value = {'trailList': [
+            {'TrailARN': TEST_TRAIL_ARN,
+             'S3BucketName': 'bucket', 'S3KeyPrefix': 'prefix'}
+        ]}
+        traverser = create_digest_traverser(
+            trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+            cloudtrail_client=cloudtrail_client,
+            organization_client=Mock(),
+            s3_client_provider=Mock())
+        self.assertEqual('bucket', traverser.starting_bucket)
+        self.assertEqual('prefix', traverser.starting_prefix)
+        digest_provider = traverser.digest_provider
+        self.assertEqual('us-east-1', digest_provider.trail_home_region)
+        self.assertEqual('foo', digest_provider.trail_name)
+        self.assertEqual(TEST_ACCOUNT_ID, digest_provider.account_id)
+
     def test_creates_traverser_and_gets_trail_by_arn_s3_bucket_specified(self):
         cloudtrail_client = Mock()
         traverser = create_digest_traverser(


### PR DESCRIPTION
`OrganizationalTrail` feature is not launched in all regions, `get-trail` api does not return this field and we get a KeyError.


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
