### PR TITLE
Fix truncating zero microseconds in `logs tail` output

### DIFF
--- a/.changes/next-release/bugfix-logs-57586.json
+++ b/.changes/next-release/bugfix-logs-57586.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``logs``",
+  "description": "Fix bug when `logs tail` truncates microseconds in output if they equals 0. `#5912 <https://github.com/aws/aws-cli/issues/5912>`__"
+}

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -76,7 +76,9 @@ class DetailedLogEventsFormatter(BaseLogEventsFormatter):
 
     def _format_timestamp(self, timestamp):
         return self._color_if_configured(
-            timestamp.isoformat(), self._TIMESTAMP_COLOR)
+            timestamp.isoformat(timespec='microseconds'),
+            self._TIMESTAMP_COLOR
+        )
 
 
 class TailCommand(BasicCommand):

--- a/tests/unit/customizations/logs/test_tail.py
+++ b/tests/unit/customizations/logs/test_tail.py
@@ -101,6 +101,17 @@ class TestDetailedLogEventsFormatter(BaseLogEventsFormatterTest):
             self.output.getvalue()
         )
 
+    def test_display_with_zero_microseconds(self):
+        self.log_event['timestamp'] = datetime(
+            2018, 1, 1, 0, 29, 43, 0, tz.tzutc())
+        DetailedLogEventsFormatter(
+            self.output).display_log_event(self.log_event)
+        self.assertEqual(
+            '\x1b[32m2018-01-01T00:29:43.000000+00:00\x1b[0m '
+            '\x1b[36mstream_name\x1b[0m '
+            'my message\n',
+            self.output.getvalue())
+
 
 class TestTimestampUtils(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:* #5912

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
