### PR TITLE
Add correct ContentType for `s3 cp` command with `--metadata-directive REPLACE`

### DIFF
--- a/.changes/next-release/enhancement-s3-56312.json
+++ b/.changes/next-release/enhancement-s3-56312.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``s3``",
+  "description": "Inject correct ContentType for `s3 cp` command with `--metadata-directive REPLACE`, fixes `#6078 <https://github.com/aws/aws-cli/issues/6078>`__"
+}

--- a/awscli/customizations/s3/subscribers.py
+++ b/awscli/customizations/s3/subscribers.py
@@ -132,6 +132,11 @@ class ProvideUploadContentTypeSubscriber(BaseProvideContentTypeSubscriber):
         return future.meta.call_args.fileobj
 
 
+class ProvideCopyContentTypeSubscriber(BaseProvideContentTypeSubscriber):
+    def _get_filename(self, future):
+        return future.meta.call_args.copy_source['Key']
+
+
 class ProvideLastModifiedTimeSubscriber(OnDoneFilteredSubscriber):
     """Sets utime for a downloaded file"""
     def __init__(self, last_modified_time, result_queue):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -693,6 +693,34 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertIn('upload failed', stderr)
         self.assertIn('warning: File has an invalid timestamp.', stderr)
 
+    def test_cp_with_replace_metadata_can_check_content_type(self):
+        full_path = self.files.create_file('foo.txt', 'contents')
+        cmdline = (
+            '%s %s s3://bucket/key.txt --metadata-directive REPLACE' % (
+                self.prefix, full_path))
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        self.assertDictEqual(
+            self.operations_called[0][1],
+            {'Key': 'key.txt', 'Bucket': 'bucket',
+             'ContentType': 'text/plain', 'Body': mock.ANY}
+        )
+
+    def test_cp_with_replace_metadata_and_content_type_set(self):
+        full_path = self.files.create_file('foo.txt', 'contents')
+        cmdline = (
+            '%s %s s3://bucket/key.txt --metadata-directive REPLACE '
+            '--content-type application/json' % (self.prefix, full_path))
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 1)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        self.assertDictEqual(
+            self.operations_called[0][1],
+            {'Key': 'key.txt', 'Bucket': 'bucket',
+             'ContentType': 'application/json', 'Body': mock.ANY}
+        )
+
 
 class TestStreamingCPCommand(BaseAWSCommandParamsTest):
     def test_streaming_upload(self):


### PR DESCRIPTION
*Issue #, if available:*  Closes #6078

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
