### PR TITLE
Update return code topic page

### DIFF
--- a/awscli/topics/return-codes.rst
+++ b/awscli/topics/return-codes.rst
@@ -6,8 +6,8 @@
 These are the following return codes returned at the end of execution
 of a CLI command:
 
-* ``0`` -- Command was successful. There were no errors thrown by either
-  the CLI or by the service the request was made to.
+* ``0`` -- The service responded with an HTTP response status code of 200 and there 
+  were no errors from either the CLI or the service the request was made to.
 
 * ``1`` -- Limited to ``s3`` commands, at least one or more s3 transfers
   failed for the command executed.
@@ -31,8 +31,8 @@ of a CLI command:
 
 * ``130`` -- The process received a SIGINT (Ctrl-C).
 
-* ``255`` -- Command failed. There were errors thrown by either the CLI or
-  by the service the request was made to.
+* ``255`` -- Command failed. There were errors from either the CLI or 
+  the service the request was made to.
 
 
 To determine the return code of a command, run the following right after


### PR DESCRIPTION
Addresses #6424

Description of changes:
There are some services that respond with a 200 when an an operation is what some would intuitively consider unsuccessful. S3 does this in certain cases, but see the issue for a concrete example. Updating the topic page to clarify that the CLI considers a response code of 200 an indicator of a successful request/operation.

Also removed usage of the "error/errors thrown" phrase from the page. This seems somewhat language and SDK-specific, so that was simplified to reduce any potential confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.