### PR TITLE
Fix typo in createcluster.py and emrfsutils.py

### DIFF
--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -573,7 +573,7 @@ class CreateCluster(Command):
     def _handle_emrfs_parameters(self, cluster, emrfs_args, release_label):
         if release_label:
             self.validate_no_emrfs_configuration(cluster)
-            emrfs_configuration = emrfsutils.build_emrfs_confiuration(
+            emrfs_configuration = emrfsutils.build_emrfs_configuration(
                 emrfs_args)
 
             self._update_cluster_dict(

--- a/awscli/customizations/emr/emrfsutils.py
+++ b/awscli/customizations/emr/emrfsutils.py
@@ -58,7 +58,7 @@ def build_bootstrap_action_configs(region, emrfs_args):
     return bootstrap_actions
 
 
-def build_emrfs_confiuration(emrfs_args):
+def build_emrfs_configuration(emrfs_args):
     _verify_emrfs_args(emrfs_args)
     emrfs_properties = _build_emrfs_properties(emrfs_args)
 


### PR DESCRIPTION
A typo is fixed: confiurations -> configurations

#6155 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
