### PR TITLE
ECS CodeDeploy: Include traffic rerouting time in deployment duration

### DIFF
--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -378,13 +378,13 @@ class CodeDeployValidator():
             return configured_wait
 
     def get_traffic_rerouting_time(self):
-        if (not hasattr(self, 'deployment_config')or
+        if (not hasattr(self, 'deployment_config') or
                 self.deployment_config is None):
             return 0
         else:
-            config_info = self.deployment_config['deploymentConfigInfo']
-            routing_config = config_info['trafficRoutingConfig']
-            routing_type = routing_config['type']
+            config_info = self.deployment_config.get('deploymentConfigInfo', {})
+            routing_config = config_info.get('trafficRoutingConfig', {})
+            routing_type = routing_config.get('type', '')
 
             if routing_type == 'AllAtOnce':
                 return 0

--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -297,10 +297,10 @@ class CodeDeployer():
     def wait_for_deploy_success(self, id, wait_min):
         waiter = self._client.get_waiter("deployment_successful")
 
-        if wait_min is not None and wait_min > MAX_WAIT_MIN:
+        if wait_min > MAX_WAIT_MIN:
             wait_min = MAX_WAIT_MIN
 
-        elif wait_min is None or wait_min < 30:
+        elif wait_min < 30:
             wait_min = 30
 
         delay_sec = DEFAULT_DELAY_SEC
@@ -355,16 +355,13 @@ class CodeDeployValidator():
         wait_time = self.get_deployment_wait_time()
         rerouting_time = self.get_traffic_rerouting_time()
 
-        if wait_time is None or rerouting_time is None:
-            return None
-
         return wait_time + rerouting_time + TIMEOUT_BUFFER_MIN
 
     def get_deployment_wait_time(self):
 
         if (not hasattr(self, 'deployment_group_details') or
                 self.deployment_group_details is None):
-            return None
+            return 0
         else:
             dgp_info = self.deployment_group_details['deploymentGroupInfo']
             blue_green_info = dgp_info['blueGreenDeploymentConfiguration']
@@ -381,9 +378,9 @@ class CodeDeployValidator():
             return configured_wait
 
     def get_traffic_rerouting_time(self):
-        if (not hasattr(self, 'deployment_config') or
+        if (not hasattr(self, 'deployment_config')or
                 self.deployment_config is None):
-            return None
+            return 0
         else:
             config_info = self.deployment_config['deploymentConfigInfo']
             routing_config = config_info['trafficRoutingConfig']
@@ -397,7 +394,7 @@ class CodeDeployValidator():
                 time_based_linear = routing_config['timeBasedLinear']
                 return int((100 / time_based_linear['linearPercentage']) * time_based_linear['linearInterval'])
             else:
-                return None
+                return 0
 
     def validate_all(self):
         self.validate_application()

--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -345,7 +345,7 @@ class CodeDeployValidator():
         try:
             dgp_info = self.deployment_group_details['deploymentGroupInfo']
             deployment_config_name = dgp_info['deploymentConfigName']
-            self.deployment_config = self._client.get_deployment_config(
+            self.deployment_config_details = self._client.get_deployment_config(
                 deploymentConfigName=deployment_config_name)
         except ClientError as e:
             raise exceptions.ServiceClientError(
@@ -378,11 +378,11 @@ class CodeDeployValidator():
             return configured_wait
 
     def get_traffic_rerouting_time(self):
-        if (not hasattr(self, 'deployment_config') or
-                self.deployment_config is None):
+        if (not hasattr(self, 'deployment_config_details') or
+                self.deployment_config_details is None):
             return 0
         else:
-            config_info = self.deployment_config.get('deploymentConfigInfo', {})
+            config_info = self.deployment_config_details.get('deploymentConfigInfo', {})
             routing_config = config_info.get('trafficRoutingConfig', {})
             routing_type = routing_config.get('type', '')
 

--- a/tests/functional/ecs/test_deploy.py
+++ b/tests/functional/ecs/test_deploy.py
@@ -224,6 +224,7 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                 'applicationName': self.application_name,
                 'deploymentGroupName': self.deployment_group_name,
                 'computePlatform': 'ECS',
+                'deploymentConfigName': 'ECS.AllAtOnce',
                 'blueGreenDeploymentConfiguration': {
                     'deploymentReadyOption': {
                         'waitTimeInMinutes': 5
@@ -295,7 +296,8 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                 'ecsServices': [{
                     'serviceName': self.service_name,
                     'clusterName': self.cluster_name
-                }]
+                }],
+                'deploymentConfigName': 'ECS.AllAtOnce'
             }
         }
         max_timeout = str(MAX_WAIT_MIN)
@@ -396,7 +398,15 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                     'ecsServices': [{
                         'serviceName': self.service_name,
                         'clusterName': self.cluster_name
-                    }]
+                    }],
+                    'deploymentConfigName': 'ECS.AllAtOnce'
+                }
+            },
+            {
+                'deploymentConfigInfo': {
+                    'trafficRoutingConfig': {
+                        'type': 'AllAtOnce'
+                    }
                 }
             },
             {
@@ -425,6 +435,12 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                 'params': {
                     'applicationName': self.application_name,
                     'deploymentGroupName': self.deployment_group_name
+                }
+            },
+            {
+                'operation': 'GetDeploymentConfig',
+                'params': {
+                    'deploymentConfigName': 'ECS.AllAtOnce'
                 }
             },
             {
@@ -474,9 +490,17 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                     'ecsServices': [{
                         'serviceName': self.service_name,
                         'clusterName': self.cluster_name
-                    }]
+                    }],
+                    'deploymentConfigName': 'ECS.AllAtOnce'
                 }
