### PR TITLE
Add acl to `copy-props` option for `s3 ` commands

### DIFF
--- a/.changes/next-release/enhancement-s3-50152.json
+++ b/.changes/next-release/enhancement-s3-50152.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``s3``",
+  "description": "Add ``acl`` to ``--copy-props`` option for ``s3`` commands. See `#901 <https://github.com/aws/aws-cli/issues/901>`__."
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -339,9 +339,9 @@ METADATA_DIRECTIVE = {
 
 
 COPY_PROPS = {
-    'name': 'copy-props',
-    'choices': ['none', 'metadata-directive', 'default'],
-    'default': 'default', 'help_text': (
+    'name': 'copy-props', 'nargs': '+',
+    'choices': ['none', 'metadata-directive', 'default', 'acl'],
+    'default': ['default'], 'help_text': (
         'Determines which properties are copied from the source S3 object. '
         'This parameter only applies for S3 to S3 copies. Valid values are: '
         '<ul>'
@@ -355,6 +355,14 @@ COPY_PROPS = {
         '<li>``default`` - The default value. Copies tags and properties '
         'covered under the ``metadata-directive`` value from the '
         'source S3 object.</li>'
+        '<li>``acl`` - Copy ACL from ф source object to destination. '
+        'It requires additional ``GetObjectAcl`` and ``PutObjectAcl`` API '
+        'calls. In case destination bucket has more restricted ACL than '
+        'the object ``PutObjectAcl`` will fail with ``AccessDenied`` exception '
+        'and this object won\'t be copied. Can be combined with any other '
+        'value (if only ``acl`` value set it\'ll be combined with '
+        '``default``). Can\'t be combined with ``--acl`` or ``--grants`` '
+        'options. </li>'
         '</ul>'
         'In order to copy the appropriate properties for multipart copies, '
         'some of the options may require additional API calls if a multipart '

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -483,6 +483,16 @@ class RequestParamsMapper(object):
         cls._set_request_payer_param(request_params, cli_params)
 
     @classmethod
+    def map_get_object_acl_params(cls, request_params, cli_params):
+        """Map CLI params to GetObjectAcl request params"""
+        cls._set_request_payer_param(request_params, cli_params)
+
+    @classmethod
+    def map_put_object_acl_params(cls, request_params, cli_params):
+        """Map CLI params to PutObjectAcl request params"""
+        cls._set_request_payer_param(request_params, cli_params)
+
+    @classmethod
     def map_put_object_tagging_params(cls, request_params, cli_params):
         """Map CLI params to PutObjectTagging request params"""
         cls._set_request_payer_param(request_params, cli_params)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -47,7 +47,7 @@ from awscli.customizations.s3.subscribers import (
     SetTagsSubscriber, ProvideUploadContentTypeSubscriber,
     ProvideLastModifiedTimeSubscriber,
     DirectoryCreatorSubscriber, DeleteSourceFileSubscriber,
-    DeleteSourceObjectSubscriber,
+    DeleteSourceObjectSubscriber, SetAclSubscriber
 
 )
 from awscli.customizations.s3.transferconfig import RuntimeConfig

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -693,6 +693,18 @@ class TestRequestParamsMapperRequestPayer(unittest.TestCase):
             params, self.cli_params)
         self.assertEqual(params, {'RequestPayer': 'requester'})
 
+    def test_map_get_object_acl_params(self):
+        params = {}
+        RequestParamsMapper.map_get_object_acl_params(
+            params, self.cli_params)
+        self.assertEqual(params, {'RequestPayer': 'requester'})
+
+    def test_map_put_object_acl_params(self):
+        params = {}
+        RequestParamsMapper.map_put_object_acl_params(
+            params, self.cli_params)
+        self.assertEqual(params, {'RequestPayer': 'requester'})
+
 
 class TestBytesPrint(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:* 

Fixes #901

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
