### PR TITLE
Document types support in CLI

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -379,6 +379,16 @@ class ParamShorthandParser(ParamShorthand):
             # {"Value": "shutdown"}
             return {'Value': value}
 
+        # Additional handling of special cases where a structure is
+        # a document type. Shorthand syntax is not supported and
+        # should therefore err out before attempt to parse.
+        if model.type_name == 'structure' and model.is_document_type:
+            raise shorthand.ShorthandParseError(
+                'Shorthand syntax not supported for document type input: %s' % (
+                    value
+                )
+            )
+
     def _should_parse_as_shorthand(self, cli_argument, value):
         # We first need to make sure this is a parameter that qualifies
         # for simplification.  The first short-circuit case is if it looks
@@ -470,6 +480,8 @@ class ParamShorthandDocGen(ParamShorthand):
         if len(stack) > self._MAX_STACK:
             raise TooComplexError()
         if argument_model.type_name == 'structure':
+            if argument_model.is_document_type:
+                return "Shorthand syntax not supported with documents."
             return self._structure_docs(argument_model, stack)
         elif argument_model.type_name == 'list':
             return self._list_docs(argument_model, stack)

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -19,7 +19,10 @@ from botocore.compat import OrderedDict, json
 
 from awscli import SCALAR_TYPES, COMPLEX_TYPES
 from awscli import shorthand
-from awscli.utils import find_service_and_method_in_event_name
+from awscli.utils import (
+    find_service_and_method_in_event_name, is_document_type,
+    is_document_type_container
+)
 from botocore.utils import is_json_value_header
 
 LOG = logging.getLogger('awscli.argprocess')
@@ -153,7 +156,8 @@ def _special_type(model):
 
 
 def _unpack_cli_arg(argument_model, value, cli_name):
-    if is_json_value_header(argument_model):
+    if is_json_value_header(argument_model) or \
+            is_document_type(argument_model):
         return _unpack_json_cli_arg(argument_model, value, cli_name)
     elif argument_model.type_name in SCALAR_TYPES:
         return unpack_scalar_cli_arg(
@@ -178,21 +182,16 @@ def _unpack_complex_cli_arg(argument_model, value, cli_name):
     type_name = argument_model.type_name
     if type_name == 'structure' or type_name == 'map':
         if value.lstrip()[0] == '{':
-            try:
-                return json.loads(value, object_pairs_hook=OrderedDict)
-            except ValueError as e:
-                raise ParamError(
-                    cli_name, "Invalid JSON: %s\nJSON received: %s"
-                    % (e, value))
+            return _unpack_json_cli_arg(argument_model, value, cli_name)
         raise ParamError(cli_name, "Invalid JSON:\n%s" % value)
     elif type_name == 'list':
         if isinstance(value, six.string_types):
             if value.lstrip()[0] == '[':
-                return json.loads(value, object_pairs_hook=OrderedDict)
+                return _unpack_json_cli_arg(argument_model, value, cli_name)
         elif isinstance(value, list) and len(value) == 1:
             single_value = value[0].strip()
             if single_value and single_value[0] == '[':
-                return json.loads(value[0], object_pairs_hook=OrderedDict)
+                return _unpack_json_cli_arg(argument_model, value[0], cli_name)
         try:
             # There's a couple of cases remaining here.
             # 1. It's possible that this is just a list of strings, i.e
@@ -232,6 +231,21 @@ def unpack_scalar_cli_arg(argument_model, value, cli_name=''):
         return bool(value)
     else:
         return value
+
+
+def _supports_shorthand_syntax(model):
+    # Shorthand syntax is only supported if:
+    #
+    # 1. The argument is not a document type nor is a wrapper around a document
+    # type (e.g. is a list of document types or a map of document types). These
+    # should all be expressed as JSON input.
+    #
+    # 2. The argument is sufficiently complex, that is, it's base type is
+    # a complex type *and* if it's a list, then it can't be a list of
+    # scalar types.
+    if is_document_type_container(model):
+        return False
+    return _is_complex_shape(model)
 
 
 def _is_complex_shape(model):
@@ -379,16 +393,6 @@ class ParamShorthandParser(ParamShorthand):
             # {"Value": "shutdown"}
             return {'Value': value}
 
-        # Additional handling of special cases where a structure is
-        # a document type. Shorthand syntax is not supported and
-        # should therefore err out before attempt to parse.
-        if model.type_name == 'structure' and model.is_document_type:
-            raise shorthand.ShorthandParseError(
-                'Shorthand syntax not supported for document type input: %s' % (
-                    value
-                )
-            )
-
     def _should_parse_as_shorthand(self, cli_argument, value):
         # We first need to make sure this is a parameter that qualifies
         # for simplification.  The first short-circuit case is if it looks
@@ -403,10 +407,7 @@ class ParamShorthandParser(ParamShorthand):
                       "param shorthand.", cli_argument.py_name)
             return False
         model = cli_argument.argument_model
