### PR TITLE
[v2] Merge develop into v2 branch

### DIFF
--- a/.changes/1.19.60.json
+++ b/.changes/1.19.60.json
@@ -1,0 +1,27 @@
+[
+  {
+    "category": "``iotsitewise``", 
+    "description": "AWS IoT SiteWise interpolation API will get interpolated values for an asset property per specified time interval during a period of time.", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``connect``", 
+    "description": "Updated max number of tags that can be attached from 200 to 50. MaxContacts is now an optional parameter for the UpdateQueueMaxContact API.", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``mediapackage-vod``", 
+    "description": "MediaPackage now offers the option to place your Sequence Parameter Set (SPS), Picture Parameter Set (PPS), and Video Parameter Set (VPS) encoder metadata in every video segment instead of in the init fragment for DASH and CMAF endpoints.", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``cloudformation``", 
+    "description": "Add CallAs parameter to GetTemplateSummary to enable use with StackSets delegated administrator integration", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``nimble``", 
+    "description": "Amazon Nimble Studio is a virtual studio service that empowers visual effects, animation, and interactive content teams to create content securely within a scalable, private cloud service.", 
+    "type": "api-change"
+  }
+]

--- a/.changes/1.19.61.json
+++ b/.changes/1.19.61.json
@@ -1,0 +1,32 @@
+[
+  {
+    "category": "arguments", 
+    "description": "Remove redundant '-' from two character pluralized acronyms in argument names", 
+    "type": "enhancement"
+  }, 
+  {
+    "category": "``macie2``", 
+    "description": "The Amazon Macie API now provides S3 bucket metadata that indicates whether a bucket policy requires server-side encryption of objects when objects are uploaded to the bucket.", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``ecs``", 
+    "description": "Add support for EphemeralStorage on TaskDefinition and TaskOverride", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``chime``", 
+    "description": "Increase AppInstanceUserId length to 64 characters", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``organizations``", 
+    "description": "Minor text updates for AWS Organizations API Reference", 
+    "type": "api-change"
+  }, 
+  {
+    "category": "``configure``", 
+    "description": "Fix `list` command to show correct profile location when AWS_DEFAULT_PROFILE set, fixes `#6119 <https://github.com/aws/aws-cli/issues/6119>`__", 
+    "type": "bugfix"
+  }
+]

