### PR TITLE
Replace deprecated unittest aliases

### DIFF
--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -54,8 +54,8 @@ class TestPackageZipFiles(TestCase):
         # Now verify that the zipfile includes contents of the data file we created
         myzip = zipfile.ZipFile(zipfile_path)
         # Data file should be the only file within the zip
-        self.assertEquals(["data-link.txt"], myzip.namelist())
+        self.assertEqual(["data-link.txt"], myzip.namelist())
         myfile = myzip.open("data-link.txt", "r")
 
         # Its content should be equal the value we wrote.
-        self.assertEquals(data.encode("utf-8"), myfile.read())
+        self.assertEqual(data.encode("utf-8"), myfile.read())

--- a/tests/functional/ecr/test_get_login.py
+++ b/tests/functional/ecr/test_get_login.py
@@ -33,7 +33,7 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
         stdout = self.run_cmd("ecr get-login")[0]
         self.assertIn(
             'docker login -u foo -p bar -e none 1235.ecr.us-east-1.io', stdout)
-        self.assertEquals(1, len(self.operations_called))
+        self.assertEqual(1, len(self.operations_called))
         self.assertNotIn('registryIds', self.operations_called[0][1])
 
     def test_prints_login_command_with_no_email(self):
@@ -68,6 +68,6 @@ class TestGetLoginCommand(BaseAWSCommandParamsTest):
         self.assertIn(
             'docker login -u abc -p 123 -e none 4567.ecr.us-east-1.io\n',
             stdout)
-        self.assertEquals(1, len(self.operations_called))
-        self.assertEquals([u'1234', u'5678'],
+        self.assertEqual(1, len(self.operations_called))
+        self.assertEqual([u'1234', u'5678'],
                           self.operations_called[0][1]['registryIds'])

--- a/tests/functional/ecr/test_get_login_password.py
+++ b/tests/functional/ecr/test_get_login_password.py
@@ -32,4 +32,4 @@ class TestGetLoginPasswordCommand(BaseAWSCommandParamsTest):
     def test_prints_login_password(self):
         stdout = self.run_cmd("ecr get-login-password")[0]
         self.assertIn('bar', stdout)
-        self.assertEquals(1, len(self.operations_called))
+        self.assertEqual(1, len(self.operations_called))

--- a/tests/functional/ecr_public/test_get_login_password.py
+++ b/tests/functional/ecr_public/test_get_login_password.py
@@ -29,4 +29,4 @@ class TestGetLoginPasswordCommand(BaseAWSCommandParamsTest):
     def test_prints_login_password(self):
         stdout = self.run_cmd("ecr-public get-login-password")[0]
         self.assertIn('bar', stdout)
-        self.assertEquals(1, len(self.operations_called))
+        self.assertEqual(1, len(self.operations_called))

--- a/tests/functional/iot/test_outfile.py
+++ b/tests/functional/iot/test_outfile.py
@@ -39,7 +39,7 @@ class TestOutFileQueryArguments(BaseAWSCommandParamsTest):
         self.run_cmd(cmdline, 0)
         self.assertTrue(os.path.exists(outfile))
         with open(outfile) as fp:
-            self.assertEquals('cert...', fp.read())
+            self.assertEqual('cert...', fp.read())
 
     def test_saves_files_for_create_keys_and_cert(self):
         self.parsed_response = {
@@ -65,11 +65,11 @@ class TestOutFileQueryArguments(BaseAWSCommandParamsTest):
         self.assertTrue(os.path.exists(out_pub))
         self.assertTrue(os.path.exists(out_priv))
         with open(out_cert) as fp:
-            self.assertEquals('cert...', fp.read())
+            self.assertEqual('cert...', fp.read())
         with open(out_pub) as fp:
-            self.assertEquals('public', fp.read())
+            self.assertEqual('public', fp.read())
         with open(out_priv) as fp:
-            self.assertEquals('private', fp.read())
+            self.assertEqual('private', fp.read())
 
     def test_bad_response(self):
         outfile = self.files.full_path('cert.pem')

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -64,12 +64,12 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
-        self.assertEquals(
+        self.assertEqual(
             ('username=foo\n'
              'password=20101008T000000Z'
              '7dc259e2d505af354a1219b9bcd784bd384dc706efa0d9aefc571f214be4c89c'),
              output)
-        self.assertEquals(0, rc)
+        self.assertEqual(0, rc)
 
     @patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
     @patch('sys.stdout', new_callable=StringIOWithFileNo)
@@ -79,12 +79,12 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
-        self.assertEquals(
+        self.assertEqual(
             ('username=foo\n'
              'password=20101008T000000Z'
              '500037cb3514b3fe01ebcda7c80973f5b4c0d8199a7a6563b85fd6edf272d460'),
              output)
-        self.assertEquals(0, rc)
+        self.assertEqual(0, rc)
 
     @patch('sys.stdin', StringIO(VPC_PROTOCOL_HOST_PATH))
     @patch('sys.stdout', new_callable=StringIOWithFileNo)
@@ -94,12 +94,12 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
-        self.assertEquals(
+        self.assertEqual(
             ('username=foo\n'
              'password=20101008T000000Z'
              '9ed987cc6336c3de2d9f06b9236c7a9fd76b660b080db15983290e636dbfbd6b'),
              output)
-        self.assertEquals(0, rc)
+        self.assertEqual(0, rc)
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -259,7 +259,7 @@ class TestArtifactExporter(unittest.TestCase):
                                   object_key_property="Key",
                                   version_property="VersionId")
 
-            self.assertEquals(result, config["result"])
+            self.assertEqual(result, config["result"])
 
         for url in invalid:
             with self.assertRaises(ValueError):
@@ -296,7 +296,7 @@ class TestArtifactExporter(unittest.TestCase):
                                             property_name,
                                             parent_dir,
                                             self.s3_uploader_mock)
-            self.assertEquals(result, expected_s3_url)
+            self.assertEqual(result, expected_s3_url)
 
             # Internally the method would convert relative paths to absolute
             # path, with respect to the parent directory
@@ -325,7 +325,7 @@ class TestArtifactExporter(unittest.TestCase):
                                             property_name,
                                             parent_dir,
                                             self.s3_uploader_mock)
-            self.assertEquals(result, expected_s3_url)
+            self.assertEqual(result, expected_s3_url)
 
             self.s3_uploader_mock.upload_with_dedup.assert_called_with(artifact_path)
             zip_and_upload_mock.assert_not_called()
@@ -349,7 +349,7 @@ class TestArtifactExporter(unittest.TestCase):
                                             property_name,
                                             parent_dir,
                                             Mock())
-            self.assertEquals(result, expected_s3_url)
+            self.assertEqual(result, expected_s3_url)
 
             absolute_artifact_path = make_abs_path(parent_dir, artifact_path)
 
@@ -373,7 +373,7 @@ class TestArtifactExporter(unittest.TestCase):
                                         property_name,
                                         parent_dir,
                                         self.s3_uploader_mock)
-        self.assertEquals(result, expected_s3_url)
+        self.assertEqual(result, expected_s3_url)
 
         zip_and_upload_mock.assert_called_once_with(parent_dir, mock.ANY)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
@@ -394,7 +394,7 @@ class TestArtifactExporter(unittest.TestCase):
                                         property_name,
                                         parent_dir,
                                         self.s3_uploader_mock)
-        self.assertEquals(result, object_s3_url)
+        self.assertEqual(result, object_s3_url)
 
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
@@ -462,7 +462,7 @@ class TestArtifactExporter(unittest.TestCase):
                                                             parent_dir,
                                                             self.s3_uploader_mock)
 
-        self.assertEquals(resource_dict[resource.PROPERTY_NAME], s3_url)
+        self.assertEqual(resource_dict[resource.PROPERTY_NAME], s3_url)
 
     @patch("shutil.rmtree")
     @patch("zipfile.is_zipfile")
@@ -596,7 +596,7 @@ class TestArtifactExporter(unittest.TestCase):
                                                             resource.PROPERTY_NAME,
                                                             parent_dir,
                                                             self.s3_uploader_mock)
-        self.assertEquals(resource_dict[resource.PROPERTY_NAME], s3_url)
+        self.assertEqual(resource_dict[resource.PROPERTY_NAME], s3_url)
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_property_value_dict(self, upload_local_artifacts_mock):
@@ -617,7 +617,7 @@ class TestArtifactExporter(unittest.TestCase):
         resource_dict[resource.PROPERTY_NAME] = {"a": "b"}
         resource.export(resource_id, resource_dict, parent_dir)
         upload_local_artifacts_mock.assert_not_called()
-        self.assertEquals(resource_dict, {"foo": {"a": "b"}})
+        self.assertEqual(resource_dict, {"foo": {"a": "b"}})
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_has_package_null_property_to_false(self, upload_local_artifacts_mock):
@@ -693,7 +693,7 @@ class TestArtifactExporter(unittest.TestCase):
                                                             parent_dir,
                                                             self.s3_uploader_mock)
 
-        self.assertEquals(resource_dict[resource.PROPERTY_NAME], {
+        self.assertEqual(resource_dict[resource.PROPERTY_NAME], {
             "b": "bucket",
             "o": "key1/key2",
             "v": "SomeVersionNumber"
@@ -723,7 +723,7 @@ class TestArtifactExporter(unittest.TestCase):
 
             stack_resource.export(resource_id, resource_dict, parent_dir)
 
-            self.assertEquals(resource_dict[property_name], result_path_style_s3_url)
+            self.assertEqual(resource_dict[property_name], result_path_style_s3_url)
 
             TemplateMock.assert_called_once_with(template_path, parent_dir, self.s3_uploader_mock)
             template_instance_mock.export.assert_called_once_with()
@@ -738,7 +738,7 @@ class TestArtifactExporter(unittest.TestCase):
 
         # Case 1: Path is already S3 url
         stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict[property_name], s3_url)
+        self.assertEqual(resource_dict[property_name], s3_url)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
     def test_export_cloudformation_stack_no_upload_path_is_s3url(self):
@@ -771,7 +771,7 @@ class TestArtifactExporter(unittest.TestCase):
         # Case 2: Path is empty
         resource_dict = {}
         stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict, {})
+        self.assertEqual(resource_dict, {})
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
     def test_export_cloudformation_stack_no_upload_path_not_file(self):
@@ -811,7 +811,7 @@ class TestArtifactExporter(unittest.TestCase):
 
             stack_resource.export(resource_id, resource_dict, parent_dir)
 
-            self.assertEquals(resource_dict[property_name], result_path_style_s3_url)
+            self.assertEqual(resource_dict[property_name], result_path_style_s3_url)
 
             TemplateMock.assert_called_once_with(template_path, parent_dir, self.s3_uploader_mock)
             template_instance_mock.export.assert_called_once_with()
@@ -827,7 +827,7 @@ class TestArtifactExporter(unittest.TestCase):
 
         # Case 1: Path is already S3 url
         stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict[property_name], s3_url)
+        self.assertEqual(resource_dict[property_name], s3_url)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
     def test_export_serverless_application_no_upload_path_is_httpsurl(self):
@@ -839,7 +839,7 @@ class TestArtifactExporter(unittest.TestCase):
 
         # Case 1: Path is already S3 url
         stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict[property_name], s3_url)
