### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ The aws-cli package works on Python versions:
 -  3.7.x and greater
 -  3.8.x and greater
 -  3.9.x and greater
+-  3.10.x and greater
 
 On 01/15/2021 deprecation for Python 2.7 was announced and support was dropped
 on 07/15/2021. To avoid disruption, customers using the AWS CLI on Python 2.7 may

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup_options = dict(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39
+envlist = py36,py37,py38,py39,py310
 
 skipsdist = True
 


### PR DESCRIPTION
This PR will start testing the (hopefully) final release candidate for Python 3.10 and ensure things are working smoothly for the release next week on October 4th.
