### PR TITLE
[v2] Add support for IMDS endpoint configuration

### DIFF
--- a/.changes/next-release/enhancement-IMDS-74079.json
+++ b/.changes/next-release/enhancement-IMDS-74079.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "IMDS",
+  "description": "Add support for configuring IMDS endpoint for region resolution via ``ec2_metadata_service_endpoint`` config option and ``AWS_EC2_METADATA_SERVICE_ENDPOINT`` environment variable."
+}

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -130,6 +130,8 @@ class IMDSRegionProvider(BaseProvider):
         metadata_num_attempts = self._session.get_config_variable(
             'metadata_service_num_attempts')
         imds_config = {
+            'ec2_metadata_service_endpoint': self._session.get_config_variable(
+                'ec2_metadata_service_endpoint'),
             'ec2_metadata_service_endpoint_mode': resolve_imds_endpoint_mode(
                 self._session
             )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -518,6 +518,28 @@ class TestIMDSRegionProvider(unittest.TestCase):
         args, _ = send.call_args
         self.assertIn('[fd00:ec2::254]', args[0].url)
 
+    @mock.patch('botocore.httpsession.URLLib3Session.send')
+    def test_can_set_imds_service_endpoint(self, send):
+        driver = create_clidriver()
+        driver.session.set_config_variable(
+            'ec2_metadata_service_endpoint', 'http://myendpoint/')
+        provider = IMDSRegionProvider(driver.session)
+        provider.provide()
+        args, _ = send.call_args
+        self.assertIn('http://myendpoint/', args[0].url)
+
+    @mock.patch('botocore.httpsession.URLLib3Session.send')
+    def test_imds_service_endpoint_overrides_ipv6_endpoint(self, send):
+        driver = create_clidriver()
+        driver.session.set_config_variable(
+            'ec2_metadata_service_endpoint_mode', 'ipv6')
+        driver.session.set_config_variable(
+            'ec2_metadata_service_endpoint', 'http://myendpoint/')
+        provider = IMDSRegionProvider(driver.session)
+        provider.provide()
+        args, _ = send.call_args
+        self.assertIn('http://myendpoint/', args[0].url)
+
 
 class TestLazyPager(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This was previously only supported for retrieving IMDS credentials and now is extended for region resolution via IMDS. This is this PR where it was added to botocore's credential resolver: https://github.com/boto/botocore/pull/2179 but it never got plumbed into the IMDS region resolver.

