### PR TITLE
Move to pytest

### DIFF
--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -135,7 +135,7 @@ def _generate_signature(params):
         policy = base64.b64encode(six.b(policy)).decode('utf-8')
         new_hmac = hmac.new(sak.encode('utf-8'), digestmod=sha1)
         new_hmac.update(six.b(policy))
-        ps = base64.encodestring(new_hmac.digest()).strip().decode('utf-8')
+        ps = base64.encodebytes(new_hmac.digest()).strip().decode('utf-8')
         params['UploadPolicySignature'] = ps
         del params['_SAK']
 

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -302,7 +302,7 @@ class OpsWorksRegister(BasicCommand):
                 if 'PublicIpAddress' in self._ec2_instance:
                     self._use_address = self._ec2_instance['PublicIpAddress']
                 elif 'PrivateIpAddress' in self._ec2_instance:
-                    LOG.warn(
+                    LOG.warning(
                         "Instance does not have a public IP address. Trying "
                         "to use the private address to connect.")
                     self._use_address = self._ec2_instance['PrivateIpAddress']

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -917,6 +917,7 @@ class TestEventHandler(object):
     def __init__(self, handler=None):
         self._handler = handler
         self._called = False
+        self.__test__ = False
 
     @property
     def called(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow",
+]

--- a/requirements-check.txt
+++ b/requirements-check.txt
@@ -1,1 +1,4 @@
 check-manifest==0.37
+
+# We need setuptools>=43.0 to include pyproject.toml
+setuptools>=43.0

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -33,10 +33,7 @@ def process_args(args):
     runner = args.test_runner
     test_args = ""
     if args.with_cov:
-        test_args += (
-            f"--with-xunit --cover-erase --with-coverage "
-            f"--cover-package {PACKAGE} --cover-xml -v "
-        )
+        test_args += f"--cov={PACKAGE} --cov-report xml "
     dirs = " ".join(args.test_dirs)
 
     return runner, test_args, dirs
@@ -53,8 +50,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "-r",
         "--test-runner",
-        default="nosetests",
-        help="Test runner to execute tests. Defaults to nose.",
+        default="pytest",
+        help="Test runner to execute tests. Defaults to pytest.",
     )
     parser.add_argument(
         "-c",

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -28,6 +28,8 @@ import docutils.nodes
 import docutils.parsers.rst
 import docutils.utils
 
+import pytest
+
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.testutils import BaseAWSHelpOutputTest, create_clidriver
@@ -66,13 +68,45 @@ class _ExampleTests(BaseAWSHelpOutputTest):
         pass
 
 
-def test_examples():
+def _get_example_test_cases():
+    test_cases = []
     for command, subcommands in COMMAND_EXAMPLES.items():
         for subcommand in subcommands:
-            yield verify_has_examples, command, subcommand
+            test_cases.append((command, subcommand))
+    return test_cases
 
 
-def verify_has_examples(command, subcommand):
+def _get_all_doc_examples():
+    rst_doc_examples = []
+    other_doc_examples = []
+    # Iterate over all rst doc examples0
+    for root, _, filenames in os.walk(EXAMPLES_DIR):
+        for filename in filenames:
+            full_path = os.path.join(root, filename)
+            if not filename.endswith('.rst'):
+                other_doc_examples.append(full_path)
+                continue
+            rst_doc_examples.append(full_path)
+    return rst_doc_examples, other_doc_examples
+
+
+RST_DOC_EXAMPLES, OTHER_DOC_EXAMPLES = _get_all_doc_examples()
+EXAMPLE_COMMAND_TESTS = _get_example_test_cases()
+
+
+@pytest.fixture(scope="module")
+def command_validator():
+    # CLIDriver can take up a lot of resources so we'll just create one
+    # instance and use it for all the validation tests.
+    driver = create_clidriver()
+    return CommandValidator(driver)
+
+
+@pytest.mark.parametrize(
+    "command, subcommand",
+    EXAMPLE_COMMAND_TESTS
+)
+def test_examples(command, subcommand):
     t = _ExampleTests(methodName='noop_test')
     t.setUp()
     try:
@@ -82,27 +116,14 @@ def verify_has_examples(command, subcommand):
         t.tearDown()
 
 
-def test_all_doc_examples():
-    # CLIDriver can take up a lot of resources so we'll just create one
-    # instance and use it for all the validation tests.
-    driver = create_clidriver()
-    command_validator = CommandValidator(driver)
-
-    for example_file in iter_all_doc_examples():
-        yield verify_has_only_ascii_chars, example_file
-        yield verify_is_valid_rst, example_file
-        yield verify_cli_commands_valid, example_file, command_validator
-
-
-def iter_all_doc_examples():
-    # Iterate over all rst doc examples0
-    _dname = os.path.dirname
-    for rootdir, _, filenames in os.walk(EXAMPLES_DIR):
-        for filename in filenames:
-            if not filename.endswith('.rst'):
-                continue
-            full_path = os.path.join(rootdir, filename)
-            yield full_path
+@pytest.mark.parametrize(
+    "example_file",
+    RST_DOC_EXAMPLES
+)
+def test_rst_doc_examples(command_validator, example_file):
+    verify_has_only_ascii_chars(example_file)
+    verify_is_valid_rst(example_file)
+    verify_cli_commands_valid(example_file, command_validator)
 
 
 def verify_has_only_ascii_chars(filename):
@@ -263,12 +284,14 @@ class CollectCLICommands(docutils.nodes.GenericNodeVisitor):
         pass
 
 
-def test_example_file_names():
-    for root, _, files in os.walk(EXAMPLES_DIR):
-        for filename in files:
-            filepath = os.path.join(root, filename)
-            yield (_assert_file_is_rst_or_txt, filepath)
-            yield (_assert_name_contains_only_allowed_characters, filename)
+@pytest.mark.parametrize(
+    "example_file",
+    RST_DOC_EXAMPLES + OTHER_DOC_EXAMPLES
+)
+def test_example_file_name(example_file):
+    filename = example_file.split(os.sep)[-1]
+    _assert_file_is_rst_or_txt(example_file)
+    _assert_name_contains_only_allowed_characters(filename)
 
 
 def _assert_file_is_rst_or_txt(filepath):

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -69,7 +69,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def test_policy_provided(self):
         policy = '{"notarealpolicy":true}'
-        base64policy = base64.encodestring(six.b(policy)).strip().decode('utf-8')
+        base64policy = base64.encodebytes(six.b(policy)).strip().decode('utf-8')
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/tests/functional/eks/test_util.py
+++ b/tests/functional/eks/test_util.py
@@ -14,17 +14,15 @@
 """This module contains some helpers for mocking eks clusters"""
 
 import os
-from nose.tools import nottest
 
 
 EXAMPLE_NAME = "ExampleCluster"
 
-@nottest
 def get_testdata(file_name):
     """Get the path of a specific fixture"""
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                        "testdata",
-                        file_name)
+    return os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "testdata", file_name
+    )
 
 
 def list_cluster_response():

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -10,25 +10,26 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from awscli.clidriver import create_clidriver
 
 
-def _assert_does_not_shadow(command_name, command_table, builtins):
-    errors = []
-    for sub_name, sub_command in command_table.items():
-        op_help = sub_command.create_help_command()
-        arg_table = op_help.arg_table
-        for arg_name in arg_table:
-            if any(p.startswith(arg_name) for p in builtins):
-                # Then we are shadowing or prefixing a top level argument
-                errors.append(
-                    'Shadowing/Prefixing a top level option: '
-                    '%s.%s.%s' % (command_name, sub_name, arg_name))
-    if errors:
-        raise AssertionError('\n' + '\n'.join(errors))
+def _generate_command_tests():
+    driver = create_clidriver()
+    help_command = driver.create_help_command()
+    top_level_params = set(driver.create_help_command().arg_table)
+    for command_name, command_obj in help_command.command_table.items():
+        sub_help = command_obj.create_help_command()
+        if hasattr(sub_help, 'command_table'):
+            yield command_name, sub_help.command_table, top_level_params
 
 
-def test_no_shadowed_builtins():
+@pytest.mark.parametrize(
+    "command_name, command_table, builtins",
+    _generate_command_tests()
+)
+def test_no_shadowed_builtins(command_name, command_table, builtins):
     """Verify no command params are shadowed or prefixed by the built in param.
 
     The CLI parses all command line options into a single namespace.
@@ -54,13 +55,15 @@ def test_no_shadowed_builtins():
     a single test failure.
 
     """
