### PR TITLE
Add profile and role sorting to sso configure

### DIFF
--- a/.changes/next-release/enhancement-ssoconfigure-32569.json
+++ b/.changes/next-release/enhancement-ssoconfigure-32569.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``sso configure``",
+  "description": "Add sorting to accounts and roles `#6108 <https://github.com/aws/aws-cli/issues/6108>`__"
+}

--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -177,7 +177,10 @@ class ConfigureSSOCommand(BasicCommand):
             'There are {} AWS accounts available to you.\n'
         )
         uni_print(available_accounts_msg.format(len(accounts)))
-        selected_account = self._selector(accounts, display_account)
+        sorted_accounts = sorted(accounts, key=lambda x: (
+            'accountName' not in x, x.get('accountName',
+                                          x.get('accountId')).lower()))
+        selected_account = self._selector(sorted_accounts, display_account)
         sso_account_id = selected_account['accountId']
         return sso_account_id
 
@@ -207,7 +210,8 @@ class ConfigureSSOCommand(BasicCommand):
     def _handle_multiple_roles(self, roles):
         available_roles_msg = 'There are {} roles available to you.\n'
         uni_print(available_roles_msg.format(len(roles)))
-        role_names = [r['roleName'] for r in roles]
+        sorted_roles = sorted(roles, key=lambda x: x['roleName'].lower())
+        role_names = [r['roleName'] for r in sorted_roles]
         sso_role_name = self._selector(role_names)
         return sso_role_name
 

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -406,6 +406,61 @@ class TestConfigureSSOCommand(unittest.TestCase):
         ]
         self.assert_prompt_completions(expected_completions)
 
+    def test_account_list_sorted_by_name(self):
+        selected_account = {
+            'accountId': self.account_id,
+            'emailAddress': 'account@example.com',
+        }
+        first_account = {
+            'accountId': '1111111111',
+            'accountName': 'alpha',
+            'emailAddress': 'alpha@example.com'
+        }
+        second_account = {
+            'accountId': '2222222222',
+            'accountName': 'Bravo',
+            'emailAddress': 'Bravo@example.com'
+        }
+        third_account = {
+            'accountId': '3333333333',
+            'emailAddress': 'charlie@example.com'
+        }
+        accounts = [selected_account, second_account,
+                    third_account, first_account]
+        expected_accounts = [first_account,
+                             second_account, selected_account, third_account]
+        self._add_prompt_responses()
+        self._add_list_accounts_response(accounts)
+        self._add_list_account_roles_response([{'roleName': self.role_name}])
+        self.selector.side_effect = [selected_account]
+        with self.sso_stub:
+            self.configure_sso(args=[], parsed_globals=self.global_args)
+        printed_accounts = self.selector.call_args[0][0]
+        self.assertEqual(printed_accounts, expected_accounts)
+
+    def test_role_list_sorted_by_name(self):
+        selected_account = {
+            'accountId': self.account_id,
+            'emailAddress': 'account@example.com',
+        }
+        first_role = {'roleName': 'AdministratorAccess',
+                      'accountId': self.account_id}
+        second_role = {'roleName': 'DataScientist',
+                       'accountId': self.account_id}
+        third_role = {'roleName': 'SystemAdministrator',
+                      'accountId': self.account_id}
+        roles = [second_role, third_role, first_role]
+        expected_roles = [first_role['roleName'],
+                          second_role['roleName'], third_role['roleName']]
+        self._add_prompt_responses()
+        self._add_list_accounts_response([selected_account])
+        self._add_list_account_roles_response(roles)
+        self.selector.side_effect = [selected_account]
+        with self.sso_stub:
+            self.configure_sso(args=[], parsed_globals=self.global_args)
+        printed_roles = self.selector.call_args[0][0]
+        self.assertEqual(printed_roles, expected_roles)
+
 
 class TestDisplayAccount(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:*
Closes #6108

*Description of changes:*
This change adds sorting to profiles and roles when running `aws sso configure` listing them in ascending alphabetical order by default (case insensitive).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
