### PR TITLE
AWSDocs fixed IVS example typo

### DIFF
--- a/awscli/examples/ivs/create-recording-configuration.rst
+++ b/awscli/examples/ivs/create-recording-configuration.rst
@@ -4,7 +4,7 @@ The following ``create-recording-configuration`` example creates RecordingConfig
 
     aws ivs create-recording-configuration \
         --name test-recording-config \
-        --destination-configuration 3={bucketName=demo-recording-bucket}
+        --destination-configuration S3={bucketName=demo-recording-bucket}
 
 Output::
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
