### PR TITLE
Mention to redact sensitive information

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -28,5 +28,7 @@ A clear and concise description of what you expected to happen.
 **Logs/output**
 Get full traceback and error logs by adding `--debug` to the command.
 
+*Important!!! Be sure to redact sensitive information like account numbers, ARNs, etc.*
+
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Create Issue template should mention that you should redact sensitive information from the `--debug` output. I accidentally leaked a secret earlier because I didn't realize this option would produce sensitive information.

This updates it to match the equivalent line in the `---signaturedoesnotmatch-error.md` file.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