-        # The second case is to make sure the argument is sufficiently
-        # complex, that is, it's base type is a complex type *and*
-        # if it's a list, then it can't be a list of scalar types.
-        return _is_complex_shape(model)
+        return _supports_shorthand_syntax(model)
 
 
 class ParamShorthandDocGen(ParamShorthand):
@@ -418,7 +419,7 @@ class ParamShorthandDocGen(ParamShorthand):
     def supports_shorthand(self, argument_model):
         """Checks if a CLI argument supports shorthand syntax."""
         if argument_model is not None:
-            return _is_complex_shape(argument_model)
+            return _supports_shorthand_syntax(argument_model)
         return False
 
     def generate_shorthand_example(self, cli_argument, service_id,
@@ -480,8 +481,6 @@ class ParamShorthandDocGen(ParamShorthand):
         if len(stack) > self._MAX_STACK:
             raise TooComplexError()
         if argument_model.type_name == 'structure':
-            if argument_model.is_document_type:
-                return "Shorthand syntax not supported with documents."
             return self._structure_docs(argument_model, stack)
         elif argument_model.type_name == 'list':
             return self._list_docs(argument_model, stack)
@@ -517,6 +516,8 @@ class ParamShorthandDocGen(ParamShorthand):
     def _structure_docs(self, argument_model, stack):
         parts = []
         for name, member_shape in argument_model.members.items():
+            if is_document_type_container(member_shape):
+                continue
             parts.append(self._member_docs(name, member_shape, stack))
         inner_part = ','.join(parts)
         if not stack:

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -43,6 +43,8 @@ class CLIDocumentEventHandler(object):
     def _get_argument_type_name(self, shape, default):
         if is_json_value_header(shape):
             return 'JSON'
+        if default == 'structure' and shape.is_document_type:
+            return 'document'
         return default
 
     def _map_handlers(self, session, event_class, mapfn):
@@ -451,7 +453,13 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             doc.style.dedent()
             doc.write('}')
         elif argument_model.type_name == 'structure':
-            self._doc_input_structure_members(doc, argument_model, stack)
+            if argument_model.is_document_type:
+                doc.write("This value is an JSON document that can have arbitrary content.")
+                doc.style.new_line()
+                doc.write("For more information on JSON document values visit: <insert section name in user guide>")
+                doc.style.new_line()
+            else:
+                self._doc_input_structure_members(doc, argument_model, stack)
 
     def _doc_input_structure_members(self, doc, argument_model, stack):
         doc.write('{')

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -406,10 +406,10 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             help_command.doc.writeln(
                 '``%s`` uses document type values. Document types follow the '
                 'JSON data model where valid values are: strings, numbers, '
-                'booleans, null, arrays, and objects. For command input,'
+                'booleans, null, arrays, and objects. For command input, '
                 'options and nested parameters that are labeled with the type '
                 '``document`` must be provided as JSON. Shorthand syntax does '
-                'not support document types' % help_command.name
+                'not support document types.' % help_command.name
             )
 
     def _json_example_value_name(self, argument_model, include_enum_values=True):

--- a/tests/functional/test_document_types.py
+++ b/tests/functional/test_document_types.py
@@ -1,0 +1,493 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import copy
+import json
+import os
+
+from botocore.loaders import Loader
+
+from awscli.testutils import (
+    create_clidriver, FileCreator, BaseAWSCommandParamsTest,
+    BaseAWSHelpOutputTest
+)
+
+# NOTE: Typically, the functional tests reuse preexisting models. However
+# because document types was released without any service model using them,
+# we are using through a fake service model to fully test document type
+# behavior.
+DOCTYPE_MODEL = {
+    "version": "2.0",
+    "metadata": {
+        "apiVersion": "2011-06-15",
+        "endpointPrefix": "doctype",
+        "protocol": "json",
+        "jsonVersion": "1.1",
+        "serviceAbbreviation": "AWS DocType",
+        "serviceFullName": "AWS DocType",
+        "serviceId": "DocType",
+        "signatureVersion": "v4",
+        "targetPrefix": "DocType",
+        "uid": "doctype-2011-06-15",
+    },
+    "operations": {
+        "DescribeResource": {
+            "name": "DescribeResource",
+            "http": {
+                "method": "POST",
+                "requestUri": "/"
+            },
+            "input": {"shape": "DescribeResourceShape"},
+            "output": {"shape": "DescribeResourceShape"},
+            "errors": [],
+            "documentation": "<p>Describes resource.</p>"
+        }
+    },
+    "shapes": {
+        "DescribeResourceShape": {
+            "type": "structure",
+            "members": {
+                "DocTypeParam": {"shape": "DocType"},
+                "ModeledMixedWithDocTypeParam": {"shape": "Mixed"},
+                "ListOfDocTypesParam": {"shape": "ListOfDocTypes"},
+                "MapOfDocTypesParam": {"shape": "MapOfDocTypes"},
+                "NestedListsOfDocTypesParam": {
+                    "shape": "NestedListsOfDocTypes"
+                }
+            }
+        },
+        "DocType": {
+            "type": "structure",
+            "members": {},
+            "document": True,
+            "documentation": "<p>Document type</p>"
+        },
+        "ListOfDocTypes": {
+            "type": "list",
+            "member": {"shape": "DocType"}
+        },
+        "MapOfDocTypes": {
+            "type": "map",
+            "key": {"shape": "String"},
+            "value": {"shape": "DocType"}
+        },
+        "NestedListsOfDocTypes": {
+            "type": "list",
+            "member": {"shape": "ListOfDocTypes"}
+        },
+        "Mixed": {
+            "type": "structure",
+            "members": {
+                "DocType": {"shape": "DocType"},
+                "StringMember": {"shape": "String"},
+                "ListOfDocTypes": {"shape": "ListOfDocTypes"},
+                "MapOfDocTypes": {"shape": "MapOfDocTypes"},
+                "NestedListsOfDocTypes": {"shape": "NestedListsOfDocTypes"}
+            },
+            "documentation": (
+                "<p>Structure with modeled and document type parameter</p>"),
+        },
+        "String": {"type": "string"}
+    }
+}
+
+
+def _add_doctype_service_model(file_creator, session, model=None):
+    if model is None:
+        model = DOCTYPE_MODEL
+    file_creator.create_file(
+        os.path.join('doctype', '2011-06-15', 'service-2.json'),
+        json.dumps(model)
+    )
+    data_path = session.get_config_variable('data_path').split(os.pathsep)
+    loader = Loader()
+    loader.search_paths.extend(data_path + [file_creator.rootdir])
+    session.register_component('data_loader', loader)
+
+
+class TestDocumentTypeIO(BaseAWSCommandParamsTest):
+    def setUp(self):
+        super(TestDocumentTypeIO, self).setUp()
+        self.files = FileCreator()
+        _add_doctype_service_model(self.files, self.driver.session)
+
+    def tearDown(self):
+        super(TestDocumentTypeIO, self).tearDown()
+        self.files.remove_all()
+
+    def assert_raises_shorthand_syntax_error(self, cmdline,
+                                             stderr_contains=None):
+        _, stderr, _ = self.run_cmd(cmdline, expected_rc=255)
+        if stderr_contains:
+            self.assertIn(stderr_contains, stderr)
+
+    def nested_doctype_shorthand_error(self, parameter_name, member_name):
+        return (
+            "Error parsing parameter '%s': Shorthand syntax does not support "
+            "document types. Use JSON input for top-level argument to specify "
+            "nested parameter: %s" % (parameter_name, member_name)
+        )
+
+    def test_can_provide_json_for_doc_type(self):
+        cmdline = [
+            'doctype', 'describe-resource', '--doc-type-param',
+            '{"foo":"bar"}'
+        ]
+        self.assert_params_for_cmd(
+            cmdline, params={'DocTypeParam': {"foo": "bar"}})
+
+    def test_can_provide_json_for_doc_type_with_scalar_value(self):
+        cmdline = [
+            'doctype', 'describe-resource', '--doc-type-param',
+            '"json-string"'
+        ]
+        self.assert_params_for_cmd(
+            cmdline, params={'DocTypeParam': 'json-string'})
+
+    def test_can_provide_json_for_doc_type_in_list(self):
+        cmdline = [
+            'doctype', 'describe-resource', '--list-of-doc-types-param',
+            '["foo", {"bar": "baz"}, 1, null]'
+        ]
+        self.assert_params_for_cmd(
+            cmdline,
+            params={'ListOfDocTypesParam': ["foo", {"bar": "baz"}, 1, None]}
+        )
+
+    def test_can_provide_json_for_doc_type_in_map(self):
+        cmdline = [
+            'doctype', 'describe-resource', '--map-of-doc-types-param',
+            '{"key1": "foo", "key2": {"bar": "baz"}, "key3": 1}'
+        ]
+        self.assert_params_for_cmd(
+            cmdline,
+            params={
+                'MapOfDocTypesParam': {
+                    "key1": "foo",
+                    "key2": {"bar": "baz"},
+                    "key3": 1
+                }
+            }
+        )
+
+    def test_can_provide_json_for_doc_type_in_nested_list(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--nested-lists-of-doc-types-param',
+            '[["foo", {"bar": "baz"}, 1, null]]'
+        ]
+        self.assert_params_for_cmd(
+            cmdline,
+            params={
+                'NestedListsOfDocTypesParam': [
+                    ["foo", {"bar": "baz"}, 1, None]
+                ]
+            }
+        )
+
+    def test_can_provide_json_for_nested_doc_type(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--modeled-mixed-with-doc-type-param',
+            (
+                '{'
+                '   "DocType": {"foo": "bar"},'
+                '   "ListOfDocTypes": ["foo", {"bar": "baz"}, 1, null],'
+                '   "MapOfDocTypes": {'
+                '       "key1": "foo", "key2": {"bar": "baz"}, "key3": 1},'
+                '   "NestedListsOfDocTypes":[["foo", {"bar": "baz"}, 1, null]]'
+                '}'
+            )
+        ]
+        self.assert_params_for_cmd(
+            cmdline,
+            params={
+                'ModeledMixedWithDocTypeParam': {
+                    'DocType': {'foo': 'bar'},
+                    'ListOfDocTypes': ["foo", {"bar": "baz"}, 1, None],
+                    'MapOfDocTypes': {
+                        "key1": "foo",
+                        "key2": {"bar": "baz"},
+                        "key3": 1
+                    },
+                    'NestedListsOfDocTypes': [["foo", {"bar": "baz"}, 1, None]]
+                }
+            }
+        )
+
+    def test_shorthand_not_supported_for_doc_type_argument(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--doc-type-param', 'foo=1',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=(
+                "Error parsing parameter '--doc-type-param': Invalid JSON"
+            )
+        )
+
+    def test_shorthand_not_supported_for_doc_type_in_list(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--list-of-doc-types-param', 'bar,1,null',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=(
+                "Error parsing parameter '--list-of-doc-types-param': "
+                "Invalid JSON"
+            )
+        )
+
+    def test_shorthand_not_supported_for_doc_type_in_map(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--map-of-doc-types-param', 'key1={foo=bar}',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=(
+                "Error parsing parameter '--map-of-doc-types-param': "
+                "Invalid JSON"
+            )
+        )
+
+    def test_shorthand_not_supported_for_doc_type_in_nested_list(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--nested-lists-of-doc-types-param', '[bar,1,null],[foo,2]',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=(
+                "Error parsing parameter '--nested-lists-of-doc-types-param': "
+                "Invalid JSON"
+            )
+        )
+
+    def test_shorthand_not_supported_for_nested_doc_type(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--modeled-mixed-with-doc-type-param',
+            'DocType={foo=bar}',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=self.nested_doctype_shorthand_error(
+                '--modeled-mixed-with-doc-type-param', member_name='DocType'
+            )
+        )
+
+    def test_shorthand_not_supported_for_nested_doc_type_in_list(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--modeled-mixed-with-doc-type-param',
+            'ListOfDocTypes=[{foo=bar}]',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=self.nested_doctype_shorthand_error(
+                '--modeled-mixed-with-doc-type-param',
+                member_name='ListOfDocTypes'
+            )
+        )
+
+    def test_shorthand_not_supported_for_nested_doc_type_in_map(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--modeled-mixed-with-doc-type-param',
+            'MapOfDocTypes={key={foo=bar}}',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=self.nested_doctype_shorthand_error(
+                '--modeled-mixed-with-doc-type-param',
+                member_name='MapOfDocTypes'
+            )
+        )
+
+    def test_shorthand_not_supported_for_nested_doc_type_in_nested_list(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--modeled-mixed-with-doc-type-param',
+            'NestedListsOfDocTypes=[[{foo=bar}]]',
+        ]
+        self.assert_raises_shorthand_syntax_error(
+            cmdline,
+            stderr_contains=self.nested_doctype_shorthand_error(
+                '--modeled-mixed-with-doc-type-param',
+                member_name='NestedListsOfDocTypes'
+            )
+        )
+
+    def test_can_use_shorthand_if_only_modeled_members_used(self):
+        cmdline = [
+            'doctype', 'describe-resource',
+            '--modeled-mixed-with-doc-type-param',
+            'StringMember=str-val',
+        ]
+        self.assert_params_for_cmd(
+            cmdline,
+            params={
+                'ModeledMixedWithDocTypeParam': {
+                    'StringMember': 'str-val',
+                }
+            }
+        )
+
+    def test_can_generate_cli_skeleton(self):
+        cmdline = [
+            'doctype', 'describe-resource', '--generate-cli-skeleton'
+        ]
+        stdout, _, _ = self.run_cmd(cmdline)
+        skeleton_output = json.loads(stdout)
+        self.assertEqual(
+            skeleton_output,
+            {
+                'DocTypeParam': {},
+                'ModeledMixedWithDocTypeParam': {
+                    'DocType': {},
+                    'StringMember': '',
+                    'ListOfDocTypes': [{}],
+                    'MapOfDocTypes': {'KeyName': {}},
+                    'NestedListsOfDocTypes': [[{}]]
+                },
+                'ListOfDocTypesParam': [{}],
+                'MapOfDocTypesParam': {'KeyName': {}},
+                'NestedListsOfDocTypesParam': [[{}]]
+            }
+        )
+
+
+class TestDocTypesHelp(BaseAWSHelpOutputTest):
+    def setUp(self):
+        super(TestDocTypesHelp, self).setUp()
+        self.files = FileCreator()
+        _add_doctype_service_model(self.files, self.driver.session)
+
+    def tearDown(self):
+        super(TestDocTypesHelp, self).tearDown()
+        self.files.remove_all()
+
+    def run_help(self):
+        self.driver.main(
+            ['doctype', 'describe-resource', 'help'])
+
+    def filter_params_in_model(self, include_params):
+        model = copy.deepcopy(DOCTYPE_MODEL)
+        request_members = model['shapes']['DescribeResourceShape']['members']
+        for request_member in list(request_members):
+            if request_member not in include_params:
+                del request_members[request_member]
+
+        self.driver = create_clidriver()
+        _add_doctype_service_model(self.files, self.driver.session, model)
+
+    def assert_has_document_value_in_json_syntax(self, parameter):
+        self.assert_text_order(
+            'JSON Syntax::',
+            '{...}',
+            starting_from=parameter
+        )
+
+    def assert_no_shorthand_syntax(self):
+        self.assert_not_contains('Shorthand Sytanx::')
+
+    def test_includes_note_about_document_types(self):
+        self.run_help()
+        self.assert_contains('uses document type values')
+
+    def test_does_not_include_note_if_no_document_types(self):
+        self.filter_params_in_model([])
+        self.assert_not_contains('uses document type values')
+
+    def test_annotates_as_document_type_for_input(self):
+        self.run_help()
+        self.assert_contains('``--doc-type-param`` (document)')
+
+    def test_annotates_as_document_type_for_output(self):
+        self.run_help()
+        self.assert_contains('DocTypeParam -> (document)')
+
+    def test_json_syntax_for_doc_type_argument(self):
+        self.filter_params_in_model(include_params=['DocTypeParam'])
+        self.run_help()
+        self.assert_has_document_value_in_json_syntax(
+            parameter='--doc-type-param')
+
+    def test_json_syntax_for_doc_type_in_list(self):
+        self.filter_params_in_model(include_params=['ListOfDocTypesParam'])
+        self.run_help()
+        self.assert_has_document_value_in_json_syntax(
+            parameter='--list-of-doc-types-param')
+
+    def test_json_syntax_for_doc_type_in_map(self):
+        self.filter_params_in_model(include_params=['MapOfDocTypesParam'])
+        self.run_help()
+        self.assert_has_document_value_in_json_syntax(
+            parameter='--map-of-doc-types-param')
+
+    def test_json_syntax_for_doc_type_in_nested_list(self):
+        self.filter_params_in_model(
+            include_params=['NestedListsOfDocTypesParam'])
+        self.run_help()
+        self.assert_has_document_value_in_json_syntax(
+            parameter='--nested-lists-of-doc-types-param')
+
+    def test_json_syntax_for_nested_doc_type(self):
+        self.filter_params_in_model(
+            include_params=['ModeledMixedWithDocTypeParam'])
+        self.run_help()
+        self.assert_text_order(
+            'JSON Syntax::',
+            '"DocType": {...},',
+            '"ListOfDocTypes": [',
+            '"MapOfDocTypes": {"string": {...}',
+            '"NestedListsOfDocTypes": [',
+            starting_from='--modeled-mixed-with-doc-type-param'
+        )
+
+    def test_shorthand_not_documented_for_doc_type_argument(self):
+        self.filter_params_in_model(include_params=['DocTypeParam'])
+        self.run_help()
+        self.assert_no_shorthand_syntax()
+
+    def test_shorthand_not_documented_for_doc_type_in_list(self):
+        self.filter_params_in_model(include_params=['ListOfDocTypesParam'])
+        self.run_help()
+        self.assert_no_shorthand_syntax()
+
+    def test_shorthand_not_documented_for_doc_type_in_map(self):
+        self.filter_params_in_model(include_params=['MapOfDocTypesParam'])
+        self.run_help()
+        self.assert_no_shorthand_syntax()
+
+    def test_shorthand_not_documented_for_doc_type_in_nested_list(self):
+        self.filter_params_in_model(
+            include_params=['NestedListsOfDocTypesParam'])
+        self.run_help()
+        self.assert_no_shorthand_syntax()
+
+    def test_documents_shorthand_for_only_modeled_members(self):
+        self.filter_params_in_model(
+            include_params=['ModeledMixedWithDocTypeParam'])
+        self.run_help()
+        self.assert_text_order(
+            'Shorthand Syntax::',
+            'StringMember=string',
+            starting_from='--modeled-mixed-with-doc-type-param'
+        )
+        self.assert_not_contains('DocTypeParam=')
+        self.assert_not_contains('ListOfDocTypesParam=')
+        self.assert_not_contains('MapOfDocTypesParam=')
+        self.assert_not_contains('NestedListsOfDocTypesParam=')

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -253,6 +253,7 @@ class TestParamShorthand(BaseArgProcessTest):
         bool_param = mock.Mock()
         bool_param.cli_type_name = 'boolean'
         bool_param.argument_model.type_name = 'boolean'
