### PR TITLE
Fix regression in not respecting --source-region

### DIFF
--- a/.changes/next-release/bugfix-s3-86653.json
+++ b/.changes/next-release/bugfix-s3-86653.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Fixed regression in not respecting ``--source-region`` for S3 to S3 copies. Fixes `#6152 <https://github.com/aws/aws-cli/issues/6152>`__"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -913,8 +913,8 @@ class CommandArchitecture(object):
         self.parameters = parameters
         self.instructions = []
         self._transfer_manager = transfer_manager
-        self._client = source_client
-        self._source_client = transfer_client
+        self._source_client = source_client
+        self._client = transfer_client
 
     def create_instructions(self):
         """


### PR DESCRIPTION
The CLI automatically does region redirects so while the source region was not being set correctly, the CLI would detect
that the region is wrong on the client and redirect it to the correct region. However, for some opt-in regions such as `af-south-1` region redirection is not supported which results in a hard fail. Also, this regression only affects v2 because the regression was introduced as a result of a v2-only refactoring when CRT support was added.

I also manually tested it out to make sure everything is working correctly now:

**Before**
```
$ aws s3 sync s3://kyleknap-eu-central-1/ s3://kyleknap-af-south-1 --region af-south-1 --source-region eu-central-1
fatal error: An error occurred (IllegalLocationConstraintException) when calling the ListObjectsV2 operation: The eu-central-1 location constraint is incompatible for the region specific endpoint this request was sent to.

$ aws history show --include HTTP_REQUEST | grep URL
to URL: https://kyleknap-eu-central-1.s3.af-south-1.amazonaws.com/?list-type=2&prefix=&encoding-type=url
```

**With this fix**
```
$ aws s3 sync s3://kyleknap-eu-central-1/ s3://kyleknap-af-south-1 --region af-south-1 --source-region eu-central-1
copy: s3://kyleknap-eu-central-1/foo to s3://kyleknap-af-south-1/foo

$ aws history show --include HTTP_REQUEST | grep URL
to URL: https://kyleknap-eu-central-1.s3.eu-central-1.amazonaws.com/?list-type=2&prefix=&encoding-type=url
to URL: https://kyleknap-af-south-1.s3.af-south-1.amazonaws.com/?list-type=2&prefix=&encoding-type=url
to URL: https://kyleknap-af-south-1.s3.af-south-1.amazonaws.com/foo
```


Fixes: https://github.com/aws/aws-cli/issues/6152