+        self.assertEqual(resource_dict[property_name], s3_url)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
     def test_export_serverless_application_no_upload_path_is_empty(self):
@@ -850,7 +850,7 @@ class TestArtifactExporter(unittest.TestCase):
         # Case 2: Path is empty
         resource_dict = {}
         stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict, {})
+        self.assertEqual(resource_dict, {})
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
     def test_export_serverless_application_no_upload_path_not_file(self):
@@ -874,7 +874,7 @@ class TestArtifactExporter(unittest.TestCase):
         location = {"ApplicationId": "id", "SemanticVersion": "1.0.1"}
         resource_dict = {property_name: location}
         stack_resource.export(resource_id, resource_dict, "dir")
-        self.assertEquals(resource_dict[property_name], location)
+        self.assertEqual(resource_dict[property_name], location)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
@@ -923,12 +923,12 @@ class TestArtifactExporter(unittest.TestCase):
                 template_path, parent_dir, self.s3_uploader_mock,
                 metadata_to_export=metadata_to_export)
             exported_template = template_exporter.export()
-            self.assertEquals(exported_template, template_dict)
+            self.assertEqual(exported_template, template_dict)
 
             open_mock.assert_called_once_with(
                     make_abs_path(parent_dir, template_path), "r")
 
-            self.assertEquals(1, yaml_parse_mock.call_count)
+            self.assertEqual(1, yaml_parse_mock.call_count)
 
             metadata_type1_class.assert_called_once_with(self.s3_uploader_mock)
             metadata_type1_instance.export.assert_called_once_with(
@@ -988,12 +988,12 @@ class TestArtifactExporter(unittest.TestCase):
                 template_path, parent_dir, self.s3_uploader_mock,
                 resources_to_export)
             exported_template = template_exporter.export()
-            self.assertEquals(exported_template, template_dict)
+            self.assertEqual(exported_template, template_dict)
 
             open_mock.assert_called_once_with(
                     make_abs_path(parent_dir, template_path), "r")
 