+        bool_param.argument_model.is_document_type = False
         self.assertTrue(unpack_cli_arg(bool_param, True))
         self.assertTrue(unpack_cli_arg(bool_param, 'True'))
         self.assertTrue(unpack_cli_arg(bool_param, 'true'))
@@ -449,61 +450,6 @@ class TestParamShorthand(BaseArgProcessTest):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue=""foo,bar"'])
         with self.assertRaisesRegexp(ParamError, error_msg):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue="foo,bar\''])
-
-
-class TestParamDocumentTypesShorthand(TestParamShorthand):
-    def setUp(self):
-        super(TestParamDocumentTypesShorthand, self).setUp()
-
-    def create_cli_argument(self, shapes):
-        service_name = 'foo'
-        service_model = model.ServiceModel({
-            'metadata': {
-                'endpointPrefix': 'bad',
-            },
-            'operations': {
-                'SampleOperation': {
-                    'name': 'SampleOperation',
-                    'input': {'shape': 'Input'}
-                }
-            },
-            'shapes': shapes
-        }, service_name)
-        operation_model = service_model.operation_model(
-            'SampleOperation')
-        argument_model = operation_model.input_shape.members['documentValue']
-        event_emitter = mock.Mock()
-        return  CLIArgument(argument_model.name, argument_model,
-                            operation_model, event_emitter)
-
-    def test_document_type_error(self):
-        service_name = 'foo'
-        shapes = {
-            'documentType': {
-                'type': 'structure',
-                'document': True
-            },
-            'Input': {
-                'type': 'structure',
-                'members': {
-                    'documentValue': {
-                        'shape': 'documentType',
-                        'documentation': 'foo'
-                    }
-                },
-            }
-        }
-        cls = self.create_cli_argument(shapes)
-        # TODO: Unable to match the full string
-        """
-        error_msg = ("Error parsing parameter '--documentType': "
-                     "Shorthand syntax not supported for document type input:"
-                     " ['foo=\"bar\",fizz=\"buzz\"']")
-        """
-        error_msg = ("Error parsing parameter '--documentType': "
-                     "Shorthand syntax not supported for document type input:")
-        with self.assertRaisesRegexp(ParamError, error_msg):
-            self.parse_shorthand(cls, ['foo="bar",fizz="buzz"'])
 
 
 class TestParamShorthandCustomArguments(BaseArgProcessTest):

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -130,6 +130,41 @@ class TestRecursiveShapes(unittest.TestCase):
         self.assert_rendered_docs_contain('None')
 
 
