### PR TITLE
Fix typos.

### DIFF
--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -54,7 +54,7 @@ class UnknownArgumentError(Exception):
 
 
 def create_argument_model_from_schema(schema):
-    # Given a JSON schems (described in schema.py), convert it
+    # Given a JSON schema (described in schema.py), convert it
     # to a shape object from `botocore.model.Shape` that can be
     # used as the argument_model for the Argument classes below.
     transformer = SchemaTransformer()
@@ -234,7 +234,7 @@ class CustomArgument(BaseCLIArgument):
         self.argument_model = argument_model
 
         # If the top level element is a list then set nargs to
-        # accept multiple values seperated by a space.
+        # accept multiple values separated by a space.
         if self.argument_model is not None and \
                 self.argument_model.type_name == 'list':
             self._nargs = '+'

--- a/awscli/customizations/putmetricdata.py
+++ b/awscli/customizations/putmetricdata.py
@@ -98,7 +98,7 @@ def insert_first_element(name):
                 # We're taking a shortcut here and assuming that the first
                 # element is a struct type, hence the default value of
                 # a dict.  If this was going to be more general we'd need
-                # to have this paramterized, i.e. you pass in some sort of
+                # to have this parameterized, i.e. you pass in some sort of
                 # factory function that creates the initial starting value.
                 parameters[name] = [{}]
             first_element = parameters[name][0]

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -286,7 +286,7 @@ class ResultRecorder(BaseResultHandler):
         # gets created that the timestamp on the progress result is less
         # than the timestamp of when the result processor actually
         # processes that initial queued result. So this will avoid
-        # negative progress being displayed or zero divison occuring.
+        # negative progress being displayed or zero divison occurring.
         if result.timestamp > self.start_time:
             self.bytes_transfer_speed = self.bytes_transferred / (
                 result.timestamp - self.start_time)

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -277,7 +277,7 @@ class BaseTransferRequestSubmitter(object):
         for warning_handler in self._get_warning_handlers():
             if warning_handler(fileinfo):
                 # On the first warning handler that returns a signal to skip
-                # immediately propogate this signal and no longer check
+                # immediately propagate this signal and no longer check
                 # the other warning handlers as no matter what the file will
                 # be skipped.
                 return True

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -636,7 +636,7 @@ class WebsiteCommand(S3Command):
         # bucketname
         #
         # We also strip off the trailing slash if a user
-        # accidently appends a slash.
+        # accidentally appends a slash.
         if path.startswith('s3://'):
             path = path[5:]
         if path.endswith('/'):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -463,7 +463,7 @@ class RequestParamsMapper(object):
         >>> print(request_params)
         {'StorageClass': 'GLACIER', 'ServerSideEncryption': 'AES256'}
 
