### PR TITLE
Use repr to format s3 exceptions

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -439,7 +439,7 @@ class ResultPrinter(BaseResultHandler):
         failure_statement = self.FAILURE_FORMAT.format(
             transfer_type=result.transfer_type,
             transfer_location=self._get_transfer_location(result),
-            exception=result.exception
+            exception=repr(result.exception)
         )
         failure_statement = self._adjust_statement_padding(failure_statement)
         self._print_to_error_file(failure_statement)


### PR DESCRIPTION
Use of repr would ensure that exceptions without any error message (like `MemoryError`) are displayed properly to support debugging.

I recently debugged a `MemoryError` where error message would just say:

```
download failed: s3://remote to local-path
```

Having exception information in the log would be very helpful, it is not even displayed in the `DEBUG` logs currently.

I am not sure if using `repr` is the best approach here though, wdyt?