+class TestDocumentTypes(unittest.TestCase):
+    def setUp(self):
+        self.arg_table = {}
+        self.help_command = mock.Mock()
+        self.help_command.event_class = 'custom'
+        self.help_command.arg_table = self.arg_table
+        self.operation_model = mock.Mock()
+        self.operation_model.service_model.operation_names = []
+        self.help_command.obj = self.operation_model
+        self.operation_handler = OperationDocumentEventHandler(
+            self.help_command)
+
+    def assert_rendered_docs_contain(self, expected):
+        writes = [args[0][0] for args in
+                  self.help_command.doc.write.call_args_list]
+        writes = '\n'.join(writes)
+        self.assertIn(expected, writes)
+
+    def test_memberless_document_type_input(self):
+        shape_map = {
+            'documentType': {
+                'type': 'structure',
+                'document': True
+            }
+        }
+        shape = StructureShape('documentType', shape_map['documentType'],
+                               ShapeResolver(shape_map))
+
+        operation_model = mock.Mock()
+        operation_model.output_shape = shape
+        self.help_command.obj = operation_model
+        self.operation_handler.doc_output(self.help_command, 'event-name')
+        self.assert_rendered_docs_contain('None')
+
+
 class TestCLIDocumentEventHandler(unittest.TestCase):
     def setUp(self):
         self.session = mock.Mock()