-    driver = create_clidriver()
-    help_command = driver.create_help_command()
-    top_level_params = set(driver.create_help_command().arg_table)
-    for command_name, command_obj in help_command.command_table.items():
-        sub_help = command_obj.create_help_command()
-        if hasattr(sub_help, 'command_table'):
-            yield (
-                _assert_does_not_shadow,
-                command_name, sub_help.command_table, top_level_params
-            )
+    errors = []
+    for sub_name, sub_command in command_table.items():
+        op_help = sub_command.create_help_command()
+        arg_table = op_help.arg_table
+        for arg_name in arg_table:
+            if any(p.startswith(arg_name) for p in builtins):
+                # Then we are shadowing or prefixing a top level argument
+                errors.append(
+                    'Shadowing/Prefixing a top level option: '
+                    '%s.%s.%s' % (command_name, sub_name, arg_name))
+    if errors:
+        raise AssertionError('\n' + '\n'.join(errors))

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -28,8 +28,9 @@ import shutil
 import copy
 import logging
 
+import pytest
+
 from awscli.compat import six, urlopen
-from nose.plugins.attrib import attr
 import botocore.session
 
 from awscli.testutils import unittest, get_stdout_encoding
@@ -179,7 +180,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
         # And verify that the object no longer exists in the from_bucket.
         self.assertTrue(self.key_not_exists(from_bucket, key_name='foo.txt'))
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_mv_s3_to_s3_multipart(self):
         from_bucket = _SHARED_BUCKET
         to_bucket = self.create_bucket()
@@ -241,7 +242,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
         self.assertTrue(self.key_not_exists(from_bucket, file_name))
         self.assertTrue(self.key_exists(to_bucket, file_name))
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_mv_with_large_file(self):
         bucket_name = _SHARED_BUCKET
         # 40MB will force a multipart upload.
@@ -373,7 +374,7 @@ class TestCp(BaseS3IntegrationTest):
             self.get_key_contents(bucket_name, key_name='foo.txt'),
             'this is foo.txt')
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_cp_s3_s3_multipart(self):
         from_bucket = _SHARED_BUCKET
         to_bucket = self.create_bucket()
@@ -398,7 +399,7 @@ class TestCp(BaseS3IntegrationTest):
             self.content_type_for_key(bucket_name, key_name='bar.jpeg'),
             'image/jpeg')
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_download_large_file(self):
         # This will force a multipart download.
         bucket_name = _SHARED_BUCKET
@@ -411,7 +412,7 @@ class TestCp(BaseS3IntegrationTest):
         self.assertEqual(os.path.getsize(local_foo_txt),
                          len(foo_contents.getvalue()))
 
-    @attr('slow')
+    @pytest.mark.slow
     @skip_if_windows('SIGINT not supported on Windows.')
     def test_download_ctrl_c_does_not_hang(self):
         bucket_name = _SHARED_BUCKET
@@ -441,7 +442,7 @@ class TestCp(BaseS3IntegrationTest):
         # about this test is that it does not hang.
         self.assertIn(process.returncode, [0, 1, -2])
 
-    @attr('slow')
+    @pytest.mark.slow
     @skip_if_windows('SIGINT not supported on Windows.')
     def test_cleans_up_aborted_uploads(self):
         bucket_name = _SHARED_BUCKET
@@ -528,7 +529,7 @@ class TestCp(BaseS3IntegrationTest):
         response = self.head_object(bucket_name, 'foo.txt')
         self.assertEqual(response['WebsiteRedirectLocation'], website_redirect)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_copy_large_file_signature_v4(self):
         # Just verify that we can upload a large file to a region
         # that uses signature version 4.
@@ -900,7 +901,7 @@ class TestSourceRegion(BaseS3IntegrationTest):
             self.key_not_exists(
                 bucket_name=self.src_bucket, key_name='foo.txt'))
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_mv_large_file_region(self):
         foo_txt = self.files.create_file('foo.txt', 'a' * 1024 * 1024 * 10)
         p = aws('s3 cp %s s3://%s/foo.txt --region %s' %
@@ -1418,7 +1419,7 @@ class TestMemoryUtilization(BaseS3IntegrationTest):
                                  peak_memory / 1024.0 / 1024.0))
             self.fail(failure_message)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_transfer_single_large_file(self):
         # 40MB will force a multipart upload.
         bucket_name = _SHARED_BUCKET
@@ -1442,7 +1443,7 @@ class TestMemoryUtilization(BaseS3IntegrationTest):
     # point where this test fails on other distros, so for now we're disabling
     # the test on RHEL until we come up with a better way to collect
     # memory usage.
-    @attr('slow')
+    @pytest.mark.slow
     @unittest.skipIf(_running_on_rhel(),
                      'Streaming memory tests no supported on RHEL.')
     def test_stream_large_file(self):
@@ -1570,8 +1571,7 @@ class TestIncludeExcludeFilters(BaseS3IntegrationTest):
                 "--exclude '*' --include 'test/*' --recursive"
                 % self.files.rootdir)
         self.assert_no_errors(p)
-        self.assertRegexpMatches(p.stdout,
-                                 r'\(dryrun\) upload:.*test/foo.txt.*')
+        self.assertRegex(p.stdout, r'\(dryrun\) upload:.*test/foo.txt.*')
 
     def test_s3_filtering(self):
         # Should behave the same as local file filtering.
@@ -1591,7 +1591,7 @@ class TestIncludeExcludeFilters(BaseS3IntegrationTest):
         p = aws("s3 rm s3://%s/ --dryrun --exclude '*.txt' --recursive"
                 % bucket_name)
         self.assert_no_errors(p)
-        self.assertRegexpMatches(p.stdout, r'\(dryrun\) delete:.*baz.jpg.*')
+        self.assertRegex(p.stdout, r'\(dryrun\) delete:.*baz.jpg.*')
         self.assertNotIn(p.stdout, 'bar.txt')
         self.assertNotIn(p.stdout, 'foo.txt')
 
@@ -1730,7 +1730,7 @@ class TestStreams(BaseS3IntegrationTest):
         self.assertEqual(self.get_key_contents(bucket_name, 'stream'),
                          unicode_str)
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_multipart_upload(self):
         """
         This tests the ability to multipart upload streams from stdin.
@@ -1776,7 +1776,7 @@ class TestStreams(BaseS3IntegrationTest):
         self.assert_no_errors(p)
         self.assertEqual(p.stdout, data_encoded.decode(get_stdout_encoding()))
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_multipart_download(self):
         """
         This tests the ability to multipart download streams to stdout.

--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -60,9 +60,9 @@ class TestConfigureCommand(unittest.TestCase):
         self.env_vars.pop('AWS_SECRET_ACCESS_KEY', None)
         p = aws('configure list', env_vars=self.env_vars)
         self.assert_no_errors(p)
