### PR TITLE
[docs] fix example for "update apikey name"

### DIFF
--- a/awscli/examples/apigateway/update-api-key.rst
+++ b/awscli/examples/apigateway/update-api-key.rst
@@ -2,7 +2,7 @@
 
 Command::
 
-  aws apigateway update-api-key --api-key sNvjQDMReA1eEQPNAW8r37XsU2rDD7fc7m2SiMnu --patch-operations op='replace',path='/description',value='newName'
+  aws apigateway update-api-key --api-key sNvjQDMReA1eEQPNAW8r37XsU2rDD7fc7m2SiMnu --patch-operations op='replace',path='/name',value='newName'
 
 Output::
 


### PR DESCRIPTION
*Description of changes:*
This fixes an example for "Update apikey name" to refer to the correct jsonpatch path of `name`

Previously the example changed the apikey description, which doesn't seem to match the intent of the example

I tested the new example with aws-cli and it seems to work as expected
> aws --version
aws-cli/2.1.38 Python/3.9.4 Darwin/20.3.0 source/x86_64 prompt/off

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