-    Note that existing parameters in ``request_params`` will be overriden if
+    Note that existing parameters in ``request_params`` will be overridden if
     a parameter in ``cli_params`` maps to the existing parameter.
     """
     @classmethod
@@ -652,7 +652,7 @@ class OnDoneFilteredSubscriber(BaseSubscriber):
             future.result()
         except Exception as e:
             future_exception = e
-        # If the result propogates an error, call the on_failure
+        # If the result propagates an error, call the on_failure
         # method instead.
         if future_exception:
             self._on_failure(future, future_exception)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -97,7 +97,7 @@ def awscli_initialize(event_handlers):
     event_handlers.register('session-initialized', register_uri_param_handler)
     param_shorthand = ParamShorthandParser()
     event_handlers.register('process-cli-arg', param_shorthand)
-    # The s3 error mesage needs to registered before the
+    # The s3 error message needs to registered before the
     # generic error handler.
     register_s3_error_msg(event_handlers)
 #    # The following will get fired for every option we are

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -71,7 +71,7 @@ class ShorthandParseError(Exception):
             num_spaces = self.index - last_newline - 1
         if '\n' in self.value[self.index:]:
             # If there's newline in the remaining, divide value
-            # into consumed and remainig
+            # into consumed and remaining
             # foo==bar,\n
             #     ^
             # bar=baz

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -185,7 +185,7 @@ class TopicTagDB(object):
             if tag in self.VALID_TAGS:
                 # Get the value of the tag.
                 values = field_body.childNodes[0].firstChild.nodeValue
-                # Seperate values into a list by splitting at commas
+                # Separate values into a list by splitting at commas
                 tag_values = values.split(',')
                 # Strip the white space around each of these values.
                 for i in range(len(tag_values)):

--- a/tests/functional/s3/test_ls_command.py
+++ b/tests/functional/s3/test_ls_command.py
@@ -106,7 +106,7 @@ class TestLSCommand(BaseS3TransferCommandTest):
         self.run_cmd('s3 ls s3://bucket/foo', expected_rc=0)
 
     def test_success_rc_empty_bucket_no_key_given(self):
-        # If no key has been provdided and the bucket is empty, it should
+        # If no key has been provided and the bucket is empty, it should
         # still return an rc of 0 since the user is not looking for an actual
         # object.
         self.parsed_responses = [{}]

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -71,7 +71,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
     def test_streaming_output_arg_with_error_response(self):
         # Checking that the StreamingOutputArg handles the
         # case where it's passed an error body.  Previously
-        # it would propogate a KeyError so we want to ensure
+        # it would propagate a KeyError so we want to ensure
         # this case is handled.
         self.parsed_response = {
             'Error': {

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -925,7 +925,7 @@ class TestWarnings(BaseS3IntegrationTest):
         bucket_name = _SHARED_BUCKET
         filename = os.path.join(self.files.rootdir, "no-exists-file")
         p = aws('s3 cp %s s3://%s/' % (filename, bucket_name))
-        # If the local path provided by the user is nonexistant for an
+        # If the local path provided by the user is nonexistent for an
         # upload, this should error out.
         self.assertEqual(p.rc, 255, p.stderr)
         self.assertIn('The user-provided path %s does not exist.' %
@@ -1479,7 +1479,7 @@ class TestMemoryUtilization(BaseS3IntegrationTest):
         full_command = 's3 cp s3://%s/foo.txt - > %s' % (bucket_name, foo_txt)
         p = aws(full_command, collect_memory=True)
         self.assert_no_errors(p)
-        # Use the ususal bar for maximum memory usage since a streaming
+        # Use the usual bar for maximum memory usage since a streaming
         # download's memory usage should be comparable to non-streaming
         # transfers.
         self.assert_max_memory_used(p, self.max_mem_allowed, full_command)
@@ -1780,7 +1780,7 @@ class TestStreams(BaseS3IntegrationTest):
     def test_multipart_download(self):
         """
         This tests the ability to multipart download streams to stdout.