-            self.assertEquals(1, yaml_parse_mock.call_count)
+            self.assertEqual(1, yaml_parse_mock.call_count)
 
             resource_type1_class.assert_called_once_with(self.s3_uploader_mock)
             resource_type1_instance.export.assert_called_once_with(
@@ -1061,10 +1061,10 @@ class TestArtifactExporter(unittest.TestCase):
                 self.assertTrue(template_dir in first_call_args)
                 self.assertTrue(template_dir in second_call_args)
                 self.assertTrue(template_dir in third_call_args)
-                self.assertEquals(include_transform_export_handler_mock.call_count, 3)
+                self.assertEqual(include_transform_export_handler_mock.call_count, 3)
                 #new s3 url is added to include location
-                self.assertEquals(exported_template["Resources"]["Resource1"]["Properties"]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
-                self.assertEquals(exported_template["List"][1]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
+                self.assertEqual(exported_template["Resources"]["Resource1"]["Properties"]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
+                self.assertEqual(exported_template["List"][1]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_relative_file_path(self, is_local_file_mock):
@@ -1077,7 +1077,7 @@ class TestArtifactExporter(unittest.TestCase):
         handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": "foo.yaml"}}, self.s3_uploader_mock, parent_dir)
         self.s3_uploader_mock.upload_with_dedup.assert_called_once_with(abs_file_path)
         is_local_file_mock.assert_called_with(abs_file_path)
-        self.assertEquals(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
+        self.assertEqual(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_absolute_file_path(self, is_local_file_mock):
@@ -1090,14 +1090,14 @@ class TestArtifactExporter(unittest.TestCase):
         handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": abs_file_path}}, self.s3_uploader_mock, parent_dir)
         self.s3_uploader_mock.upload_with_dedup.assert_called_once_with(abs_file_path)
         is_local_file_mock.assert_called_with(abs_file_path)
-        self.assertEquals(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
+        self.assertEqual(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_s3_uri(self, is_local_file_mock):
 
         handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": "s3://bucket/foo.yaml"}}, self.s3_uploader_mock, "parent_dir")
         # Input is returned unmodified
-        self.assertEquals(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": "s3://bucket/foo.yaml"}})
+        self.assertEqual(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": "s3://bucket/foo.yaml"}})
 
         is_local_file_mock.assert_not_called()
         self.s3_uploader_mock.assert_not_called()
@@ -1107,7 +1107,7 @@ class TestArtifactExporter(unittest.TestCase):
 
         handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": ""}}, self.s3_uploader_mock, "parent_dir")
         # Input is returned unmodified
-        self.assertEquals(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": ""}})
+        self.assertEqual(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": ""}})
 
         is_local_file_mock.assert_not_called()
         self.s3_uploader_mock.assert_not_called()
@@ -1120,7 +1120,7 @@ class TestArtifactExporter(unittest.TestCase):
             self.s3_uploader_mock,
             "parent_dir")
         # Input is returned unmodified
-        self.assertEquals(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": {"Fn::Sub": "${S3Bucket}/file.txt"}}})
+        self.assertEqual(handler_output, {"Name": "AWS::Include", "Parameters": {"Location": {"Fn::Sub": "${S3Bucket}/file.txt"}}})
 
         is_local_file_mock.assert_not_called()
         self.s3_uploader_mock.assert_not_called()
@@ -1141,7 +1141,7 @@ class TestArtifactExporter(unittest.TestCase):
         #ignores transform that is not aws::include
         handler_output = include_transform_export_handler({"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}}, self.s3_uploader_mock, "parent_dir")
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
-        self.assertEquals(handler_output, {"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}})
+        self.assertEqual(handler_output, {"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}})
 
     def test_template_export_path_be_folder(self):
 
@@ -1177,7 +1177,7 @@ class TestArtifactExporter(unittest.TestCase):
                 for info in zf.infolist():
                     files_in_zip.add(info.filename)
 
-                self.assertEquals(files_in_zip, expected_files)
+                self.assertEqual(files_in_zip, expected_files)
 
         finally:
             if zipfile_name:

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -106,7 +106,7 @@ class TestDeployCommand(unittest.TestCase):
                 self.parsed_args.template_file = file_path
                 result = self.deploy_command._run_main(self.parsed_args,
                                               parsed_globals=self.parsed_globals)
-                self.assertEquals(0, result)
+                self.assertEqual(0, result)
 
                 open_mock.assert_called_once_with(file_path, "r")
 
@@ -138,7 +138,7 @@ class TestDeployCommand(unittest.TestCase):
                 self.deploy_command.merge_parameters.assert_called_once_with(
                         fake_template, fake_parameter_overrides)
 
-                self.assertEquals(1, mock_yaml_parse.call_count)
+                self.assertEqual(1, mock_yaml_parse.call_count)
 
     def test_invalid_template_file(self):
         self.parsed_args.template_file = "sometemplate"

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -134,8 +134,8 @@ class TestDeployer(unittest.TestCase):
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
                     notification_arns, s3_uploader, tags)
-            self.assertEquals(response["Id"], result.changeset_id)
-            self.assertEquals("CREATE", result.changeset_type)
+            self.assertEqual(response["Id"], result.changeset_id)
+            self.assertEqual("CREATE", result.changeset_type)
 
         # Case 2: Stack exists. We are updating it
         self.deployer.has_stack.return_value = True
@@ -155,8 +155,8 @@ class TestDeployer(unittest.TestCase):
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
                     notification_arns, s3_uploader, tags)
-            self.assertEquals(response["Id"], result.changeset_id)
-            self.assertEquals("UPDATE", result.changeset_type)
+            self.assertEqual(response["Id"], result.changeset_id)
+            self.assertEqual("UPDATE", result.changeset_type)
 
     def test_create_changeset_success_s3_bucket(self):
         stack_name = "stack_name"
@@ -212,8 +212,8 @@ class TestDeployer(unittest.TestCase):
             result = self.deployer.create_changeset(
                 stack_name, template, parameters, capabilities, role_arn,
                 notification_arns, s3_uploader, [])
-            self.assertEquals(response["Id"], result.changeset_id)
-            self.assertEquals("CREATE", result.changeset_type)
+            self.assertEqual(response["Id"], result.changeset_id)
+            self.assertEqual("CREATE", result.changeset_type)
 
         # Case 2: Stack exists. We are updating it
         self.deployer.has_stack.return_value = True
@@ -233,8 +233,8 @@ class TestDeployer(unittest.TestCase):
             result = self.deployer.create_changeset(
                     stack_name, template, parameters, capabilities, role_arn,
                     notification_arns, s3_uploader, [])
-            self.assertEquals(response["Id"], result.changeset_id)
-            self.assertEquals("UPDATE", result.changeset_type)
+            self.assertEqual(response["Id"], result.changeset_id)
+            self.assertEqual("UPDATE", result.changeset_type)
 
     def test_create_changeset_exception(self):
         stack_name = "stack_name"
@@ -301,8 +301,8 @@ class TestDeployer(unittest.TestCase):
         result = self.deployer.create_and_wait_for_changeset(
                 stack_name, template, parameters, capabilities, role_arn,
                 notification_arns, s3_uploader, tags)
-        self.assertEquals(result.changeset_id, changeset_id)
-        self.assertEquals(result.changeset_type, changeset_type)
+        self.assertEqual(result.changeset_id, changeset_id)
+        self.assertEqual(result.changeset_type, changeset_type)
 
     def test_create_and_wait_for_changeset_error_waiting_for_changeset(self):
         stack_name = "stack_name"

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -76,7 +76,7 @@ class TestPackageCommand(unittest.TestCase):
                 self.parsed_args.use_json=use_json
 
                 rc = self.package_command._run_main(self.parsed_args, self.parsed_globals)
-                self.assertEquals(rc, 0)
+                self.assertEqual(rc, 0)
 
                 self.package_command._export.assert_called_once_with(filename, use_json)
                 self.package_command.write_output.assert_called_once_with(

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -64,12 +64,12 @@ class TestYaml(unittest.TestCase):
 
     def test_yaml_with_tags(self):
         output = yaml_parse(self.yaml_with_tags)
-        self.assertEquals(self.parsed_yaml_dict, output)
+        self.assertEqual(self.parsed_yaml_dict, output)
 
         # Make sure formatter and parser work well with each other
         formatted_str = yaml_dump(output)
         output_again = yaml_parse(formatted_str)
-        self.assertEquals(output, output_again)
+        self.assertEqual(output, output_again)
 
     def test_yaml_getatt(self):
         # This is an invalid syntax for !GetAtt. But make sure the code does
@@ -90,7 +90,7 @@ class TestYaml(unittest.TestCase):
         }
 
         actual_output = yaml_parse(yaml_input)
-        self.assertEquals(actual_output, output)
+        self.assertEqual(actual_output, output)
 
     def test_parse_json_with_tabs(self):
         template = '{\n\t"foo": "bar"\n}'

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -359,7 +359,7 @@ class TestPublicKeyProvider(unittest.TestCase):
         start_date = START_DATE
         end_date = start_date + timedelta(days=2)
         keys = provider.get_public_keys(start_date, end_date)
-        self.assertEquals({
+        self.assertEqual({
             'a': {'Fingerprint': 'a', 'OtherData': 'a', 'Value': 'a'},
             'b': {'Fingerprint': 'b', 'OtherData': 'b', 'Value': 'b'},
             'c': {'Fingerprint': 'c', 'OtherData': 'c', 'Value': 'c'},
@@ -714,7 +714,7 @@ class TestDigestTraverser(unittest.TestCase):
         self.assertEqual(
             1, len(digest_provider.calls['load_digest_keys_in_range']))
         self.assertEqual(4, len(digest_provider.calls['fetch_digest']))
-        self.assertEquals(4, len(collected))
+        self.assertEqual(4, len(collected))
 
     def test_invokes_cb_and_continues_when_missing(self):
         start_date = START_DATE
@@ -727,9 +727,9 @@ class TestDigestTraverser(unittest.TestCase):
             starting_prefix='baz', public_key_provider=key_provider,
             digest_validator=validator, on_missing=on_missing)
         collected = list(traverser.traverse(start_date, end_date))
-        self.assertEquals(3, len(collected))
+        self.assertEqual(3, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
-        self.assertEquals(1, len(missing_calls))
+        self.assertEqual(1, len(missing_calls))
         # Ensure the keys were provided in the correct order.
         self.assertIn('bucket', missing_calls[0])
         self.assertIn('next_end_date', missing_calls[0])
@@ -755,9 +755,9 @@ class TestDigestTraverser(unittest.TestCase):
             starting_prefix='baz', public_key_provider=key_provider,
             digest_validator=validator, on_invalid=on_invalid)
         collected = list(traverser.traverse(start_date, end_date))
-        self.assertEquals(3, len(collected))
+        self.assertEqual(3, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
-        self.assertEquals(2, len(invalid_calls))
+        self.assertEqual(2, len(invalid_calls))
         # Ensure it was invoked with all the kwargs we expected.
         self.assertIn('bucket', invalid_calls[0])
         self.assertIn('next_end_date', invalid_calls[0])
@@ -787,9 +787,9 @@ class TestDigestTraverser(unittest.TestCase):
             starting_prefix='baz', public_key_provider=key_provider,
             digest_validator=validator, on_gap=on_gap)
         collected = list(traverser.traverse(start_date, end_date))
-        self.assertEquals(4, len(collected))
+        self.assertEqual(4, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
-        self.assertEquals(2, len(gap_calls))
+        self.assertEqual(2, len(gap_calls))
         # Ensure it was invoked with all the kwargs we expected.
         self.assertIn('bucket', gap_calls[0])
         self.assertIn('next_key', gap_calls[0])
@@ -817,14 +817,14 @@ class TestDigestTraverser(unittest.TestCase):
             starting_prefix='baz', public_key_provider=key_provider,
             digest_validator=validator)
         collected = list(traverser.traverse(start_date, end_date))
-        self.assertEquals(4, len(collected))
+        self.assertEqual(4, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         # Ensure the provider was called correctly
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(
             2, len(digest_provider.calls['load_digest_keys_in_range']))
-        self.assertEquals(['1', '1', '2', '2'],
-                          [c['digestS3Bucket'] for c in collected])
+        self.assertEqual(['1', '1', '2', '2'],
+                         [c['digestS3Bucket'] for c in collected])
 
     def test_does_not_hard_fail_on_invalid_signature(self):
         start_date = START_DATE

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -52,7 +52,7 @@ class TestBaseLogin(unittest.TestCase):
             errno.ENOENT, 'not found error'
         )
         tool = 'NotSupported'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, '%s was not found.' % tool):
             self.test_subject._run_commands(tool, ['echo', tool])
 
@@ -61,7 +61,7 @@ class TestBaseLogin(unittest.TestCase):
             errno.ENOSYS, 'unhandled error'
         )
         tool = 'NotSupported'
-        with self.assertRaisesRegexp(OSError, 'unhandled error'):
+        with self.assertRaisesRegex(OSError, 'unhandled error'):
             self.test_subject._run_commands(tool, ['echo', tool])
 
 
@@ -227,7 +227,7 @@ Registered Sources:
         self.subprocess_utils.check_output.side_effect = OSError(
             errno.ENOENT, 'not found error'
         )
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'nuget was not found. Please verify installation.'):
             self.test_subject.login()
@@ -385,7 +385,7 @@ Registered Sources:
         self.subprocess_utils.check_output.side_effect = OSError(
             errno.ENOENT, 'not found error'
         )
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'dotnet was not found. Please verify installation.'):
             self.test_subject.login()

--- a/tests/unit/customizations/codedeploy/test_deregister.py
+++ b/tests/unit/customizations/codedeploy/test_deregister.py
@@ -66,12 +66,12 @@ class TestDeregister(unittest.TestCase):
     def test_deregister_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        with self.assertRaisesRegex(RuntimeError, 'Region not specified.'):
             self.deregister._run_main(self.args, self.globals)
 
     def test_deregister_throws_on_invalid_instance_name(self):
         self.args.instance_name = 'invalid%@^&%#&'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Instance name contains invalid characters.'):
             self.deregister._run_main(self.args, self.globals)
 
@@ -99,11 +99,11 @@ class TestDeregister(unittest.TestCase):
             instanceName=self.instance_name
         )
         self.assertIn('iam_user_arn', self.args)
-        self.assertEquals(self.iam_user_arn, self.args.iam_user_arn)
+        self.assertEqual(self.iam_user_arn, self.args.iam_user_arn)
         self.assertIn('user_name', self.args)
-        self.assertEquals(self.instance_name, self.args.user_name)
+        self.assertEqual(self.instance_name, self.args.user_name)
         self.assertIn('tags', self.args)
-        self.assertEquals(self.tags, self.args.tags)
+        self.assertEqual(self.tags, self.args.tags)
         self.codedeploy.remove_tags_from_on_premises_instances.\
             assert_called_with(
                 tags=self.tags,
@@ -126,11 +126,11 @@ class TestDeregister(unittest.TestCase):
             instanceName=self.instance_name
         )
         self.assertIn('iam_user_arn', self.args)
-        self.assertEquals(self.iam_user_arn, self.args.iam_user_arn)
+        self.assertEqual(self.iam_user_arn, self.args.iam_user_arn)
         self.assertIn('user_name', self.args)
-        self.assertEquals(self.instance_name, self.args.user_name)
+        self.assertEqual(self.instance_name, self.args.user_name)
         self.assertIn('tags', self.args)
-        self.assertEquals(None, self.args.tags)
+        self.assertEqual(None, self.args.tags)
         self.assertFalse(
             self.codedeploy.remove_tags_from_on_premises_instances.called
         )

--- a/tests/unit/customizations/codedeploy/test_install.py
+++ b/tests/unit/customizations/codedeploy/test_install.py
@@ -95,18 +95,18 @@ class TestInstall(unittest.TestCase):
     def test_install_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        with self.assertRaisesRegex(RuntimeError, 'Region not specified.'):
             self.install._run_main(self.args, self.globals)
 
     def test_install_throws_on_unsupported_system(self):
         self.system.return_value = 'Unsupported'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, System.UNSUPPORTED_SYSTEM_MSG):
             self.install._run_main(self.args, self.globals)
 
     def test_install_throws_on_ec2_instance(self):
         self.urlopen.side_effect = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'Amazon EC2 instances are not supported.'):
             self.install._run_main(self.args, self.globals)
         self.assertIn('system', self.args)
@@ -114,14 +114,14 @@ class TestInstall(unittest.TestCase):
 
     def test_install_throws_on_non_administrator(self):
         self.geteuid.return_value = 1
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'You must run this command as sudo.'):
             self.install._run_main(self.args, self.globals)
 
     def test_install_throws_on_no_override_config(self):
         self.isfile.return_value = True
         self.args.override_config = False
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError,
                 'The on-premises instance configuration file already exists. '
                 'Specify --override-config to update the existing on-premises '
@@ -130,7 +130,7 @@ class TestInstall(unittest.TestCase):
 
     def test_install_throws_on_invalid_agent_installer(self):
         self.args.agent_installer = 'invalid-s3-location'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 '--agent-installer must specify the Amazon S3 URL format as '
                 's3://<bucket>/<key>.'):
@@ -154,11 +154,11 @@ class TestInstall(unittest.TestCase):
         self.linux_distribution.return_value = ('Ubuntu', '', '')
         self.install._run_main(self.args, self.globals)
         self.assertIn('bucket', self.args)
-        self.assertEquals(self.bucket, self.args.bucket)
+        self.assertEqual(self.bucket, self.args.bucket)
         self.assertIn('key', self.args)
-        self.assertEquals('latest/install', self.args.key)
+        self.assertEqual('latest/install', self.args.key)
         self.assertIn('installer', self.args)
-        self.assertEquals('install', self.args.installer)
+        self.assertEqual('install', self.args.installer)
         self.makedirs.assert_called_with('/etc/codedeploy-agent/conf')
         self.copyfile.assset_called_with(
             'codedeploy.onpremises.yml',
@@ -172,11 +172,11 @@ class TestInstall(unittest.TestCase):
         self.system.return_value = 'Windows'
         self.install._run_main(self.args, self.globals)
         self.assertIn('bucket', self.args)
-        self.assertEquals(self.bucket, self.args.bucket)
+        self.assertEqual(self.bucket, self.args.bucket)
         self.assertIn('key', self.args)
-        self.assertEquals('latest/codedeploy-agent.msi', self.args.key)
+        self.assertEqual('latest/codedeploy-agent.msi', self.args.key)
         self.assertIn('installer', self.args)
-        self.assertEquals('codedeploy-agent.msi', self.args.installer)
+        self.assertEqual('codedeploy-agent.msi', self.args.installer)
         self.makedirs.assert_called_with(r'C:\ProgramData\Amazon\CodeDeploy')
         self.copyfile.assset_called_with(
             'conf.onpremises.yml',

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -163,7 +163,7 @@ class TestPush(unittest.TestCase):
         self.push._register_revision = MagicMock()
         self.push._push(self.args)
         self.push._register_revision.assert_called_with(self.args)
-        self.assertEquals(str(self.args.eTag), self.upload_response['ETag'].replace('"',""))
+        self.assertEqual(str(self.args.eTag), self.upload_response['ETag'].replace('"',""))
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_push_output_message(self, stdout_mock):
@@ -193,7 +193,7 @@ class TestPush(unittest.TestCase):
                 expected_revision_output
             )
         )
-        self.assertEquals(expected_output, output)
+        self.assertEqual(expected_output, output)
 
     @patch('zipfile.ZipFile')
     @patch('tempfile.TemporaryFile')

--- a/tests/unit/customizations/codedeploy/test_register.py
+++ b/tests/unit/customizations/codedeploy/test_register.py
@@ -80,12 +80,12 @@ class TestRegister(unittest.TestCase):
     def test_register_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        with self.assertRaisesRegex(RuntimeError, 'Region not specified.'):
             self.register._run_main(self.args, self.globals)
 
     def test_register_throws_on_invalid_instance_name(self):
         self.args.instance_name = 'invalid%@^&%#&'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Instance name contains invalid characters.'):
             self.register._run_main(self.args, self.globals)
 
@@ -93,7 +93,7 @@ class TestRegister(unittest.TestCase):
         self.args.tags = [
             {'Key': 'k' + str(x), 'Value': 'v' + str(x)} for x in range(11)
         ]
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'Instances can only have a maximum of {0} tags.'.format(
                     MAX_TAGS_PER_INSTANCE)):
@@ -101,7 +101,7 @@ class TestRegister(unittest.TestCase):
 
     def test_register_throws_on_invalid_iam_user_arn(self):
         self.args.iam_user_arn = 'invalid%@^&%#&'
-        with self.assertRaisesRegexp(ValueError, 'Invalid IAM user ARN.'):
+        with self.assertRaisesRegex(ValueError, 'Invalid IAM user ARN.'):
             self.register._run_main(self.args, self.globals)
 
     def test_register_creates_clients(self):

--- a/tests/unit/customizations/codedeploy/test_systems.py
+++ b/tests/unit/customizations/codedeploy/test_systems.py
@@ -67,13 +67,13 @@ class TestWindows(unittest.TestCase):
         self.assertEqual(self.config_dir, self.windows.CONFIG_DIR)
 
     def test_config_file(self):
-        self.assertEquals(self.config_file, self.windows.CONFIG_FILE)
+        self.assertEqual(self.config_file, self.windows.CONFIG_FILE)
 
     def test_config_path(self):
-        self.assertEquals(self.config_path, self.windows.CONFIG_PATH)
+        self.assertEqual(self.config_path, self.windows.CONFIG_PATH)
 
     def test_installer(self):
-        self.assertEquals(self.installer, self.windows.INSTALLER)
+        self.assertEqual(self.installer, self.windows.INSTALLER)
 
     def test_install(self):
         process = MagicMock()
@@ -221,21 +221,21 @@ class TestUbuntu(TestLinux):
         self.ubuntu = Ubuntu(self.params)
 
     def test_config_dir(self):
-        self.assertEquals(self.config_dir, self.ubuntu.CONFIG_DIR)
+        self.assertEqual(self.config_dir, self.ubuntu.CONFIG_DIR)
 
     def test_config_file(self):
-        self.assertEquals(self.config_file, self.ubuntu.CONFIG_FILE)
+        self.assertEqual(self.config_file, self.ubuntu.CONFIG_FILE)
 
     def test_config_path(self):
-        self.assertEquals(self.config_path, self.ubuntu.CONFIG_PATH)
+        self.assertEqual(self.config_path, self.ubuntu.CONFIG_PATH)
 
     def test_installer(self):
-        self.assertEquals(self.installer, self.ubuntu.INSTALLER)
+        self.assertEqual(self.installer, self.ubuntu.INSTALLER)
 
     @patch('os.geteuid', create=True)
     def test_validate_administrator_throws(self, geteuid):
         geteuid.return_value = 1
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'You must run this command as sudo.'):
             self.ubuntu.validate_administrator()
 
@@ -289,21 +289,21 @@ class TestRHEL(TestLinux):
         self.rhel = RHEL(self.params)
 
     def test_config_dir(self):
-        self.assertEquals(self.config_dir, self.rhel.CONFIG_DIR)
+        self.assertEqual(self.config_dir, self.rhel.CONFIG_DIR)
 
     def test_config_file(self):
-        self.assertEquals(self.config_file, self.rhel.CONFIG_FILE)
+        self.assertEqual(self.config_file, self.rhel.CONFIG_FILE)
 
     def test_config_path(self):
-        self.assertEquals(self.config_path, self.rhel.CONFIG_PATH)
+        self.assertEqual(self.config_path, self.rhel.CONFIG_PATH)
 
     def test_installer(self):
-        self.assertEquals(self.installer, self.rhel.INSTALLER)
+        self.assertEqual(self.installer, self.rhel.INSTALLER)
 
     @patch('os.geteuid', create=True)
     def test_validate_administrator_throws(self, geteuid):
         geteuid.return_value = 1
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'You must run this command as sudo.'):
             self.rhel.validate_administrator()
 

--- a/tests/unit/customizations/codedeploy/test_uninstall.py
+++ b/tests/unit/customizations/codedeploy/test_uninstall.py
@@ -62,18 +62,18 @@ class TestUninstall(unittest.TestCase):
     def test_uninstall_throws_on_invalid_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        with self.assertRaisesRegex(RuntimeError, 'Region not specified.'):
             self.uninstall._run_main(self.args, self.globals)
 
     def test_uninstall_throws_on_unsupported_system(self):
         self.system.return_value = 'Unsupported'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, System.UNSUPPORTED_SYSTEM_MSG):
             self.uninstall._run_main(self.args, self.globals)
 
     def test_uninstall_throws_on_ec2_instance(self):
         self.urlopen.side_effect = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'Amazon EC2 instances are not supported.'):
             self.uninstall._run_main(self.args, self.globals)
         self.assertIn('system', self.args)
@@ -81,7 +81,7 @@ class TestUninstall(unittest.TestCase):
 
     def test_uninstall_throws_on_non_administrator(self):
         self.geteuid.return_value = 1
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'You must run this command as sudo.'):
             self.uninstall._run_main(self.args, self.globals)
 

--- a/tests/unit/customizations/codedeploy/test_utils.py
+++ b/tests/unit/customizations/codedeploy/test_utils.py
@@ -62,19 +62,19 @@ class TestUtils(unittest.TestCase):
         self.session.get_config_variable.return_value = None
         validate_region(self.params, self.globals)
         self.assertIn('region', self.params)
-        self.assertEquals(self.region, self.params.region)
+        self.assertEqual(self.region, self.params.region)
 
     def test_validate_region_returns_session_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = self.region
         validate_region(self.params, self.globals)
         self.assertIn('region', self.params)
-        self.assertEquals(self.region, self.params.region)
+        self.assertEqual(self.region, self.params.region)
 
     def test_validate_region_throws_on_no_region(self):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
-        with self.assertRaisesRegexp(RuntimeError, 'Region not specified.'):
+        with self.assertRaisesRegex(RuntimeError, 'Region not specified.'):
             validate_region(self.params, self.globals)
 
     def test_validate_instance_name(self):
@@ -84,13 +84,13 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_instance_name_throws_on_invalid_characters(self):
         self.params.instance_name = '!#$%^&*()<>/?;:[{]}'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Instance name contains invalid characters.'):
             validate_instance_name(self.params)
 
     def test_validate_instance_name_throws_on_i_dash(self):
         self.params.instance_name = 'i-instance'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, "Instance name cannot start with 'i-'."):
             validate_instance_name(self.params)
 
@@ -99,7 +99,7 @@ class TestUtils(unittest.TestCase):
             '01234567890123456789012345678901234567890123456789'
             '012345678901234567890123456789012345678901234567891'
         )
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'Instance name cannot be longer than {0} characters.'.format(
                     MAX_INSTANCE_NAME_LENGTH)):
@@ -109,7 +109,7 @@ class TestUtils(unittest.TestCase):
         self.params.tags = [
             {'Key': 'k' + str(x), 'Value': 'v' + str(x)} for x in range(11)
         ]
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'Instances can only have a maximum of {0} '
                 'tags.'.format(MAX_TAGS_PER_INSTANCE)):
@@ -123,7 +123,7 @@ class TestUtils(unittest.TestCase):
     def test_validate_tags_throws_on_long_key(self):
         key = 'k' * 129
         self.params.tags = [{'Key': key, 'Value': 'v1'}]
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'Tag Key cannot be longer than {0} characters.'.format(
                     MAX_TAG_KEY_LENGTH)):
