### PR TITLE
Fix `configure list` profiles resolution when AWS_DEFAULT_PROFILE set

### DIFF
--- a/.changes/next-release/bugfix-configure-86220.json
+++ b/.changes/next-release/bugfix-configure-86220.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``configure``",
+  "description": "Fix `list` command to show correct profile location when AWS_DEFAULT_PROFILE set, fixes `#6119 <https://github.com/aws/aws-cli/issues/6119>`__"
+}

--- a/awscli/customizations/configure/list.py
+++ b/awscli/customizations/configure/list.py
@@ -54,9 +54,8 @@ class ConfigureListCommand(BasicCommand):
         self._display_config_value(ConfigValue('-----', '----', '--------'),
                                    '----')
 
-        if self._session.profile is not None:
-            profile = ConfigValue(self._session.profile, 'manual',
-                                  '--profile')
+        if parsed_globals and parsed_globals.profile is not None:
+            profile = ConfigValue(self._session.profile, 'manual', '--profile')
         else:
             profile = self._lookup_config('profile')
         self._display_config_value(profile, 'profile')

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import mock
+from argparse import Namespace
 
 from awscli.testutils import unittest
 from awscli.compat import six
@@ -111,3 +112,21 @@ class TestConfigureListCommand(unittest.TestCase):
             rendered, r'access_key\s+\*+_key\s+iam-role')
         self.assertRegexpMatches(
             rendered, r'secret_key\s+\*+_key\s+iam-role')
+
+    def test_configure_from_args(self):
+        parsed_globals = Namespace(profile='foo')
+        env_vars = {
+            'profile': 'myprofilename'
+        }
+        session = FakeSession(
+            all_variables={'config_file': '/config/location'},
+            profile='foo', environment_vars=env_vars)
+        session.session_var_map = {'profile': (None, ['AWS_PROFILE'])}
+        session.full_config = {
+            'profiles': {'foo': {'region': 'AWS_REGION'}}}
+        stream = six.StringIO()
+        self.configure_list = ConfigureListCommand(session, stream)
+        self.configure_list(args=[], parsed_globals=parsed_globals)
+        rendered = stream.getvalue()
+        self.assertRegexpMatches(
+            rendered, 'profile\s+foo\s+manual\s+--profile')


### PR DESCRIPTION
Fix `configure list` profiles resolution when AWS_DEFAULT_PROFILE env variable set

*Issue #, if available:* #2028

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
