### PR TITLE
[v2] Remove repo root from path when running tests

### DIFF
--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -17,6 +17,7 @@ os.chdir(os.path.join(REPO_ROOT, 'tests'))
 def main():
     args = ['-v', 'integration/']
     print(f'Running py.test with args: {args}')
+    os.environ['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
     return pytest.main(args)
 
 

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -13,7 +13,9 @@ os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
 def run(command):
-    return check_call(command, shell=True)
+    env = os.environ.copy()
+    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    return check_call(command, shell=True, env=env)
 
 
 run('nosetests --with-coverage --cover-erase --cover-package awscli '

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,22 @@ from io import BytesIO, TextIOWrapper
 import collections
 import copy
 import os
+import sys
 from typing import Optional, Callable
+
+# Both nose and py.test will add the first parent directory it
+# encounters that does not have a __init__.py to the sys.path. In
+# our case, this is the root of the repository. This means that Python
+# will import the awscli package from source instead of any installed
+# distribution. This environment variable provides the option to remove the
+# repository root from sys.path to be able to rely on the installed
+# distribution when running the tests.
+if os.environ.get('TESTS_REMOVE_REPO_ROOT_FROM_PATH'):
+    rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path = [
+        path for path in sys.path
+        if not os.path.isdir(path) or not os.path.samefile(path, rootdir)
+    ]
 
 import awscli
 from awscli.clidriver import create_clidriver, AWSCLIEntryPoint


### PR DESCRIPTION
Both nose and py.test will add the first parent directory it encounters that does not have a` __init__.py` to the `sys.path`. In our case, this is the root of the repository. This means that Python will import the `awscli` package from source instead of the installed wheel distribution. So the new environment variable provides the option to remove the repository root from `sys.path` to be able to rely on the installed distribution when running the tests.

It is also worth noting that nose has `--no-path-adjustment` to fix this, but py.test does not have an option available without large refactorings of the tests.
