### PR TITLE
S3 cp large file example

### DIFF
--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -151,7 +151,7 @@ Output::
 
 **Uploading a local file stream to S3**
 
-WARNING:: PowerShell may alter the encoding of or add a CRLF to piped input.
+.. WARNING:: PowerShell may alter the encoding of or add a CRLF to piped input.
 
 The following ``cp`` command uploads a local file stream from standard input to a specified bucket and key::
 
@@ -160,7 +160,7 @@ The following ``cp`` command uploads a local file stream from standard input to 
 
 **Downloading an S3 object as a local file stream**
 
-WARNING:: PowerShell may alter the encoding of or add a CRLF to piped or redirected output.
+.. WARNING:: PowerShell may alter the encoding of or add a CRLF to piped or redirected output.
 
 The following ``cp`` command downloads an S3 object locally as a stream to standard output. Downloading as a stream is not currently compatible with the ``--recursive`` parameter::
 

--- a/awscli/examples/s3/cp.rst
+++ b/awscli/examples/s3/cp.rst
@@ -157,6 +157,11 @@ The following ``cp`` command uploads a local file stream from standard input to 
 
     aws s3 cp - s3://mybucket/stream.txt
 
+**Uploading a local file stream that is larger than 50GB to S3**
+
+The following ``cp`` command uploads a 51GB local file stream from standard input to a specified bucket and key.  The ``--expected-size`` option must be provided, or the upload may fail when it reaches the default part limit of 10,000::
+
+    aws s3 cp - s3://mybucket/stream.txt --expected-size 54760833024
 
 **Downloading an S3 object as a local file stream**
 


### PR DESCRIPTION
Addresses #6120.

Added an example that shows usage of the `--expected-size` option and fixed two warning directives that weren't rendering correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
