### PR TITLE
Revert "[customizations/eks]: Update credential API version"

### DIFF
--- a/.changes/next-release/bugfix-EKS-22364.json
+++ b/.changes/next-release/bugfix-EKS-22364.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``eks``",
+  "description": "Fixes `#6308 <https://github.com/aws/aws-cli/issues/6308>`__ version mismatch running eks get-login without eks update-config"
+}

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -74,7 +74,7 @@ class GetTokenCommand(BasicCommand):
 
         full_object = {
             "kind": "ExecCredential",
-            "apiVersion": "client.authentication.k8s.io/v1beta1",
+            "apiVersion": "client.authentication.k8s.io/v1alpha1",
             "spec": {},
             "status": {
                 "expirationTimestamp": token_expiration,

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -34,7 +34,7 @@ DEFAULT_PATH = os.path.expanduser("~/.kube/config")
 # Use the endpoint for kubernetes 1.10
 # To get the most recent endpoint we will need to
 # Do a check on the cluster's version number
-API_VERSION = "client.authentication.k8s.io/v1beta1"
+API_VERSION = "client.authentication.k8s.io/v1alpha1"
 
 class UpdateKubeconfigCommand(BasicCommand):
     NAME = 'update-kubeconfig'

--- a/awscli/examples/eks/get-token.rst
+++ b/awscli/examples/eks/get-token.rst
@@ -10,7 +10,7 @@ Output::
 
   {
     "kind": "ExecCredential",
-    "apiVersion": "client.authentication.k8s.io/v1beta1",
+    "apiVersion": "client.authentication.k8s.io/v1alpha1",
     "spec": {},
     "status": {
       "expirationTimestamp": "2019-08-14T18:44:27Z",

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -72,7 +72,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             response,
             {
                 "kind": "ExecCredential",
-                "apiVersion": "client.authentication.k8s.io/v1beta1",
+                "apiVersion": "client.authentication.k8s.io/v1alpha1",
                 "spec": {},
                 "status": {
                     "expirationTimestamp": "2019-10-23T23:14:00Z",

--- a/tests/functional/eks/testdata/invalid_string_cluster_entry
+++ b/tests/functional/eks/testdata/invalid_string_cluster_entry
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/invalid_string_clusters
+++ b/tests/functional/eks/testdata/invalid_string_clusters
@@ -12,7 +12,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/invalid_string_context_entry
+++ b/tests/functional/eks/testdata/invalid_string_context_entry
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/invalid_string_contexts
+++ b/tests/functional/eks/testdata/invalid_string_contexts
@@ -12,7 +12,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/output_combined
+++ b/tests/functional/eks/testdata/output_combined
@@ -24,7 +24,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2
@@ -36,7 +36,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - region

--- a/tests/functional/eks/testdata/output_combined_changed_ordering
+++ b/tests/functional/eks/testdata/output_combined_changed_ordering
@@ -2,7 +2,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2
@@ -14,7 +14,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - region

--- a/tests/functional/eks/testdata/output_single
+++ b/tests/functional/eks/testdata/output_single
@@ -16,7 +16,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - region

--- a/tests/functional/eks/testdata/valid_bad_cluster
+++ b/tests/functional/eks/testdata/valid_bad_cluster
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_cluster2
+++ b/tests/functional/eks/testdata/valid_bad_cluster2
@@ -15,7 +15,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_context
+++ b/tests/functional/eks/testdata/valid_bad_context
@@ -13,7 +13,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_context2
+++ b/tests/functional/eks/testdata/valid_bad_context2
@@ -15,7 +15,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_bad_user
+++ b/tests/functional/eks/testdata/valid_bad_user
@@ -15,7 +15,7 @@ preferences: {}
 users:
 - user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_changed_ordering
+++ b/tests/functional/eks/testdata/valid_changed_ordering
@@ -2,7 +2,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_existing
+++ b/tests/functional/eks/testdata/valid_existing
@@ -16,7 +16,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_no_cluster
+++ b/tests/functional/eks/testdata/valid_no_cluster
@@ -11,7 +11,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_no_context
+++ b/tests/functional/eks/testdata/valid_no_context
@@ -11,7 +11,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_no_current_context
+++ b/tests/functional/eks/testdata/valid_no_current_context
@@ -15,7 +15,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2

--- a/tests/functional/eks/testdata/valid_old_data
+++ b/tests/functional/eks/testdata/valid_old_data
@@ -24,7 +24,7 @@ users:
 - name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - --region
       - us-west-2
@@ -36,7 +36,7 @@ users:
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
+      apiVersion: client.authentication.k8s.io/v1alpha1
       args:
       - token
       - -i


### PR DESCRIPTION
Reverts aws/aws-cli#6289 in response to #6308. This will migrate back to the previous usage of the v1alpha1 endpoint