### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ The aws-cli package works on Python versions:
 -  3.6.x and greater
 -  3.7.x and greater
 -  3.8.x and greater
+-  3.9.x and greater
 
 On 01/15/2021 deprecation for Python 2.7 was announced and support was dropped
 on 07/15/2021. To avoid disruption, customers using the AWS CLI on Python 2.7 may

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -135,7 +135,7 @@ def _generate_signature(params):
         policy = base64.b64encode(six.b(policy)).decode('utf-8')
         new_hmac = hmac.new(sak.encode('utf-8'), digestmod=sha1)
         new_hmac.update(six.b(policy))
-        ps = base64.encodestring(new_hmac.digest()).strip().decode('utf-8')
+        ps = base64.encodebytes(new_hmac.digest()).strip().decode('utf-8')
         params['UploadPolicySignature'] = ps
         del params['_SAK']
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup_options = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )
 

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -70,7 +70,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def test_policy_provided(self):
         policy = '{"notarealpolicy":true}'
-        base64policy = base64.encodestring(six.b(policy)).strip().decode('utf-8')
+        base64policy = base64.encodebytes(six.b(policy)).strip().decode('utf-8')
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 
 skipsdist = True
 


### PR DESCRIPTION
*Description of changes:*

* Add support for Python 3.9, released in October 2020.

* Replace alias `base64.encodestring` (deprecated in Python 3.1, removed in 3.1) with `base64.encodebytes` (added in 3.9)
  * https://docs.python.org/3.8/library/base64.html#base64.encodestring
  * https://docs.python.org/3.9/whatsnew/3.9.html#removed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

And a heads-up, nose is unmaintained (last release 1.3.7 was in 2015) and will stop working in Python 3.10 (to be released October 2021 and RC now available on GHA as `3.10-dev`) due to:

> Remove deprecated aliases to Collections Abstract Base Classes from the `collections` module. 

https://docs.python.org/3.10/whatsnew/3.10.html#removed