### PR TITLE
Rework test runners to centralized workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,3 @@
-
 name: Run tests
 
 on:
@@ -28,10 +27,9 @@ jobs:
         python scripts/ci/install
         python scripts/ci/install-check
     - name: Run tests
-      run: python scripts/ci/run-tests
+      run: python scripts/ci/run-tests --with-cov
     - name: Run checks
       run: python scripts/ci/run-check
-
     - name: codecov
       run: |
         rm tests/coverage.xml

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -9,12 +9,11 @@ from subprocess import check_call
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+os.chdir(os.path.join(REPO_ROOT, "tests"))
 
 
 def run(command):
     return check_call(command, shell=True)
 
 
-run('nosetests --with-xunit --cover-erase --with-coverage '
-    '--cover-package awscli --cover-xml -v integration')
+run(f"{REPO_ROOT}/scripts/ci/run-tests --with-cov integration")

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -3,18 +3,58 @@
 # We want to ensure we're importing from the installed
 # binary package not from the CWD.
 
+import argparse
 import os
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+PACKAGE = "awscli"
+os.chdir(os.path.join(REPO_ROOT, "tests"))
 
 
 def run(command):
     return check_call(command, shell=True)
 
 
-run('nosetests --with-coverage --cover-erase --cover-package awscli '
-    '--traverse-namespace --with-xunit --cover-xml unit/ functional/')
+def process_args(args):
+    runner = args.test_runner
+    test_args = ''
+    if args.with_cov:
+        test_args += (
+            f"--with-xunit --cover-erase --with-coverage "
+            f"--cover-package {PACKAGE} --cover-xml -v "
+        )
+    dirs = " ".join(args.test_dirs)
+
+    return runner, test_args, dirs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "test_dirs",
+        default=["unit/", "functional/"],
+        nargs="*",
+        help="One or more directories containing tests.",
+    )
+    parser.add_argument(
+        "-r",
+        "--test-runner",
+        default="nosetests",
+        help="Test runner to execute tests. Defaults to nose.",
+    )
+    parser.add_argument(
+        "-c",
+        "--with-cov",
+        default=False,
+        action="store_true",
+        help="Run default test-runner with code coverage enabled.",
+    )
+    raw_args = parser.parse_args()
+    test_runner, test_args, test_dirs = process_args(raw_args)
+
+    cmd = f"{test_runner} {test_args}{test_dirs}"
+    print(f"Running {cmd}...")
+    run(cmd)


### PR DESCRIPTION
This is part of a series of PRs to standardize our test runner scripts for CI across repos. This will work as a stepping block to getting us migrated to arbitrary test runners such as pytest that can be used on a per project basis.