@@ -137,7 +137,7 @@ class TestUtils(unittest.TestCase):
     def test_validate_tags_throws_on_long_value(self):
         value = 'v' * 257
         self.params.tags = [{'Key': 'k1', 'Value': value}]
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 'Tag Value cannot be longer than {0} characters.'.format(
                     MAX_TAG_VALUE_LENGTH)):
@@ -149,7 +149,7 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_iam_user_arn_throws_on_invalid_arn_pattern(self):
         self.params.iam_user_arn = 'invalid-arn-pattern'
-        with self.assertRaisesRegexp(ValueError, 'Invalid IAM user ARN.'):
+        with self.assertRaisesRegex(ValueError, 'Invalid IAM user ARN.'):
             validate_iam_user_arn(self.params)
 
     def test_validate_instance_ubuntu(self):
@@ -183,7 +183,7 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_instance_throws_on_unsupported_system(self):
         self.system.return_value = 'Unsupported'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, System.UNSUPPORTED_SYSTEM_MSG):
             validate_instance(self.params)
 
@@ -191,7 +191,7 @@ class TestUtils(unittest.TestCase):
         self.params.session = self.session
         self.params.region = self.region
         self.urlopen.side_effect = None
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 RuntimeError, 'Amazon EC2 instances are not supported.'):
             validate_instance(self.params)
 
@@ -199,9 +199,9 @@ class TestUtils(unittest.TestCase):
         self.params.s3_location = 's3://{0}/{1}'.format(self.bucket, self.key)
         validate_s3_location(self.params, self.arg_name)
         self.assertIn('bucket', self.params)
