### PR TITLE
Add quotes to the last parameter in the command

### DIFF
--- a/awscli/examples/ec2/update-security-group-rule-descriptions-ingress.rst
+++ b/awscli/examples/ec2/update-security-group-rule-descriptions-ingress.rst
@@ -4,7 +4,7 @@ The following ``update-security-group-rule-descriptions-ingress`` example update
 
     aws ec2 update-security-group-rule-descriptions-ingress \
         --group-id sg-02f0d35a850ba727f \
-        --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=203.0.113.0/16,Description="SSH access from corpnet"}]
+        --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges='[{CidrIp=203.0.113.0/16,Description="SSH access from corpnet"}]'
 
 Output::
 
@@ -20,7 +20,7 @@ The following ``update-security-group-rule-descriptions-ingress`` example update
 
     aws ec2 update-security-group-rule-descriptions-ingress \
         --group-id sg-02f0d35a850ba727f \
-        --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,PrefixListIds=[{PrefixListId=pl-12345678,Description="SSH access from corpnet"}]
+        --ip-permissions IpProtocol=tcp,FromPort=22,ToPort=22,PrefixListIds='[{PrefixListId=pl-12345678,Description="SSH access from corpnet"}]'
 
 Output::
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add quotes to the last parameter in the command. Without these quotes command will return following error,
Parameter validation failed:
Invalid type for parameter IpPermissions[0].IpRanges[0], value: CidrIp=XX.XX.XX.XX/32, type: <class 'str'>, valid types: <class 'dict'>
Invalid type for parameter IpPermissions[1].IpRanges[0], value: Description=Access from Xyz, type: <class 'str'>, valid types: <class 'dict'>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
