### PR TITLE
Add documentation for maximum expiration time for an S3 presigned URL…

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -687,7 +687,7 @@ class PresignCommand(S3Command):
                   'cli_type_name': 'integer',
                   'help_text': (
                       'Number of seconds until the pre-signed '
-                      'URL expires.  Default is 3600 seconds.')}]
+                      'URL expires.  Default is 3600 seconds. Maximum is 604800 seconds.')}]
 
     def _run_main(self, parsed_args, parsed_globals):
         super(PresignCommand, self)._run_main(parsed_args, parsed_globals)


### PR DESCRIPTION
*Issue #, if available:*

Fixes #5464 

*Description of changes:*

Add documentation for the max expiration time of an S3 presigned URL when using SigV4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