--- a/.changes/next-release/apichange-chime-63590.json
+++ b/.changes/next-release/apichange-chime-63590.json
@@ -1,0 +1,5 @@
+{
+  "category": "``chime``",
+  "description": "Increase AppInstanceUserId length to 64 characters",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-cloudformation-57016.json
+++ b/.changes/next-release/apichange-cloudformation-57016.json
@@ -1,0 +1,5 @@
+{
+  "category": "``cloudformation``",
+  "description": "Add CallAs parameter to GetTemplateSummary to enable use with StackSets delegated administrator integration",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-connect-47771.json
+++ b/.changes/next-release/apichange-connect-47771.json
@@ -1,0 +1,5 @@
+{
+  "category": "``connect``",
+  "description": "Updated max number of tags that can be attached from 200 to 50. MaxContacts is now an optional parameter for the UpdateQueueMaxContact API.",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-ecs-67835.json
+++ b/.changes/next-release/apichange-ecs-67835.json
@@ -1,0 +1,5 @@
+{
+  "category": "``ecs``",
+  "description": "Add support for EphemeralStorage on TaskDefinition and TaskOverride",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-iotsitewise-40382.json
+++ b/.changes/next-release/apichange-iotsitewise-40382.json
@@ -1,0 +1,5 @@
+{
+  "category": "``iotsitewise``",
+  "description": "AWS IoT SiteWise interpolation API will get interpolated values for an asset property per specified time interval during a period of time.",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-macie2-23244.json
+++ b/.changes/next-release/apichange-macie2-23244.json
@@ -1,0 +1,5 @@
+{
+  "category": "``macie2``",
+  "description": "The Amazon Macie API now provides S3 bucket metadata that indicates whether a bucket policy requires server-side encryption of objects when objects are uploaded to the bucket.",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-mediapackagevod-1727.json
+++ b/.changes/next-release/apichange-mediapackagevod-1727.json
@@ -1,0 +1,5 @@
+{
+  "category": "``mediapackage-vod``",
+  "description": "MediaPackage now offers the option to place your Sequence Parameter Set (SPS), Picture Parameter Set (PPS), and Video Parameter Set (VPS) encoder metadata in every video segment instead of in the init fragment for DASH and CMAF endpoints.",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-nimble-48410.json
+++ b/.changes/next-release/apichange-nimble-48410.json
@@ -1,0 +1,5 @@
+{
+  "category": "``nimble``",
+  "description": "Amazon Nimble Studio is a virtual studio service that empowers visual effects, animation, and interactive content teams to create content securely within a scalable, private cloud service.",
+  "type": "api-change"
+}

--- a/.changes/next-release/apichange-organizations-98665.json
+++ b/.changes/next-release/apichange-organizations-98665.json
@@ -1,0 +1,5 @@
+{
+  "category": "``organizations``",
+  "description": "Minor text updates for AWS Organizations API Reference",
+  "type": "api-change"
+}

--- a/.changes/next-release/bugfix-configure-32490.json
+++ b/.changes/next-release/bugfix-configure-32490.json
@@ -1,0 +1,5 @@
+{
+  "category": "``configure``",
+  "description": "Fix `list` command to show correct profile location when AWS_DEFAULT_PROFILE set, fixes `#6119 <https://github.com/aws/aws-cli/issues/6119>`__",
+  "type": "bugfix"
+}

--- a/.changes/next-release/enhancement-arguments-1268.json
+++ b/.changes/next-release/enhancement-arguments-1268.json
@@ -1,0 +1,5 @@
+{
+  "category": "arguments",
+  "description": "Remove redundant '-' from two character pluralized acronyms in argument names",
+  "type": "enhancement"
+}

--- a/.changes/next-release/enhancement-renames-91454.json
+++ b/.changes/next-release/enhancement-renames-91454.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "arguments",
+  "description": "Remove redundant '-' from two character pluralized acronyms in argument names"
+}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1840,6 +1840,27 @@ CHANGELOG
 * feature:wizard: Added support for AWS CLI Wizards. See `#3752 <https://github.com/aws/aws-cli/issues/3752>`__.
 
 
+1.19.61
+=======
+
+* enhancement:arguments: Remove redundant '-' from two character pluralized acronyms in argument names
+* api-change:``macie2``: The Amazon Macie API now provides S3 bucket metadata that indicates whether a bucket policy requires server-side encryption of objects when objects are uploaded to the bucket.
+* api-change:``ecs``: Add support for EphemeralStorage on TaskDefinition and TaskOverride
+* api-change:``chime``: Increase AppInstanceUserId length to 64 characters
+* api-change:``organizations``: Minor text updates for AWS Organizations API Reference
+* bugfix:``configure``: Fix `list` command to show correct profile location when AWS_DEFAULT_PROFILE set, fixes `#6119 <https://github.com/aws/aws-cli/issues/6119>`__
+
+
+1.19.60
+=======
+
+* api-change:``iotsitewise``: AWS IoT SiteWise interpolation API will get interpolated values for an asset property per specified time interval during a period of time.
+* api-change:``connect``: Updated max number of tags that can be attached from 200 to 50. MaxContacts is now an optional parameter for the UpdateQueueMaxContact API.
+* api-change:``mediapackage-vod``: MediaPackage now offers the option to place your Sequence Parameter Set (SPS), Picture Parameter Set (PPS), and Video Parameter Set (VPS) encoder metadata in every video segment instead of in the init fragment for DASH and CMAF endpoints.
+* api-change:``cloudformation``: Add CallAs parameter to GetTemplateSummary to enable use with StackSets delegated administrator integration
+* api-change:``nimble``: Amazon Nimble Studio is a virtual studio service that empowers visual effects, animation, and interactive content teams to create content securely within a scalable, private cloud service.
+
+
 1.19.59
 =======
 

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -103,6 +103,20 @@ ARGUMENT_RENAMES = {
     'ecs.execute-command.no-interactive': 'non-interactive',
 }
 
+# Same format as ARGUMENT_RENAMES, but instead of renaming the arguments,
+# an alias is created to the original argument and marked as undocumented.
+# This is useful when you need to change the name of an argument but you
+# still need to support the old argument.
+HIDDEN_ALIASES = {
+    'mgn.*.replication-servers-security-groups-ids':
+        'replication-servers-security-groups-i-ds',
+    'mgn.*.source-server-ids': 'source-server-i-ds',
+    'mgn.*.replication-configuration-template-ids':
+        'replication-configuration-template-i-ds',
+    'elasticache.create-replication-group.preferred-cache-cluster-azs':
+        'preferred-cache-cluster-a-zs'
+}
+
 
 def register_arg_renames(cli):
     for original, new_name in ARGUMENT_RENAMES.items():

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -123,6 +123,10 @@ def register_arg_renames(cli):
         event_portion, original_arg_name = original.rsplit('.', 1)
         cli.register('building-argument-table.%s' % event_portion,
                      rename_arg(original_arg_name, new_name))
+    for original, new_name in HIDDEN_ALIASES.items():
+        event_portion, original_arg_name = original.rsplit('.', 1)
+        cli.register('building-argument-table.%s' % event_portion,
+                     hidden_alias(original_arg_name, new_name))
 
 
 def rename_arg(original_arg_name, new_name):
@@ -130,3 +134,10 @@ def rename_arg(original_arg_name, new_name):
         if original_arg_name in argument_table:
             utils.rename_argument(argument_table, original_arg_name, new_name)
     return _rename_arg
+
+
+def hidden_alias(original_arg_name, alias_name):
+    def _alias_arg(argument_table, **kwargs):
+        if original_arg_name in argument_table:
+            utils.make_hidden_alias(argument_table, original_arg_name, alias_name)
+    return _alias_arg

--- a/awscli/customizations/configure/list.py
+++ b/awscli/customizations/configure/list.py
@@ -54,9 +54,8 @@ class ConfigureListCommand(BasicCommand):
         self._display_config_value(ConfigValue('-----', '----', '--------'),
                                    '----')
 
-        if self._session.profile is not None:
-            profile = ConfigValue(self._session.profile, 'manual',
-                                  '--profile')
+        if parsed_globals and parsed_globals.profile is not None:
+            profile = ConfigValue(self._session.profile, 'manual', '--profile')
         else:
             profile = self._lookup_config('profile')
         self._display_config_value(profile, 'profile')

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -44,6 +44,28 @@ def _copy_argument(argument_table, current_name, copy_name):
     return copy_arg
 
 
+def make_hidden_alias(argument_table, existing_name, alias_name):
+    """Create a hidden alias for an existing argument.
+    This will copy an existing argument object in an arg table,
+    and add a new entry to the arg table with a different name.
+    The new argument will also be undocumented.
+    This is needed if you want to check an existing argument,
+    but you still need the other one to work for backwards
+    compatibility reasons.
+    """
+    current = argument_table[existing_name]
+    copy_arg = _copy_argument(argument_table, existing_name, alias_name)
+    copy_arg._UNDOCUMENTED = True
+    if current.required:
+        # If the current argument is required, then
+        # we'll mark both as not required, but
+        # flag _DOCUMENT_AS_REQUIRED so our doc gen
+        # knows to still document this argument as required.
+        copy_arg.required = False
+        current.required = False
+        current._DOCUMENT_AS_REQUIRED = True
+
+
 def rename_command(command_table, existing_name, new_name):
     current = command_table[existing_name]
     command_table[new_name] = current

--- a/tests/functional/elasticache/test_create_replication_group.py
+++ b/tests/functional/elasticache/test_create_replication_group.py
@@ -1,0 +1,46 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateReplicationGroup(BaseAWSCommandParamsTest):
+    GROUP_ID = 'a' * 50
+    GROUP_DESCRIPTION = 'b' * 50
+    PREFERRED_AZ = 'az'
+    PREFIX = (
+        f'elasticache create-replication-group'
+        f' --replication-group-id {GROUP_ID}'
+        f' --replication-group-description {GROUP_DESCRIPTION}'
+    )
+
+    def test_accepts_old_argname(self):
+        cmdline = (
+            f'{self.PREFIX} --preferred-cache-cluster-a-zs {self.PREFERRED_AZ}'
+        )
+        params = {
+            'ReplicationGroupId': self.GROUP_ID,
+            'ReplicationGroupDescription': self.GROUP_DESCRIPTION,
+            'PreferredCacheClusterAZs': [self.PREFERRED_AZ]
+        }
+        self.assert_params_for_cmd(cmdline, params)
+
+    def test_accepts_fixed_param_name(self):
+        cmdline = (
+            f'{self.PREFIX} --preferred-cache-cluster-azs {self.PREFERRED_AZ}'
+        )
+        params = {
+            'ReplicationGroupId': self.GROUP_ID,
+            'ReplicationGroupDescription': self.GROUP_DESCRIPTION,
+            'PreferredCacheClusterAZs': [self.PREFERRED_AZ]
+        }
+        self.assert_params_for_cmd(cmdline, params)

--- a/tests/functional/mgn/__init__.py
+++ b/tests/functional/mgn/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/mgn/test_start_cutover.py
+++ b/tests/functional/mgn/test_start_cutover.py
@@ -1,0 +1,36 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestStartCutover(BaseAWSCommandParamsTest):
+    PREFIX = 'mgn start-cutover'
+    SOURCE_SERVER_ID = 'a' * 50
+
+    def test_accepts_old_argname(self):
+        cmdline = (
+            f'{self.PREFIX} --source-server-i-ds {self.SOURCE_SERVER_ID}'
+        )
+        params = {
+            'sourceServerIDs': [self.SOURCE_SERVER_ID],
+        }
+        self.assert_params_for_cmd(cmdline, params)
+
+    def test_accepts_fixed_param_name(self):
+        cmdline = (
+            f'{self.PREFIX} --source-server-ids {self.SOURCE_SERVER_ID}'
+        )
+        params = {
+            'sourceServerIDs': [self.SOURCE_SERVER_ID],
+        }
+        self.assert_params_for_cmd(cmdline, params)

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import mock
+from argparse import Namespace
 
 from awscli.testutils import unittest
 from awscli.compat import six
@@ -120,3 +121,21 @@ class TestConfigureListCommand(unittest.TestCase):
         rendered = stream.getvalue()
         self.assertRegexpMatches(
             rendered, 'region\s+from-imds\s+imds')
+
+    def test_configure_from_args(self):
+        parsed_globals = Namespace(profile='foo')
+        env_vars = {
+            'profile': 'myprofilename'
+        }
+        session = FakeSession(
+            all_variables={'config_file': '/config/location'},
+            profile='foo', environment_vars=env_vars)
+        session.session_var_map = {'profile': (None, ['AWS_PROFILE'])}
+        session.full_config = {
+            'profiles': {'foo': {'region': 'AWS_REGION'}}}
+        stream = six.StringIO()
+        self.configure_list = ConfigureListCommand(session, stream)
+        self.configure_list(args=[], parsed_globals=parsed_globals)
+        rendered = stream.getvalue()
+        self.assertRegexpMatches(
+            rendered, 'profile\s+foo\s+manual\s+--profile')

--- a/tests/unit/customizations/test_argrename.py
+++ b/tests/unit/customizations/test_argrename.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import unittest
+from awscli.customizations import argrename
+from awscli.customizations import arguments
+
+from botocore import model
+
+
+class TestArgumentManipulations(unittest.TestCase):
+    def setUp(self):
+        self.argument_table = {}
+
+    def test_can_rename_argument(self):
+        arg = arguments.CustomArgument('foo')
+        self.argument_table['foo'] = arg
+        handler = argrename.rename_arg('foo', 'bar')
+        handler(self.argument_table)
+
+        self.assertIn('bar', self.argument_table)
+        self.assertNotIn('foo', self.argument_table)
+        self.assertEqual(arg.name, 'bar')
+
+    def test_can_alias_an_argument(self):
+        arg = arguments.CustomArgument(
+            'foo', dest='foo',
+            argument_model=model.Shape('FooArg', {'type': 'string'}))
+        self.argument_table['foo'] = arg
+        handler = argrename.hidden_alias('foo', 'alias-name')
+
+        handler(self.argument_table)
+
+        self.assertIn('alias-name', self.argument_table)
+        self.assertIn('foo', self.argument_table)
+        self.assertEqual(self.argument_table['alias-name'].name, 'alias-name')

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -71,6 +71,29 @@ class TestCommandTableAlias(BaseAWSHelpOutputTest):
         self.assert_contains('get-room')
 
 
+class TestHiddenAlias(unittest.TestCase):
+    def test_not_marked_as_required_if_not_needed(self):
+        original_arg_required = mock.Mock()
+        original_arg_required.required = False
+        arg_table = {'original': original_arg_required}
+        utils.make_hidden_alias(arg_table, 'original', 'new-name')
+        self.assertIn('new-name', arg_table)
+        # Note: the _DOCUMENT_AS_REQUIRED is tested as a functional
+        # test because it only affects how the doc synopsis is
+        # rendered.
+        self.assertFalse(arg_table['original'].required)
+        self.assertFalse(arg_table['new-name'].required)
+
+    def test_hidden_alias_marks_as_not_required(self):
+        original_arg_required = mock.Mock()
+        original_arg_required.required = True
+        arg_table = {'original': original_arg_required}
+        utils.make_hidden_alias(arg_table, 'original', 'new-name')
+        self.assertIn('new-name', arg_table)
+        self.assertFalse(arg_table['original'].required)
+        self.assertFalse(arg_table['new-name'].required)
+
+
 class TestValidateMututuallyExclusiveGroups(unittest.TestCase):
     def test_two_single_groups(self):
         # The most basic example of mutually exclusive args.


### PR DESCRIPTION
Pulled in changes from 1.19.60 to 1.19.61. Also added back hidden aliases to the v2 branch to make the changes from this PR applicable: https://github.com/aws/aws-cli/pull/6124. I basically manually cherry-picked the parts from this PR: https://github.com/aws/aws-cli/pull/3640 that were relevant to hidden parameter aliasing and added some functional tests for a couple of the new hidden aliases being introduced.
