### PR TITLE
V2 -> Allow S3 url in template path for `cloudformation deploy` command

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -308,13 +308,16 @@ class DeployCommand(BasicCommand):
                     verify=parsed_globals.verify_ssl)
 
         template_path = parsed_args.template_file
-        if not os.path.isfile(template_path):
-            raise exceptions.InvalidTemplatePathError(
-                    template_path=template_path)
+        if template_path.startswith("https://"):
+            template_str = template_path
+        else:
+            if not os.path.isfile(template_path):
+                raise exceptions.InvalidTemplatePathError(
+                        template_path=template_path)
 
-        # Parse parameters
-        with compat_open(template_path, "r") as handle:
-            template_str = handle.read()
+            # Parse parameters
+            with open(template_path, "r") as handle:
+                template_str = handle.read()
 
         stack_name = parsed_args.stack_name
         parameter_overrides = self.parse_parameter_overrides(

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -122,7 +122,7 @@ class DeployCommand(BasicCommand):
             'name': 'template-file',
             'required': True,
             'help_text': (
-                'The path where your AWS CloudFormation'
+                'The local path or s3 url where your AWS CloudFormation'
                 ' template is located.'
             )
         },

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -111,13 +111,17 @@ class Deployer(object):
         kwargs = {
             'ChangeSetName': changeset_name,
             'StackName': stack_name,
-            'TemplateBody': cfn_template,
             'ChangeSetType': changeset_type,
             'Parameters': parameter_values,
             'Capabilities': capabilities,
             'Description': description,
             'Tags': tags,
         }
+
+        if cfn_template.startswith('https://'):
+            kwargs['TemplateUrl'] = cfn_template
+        else:
+            kwargs['TemplateBody'] = cfn_template
 
         # If an S3 uploader is available, use TemplateURL to deploy rather than
         # TemplateBody. This is required for large templates.

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -119,7 +119,7 @@ class Deployer(object):
         }
 
         if cfn_template.startswith('https://'):
-            kwargs['TemplateUrl'] = cfn_template
+            kwargs['TemplateURL'] = cfn_template
         else:
             kwargs['TemplateBody'] = cfn_template
 


### PR DESCRIPTION
*Issues*
https://github.com/aws/aws-cli/issues/2461
https://github.com/aws/aws-cli/issues/4773
https://github.com/aws/aws-cli/issues/3643

*Description of changes:*
Updated code so that an s3 url can be passed in with --template-file in addition to the a local path.

*Steps to Test Usage*
Install proper version of awscli v2.
```
pip uninstall awscli
pip uninstall botocore
pip install git+https://github.com/boto/botocore.git@v2
pip install git+https://github.com/chikin-4x/aws-cli@feature-cfn-deploy-allow-s3-url 
```
Run command and give it the s3 url of an existing cloudformation template.
```
aws cloudformation deploy --stack-name <<stack-name>> --template-file https://<<bucket-name>>.s3.amazonaws.com/template.json 
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
