### PR TITLE
[v2] Migrate to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,20 @@
 [run]
 branch = True
-include =
-    awscli/*
-omit = awscli/testutils.py
 
 [report]
 show_missing = True
+omit =
+    # For run-tests, we install the awscli package via a distribution
+    # which means it will only be collecting coverage for the package
+    # installed in site-packages. However, the test report still finds
+    # the awscli package in the git repository and thus shows zero
+    # coverage in the report. So, we purposely exclude any directory
+    # named aws-cli (i.e., the name of the repository) as that path would
+    # indicate it is part of the git repository and should not be included
+    # in the report.
+    */aws-cli/*
+    # The testutils module is strictly for testing and should not be included
+    # in the coverage report. The wildcard prefix ensures it is not being
+    # included in the report even if it is being installed as part of
+    # a distribution (i.e., in site-packages directory)
+    */awscli/testutils.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,15 +24,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install codecov
         python scripts/ci/install
         python scripts/ci/install-check
     - name: Run tests
-      run: python scripts/ci/run-tests
+      run: python scripts/ci/run-tests --with-cov
     - name: Run checks
       run: python scripts/ci/run-check
     - name: codecov
-      run: |
-        rm tests/coverage.xml
-        mv tests/.coverage ./
-        codecov
+      uses: codecov/codecov-action@v2
+      with:
+        directory: tests

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -58,9 +58,11 @@ class PromptToolkitPrompter:
 
     """
     def __init__(self, completion_source, driver, completer=None,
-                 factory=None, app=None, cli_parser=None, output=None):
+                 factory=None, app=None, cli_parser=None, output=None,
+                 app_input=None):
         self._completion_source = completion_source
         self._output = output
+        self._input = app_input
         if completer is None:
             completer = PromptToolkitCompleter(self._completion_source)
         # We wrap our completer with a ThreadedCompleter to make autocompletion
@@ -116,7 +118,8 @@ class PromptToolkitPrompter:
         kb_manager = self._factory.create_key_bindings()
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
-                          output=self._output, erase_when_done=True)
+                          output=self._output, erase_when_done=True,
+                          input=self._input)
         self._set_app_defaults(app)
         return app
 

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -136,7 +136,7 @@ def _generate_signature(params):
         policy = base64.b64encode(policy).decode('utf-8')
         new_hmac = hmac.new(sak.encode('utf-8'), digestmod=sha1)
         new_hmac.update(six.b(policy))
-        ps = base64.encodestring(new_hmac.digest()).strip().decode('utf-8')
+        ps = base64.encodebytes(new_hmac.digest()).strip().decode('utf-8')
         params['UploadPolicySignature'] = ps
         del params['_SAK']
 

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -304,7 +304,7 @@ class OpsWorksRegister(BasicCommand):
                 if 'PublicIpAddress' in self._ec2_instance:
                     self._use_address = self._ec2_instance['PublicIpAddress']
                 elif 'PrivateIpAddress' in self._ec2_instance:
-                    LOG.warn(
+                    LOG.warning(
                         "Instance does not have a public IP address. Trying "
                         "to use the private address to connect.")
                     self._use_address = self._ec2_instance['PrivateIpAddress']

--- a/awscli/customizations/wizard/app.py
+++ b/awscli/customizations/wizard/app.py
@@ -41,7 +41,8 @@ class WizardAppRunner(object):
 
 class WizardApp(Application):
     def __init__(self, layout, values, traverser, executor, style=None,
-                 key_bindings=None, full_screen=True, output=None):
+                 key_bindings=None, full_screen=True, output=None,
+                 app_input=None):
         self.values = values
         self.traverser = traverser
         self.executor = executor
@@ -53,7 +54,7 @@ class WizardApp(Application):
         self.error_bar_visible = None
         super().__init__(
             layout=layout, style=style, key_bindings=key_bindings,
-            full_screen=full_screen, output=output
+            full_screen=full_screen, output=output, input=app_input,
         )
 
     def run(self, pre_run=None, **kwargs):

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -59,7 +59,7 @@ def create_default_wizard_v2_runner(session):
     return WizardAppRunner(session=session, app_factory=create_wizard_app)
 
 
-def create_wizard_app(definition, session, output=None):
+def create_wizard_app(definition, session, output=None, app_input=None):
     api_invoker = core.APIInvoker(session=session)
     shared_config = core.SharedConfigAPI(session=session,
                                          config_writer=ConfigFileWriter())
@@ -78,5 +78,5 @@ def create_wizard_app(definition, session, output=None):
     traverser = WizardTraverser(definition, values, executor)
     return WizardApp(
         layout=layout, values=values, traverser=traverser,
-        executor=executor, output=output
+        executor=executor, output=output, app_input=app_input
     )

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -925,6 +925,7 @@ class TestEventHandler(object):
     def __init__(self, handler=None):
         self._handler = handler
         self._called = False
+        self.__test__ = False
 
     @property
     def called(self):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 jsonschema==2.5.1
-nose==1.3.7
 mock==1.3.0
-pytest==6.2.1
+pytest==6.2.5
+coverage==5.5
+pytest-cov==2.12.1

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -15,15 +15,7 @@ def run(command):
     return check_call(command, shell=True)
 
 
-try:
-    # Has the form "major.minor"
-    python_version = os.environ['PYTHON_VERSION']
-except KeyError:
-    python_version = '.'.join([str(i) for i in sys.version_info[:2]])
-
-
 run('pip install -r requirements.txt')
-run('pip install coverage')
 if os.path.isdir('dist') and os.listdir('dist'):
     shutil.rmtree('dist')
 run('python -m build --no-isolation')

--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -4,22 +4,31 @@
 # binary package not from the CWD.
 
 import os
-import sys
-
-import pytest
+from contextlib import contextmanager
+from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
 
 
-def main():
-    args = ['-v', 'integration/']
-    print(f'Running py.test with args: {args}')
-    os.environ['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
-    return pytest.main(args)
+@contextmanager
+def cd(path):
+    """Change directory while inside context manager."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
 
 
-if __name__ == '__main__':
-    sys.exit(main())
+def run(command):
+    env = os.environ.copy()
+    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    return check_call(command, shell=True, env=env)
+
+
+if __name__ == "__main__":
+    with cd(os.path.join(REPO_ROOT, "tests")):
+        run(f"{REPO_ROOT}/scripts/ci/run-tests integration")

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -3,13 +3,26 @@
 # We want to ensure we're importing from the installed
 # binary package not from the CWD.
 
+import argparse
 import os
+from contextlib import contextmanager
 from subprocess import check_call
 
 _dname = os.path.dirname
 
 REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
