### PR TITLE
raise SessionManagerPlugin is not found even if terminate session failed

### DIFF
--- a/awscli/customizations/sessionmanager.py
+++ b/awscli/customizations/sessionmanager.py
@@ -98,5 +98,8 @@ class StartSessionCaller(CLIOperationCaller):
                 # is called so that service and ssm-agent terminates the
                 # session to avoid zombie session active on ssm-agent for
                 # default self terminate time
-                client.terminate_session(SessionId=session_id)
+                try:
+                    client.terminate_session(SessionId=session_id)
+                except Exception as e:
+                    logger.debug('Error processing terminate session: %s', e)
                 raise ValueError(''.join(ERROR_MESSAGE))


### PR DESCRIPTION
## *Issue*

When not installing `session-manager-plugin` and failed to call ssm:TerminateSession, users see only following logs.

```
botocore.exceptions.ClientError: An error occurred (AccessDeniedExceptio) when calling the TerminateSession operation:
```

## *Description of changes:*

Users want to know `SessionManagerPlugin is not found` error. So change the raising error when failing terminate-session.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
