### PR TITLE
Replace use of deprecated base64.encodestring()

### DIFF
--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -17,6 +17,8 @@ import hmac
 import base64
 import datetime
 
+from botocore.compat import encodebytes
+
 from awscli.compat import six
 
 from awscli.arguments import CustomArgument
@@ -135,7 +137,7 @@ def _generate_signature(params):
         policy = base64.b64encode(six.b(policy)).decode('utf-8')
         new_hmac = hmac.new(sak.encode('utf-8'), digestmod=sha1)
         new_hmac.update(six.b(policy))
-        ps = base64.encodestring(new_hmac.digest()).strip().decode('utf-8')
+        ps = encodebytes(new_hmac.digest()).strip().decode('utf-8')
         params['UploadPolicySignature'] = ps
         del params['_SAK']
 

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -17,6 +17,8 @@ import datetime
 import mock
 from six.moves import cStringIO
 
+from botocore.compat import encodebytes
+
 import awscli.customizations.ec2.bundleinstance
 from awscli.compat import six
 from awscli.testutils import BaseAWSCommandParamsTest
@@ -70,7 +72,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def test_policy_provided(self):
         policy = '{"notarealpolicy":true}'
-        base64policy = base64.encodestring(six.b(policy)).strip().decode('utf-8')
+        base64policy = encodebytes(six.b(policy)).strip().decode('utf-8')
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Replace the uses of deprecated base64.encodestring() in favor
of botocore.compat.encodebytes().  This fixes incompatibility with
Python 3.9 where the former function has finally been removed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
