### PR TITLE
Add documentation for the default timeout values.

### DIFF
--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -58,12 +58,12 @@
         "cli-read-timeout": {
             "dest": "read_timeout",
             "type": "int",
-            "help": "<p>The maximum socket read time in seconds. If the value is set to 0, the socket read will be blocking and not timeout.</p>"
+            "help": "<p>The maximum socket read time in seconds. If the value is set to 0, the socket read will be blocking and not timeout. The default value is 60 seconds.</p>"
         },
         "cli-connect-timeout": {
             "dest": "connect_timeout",
             "type": "int",
-            "help": "<p>The maximum socket connect time in seconds. If the value is set to 0, the socket connect will be blocking and not timeout.</p>"
+            "help": "<p>The maximum socket connect time in seconds. If the value is set to 0, the socket connect will be blocking and not timeout. The default value is 60 seconds.</p>"
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

#6277 

*Description of changes:*

Update docstring for timeout values. This puts it in line with the documentation for `botocore`:

https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html#botocore-config


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
