### PR TITLE
Remove redundat '-' from two character pluralized acronyms in argument names

### DIFF
--- a/.changes/next-release/enhancment-mgn-91454.json
+++ b/.changes/next-release/enhancment-mgn-91454.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "arguments",
+  "description": "Remove redundant '-' from two character pluralized acronyms in argument names"
+}

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -132,6 +132,13 @@ HIDDEN_ALIASES = {
     'lambda.publish-version.code-sha256': 'code-sha-256',
     'lightsail.import-key-pair.public-key-base64': 'public-key-base-64',
     'opsworks.register-volume.ec2-volume-id': 'ec-2-volume-id',
+    'mgn.*.replication-servers-security-groups-ids':
+        'replication-servers-security-groups-i-ds',
+    'mgn.*.source-server-ids': 'source-server-i-ds',
+    'mgn.*.replication-configuration-template-ids':
+        'replication-configuration-template-i-ds',
+    'elasticache.create-replication-group.preferred-cache-cluster-azs':
+        'preferred-cache-cluster-a-zs'
 }
 
 

--- a/scripts/new-change
+++ b/scripts/new-change
@@ -57,7 +57,7 @@ TEMPLATE = """\
 # feature: A larger feature or change in behavior, usually resulting in a
 #          minor version bump.
 # bugfix: Fixing a bug in an existing code path.
-# enhancment: Small change to an underlying implementation detail.
+# enhancement: Small change to an underlying implementation detail.
 # api-change: Changes to a modeled API.
 type: {change_type}
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