-            }
+            },
+            {
+                'deploymentConfigInfo': {
+                    'trafficRoutingConfig': {
+                        'type': 'AllAtOnce'
+                    }
+                }
+            },
         ]
 
         expected_params = [
@@ -496,6 +520,12 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                 'params': {
                     'applicationName': self.application_name,
                     'deploymentGroupName': self.deployment_group_name
+                }
+            },
+            {
+                'operation': 'GetDeploymentConfig',
+                'params': {
+                    'deploymentConfigName': 'ECS.AllAtOnce'
                 }
             }
         ]
@@ -546,6 +576,12 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                 }
             },
             {
+                'operation': 'GetDeploymentConfig',
+                'params': {
+                    'deploymentConfigName': 'ECS.AllAtOnce'
+                }
+            },
+            {
                 'operation': 'RegisterTaskDefinition',
                 'params': self.TASK_DEFINITION_JSON
             },
@@ -593,7 +629,15 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
                     'ecsServices': [{
                         'serviceName': self.service_name,
                         'clusterName': cluster_name
-                    }]
+                    }],
+                    'deploymentConfigName': 'ECS.AllAtOnce'
+                }
+            },
+            {
+                'deploymentConfigInfo': {
+                    'trafficRoutingConfig': {
+                        'type': 'AllAtOnce'
+                    }
                 }
             },
             {

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -110,6 +110,18 @@ class TestCodeDeployValidator(unittest.TestCase):
         actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
 
+    def test_unknown_traffic_routing_config_get_deployment_duration(self):
+        self.validator.deployment_config = {
+            'deploymentConfigInfo': {
+                'trafficRoutingConfig': {
+                    'type': 'NewTypeNotKnownYet'
+                }
+            }
+        }
+
+        expected_wait = None
+        actual_wait = self.validator.get_deployment_duration()
+        self.assertEqual(expected_wait, actual_wait)
 
     def test_get_deployment_duration_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -119,14 +119,14 @@ class TestCodeDeployValidator(unittest.TestCase):
             }
         }
 
-        expected_wait = None
+        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
         actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
 
     def test_get_deployment_duration_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)
         actual_wait = empty_validator.get_deployment_duration()
-        self.assertEqual(None, actual_wait)
+        self.assertEqual(TIMEOUT_BUFFER_MIN, actual_wait)
 
     def test_validations(self):
         self.validator.validate_application()

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -57,29 +57,59 @@ class TestCodeDeployValidator(unittest.TestCase):
         }
     }
 
-    TEST_DEPLOYMENT_CONFIG = {
-        'deploymentConfigInfo': {
-            'trafficRoutingConfig': {
-                'type': 'TimeBasedLinear',
-                'timeBasedLinear': {
-                    'linearPercentage': 10,
-                    'linearInterval': 5
-                }
-            }
-        }
-    }
     def setUp(self):
         self.validator = CodeDeployValidator(None, self.TEST_RESOURCES)
         self.validator.app_details = self.TEST_APP_DETAILS
         self.validator.deployment_group_details = \
             self.TEST_DEPLOYMENT_GROUP_DETAILS
-        self.validator.deployment_config = \
-            self.TEST_DEPLOYMENT_CONFIG
 
-    def test_get_deployment_duration(self):
+    def test_time_based_linear_get_deployment_duration(self):
+        self.validator.deployment_config = {
+            'deploymentConfigInfo': {
+                'trafficRoutingConfig': {
+                    'type': 'TimeBasedLinear',
+                    'timeBasedLinear': {
+                        'linearPercentage': 10,
+                        'linearInterval': 5
+                    }
+                }
+            }
+        }
+
         expected_wait = 5 + 10 + (10 * 5) + TIMEOUT_BUFFER_MIN
         actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
