### PR TITLE
Fix unexecuted test: "test_multiple_calls_present"

### DIFF
--- a/tests/functional/history/test_list.py
+++ b/tests/functional/history/test_list.py
@@ -78,12 +78,12 @@ class TestListCommand(BaseHistoryCommandParamsTest):
                 "Arn": "arn:aws:iam::1234567:user/baz"
             }
         ]
-        _, _, rc = self.run_cmd('ec2 describe-instances', expected_rc=0)
+        _, _, rc = self.run_cmd('ec2 describe-regions', expected_rc=0)
         self.history_recorder.record('CLI_RC', rc, 'CLI')
         _, _, rc = self.run_cmd('sts get-caller-identity', expected_rc=0)
         self.history_recorder.record('CLI_RC', rc, 'CLI')
         self.run_cmd('history list', expected_rc=0)
-        self.assertIn(b'ec2 describe-instances',
+        self.assertIn(b'ec2 describe-regions',
                       self.binary_stdout.getvalue())
         self.assertIn(b'sts get-caller-identity',
                       self.binary_stdout.getvalue())

--- a/tests/functional/history/test_list.py
+++ b/tests/functional/history/test_list.py
@@ -61,6 +61,7 @@ class TestListCommand(BaseHistoryCommandParamsTest):
         self.history_recorder.record('CLI_RC', rc, 'CLI')
         self.run_cmd('history list', expected_rc=0)
         self.assertIn(b'ec2 describe-regions', self.binary_stdout.getvalue())
+
     def test_multiple_calls_present(self):
         self.parsed_responses = [
             {

--- a/tests/functional/history/test_list.py
+++ b/tests/functional/history/test_list.py
@@ -61,28 +61,28 @@ class TestListCommand(BaseHistoryCommandParamsTest):
         self.history_recorder.record('CLI_RC', rc, 'CLI')
         self.run_cmd('history list', expected_rc=0)
         self.assertIn(b'ec2 describe-regions', self.binary_stdout.getvalue())
-        def test_multiple_calls_present(self):
-            self.parsed_responses = [
-                {
-                    "Regions": [
-                        {
-                            "Endpoint": "ec2.ap-south-1.amazonaws.com",
-                            "RegionName": "ap-south-1"
-                        },
-                    ]
-                },
-                {
-                    "UserId": "foo",
-                    "Account": "bar",
-                    "Arn": "arn:aws:iam::1234567:user/baz"
-                }
-            ]
-            _, _, rc = self.run_cmd('ec2 describe-instances', expected_rc=0)
-            self.history_recorder.record('CLI_RC', rc, 'CLI')
-            _, _, rc = self.run_cmd('sts get-caller-identity', expected_rc=0)
-            self.history_recorder.record('CLI_RC', rc, 'CLI')
-            self.run_cmd('history list', expected_rc=0)
-            self.assertIn(b'ec2 describe-regions',
-                          self.binary_stdout.getvalue())
-            self.assertIn(b'sts get-caller-identity',
-                          self.binary_stdout.getvalue())
+    def test_multiple_calls_present(self):
+        self.parsed_responses = [
+            {
+                "Regions": [
+                    {
+                        "Endpoint": "ec2.ap-south-1.amazonaws.com",
+                        "RegionName": "ap-south-1"
+                    },
+                ]
+            },
+            {
+                "UserId": "foo",
+                "Account": "bar",
+                "Arn": "arn:aws:iam::1234567:user/baz"
+            }
+        ]
+        _, _, rc = self.run_cmd('ec2 describe-instances', expected_rc=0)
+        self.history_recorder.record('CLI_RC', rc, 'CLI')
+        _, _, rc = self.run_cmd('sts get-caller-identity', expected_rc=0)
+        self.history_recorder.record('CLI_RC', rc, 'CLI')
+        self.run_cmd('history list', expected_rc=0)
+        self.assertIn(b'ec2 describe-instances',
+                      self.binary_stdout.getvalue())
+        self.assertIn(b'sts get-caller-identity',
+                      self.binary_stdout.getvalue())


### PR DESCRIPTION
*Issue*

Test `test_multiple_calls_present` is never executed because of a bad indent: the test is considered as an inner function of `test_show_one_call_present`.

*Description of changes:*

The `test_multiple_calls_present` indent is fixed to bring it back as a method instead of an inner class.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