@@ -340,6 +375,86 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         self.assertEqual(rendered.count('value -> (structure)'), 1)
         self.assertEqual(rendered.count('Nested_A -> (string)'), 2)
         self.assertEqual(rendered.count('Nested_B -> (string)'), 2)
+
+    def test_document_type(self):
+        shape_map = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'documentValue': {
+                        'shape': 'documentType'
+                    }
+                }
+            },
+            'documentType': {
+                'type': 'structure',
+                'document': True
+            }
+        }
+        shape = StructureShape('Input', shape_map['Input'],
+                               ShapeResolver(shape_map))
+        rendered = self.get_help_docs_for_argument(shape)
+        self.assertEqual(rendered.count('(structure)'), 0)
+        self.assertEqual(rendered.count('(document)'), 1)
+
+    def test_document_type_nested(self):
+        shape_map = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'UpperStruct': {
+                        'shape': 'NestedStruct'
+                    }
+                }
+            },
+            'NestedStruct':{
+                'type': 'structure',
+                'members':{
+                    'documentValue': {
+                        'shape': 'documentType'
+                    }
+                }
+            },
+            'documentType': {
+                'type': 'structure',
+                'document': True
+            }
+        }
+        shape = StructureShape('Input', shape_map['Input'],
+                               ShapeResolver(shape_map))
+        rendered = self.get_help_docs_for_argument(shape)
+        self.assertEqual(rendered.count('(structure)'), 1)
+        self.assertEqual(rendered.count('(document)'), 1)
+
+    def test_document_type_examples(self):
+        shape_map = {
+            'Input': {
+                'type': 'structure',
+                'members': {
+                    'documentValue': {
+                        'shape': 'documentType'
+                    }
+                }
+            },
+            'documentType': {
+                'type': 'structure',
+                'document': True
+            }
+        }
+        shape = StructureShape('Input', shape_map['Input'],
+                               ShapeResolver(shape_map))
+        help_command = self.create_help_command()
+        help_command.arg_table['arg-name'] =  mock.Mock(argument_model=shape)
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_option_example(
+        'arg-name', help_command, 'process-cli-arg.foo.bar')
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertIn(
+            'This value is an JSON document that can have arbitrary '
+            'content.\n    For more information on JSON document values '
+            'visit', rendered)
+        self.assertIn(
+            'Shorthand syntax not supported with documents', rendered)
 
     def test_description_only_for_crosslink_manpage(self):
         help_command = self.create_help_command()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -15,10 +15,15 @@ import platform
 import subprocess
 import os
 