-os.chdir(os.path.join(REPO_ROOT, 'tests'))
+PACKAGE = "awscli"
+
+
+@contextmanager
+def cd(path):
+    """Change directory while inside context manager."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
 
 
 def run(command):
@@ -18,5 +31,41 @@ def run(command):
     return check_call(command, shell=True, env=env)
 
 
-run('nosetests --with-coverage --cover-erase --cover-package awscli '
-    '--traverse-namespace --with-xunit --cover-xml unit/ functional/')
+def process_args(args):
+    runner = args.test_runner
+    test_args = ""
+    if args.with_cov:
+        test_args += f"--cov={PACKAGE} --cov-report xml "
+    dirs = " ".join(args.test_dirs)
+
+    return runner, test_args, dirs
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "test_dirs",
+        default=["unit/", "functional/"],
+        nargs="*",
+        help="One or more directories containing tests.",
+    )
+    parser.add_argument(
+        "-r",
+        "--test-runner",
+        default="pytest",
+        help="Test runner to execute tests. Defaults to pytest.",
+    )
+    parser.add_argument(
+        "-c",
+        "--with-cov",
+        default=False,
+        action="store_true",
+        help="Run default test-runner with code coverage enabled.",
+    )
+    raw_args = parser.parse_args()
+    test_runner, test_args, test_dirs = process_args(raw_args)
+
+    cmd = f"{test_runner} {test_args}{test_dirs}"
+    print(f"Running {cmd}...")
+    with cd(os.path.join(REPO_ROOT, "tests")):
+        run(cmd)

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -35,7 +35,11 @@ def process_args(args):
     runner = args.test_runner
     test_args = ""
     if args.with_cov:
-        test_args += f"--cov={PACKAGE} --cov-report xml "
+        test_args += (
+            f"--cov={PACKAGE} "
+            f"--cov-config={os.path.join(REPO_ROOT, '.coveragerc')} "
+            f"--cov-report xml "
+        )
     dirs = " ".join(args.test_dirs)
 
     return runner, test_args, dirs

--- a/tests/functional/autocomplete/test_main.py
+++ b/tests/functional/autocomplete/test_main.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from nose.tools import assert_in, assert_true
-
 from awscli.autocomplete import main, generator
 from awscli.autocomplete.local import indexer
 from awscli import clidriver
@@ -40,13 +38,13 @@ def test_smoke_test_completer():
         # The API can change so we won't assert a specific list, but we'll
         # pick a few operations that we know will always be there.
         completion_strings = [c.name for c in completions]
-        assert_in('describe-instances', completion_strings)
-        assert_in('describe-regions', completion_strings)
+        assert 'describe-instances' in completion_strings
+        assert 'describe-regions' in completion_strings
 
         completions = _autocomplete(f.name, 'aws dynamodb describe-tab')
         completion_strings = [c.name for c in completions]
-        assert_true(all(completion.startswith('describe-table')
-                        for completion in completion_strings))
+        assert all(completion.startswith('describe-table')
+                   for completion in completion_strings)
 
 
 def _autocomplete(filename, command_line):

--- a/tests/functional/autoprompt/test_autoprompt.py
+++ b/tests/functional/autoprompt/test_autoprompt.py
@@ -1,6 +1,7 @@
 import mock
-import nose
 import os
+
+import pytest
 
 from awscli.clidriver import create_clidriver
 from awscli.testutils import FileCreator
@@ -43,12 +44,9 @@ def set_env_var(environ, env_var=None):
     return environ
 
 
-def test_autoprompt_config_provider():
-    # Each case is a 3-tuple with the following meaning:
-    # First index is the config value. None means not specified.
-    # Second index is the environment variable. None means not set.
-    # The third index is the expected configuration value.
-    cases = [
+@pytest.mark.parametrize(
+    "config,env_var,expected_result",
+    [
         ('on', 'on', 'on'),
         ('on', 'off', 'off'),
         ('on', None, 'on'),
@@ -59,17 +57,16 @@ def test_autoprompt_config_provider():
         (None, 'off', 'off'),
         (None, None, 'off'),
     ]
-    for case in cases:
-        config, env_var, expected_result = case
-        try:
-            driver, environ_patch, files = set_up(config, env_var)
-            yield (_assert_auto_prompt_configures_as_expected, driver,
-                   expected_result)
-        finally:
-            environ_patch.stop()
-            files.remove_all()
+)
+def test_autoprompt_config_provider(config, env_var, expected_result):
+    try:
+        driver, environ_patch, files = set_up(config, env_var)
+        _assert_auto_prompt_configures_as_expected(driver, expected_result)
+    finally:
+        environ_patch.stop()
+        files.remove_all()
 
 
 def _assert_auto_prompt_configures_as_expected(driver, expected_result):
     actual = driver.session.get_config_variable('cli_auto_prompt')
-    nose.tools.eq_(actual, expected_result)
+    assert actual == expected_result

--- a/tests/functional/autoprompt/test_prompttoolkit.py
+++ b/tests/functional/autoprompt/test_prompttoolkit.py
@@ -30,7 +30,7 @@ from awscli.autoprompt.prompttoolkit import (
 from awscli.autoprompt.history import HistoryDriver
 from awscli.testutils import unittest, mock, FileCreator, cd
 from tests import PromptToolkitApplicationStubber as ApplicationStubber
-from tests import FakeApplicationOutput
+from tests import FakeApplicationOutput, FakeApplicationInput
 
 
 def _ec2_only_command_table(command_table, **kwargs):
@@ -106,7 +106,8 @@ class BasicPromptToolkitTest(unittest.TestCase):
             driver=self.driver,
             factory=self.factory,
             cli_parser=self.cli_parser,
-            output=FakeApplicationOutput()
+            output=FakeApplicationOutput(),
+            app_input=FakeApplicationInput(),
         )
         self.prompter.args = []
         self.prompter.input_buffer = self.factory.create_input_buffer()

--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -17,6 +17,8 @@ import tempfile
 import os
 import zipfile
 
+import pytest
+
 from unittest import TestCase
 from awscli.customizations.cloudformation.artifact_exporter import make_zip
 from awscli.customizations.cloudformation.yamlhelper import yaml_dump
@@ -63,21 +65,26 @@ class TestPackageZipFiles(TestCase):
         self.assertEquals(data.encode("utf-8"), myfile.read())
 
 
-def test_known_templates():
+def _generate_template_cases():
     test_case_path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         'deploy_templates'
     )
+    cases = []
     for case in os.listdir(test_case_path):
         case_path = os.path.join(test_case_path, case)
-        yield (
-            _assert_input_does_match_expected_output,
-            os.path.join(case_path, 'input.yml'),
-            os.path.join(case_path, 'output.yml'),
+        cases.append(
+            (
+                os.path.join(case_path, 'input.yml'),
+                os.path.join(case_path, 'output.yml')
+             )
         )
+    return cases
 
 
-def _assert_input_does_match_expected_output(input_template, output_template):
+@pytest.mark.parametrize(
+    'input_template,output_template', _generate_template_cases())
+def test_known_templates(input_template, output_template):
     template = Template(input_template, os.getcwd(), None)
     exported = template.export()
     result = yaml_dump(exported)

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -28,6 +28,8 @@ import docutils.nodes
 import docutils.parsers.rst
 import docutils.utils
 
+import pytest
+
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.testutils import BaseAWSHelpOutputTest, create_clidriver
@@ -66,13 +68,45 @@ class _ExampleTests(BaseAWSHelpOutputTest):
         pass
 
 
-def test_examples():
+def _get_example_test_cases():
+    test_cases = []
     for command, subcommands in COMMAND_EXAMPLES.items():
         for subcommand in subcommands:
-            yield verify_has_examples, command, subcommand
+            test_cases.append((command, subcommand))
+    return test_cases
 
 
-def verify_has_examples(command, subcommand):
+def _get_all_doc_examples():
+    rst_doc_examples = []
+    other_doc_examples = []
+    # Iterate over all rst doc examples0
+    for root, _, filenames in os.walk(EXAMPLES_DIR):
+        for filename in filenames:
+            full_path = os.path.join(root, filename)
+            if not filename.endswith('.rst'):
+                other_doc_examples.append(full_path)
+                continue
+            rst_doc_examples.append(full_path)
+    return rst_doc_examples, other_doc_examples
+
+
+RST_DOC_EXAMPLES, OTHER_DOC_EXAMPLES = _get_all_doc_examples()
+EXAMPLE_COMMAND_TESTS = _get_example_test_cases()
+
+
+@pytest.fixture(scope="module")
+def command_validator():
+    # CLIDriver can take up a lot of resources so we'll just create one
+    # instance and use it for all the validation tests.
+    driver = create_clidriver()
+    return CommandValidator(driver)
+
+
+@pytest.mark.parametrize(
+    "command, subcommand",
+    EXAMPLE_COMMAND_TESTS
+)
+def test_examples(command, subcommand):
     t = _ExampleTests(methodName='noop_test')
     t.setUp()
     try:
@@ -82,27 +116,14 @@ def verify_has_examples(command, subcommand):
         t.tearDown()
 
 
-def test_all_doc_examples():
-    # CLIDriver can take up a lot of resources so we'll just create one
-    # instance and use it for all the validation tests.
-    driver = create_clidriver()
-    command_validator = CommandValidator(driver)
-
-    for example_file in iter_all_doc_examples():
-        yield verify_has_only_ascii_chars, example_file
-        yield verify_is_valid_rst, example_file
-        yield verify_cli_commands_valid, example_file, command_validator
-
-
-def iter_all_doc_examples():
-    # Iterate over all rst doc examples0
-    _dname = os.path.dirname
-    for rootdir, _, filenames in os.walk(EXAMPLES_DIR):
-        for filename in filenames:
-            if not filename.endswith('.rst'):
-                continue
-            full_path = os.path.join(rootdir, filename)
-            yield full_path
+@pytest.mark.parametrize(
+    "example_file",
+    RST_DOC_EXAMPLES
+)
+def test_rst_doc_examples(command_validator, example_file):
+    verify_has_only_ascii_chars(example_file)
+    verify_is_valid_rst(example_file)
+    verify_cli_commands_valid(example_file, command_validator)
 
 
 def verify_has_only_ascii_chars(filename):
@@ -263,12 +284,14 @@ class CollectCLICommands(docutils.nodes.GenericNodeVisitor):
         pass
 
 
-def test_example_file_names():
-    for root, _, files in os.walk(EXAMPLES_DIR):
-        for filename in files:
-            filepath = os.path.join(root, filename)
-            yield (_assert_file_is_rst_or_txt, filepath)
-            yield (_assert_name_contains_only_allowed_characters, filename)
+@pytest.mark.parametrize(
+    "example_file",
+    RST_DOC_EXAMPLES + OTHER_DOC_EXAMPLES
+)
+def test_example_file_name(example_file):
+    filename = example_file.split(os.sep)[-1]
+    _assert_file_is_rst_or_txt(example_file)
+    _assert_name_contains_only_allowed_characters(filename)
 
 
 def _assert_file_is_rst_or_txt(filepath):

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -70,7 +70,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def test_policy_provided(self):
         policy = '{"notarealpolicy":true}'
-        base64policy = base64.encodestring(six.b(policy)).strip().decode('utf-8')
+        base64policy = base64.encodebytes(six.b(policy)).strip().decode('utf-8')
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'

--- a/tests/functional/eks/test_util.py
+++ b/tests/functional/eks/test_util.py
@@ -14,17 +14,15 @@
 """This module contains some helpers for mocking eks clusters"""
 
 import os
-from nose.tools import nottest
 
 
 EXAMPLE_NAME = "ExampleCluster"
 
-@nottest
 def get_testdata(file_name):
     """Get the path of a specific fixture"""
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                        "testdata",
-                        file_name)
+    return os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "testdata", file_name
+    )
 
 
 def list_cluster_response():

--- a/tests/functional/kinesis/test_remove_operations.py
+++ b/tests/functional/kinesis/test_remove_operations.py
@@ -10,12 +10,10 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from tests import CLIRunner
 
-from awscli.testutils import unittest, aws
 
-
-class TestKinesisRemoveOperations(unittest.TestCase):
-    def test_subscribe_to_shard_removed(self):
-        result = aws('kinesis subscribe-to-shard help')
-        error_msg = 'argument operation: Invalid choice, valid choices are:'
-        self.assertIn(error_msg, result.stderr)
+def test_subscribe_to_shard_removed():
+    result = CLIRunner().run(['kinesis', 'subscribe-to-shard', 'help'])
+    expected_error = 'argument operation: Invalid choice, valid choices are:'
+    assert expected_error in result.stderr

--- a/tests/functional/lex/test_remove_operations.py
+++ b/tests/functional/lex/test_remove_operations.py
@@ -10,12 +10,10 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from tests import CLIRunner
 
-from awscli.testutils import unittest, aws
 
-
-class TestLexV2RuntimeRemoveOperations(unittest.TestCase):
-    def test_start_conversation_removed(self):
-        result = aws('lexv2-runtime start-conversation help')
-        error_msg = 'argument operation: Invalid choice, valid choices are:'
-        self.assertIn(error_msg, result.stderr)
+def test_start_conversation_removed():
+    result = CLIRunner().run(['lexv2-runtime', 'start-conversation', 'help'])
+    expected_error = 'argument operation: Invalid choice, valid choices are:'
+    assert expected_error in result.stderr

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -10,25 +10,26 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from awscli.clidriver import create_clidriver
 
 
-def _assert_does_not_shadow(command_name, command_table, builtins):
-    errors = []
-    for sub_name, sub_command in command_table.items():
-        op_help = sub_command.create_help_command()
-        arg_table = op_help.arg_table
-        for arg_name in arg_table:
-            if any(p.startswith(arg_name) for p in builtins):
-                # Then we are shadowing or prefixing a top level argument
-                errors.append(
-                    'Shadowing/Prefixing a top level option: '
-                    '%s.%s.%s' % (command_name, sub_name, arg_name))
-    if errors:
-        raise AssertionError('\n' + '\n'.join(errors))
+def _generate_command_tests():
+    driver = create_clidriver()
+    help_command = driver.create_help_command()
+    top_level_params = set(driver.create_help_command().arg_table)
+    for command_name, command_obj in help_command.command_table.items():
+        sub_help = command_obj.create_help_command()
+        if hasattr(sub_help, 'command_table'):
+            yield command_name, sub_help.command_table, top_level_params
 
 
-def test_no_shadowed_builtins():
+@pytest.mark.parametrize(
+    "command_name, command_table, builtins",
+    _generate_command_tests()
+)
+def test_no_shadowed_builtins(command_name, command_table, builtins):
     """Verify no command params are shadowed or prefixed by the built in param.
 
     The CLI parses all command line options into a single namespace.