+
+    def test_time_based_canary_get_deployment_duration(self):
+        self.validator.deployment_config = {
+            'deploymentConfigInfo': {
+                'trafficRoutingConfig': {
+                    'type': 'TimeBasedCanary',
+                    'timeBasedCanary': {
+                        'canaryPercentage': 10,
+                        'canaryInterval': 5
+                    }
+                }
+            }
+        }
+
+        expected_wait = 5 + 10 + 5 + TIMEOUT_BUFFER_MIN
+        actual_wait = self.validator.get_deployment_duration()
+        self.assertEqual(expected_wait, actual_wait)
+
+    def test_all_at_once_get_deployment_duration(self):
+        self.validator.deployment_config = {
+            'deploymentConfigInfo': {
+                'trafficRoutingConfig': {
+                    'type': 'AllAtOnce'
+                }
+            }
+        }
+
+        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
+        actual_wait = self.validator.get_deployment_duration()
+        self.assertEqual(expected_wait, actual_wait)
+
 
     def test_get_deployment_duration_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -67,6 +67,14 @@ class TestCodeDeployValidator(unittest.TestCase):
         actual_wait = self.validator.get_deployment_wait_time()
         self.assertEqual(15, actual_wait)
 
+    def test_get_traffic_rerouting_missing_traffic_routing_config(self):
+        self.validator.deployment_config = {
+            'deploymentConfigInfo': {}
+        }
+
+        actual_wait = self.validator.get_traffic_rerouting_time()
+        self.assertEqual(0, actual_wait)
+
     def test_get_traffic_rerouting_time_based_linear(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -63,7 +63,11 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.validator.deployment_group_details = \
             self.TEST_DEPLOYMENT_GROUP_DETAILS
 
-    def test_get_deployment_duration_time_based_linear(self):
+    def test_get_deployment_wait_time(self):
+        actual_wait = self.validator.get_deployment_wait_time()
+        self.assertEqual(15, actual_wait)
+
+    def test_get_traffic_rerouting_time_based_linear(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -76,11 +80,10 @@ class TestCodeDeployValidator(unittest.TestCase):
             }
         }
 
-        expected_wait = 5 + 10 + (10 * 5) + TIMEOUT_BUFFER_MIN
-        actual_wait = self.validator.get_deployment_duration()
-        self.assertEqual(expected_wait, actual_wait)
+        actual_wait = self.validator.get_traffic_rerouting_time()
+        self.assertEqual(10 * 5, actual_wait)
 
-    def test_get_deployment_duration_time_based_canary(self):
+    def test_get_traffic_rerouting_time_based_canary(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -93,11 +96,10 @@ class TestCodeDeployValidator(unittest.TestCase):
             }
         }
 
-        expected_wait = 5 + 10 + 5 + TIMEOUT_BUFFER_MIN
-        actual_wait = self.validator.get_deployment_duration()
-        self.assertEqual(expected_wait, actual_wait)
+        actual_wait = self.validator.get_traffic_rerouting_time()
+        self.assertEqual(5, actual_wait)
 
-    def test_get_deployment_duration_all_at_once(self):
+    def test_get_traffic_rerouting_time_all_at_once(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -106,11 +108,10 @@ class TestCodeDeployValidator(unittest.TestCase):
             }
         }
 
-        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
-        actual_wait = self.validator.get_deployment_duration()
-        self.assertEqual(expected_wait, actual_wait)
+        actual_wait = self.validator.get_traffic_rerouting_time()
+        self.assertEqual(0, actual_wait)
 
-    def test_get_deployment_duration_unknown_traffic_routing_config(self):
+    def test_get_traffic_rerouting_time_unknown_traffic_routing_config(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -119,9 +120,12 @@ class TestCodeDeployValidator(unittest.TestCase):
             }
         }
 
-        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
+        actual_wait = self.validator.get_traffic_rerouting_time()
+        self.assertEqual(0, actual_wait)
+
+    def test_get_deployment_duration(self):
         actual_wait = self.validator.get_deployment_duration()
-        self.assertEqual(expected_wait, actual_wait)
+        self.assertEqual(25, actual_wait)
 
     def test_get_deployment_duration_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -63,7 +63,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.validator.deployment_group_details = \
             self.TEST_DEPLOYMENT_GROUP_DETAILS
 