-        self.assertEquals(self.bucket, self.params.bucket)
+        self.assertEqual(self.bucket, self.params.bucket)
         self.assertIn('key', self.params)
-        self.assertEquals(self.key, self.params.key)
+        self.assertEqual(self.key, self.params.key)
 
     def test_validate_s3_location_not_present(self):
         validate_s3_location(self.params, 'unknown')
@@ -210,7 +210,7 @@ class TestUtils(unittest.TestCase):
 
     def test_validate_s3_location_throws_on_invalid_location(self):
         self.params.s3_location = 'invalid-s3-location'
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError,
                 '--{0} must specify the Amazon S3 URL format as '
                 's3://<bucket>/<key>.'.format(self.arg_name)):

--- a/tests/unit/customizations/datapipeline/test_create_default_role.py
+++ b/tests/unit/customizations/datapipeline/test_create_default_role.py
@@ -168,7 +168,7 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
         result = self.run_cmd(self.prefix, 0)
         expected_output = json.dumps(self.CONSTRUCTED_RESULT_OUTPUT,
                                      indent=4) + '\n'
-        self.assertEquals(result[0], expected_output)
+        self.assertEqual(result[0], expected_output)
 
     def toggle_for_check_if_exists(self, *args):
         if args[0] == DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME:

--- a/tests/unit/customizations/ecs/test_ecsclient.py
+++ b/tests/unit/customizations/ecs/test_ecsclient.py
@@ -39,8 +39,8 @@ class TestECSClient(unittest.TestCase):
         expected_user_agent_extra = 'customization/ecs-deploy'
 
         create_args = self.session.create_client.call_args