+import botocore.model
+
 from awscli.testutils import unittest, skip_if_windows, mock
-from awscli.utils import (split_on_commas, ignore_ctrl_c,
-                          find_service_and_method_in_event_name,
-                          OutputStreamFactory)
+from awscli.utils import (
+    split_on_commas, ignore_ctrl_c, find_service_and_method_in_event_name,
+    is_document_type, is_document_type_container,
+    operation_uses_document_types, ShapeWalker, ShapeRecordingVisitor,
+    OutputStreamFactory
+)
 
 
 class TestCSVSplit(unittest.TestCase):
@@ -203,3 +208,203 @@ class TestOutputStreamFactory(unittest.TestCase):
                     pass
         except IOError:
             self.fail('Should not raise IOError')
+
+
+class BaseShapeTest(unittest.TestCase):
+    def setUp(self):
+        self.shapes = {}
+
+    def get_shape_model(self, shape_name):
+        shape_model = self.shapes[shape_name]
+        resolver = botocore.model.ShapeResolver(self.shapes)
+        shape_cls = resolver.SHAPE_CLASSES.get(
+            shape_model['type'], botocore.model.Shape
+        )
+        return shape_cls(shape_name, shape_model, resolver)
+
+    def get_doc_type_shape_definition(self):
+        return {
+            'type': 'structure',
+            'members': {},
+            'document': True
+        }
+
+
+class TestIsDocumentType(BaseShapeTest):
+    def test_is_document_type(self):
+        self.shapes['DocStructure'] = self.get_doc_type_shape_definition()
+        self.assertTrue(is_document_type(self.get_shape_model('DocStructure')))
+
+    def test_is_not_document_type_if_missing_document_trait(self):
+        self.shapes['NonDocStructure'] = {
+            'type': 'structure',
+            'members': {},
+        }
+        self.assertFalse(
+            is_document_type(self.get_shape_model('NonDocStructure'))
+        )
+
+    def test_is_not_document_type_if_not_structure(self):
+        self.shapes['String'] = {'type': 'string'}
+        self.assertFalse(is_document_type(self.get_shape_model('String')))
+
+
+class TestIsDocumentTypeContainer(BaseShapeTest):
+    def test_is_document_type_container_for_doc_type(self):
+        self.shapes['DocStructure'] = self.get_doc_type_shape_definition()
+        self.assertTrue(
+            is_document_type_container(self.get_shape_model('DocStructure'))
+        )
+
+    def test_is_not_document_type_container_if_missing_document_trait(self):
+        self.shapes['NonDocStructure'] = {
+            'type': 'structure',
+            'members': {},
+        }
+        self.assertFalse(
+            is_document_type_container(self.get_shape_model('NonDocStructure'))
+        )
+
+    def test_is_not_document_type_container_if_not_scalar(self):
+        self.shapes['String'] = {'type': 'string'}
+        self.assertFalse(
+            is_document_type_container(self.get_shape_model('String')))
+
+    def test_is_document_type_container_if_list_member(self):
+        self.shapes['ListOfDocTypes'] = {
+            'type': 'list',
+            'member': {'shape': 'DocType'}
+        }
+        self.shapes['DocType'] = self.get_doc_type_shape_definition()
+        self.assertTrue(
+            is_document_type_container(self.get_shape_model('ListOfDocTypes'))
+        )
+
+    def test_is_document_type_container_if_map_value(self):
+        self.shapes['MapOfDocTypes'] = {
+            'type': 'map',
+            'key': {'shape': 'String'},
+            'value': {'shape': 'DocType'}
+        }
+        self.shapes['DocType'] = self.get_doc_type_shape_definition()
+        self.shapes['String'] = {'type': 'string'}
+        self.assertTrue(
+            is_document_type_container(self.get_shape_model('MapOfDocTypes'))
+        )
+
+    def test_is_document_type_container_if_nested_list_member(self):
+        self.shapes['NestedListsOfDocTypes'] = {
+            'type': 'list',
+            'member': {'shape': 'ListOfDocTypes'}
+        }
+        self.shapes['ListOfDocTypes'] = {
+            'type': 'list',
+            'member': {'shape': 'DocType'}
+        }
+        self.shapes['DocType'] = self.get_doc_type_shape_definition()
+        self.assertTrue(
+            is_document_type_container(
+                self.get_shape_model('NestedListsOfDocTypes')
+            )
+        )
+
+
+class TestOperationUsesDocumentTypes(BaseShapeTest):
+    def setUp(self):
+        super(TestOperationUsesDocumentTypes, self).setUp()
+        self.input_shape_definition = {
+            'type': 'structure',
+            'members': {}
+        }
+        self.shapes['Input'] = self.input_shape_definition
+        self.output_shape_definition = {
+            'type': 'structure',
+            'members': {}
+        }
+        self.shapes['Output'] = self.output_shape_definition
+        self.operation_definition = {
+            'input': {'shape': 'Input'},
+            'output': {'shape': 'Output'}
+        }
+        self.service_model = botocore.model.ServiceModel(
+            {
+                'operations': {'DescribeResource': self.operation_definition},
+                'shapes': self.shapes
+            }
+        )
+        self.operation_model = self.service_model.operation_model(
+            'DescribeResource')
+
+    def test_operation_uses_document_types_if_doc_type_in_input(self):
+        self.shapes['DocType'] = self.get_doc_type_shape_definition()
+        self.input_shape_definition['members']['DocType'] = {
+            'shape': 'DocType'}
+        self.assertTrue(operation_uses_document_types(self.operation_model))
+
+    def test_operation_uses_document_types_if_doc_type_in_output(self):
+        self.shapes['DocType'] = self.get_doc_type_shape_definition()
+        self.output_shape_definition['members']['DocType'] = {
+            'shape': 'DocType'}
+        self.assertTrue(operation_uses_document_types(self.operation_model))
+
+    def test_operation_uses_document_types_is_false_when_no_doc_types(self):
+        self.assertFalse(operation_uses_document_types(self.operation_model))
+
+
+class TestShapeWalker(BaseShapeTest):
+    def setUp(self):
+        super(TestShapeWalker, self).setUp()
+        self.walker = ShapeWalker()
+        self.visitor = ShapeRecordingVisitor()
+
+    def assert_visited_shapes(self, expected_shape_names):
+        self.assertEqual(
+            expected_shape_names,
+            [shape.name for shape in self.visitor.visited]
+        )
+
+    def test_walk_scalar(self):
+        self.shapes['String'] = {'type': 'string'}
+        self.walker.walk(self.get_shape_model('String'), self.visitor)
+        self.assert_visited_shapes(['String'])
+
+    def test_walk_structure(self):
+        self.shapes['Structure'] = {
+            'type': 'structure',
+            'members': {
+                'String1': {'shape': 'String'},
+                'String2': {'shape': 'String'}
+            }
+        }
+        self.shapes['String'] = {'type': 'string'}
+        self.walker.walk(self.get_shape_model('Structure'), self.visitor)
+        self.assert_visited_shapes(['Structure', 'String', 'String'])
+
+    def test_walk_list(self):
+        self.shapes['List'] = {
+            'type': 'list',
+            'member': {'shape': 'String'}
+        }
+        self.shapes['String'] = {'type': 'string'}
+        self.walker.walk(self.get_shape_model('List'), self.visitor)
+        self.assert_visited_shapes(['List', 'String'])
+
+    def test_walk_map(self):
+        self.shapes['Map'] = {
+            'type': 'map',
+            'key': {'shape': 'String'},
+            'value': {'shape': 'String'}
+        }
+        self.shapes['String'] = {'type': 'string'}
+        self.walker.walk(self.get_shape_model('Map'), self.visitor)
+        self.assert_visited_shapes(['Map', 'String'])
+
+    def test_can_escape_recursive_shapes(self):
+        self.shapes['Recursive'] = {
+            'type': 'structure',
+            'members': {
+                'Recursive': {'shape': 'Recursive'},
+            }
+        }
+        self.walker.walk(self.get_shape_model('Recursive'), self.visitor)
+        self.assert_visited_shapes(['Recursive'])

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -392,12 +392,13 @@ class TestShapeWalker(BaseShapeTest):
     def test_walk_map(self):
         self.shapes['Map'] = {
             'type': 'map',
-            'key': {'shape': 'String'},
-            'value': {'shape': 'String'}
+            'key': {'shape': 'KeyString'},
+            'value': {'shape': 'ValueString'}
         }
-        self.shapes['String'] = {'type': 'string'}
+        self.shapes['KeyString'] = {'type': 'string'}
+        self.shapes['ValueString'] = {'type': 'string'}
         self.walker.walk(self.get_shape_model('Map'), self.visitor)
-        self.assert_visited_shapes(['Map', 'String'])
+        self.assert_visited_shapes(['Map', 'ValueString'])
 
     def test_can_escape_recursive_shapes(self):
         self.shapes['Recursive'] = {


### PR DESCRIPTION
*Description of changes:*

Introducing document type support. Changes made to help docs and error raised if short hand syntax is used with a document type input. Additional testing dependency and service modifications to test changes in theory: https://github.com/zdutta/botocore/tree/document-types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