-    def test_time_based_linear_get_deployment_duration(self):
+    def test_get_deployment_duration_time_based_linear(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -80,7 +80,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
 
-    def test_time_based_canary_get_deployment_duration(self):
+    def test_get_deployment_duration_time_based_canary(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -97,7 +97,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
 
-    def test_all_at_once_get_deployment_duration(self):
+    def test_get_deployment_duration_all_at_once(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
@@ -110,7 +110,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
 
-    def test_unknown_traffic_routing_config_get_deployment_duration(self):
+    def test_get_deployment_duration_unknown_traffic_routing_config(self):
         self.validator.deployment_config = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -52,24 +52,38 @@ class TestCodeDeployValidator(unittest.TestCase):
             'ecsServices': [{
                 'serviceName': 'test-service',
                 'clusterName': 'test-cluster'
-            }]
+            }],
+            'deploymentConfigName': 'CodeDeployDefault.ECSLinear10PercentEvery1Minutes'
         }
     }
 
+    TEST_DEPLOYMENT_CONFIG = {
+        'deploymentConfigInfo': {
+            'trafficRoutingConfig': {
+                'type': 'TimeBasedLinear',
+                'timeBasedLinear': {
+                    'linearPercentage': 10,
+                    'linearInterval': 5
+                }
+            }
+        }
+    }
     def setUp(self):
         self.validator = CodeDeployValidator(None, self.TEST_RESOURCES)
         self.validator.app_details = self.TEST_APP_DETAILS
         self.validator.deployment_group_details = \
             self.TEST_DEPLOYMENT_GROUP_DETAILS
+        self.validator.deployment_config = \
+            self.TEST_DEPLOYMENT_CONFIG
 
-    def test_get_deployment_wait_time(self):
-        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
-        actual_wait = self.validator.get_deployment_wait_time()
+    def test_get_deployment_duration(self):
+        expected_wait = 5 + 10 + (10 * 5) + TIMEOUT_BUFFER_MIN
+        actual_wait = self.validator.get_deployment_duration()
         self.assertEqual(expected_wait, actual_wait)
 
-    def test_get_deployment_wait_time_no_dgp(self):
+    def test_get_deployment_duration_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)
-        actual_wait = empty_validator.get_deployment_wait_time()
+        actual_wait = empty_validator.get_deployment_duration()
         self.assertEqual(None, actual_wait)
 
     def test_validations(self):

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -132,8 +132,9 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.assertEqual(0, actual_wait)
 
     def test_get_deployment_duration(self):
+        expected_wait = 5 + 10 + TIMEOUT_BUFFER_MIN
         actual_wait = self.validator.get_deployment_duration()
-        self.assertEqual(25, actual_wait)
+        self.assertEqual(expected_wait, actual_wait)
 
     def test_get_deployment_duration_no_dgp(self):
         empty_validator = CodeDeployValidator(None, self.TEST_RESOURCES)

--- a/tests/unit/customizations/ecs/test_codedeployvalidator.py
+++ b/tests/unit/customizations/ecs/test_codedeployvalidator.py
@@ -68,7 +68,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.assertEqual(15, actual_wait)
 
     def test_get_traffic_rerouting_missing_traffic_routing_config(self):
-        self.validator.deployment_config = {
+        self.validator.deployment_config_details = {
             'deploymentConfigInfo': {}
         }
 
@@ -76,7 +76,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.assertEqual(0, actual_wait)
 
     def test_get_traffic_rerouting_time_based_linear(self):
-        self.validator.deployment_config = {
+        self.validator.deployment_config_details = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
                     'type': 'TimeBasedLinear',
@@ -92,7 +92,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.assertEqual(10 * 5, actual_wait)
 
     def test_get_traffic_rerouting_time_based_canary(self):
-        self.validator.deployment_config = {
+        self.validator.deployment_config_details = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
                     'type': 'TimeBasedCanary',
@@ -108,7 +108,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.assertEqual(5, actual_wait)
 
     def test_get_traffic_rerouting_time_all_at_once(self):
-        self.validator.deployment_config = {
+        self.validator.deployment_config_details = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
                     'type': 'AllAtOnce'
@@ -120,7 +120,7 @@ class TestCodeDeployValidator(unittest.TestCase):
         self.assertEqual(0, actual_wait)
 
     def test_get_traffic_rerouting_time_unknown_traffic_routing_config(self):
-        self.validator.deployment_config = {
+        self.validator.deployment_config_details = {
             'deploymentConfigInfo': {
                 'trafficRoutingConfig': {
                     'type': 'NewTypeNotKnownYet'


### PR DESCRIPTION
*Issue #, if available:*

Fixes #5963

Picks up on #5964 from @oliver-schoenherr to rebase develop after fixing other tests.

*Description of changes:*

Retrieve the configured ECS CodeDeploy rerouting config and calculated the expected time base on the configuration. This time is added to the already previously calculated deployment time based on wait and termination time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
