### PR TITLE
Update regex for MRAP ARNs

### DIFF
--- a/.changes/next-release/enhancement-s3-98502.json
+++ b/.changes/next-release/enhancement-s3-98502.json
@@ -1,0 +1,5 @@
+{
+  "category": "``s3``", 
+  "type": "enhancement", 
+  "description": "Add support for multi-region access points."
+}

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -44,7 +44,7 @@ SIZE_SUFFIX = {
     'tib': 1024 ** 4,
 }
 _S3_ACCESSPOINT_TO_BUCKET_KEY_REGEX = re.compile(
-    r'^(?P<bucket>arn:(aws).*:s3:[a-z\-0-9]+:[0-9]{12}:accesspoint[:/][^/]+)/?'
+    r'^(?P<bucket>arn:(aws).*:s3:[a-z\-0-9]*:[0-9]{12}:accesspoint[:/][^/]+)/?'
     r'(?P<key>.*)$'
 )
 _S3_OUTPOST_TO_BUCKET_KEY_REGEX = re.compile(

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -1146,3 +1146,33 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
                     'mykey'),
             ]
         )
+
+    def test_accepts_mrap_arns(self):
+        mrap_arn = (
+            'arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap'
+        )
+        filename = self.files.create_file('myfile', 'mycontent')
+        cmdline = self.prefix
+        cmdline += ' %s' % filename
+        cmdline += ' s3://%s/mykey' % mrap_arn
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                self.put_object_request(mrap_arn, 'mykey')
+            ]
+        )
+
+    def test_accepts_mrap_arns_with_slash(self):
+        mrap_arn = (
+            'arn:aws:s3::123456789012:accesspoint/mfzwi23gnjvgw.mrap'
+        )
+        filename = self.files.create_file('myfile', 'mycontent')
+        cmdline = self.prefix
+        cmdline += ' %s' % filename
+        cmdline += ' s3://%s/mykey' % mrap_arn
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                self.put_object_request(mrap_arn, 'mykey')
+            ]
+        )


### PR DESCRIPTION
For MRAP arns there is no region field so we needed to relax the regex to allow for empty region values in the arn.