-        self.assertRegexpMatches(p.stdout, r'access_key.+config-file')
-        self.assertRegexpMatches(p.stdout, r'secret_key.+config-file')
-        self.assertRegexpMatches(p.stdout, r'region\s+us-west-2\s+config-file')
+        self.assertRegex(p.stdout, r'access_key.+config-file')
+        self.assertRegex(p.stdout, r'secret_key.+config-file')
+        self.assertRegex(p.stdout, r'region\s+us-west-2\s+config-file')
 
     def test_get_command(self):
         self.set_config_file_contents(

--- a/tests/integration/customizations/test_generatecliskeleton.py
+++ b/tests/integration/customizations/test_generatecliskeleton.py
@@ -14,7 +14,7 @@ import os
 import json
 import logging
 
-from nose.tools import assert_equal
+import pytest
 
 from awscli.testutils import mock, unittest, aws, capture_output
 from awscli.clidriver import create_clidriver
@@ -70,7 +70,7 @@ class TestIntegGenerateCliSkeleton(unittest.TestCase):
         self._assert_skeleton_matches(actual_skeleton, expected_skeleton)
 
 
-def test_can_generate_skeletons_for_all_service_comands():
+def _all_commands():
     environ = {
         'AWS_DATA_PATH': os.environ['AWS_DATA_PATH'],
         'AWS_DEFAULT_REGION': 'us-east-1',
@@ -95,10 +95,14 @@ def test_can_generate_skeletons_for_all_service_comands():
                     op_help = sub_command.create_help_command()
                     arg_table = op_help.arg_table
                     if 'generate-cli-skeleton' in arg_table:
-                        yield _test_gen_skeleton, command_name, sub_name,
+                        yield command_name, sub_name
 
 
-def _test_gen_skeleton(command_name, operation_name):
+@pytest.mark.parametrize(
+    "command_name, operation_name",
+    _all_commands()
+)
+def test_can_generate_skeletons_for_all_service_comands(command_name, operation_name):
     command = '%s %s --generate-cli-skeleton' % (command_name,
                                                  operation_name)
     stdout, stderr, _ = _run_cmd(command)
@@ -107,10 +111,9 @@ def _test_gen_skeleton(command_name, operation_name):
         json.loads(stdout)
     except ValueError as e:
         raise AssertionError(
-            "Could not generate CLI skeleton for command: %s %s\n"
-            "stdout:\n%s\n"
-            "stderr:\n%s\n" % (command_name, operation_name, stdout,
-                               stderr))
+            f"Could not generate CLI skeleton for command: {command_name} "
+            f"{operation_name}\n stdout:\n{stdout}\nstderr:\n{stderr}\n"
+        )
 
 
 def _run_cmd(cmd, expected_rc=0):
@@ -138,9 +141,8 @@ def _run_cmd(cmd, expected_rc=0):
             rc = e.code
     stderr = captured.stderr.getvalue()
     stdout = captured.stdout.getvalue()
-    assert_equal(
-        rc, expected_rc,
+    assert rc == expected_rc, (
         "Unexpected rc (expected: %s, actual: %s) for command: %s\n"
-        "stdout:\n%sstderr:\n%s" % (
-            expected_rc, rc, cmd, stdout, stderr))
+        "stdout:\n%sstderr:\n%s" % (expected_rc, rc, cmd, stdout, stderr)
+    )
     return stdout, stderr, rc

--- a/tests/integration/customizations/test_waiters.py
+++ b/tests/integration/customizations/test_waiters.py
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 import random
 
-from nose.plugins.attrib import attr
-import botocore.session
+import pytest
 
+import botocore.session
 from awscli.testutils import unittest, aws, random_chars
 
 
@@ -23,7 +23,7 @@ class TestDynamoDBWait(unittest.TestCase):
         self.session = botocore.session.get_session()
         self.client = self.session.create_client('dynamodb', 'us-west-2')
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_wait_table_exists(self):
         # Create a table.
         table_name = 'awscliddb-%s' % random_chars(10)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -58,8 +58,8 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         p = aws('help')
         self.assertEqual(p.rc, 0)
         self.assertIn('AWS', p.stdout)
-        self.assertRegexpMatches(
-            p.stdout, 'The\s+AWS\s+Command\s+Line\s+Interface')
+        self.assertRegex(
+            p.stdout, r'The\s+AWS\s+Command\s+Line\s+Interface')
 
     def test_service_help_output(self):
         p = aws('ec2 help')
@@ -74,25 +74,24 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         # For now we're making the test less strict about formatting, but
         # we eventually should update this test to check exactly for
         # 'The describe-instances operation'.
-        self.assertRegexpMatches(p.stdout,
-                                 '\s+Describes\s+the\s+specified\s+instances')
+        self.assertRegex(p.stdout, r'\s+Describes\s+the\s+specified\s+instances')
 
     def test_topic_list_help_output(self):
         p = aws('help topics')
         self.assertEqual(p.rc, 0)
-        self.assertRegexpMatches(p.stdout, '\s+AWS\s+CLI\s+Topic\s+Guide')
-        self.assertRegexpMatches(
+        self.assertRegex(p.stdout, r'\s+AWS\s+CLI\s+Topic\s+Guide')
+        self.assertRegex(
             p.stdout,
-            '\s+This\s+is\s+the\s+AWS\s+CLI\s+Topic\s+Guide'
+            r'\s+This\s+is\s+the\s+AWS\s+CLI\s+Topic\s+Guide'
         )
 
     def test_topic_help_output(self):
         p = aws('help return-codes')
         self.assertEqual(p.rc, 0)
-        self.assertRegexpMatches(p.stdout, '\s+AWS\s+CLI\s+Return\s+Codes')
-        self.assertRegexpMatches(
+        self.assertRegex(p.stdout, r'\s+AWS\s+CLI\s+Return\s+Codes')
+        self.assertRegex(
             p.stdout,
-            'These\s+are\s+the\s+following\s+return\s+codes'
+            r'These\s+are\s+the\s+following\s+return\s+codes'
         )
 
     def test_operation_help_with_required_arg(self):
@@ -122,7 +121,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         self.assertEqual(p.rc, 0, p.stderr)
         # Check text that appears in the warning block to ensure
         # the block was actually rendered.
-        self.assertRegexpMatches(p.stdout, 'To\s+receive\s+notifications')
+        self.assertRegex(p.stdout, r'To\s+receive\s+notifications')
 
     def test_param_shorthand(self):
         p = aws(

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -14,7 +14,8 @@ import re
 import os
 import random
 import time
-from nose.tools import assert_equal
+
+import pytest
 
 from awscli.testutils import aws
 
@@ -131,30 +132,32 @@ def _aws(command_string, max_attempts=1, delay=5, target_rc=0):
     return aws(command_string, env_vars=env)
 
 
-def test_can_make_success_request():
-    for cmd in COMMANDS:
-        yield _run_successful_aws_command, cmd
+@pytest.mark.parametrize(
+    "cmd",
+    COMMANDS
+)
+def test_can_make_success_request(cmd):
+    result = _aws(cmd, max_attempts=5, delay=5, target_rc=0)
+    assert result.rc == 0
+    assert result.stderr == ''
 
 
-def _run_successful_aws_command(command_string):
-    result = _aws(command_string, max_attempts=5, delay=5, target_rc=0)
-    assert_equal(result.rc, 0)
-    assert_equal(result.stderr, '')
+ERROR_MESSAGE_RE = re.compile(
+    r'An error occurred \(.+\) when calling the \w+ operation: \w+'
+)
 
 
-def test_display_error_message():
+@pytest.mark.parametrize(
+    "cmd",
+    ERROR_COMMANDS
+)
+def test_display_error_message(cmd):
     identifier = 'foo-awscli-test-%s' % random.randint(1000, 100000)
-    for cmd in ERROR_COMMANDS:
-        yield _run_error_aws_command, cmd % identifier
-
-
-def _run_error_aws_command(command_string):
+    command_string = cmd % identifier
     result = _aws(command_string, target_rc=255)
-    assert_equal(result.rc, 255)
-    error_message = re.compile(
-        'An error occurred \(.+\) when calling the \w+ operation: \w+')
-    match = error_message.search(result.stderr)
-    if match is None:
-        raise AssertionError(
-            'Error message was not displayed for command "%s": %s' % (
-                command_string, result.stderr))
+    assert result.rc == 255
+
+    match = ERROR_MESSAGE_RE.search(result.stderr)
+    assert match is not None, (
+        f'Error message was not displayed for command "{command_string}": {result.stderr}'
+    )

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -5,7 +5,8 @@ import string
 import random
 import zipfile
 
-from nose.tools import assert_true, assert_false, assert_equal
+import pytest
+
 from contextlib import contextmanager, closing
 from botocore.stub import Stubber
 from awscli.testutils import mock, unittest, FileCreator
@@ -29,151 +30,161 @@ from awscli.customizations.cloudformation.artifact_exporter \
     StepFunctionsStateMachineDefinitionResource
 
 
-def test_is_s3_url():
-    valid = [
-        "s3://foo/bar",
-        "s3://foo/bar/baz/cat/dog",
-        "s3://foo/bar?versionId=abc",
-        "s3://foo/bar/baz?versionId=abc&versionId=123",
-        "s3://foo/bar/baz?versionId=abc",
-        "s3://www.amazon.com/foo/bar",
-        "s3://my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
-    ]
+VALID_CASES = [
+    "s3://foo/bar",
+    "s3://foo/bar/baz/cat/dog",
+    "s3://foo/bar?versionId=abc",
+    "s3://foo/bar/baz?versionId=abc&versionId=123",
+    "s3://foo/bar/baz?versionId=abc",
+    "s3://www.amazon.com/foo/bar",
+    "s3://my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
+]
 
-    invalid = [
+INVALID_CASES = [
+    # For purposes of exporter, we need S3 URLs to point to an object
+    # and not a bucket
+    "s3://foo",
 
-        # For purposes of exporter, we need S3 URLs to point to an object
-        # and not a bucket
-        "s3://foo",
+    # two versionIds is invalid
+    "https://s3-eu-west-1.amazonaws.com/bucket/key",
+    "https://www.amazon.com"
+]
 
-        # two versionIds is invalid
-        "https://s3-eu-west-1.amazonaws.com/bucket/key",
-        "https://www.amazon.com"
-    ]
 
-    for url in valid:
-        yield _assert_is_valid_s3_url, url
+@pytest.mark.parametrize(
+    "url",
+    VALID_CASES
+)
+def test_is_valid_s3_url(url):
+    assert is_s3_url(url), f"{url} should be valid"
 
-    for url in invalid:
-        yield _assert_is_invalid_s3_url, url
 
-def _assert_is_valid_s3_url(url):
-    assert_true(is_s3_url(url), "{0} should be valid".format(url))
+@pytest.mark.parametrize(
+    "url",
+    INVALID_CASES
+)
+def test_is_invalid_s3_url(url):
+    assert not is_s3_url(url), f"{url} should be invalid"
 
-def _assert_is_invalid_s3_url(url):
-    assert_false(is_s3_url(url), "{0} should be valid".format(url))
 
-def test_all_resources_export():
-    uploaded_s3_url = "s3://foo/bar?versionId=baz"
+UPLOADED_S3_URL = "s3://foo/bar?versionId=baz"
 
-    setup = [
-        {
-            "class": ServerlessFunctionResource,
-            "expected_result": uploaded_s3_url
-        },
+RESOURCE_EXPORT_TEST_CASES = [
+    {
+        "class": ServerlessFunctionResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": ServerlessApiResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": ServerlessApiResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": GraphQLSchemaResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": GraphQLSchemaResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncResolverRequestTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncResolverRequestTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncResolverResponseTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncResolverResponseTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncFunctionConfigurationRequestTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncFunctionConfigurationRequestTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncFunctionConfigurationResponseTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncFunctionConfigurationResponseTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": ApiGatewayRestApiResource,
-            "expected_result": {
-                "Bucket": "foo", "Key": "bar", "Version": "baz"
-            }
-        },
+    {
+        "class": ApiGatewayRestApiResource,
+        "expected_result": {
+            "Bucket": "foo", "Key": "bar", "Version": "baz"
+        }
+    },
 
-        {
-            "class": LambdaFunctionResource,
-            "expected_result": {
-                "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
-            }
-        },
+    {
+        "class": LambdaFunctionResource,
+        "expected_result": {
+            "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
+        }
+    },
 
-        {
-            "class": ElasticBeanstalkApplicationVersion,
-            "expected_result": {
-                "S3Bucket": "foo", "S3Key": "bar"
-            }
-        },
-        {
-            "class": LambdaLayerVersionResource,
-            "expected_result": {
-                "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
-            }
-        },
-        {
-            "class": ServerlessLayerVersionResource,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": ServerlessRepoApplicationReadme,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": ServerlessRepoApplicationLicense,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": ServerlessRepoApplicationLicense,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": GlueJobCommandScriptLocationResource,
-            "expected_result": {
-                    "ScriptLocation": uploaded_s3_url
-            }
-        },
-        {
-            "class": StepFunctionsStateMachineDefinitionResource,
-            "expected_result": {
-                "Bucket": "foo", "Key": "bar", "Version": "baz"
-            }
-        },
-    ]
+    {
+        "class": ElasticBeanstalkApplicationVersion,
+        "expected_result": {
+            "S3Bucket": "foo", "S3Key": "bar"
+        }
+    },
+    {
+        "class": LambdaLayerVersionResource,
+        "expected_result": {
+            "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
+        }
+    },
+    {
+        "class": ServerlessLayerVersionResource,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": ServerlessRepoApplicationReadme,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": ServerlessRepoApplicationLicense,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": ServerlessRepoApplicationLicense,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": GlueJobCommandScriptLocationResource,
+        "expected_result": {
+                "ScriptLocation": UPLOADED_S3_URL
+        }
+    },
+    {
+        "class": StepFunctionsStateMachineDefinitionResource,
+        "expected_result": {
+            "Bucket": "foo", "Key": "bar", "Version": "baz"
+        }
+    },
+]
 
-    with mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts") as upload_local_artifacts_mock:
-        for test in setup:
-            yield _helper_verify_export_resources, \
-                    test["class"], uploaded_s3_url, \
-                    upload_local_artifacts_mock, \
-                    test["expected_result"]
+
+@pytest.mark.parametrize(
+    "test",
+    RESOURCE_EXPORT_TEST_CASES
+)
+def test_all_resources_export(test):
+    mock_path = (
+        "awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts"
+    )
+    with mock.patch(mock_path) as upload_local_artifacts_mock:
+        _helper_verify_export_resources(
+            test["class"], upload_local_artifacts_mock, test["expected_result"]
+        )
 
 
 def _helper_verify_export_resources(
-        test_class, uploaded_s3_url, upload_local_artifacts_mock,
-        expected_result):
+    test_class, upload_local_artifacts_mock, expected_result
+):
 
     s3_uploader_mock = mock.Mock()
     upload_local_artifacts_mock.reset_mock()
 
     resource_id = "id"
+    parent_dir = "dir"
 
     if '.' in test_class.PROPERTY_NAME:
         reversed_property_names = test_class.PROPERTY_NAME.split('.')
@@ -190,25 +201,22 @@ def _helper_verify_export_resources(
         resource_dict = {
             test_class.PROPERTY_NAME: "foo"
         }
-    parent_dir = "dir"
 
-    upload_local_artifacts_mock.return_value = uploaded_s3_url
-
+    upload_local_artifacts_mock.return_value = UPLOADED_S3_URL
     resource_obj = test_class(s3_uploader_mock)
-
     resource_obj.export(resource_id, resource_dict, parent_dir)
 
-    upload_local_artifacts_mock.assert_called_once_with(resource_id,
-                                                        resource_dict,
-                                                        test_class.PROPERTY_NAME,
-                                                        parent_dir,
-                                                        s3_uploader_mock)
+    upload_local_artifacts_mock.assert_called_once_with(
+        resource_id, resource_dict, test_class.PROPERTY_NAME,
+        parent_dir, s3_uploader_mock
+    )
     if '.' in test_class.PROPERTY_NAME:
         top_level_property_name = test_class.PROPERTY_NAME.split('.')[0]
         result = resource_dict[top_level_property_name]
     else:
         result = resource_dict[test_class.PROPERTY_NAME]
-    assert_equal(result, expected_result)
+
+    assert result == expected_result
 
 
 class TestArtifactExporter(unittest.TestCase):
@@ -499,7 +507,7 @@ class TestArtifactExporter(unittest.TestCase):
             zip_and_upload_mock.assert_called_once_with(tmp_dir, mock.ANY)
             rmtree_mock.assert_called_once_with(tmp_dir)
             is_zipfile_mock.assert_called_once_with(original_path)
-            assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
+            assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
     @mock.patch("shutil.rmtree")
     @mock.patch("zipfile.is_zipfile")
@@ -536,7 +544,7 @@ class TestArtifactExporter(unittest.TestCase):
         zip_and_upload_mock.assert_not_called()
         rmtree_mock.assert_not_called()
         is_zipfile_mock.assert_called_once_with(original_path)
-        assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
+        assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
     @mock.patch("shutil.rmtree")
     @mock.patch("zipfile.is_zipfile")
@@ -570,7 +578,7 @@ class TestArtifactExporter(unittest.TestCase):
         zip_and_upload_mock.assert_not_called()
         rmtree_mock.assert_not_called()
         is_zipfile_mock.assert_called_once_with(original_path)
-        assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
+        assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
     @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_empty_property_value(self, upload_local_artifacts_mock):

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -140,7 +140,7 @@ class TestPush(unittest.TestCase):
     def test_validate_args_default_description(self):
         self.args.description = None
         self.push._validate_args(self.args)
-        self.assertRegexpMatches(
+        self.assertRegex(
             self.args.description,
             'Uploaded by AWS CLI .* UTC'
         )

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -154,7 +154,7 @@ class TestInteractivePrompter(unittest.TestCase):
         # We should also not display the entire access key.
         prompt_text = self.stdout.getvalue()
         self.assertNotIn('myaccesskey', prompt_text)
-        self.assertRegexpMatches(prompt_text, r'\[\*\*\*\*.*\]')
+        self.assertRegex(prompt_text, r'\[\*\*\*\*.*\]')
 
     def test_access_key_not_masked_when_none(self):
         self.mock_raw_input.return_value = 'foo'
@@ -176,7 +176,7 @@ class TestInteractivePrompter(unittest.TestCase):
         # We should also not display the entire secret key.
         prompt_text = self.stdout.getvalue()
         self.assertNotIn('mysupersecretkey', prompt_text)
-        self.assertRegexpMatches(prompt_text, r'\[\*\*\*\*.*\]')
+        self.assertRegex(prompt_text, r'\[\*\*\*\*.*\]')
 
     def test_non_secret_keys_are_not_masked(self):
         prompter = configure.InteractivePrompter()
@@ -186,7 +186,7 @@ class TestInteractivePrompter(unittest.TestCase):
         # We should also not display the entire secret key.
         prompt_text = self.stdout.getvalue()
         self.assertIn('mycurrentvalue', prompt_text)
-        self.assertRegexpMatches(prompt_text, r'\[mycurrentvalue\]')
+        self.assertRegex(prompt_text, r'\[mycurrentvalue\]')
 
     def test_user_hits_enter_returns_none(self):
         # If a user hits enter, then raw_input returns the empty string.

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -31,10 +31,10 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(rendered, 'profile\s+<not set>')
-        self.assertRegexpMatches(rendered, 'access_key\s+<not set>')
-        self.assertRegexpMatches(rendered, 'secret_key\s+<not set>')
-        self.assertRegexpMatches(rendered, 'region\s+<not set>')
+        self.assertRegex(rendered, r'profile\s+<not set>')
+        self.assertRegex(rendered, r'access_key\s+<not set>')
+        self.assertRegex(rendered, r'secret_key\s+<not set>')
+        self.assertRegex(rendered, r'region\s+<not set>')
 
     def test_configure_from_env(self):
         env_vars = {
@@ -50,8 +50,8 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(
-            rendered, 'profile\s+myprofilename\s+env\s+PROFILE_ENV_VAR')
+        self.assertRegex(
+            rendered, r'profile\s+myprofilename\s+env\s+PROFILE_ENV_VAR')
 
     def test_configure_from_config_file(self):
         config_file_vars = {
@@ -67,8 +67,8 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(
-            rendered, 'region\s+us-west-2\s+config-file\s+/config/location')
+        self.assertRegex(
+            rendered, r'region\s+us-west-2\s+config-file\s+/config/location')
 
     def test_configure_from_multiple_sources(self):
         # Here the profile is from an env var, the
@@ -99,17 +99,17 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
         # The profile came from an env var.
-        self.assertRegexpMatches(
-            rendered, 'profile\s+myprofilename\s+env\s+AWS_DEFAULT_PROFILE')
+        self.assertRegex(
+            rendered, r'profile\s+myprofilename\s+env\s+AWS_DEFAULT_PROFILE')
         # The region came from the config file.
-        self.assertRegexpMatches(
-            rendered, 'region\s+us-west-2\s+config-file\s+/config/location')
+        self.assertRegex(
+            rendered, r'region\s+us-west-2\s+config-file\s+/config/location')
         # The credentials came from an IAM role.  Note how we're
         # also checking that the access_key/secret_key are masked
         # with '*' chars except for the last 4 chars.
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered, r'access_key\s+\*+_key\s+iam-role')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered, r'secret_key\s+\*+_key\s+iam-role')
 
     def test_configure_from_args(self):
@@ -127,5 +127,5 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=parsed_globals)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(
-            rendered, 'profile\s+foo\s+manual\s+--profile')
+        self.assertRegex(
+            rendered, r'profile\s+foo\s+manual\s+--profile')

--- a/tests/unit/customizations/emr/test_emr_utils.py
+++ b/tests/unit/customizations/emr/test_emr_utils.py
@@ -12,16 +12,14 @@
 # language governing permissions and limitations under the License.
 
 from awscli.customizations.emr.emrutils import which
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
 
 
 class TestEMRutils(object):
 
     def test_which_with_existing_command(self):
         pythonPath = which('python') or which('python.exe')
-        assert_not_equal(pythonPath, None)
+        assert pythonPath is not None
 
     def test_which_with_non_existing_command(self):
         path = which('klajsflklj')
-        assert_equal(path, None)
+        assert path is None

--- a/tests/unit/customizations/emr/test_modify_cluster_attributes.py
+++ b/tests/unit/customizations/emr/test_modify_cluster_attributes.py
@@ -13,7 +13,6 @@
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
-from nose.tools import raises
 
 
 class TestModifyClusterAttributes(BaseAWSCommandParamsTest):

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -20,8 +20,8 @@ import ntpath
 import time
 import datetime
 
+import pytest
 from dateutil.tz import tzlocal
-from nose.tools import assert_equal
 from s3transfer.futures import TransferMeta, TransferFuture
 from s3transfer.compat import seekable
 from botocore.hooks import HierarchicalEmitter
@@ -46,47 +46,45 @@ from tests.unit.customizations.s3 import FakeTransferFutureMeta
 from tests.unit.customizations.s3 import FakeTransferFutureCallArgs
 
 
-def test_human_readable_size():
-    yield _test_human_size_matches, 1, '1 Byte'
-    yield _test_human_size_matches, 10, '10 Bytes'
-    yield _test_human_size_matches, 1000, '1000 Bytes'
-    yield _test_human_size_matches, 1024, '1.0 KiB'
-    yield _test_human_size_matches, 1024 ** 2, '1.0 MiB'
-    yield _test_human_size_matches, 1024 ** 2, '1.0 MiB'
-    yield _test_human_size_matches, 1024 ** 3, '1.0 GiB'
-    yield _test_human_size_matches, 1024 ** 4, '1.0 TiB'
-    yield _test_human_size_matches, 1024 ** 5, '1.0 PiB'
-    yield _test_human_size_matches, 1024 ** 6, '1.0 EiB'
-
-    # Round to the nearest block.
-    yield _test_human_size_matches, 1024 ** 2 - 1, '1.0 MiB'
-    yield _test_human_size_matches, 1024 ** 3 - 1, '1.0 GiB'
-
-
-def _test_human_size_matches(bytes_int, expected):
-    assert_equal(human_readable_size(bytes_int), expected)
-
-
-def test_convert_human_readable_to_bytes():
-    yield _test_convert_human_readable_to_bytes, "1", 1
-    yield _test_convert_human_readable_to_bytes, "1024", 1024
-    yield _test_convert_human_readable_to_bytes, "1KB", 1024
-    yield _test_convert_human_readable_to_bytes, "1kb", 1024
-    yield _test_convert_human_readable_to_bytes, "1MB", 1024 ** 2
-    yield _test_convert_human_readable_to_bytes, "1GB", 1024 ** 3
-    yield _test_convert_human_readable_to_bytes, "1TB", 1024 ** 4
-
-    # Also because of the "ls" output for s3, we support
-    # the IEC "mebibyte" format (MiB).
-    yield _test_convert_human_readable_to_bytes, "1KiB", 1024
-    yield _test_convert_human_readable_to_bytes, "1kib", 1024
-    yield _test_convert_human_readable_to_bytes, "1MiB", 1024 ** 2
-    yield _test_convert_human_readable_to_bytes, "1GiB", 1024 ** 3
-    yield _test_convert_human_readable_to_bytes, "1TiB", 1024 ** 4
+@pytest.mark.parametrize(
+    'bytes_int, expected',
+    (
+        (1, '1 Byte'),
+        (10, '10 Bytes'),
+        (1000, '1000 Bytes'),
+        (1024, '1.0 KiB'),
+        (1024 ** 2, '1.0 MiB'),
+        (1024 ** 3, '1.0 GiB'),
+        (1024 ** 4, '1.0 TiB'),
+        (1024 ** 5, '1.0 PiB'),
+        (1024 ** 6, '1.0 EiB'),
+        (1024 ** 2 - 1, '1.0 MiB'),
+        (1024 ** 3 - 1, '1.0 GiB'),
+    )
+)
+def test_human_readable_size(bytes_int, expected):
+    assert human_readable_size(bytes_int) == expected
 
 
-def _test_convert_human_readable_to_bytes(size_str, expected):
-    assert_equal(human_readable_to_bytes(size_str), expected)
+@pytest.mark.parametrize(
+    'size_str, expected',
+    (
+        ("1", 1),
+        ("1024", 1024),
+        ("1KB", 1024),
+        ("1kb", 1024),
+        ("1MB", 1024 ** 2),
+        ("1GB", 1024 ** 3),
+        ("1TB", 1024 ** 4),
+        ("1KiB", 1024),
+        ("1kib", 1024),
+        ("1MiB", 1024 ** 2),
+        ("1GiB", 1024 ** 3),
+        ("1TiB", 1024 ** 4),
+    )
+)
+def test_convert_human_readable_to_bytes(size_str, expected):
+    assert human_readable_to_bytes(size_str) == expected
 
 
 class AppendFilterTest(unittest.TestCase):
@@ -501,7 +499,7 @@ class TestGetFileStat(unittest.TestCase):
 
     def test_error_message(self):
         with mock.patch('os.stat', mock.Mock(side_effect=IOError('msg'))):
-            with self.assertRaisesRegex(ValueError, 'myfilename\.txt'):
+            with self.assertRaisesRegex(ValueError, r'myfilename\.txt'):
                 get_file_stat('myfilename.txt')
 
     def assert_handles_fromtimestamp_error(self, error):

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -86,7 +86,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -95,7 +95,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -104,7 +104,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -115,7 +115,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -126,7 +126,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -137,7 +137,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -148,7 +148,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -159,7 +159,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -168,7 +168,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -192,7 +192,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             'username={0}%{1}\npassword=.+'.format('access', 'token'))
 

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -500,7 +500,7 @@ class TestOpsWorksRegister(TestOpsWorksBase):
         self.assertEqual(cmd[0], "ssh")
         self.assertEqual(cmd[1], "-tt")
         self.assertEqual(cmd[2], "ip")
-        self.assertRegexpMatches(cmd[3], r"/bin/sh -c ")
+        self.assertRegex(cmd[3], r"/bin/sh -c ")
 
     @mock.patch.object(opsworks, "platform")
     @mock.patch.object(opsworks, "subprocess")
@@ -527,7 +527,7 @@ class TestOpsWorksRegister(TestOpsWorksBase):
         self.register.setup_target_machine(args)
 
         cmd = mock_subprocess.check_call.call_args[0][0]
-        self.assertRegexpMatches(cmd, r'^plink ".*" -m ".*"$')
+        self.assertRegex(cmd, r'^plink ".*" -m ".*"$')
 
     @mock.patch.object(opsworks, "subprocess")
     def test_setup_target_machine_local(self, mock_subprocess):

--- a/tests/unit/test_alias.py
+++ b/tests/unit/test_alias.py
@@ -98,8 +98,9 @@ class TestAliasLoader(unittest.TestCase):
         with open(self.alias_file, 'a+') as f:
             f.write(
                 'my-alias = \n'
-                '  my-alias-value \ \n'
-                '  --parameter foo\n')
+                '  my-alias-value \\ \n'
+                '  --parameter foo\n'
+            )
         alias_interface = AliasLoader(self.alias_file)
         self.assertEqual(
             alias_interface.get_aliases(),
@@ -462,7 +463,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         with self.assertRaises(SystemExit):
             # Even though we catch the system exit, a message will always
             # be forced to screen because it happened at system exit.
-            # The patch is to ensure it does not get displayed by nosetests.
+            # The patch is to ensure it does not get displayed.
             with mock.patch('sys.stderr'):
                 alias_cmd([], FakeParsedArgs(command=self.alias_name))
 
@@ -478,7 +479,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         with self.assertRaises(SystemExit):
             # Even though we catch the system exit, a message will always
             # be forced to screen because it happened at system exit.
-            # The patch is to ensure it does not get displayed by nosetests.
+            # The patch is to ensure it does not get displayed.
             with mock.patch('sys.stderr'):
                 alias_cmd([], FakeParsedArgs(command=self.alias_name))
 

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -418,7 +418,7 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_csv_syntax_escaped(self):
         p = self.get_param_model('cloudformation.CreateStack.Parameters')
         returned = self.parse_shorthand(
-            p, ["ParameterKey=key,ParameterValue=foo\,bar"])
+            p, [r"ParameterKey=key,ParameterValue=foo\,bar"])
         expected = [{"ParameterKey": "key",
                      "ParameterValue": "foo,bar"}]
         self.assertEqual(returned, expected)
@@ -680,7 +680,7 @@ class TestDocGen(BaseArgProcessTest):
     def test_can_document_nested_structs(self):
         argument = self.get_param_model('ec2.RunInstances.BlockDeviceMappings')
         generated_example = self.get_generated_example_for(argument)
-        self.assertRegexpMatches(generated_example, 'Ebs={\w+=\w+')
+        self.assertRegex(generated_example, r'Ebs={\w+=\w+')
 
     def test_can_document_nested_lists(self):
         argument = self.create_argument({

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -18,7 +18,6 @@ import logging
 import io
 import sys
 
-import nose
 from awscli.compat import six
 from botocore.awsrequest import AWSResponse
 from botocore.exceptions import NoCredentialsError
@@ -576,7 +575,6 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             value='file:///foo',
         )
 
-    @unittest.skip
     def test_custom_arg_no_paramfile(self):
         driver = create_clidriver()
         driver.session.register(

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -10,191 +10,155 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from awscli import shorthand
 from awscli.testutils import unittest
 
 from botocore import model
 
-from nose.tools import assert_equal
 
-
-def test_parse():
+PARSING_TEST_CASES = (
     # Key val pairs with scalar value.
-    yield (_can_parse, 'foo=bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo=bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo=bar,baz=qux', {'foo': 'bar', 'baz': 'qux'})
-    yield (_can_parse, 'a=b,c=d,e=f', {'a': 'b', 'c': 'd', 'e': 'f'})
+    ('foo=bar', {'foo': 'bar'}),
+    ('foo=bar', {'foo': 'bar'}),
+    ('foo=bar,baz=qux', {'foo': 'bar', 'baz': 'qux'}),
+    ('a=b,c=d,e=f', {'a': 'b', 'c': 'd', 'e': 'f'}),
     # Empty values are allowed.
-    yield (_can_parse, 'foo=', {'foo': ''})
-    yield (_can_parse, 'foo=,bar=', {'foo': '', 'bar': ''})
+    ('foo=', {'foo': ''}),
+    ('foo=,bar=', {'foo': '', 'bar': ''}),
     # Unicode is allowed.
-    yield (_can_parse, u'foo=\u2713', {'foo': u'\u2713'})
-    yield (_can_parse, u'foo=\u2713,\u2713', {'foo': [u'\u2713', u'\u2713']})
+    (u'foo=\u2713', {'foo': u'\u2713'}),
+    (u'foo=\u2713,\u2713', {'foo': [u'\u2713', u'\u2713']}),
     # Key val pairs with csv values.
-    yield (_can_parse, 'foo=a,b', {'foo': ['a', 'b']})
-    yield (_can_parse, 'foo=a,b,c', {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo=a,b,bar=c,d', {'foo': ['a', 'b'],
-                                           'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=a,b,c,bar=d,e,f',
-           {'foo': ['a', 'b', 'c'], 'bar': ['d', 'e', 'f']})
+    ('foo=a,b', {'foo': ['a', 'b']}),
+    ('foo=a,b,c', {'foo': ['a', 'b', 'c']}),
+    ('foo=a,b,bar=c,d', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=a,b,c,bar=d,e,f', {'foo': ['a', 'b', 'c'], 'bar': ['d', 'e', 'f']}),
     # Spaces in values are allowed.
-    yield (_can_parse, 'foo=a,b=with space', {'foo': 'a', 'b': 'with space'})
+    ('foo=a,b=with space', {'foo': 'a', 'b': 'with space'}),
     # Trailing spaces are still ignored.
-    yield (_can_parse, 'foo=a,b=with trailing space  ',
-           {'foo': 'a', 'b': 'with trailing space'})
-    yield (_can_parse, 'foo=first space',
-           {'foo': 'first space'})
-    yield (_can_parse, 'foo=a space,bar=a space,baz=a space',
-           {'foo': 'a space', 'bar': 'a space', 'baz': 'a space'})
-
+    ('foo=a,b=with trailing space  ', {'foo': 'a', 'b': 'with trailing space'}),
+    ('foo=first space', {'foo': 'first space'}),
+    (
+        'foo=a space,bar=a space,baz=a space',
+        {'foo': 'a space', 'bar': 'a space', 'baz': 'a space'}
+    ),
     # Dashes are allowed in key names.
-    yield (_can_parse, 'with-dash=bar', {'with-dash': 'bar'})
-
+    ('with-dash=bar', {'with-dash': 'bar'}),
     # Underscore are also allowed.
-    yield (_can_parse, 'with_underscore=bar', {'with_underscore': 'bar'})
-
+    ('with_underscore=bar', {'with_underscore': 'bar'}),
     # Dots are allowed.
-    yield (_can_parse, 'with.dot=bar', {'with.dot': 'bar'})
-
+    ('with.dot=bar', {'with.dot': 'bar'}),
     # Pound signs are allowed.
-    yield (_can_parse, '#key=value', {'#key': 'value'})
-
+    ('#key=value', {'#key': 'value'}),
     # Forward slashes are allowed in keys.
-    yield (_can_parse, 'some/thing=value', {'some/thing': 'value'})
-
+    ('some/thing=value', {'some/thing': 'value'}),
     # Colon chars are allowed in keys:
-    yield (_can_parse, 'aws:service:region:124:foo/bar=baz',
-           {'aws:service:region:124:foo/bar': 'baz'})
-
+    ('aws:service:region:124:foo/bar=baz', {'aws:service:region:124:foo/bar': 'baz'}),
     # Explicit lists.
-    yield (_can_parse, 'foo=[]', {'foo': []})
-    yield (_can_parse, 'foo=[a]', {'foo': ['a']})
-    yield (_can_parse, 'foo=[a,b]', {'foo': ['a', 'b']})
-    yield (_can_parse, 'foo=[a,b,c]', {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo=[a,b],bar=c,d',
-           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=[a,b],bar=[c,d]',
-           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=a,b,bar=[c,d]',
-           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']})
-    yield (_can_parse, 'foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']})
+    ('foo=[]', {'foo': []}),
+    ('foo=[a]', {'foo': ['a']}),
+    ('foo=[a,b]', {'foo': ['a', 'b']}),
+    ('foo=[a,b,c]', {'foo': ['a', 'b', 'c']}),
+    ('foo=[a,b],bar=c,d', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=[a,b],bar=[c,d]', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=a,b,bar=[c,d]', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']}),
+    ('foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']}),
     # Lists with whitespace.
-    yield (_can_parse, 'foo=[ a , b  , c  ]',
-           {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo  =  [ a , b  , c  ]',
-           {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo=[,,]', {'foo': ['', '']})
-
+    ('foo=[ a , b  , c  ]', {'foo': ['a', 'b', 'c']}),
+    ('foo  =  [ a , b  , c  ]', {'foo': ['a', 'b', 'c']}),
+    ('foo=[,,]', {'foo': ['', '']}),
     # Single quoted strings.
-    yield (_can_parse, "foo='bar'", {"foo": "bar"})
-    yield (_can_parse, "foo='bar,baz'", {"foo": "bar,baz"})
+    ("foo='bar'", {"foo": "bar"}),
+    ("foo='bar,baz'", {"foo": "bar,baz"}),
     # Single quoted strings for each value in a CSV list.
-    yield (_can_parse, "foo='bar','baz'", {"foo": ['bar', 'baz']})
+    ("foo='bar','baz'", {"foo": ['bar', 'baz']}),
     # Can mix single quoted and non quoted values.
-    yield (_can_parse, "foo=bar,'baz'", {"foo": ['bar', 'baz']})
+    ("foo=bar,'baz'", {"foo": ['bar', 'baz']}),
     # Quoted strings can include chars not allowed in unquoted strings.
-    yield (_can_parse, "foo=bar,'baz=qux'", {"foo": ['bar', 'baz=qux']})
-    yield (_can_parse, "foo=bar,'--option=bar space'",
-           {"foo": ['bar', '--option=bar space']})
+    ("foo=bar,'baz=qux'", {"foo": ['bar', 'baz=qux']}),
+    ("foo=bar,'--option=bar space'", {"foo": ['bar', '--option=bar space']}),
     # Can escape the single quote.
-    yield (_can_parse, "foo='bar\\'baz'", {"foo": "bar'baz"})
-    yield (_can_parse, "foo='bar\\\\baz'", {"foo": "bar\\baz"})
-
+    ("foo='bar\\'baz'", {"foo": "bar'baz"}),
+    ("foo='bar\\\\baz'", {"foo": "bar\\baz"}),
     # Double quoted strings.
-    yield (_can_parse, 'foo="bar"', {'foo': 'bar'})
-    yield (_can_parse, 'foo="bar,baz"', {'foo': 'bar,baz'})
-    yield (_can_parse, 'foo="bar","baz"', {'foo': ['bar', 'baz']})
-    yield (_can_parse, 'foo=bar,"baz=qux"', {'foo': ['bar', 'baz=qux']})
-    yield (_can_parse, 'foo=bar,"--option=bar space"',
-           {'foo': ['bar', '--option=bar space']})
-    yield (_can_parse, 'foo="bar\\"baz"', {'foo': 'bar"baz'})
-    yield (_can_parse, 'foo="bar\\\\baz"', {'foo': 'bar\\baz'})
-
+    ('foo="bar"', {'foo': 'bar'}),
+    ('foo="bar,baz"', {'foo': 'bar,baz'}),
+    ('foo="bar","baz"', {'foo': ['bar', 'baz']}),
+    ('foo=bar,"baz=qux"', {'foo': ['bar', 'baz=qux']}),
+    ('foo=bar,"--option=bar space"', {'foo': ['bar', '--option=bar space']}),
+    ('foo="bar\\"baz"', {'foo': 'bar"baz'}),
+    ('foo="bar\\\\baz"', {'foo': 'bar\\baz'}),
     # Can escape comma in CSV list.
-    yield (_can_parse, 'foo=a\\,b', {"foo": "a,b"})
-    yield (_can_parse, 'foo=a\\,b', {"foo": "a,b"})
-    yield (_can_parse, 'foo=a\\,', {"foo": "a,"})
-    yield (_can_parse, 'foo=\\,', {"foo": ","})
-    yield (_can_parse, 'foo=a,b\\,c', {"foo": ['a', 'b,c']})
-    yield (_can_parse, 'foo=a,b\\,', {"foo": ['a', 'b,']})
-    yield (_can_parse, 'foo=a,\\,bc', {"foo": ['a', ',bc']})
-
+    ('foo=a\\,b', {"foo": "a,b"}),
+    ('foo=a\\,b', {"foo": "a,b"}),
+    ('foo=a\\,', {"foo": "a,"}),
+    ('foo=\\,', {"foo": ","}),
+    ('foo=a,b\\,c', {"foo": ['a', 'b,c']}),
+    ('foo=a,b\\,', {"foo": ['a', 'b,']}),
+    ('foo=a,\\,bc', {"foo": ['a', ',bc']}),
     # Ignores whitespace around '=' and ','
-    yield (_can_parse, 'foo= bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo =bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo = bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo  =   bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo = bar,baz = qux', {'foo': 'bar', 'baz': 'qux'})
-    yield (_can_parse, 'a = b,  c = d , e = f', {'a': 'b', 'c': 'd', 'e': 'f'})
-    yield (_can_parse, 'foo = ', {'foo': ''})
-    yield (_can_parse, 'a=b,c=  d,  e,  f', {'a': 'b', 'c': ['d', 'e', 'f']})
-    yield (_can_parse, 'Name=foo,Values=  a  ,  b  ,  c  ',
-           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
-    yield (_can_parse, 'Name=foo,Values= a,  b  ,  c',
-           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
-
+    ('foo= bar', {'foo': 'bar'}),
+    ('foo =bar', {'foo': 'bar'}),
+    ('foo = bar', {'foo': 'bar'}),
+    ('foo  =   bar', {'foo': 'bar'}),
+    ('foo = bar,baz = qux', {'foo': 'bar', 'baz': 'qux'}),
+    ('a = b,  c = d , e = f', {'a': 'b', 'c': 'd', 'e': 'f'}),
+    ('foo = ', {'foo': ''}),
+    ('a=b,c=  d,  e,  f', {'a': 'b', 'c': ['d', 'e', 'f']}),
+    ('Name=foo,Values=  a  ,  b  ,  c  ', {'Name': 'foo', 'Values': ['a', 'b', 'c']}),
+    ('Name=foo,Values= a,  b  ,  c', {'Name': 'foo', 'Values': ['a', 'b', 'c']}),
     # Can handle newlines between values.
-    yield (_can_parse, 'Name=foo,\nValues=a,b,c',
-           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
-    yield (_can_parse, 'A=b,\nC=d,\nE=f\n',
-           {'A': 'b', 'C': 'd', 'E': 'f'})
-
+    ('Name=foo,\nValues=a,b,c', {'Name': 'foo', 'Values': ['a', 'b', 'c']}),
+    ('A=b,\nC=d,\nE=f\n', {'A': 'b', 'C': 'd', 'E': 'f'}),
     # Hashes
-    yield (_can_parse, 'Name={foo=bar,baz=qux}',
-           {'Name': {'foo': 'bar', 'baz': 'qux'}})
-    yield (_can_parse, 'Name={foo=[a,b,c],bar=baz}',
-           {'Name': {'foo': ['a', 'b', 'c'], 'bar': 'baz'}})
-    yield (_can_parse, 'Name={foo=bar},Bar=baz',
-           {'Name': {'foo': 'bar'}, 'Bar': 'baz'})
-    yield (_can_parse, 'Bar=baz,Name={foo=bar}',
-           {'Bar': 'baz', 'Name': {'foo': 'bar'}})
-    yield (_can_parse, 'a={b={c=d}}',
-           {'a': {'b': {'c': 'd'}}})
-    yield (_can_parse, 'a={b={c=d,e=f},g=h}',
-           {'a': {'b': {'c': 'd', 'e': 'f'}, 'g': 'h'}})
-
+    ('Name={foo=bar,baz=qux}', {'Name': {'foo': 'bar', 'baz': 'qux'}}),
+    ('Name={foo=[a,b,c],bar=baz}', {'Name': {'foo': ['a', 'b', 'c'], 'bar': 'baz'}}),
+    ('Name={foo=bar},Bar=baz', {'Name': {'foo': 'bar'}, 'Bar': 'baz'}),
+    ('Bar=baz,Name={foo=bar}', {'Bar': 'baz', 'Name': {'foo': 'bar'}}),
+    ('a={b={c=d}}', {'a': {'b': {'c': 'd'}}}),
+    ('a={b={c=d,e=f},g=h}', {'a': {'b': {'c': 'd', 'e': 'f'}, 'g': 'h'}}),
     # Combining lists and hashes.
-    yield (_can_parse, 'Name=[{foo=bar}, {baz=qux}]',
-           {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]})
-
+    ('Name=[{foo=bar}, {baz=qux}]', {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]}),
     # Combining hashes and lists.
-    yield (_can_parse, 'Name=[{foo=[a,b]}, {bar=[c,d]}]',
-           {'Name': [{'foo': ['a', 'b']}, {'bar': ['c', 'd']}]})
+    (
+        'Name=[{foo=[a,b]}, {bar=[c,d]}]',
+        {'Name': [{'foo': ['a', 'b']}, {'bar': ['c', 'd']}]}
+    ),
+)
 
 
-def test_error_parsing():
-    yield (_is_error, 'foo')
-    # Missing closing quotes
-    yield (_is_error, 'foo="bar')
-    yield (_is_error, "foo='bar")
-    yield (_is_error, "foo=[bar")
-    yield (_is_error, "foo={bar")
-    yield (_is_error, "foo={bar}")
-    yield (_is_error, "foo={bar=bar")
-    yield (_is_error, "foo=bar,")
-    yield (_is_error, "foo==bar,\nbar=baz")
-    # Duplicate keys should error otherwise they silently
-    # set only one of the values.
-    yield (_is_error, 'foo=bar,foo=qux')
-
-
-def _is_error(expr):
-    try:
+@pytest.mark.parametrize(
+    "expr", (
+        'foo',
+        # Missing closing quotes
+        'foo="bar',
+        "foo='bar",
+        "foo=[bar",
+        "foo={bar",
+        "foo={bar}",
+        "foo={bar=bar",
+        "foo=bar,",
+        "foo==bar,\nbar=baz",
+        # Duplicate keys should error otherwise they silently
+        # set only one of the values.
+        'foo=bar,foo=qux'
+    )
+)
+def test_error_parsing(expr):
+    with pytest.raises(shorthand.ShorthandParseError):
         shorthand.ShorthandParser().parse(expr)
-    except shorthand.ShorthandParseError:
-        pass
-    except Exception as e:
-        raise AssertionError(
-            "Expected ShorthandParseError, but received unexpected "
-            "exception instead (%s): %s" % (e.__class__, e))
-    else:
-        raise AssertionError("Expected ShorthandParseError, but no "
-                            "exception was raised for expression: %s" % expr)
 
-def _can_parse(data, expected):
+
+@pytest.mark.parametrize(
+    'data, expected',
+    PARSING_TEST_CASES
+)
+def test_parse(data, expected):
     actual = shorthand.ShorthandParser().parse(data)
-    assert_equal(actual, expected)
+    assert actual == expected
 
 
 class TestModelVisitor(unittest.TestCase):


### PR DESCRIPTION
This PR will move aws-cli from `nosetests` to `pytest`. The change requires us to move off of `yield` tests which introduced some additional complexity. This led to a significant shift in the test counts compared to nose which I'll walk through below.

## Differences

### Unit/Functional:
* pytest: `12862 passed` (12862 total)
* nose: `Ran 27068 tests` (27068 total)

**Total difference: -14206**

* `tests/functional/docs/test_examples.py`: This file was previously composed of 2 tests that yielded 3 "sub-tests" and another 2 "sub-tests" respectively. The test argument construction is very expensive which made breaking this into 5 individual tests prohibitive. The first test had 4735 test cases and the second had one additional case for 4736 cases. This resulted in:
    * `test_all_doc_examples`: 14205 (4735*3) -> 4735
    * `test_example_file_names`: 9472 (4736*2) -> 4736

(14205+9472) - (4735+4736) == 14206

### Integration:
* pytest: `10386 passed` (10386 total)
* nose: `Ran 10386 tests` (10386 total)

**Total difference: 0**

**Pytest Unit/Functional**
------
```
=================== 12862 passed ===================
```

**Nose Unit/Functional:**
-------
```
Ran 27068 tests

OK
```

**Pytest Integration:**
----
```
=================== 10386 passed ===================
```

**Nose Integration:**
----
```
Ran 10386 tests

OK
```
