### PR TITLE
Fix the help string for specifying multiple To, CC, BCC addresses

### DIFF
--- a/awscli/customizations/sessendemail.py
+++ b/awscli/customizations/sessendemail.py
@@ -28,11 +28,11 @@ from awscli.customizations.utils import validate_mutually_exclusive_handler
 
 
 TO_HELP = ('The email addresses of the primary recipients.  '
-           'You can specify multiple recipients as space-separated values')
+           'You can specify multiple recipients by specifying this option mulitple times.')
 CC_HELP = ('The email addresses of copy recipients (Cc).  '
-           'You can specify multiple recipients as space-separated values')
+           'You can specify multiple recipients by specifying this option mulitple times.')
 BCC_HELP = ('The email addresses of blind-carbon-copy recipients (Bcc).  '
-            'You can specify multiple recipients as space-separated values')
+            'You can specify multiple recipients by specifying this option mulitple times.')
 SUBJECT_HELP = 'The subject of the message'
 TEXT_HELP = 'The raw text body of the message'
 HTML_HELP = 'The HTML body of the message'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**No code changes - only modification of the help strings that appear in the docs pages.**

The To, CC, and BCC fields do support multiple addresses, but not as space separated values. The API would respond with an error:

`An error occurred (InvalidParameterValue) when calling the SendEmail operation: Domain contains control or whitespace`

Instead, multiple address have to be specified with multiple `--to` fields, as alluded to in the Synopsis section further up the page.

Example - multiple To addresses:

The previous sentence suggests this would work:

```bash
$ aws ses send-email --from "sender@example.com" --to "recipient1@example.com recipient2@example.com" --subject "foo" --text "bar"
```

Whereas this is how multiple recipients should be specified:

```bash
$ aws ses send-email --from "sender@example.com" --to "recipient1@example.com" --to "recipient2@example.com" --subject "foo" --text "bar"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
