### PR TITLE
Fixed emr-containers update-role-trust-policy for non aws partition

### DIFF
--- a/.changes/next-release/enhancement-emrcontainers-7288.json
+++ b/.changes/next-release/enhancement-emrcontainers-7288.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "emr-containers",
+  "description": "Adds addition aws partition support for update-role-trust-policy"
+}

--- a/awscli/customizations/emrcontainers/constants.py
+++ b/awscli/customizations/emrcontainers/constants.py
@@ -17,7 +17,7 @@
 TRUST_POLICY_STATEMENT_FORMAT = '{ \
     "Effect": "Allow", \
     "Principal": { \
-        "Federated": "arn:%(POLICY_ARN)s:iam::%(AWS_ACCOUNT_ID)s:oidc-provider/' \
+        "Federated": "arn:%(AWS_PARTITION)s:iam::%(AWS_ACCOUNT_ID)s:oidc-provider/' \
                                 '%(OIDC_PROVIDER)s" \
     }, \
     "Action": "sts:AssumeRoleWithWebIdentity", \

--- a/awscli/customizations/emrcontainers/constants.py
+++ b/awscli/customizations/emrcontainers/constants.py
@@ -17,7 +17,7 @@
 TRUST_POLICY_STATEMENT_FORMAT = '{ \
     "Effect": "Allow", \
     "Principal": { \
-        "Federated": "arn:aws:iam::%(AWS_ACCOUNT_ID)s:oidc-provider/' \
+        "Federated": "arn:%(POLICY_ARN)s:iam::%(AWS_ACCOUNT_ID)s:oidc-provider/' \
                                 '%(OIDC_PROVIDER)s" \
     }, \
     "Action": "sts:AssumeRoleWithWebIdentity", \

--- a/awscli/customizations/emrcontainers/update_role_trust_policy.py
+++ b/awscli/customizations/emrcontainers/update_role_trust_policy.py
@@ -22,7 +22,7 @@ from awscli.customizations.emrcontainers.constants \
 from awscli.customizations.emrcontainers.base36 import Base36
 from awscli.customizations.emrcontainers.eks import EKS
 from awscli.customizations.emrcontainers.iam import IAM
-from awscli.customizations.utils import uni_print
+from awscli.customizations.utils import uni_print, get_policy_arn_suffix
 
 LOG = logging.getLogger(__name__)
 
@@ -152,7 +152,8 @@ class UpdateRoleTrustPolicyCommand(BasicCommand):
                 "AWS_ACCOUNT_ID": account_id,
                 "OIDC_PROVIDER": oidc_provider,
                 "NAMESPACE": self._namespace,
-                "BASE36_ENCODED_ROLE_NAME": base36_encoded_role_name
+                "BASE36_ENCODED_ROLE_NAME": base36_encoded_role_name,
+                "POLICY_ARN": get_policy_arn_suffix(self._region)
             }
         )
 

--- a/awscli/customizations/emrcontainers/update_role_trust_policy.py
+++ b/awscli/customizations/emrcontainers/update_role_trust_policy.py
@@ -147,15 +147,13 @@ class UpdateRoleTrustPolicyCommand(BasicCommand):
 
         base36_encoded_role_name = base36.encode(self._role_name)
         LOG.debug('Base36 encoded role name: %s', base36_encoded_role_name)
-        trust_policy_statement = json.loads(TRUST_POLICY_STATEMENT_FORMAT %
-            {
-                "AWS_ACCOUNT_ID": account_id,
-                "OIDC_PROVIDER": oidc_provider,
-                "NAMESPACE": self._namespace,
-                "BASE36_ENCODED_ROLE_NAME": base36_encoded_role_name,
-                "POLICY_ARN": get_policy_arn_suffix(self._region)
-            }
-        )
+        trust_policy_statement = json.loads(TRUST_POLICY_STATEMENT_FORMAT % {
+            "AWS_ACCOUNT_ID": account_id,
+            "OIDC_PROVIDER": oidc_provider,
+            "NAMESPACE": self._namespace,
+            "BASE36_ENCODED_ROLE_NAME": base36_encoded_role_name,
+            "AWS_PARTITION": get_policy_arn_suffix(self._region)
+        })
 
         LOG.debug('Computed Trust Policy Statement:\n%s', json.dumps(
             trust_policy_statement, indent=2))


### PR DESCRIPTION
Fix emr-containers update-role-trust-policy for non aws partition

*Issue #, if available:*

*Description of changes:*

* Updated TRUST_POLICY_STATEMENT_FORMAT with correct AWS partition in arn for emr-containers update-role-trust-policy
* Added unit test to test update-role-trust-policy in a CN partition

*Testing:*

Tested update-role-trust-policy against a EKS cluster in cn-north-1

```
aws emr-containers update-role-trust-policy \
       --cluster-name lamricky-test \
       --namespace namespace \
       --role-name lamrickyJobExecutionRole
```
The following policy was added:

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Service": "ec2.amazonaws.com.cn"
      },
      "Action": "sts:AssumeRole"
    },
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws-cn:iam::065596917820:oidc-provider/oidc.eks.cn-north-1.amazonaws.com.cn/id/03844B1E626AF1801BDABC572F744B3E"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringLike": {
          "oidc.eks.cn-north-1.amazonaws.com.cn/id/03844B1E626AF1801BDABC572F744B3E:sub": "system:serviceaccount:namespace:emr-containers-sa-*-*-065596917820-oz977czyn9caw6ow33q8eppc4tg1kr4kekspx"
        }
      }
    }
  ]
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