-        The data has some unicode in it to avoid having to do a seperate
+        The data has some unicode in it to avoid having to do a separate
         multipart download test just for unicode.
         """
         bucket_name = _SHARED_BUCKET

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -414,14 +414,14 @@ class TestDeployCommand(unittest.TestCase):
         }
 
         expected_result = [
-            # Overriden values
+            # Overridden values
             {"ParameterKey": "Key1", "ParameterValue": "Value1"},
             {"ParameterKey": "Key3", "ParameterValue": "Value3"},
 
             # Parameter contains default value, but overridden with new value
             {"ParameterKey": "KeyWithDefaultValueButOverridden", "ParameterValue": "Value4"},
 
-            # non-overriden values
+            # non-overridden values
             {"ParameterKey": "Key2", "UsePreviousValue": True},
             {"ParameterKey": "Key4", "UsePreviousValue": True},
 

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -339,7 +339,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                                       {'region': 'us-east-1',
                                        'endpoint_url': None,
                                        'verify_ssl': None})
-        # Check that the default sync strategy is overwritted if a plugin
+        # Check that the default sync strategy is overwritten if a plugin
         # returns its sync strategy.
         mock_strategy = Mock()
         mock_strategy.sync_type = 'file_at_src_and_dest'

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -850,18 +850,18 @@ class TestDirectoryCreatorSubscriber(BaseTestWithFileCreator):
         # The directory should still exist
         self.assertTrue(os.path.exists(self.directory_to_create))
 
-    def test_on_queued_failure_propogates_create_directory_error(self):
+    def test_on_queued_failure_propagates_create_directory_error(self):
         # If makedirs() raises an OSError of exception, we should
-        # propogate the exception with a better worded CreateDirectoryError.
+        # propagate the exception with a better worded CreateDirectoryError.
         with mock.patch('os.makedirs') as makedirs_patch:
             makedirs_patch.side_effect = OSError()
             with self.assertRaises(CreateDirectoryError):
                 self.subscriber.on_queued(self.future)
         self.assertFalse(os.path.exists(self.directory_to_create))
 
-    def test_on_queued_failure_propogates_clear_error_message(self):
+    def test_on_queued_failure_propagates_clear_error_message(self):
         # If makedirs() raises an OSError of exception, we should
-        # propogate the exception.
+        # propagate the exception.
         with mock.patch('os.makedirs') as makedirs_patch:
             os_error = OSError()
             os_error.errno = errno.EEXIST

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -92,7 +92,7 @@ class TestBasicCommand(unittest.TestCase):
         sub_help_command = subcommand.create_help_command()
         # Note that the name of this Subcommand was never changed even
         # though it was put into the table as ``basic``. If no name
-        # is overriden it uses the name ``commandname``.
+        # is overridden it uses the name ``commandname``.
         self.assertEqual(sub_help_command.event_class, 'mock.commandname')
 
 

--- a/tests/unit/customizations/test_flatten.py
+++ b/tests/unit/customizations/test_flatten.py
@@ -212,6 +212,6 @@ class TestFlattenCommands(unittest.TestCase):
         self.assertEqual(False, argument_table['foo'].required)
         self.assertEqual(True, argument_table['bar'].required)
 
-        # Make sure docs can be overriden and get the defaults
+        # Make sure docs can be overridden and get the defaults
         self.assertEqual('Original docs', argument_table['foo'].documentation)
         self.assertEqual('Some help text', argument_table['bar'].documentation)

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -61,7 +61,7 @@ class TestArgumentTableModifications(TestPaginateBase):
         self.assertTrue(argument_table['foo']._UNDOCUMENTED)
         # Also need to hide the limit key.
         self.assertTrue(argument_table['bar']._UNDOCUMENTED)
-        # We also need to inject startin-token and max-items.
+        # We also need to inject starting-token and max-items.
         self.assertIn('starting-token', argument_table)
         self.assertIn('max-items', argument_table)
         self.assertIn('page-size', argument_table)

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -89,7 +89,7 @@ class TestListUsers(BaseAWSCommandParamsTest):
     def test_zero_value_is_printed(self):
         # Even though the integer 0 is false-like, we still
         # should be printing it to stdout if a jmespath query
-        # evalutes to 0.
+        # evaluates to 0.
         jmespath_query = '`0`'
         output = self.run_cmd('iam list-users --query %s' % jmespath_query,
                               expected_rc=0)[0]
@@ -125,7 +125,7 @@ class TestFormattersHandleClosedPipes(unittest.TestCase):
         fake_closed_stream.flush.side_effect = IOError
         formatter = JSONFormatter(args)
         formatter('command_name', response, stream=fake_closed_stream)
-        # We should not have let the IOError propogate, but
+        # We should not have let the IOError propagate, but
         # we still should have called the flush() on the
         # stream.
         fake_closed_stream.flush.assert_called_with()

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -828,7 +828,7 @@ class TestUnpackJSONParams(BaseArgProcessTest):
         # Parameter name should be in error message.
         self.assertIn('--block-device-mappings', str(e.exception))
         # The actual JSON itself should be in the error message.
-        # Becaues this is a list, only the first element in the JSON
+        # Because this is a list, only the first element in the JSON
         # will show.  This will at least let customers know what
         # we tried to parse.
         self.assertIn('[{', str(e.exception))

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -359,7 +359,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         operation_handler = OperationDocumentEventHandler(help_command)
         operation_handler.doc_description(help_command=help_command)
         rendered = help_command.doc.getvalue().decode('utf-8')
-        # Should expect an externa link because we're generating html.
+        # Should expect an external link because we're generating html.
         self.assertIn(
             'See also: `AWS API Documentation '
             '<https://docs.aws.amazon.com/goto/'

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -254,7 +254,7 @@ class FakeSession(object):
 class FakeCommand(BasicCommand):
     def _run_main(self, args, parsed_globals):
         # We just return success. If this code is reached, it means that
-        # all the logic in the __call__ method has sucessfully been run.
+        # all the logic in the __call__ method has successfully been run.
         # We subclass it here because the default implementation raises
         # an exception and we don't want that behavior.
         return 0
@@ -674,7 +674,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
 
         self.driver.session.register('calling-command', override_with_rc)
         rc = self.driver.main('ec2 describe-instances'.split())
-        # Check that the overriden rc is as expected.
+        # Check that the overridden rc is as expected.
         self.assertEqual(rc, 20)
 
     def test_override_calling_command_error(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -106,7 +106,7 @@ class TestIgnoreCtrlC(unittest.TestCase):
             # Should have the noop signal handler installed.
             self.assertEqual(signal.getsignal(signal.SIGINT), signal.SIG_IGN)
             # And if we actually try to sigint ourselves, an exception
-            # should not propogate.
+            # should not propagate.
             os.kill(os.getpid(), signal.SIGINT)
 
 


### PR DESCRIPTION
*Issue #, if available:*

Continuation of #2889. This fixes numerous typos in docstrings and inline comments. It also fixes a typo in one test function name.

*Description of changes:*

Rebased and fixed merge conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