@@ -54,13 +55,15 @@ def test_no_shadowed_builtins():
     a single test failure.
 
     """
-    driver = create_clidriver()
-    help_command = driver.create_help_command()
-    top_level_params = set(driver.create_help_command().arg_table)
-    for command_name, command_obj in help_command.command_table.items():
-        sub_help = command_obj.create_help_command()
-        if hasattr(sub_help, 'command_table'):
-            yield (
-                _assert_does_not_shadow,
-                command_name, sub_help.command_table, top_level_params
-            )
+    errors = []
+    for sub_name, sub_command in command_table.items():
+        op_help = sub_command.create_help_command()
+        arg_table = op_help.arg_table
+        for arg_name in arg_table:
+            if any(p.startswith(arg_name) for p in builtins):
+                # Then we are shadowing or prefixing a top level argument
+                errors.append(
+                    'Shadowing/Prefixing a top level option: '
+                    '%s.%s.%s' % (command_name, sub_name, arg_name))
+    if errors:
+        raise AssertionError('\n' + '\n'.join(errors))

--- a/tests/functional/wizards/__init__.py
+++ b/tests/functional/wizards/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -10,9 +10,3 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.autocomplete import main, completer
-
-
-def test_can_create_completer():
-    cli_completer = main.create_autocompleter()
-    assert isinstance(cli_completer, completer.AutoCompleter)

--- a/tests/functional/wizards/test_command.py
+++ b/tests/functional/wizards/test_command.py
@@ -40,7 +40,7 @@ class TestRunWizard(BaseAWSCommandParamsTest):
         wizard_path = os.path.join(self.tempdir, 'iam', 'test-wizard.yml')
         with open(wizard_path, 'w') as f:
             f.write(
-                'version: "0.9"\n'
+                'version: "0.1"\n'
                 'plan:\n'
                 '  start:\n'
                 '    values:\n'
@@ -64,7 +64,7 @@ class TestRunWizard(BaseAWSCommandParamsTest):
         wizard_path = os.path.join(self.tempdir, 'iam', '_main.yml')
         with open(wizard_path, 'w') as f:
             f.write(
-                'version: "0.9"\n'
+                'version: "0.1"\n'
                 'plan:\n'
                 '  start:\n'
                 '    values:\n'
@@ -85,10 +85,10 @@ class TestRunWizard(BaseAWSCommandParamsTest):
 
 
 class TestWizardHelpCommand(BaseAWSHelpOutputTest):
-    def test_wait_help_command(self):
+    def test_wizard_help_command(self):
         self.driver.main(['iam', 'wizard', 'help'])
         self.assert_contains('new-role')
 
-    def test_wait_help_command(self):
+    def test_wizard_subcommand_help_command(self):
         self.driver.main(['iam', 'wizard', 'new-role', 'help'])
         self.assert_contains('new-role')

--- a/tests/functional/wizards/test_devcommand.py
+++ b/tests/functional/wizards/test_devcommand.py
@@ -10,31 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseAWSCommandParamsTest, temporary_file
+from awscli.testutils import BaseAWSHelpOutputTest
 
 
-class TestRunWizard(BaseAWSCommandParamsTest):
-    def setUp(self):
-        super(TestRunWizard, self).setUp()
-        self.parsed_responses = [{"Roles": []}]
-
-    def test_can_run_wizard(self):
-        with temporary_file('r+') as f:
-            f.write(
-                'version: "0.9"\n'
-                'plan:\n'
-                '  start:\n'
-                '    values:\n'
-                '      foo:\n'
-                '        type: static\n'
-                '        value: myvalue\n'
-                'execute:\n'
-                '  default:\n'
-                '    - type: apicall\n'
-                '      operation: iam.ListRoles\n'
-                '      params: {}\n'
-            )
-            f.flush()
-            stdout, _, _ = self.assert_params_for_cmd(
-                'cli-dev wizard-dev --run-wizard file://%s' % f.name, params={}
-            )
+class TestWizardDevHelpCommand(BaseAWSHelpOutputTest):
+    def test_wizard_dev_command_help(self):
+        self.driver.main(['cli-dev', 'wizard-dev', 'help'])
+        self.assert_contains('wizard-dev')

--- a/tests/integration/customizations/test_configure.py
+++ b/tests/integration/customizations/test_configure.py
@@ -63,9 +63,9 @@ class TestConfigureCommand(unittest.TestCase):
         self.env_vars.pop('AWS_SECRET_ACCESS_KEY', None)
         p = aws('configure list', env_vars=self.env_vars)
         self.assert_no_errors(p)
-        self.assertRegexpMatches(p.stdout, r'access_key.+config-file')
-        self.assertRegexpMatches(p.stdout, r'secret_key.+config-file')
-        self.assertRegexpMatches(p.stdout, r'region\s+us-west-2\s+config-file')
+        self.assertRegex(p.stdout, r'access_key.+config-file')
+        self.assertRegex(p.stdout, r'secret_key.+config-file')
+        self.assertRegex(p.stdout, r'region\s+us-west-2\s+config-file')
 
     def test_get_command(self):
         self.set_config_file_contents(

--- a/tests/integration/customizations/test_waiters.py
+++ b/tests/integration/customizations/test_waiters.py
@@ -12,9 +12,9 @@
 # language governing permissions and limitations under the License.
 import random
 
-from nose.plugins.attrib import attr
-import botocore.session
+import pytest
 
+import botocore.session
 from awscli.testutils import unittest, aws, random_chars
 
 
@@ -23,7 +23,7 @@ class TestDynamoDBWait(unittest.TestCase):
         self.session = botocore.session.get_session()
         self.client = self.session.create_client('dynamodb', 'us-west-2')
 
-    @attr('slow')
+    @pytest.mark.slow
     def test_wait_table_exists(self):
         # Create a table.
         table_name = 'awscliddb-%s' % random_chars(10)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -58,8 +58,8 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         p = aws('help')
         self.assertEqual(p.rc, 0)
         self.assertIn('AWS', p.stdout)
-        self.assertRegexpMatches(
-            p.stdout, 'The\s+AWS\s+Command\s+Line\s+Interface')
+        self.assertRegex(
+            p.stdout, r'The\s+AWS\s+Command\s+Line\s+Interface')
 
     def test_service_help_output(self):
         p = aws('ec2 help')
@@ -74,25 +74,24 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         # For now we're making the test less strict about formatting, but
         # we eventually should update this test to check exactly for
         # 'The describe-instances operation'.
-        self.assertRegexpMatches(p.stdout,
-                                 '\s+Describes\s+the\s+specified\s+instances')
+        self.assertRegex(p.stdout, r'\s+Describes\s+the\s+specified\s+instances')
 
     def test_topic_list_help_output(self):
         p = aws('help topics')
         self.assertEqual(p.rc, 0)
-        self.assertRegexpMatches(p.stdout, '\s+AWS\s+CLI\s+Topic\s+Guide')
-        self.assertRegexpMatches(
+        self.assertRegex(p.stdout, r'\s+AWS\s+CLI\s+Topic\s+Guide')
+        self.assertRegex(
             p.stdout,
-            '\s+This\s+is\s+the\s+AWS\s+CLI\s+Topic\s+Guide'
+            r'\s+This\s+is\s+the\s+AWS\s+CLI\s+Topic\s+Guide'
         )
 
     def test_topic_help_output(self):
         p = aws('help return-codes')
         self.assertEqual(p.rc, 0)
-        self.assertRegexpMatches(p.stdout, '\s+AWS\s+CLI\s+Return\s+Codes')
-        self.assertRegexpMatches(
+        self.assertRegex(p.stdout, r'\s+AWS\s+CLI\s+Return\s+Codes')
+        self.assertRegex(
             p.stdout,
-            'These\s+are\s+the\s+following\s+return\s+codes'
+            r'These\s+are\s+the\s+following\s+return\s+codes'
         )
 
     def test_operation_help_with_required_arg(self):
@@ -122,7 +121,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         self.assertEqual(p.rc, 0, p.stderr)
         # Check text that appears in the warning block to ensure
         # the block was actually rendered.
-        self.assertRegexpMatches(p.stdout, 'To\s+receive\s+notifications')
+        self.assertRegex(p.stdout, r'To\s+receive\s+notifications')
 
     def test_param_shorthand(self):
         p = aws(

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -6,7 +6,8 @@ import string
 import random
 import zipfile
 
-from nose.tools import assert_true, assert_false, assert_equal
+import pytest
+
 from contextlib import contextmanager, closing
 from mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
@@ -32,151 +33,161 @@ from awscli.customizations.cloudformation.artifact_exporter \
 from tests.unit.customizations.cloudformation import BaseYAMLTest
 
 
-def test_is_s3_url():
-    valid = [
-        "s3://foo/bar",
-        "s3://foo/bar/baz/cat/dog",
-        "s3://foo/bar?versionId=abc",
-        "s3://foo/bar/baz?versionId=abc&versionId=123",
-        "s3://foo/bar/baz?versionId=abc",
-        "s3://www.amazon.com/foo/bar",
-        "s3://my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
-    ]
+VALID_CASES = [
+    "s3://foo/bar",
+    "s3://foo/bar/baz/cat/dog",
+    "s3://foo/bar?versionId=abc",
+    "s3://foo/bar/baz?versionId=abc&versionId=123",
+    "s3://foo/bar/baz?versionId=abc",
+    "s3://www.amazon.com/foo/bar",
+    "s3://my-new-bucket/foo/bar?a=1&a=2&a=3&b=1",
+]
 
-    invalid = [
+INVALID_CASES = [
+    # For purposes of exporter, we need S3 URLs to point to an object
+    # and not a bucket
+    "s3://foo",
 
-        # For purposes of exporter, we need S3 URLs to point to an object
-        # and not a bucket
-        "s3://foo",
+    # two versionIds is invalid
+    "https://s3-eu-west-1.amazonaws.com/bucket/key",
+    "https://www.amazon.com"
+]
 
-        # two versionIds is invalid
-        "https://s3-eu-west-1.amazonaws.com/bucket/key",
-        "https://www.amazon.com"
-    ]
 
-    for url in valid:
-        yield _assert_is_valid_s3_url, url
+@pytest.mark.parametrize(
+    "url",
+    VALID_CASES
+)
+def test_is_valid_s3_url(url):
+    assert is_s3_url(url), f"{url} should be valid"
 
-    for url in invalid:
-        yield _assert_is_invalid_s3_url, url
 
-def _assert_is_valid_s3_url(url):
-    assert_true(is_s3_url(url), "{0} should be valid".format(url))
+@pytest.mark.parametrize(
+    "url",
+    INVALID_CASES
+)
+def test_is_invalid_s3_url(url):
+    assert not is_s3_url(url), f"{url} should be invalid"
 
-def _assert_is_invalid_s3_url(url):
-    assert_false(is_s3_url(url), "{0} should be valid".format(url))
 
-def test_all_resources_export():
-    uploaded_s3_url = "s3://foo/bar?versionId=baz"
+UPLOADED_S3_URL = "s3://foo/bar?versionId=baz"
 
-    setup = [
-        {
-            "class": ServerlessFunctionResource,
-            "expected_result": uploaded_s3_url
-        },
+RESOURCE_EXPORT_TEST_CASES = [
+    {
+        "class": ServerlessFunctionResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": ServerlessApiResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": ServerlessApiResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": GraphQLSchemaResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": GraphQLSchemaResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncResolverRequestTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncResolverRequestTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncResolverResponseTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncResolverResponseTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncFunctionConfigurationRequestTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncFunctionConfigurationRequestTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": AppSyncFunctionConfigurationResponseTemplateResource,
-            "expected_result": uploaded_s3_url
-        },
+    {
+        "class": AppSyncFunctionConfigurationResponseTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
 
-        {
-            "class": ApiGatewayRestApiResource,
-            "expected_result": {
-                "Bucket": "foo", "Key": "bar", "Version": "baz"
-            }
-        },
+    {
+        "class": ApiGatewayRestApiResource,
+        "expected_result": {
+            "Bucket": "foo", "Key": "bar", "Version": "baz"
+        }
+    },
 
-        {
-            "class": LambdaFunctionResource,
-            "expected_result": {
-                "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
-            }
-        },
+    {
+        "class": LambdaFunctionResource,
+        "expected_result": {
+            "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
+        }
+    },
 
-        {
-            "class": ElasticBeanstalkApplicationVersion,
-            "expected_result": {
-                "S3Bucket": "foo", "S3Key": "bar"
-            }
-        },
-        {
-            "class": LambdaLayerVersionResource,
-            "expected_result": {
-                "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
-            }
-        },
-        {
-            "class": ServerlessLayerVersionResource,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": ServerlessRepoApplicationReadme,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": ServerlessRepoApplicationLicense,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": ServerlessRepoApplicationLicense,
-            "expected_result": uploaded_s3_url
-        },
-        {
-            "class": GlueJobCommandScriptLocationResource,
-            "expected_result": {
-                    "ScriptLocation": uploaded_s3_url
-            }
-        },
-        {
-            "class": StepFunctionsStateMachineDefinitionResource,
-            "expected_result": {
-                "Bucket": "foo", "Key": "bar", "Version": "baz"
-            }
-        },
-    ]
+    {
+        "class": ElasticBeanstalkApplicationVersion,
+        "expected_result": {
+            "S3Bucket": "foo", "S3Key": "bar"
+        }
+    },
+    {
+        "class": LambdaLayerVersionResource,
+        "expected_result": {
+            "S3Bucket": "foo", "S3Key": "bar", "S3ObjectVersion": "baz"
+        }
+    },
+    {
+        "class": ServerlessLayerVersionResource,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": ServerlessRepoApplicationReadme,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": ServerlessRepoApplicationLicense,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": ServerlessRepoApplicationLicense,
+        "expected_result": UPLOADED_S3_URL
+    },
+    {
+        "class": GlueJobCommandScriptLocationResource,
+        "expected_result": {
+                "ScriptLocation": UPLOADED_S3_URL
+        }
+    },
+    {
+        "class": StepFunctionsStateMachineDefinitionResource,
+        "expected_result": {
+            "Bucket": "foo", "Key": "bar", "Version": "baz"
+        }
+    },
+]
 
-    with patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts") as upload_local_artifacts_mock:
-        for test in setup:
-            yield _helper_verify_export_resources, \
-                    test["class"], uploaded_s3_url, \
-                    upload_local_artifacts_mock, \
-                    test["expected_result"]
+
+@pytest.mark.parametrize(
+    "test",
+    RESOURCE_EXPORT_TEST_CASES
+)
+def test_all_resources_export(test):
+    mock_path = (
+        "awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts"
+    )
+    with mock.patch(mock_path) as upload_local_artifacts_mock:
+        _helper_verify_export_resources(
+            test["class"], upload_local_artifacts_mock, test["expected_result"]
+        )
 
 
 def _helper_verify_export_resources(
-        test_class, uploaded_s3_url, upload_local_artifacts_mock,
-        expected_result):
+    test_class, upload_local_artifacts_mock, expected_result
+):
 
     s3_uploader_mock = Mock()
     upload_local_artifacts_mock.reset_mock()
 
     resource_id = "id"
+    parent_dir = "dir"
 
     if '.' in test_class.PROPERTY_NAME:
         reversed_property_names = test_class.PROPERTY_NAME.split('.')
@@ -193,25 +204,22 @@ def _helper_verify_export_resources(
         resource_dict = {
             test_class.PROPERTY_NAME: "foo"
         }
-    parent_dir = "dir"
 
-    upload_local_artifacts_mock.return_value = uploaded_s3_url
-
+    upload_local_artifacts_mock.return_value = UPLOADED_S3_URL
     resource_obj = test_class(s3_uploader_mock)
-
     resource_obj.export(resource_id, resource_dict, parent_dir)
 
-    upload_local_artifacts_mock.assert_called_once_with(resource_id,
-                                                        resource_dict,
-                                                        test_class.PROPERTY_NAME,
-                                                        parent_dir,
-                                                        s3_uploader_mock)
+    upload_local_artifacts_mock.assert_called_once_with(
+        resource_id, resource_dict, test_class.PROPERTY_NAME,
+        parent_dir, s3_uploader_mock
+    )
     if '.' in test_class.PROPERTY_NAME:
         top_level_property_name = test_class.PROPERTY_NAME.split('.')[0]
         result = resource_dict[top_level_property_name]
     else:
         result = resource_dict[test_class.PROPERTY_NAME]
-    assert_equal(result, expected_result)
+
+    assert result == expected_result
 
 
 class TestArtifactExporter(BaseYAMLTest):
@@ -503,7 +511,7 @@ class TestArtifactExporter(BaseYAMLTest):
             zip_and_upload_mock.assert_called_once_with(tmp_dir, mock.ANY)
             rmtree_mock.assert_called_once_with(tmp_dir)
             is_zipfile_mock.assert_called_once_with(original_path)
-            assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
+            assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
     @patch("shutil.rmtree")
     @patch("zipfile.is_zipfile")
@@ -540,7 +548,7 @@ class TestArtifactExporter(BaseYAMLTest):
         zip_and_upload_mock.assert_not_called()
         rmtree_mock.assert_not_called()
         is_zipfile_mock.assert_called_once_with(original_path)
-        assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
+        assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
     @patch("shutil.rmtree")
     @patch("zipfile.is_zipfile")
@@ -574,7 +582,7 @@ class TestArtifactExporter(BaseYAMLTest):
         zip_and_upload_mock.assert_not_called()
         rmtree_mock.assert_not_called()
         is_zipfile_mock.assert_called_once_with(original_path)
-        assert_equal(resource_dict[resource.PROPERTY_NAME], s3_url)
+        assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
     @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_empty_property_value(self, upload_local_artifacts_mock):

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -142,7 +142,7 @@ class TestPush(unittest.TestCase):
     def test_validate_args_default_description(self):
         self.args.description = None
         self.push._validate_args(self.args)
-        self.assertRegexpMatches(
+        self.assertRegex(
             self.args.description,
             'Uploaded by AWS CLI .* UTC'
         )

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -155,7 +155,7 @@ class TestInteractivePrompter(unittest.TestCase):
         # We should also not display the entire access key.
         prompt_text = self.stdout.getvalue()
         self.assertNotIn('myaccesskey', prompt_text)
-        self.assertRegexpMatches(prompt_text, r'\[\*\*\*\*.*\]')
+        self.assertRegex(prompt_text, r'\[\*\*\*\*.*\]')
 
     def test_access_key_not_masked_when_none(self):
         self.mock_raw_input.return_value = 'foo'
@@ -177,7 +177,7 @@ class TestInteractivePrompter(unittest.TestCase):
         # We should also not display the entire secret key.
         prompt_text = self.stdout.getvalue()
         self.assertNotIn('mysupersecretkey', prompt_text)
-        self.assertRegexpMatches(prompt_text, r'\[\*\*\*\*.*\]')
+        self.assertRegex(prompt_text, r'\[\*\*\*\*.*\]')
 
     def test_non_secret_keys_are_not_masked(self):
         prompter = configure.InteractivePrompter()
@@ -187,7 +187,7 @@ class TestInteractivePrompter(unittest.TestCase):
         # We should also not display the entire secret key.
         prompt_text = self.stdout.getvalue()
         self.assertIn('mycurrentvalue', prompt_text)
-        self.assertRegexpMatches(prompt_text, r'\[mycurrentvalue\]')
+        self.assertRegex(prompt_text, r'\[mycurrentvalue\]')
 
     def test_user_hits_enter_returns_none(self):
         # If a user hits enter, then raw_input returns the empty string.

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -32,10 +32,10 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(rendered, 'profile\s+<not set>')
-        self.assertRegexpMatches(rendered, 'access_key\s+<not set>')
-        self.assertRegexpMatches(rendered, 'secret_key\s+<not set>')
-        self.assertRegexpMatches(rendered, 'region\s+<not set>')
+        self.assertRegex(rendered, r'profile\s+<not set>')
+        self.assertRegex(rendered, r'access_key\s+<not set>')
+        self.assertRegex(rendered, r'secret_key\s+<not set>')
+        self.assertRegex(rendered, r'region\s+<not set>')
 
     def test_configure_from_env(self):
         env_vars = {
@@ -51,8 +51,8 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(
-            rendered, 'profile\s+myprofilename\s+env\s+PROFILE_ENV_VAR')
+        self.assertRegex(
+            rendered, r'profile\s+myprofilename\s+env\s+PROFILE_ENV_VAR')
 
     def test_configure_from_config_file(self):
         config_file_vars = {
@@ -68,8 +68,8 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(
-            rendered, 'region\s+us-west-2\s+config-file\s+/config/location')
+        self.assertRegex(
+            rendered, r'region\s+us-west-2\s+config-file\s+/config/location')
 
     def test_configure_from_multiple_sources(self):
         # Here the profile is from an env var, the
@@ -100,17 +100,17 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
         # The profile came from an env var.
-        self.assertRegexpMatches(
-            rendered, 'profile\s+myprofilename\s+env\s+AWS_DEFAULT_PROFILE')
+        self.assertRegex(
+            rendered, r'profile\s+myprofilename\s+env\s+AWS_DEFAULT_PROFILE')
         # The region came from the config file.
-        self.assertRegexpMatches(
-            rendered, 'region\s+us-west-2\s+config-file\s+/config/location')
+        self.assertRegex(
+            rendered, r'region\s+us-west-2\s+config-file\s+/config/location')
         # The credentials came from an IAM role.  Note how we're
         # also checking that the access_key/secret_key are masked
         # with '*' chars except for the last 4 chars.
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered, r'access_key\s+\*+_key\s+iam-role')
-        self.assertRegexpMatches(
+        self.assertRegex(
             rendered, r'secret_key\s+\*+_key\s+iam-role')
 
     def test_configure_region_from_imds(self):
@@ -137,5 +137,5 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=parsed_globals)
         rendered = stream.getvalue()
-        self.assertRegexpMatches(
-            rendered, 'profile\s+foo\s+manual\s+--profile')
+        self.assertRegex(
+            rendered, r'profile\s+foo\s+manual\s+--profile')

--- a/tests/unit/customizations/emr/test_emr_utils.py
+++ b/tests/unit/customizations/emr/test_emr_utils.py
@@ -12,16 +12,14 @@
 # language governing permissions and limitations under the License.
 
 from awscli.customizations.emr.emrutils import which
-from nose.tools import assert_equal
-from nose.tools import assert_not_equal
 
 
 class TestEMRutils(object):
 
     def test_which_with_existing_command(self):
         pythonPath = which('python') or which('python.exe')
-        assert_not_equal(pythonPath, None)
+        assert pythonPath is not None
 
     def test_which_with_non_existing_command(self):
         path = which('klajsflklj')
-        assert_equal(path, None)
+        assert path is None

--- a/tests/unit/customizations/emr/test_modify_cluster_attributes.py
+++ b/tests/unit/customizations/emr/test_modify_cluster_attributes.py
@@ -13,7 +13,6 @@
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
-from nose.tools import raises
 
 
 class TestModifyClusterAttributes(BaseAWSCommandParamsTest):

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -88,7 +88,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -97,7 +97,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -106,7 +106,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -117,7 +117,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -128,7 +128,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -139,7 +139,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -150,7 +150,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -161,7 +161,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -170,7 +170,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
     @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
@@ -194,7 +194,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegexpMatches(
+        self.assertRegex(
             output,
             'username={0}%{1}\npassword=.+'.format('access', 'token'))
 

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -502,7 +502,7 @@ class TestOpsWorksRegister(TestOpsWorksBase):
         self.assertEqual(cmd[0], "ssh")
         self.assertEqual(cmd[1], "-tt")
         self.assertEqual(cmd[2], "ip")
-        self.assertRegexpMatches(cmd[3], r"/bin/sh -c ")
+        self.assertRegex(cmd[3], r"/bin/sh -c ")
 
     @mock.patch.object(opsworks, "platform")
     @mock.patch.object(opsworks, "subprocess")
@@ -529,7 +529,7 @@ class TestOpsWorksRegister(TestOpsWorksBase):
         self.register.setup_target_machine(args)
 
         cmd = mock_subprocess.check_call.call_args[0][0]
-        self.assertRegexpMatches(cmd, r'^plink ".*" -m ".*"$')
+        self.assertRegex(cmd, r'^plink ".*" -m ".*"$')
 
     @mock.patch.object(opsworks, "subprocess")
     def test_setup_target_machine_local(self, mock_subprocess):

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -23,7 +23,7 @@ from prompt_toolkit.layout import walk
 
 from tests import (
     PromptToolkitApplicationStubber as ApplicationStubber,
-    FakeApplicationOutput
+    FakeApplicationOutput, FakeApplicationInput
 )
 from awscli.customizations.wizard.factory import create_wizard_app
 from awscli.customizations.wizard.app import (
@@ -67,7 +67,9 @@ class BaseWizardApplicationTest(unittest.TestCase):
         self.definition = self.get_definition()
         self.session = mock.Mock(spec=Session)
         self.app = create_wizard_app(
-            self.definition, self.session, FakeApplicationOutput())
+            self.definition, self.session, FakeApplicationOutput(),
+            app_input=FakeApplicationInput()
+        )
         self.stubbed_app = ApplicationStubber(self.app)
 
     def get_definition(self):

--- a/tests/unit/test_alias.py
+++ b/tests/unit/test_alias.py
@@ -98,8 +98,9 @@ class TestAliasLoader(unittest.TestCase):
         with open(self.alias_file, 'a+') as f:
             f.write(
                 'my-alias = \n'
-                '  my-alias-value \ \n'
-                '  --parameter foo\n')
+                '  my-alias-value \\ \n'
+                '  --parameter foo\n'
+            )
         alias_interface = AliasLoader(self.alias_file)
         self.assertEqual(
             alias_interface.get_aliases(),
@@ -462,7 +463,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         with self.assertRaises(ArgParseException):
             # Even though we catch the system exit, a message will always
             # be forced to screen because it happened at system exit.
-            # The patch is to ensure it does not get displayed by nosetests.
+            # The patch is to ensure it does not get displayed.
             with mock.patch('sys.stderr'):
                 alias_cmd([], FakeParsedArgs(command=self.alias_name))
 
@@ -478,7 +479,7 @@ class TestServiceAliasCommand(unittest.TestCase):
         with self.assertRaises(ArgParseException):
             # Even though we catch the system exit, a message will always
             # be forced to screen because it happened at system exit.
-            # The patch is to ensure it does not get displayed by nosetests.
+            # The patch is to ensure it does not get displayed.
             with mock.patch('sys.stderr'):
                 alias_cmd([], FakeParsedArgs(command=self.alias_name))
 

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -399,7 +399,7 @@ class TestParamShorthand(BaseArgProcessTest):
     def test_csv_syntax_escaped(self):
         p = self.get_param_model('cloudformation.CreateStack.Parameters')
         returned = self.parse_shorthand(
-            p, ["ParameterKey=key,ParameterValue=foo\,bar"])
+            p, [r"ParameterKey=key,ParameterValue=foo\,bar"])
         expected = [{"ParameterKey": "key",
                      "ParameterValue": "foo,bar"}]
         self.assertEqual(returned, expected)
@@ -659,7 +659,7 @@ class TestDocGen(BaseArgProcessTest):
     def test_can_document_nested_structs(self):
         argument = self.get_param_model('ec2.RunInstances.BlockDeviceMappings')
         generated_example = self.get_generated_example_for(argument)
-        self.assertRegexpMatches(generated_example, 'Ebs={\w+=\w+')
+        self.assertRegex(generated_example, r'Ebs={\w+=\w+')
 
     def test_can_document_nested_lists(self):
         argument = self.create_argument({

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -639,7 +639,6 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             value='file:///foo',
         )
 
-    @unittest.skip
     def test_custom_arg_no_paramfile(self):
         driver = create_clidriver()
         driver.session.register(

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -516,10 +516,6 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         argument = CustomArgument('unknown-arg', {})
         argument.add_to_arg_table(argument_table)
 
-    def inject_new_param_no_paramfile(self, argument_table, **kwargs):
-        argument = CustomArgument('unknown-arg', no_paramfile=True)
-        argument.add_to_arg_table(argument_table)
-
     def inject_command(self, command_table, session, **kwargs):
         command = FakeCommand(session)
         command.NAME = 'foo'
@@ -638,17 +634,6 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
             service_name='custom',
             value='file:///foo',
         )
-
-    def test_custom_arg_no_paramfile(self):
-        driver = create_clidriver()
-        driver.session.register(
-            'building-argument-table', self.inject_new_param_no_paramfile)
-
-        self.patch_make_request()
-        rc = driver.main(
-            'ec2 describe-instances --unknown-arg file:///foo'.split())
-
-        self.assertEqual(rc, 0)
 
     def test_custom_command_schema(self):
         driver = create_clidriver()

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -14,7 +14,8 @@ import locale
 import os
 import signal
 
-from nose.tools import assert_equal
+import pytest
+
 from botocore.compat import six
 
 from awscli.compat import ensure_text_type
@@ -57,40 +58,54 @@ class TestEnsureText(unittest.TestCase):
             ensure_text_type(value)
 
 
-def test_compat_shell_quote_windows():
-    windows_cases = {
-        '': '""',
-        '"': '\\"',
-        '\\': '\\',
-        '\\a': '\\a',
-        '\\\\': '\\\\',
-        '\\"': '\\\\\\"',
-        '\\\\"': '\\\\\\\\\\"',
-        'foo bar': '"foo bar"',
-        'foo\tbar': '"foo\tbar"',
-    }
-    for input_string, expected_output in windows_cases.items():
-        yield ShellQuoteTestCase().run, input_string, expected_output, "win32"
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    (
+        ('', '""'),
+        ('"', '\\"'),
+        ('\\', '\\'),
+        ('\\a', '\\a'),
+        ('\\\\', '\\\\'),
+        ('\\"', '\\\\\\"'),
+        ('\\\\"', '\\\\\\\\\\"'),
+        ('foo bar', '"foo bar"'),
+        ('foo\tbar', '"foo\tbar"'),
+    )
+)
+def test_compat_shell_quote_windows(input_string, expected_output):
+    assert compat_shell_quote(input_string, "win32") == expected_output
 
 
-def test_comat_shell_quote_unix():
-    unix_cases = {
-        "": "''",
-        "*": "'*'",
-        "foo": "foo",
-        "foo bar": "'foo bar'",
-        "foo\tbar": "'foo\tbar'",
-        "foo\nbar": "'foo\nbar'",
-        "foo'bar": "'foo'\"'\"'bar'",
-    }
-    for input_string, expected_output in unix_cases.items():
-        yield ShellQuoteTestCase().run, input_string, expected_output, "linux2"
-        yield ShellQuoteTestCase().run, input_string, expected_output, "darwin"
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    (
+        ('', "''"),
+        ('*', "'*'"),
+        ('foo', 'foo'),
+        ('foo bar', "'foo bar'"),
+        ('foo\tbar', "'foo\tbar'"),
+        ('foo\nbar', "'foo\nbar'"),
+        ("foo'bar", '\'foo\'"\'"\'bar\'')
+    )
+)
+def test_comat_shell_quote_linux(input_string, expected_output):
+    assert compat_shell_quote(input_string, "linux2") == expected_output
 
 
-class ShellQuoteTestCase(object):
-    def run(self, s, expected, platform=None):
-        assert_equal(compat_shell_quote(s, platform), expected)
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    (
+        ('', "''"),
+        ('*', "'*'"),
+        ('foo', 'foo'),
+        ('foo bar', "'foo bar'"),
+        ('foo\tbar', "'foo\tbar'"),
+        ('foo\nbar', "'foo\nbar'"),
+        ("foo'bar", '\'foo\'"\'"\'bar\'')
+    )
+)
+def test_comat_shell_quote_darwin(input_string, expected_output):
+    assert compat_shell_quote(input_string, "darwin") == expected_output
 
 
 class TestGetPopenPagerCmd(unittest.TestCase):

--- a/tests/unit/test_errorhandler.py
+++ b/tests/unit/test_errorhandler.py
@@ -46,7 +46,7 @@ def _assert_rc_and_error_message(case, error_handler):
         cr = error_handler.handle_exception(e, stdout, stderr)
         assert cr == case.rc, case.exception.__class__
         assert case.stderr in stderr.getvalue()
-        assert case.stdout in stdout.getvalue()
+        assert case.stdout == stdout.getvalue()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_errorhandler.py
+++ b/tests/unit/test_errorhandler.py
@@ -11,8 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import io
-import nose
 from collections import namedtuple
+
+import pytest
 
 from botocore.exceptions import (
     NoRegionError, NoCredentialsError, ClientError,
@@ -43,13 +44,14 @@ def _assert_rc_and_error_message(case, error_handler):
         raise case.exception
     except BaseException as e:
         cr = error_handler.handle_exception(e, stdout, stderr)
-        nose.tools.eq_(cr, case.rc, case.exception.__class__)
-        nose.tools.assert_in(case.stderr, stderr.getvalue())
-        nose.tools.eq_(case.stdout, stdout.getvalue())
+        assert cr == case.rc, case.exception.__class__
+        assert case.stderr in stderr.getvalue()
+        assert case.stdout in stdout.getvalue()
 
 
-def test_cli_error_handling_chain():
-    cases = [
+@pytest.mark.parametrize(
+    "case",
+    [
         Case(Exception('error'), 255, 'error', ''),
         Case(KeyboardInterrupt(), 130, '', '\n'),
         Case(NoRegionError(), 253, 'region', ''),
@@ -66,13 +68,15 @@ def test_cli_error_handling_chain():
         Case(ParamValidationError('error'), 252, 'error', ''),
         Case(ConfigurationError('error'), 253, 'error', ''),
     ]
+)
+def test_cli_error_handling_chain(case):
     error_handler = errorhandler.construct_cli_error_handlers_chain()
-    for case in cases:
-        yield _assert_rc_and_error_message, case, error_handler
+    _assert_rc_and_error_message(case, error_handler)
 
 
-def test_cli_error_handling_chain_injection():
-    cases = [
+@pytest.mark.parametrize(
+    "case",
+    [
         Case(Exception('error'), 255, 'error', ''),
         Case(KeyboardInterrupt(), 130, '', '\n'),
         Case(NoRegionError(), 253, 'region', ''),
@@ -87,21 +91,24 @@ def test_cli_error_handling_chain_injection():
         Case(ParamValidationError('error'), 252, '', ''),
         Case(ConfigurationError('error'), 253, 'error', ''),
     ]
+)
+def test_cli_error_handling_chain_injection(case):
     error_handler = errorhandler.construct_cli_error_handlers_chain()
     error_handler.inject_handler(
         0, errorhandler.SilenceParamValidationMsgErrorHandler()
     )
-    for case in cases:
-        yield _assert_rc_and_error_message, case, error_handler
+    _assert_rc_and_error_message(case, error_handler)
 
 
-def test_entry_point_error_handling_chain():
-    cases = [
+@pytest.mark.parametrize(
+    "case",
+    [
         Case(Exception('error'), 255, 'error', ''),
         Case(KeyboardInterrupt(), 130, '', '\n'),
         Case(PrompterKeyboardInterrupt('error'), 130, 'error', ''),
         Case(ParamValidationError('error'), 252, 'error', ''),
     ]
+)
+def test_entry_point_error_handling_chain(case):
     error_handler = errorhandler.construct_entry_point_handlers_chain()
-    for case in cases:
-        yield _assert_rc_and_error_message, case, error_handler
+    _assert_rc_and_error_message(case, error_handler)

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -10,191 +10,155 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
+
 from awscli import shorthand
 from awscli.testutils import unittest
 
 from botocore import model
 
-from nose.tools import assert_equal
 
-
-def test_parse():
+PARSING_TEST_CASES = (
     # Key val pairs with scalar value.
-    yield (_can_parse, 'foo=bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo=bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo=bar,baz=qux', {'foo': 'bar', 'baz': 'qux'})
-    yield (_can_parse, 'a=b,c=d,e=f', {'a': 'b', 'c': 'd', 'e': 'f'})
+    ('foo=bar', {'foo': 'bar'}),
+    ('foo=bar', {'foo': 'bar'}),
+    ('foo=bar,baz=qux', {'foo': 'bar', 'baz': 'qux'}),
+    ('a=b,c=d,e=f', {'a': 'b', 'c': 'd', 'e': 'f'}),
     # Empty values are allowed.
-    yield (_can_parse, 'foo=', {'foo': ''})
-    yield (_can_parse, 'foo=,bar=', {'foo': '', 'bar': ''})
+    ('foo=', {'foo': ''}),
+    ('foo=,bar=', {'foo': '', 'bar': ''}),
     # Unicode is allowed.
-    yield (_can_parse, u'foo=\u2713', {'foo': u'\u2713'})
-    yield (_can_parse, u'foo=\u2713,\u2713', {'foo': [u'\u2713', u'\u2713']})
+    (u'foo=\u2713', {'foo': u'\u2713'}),
+    (u'foo=\u2713,\u2713', {'foo': [u'\u2713', u'\u2713']}),
     # Key val pairs with csv values.
-    yield (_can_parse, 'foo=a,b', {'foo': ['a', 'b']})
-    yield (_can_parse, 'foo=a,b,c', {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo=a,b,bar=c,d', {'foo': ['a', 'b'],
-                                           'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=a,b,c,bar=d,e,f',
-           {'foo': ['a', 'b', 'c'], 'bar': ['d', 'e', 'f']})
+    ('foo=a,b', {'foo': ['a', 'b']}),
+    ('foo=a,b,c', {'foo': ['a', 'b', 'c']}),
+    ('foo=a,b,bar=c,d', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=a,b,c,bar=d,e,f', {'foo': ['a', 'b', 'c'], 'bar': ['d', 'e', 'f']}),
     # Spaces in values are allowed.
-    yield (_can_parse, 'foo=a,b=with space', {'foo': 'a', 'b': 'with space'})
+    ('foo=a,b=with space', {'foo': 'a', 'b': 'with space'}),
     # Trailing spaces are still ignored.
-    yield (_can_parse, 'foo=a,b=with trailing space  ',
-           {'foo': 'a', 'b': 'with trailing space'})
-    yield (_can_parse, 'foo=first space',
-           {'foo': 'first space'})
-    yield (_can_parse, 'foo=a space,bar=a space,baz=a space',
-           {'foo': 'a space', 'bar': 'a space', 'baz': 'a space'})
-
+    ('foo=a,b=with trailing space  ', {'foo': 'a', 'b': 'with trailing space'}),
+    ('foo=first space', {'foo': 'first space'}),
+    (
+        'foo=a space,bar=a space,baz=a space',
+        {'foo': 'a space', 'bar': 'a space', 'baz': 'a space'}
+    ),
     # Dashes are allowed in key names.
-    yield (_can_parse, 'with-dash=bar', {'with-dash': 'bar'})
-
+    ('with-dash=bar', {'with-dash': 'bar'}),
     # Underscore are also allowed.
-    yield (_can_parse, 'with_underscore=bar', {'with_underscore': 'bar'})
-
+    ('with_underscore=bar', {'with_underscore': 'bar'}),
     # Dots are allowed.
-    yield (_can_parse, 'with.dot=bar', {'with.dot': 'bar'})
-
+    ('with.dot=bar', {'with.dot': 'bar'}),
     # Pound signs are allowed.
-    yield (_can_parse, '#key=value', {'#key': 'value'})
-
+    ('#key=value', {'#key': 'value'}),
     # Forward slashes are allowed in keys.
-    yield (_can_parse, 'some/thing=value', {'some/thing': 'value'})
-
+    ('some/thing=value', {'some/thing': 'value'}),
     # Colon chars are allowed in keys:
-    yield (_can_parse, 'aws:service:region:124:foo/bar=baz',
-           {'aws:service:region:124:foo/bar': 'baz'})
-
+    ('aws:service:region:124:foo/bar=baz', {'aws:service:region:124:foo/bar': 'baz'}),
     # Explicit lists.
-    yield (_can_parse, 'foo=[]', {'foo': []})
-    yield (_can_parse, 'foo=[a]', {'foo': ['a']})
-    yield (_can_parse, 'foo=[a,b]', {'foo': ['a', 'b']})
-    yield (_can_parse, 'foo=[a,b,c]', {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo=[a,b],bar=c,d',
-           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=[a,b],bar=[c,d]',
-           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=a,b,bar=[c,d]',
-           {'foo': ['a', 'b'], 'bar': ['c', 'd']})
-    yield (_can_parse, 'foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']})
-    yield (_can_parse, 'foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']})
+    ('foo=[]', {'foo': []}),
+    ('foo=[a]', {'foo': ['a']}),
+    ('foo=[a,b]', {'foo': ['a', 'b']}),
+    ('foo=[a,b,c]', {'foo': ['a', 'b', 'c']}),
+    ('foo=[a,b],bar=c,d', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=[a,b],bar=[c,d]', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=a,b,bar=[c,d]', {'foo': ['a', 'b'], 'bar': ['c', 'd']}),
+    ('foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']}),
+    ('foo=[a=b,c=d]', {'foo': ['a=b', 'c=d']}),
     # Lists with whitespace.
-    yield (_can_parse, 'foo=[ a , b  , c  ]',
-           {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo  =  [ a , b  , c  ]',
-           {'foo': ['a', 'b', 'c']})
-    yield (_can_parse, 'foo=[,,]', {'foo': ['', '']})
-
+    ('foo=[ a , b  , c  ]', {'foo': ['a', 'b', 'c']}),
+    ('foo  =  [ a , b  , c  ]', {'foo': ['a', 'b', 'c']}),
+    ('foo=[,,]', {'foo': ['', '']}),
     # Single quoted strings.
-    yield (_can_parse, "foo='bar'", {"foo": "bar"})
-    yield (_can_parse, "foo='bar,baz'", {"foo": "bar,baz"})
+    ("foo='bar'", {"foo": "bar"}),
+    ("foo='bar,baz'", {"foo": "bar,baz"}),
     # Single quoted strings for each value in a CSV list.
-    yield (_can_parse, "foo='bar','baz'", {"foo": ['bar', 'baz']})
+    ("foo='bar','baz'", {"foo": ['bar', 'baz']}),
     # Can mix single quoted and non quoted values.
-    yield (_can_parse, "foo=bar,'baz'", {"foo": ['bar', 'baz']})
+    ("foo=bar,'baz'", {"foo": ['bar', 'baz']}),
     # Quoted strings can include chars not allowed in unquoted strings.
-    yield (_can_parse, "foo=bar,'baz=qux'", {"foo": ['bar', 'baz=qux']})
-    yield (_can_parse, "foo=bar,'--option=bar space'",
-           {"foo": ['bar', '--option=bar space']})
+    ("foo=bar,'baz=qux'", {"foo": ['bar', 'baz=qux']}),
+    ("foo=bar,'--option=bar space'", {"foo": ['bar', '--option=bar space']}),
     # Can escape the single quote.
-    yield (_can_parse, "foo='bar\\'baz'", {"foo": "bar'baz"})
-    yield (_can_parse, "foo='bar\\\\baz'", {"foo": "bar\\baz"})
-
+    ("foo='bar\\'baz'", {"foo": "bar'baz"}),
+    ("foo='bar\\\\baz'", {"foo": "bar\\baz"}),
     # Double quoted strings.
-    yield (_can_parse, 'foo="bar"', {'foo': 'bar'})
-    yield (_can_parse, 'foo="bar,baz"', {'foo': 'bar,baz'})
-    yield (_can_parse, 'foo="bar","baz"', {'foo': ['bar', 'baz']})
-    yield (_can_parse, 'foo=bar,"baz=qux"', {'foo': ['bar', 'baz=qux']})
-    yield (_can_parse, 'foo=bar,"--option=bar space"',
-           {'foo': ['bar', '--option=bar space']})
-    yield (_can_parse, 'foo="bar\\"baz"', {'foo': 'bar"baz'})
-    yield (_can_parse, 'foo="bar\\\\baz"', {'foo': 'bar\\baz'})
-
+    ('foo="bar"', {'foo': 'bar'}),
+    ('foo="bar,baz"', {'foo': 'bar,baz'}),
+    ('foo="bar","baz"', {'foo': ['bar', 'baz']}),
+    ('foo=bar,"baz=qux"', {'foo': ['bar', 'baz=qux']}),
+    ('foo=bar,"--option=bar space"', {'foo': ['bar', '--option=bar space']}),
+    ('foo="bar\\"baz"', {'foo': 'bar"baz'}),
+    ('foo="bar\\\\baz"', {'foo': 'bar\\baz'}),
     # Can escape comma in CSV list.
-    yield (_can_parse, 'foo=a\\,b', {"foo": "a,b"})
-    yield (_can_parse, 'foo=a\\,b', {"foo": "a,b"})
-    yield (_can_parse, 'foo=a\\,', {"foo": "a,"})
-    yield (_can_parse, 'foo=\\,', {"foo": ","})
-    yield (_can_parse, 'foo=a,b\\,c', {"foo": ['a', 'b,c']})
-    yield (_can_parse, 'foo=a,b\\,', {"foo": ['a', 'b,']})
-    yield (_can_parse, 'foo=a,\\,bc', {"foo": ['a', ',bc']})
-
+    ('foo=a\\,b', {"foo": "a,b"}),
+    ('foo=a\\,b', {"foo": "a,b"}),
+    ('foo=a\\,', {"foo": "a,"}),
+    ('foo=\\,', {"foo": ","}),
+    ('foo=a,b\\,c', {"foo": ['a', 'b,c']}),
+    ('foo=a,b\\,', {"foo": ['a', 'b,']}),
+    ('foo=a,\\,bc', {"foo": ['a', ',bc']}),
     # Ignores whitespace around '=' and ','
-    yield (_can_parse, 'foo= bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo =bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo = bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo  =   bar', {'foo': 'bar'})
-    yield (_can_parse, 'foo = bar,baz = qux', {'foo': 'bar', 'baz': 'qux'})
-    yield (_can_parse, 'a = b,  c = d , e = f', {'a': 'b', 'c': 'd', 'e': 'f'})
-    yield (_can_parse, 'foo = ', {'foo': ''})
-    yield (_can_parse, 'a=b,c=  d,  e,  f', {'a': 'b', 'c': ['d', 'e', 'f']})
-    yield (_can_parse, 'Name=foo,Values=  a  ,  b  ,  c  ',
-           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
-    yield (_can_parse, 'Name=foo,Values= a,  b  ,  c',
-           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
-
+    ('foo= bar', {'foo': 'bar'}),
+    ('foo =bar', {'foo': 'bar'}),
+    ('foo = bar', {'foo': 'bar'}),
+    ('foo  =   bar', {'foo': 'bar'}),
+    ('foo = bar,baz = qux', {'foo': 'bar', 'baz': 'qux'}),
+    ('a = b,  c = d , e = f', {'a': 'b', 'c': 'd', 'e': 'f'}),
+    ('foo = ', {'foo': ''}),
+    ('a=b,c=  d,  e,  f', {'a': 'b', 'c': ['d', 'e', 'f']}),
+    ('Name=foo,Values=  a  ,  b  ,  c  ', {'Name': 'foo', 'Values': ['a', 'b', 'c']}),
+    ('Name=foo,Values= a,  b  ,  c', {'Name': 'foo', 'Values': ['a', 'b', 'c']}),
     # Can handle newlines between values.
-    yield (_can_parse, 'Name=foo,\nValues=a,b,c',
-           {'Name': 'foo', 'Values': ['a', 'b', 'c']})
-    yield (_can_parse, 'A=b,\nC=d,\nE=f\n',
-           {'A': 'b', 'C': 'd', 'E': 'f'})
-
+    ('Name=foo,\nValues=a,b,c', {'Name': 'foo', 'Values': ['a', 'b', 'c']}),
+    ('A=b,\nC=d,\nE=f\n', {'A': 'b', 'C': 'd', 'E': 'f'}),
     # Hashes
-    yield (_can_parse, 'Name={foo=bar,baz=qux}',
-           {'Name': {'foo': 'bar', 'baz': 'qux'}})
-    yield (_can_parse, 'Name={foo=[a,b,c],bar=baz}',
-           {'Name': {'foo': ['a', 'b', 'c'], 'bar': 'baz'}})
-    yield (_can_parse, 'Name={foo=bar},Bar=baz',
-           {'Name': {'foo': 'bar'}, 'Bar': 'baz'})
-    yield (_can_parse, 'Bar=baz,Name={foo=bar}',
-           {'Bar': 'baz', 'Name': {'foo': 'bar'}})
-    yield (_can_parse, 'a={b={c=d}}',
-           {'a': {'b': {'c': 'd'}}})
-    yield (_can_parse, 'a={b={c=d,e=f},g=h}',
-           {'a': {'b': {'c': 'd', 'e': 'f'}, 'g': 'h'}})
-
+    ('Name={foo=bar,baz=qux}', {'Name': {'foo': 'bar', 'baz': 'qux'}}),
+    ('Name={foo=[a,b,c],bar=baz}', {'Name': {'foo': ['a', 'b', 'c'], 'bar': 'baz'}}),
+    ('Name={foo=bar},Bar=baz', {'Name': {'foo': 'bar'}, 'Bar': 'baz'}),
+    ('Bar=baz,Name={foo=bar}', {'Bar': 'baz', 'Name': {'foo': 'bar'}}),
+    ('a={b={c=d}}', {'a': {'b': {'c': 'd'}}}),
+    ('a={b={c=d,e=f},g=h}', {'a': {'b': {'c': 'd', 'e': 'f'}, 'g': 'h'}}),
     # Combining lists and hashes.
-    yield (_can_parse, 'Name=[{foo=bar}, {baz=qux}]',
-           {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]})
-
+    ('Name=[{foo=bar}, {baz=qux}]', {'Name': [{'foo': 'bar'}, {'baz': 'qux'}]}),
     # Combining hashes and lists.
-    yield (_can_parse, 'Name=[{foo=[a,b]}, {bar=[c,d]}]',
-           {'Name': [{'foo': ['a', 'b']}, {'bar': ['c', 'd']}]})
+    (
+        'Name=[{foo=[a,b]}, {bar=[c,d]}]',
+        {'Name': [{'foo': ['a', 'b']}, {'bar': ['c', 'd']}]}
+    ),
+)
 
 
-def test_error_parsing():
-    yield (_is_error, 'foo')
-    # Missing closing quotes
-    yield (_is_error, 'foo="bar')
-    yield (_is_error, "foo='bar")
-    yield (_is_error, "foo=[bar")
-    yield (_is_error, "foo={bar")
-    yield (_is_error, "foo={bar}")
-    yield (_is_error, "foo={bar=bar")
-    yield (_is_error, "foo=bar,")
-    yield (_is_error, "foo==bar,\nbar=baz")
-    # Duplicate keys should error otherwise they silently
-    # set only one of the values.
-    yield (_is_error, 'foo=bar,foo=qux')
-
-
-def _is_error(expr):
-    try:
+@pytest.mark.parametrize(
+    "expr", (
+        'foo',
+        # Missing closing quotes
+        'foo="bar',
+        "foo='bar",
+        "foo=[bar",
+        "foo={bar",
+        "foo={bar}",
+        "foo={bar=bar",
+        "foo=bar,",
+        "foo==bar,\nbar=baz",
+        # Duplicate keys should error otherwise they silently
+        # set only one of the values.
+        'foo=bar,foo=qux'
+    )
+)
+def test_error_parsing(expr):
+    with pytest.raises(shorthand.ShorthandParseError):
         shorthand.ShorthandParser().parse(expr)
-    except shorthand.ShorthandParseError:
-        pass
-    except Exception as e:
-        raise AssertionError(
-            "Expected ShorthandParseError, but received unexpected "
-            "exception instead (%s): %s" % (e.__class__, e))
-    else:
-        raise AssertionError("Expected ShorthandParseError, but no "
-                            "exception was raised for expression: %s" % expr)
 
-def _can_parse(data, expected):
+
+@pytest.mark.parametrize(
+    'data, expected',
+    PARSING_TEST_CASES
+)
+def test_parse(data, expected):
     actual = shorthand.ShorthandParser().parse(data)
-    assert_equal(actual, expected)
+    assert actual == expected
 
 
 class TestModelVisitor(unittest.TestCase):


### PR DESCRIPTION
This corresponds to this PR for the develop branch: https://github.com/aws/aws-cli/pull/6427. Note that v2 already was relying on `pytest` for the `integration` suite so minimal work was needed there.

With regards to comparing tests between `nosetests` and `pytest`, these were the numbers:

| Test directory | `nosetests` results | `pytest` results | Net difference |
| --- | --- | --- | --- |
| `unit/` | 3275 total with 2 skip | 3273 total with 1 skip | -2 total, -1 skip with `pytest` |
| `functional/` | 25119 total with 1 skip | 10926 total with 1 skip | -14193 total with `pytest` |

The specific break down for the net difference is as follows:

* `/tests/unit/test_clidriver.py` - Removed test that had a decorated `unittest.skip` . CLI v2 did not support that functionality anymore (**Net: -1 total and -1 skip**)
* `/tests/unit/customizations/s3/test_utils.py` - `test_human_readable_size` had an extra `1.0 MiB` case that was removed in the port (**Net: -1 total**)

* `/tests/functional/wizards/` - The tests in this directory were not being ran before because it was missing a `__init__.py`. They are now being ran with `pytest`. (**Net: +10 total**)
* `tests/functional/docs/test_examples.py` - Same calculation as in [original PR](https://github.com/aws/aws-cli/pull/6427) but v2 has one less RST example (**Net: -14203 total**)

Based on that break down, everything should line up.

In addition, I pulled in test script updates from this PR to be consistent between the branches: https://github.com/aws/aws-cli/pull/6413

For any additional details, see the commit messages. I tried to add a good amount of context there.