### PR TITLE
Fixed typo in "examples/ec2/copy-snapshot.rst"

### DIFF
--- a/awscli/examples/ec2/copy-snapshot.rst
+++ b/awscli/examples/ec2/copy-snapshot.rst
@@ -22,4 +22,4 @@ The following ``copy-snapshot`` command copies the specified unencrypted snapsho
         --source-region us-west-2 \
         --source-snapshot-id snap-066877671789bd71b \
         --encrypted \
-        --kmd-key-id alias/my-cmk
+        --kms-key-id alias/my-cmk


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

https://awscli.amazonaws.com/v2/documentation/api/latest/reference/ec2/copy-snapshot.html

At "Example 2: To copy an unencrypted snapshot and encrypt the new snapshot",  `kmd` should read `kms`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
