### PR TITLE
Update wait service-stable example

### DIFF
--- a/awscli/examples/ecs/wait/services-stable.rst
+++ b/awscli/examples/ecs/wait/services-stable.rst
@@ -5,11 +5,3 @@ The following ``wait`` example pauses and continues only after it can confirm th
     aws ecs wait services-stable \
         --cluster MyCluster \
         --services MyService
-
-**Example 2: To pause running until a task is confirmed to be running**
-
-The following ``wait`` example pauses and continues only after the specified task enters a ``RUNNING`` state. ::
-
-    aws ecs wait services-stable \
-        --cluster MyCluster \
-        --tasks arn:aws:ecs:us-west-2:123456789012:task/a1b2c3d4-5678-90ab-cdef-44444EXAMPLE

--- a/awscli/examples/ecs/wait/tasks-running.rst
+++ b/awscli/examples/ecs/wait/tasks-running.rst
@@ -1,0 +1,7 @@
+**Example 1: To pause running until a task is confirmed to be running**
+
+The following ``wait`` example pauses and continues only after the specified task enters a ``RUNNING`` state. ::
+
+    aws ecs wait tasks-running \
+        --cluster MyCluster \
+        --tasks arn:aws:ecs:us-west-2:123456789012:task/a1b2c3d4-5678-90ab-cdef-44444EXAMPLE


### PR DESCRIPTION
*Issue #, if available:*
#6959 

*Description of changes:*

When trying the second example, I get the error:

```sh
aws: error: the following arguments are required: --services
```

it seems `--services` is a mandatory flag, so the example should either be `tasks-running`, or just removed altogether.
