### PR TITLE
[customizations/eks]: Update credential API version

### DIFF
--- a/.changes/next-release/enhancement-eks-98667.json
+++ b/.changes/next-release/enhancement-eks-98667.json
@@ -1,0 +1,5 @@
+{
+  "category": "eks", 
+  "type": "enhancement", 
+  "description": "Updated Kubernetes client authentication API version"
+}

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -74,7 +74,7 @@ class GetTokenCommand(BasicCommand):
 
         full_object = {
             "kind": "ExecCredential",
-            "apiVersion": "client.authentication.k8s.io/v1alpha1",
+            "apiVersion": "client.authentication.k8s.io/v1beta1",
             "spec": {},
             "status": {
                 "expirationTimestamp": token_expiration,

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -34,7 +34,7 @@ DEFAULT_PATH = os.path.expanduser("~/.kube/config")
 # Use the endpoint for kubernetes 1.10
 # To get the most recent endpoint we will need to
 # Do a check on the cluster's version number
-API_VERSION = "client.authentication.k8s.io/v1alpha1"
+API_VERSION = "client.authentication.k8s.io/v1beta1"
 
 class UpdateKubeconfigCommand(BasicCommand):
     NAME = 'update-kubeconfig'

--- a/awscli/examples/eks/get-token.rst
+++ b/awscli/examples/eks/get-token.rst
@@ -10,7 +10,7 @@ Output::
 
   {
     "kind": "ExecCredential",
-    "apiVersion": "client.authentication.k8s.io/v1alpha1",
+    "apiVersion": "client.authentication.k8s.io/v1beta1",
     "spec": {},
     "status": {
       "expirationTimestamp": "2019-08-14T18:44:27Z",

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -72,7 +72,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             response,
             {
                 "kind": "ExecCredential",
-                "apiVersion": "client.authentication.k8s.io/v1alpha1",
+                "apiVersion": "client.authentication.k8s.io/v1beta1",
                 "spec": {},
                 "status": {
                     "expirationTimestamp": "2019-10-23T23:14:00Z",

--- a/tests/functional/eks/testdata/invalid_string_cluster_entry
+++ b/tests/functional/eks/testdata/invalid_string_cluster_entry
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/invalid_string_clusters
+++ b/tests/functional/eks/testdata/invalid_string_clusters
@@ -12,7 +12,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/invalid_string_context_entry
+++ b/tests/functional/eks/testdata/invalid_string_context_entry
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/invalid_string_contexts
+++ b/tests/functional/eks/testdata/invalid_string_contexts
@@ -12,7 +12,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/output_combined
+++ b/tests/functional/eks/testdata/output_combined
@@ -24,7 +24,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2
@@ -36,7 +36,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - region

--- a/tests/functional/eks/testdata/output_combined_changed_ordering
+++ b/tests/functional/eks/testdata/output_combined_changed_ordering
@@ -2,7 +2,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2
@@ -14,7 +14,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - region

--- a/tests/functional/eks/testdata/output_single
+++ b/tests/functional/eks/testdata/output_single
@@ -16,7 +16,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - region

--- a/tests/functional/eks/testdata/valid_bad_cluster
+++ b/tests/functional/eks/testdata/valid_bad_cluster
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_cluster2
+++ b/tests/functional/eks/testdata/valid_bad_cluster2
@@ -15,7 +15,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_context
+++ b/tests/functional/eks/testdata/valid_bad_context
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_context2
+++ b/tests/functional/eks/testdata/valid_bad_context2
@@ -15,7 +15,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_user
+++ b/tests/functional/eks/testdata/valid_bad_user
@@ -15,7 +15,7 @@ preferences: {}
 users:
 - user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_changed_ordering
+++ b/tests/functional/eks/testdata/valid_changed_ordering
@@ -2,7 +2,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_existing
+++ b/tests/functional/eks/testdata/valid_existing
@@ -16,7 +16,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_no_cluster
+++ b/tests/functional/eks/testdata/valid_no_cluster
@@ -11,7 +11,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_no_context
+++ b/tests/functional/eks/testdata/valid_no_context
@@ -11,7 +11,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_no_current_context
+++ b/tests/functional/eks/testdata/valid_no_current_context
@@ -15,7 +15,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_old_data
+++ b/tests/functional/eks/testdata/valid_old_data
@@ -24,7 +24,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - --region
       - us-west-2
@@ -36,7 +36,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       args:
       - token
       - -i


### PR DESCRIPTION
Kubernetes has deprecated v1alpha1, v1beta1 has been available since Kubernetes
v1.11 (kubernetes/kubernetes#64482), and EKS currently supports Kubernetes
versions v1.16 through v1.21. This is a breaking change for clients running
versions v1.10 and older, which haven't been supported by EKS since September
2019.

Signed-off-by: Micah Hausler <mhausler@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*

Update Kubernetes client authentication API version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