-        self.assertEquals(create_args[0][0], 'ecs')
-        self.assertEquals(
+        self.assertEqual(create_args[0][0], 'ecs')
+        self.assertEqual(
             create_args[1]['region_name'], self.global_args.region)
-        self.assertEquals(create_args[1]['config'].user_agent_extra,
+        self.assertEqual(create_args[1]['config'].user_agent_extra,
                           expected_user_agent_extra)

--- a/tests/unit/customizations/ecs/test_executecommand_startsession.py
+++ b/tests/unit/customizations/ecs/test_executecommand_startsession.py
@@ -107,7 +107,7 @@ class TestExecuteCommand(unittest.TestCase):
     def test_when_calls_fails_from_ecs(self, mock_check_call):
         self.client.execute_command.side_effect = Exception('some exception')
         mock_check_call.return_value = 0
-        with self.assertRaisesRegexp(Exception, 'some exception'):
+        with self.assertRaisesRegex(Exception, 'some exception'):
             self.caller.invoke('ecs', 'ExecuteCommand', {}, mock.Mock())
 
     @mock.patch('awscli.customizations.ecs.executecommand.check_call')
@@ -128,7 +128,7 @@ class TestExecuteCommand(unittest.TestCase):
         rc = self.caller.invoke('ecs', 'ExecuteCommand',
                                 self.execute_command_params, mock.Mock())
 
-        self.assertEquals(rc, 0)
+        self.assertEqual(rc, 0)
         self.client.execute_command.\
             assert_called_with(**self.execute_command_params)
 
@@ -155,10 +155,10 @@ class TestExecuteCommand(unittest.TestCase):
         self.client.describe_tasks.side_effect = \
             Exception("Some Server Exception")
 
-        with self.assertRaisesRegexp(Exception, 'Some Server Exception'):
+        with self.assertRaisesRegex(Exception, 'Some Server Exception'):
             rc = self.caller.invoke('ecs', 'ExecuteCommand',
                                     self.execute_command_params, mock.Mock())
-            self.assertEquals(rc, 0)
+            self.assertEqual(rc, 0)
             self.client.execute_command. \
                 assert_called_with(**self.execute_command_params)
 
@@ -174,7 +174,7 @@ class TestExecuteCommand(unittest.TestCase):
         with self.assertRaises(Exception):
             rc = self.caller.invoke('ecs', 'ExecuteCommand',
                                     self.execute_command_params, mock.Mock())
-            self.assertEquals(rc, 0)
+            self.assertEqual(rc, 0)
             self.client.execute_command. \
                 assert_called_with(**self.execute_command_params)
 

--- a/tests/unit/customizations/emr/__init__.py
+++ b/tests/unit/customizations/emr/__init__.py
@@ -45,4 +45,4 @@ class EMRBaseAWSCommandParamsTest(BaseAWSCommandParamsTest):
         exception_class = getattr(exceptions, exception_class_name)
         error_msg = "\n%s\n" % exception_class.fmt.format(**error_msg_kwargs)
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(error_msg, result[1])
+        self.assertEqual(error_msg, result[1])

--- a/tests/unit/customizations/emr/test_add_instance_groups.py
+++ b/tests/unit/customizations/emr/test_add_instance_groups.py
@@ -367,7 +367,7 @@ class TestAddInstanceGroups(BaseAWSCommandParamsTest):
         result = self.run_cmd(cmd, expected_rc=0)
         result_json = json.loads(result[0])
 
-        self.assertEquals(result_json, CONSTRUCTED_RESULT)
+        self.assertEqual(result_json, CONSTRUCTED_RESULT)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -630,11 +630,11 @@ class TestAddSteps(BaseAWSCommandParamsTest):
         if expected_error_msg:
             grl_patch.return_value = None
             result = self.run_cmd(cmd, 255)
-            self.assertEquals(expected_error_msg, result[1])
+            self.assertEqual(expected_error_msg, result[1])
         if expected_result_release:
             grl_patch.return_value = 'emr-4.0'
             result = self.run_cmd(cmd, 255)
-            self.assertEquals(expected_result_release, result[1])
+            self.assertEqual(expected_result_release, result[1])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_command.py
+++ b/tests/unit/customizations/emr/test_command.py
@@ -44,4 +44,4 @@ class TestCommand(BaseAWSCommandParamsTest):
         cmd = FakeCommand(mock_session)
         cmd._run_main(mocked_parsed_args, parsed_globals)
 
-        self.assertEquals(cmd.region, 'eu-central-1')
+        self.assertEqual(cmd.region, 'eu-central-1')

--- a/tests/unit/customizations/emr/test_config.py
+++ b/tests/unit/customizations/emr/test_config.py
@@ -102,7 +102,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             config_value='False1', config_key='enable_debugging',
             profile_var_name='default'))
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     @mock.patch.object(CreateCluster, '_run_main_command')
     def test_ignore_role_configs_when_use_default_roles(self,

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -391,7 +391,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'choose --use-default-roles or use both --service-role <roleName>'
             ' and --ec2-attributes InstanceProfile=<profileName>.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_mutual_exclusive_use_default_roles_and_instance_profile(self):
         cmd = (DEFAULT_CMD + '--service-role ServiceRole '
@@ -402,7 +402,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--use-default-roles or use both --service-role <roleName> '
             'and --ec2-attributes InstanceProfile=<profileName>.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_cluster_name_no_space(self):
         cmd = DEFAULT_CMD + '--name MyCluster'
@@ -453,7 +453,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --no-auto-terminate and'
             ' --auto-terminate options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_termination_protected(self):
         cmd = DEFAULT_CMD + '--termination-protected'
@@ -474,7 +474,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --termination-protected'
             ' and --no-termination-protected options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_visible_to_all_users(self):
         cmd = DEFAULT_CMD + '--visible-to-all-users'
@@ -492,7 +492,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --visible-to-all-users and '
             '--no-visible-to-all-users options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_tags(self):
         cmd = DEFAULT_CMD.split() + ['--tags', 'k1=v1', 'k2', 'k3=spaces  v3']
@@ -545,7 +545,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: LogUri not specified. You must specify a logUri'
             ' if you enable debugging when creating a cluster.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_enable_debugging_and_no_enable_debugging(self):
         cmd = DEFAULT_CMD + '--enable-debugging --no-enable-debugging' + \
@@ -554,7 +554,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --enable-debugging and '
             '--no-enable-debugging options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_instance_groups_default_name_market(self):
         cmd = (
@@ -622,7 +622,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = (
             'emr create-cluster --use-default-roles --ami-version 3.0.4 '
@@ -632,7 +632,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_instance_groups_exclusive_parameter_validation_error(self):
         cmd = (
@@ -645,7 +645,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = (
             'emr create-cluster --use-default-roles --ami-version 3.0.4 '
@@ -657,7 +657,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_instance_groups_missing_instance_group_type_error(self):
         cmd = (
@@ -773,7 +773,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: You may not specify both a SubnetId and an Availab'
             'ilityZone (placement) because ec2SubnetId implies a placement.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_ec2_attributes_with_subnet_from_json_file(self):
         data_path = os.path.join(
@@ -827,7 +827,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                              'bootstrap actions for a cluster exceeded.\n'
         result = self.run_cmd(cmd, 255)
 
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_bootstrap_actions_exceed_maximum_with_applications_error(self):
         cmd = DEFAULT_CMD + ' --applications Name=GANGLIA Name=HBASE' +\
@@ -838,7 +838,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = '\naws: error: maximum number of ' +\
                              'bootstrap actions for a cluster exceeded.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_boostrap_actions_with_default_fields(self):
         cmd = DEFAULT_CMD + (
@@ -1003,7 +1003,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: The step type unknown is not supported.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_default_step_type_name_action_on_failure(self):
         cmd = DEFAULT_CMD + '--steps Jar=s3://mybucket/mytest.jar'
@@ -1016,7 +1016,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for CustomJARStepConfig: Jar.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_custom_jar_step_with_all_fields(self):
         cmd = DEFAULT_CMD + '--steps ' + (
@@ -1052,7 +1052,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for StreamingStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_streaming_jar_with_all_fields(self):
         test_step_config = (
@@ -1079,7 +1079,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for HiveStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_hive_step_with_all_fields(self):
         test_step_config = (
@@ -1104,7 +1104,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for PigStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_pig_step_with_all_fields(self):
         test_step_config = (
@@ -1131,7 +1131,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for ImpalaStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_impala_step_with_all_fields(self):
         test_step_config = (
@@ -1182,21 +1182,21 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = ('\naws: error: The prameter Args cannot '
                             'be an empty list.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = DEFAULT_CMD + '--steps Type=Pig,Args= '
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = DEFAULT_CMD + '--steps Type=Hive,Args= '
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = DEFAULT_CMD + '--steps Args= '
         expect_error_msg = ('\naws: error: The following required parameters '
                             'are missing for CustomJARStepConfig: Jar.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_missing_applications_for_steps(self):
         cmd = DEFAULT_CMD +\
@@ -1262,7 +1262,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD
         result = self.run_cmd(cmd, expected_rc=0)
         result_json = json.loads(result[0])
-        self.assertEquals(result_json, CONSTRUCTED_RESULT)
+        self.assertEqual(result_json, CONSTRUCTED_RESULT)
 
     def test_all_security_groups(self):
         cmd = DEFAULT_CMD + (
@@ -1366,7 +1366,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Must specify --auto-scaling-role when'
             ' configuring an AutoScaling policy for an instance group.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_scale_down_behavior(self):
         cmd = (self.prefix + '--ami-version 3.1.0 --scale-down-behavior TERMINATE_AT_TASK_COMPLETION '
@@ -1668,7 +1668,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: You cannot specify both AvailabilityZone'
             ' and AvailabilityZones options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -263,7 +263,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: You cannot specify both --ami-version'
             ' and --release-label options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_if_ami_version_or_release_label_is_provided(self):
         cmd = (self.prefix + ' --instance-groups ' +
@@ -271,7 +271,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = ('\naws: error: Either --ami-version or'
                               ' --release-label is required.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_no_special_steps_added_for_applications(self):
         cmd = (DEFAULT_CMD + '--applications Name=MapR')
@@ -370,7 +370,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'choose --use-default-roles or use both --service-role <roleName>'
             ' and --ec2-attributes InstanceProfile=<profileName>.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_mutual_exclusive_use_default_roles_and_instance_profile(self):
         cmd = (DEFAULT_CMD + '--service-role ServiceRole '
@@ -381,7 +381,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--use-default-roles or use both --service-role <roleName> '
             'and --ec2-attributes InstanceProfile=<profileName>.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_cluster_name_no_space(self):
         cmd = DEFAULT_CMD + '--name MyCluster'
@@ -433,7 +433,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --no-auto-terminate and'
             ' --auto-terminate options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_termination_protected(self):
         cmd = DEFAULT_CMD + '--termination-protected'
@@ -454,7 +454,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --termination-protected'
             ' and --no-termination-protected options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_visible_to_all_users(self):
         cmd = DEFAULT_CMD + '--visible-to-all-users'
@@ -472,7 +472,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --visible-to-all-users and '
             '--no-visible-to-all-users options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_tags(self):
         cmd = DEFAULT_CMD.split() + ['--tags', 'k1=v1', 'k2', 'k3=spaces  v3']
@@ -517,7 +517,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: LogUri not specified. You must specify a logUri'
             ' if you enable debugging when creating a cluster.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_enable_debugging_and_no_enable_debugging(self):
         cmd = DEFAULT_CMD + '--enable-debugging --no-enable-debugging' + \
@@ -526,7 +526,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: cannot use both --enable-debugging and '
             '--no-enable-debugging options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_instance_groups_default_name_market(self):
         cmd = (
@@ -594,7 +594,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = (
             'emr create-cluster --use-default-roles --release-label emr-4.0.0 '
@@ -604,7 +604,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '--instance-type with --instance-count(optional) to '
             'configure instance groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_instance_groups_exclusive_parameter_validation_error(self):
         cmd = (
@@ -617,7 +617,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
         cmd = (
             'emr create-cluster --use-default-roles --release-label emr-4.0.0 '
@@ -629,7 +629,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             'because --instance-type and --instance-count are '
             'shortcut options for --instance-groups.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_instance_groups_missing_instance_group_type_error(self):
         cmd = (
@@ -766,7 +766,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: You may not specify both a SubnetId and an Availab'
             'ilityZone (placement) because ec2SubnetId implies a placement.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_ec2_attributes_with_subnet_from_json_file(self):
         data_path = os.path.join(
@@ -820,7 +820,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
                              'bootstrap actions for a cluster exceeded.\n'
         result = self.run_cmd(cmd, 255)
 
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_bootstrap_actions_exceed_maximum_with_applications_error(self):
         cmd = DEFAULT_CMD + ' --bootstrap-actions'
@@ -830,7 +830,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = '\naws: error: maximum number of ' +\
                              'bootstrap actions for a cluster exceeded.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_boostrap_actions_with_default_fields(self):
         cmd = DEFAULT_CMD + (
@@ -875,7 +875,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expected_error_msg = (
             '\naws: error: The step type unknown is not supported.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_default_step_type_name_action_on_failure(self):
         cmd = DEFAULT_CMD + '--steps Jar=s3://mybucket/mytest.jar'
@@ -888,7 +888,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for CustomJARStepConfig: Jar.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_custom_jar_step_with_all_fields(self):
         cmd = DEFAULT_CMD + '--steps ' + (
@@ -924,7 +924,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for StreamingStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_streaming_jar_with_all_fields(self):
         test_step_config = (
@@ -952,7 +952,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for HiveStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_hive_step_with_all_fields(self):
         test_step_config = (
@@ -978,7 +978,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         expect_error_msg = '\naws: error: The following ' + \
             'required parameters are missing for PigStepConfig: Args.\n'
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expect_error_msg, result[1])
+        self.assertEqual(expect_error_msg, result[1])
 
     def test_pig_step_with_all_fields(self):
         test_step_config = (
@@ -997,7 +997,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         cmd = DEFAULT_CMD
         result = self.run_cmd(cmd, expected_rc=0)
         result_json = json.loads(result[0])
-        self.assertEquals(result_json, CONSTRUCTED_RESULT)
+        self.assertEqual(result_json, CONSTRUCTED_RESULT)
 
     def test_all_security_groups(self):
         cmd = DEFAULT_CMD + (
@@ -1101,7 +1101,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: Must specify --auto-scaling-role when'
             ' configuring an AutoScaling policy for an instance group.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
         
     def test_scale_down_behavior(self):
         cmd = (self.prefix + '--release-label emr-4.0.0 --scale-down-behavior TERMINATE_AT_INSTANCE_HOUR '
@@ -1311,7 +1311,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: You cannot specify both --instance-groups'
             ' and --instance-fleets options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_instance_fleets_with_both_subnetid_subnetids_specified(self):
         cmd = (self.prefix + '--release-label emr-4.2.0 --instance-fleets ' +
@@ -1321,7 +1321,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
             '\naws: error: You cannot specify both SubnetId'
             ' and SubnetIds options together.\n')
         result = self.run_cmd(cmd, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_create_cluster_with_security_config(self):
         cmd = (self.prefix + '--release-label emr-4.7.2 --security-configuration MySecurityConfig '+ 

--- a/tests/unit/customizations/emr/test_create_default_role.py
+++ b/tests/unit/customizations/emr/test_create_default_role.py
@@ -182,7 +182,7 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[2][1]['RoleName'],
                          EMR_ROLE_NAME)
 
-        self.assertEquals(self.operations_called[3][0].name, 'GetRole')
+        self.assertEqual(self.operations_called[3][0].name, 'GetRole')
         self.assertEqual(self.operations_called[3][1]['RoleName'],
                          EMR_AUTOSCALING_ROLE_NAME)
 
@@ -315,28 +315,28 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
         endpoint_url = 'https://elasticmapreduce.abc'
         cmdline = self.prefix + ' --endpoint ' + endpoint_url
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(get_sp_patch.call_args[0][1], endpoint_url)
+        self.assertEqual(get_sp_patch.call_args[0][1], endpoint_url)
 
     @mock.patch('botocore.session.Session.create_client')
     def test_call_parameters(self, call_patch):
         cmdline = self.prefix + ' --region eu-west-1' + ' --no-verify-ssl'
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(call_patch.call_args[1]['region_name'], 'eu-west-1')
-        self.assertEquals(call_patch.call_args[1]['verify'], False)
+        self.assertEqual(call_patch.call_args[1]['region_name'], 'eu-west-1')
+        self.assertEqual(call_patch.call_args[1]['verify'], False)
 
     @mock.patch('botocore.session.Session.create_client')
     def test_call_parameters_only_endpoint(self, call_patch):
         endpoint_arg = 'https://elasticmapreduce.us-unknown-1.amazonaws.com'
         cmdline = self.prefix + ' --endpoint ' + endpoint_arg
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(call_patch.call_args[1]['endpoint_url'], None)
+        self.assertEqual(call_patch.call_args[1]['endpoint_url'], None)
 
     @mock.patch('botocore.session.Session.create_client')
     def test_call_parameters_only_iam_endpoint(self, call_patch):
         endpoint_arg = 'https://elasticmapreduce.us-unknown-1.amazonaws.com'
         cmdline = self.prefix + ' --iam-endpoint ' + endpoint_arg
         self.run_cmd(cmdline, expected_rc=0)
-        self.assertEquals(call_patch.call_args[1]['endpoint_url'],
+        self.assertEqual(call_patch.call_args[1]['endpoint_url'],
                           endpoint_arg)
 
     @mock.patch('awscli.customizations.emr.emr.'
@@ -360,35 +360,35 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
         result = self.run_cmd(cmdline, 0)
         expected_output = json.dumps(CONSTRUCTED_RESULT_OUTPUT, indent=4) +\
             '\n'
-        self.assertEquals(result[0], expected_output)
+        self.assertEqual(result[0], expected_output)
 
     def test_policy_arn_construction(self):
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("cn-north-1", createdefaultroles.EC2_ROLE_POLICY_NAME),
             CN_EC2_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("us-gov-west-1", createdefaultroles.EC2_ROLE_POLICY_NAME),
             US_GOV_EC2_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("eu-west-1", createdefaultroles.EC2_ROLE_POLICY_NAME),
             EC2_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("cn-north-1", createdefaultroles.EMR_ROLE_POLICY_NAME),
             CN_EMR_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("us-gov-west-1", createdefaultroles.EMR_ROLE_POLICY_NAME),
             US_GOV_EMR_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("eu-west-1", createdefaultroles.EMR_ROLE_POLICY_NAME),
             EMR_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("cn-north-1", createdefaultroles.EMR_AUTOSCALING_ROLE_POLICY_NAME),
             CN_EMR_AUTOSCALING_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("us-gov-west-1",
                                                    createdefaultroles.EMR_AUTOSCALING_ROLE_POLICY_NAME),
             US_GOV_EMR_AUTOSCALING_ROLE_ARN)
-        self.assertEquals(
+        self.assertEqual(
             createdefaultroles.get_role_policy_arn("eu-west-1", createdefaultroles.EMR_AUTOSCALING_ROLE_POLICY_NAME),
             EMR_AUTOSCALING_ROLE_ARN)
 

--- a/tests/unit/customizations/emr/test_describe_cluster.py
+++ b/tests/unit/customizations/emr/test_describe_cluster.py
@@ -403,7 +403,7 @@ class TestDescribeCluster(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = self.run_cmd(cmdline, expected_rc=0)
         result_json = json.loads(result[0])
-        self.assertEquals(result_json, EXPECTED_RESULT_IG)
+        self.assertEqual(result_json, EXPECTED_RESULT_IG)
 
     @patch('awscli.customizations.emr.emr.DescribeCluster._call')
     def test_constructed_result_if(self, call_patch):
@@ -413,7 +413,7 @@ class TestDescribeCluster(BaseAWSCommandParamsTest):
         cmdline = self.prefix + args
         result = self.run_cmd(cmdline, expected_rc=0)
         result_json = json.loads(result[0])
-        self.assertEquals(result_json, EXPECTED_RESULT_IF)
+        self.assertEqual(result_json, EXPECTED_RESULT_IF)
 
 def side_effect_of_call_ig(*args, **kwargs):
     if args[1] == 'describe_cluster':

--- a/tests/unit/customizations/emr/test_disable_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_disable_hbase_backup.py
@@ -73,7 +73,7 @@ class TestDisableHBaseBackups(BaseAWSCommandParamsTest):
                              ' and --incremental.\n'
         result = self.run_cmd(cmdline, 255)
 
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     @mock.patch('awscli.customizations.emr.'
                 'emrutils.get_release_label')

--- a/tests/unit/customizations/emr/test_list_clusters.py
+++ b/tests/unit/customizations/emr/test_list_clusters.py
@@ -57,7 +57,7 @@ class TestListClusters(BaseAWSCommandParamsTest):
             '\naws: error: You can specify only one of the cluster state '
             'filters: --cluster-states, --active, --terminated, --failed.\n')
         result = self.run_cmd(cmdline, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
         args = '--cluster-states STARTING RUNNING --terminated'
         cmdline = self.prefix + args
@@ -65,7 +65,7 @@ class TestListClusters(BaseAWSCommandParamsTest):
             '\naws: error: You can specify only one of the cluster state '
             'filters: --cluster-states, --active, --terminated, --failed.\n')
         result = self.run_cmd(cmdline, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/emr/test_modify_cluster_attributes.py
+++ b/tests/unit/customizations/emr/test_modify_cluster_attributes.py
@@ -51,7 +51,7 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
             '\naws: error: You cannot specify both --visible-to-all-users '
             'and --no-visible-to-all-users options together.\n')
         result = self.run_cmd(cmdline, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_temination_protected_and_no_termination_protected(self):
         args = ' --cluster-id j-ABC123456 --no-termination-protected'\
@@ -61,7 +61,7 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
             '\naws: error: You cannot specify both --termination-protected '
             'and --no-termination-protected options together.\n')
         result = self.run_cmd(cmdline, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_termination_protected_and_visible_to_all(self):
         args = ' --cluster-id j-ABC123456 --termination-protected'\
@@ -99,7 +99,7 @@ class TestModifyClusterAttributes(BaseAWSCommandParamsTest):
             '--visible-to-all-users|--no-visible-to-all-users, '
             '--termination-protected|--no-termination-protected.\n')
         result = self.run_cmd(cmdline, 255)
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/emr/test_schedule_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_schedule_hbase_backup.py
@@ -95,7 +95,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
                              ' either full or incremental.\n'
         result = self.run_cmd(cmdline, 255)
 
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_schedule_hbase_backup_wrong_unit(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/  --type full' +\
@@ -106,7 +106,7 @@ class TestScheduleHBaseBackup(BaseAWSCommandParamsTest):
                              ' hours or days.\n'
         result = self.run_cmd(cmdline, 255)
 
-        self.assertEquals(expected_error_msg, result[1])
+        self.assertEqual(expected_error_msg, result[1])
 
     def test_schedule_hbase_backup_consistent(self):
         args = ' --cluster-id j-ABCD --dir s3://abc/ --type full' +\

--- a/tests/unit/customizations/history/test_show.py
+++ b/tests/unit/customizations/history/test_show.py
@@ -638,7 +638,7 @@ class TestShowCommand(unittest.TestCase):
 
         db_filename = os.path.join(self.files.rootdir, 'name.db')
         with mock.patch('os.environ', {'AWS_CLI_HISTORY_FILE': db_filename}):
-            with self.assertRaisesRegexp(
+            with self.assertRaisesRegex(
                     RuntimeError, 'Could not locate history'):
                 self.show_cmd._run_main(self.parsed_args, self.parsed_globals)
 

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -531,7 +531,7 @@ class S3FileGeneratorTest(BaseAWSCommandParamsTest):
         file_gen = FileGenerator(self.client, '')
         files = file_gen.call(input_s3_file)
         # The error should include 404 and should include the key name.
-        with self.assertRaisesRegexp(ClientError, '404.*text1.txt'):
+        with self.assertRaisesRegex(ClientError, '404.*text1.txt'):
             list(files)
 
     def test_s3_single_file_delete(self):

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -48,8 +48,8 @@ class TestFileInfoBuilder(unittest.TestCase):
                           operation_name='delete')]
         file_infos = info_setter.call(files)
         for file_info in file_infos:
-            self.assertEquals(file_info.client, source_client_name)
-            self.assertEquals(file_info.source_client, client_name)
+            self.assertEqual(file_info.client, source_client_name)
+            self.assertEqual(file_info.source_client, client_name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/customizations/s3/test_filters.py
+++ b/tests/unit/customizations/s3/test_filters.py
@@ -215,11 +215,11 @@ class FiltersTest(unittest.TestCase):
 
         source_pattern = s3_filter.patterns[0][1]
         destination_pattern = s3_filter.dst_patterns[0][1]
-        self.assertEquals(source_pattern, source + pattern)
-        self.assertEquals(destination_pattern, destination + pattern)
+        self.assertEqual(source_pattern, source + pattern)
+        self.assertEqual(destination_pattern, destination + pattern)
 
         filtered = list(s3_filter.call(self.s3_files))
-        self.assertEquals(len(filtered), 2)
+        self.assertEqual(len(filtered), 2)
         for filtered_file in filtered:
             self.assertFalse('.txt' in filtered_file.src)
 

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -661,14 +661,14 @@ class CommandParametersTest(unittest.TestCase):
         paths = ['s3://bucket/foo', 's3://bucket/bar']
         params = {'dir_op': False, 'sse_c_key': 'foo'}
         cmd_param = CommandParameters('cp', params, '')
-        with self.assertRaisesRegexp(ValueError, '--sse-c must be specified'):
+        with self.assertRaisesRegex(ValueError, '--sse-c must be specified'):
             cmd_param.add_paths(paths)
 
     def test_validate_sse_c_args_missing_sse_c_key(self):
         paths = ['s3://bucket/foo', 's3://bucket/bar']
         params = {'dir_op': False, 'sse_c': 'AES256'}
         cmd_param = CommandParameters('cp', params, '')
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      '--sse-c-key must be specified'):
             cmd_param.add_paths(paths)
 
@@ -676,7 +676,7 @@ class CommandParametersTest(unittest.TestCase):
         paths = ['s3://bucket/foo', 's3://bucket/bar']
         params = {'dir_op': False, 'sse_c_copy_source_key': 'foo'}
         cmd_param = CommandParameters('cp', params, '')
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      '--sse-c-copy-source must be specified'):
             cmd_param.add_paths(paths)
 
@@ -684,7 +684,7 @@ class CommandParametersTest(unittest.TestCase):
         paths = ['s3://bucket/foo', 's3://bucket/bar']
         params = {'dir_op': False, 'sse_c_copy_source': 'AES256'}
         cmd_param = CommandParameters('cp', params, '')
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                 '--sse-c-copy-source-key must be specified'):
             cmd_param.add_paths(paths)
 
@@ -693,7 +693,7 @@ class CommandParametersTest(unittest.TestCase):
         params = {'dir_op': False, 'sse_c_copy_source': 'AES256',
                   'sse_c_copy_source_key': 'foo'}
         cmd_param = CommandParameters('cp', params, '')
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      'only supported for copy operations'):
             cmd_param.add_paths(paths)
 

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -301,7 +301,7 @@ class TestFindBucketKey(unittest.TestCase):
 
 class TestBlockUnsupportedResources(unittest.TestCase):
     def test_object_lambda_arn_with_colon_raises_exception(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Use s3api commands instead'):
             block_unsupported_resources(
                 'arn:aws:s3-object-lambda:us-west-2:123456789012:'
@@ -309,7 +309,7 @@ class TestBlockUnsupportedResources(unittest.TestCase):
             )
 
     def test_object_lambda_arn_with_slash_raises_exception(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Use s3api commands instead'):
             block_unsupported_resources(
                  'arn:aws:s3-object-lambda:us-west-2:123456789012:'
@@ -317,7 +317,7 @@ class TestBlockUnsupportedResources(unittest.TestCase):
             )
 
     def test_outpost_bucket_arn_with_colon_raises_exception(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Use s3control commands instead'):
             block_unsupported_resources(
                 'arn:aws:s3-outposts:us-west-2:123456789012:'
@@ -325,7 +325,7 @@ class TestBlockUnsupportedResources(unittest.TestCase):
             )
 
     def test_outpost_bucket_arn_with_slash_raises_exception(self):
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 ValueError, 'Use s3control commands instead'):
             block_unsupported_resources(
                  'arn:aws:s3-outposts:us-west-2:123456789012:'
@@ -502,7 +502,7 @@ class TestGetFileStat(unittest.TestCase):
 
     def test_error_message(self):
         with mock.patch('os.stat', mock.Mock(side_effect=IOError('msg'))):
-            with self.assertRaisesRegexp(ValueError, 'myfilename\.txt'):
+            with self.assertRaisesRegex(ValueError, 'myfilename\.txt'):
                 get_file_stat('myfilename.txt')
 
     def assert_handles_fromtimestamp_error(self, error):

--- a/tests/unit/customizations/servicecatalog/test_generateproduct.py
+++ b/tests/unit/customizations/servicecatalog/test_generateproduct.py
@@ -107,7 +107,7 @@ class TestCreateProductCommand(unittest.TestCase):
         self.assertEqual(expected_response_output,
                          captured.stdout.getvalue()
                          )
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
     @patch('os.path.getsize', return_value=1)
     def test_happy_path_unicode(self, getsize_patch):
@@ -160,11 +160,11 @@ class TestCreateProductCommand(unittest.TestCase):
         self.assertEqual(expected_response_output,
                          captured.stdout.getvalue()
                          )
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
     def test_region_not_supported(self):
         self.global_args.region = 'not-supported-region'
-        with self.assertRaisesRegexp(exceptions.InvalidParametersException,
+        with self.assertRaisesRegex(exceptions.InvalidParametersException,
                                      "not supported"):
             self.cmd._run_main(self.args, self.global_args)
 
@@ -212,7 +212,7 @@ class TestCreateProductCommand(unittest.TestCase):
 
         self.assertEqual(expected_response_output,
                          captured.stdout.getvalue())
-        self.assertEquals(0, result)
+        self.assertEqual(0, result)
 
     def get_product_view_detail(self):
         return {

--- a/tests/unit/customizations/servicecatalog/test_generateprovisioningartifact.py
+++ b/tests/unit/customizations/servicecatalog/test_generateprovisioningartifact.py
@@ -122,7 +122,7 @@ class TestCreateProvisioningArtifactCommand(unittest.TestCase):
 
     def test_region_not_supported(self):
         self.global_args.region = 'not-supported-region'
-        with self.assertRaisesRegexp(exceptions.InvalidParametersException,
+        with self.assertRaisesRegex(exceptions.InvalidParametersException,
                                      "not supported"):
             self.cmd._run_main(self.args, self.global_args)
 

--- a/tests/unit/customizations/test_arguments.py
+++ b/tests/unit/customizations/test_arguments.py
@@ -70,11 +70,11 @@ class TestArgumentHelpers(unittest.TestCase):
 
     def test_works_with_valid_filename(self):
         filename = self.files.create_file('valid', '')
-        self.assertEquals(filename, resolve_given_outfile_path(filename))
+        self.assertEqual(filename, resolve_given_outfile_path(filename))
 
     def test_works_with_relative_filename(self):
         filename = '../valid'
-        self.assertEquals(filename, resolve_given_outfile_path(filename))
+        self.assertEqual(filename, resolve_given_outfile_path(filename))
 
     def test_raises_when_cannot_write_to_file(self):
         filename = os.sep.join(['_path', 'not', '_exist_', 'file.xyz'])
@@ -123,14 +123,14 @@ class TestQueryFileArgument(unittest.TestCase):
         arg.save_query({'ResponseMetadata': {'HTTPStatusCode': 200},
                         'baz': 'abc123'})
         with open(outfile) as fp:
-            self.assertEquals('abc123', fp.read())
-        self.assertEquals(1, session.register.call_count)
+            self.assertEqual('abc123', fp.read())
+        self.assertEqual(1, session.register.call_count)
         session.register.assert_called_with('event', arg.save_query)
 
     def test_does_not_save_when_not_set(self):
         session = mock.Mock()
         QueryOutFileArgument(session, 'foo', 'baz', 'event', 0o600)
-        self.assertEquals(0, session.register.call_count)
+        self.assertEqual(0, session.register.call_count)
 
     def test_saves_query_to_file_as_empty_string_when_none_result(self):
         outfile = self.files.create_file('none-test', '')
@@ -139,7 +139,7 @@ class TestQueryFileArgument(unittest.TestCase):
         arg.add_to_params({}, outfile)
         arg.save_query({'ResponseMetadata': {'HTTPStatusCode': 200}})
         with open(outfile) as fp:
-            self.assertEquals('', fp.read())
+            self.assertEqual('', fp.read())
 
     @skip_if_windows("Test not valid on windows.")
     def test_permissions_on_created_file(self):

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -178,7 +178,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertEquals('', output)
+        self.assertEqual('', output)
 
     def test_raises_value_error_when_not_provided_any_subcommands(self):
         self.get_command = CodeCommitCommand(self.session)
@@ -208,11 +208,11 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         aws_request = signature.call_args[0][1]
-        self.assertEquals('GIT', aws_request.method)
-        self.assertEquals(
+        self.assertEqual('GIT', aws_request.method)
+        self.assertEqual(
             'https://git-codecommit.us-east-1.amazonaws.com//v1/repos/myrepo',
             aws_request.url)
-        self.assertEquals(
+        self.assertEqual(
             ('GIT\n//v1/repos/myrepo\n\n'
              'host:git-codecommit.us-east-1.amazonaws.com\n\n'
              'host\n'),

--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -70,7 +70,7 @@ class TestS3Uploader(unittest.TestCase):
         s3uploader.artifact_metadata = artifact_metadata
 
         upload_url = s3uploader.upload(file_name, remote_path)
-        self.assertEquals(expected_upload_url, upload_url)
+        self.assertEqual(expected_upload_url, upload_url)
 
         expected_extra_args = {
             # expected encryption args
@@ -104,7 +104,7 @@ class TestS3Uploader(unittest.TestCase):
         s3uploader.artifact_metadata = artifact_metadata
 
         upload_url = s3uploader.upload(file_name, remote_path)
-        self.assertEquals(expected_upload_url, upload_url)
+        self.assertEqual(expected_upload_url, upload_url)
 
         expected_extra_args = {
             # expected encryption args
@@ -150,7 +150,7 @@ class TestS3Uploader(unittest.TestCase):
 
         # Because we forced an update, this should reupload even if file exists
         upload_url = self.s3uploader.upload(file_name, remote_path)
-        self.assertEquals(expected_upload_url, upload_url)
+        self.assertEqual(expected_upload_url, upload_url)
 
         expected_encryption_args = {
             "ServerSideEncryption": "AES256"
@@ -180,7 +180,7 @@ class TestS3Uploader(unittest.TestCase):
         self.s3uploader.file_exists.return_value = False
 
         upload_url = self.s3uploader.upload(file_name, remote_path)
-        self.assertEquals(expected_upload_url, upload_url)
+        self.assertEqual(expected_upload_url, upload_url)
 
         expected_encryption_args = {
             "ServerSideEncryption": "aws:kms",
@@ -309,7 +309,7 @@ class TestS3Uploader(unittest.TestCase):
     def test_make_url(self):
         path = "Hello/how/are/you"
         expected = "s3://{0}/{1}".format(self.bucket_name, path)
-        self.assertEquals(expected, self.s3uploader.make_url(path))
+        self.assertEqual(expected, self.s3uploader.make_url(path))
 
     def test_to_path_style_s3_url_us_east_1(self):
         key = "path/to/file"

--- a/tests/unit/customizations/test_sessionmanager.py
+++ b/tests/unit/customizations/test_sessionmanager.py
@@ -36,7 +36,7 @@ class TestSessionManager(unittest.TestCase):
     def test_start_session_when_non_custom_start_session_fails(self):
         self.client.start_session.side_effect = Exception('some exception')
         params = {}
-        with self.assertRaisesRegexp(Exception, 'some exception'):
+        with self.assertRaisesRegex(Exception, 'some exception'):
             self.caller.invoke('ssm', 'StartSession', params, mock.Mock())
 
     @mock.patch('awscli.customizations.sessionmanager.check_call')
@@ -57,7 +57,7 @@ class TestSessionManager(unittest.TestCase):
 
         rc = self.caller.invoke('ssm', 'StartSession',
                                 start_session_params, mock.Mock())
-        self.assertEquals(rc, 0)
+        self.assertEqual(rc, 0)
         self.client.start_session.assert_called_with(**start_session_params)
         mock_check_call_list = mock_check_call.call_args[0][0]
         mock_check_call_list[1] = json.loads(mock_check_call_list[1])
@@ -133,7 +133,7 @@ class TestSessionManager(unittest.TestCase):
 
         rc = self.caller.invoke('ssm', 'StartSession',
                                 start_session_params, mock.Mock())
-        self.assertEquals(rc, 0)
+        self.assertEqual(rc, 0)
         self.client.start_session.assert_called_with(**start_session_params)
         mock_check_call_list = mock_check_call.call_args[0][0]
-        self.assertEquals(mock_check_call_list[4], '')
+        self.assertEqual(mock_check_call_list[4], '')

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -396,7 +396,7 @@ class TestParamShorthand(BaseArgProcessTest):
             'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration')
         value = 'ApplicationName:foo,TemplateName=bar'
         error_msg = "Error parsing parameter '--source-configuration'.*Expected"
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, value)
 
     def test_improper_separator(self):
@@ -406,13 +406,13 @@ class TestParamShorthand(BaseArgProcessTest):
             'elasticbeanstalk.CreateConfigurationTemplate.SourceConfiguration')
         value = 'ApplicationName:foo,TemplateName:bar'
         error_msg = "Error parsing parameter '--source-configuration'.*Expected"
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, value)
 
     def test_improper_separator_for_filters_param(self):
         p = self.get_param_model('ec2.DescribeInstances.Filters')
         error_msg = "Error parsing parameter '--filters'.*Expected"
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, ["Name:tag:Name,Values:foo"])
 
     def test_csv_syntax_escaped(self):
@@ -442,13 +442,13 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_csv_syntax_errors(self):
         p = self.get_param_model('cloudformation.CreateStack.Parameters')
         error_msg = "Error parsing parameter '--parameters'.*Expected"
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue="foo,bar'])
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue=foo,bar"'])
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue=""foo,bar"'])
-        with self.assertRaisesRegexp(ParamError, error_msg):
+        with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue="foo,bar\''])
 
 

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -47,7 +47,7 @@ class TestRecursiveShapes(unittest.TestCase):
         indent = self.help_command.doc.style.indent.call_count
         dedent = self.help_command.doc.style.dedent.call_count
         message = 'Imbalanced indentation: indent (%s) != dedent (%s)'
-        self.assertEquals(indent, dedent, message % (indent, dedent))
+        self.assertEqual(indent, dedent, message % (indent, dedent))
 
     def test_handle_recursive_input(self):
         shape_map = {

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -102,7 +102,7 @@ class TestHelpPager(unittest.TestCase):
         renderer = FakePosixHelpRenderer()
         renderer.exists_on_path['groff'] = False
         expected_error = 'Could not find executable named "groff"'
-        with self.assertRaisesRegexp(ExecutableNotFoundError, expected_error):
+        with self.assertRaisesRegex(ExecutableNotFoundError, expected_error):
             renderer.render('foo')
 
     @skip_if_windows('Requires POSIX system.')

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -93,12 +93,12 @@ class TestHTTPBasedResourceLoading(unittest.TestCase):
 
     def test_non_200_raises_error(self):
         self.response.status_code = 500
-        with self.assertRaisesRegexp(ResourceLoadingError, 'foo\.bar\.baz'):
+        with self.assertRaisesRegex(ResourceLoadingError, 'foo\.bar\.baz'):
             self.get_paramfile('https://foo.bar.baz')
 
     def test_connection_error_raises_error(self):
         self.session_mock.side_effect = Exception("Connection error.")
-        with self.assertRaisesRegexp(ResourceLoadingError, 'foo\.bar\.baz'):
+        with self.assertRaisesRegex(ResourceLoadingError, 'foo\.bar\.baz'):
             self.get_paramfile('https://foo.bar.baz')
 
 


### PR DESCRIPTION
*Description of changes:*

Replace deprecated unittest aliases:

* `assertEquals` -> `assertEqual`
* `assertRaisesRegexp` -> `assertRaisesRegex`
* https://docs.python.org/3/library/unittest.html#deprecated-aliases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
