### PR TITLE
[v2] Display error message when unable to open pager

### DIFF
--- a/.changes/next-release/bugfix-Pager-49643.json
+++ b/.changes/next-release/bugfix-Pager-49643.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Pager",
+  "description": "Display error message when unable to open pager. Fixes `#6225 <https://github.com/aws/aws-cli/issues/6225>`__"
+}

--- a/awscli/errorhandler.py
+++ b/awscli/errorhandler.py
@@ -25,6 +25,7 @@ from awscli.constants import (
     PARAM_VALIDATION_ERROR_RC, CONFIGURATION_ERROR_RC, CLIENT_ERROR_RC,
     GENERAL_ERROR_RC
 )
+from awscli.utils import PagerInitializationException
 from awscli.autoprompt.factory import PrompterKeyboardInterrupt
 from awscli.customizations.exceptions import (
     ParamValidationError, ConfigurationError
@@ -51,6 +52,7 @@ def construct_cli_error_handlers_chain():
         ConfigurationErrorHandler(),
         NoRegionErrorHandler(),
         NoCredentialsErrorHandler(),
+        PagerErrorHandler(),
         InterruptExceptionHandler(),
         ClientErrorHandler(),
         GeneralExceptionHandler()
@@ -113,6 +115,17 @@ class NoCredentialsErrorHandler(FilteredExceptionHandler):
     EXCEPTIONS_TO_HANDLE = NoCredentialsError
     RC = CONFIGURATION_ERROR_RC
     MESSAGE = '%s. You can configure credentials by running "aws configure".'
+
+
+class PagerErrorHandler(FilteredExceptionHandler):
+    EXCEPTIONS_TO_HANDLE = PagerInitializationException
+    RC = CONFIGURATION_ERROR_RC
+    MESSAGE = (
+        'Unable to redirect output to pager. Received the '
+        'following error when opening pager:\n%s\n\n'
+        'Learn more about configuring the output pager by running '
+        '"aws help config-vars".'
+    )
 
 
 class UnknownArgumentErrorHandler(FilteredExceptionHandler):

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -183,6 +183,14 @@ class TestOutput(BaseAWSCommandParamsTest):
             expected_less_flags='S'
         )
 
+    def test_raises_exception_when_pager_cannot_be_opened(self):
+        self.environ['AWS_PAGER'] = 'no-exists'
+        pager_error_message = 'Cannot open no-exists'
+        self.mock_popen.side_effect = FileNotFoundError(pager_error_message)
+        _, stderr, _ = self.run_cmd(self.cmdline, expected_rc=253)
+        self.assertIn('Unable to redirect output to pager', stderr)
+        self.assertIn(pager_error_message, stderr)
+
 
 class TestYAMLStream(BaseAWSCommandParamsTest):
     def assert_yaml_response_equal(self, response, expected):


### PR DESCRIPTION
When logic was added to lazily open the pager based on if there was output from a CLI command (https://github.com/aws/aws-cli/pull/6117), it introduced new behavior where no output would be displayed if the pager could not be opened as a subprocess. This is because the popen call on the pager was now happening under the same try/except blocks that suppressed `IOError`'s related to the output stream closing prematurely, and `IOError` is also a parent class for the `FileNotFoundError` that is thrown when the pager cannot be opened.

To fix this issue, the `FileNotFoundError` is converted to a new custom error that allows us to control both the error message and return code. However, it still does not propagate the command output that would have been sent to the pager. In the future, we should consider adding extra logic that prints both a warning message that the pager cannot be opened and the output that would have been sent to the pager. However, that would likely require a larger refactor.


Prior to versions 2.2.x, the behavior for the pager being unavailable was:
```
$ AWS_PAGER=no-exist aws sts get-caller-identity

[Errno 2] No such file or directory: 'no-exist'
/tmp$ echo $?
255
```
With this change, it make it consistent with the behavior from versions less than 2.2.x, but includes a better error message and more appropriate return code (`253` for invalid configuration):
```
$ AWS_PAGER="no-exists" aws sts get-caller-identity

Unable to redirect output to pager. Received the following error when opening pager:
[Errno 2] No such file or directory: 'no-exists': 'no-exists'

Learn more about configuring the output pager by running "aws help config-vars".

$ echo $?
253
```
Also note that the Windows was never affected by the regression as it does not raise an error when the popen object is instantiated, but rather propagates errors through stderr/returncode when `communicate()` is called on the the popen object:
```
> aws ec2 describe-regions
'no-exist' is not recognized as an internal or external command,
operable program or batch file.
```
It would be interesting if we could improve the error message here but that would require relying solely on the return code of the subprocess to make assumptions on if the pager failed to be opened (right now it is `1` when the pager is not available). However, I'm not sure if that is a reliable assumption to make and would need to do more research regarding return codes of pagers.

Fixes https://github.com/aws/aws-cli/issues/6225
