### PR TITLE
[v2] Bump CRT dependency to match botocore v2 branch

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ requires_dist =
         wcwidth<0.2.0
         prompt-toolkit>=2.0.0,<3.0.0
         distro>=1.5.0,<1.6.0
-        awscrt==0.11.13
+        awscrt==0.11.24
 
 
 [check-manifest]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requires = [
     'wcwidth<0.2.0',
     'prompt-toolkit>=2.0.0,<3.0.0',
     'distro>=1.5.0,<1.6.0',
-    'awscrt==0.11.13',
+    'awscrt==0.11.24',
 ]
 
 


### PR DESCRIPTION
Corresponds to the inclusion of CRT in the botocore `v2` branch: https://github.com/boto/botocore/pull/2417
