### PR TITLE
Update make-exe to allow installation of wheels

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,5 +1,4 @@
 # Requirements we need to run our build jobs for the installers.
 # We create the separation for cases where we're doing installation
 # from a local dependency directory instead of requirements.txt.
-cryptography==3.3.2
 PyInstaller==4.2

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -2,7 +2,7 @@ import os
 
 from utils import cd, bin_path, run, virtualenv_enabled
 
-INSTALL_ARGS = "--no-binary :all: --no-build-isolation --no-cache-dir --no-index "
+INSTALL_ARGS = "--no-build-isolation --no-cache-dir --no-index "
 PINNED_PIP_VERSION = '20.0.2'
 SETUP_DEPS = ("setuptools-", "setuptools_scm", "wheel")
 


### PR DESCRIPTION
This enables the building of the exe from a source directory that has wheels in it. This in turn allows for the removal of
`cryptography` from the `requirements-build.txt` so it does not need to be installed (via its wheel) prior to running the `make-exe` script because the wheel can now be included in the source directory.