### PR TITLE
Update sphinx to 1.2.3

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,3 @@
 docutils>=0.10,<0.16
-Sphinx==1.1.3
+Sphinx==1.2.3
 -e .


### PR DESCRIPTION
This matches the version used for botocore/boto3 and has wheel available to use.
