### PR TITLE
[v2] Add in-tree PEP 517 build backend for building auto-complete index

### DIFF
--- a/.changes/next-release/enhancement-Source-37220.json
+++ b/.changes/next-release/enhancement-Source-37220.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Source",
+  "description": "Automatically build auto-complete index as part of building the wheel (`#6448 <https://github.com/aws/aws-cli/pull/6448>`__)."
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,10 +26,14 @@ jobs:
       run: |
         python scripts/ci/install
         python scripts/ci/install-check
-    - name: Run tests
-      run: python scripts/ci/run-tests --with-cov
     - name: Run checks
       run: python scripts/ci/run-check
+    - name: Run tests
+      run: python scripts/ci/run-tests --with-cov
+    - name: Run backend tests
+      run: |
+        pip uninstall -y awscli
+        python scripts/ci/run-backend-tests
     - name: codecov
       uses: codecov/codecov-action@v2
       with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include awscli/topics *.rst *.json
 recursive-include awscli/examples *.rst *.txt
 recursive-include awscli/data *.json
 recursive-include awscli/customizations/wizard/wizards *.yml
+recursive-include backends *.py

--- a/README.rst
+++ b/README.rst
@@ -354,7 +354,7 @@ This file points to the development version of our dependencies::
 
     $ cd <path_to_awscli> && git checkout v2
     $ pip install -r requirements.txt
-    $ pip install -e .
+    $ pip install -e . --no-build-isolation
 
 However, to keep up to date, you will continually have to run the
 ``pip install -r requirements.txt`` file to pull in the latest changes

--- a/awscli/autocomplete/generator.py
+++ b/awscli/autocomplete/generator.py
@@ -11,6 +11,48 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Generates auto completion index."""
+import os
+
+from awscli.autocomplete.local import indexer
+from awscli.autocomplete.serverside.indexer import APICallIndexer
+from awscli.autocomplete import db
+from awscli import clidriver
+
+
+def generate_index(filename):
+    """Generates the default auto-complete index"""
+    filename = os.path.abspath(filename)
+    index_dir = os.path.dirname(filename)
+    if not os.path.isdir(index_dir):
+        os.makedirs(index_dir)
+
+    # Using a temporary name so if the index already exists, we'll
+    # only replace the entire file once we successfully regenerate the
+    # index.
+    temp_name = f'{filename}.temp'
+    try:
+        _do_generate_index(temp_name)
+    except BaseException:
+        if os.path.exists(temp_name):
+            os.remove(temp_name)
+        raise
+
+    os.rename(temp_name, filename)
+    return filename
+
+
+def _do_generate_index(filename):
+    db_connection = db.DatabaseConnection(filename)
+    indexers = [
+        indexer.ModelIndexer(db_connection),
+        APICallIndexer(db_connection),
+    ]
+    driver = clidriver.create_clidriver()
+    index_gen = IndexGenerator(indexers=indexers)
+    try:
+        index_gen.generate_index(driver)
+    finally:
+        db_connection.close()
 
 
 class IndexGenerator(object):

--- a/backends/__init__.py
+++ b/backends/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/backends/pep517.py
+++ b/backends/pep517.py
@@ -1,0 +1,129 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""PEP 517 interface for building the AWS CLI
+
+The interface for the public functions defined in this module are dictated by
+PEP 517: https://www.python.org/dev/peps/pep-0517/#build-backend-interface.
+Typically projects just rely directly on public build libraries (e.g.,
+setuptools + wheel) in their pyproject.toml. However, the AWS CLI requires an
+auto-complete index to function properly, and instead of directly committing
+this index (which is MBs in size and changes with each API update) to the
+repository, it is built as part of building the wheel. For the most part,
+this in-tree backend just proxies to setuptools/wheel logic. The only exception
+is that it builds the auto-complete index and injects it into the wheel
+built by setuptools/wheel prior to returning.
+"""
+import contextlib
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
+
+import setuptools.build_meta
+import setuptools.config
+
+
+ROOT_DIR = os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))
+)
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    return setuptools.build_meta.build_sdist(sdist_directory, config_settings)
+
+
+def build_wheel(wheel_directory, config_settings=None,
+                metadata_directory=None):
+    whl_filename = setuptools.build_meta.build_wheel(
+            wheel_directory, config_settings, metadata_directory)
+    _build_and_inject_ac_index(os.path.join(wheel_directory, whl_filename))
+    return whl_filename
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    return setuptools.build_meta.prepare_metadata_for_build_wheel(
+        metadata_directory, config_settings)
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    return setuptools.build_meta.get_requires_for_build_sdist(
+        config_settings)
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    requires = setuptools.build_meta.get_requires_for_build_wheel(
+        config_settings)
+    # Generation of the auto-complete index requires importing from the
+    # awscli package and iterating over the commands from the clidriver. In
+    # order to be able to do this, it requires all of the CLI's runtime
+    # dependencies to be present to avoid import errors.
+    requires += setuptools.config.read_configuration(
+        os.path.join(ROOT_DIR, 'setup.cfg'))['options']['install_requires']
+    return requires
+
+
+def _build_and_inject_ac_index(whl_path):
+    from awscli.autocomplete.generator import generate_index
+
+    build_dir = os.path.join(ROOT_DIR, 'build')
+    _create_dir_if_not_exists(build_dir)
+    ac_index_build_name = os.path.join(build_dir, 'ac.index')
+    _remove_file_if_exists(ac_index_build_name)
+    print('Generating auto-complete index')
+    generate_index(ac_index_build_name)
+    unpack_wheel_dir = os.path.join(build_dir, 'unpacked_wheel')
+    _remove_dir_if_exists(unpack_wheel_dir)
+    print('Adding auto-complete index into wheel')
+    with _open_wheel(whl_path, unpack_wheel_dir) as extracted_wheel_dir:
+        os.rename(
+            ac_index_build_name,
+            os.path.join(extracted_wheel_dir, 'awscli', 'data', 'ac.index')
+        )
+
+
+@contextlib.contextmanager
+def _open_wheel(whl_path, extract_dir='.'):
+    _extract_zip(whl_path, extract_dir)
+    yield extract_dir
+    subprocess.run(
+        [
+            sys.executable, '-m', 'wheel', 'pack', '--dest',
+            os.path.dirname(whl_path), extract_dir,
+        ],
+        check=True
+    )
+
+
+def _extract_zip(zipfile_name, target_dir):
+    with zipfile.ZipFile(zipfile_name, 'r') as zf:
+        for zf_info in zf.infolist():
+            # Works around extractall not preserving file permissions:
+            # https://bugs.python.org/issue15795
+            extracted_path = zf.extract(zf_info, target_dir)
+            os.chmod(extracted_path, zf_info.external_attr >> 16)
+
+
+def _remove_file_if_exists(filename):
+    if os.path.exists(filename):
+        os.remove(filename)
+
+
+def _remove_dir_if_exists(dirname):
+    if os.path.isdir(dirname):
+        shutil.rmtree(dirname)
+
+
+def _create_dir_if_not_exists(dirname):
+    if not os.path.isdir(dirname):
+        os.makedirs(dirname)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel"]
+requires = ["setuptools>=40.6.0<59.0.0", "wheel<=0.37.0"]
 build-backend = "backends.pep517"
 backend-path = ["."]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [build-system]
 requires = ["setuptools >= 40.6.0", "wheel"]
-build-backend = "setuptools.build_meta"
+build-backend = "backends.pep517"
+backend-path = ["."]

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,25 @@
+# This requirements file should only be temporary until there is a better
+# story around handling the AWS CLI v2's implementation of botocore.
+# Specifically, when directly pip installing the repository, pip will try
+# to build the wheel for the AWS CLI which requires all of its runtime
+# dependencies in order to build the auto-complete index. However, pip tries to
+# do this in isolation which will fail because the botocore implementation is
+# not on PyPI. To work around this, you need to specify --no-build-isolation
+# so pip uses the current virtualenv, but that also disables pip's logic to
+# try install the build dependencies on your behalf and you have to install
+# the dependencies yourself. Unfortunately, there is no utility built into
+# pip to get/install the build dependencies returned from the PEP 517 hooks.
+# So this requirements file allows you to install all of the runtime
+# dependencies so you do not have to programmatically call the PEP 517 hooks
+# yourself. Ideally, once we can install the repository without the
+# --no-build-isolation flag we can just remove this file altogether.
+https://github.com/boto/botocore/zipball/v2#egg=botocore
+colorama>=0.2.5,<0.4.4
+docutils>=0.10,<0.16
+cryptography>=3.3.2,<3.4.0
+ruamel.yaml>=0.15.0,<0.16.0
+s3transfer>=0.4.2,<0.5.0
+wcwidth<0.2.0
+prompt-toolkit>=2.0.0,<3.0.0
+distro>=1.5.0,<1.6.0
+awscrt==0.11.24

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ tox>=2.3.1,<3.0.0
 setuptools==57.5.0
 wheel==0.37.0
 build==0.7.0
-ruamel.yaml>=0.15.0,<0.16.0
 -r requirements-test.txt
 -r requirements-build.txt
-https://github.com/boto/botocore/zipball/v2#egg=botocore
+-r requirements-runtime.txt

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import os
 import glob
-import sys
 from subprocess import check_call
 import shutil
 

--- a/scripts/ci/run-backend-tests
+++ b/scripts/ci/run-backend-tests
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+import os
+import sys
+from contextlib import contextmanager
+from subprocess import check_call
+
+_dname = os.path.dirname
+
+REPO_ROOT = _dname(_dname(_dname(os.path.abspath(__file__))))
+RUN_TESTS_SCRIPTS = os.path.join(REPO_ROOT, 'scripts', 'ci', 'run-tests')
+
+
+@contextmanager
+def cd(path):
+    """Change directory while inside context manager."""
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(cwd)
+
+
+def run(command):
+    return check_call(command, shell=True)
+
+
+if __name__ == "__main__":
+    with cd(os.path.join(REPO_ROOT, "tests")):
+        run(
+            f"{sys.executable} {RUN_TESTS_SCRIPTS} "
+            f"backends --allow-repo-root-on-path"
+        )

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -25,9 +25,10 @@ def cd(path):
         os.chdir(cwd)
 
 
-def run(command):
+def run(command, allow_repo_root_on_path=False):
     env = os.environ.copy()
-    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    if not allow_repo_root_on_path:
+        env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
     return check_call(command, shell=True, env=env)
 
 
@@ -66,10 +67,21 @@ if __name__ == "__main__":
         action="store_true",
         help="Run default test-runner with code coverage enabled.",
     )
+    parser.add_argument(
+        "--allow-repo-root-on-path",
+        default=False,
+        action="store_true",
+        help=(
+            "Do not remove the repository root from the Python path when "
+            "running tests. This allows you to run the tests against the "
+            "current repository without have to install the package as a "
+            "distribution."
+        )
+    )
     raw_args = parser.parse_args()
     test_runner, test_args, test_dirs = process_args(raw_args)
 
     cmd = f"{test_runner} {test_args}{test_dirs}"
     print(f"Running {cmd}...")
     with cd(os.path.join(REPO_ROOT, "tests")):
-        run(cmd)
+        run(cmd, allow_repo_root_on_path=raw_args.allow_repo_root_on_path)

--- a/scripts/gen-ac-index
+++ b/scripts/gen-ac-index
@@ -5,11 +5,8 @@
 import os
 import argparse
 
-from awscli.autocomplete.local import indexer
-from awscli.autocomplete.serverside.indexer import APICallIndexer
 from awscli.autocomplete import db
 from awscli.autocomplete import generator
-from awscli import clidriver
 
 
 def main():
@@ -25,28 +22,9 @@ def main():
     index_dir = os.path.dirname(os.path.abspath(args.index_location))
     if not os.path.isdir(index_dir):
         os.makedirs(index_dir)
-    _generate_index(args.index_location)
+    generator.generate_index(args.index_location)
     if args.include_builtin_index:
-        _generate_index(db.BUILTIN_INDEX_FILE)
-
-
-def _generate_index(filename):
-    # Using a temporary name so if the index already exists, we'll
-    # only replace the entire file once we successfully regenerate the
-    # index.
-    temp_name = '%s.temp' % filename
-    db_connection = db.DatabaseConnection(temp_name)
-    indexers = [
-        indexer.ModelIndexer(db_connection),
-        APICallIndexer(db_connection),
-    ]
-    driver = clidriver.create_clidriver()
-    index_gen = generator.IndexGenerator(indexers=indexers)
-    try:
-        index_gen.generate_index(driver)
-    finally:
-        db_connection.close()
-    os.rename(temp_name, filename)
+        generator.generate_index(db.BUILTIN_INDEX_FILE)
 
 
 if __name__ == '__main__':

--- a/scripts/installers/make-exe
+++ b/scripts/installers/make-exe
@@ -136,7 +136,7 @@ def main():
         install_packages(args.src_dir)
     else:
         run('pip install -r requirements.txt')
-        run('pip install .')
+        run('pip install . --no-build-isolation')
 
     make_exe(output, cleanup=args.cleanup, ac_index=args.ac_index_path)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
 
 [options.packages.find]
 exclude =
+    backends*
     tests*
 
 [check-manifest]

--- a/tests/backends/__init__.py
+++ b/tests/backends/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/backends/test_pep517.py
+++ b/tests/backends/test_pep517.py
@@ -1,0 +1,159 @@
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import re
+import shutil
+
+import pytest
+import setuptools.config
+
+import awscli
+import backends.pep517
+
+
+@pytest.fixture
+def config_settings():
+    return {}
+
+
+@pytest.fixture
+def repo_root():
+    return os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(
+                os.path.abspath(__file__)
+            )
+        )
+    )
+
+
+@pytest.fixture(autouse=True)
+def cd_to_repo_root(repo_root):
+    # In general, we want to be at the root of the repository when running
+    # PEP 517 hooks since setuptools generally expects you to be there when
+    # running its hooks (which we use).
+    original = os.getcwd()
+    os.chdir(repo_root)
+    yield
+    os.chdir(original)
+
+
+def assert_dist_info_correctness(dist_info_dir):
+    # A helper utility to do sanity checks on the generated wheel .dist-info
+    # directory. Right now we only look at the generated METADATA file,
+    # but this could be expanded to other files that are expected to be in
+    # the .dist-info directory
+    metadata_file = dist_info_dir.join('METADATA')
+    assert metadata_file.check()
+    metadata_content = metadata_file.read()
+    assert 'Metadata-Version: 2.1' in metadata_content
+    assert 'Name: awscli' in metadata_content
+    assert f'Version: {awscli.__version__}' in metadata_content
+
+
+def assert_dependency_in_requirements(package_name, requirements):
+    pattern = re.compile(rf'^{package_name}.*$')
+    for req in requirements:
+        if pattern.match(req):
+            return
+    raise AssertionError(
+        f'Could not find package: "{package_name}" in '
+        f'requirements: {requirements}')
+
+
+def test_build_sdist(tmpdir, config_settings):
+    sdist_name = backends.pep517.build_sdist(str(tmpdir), config_settings)
+    expected_sdist_name = f'awscli-{awscli.__version__}.tar.gz'
+    assert sdist_name == expected_sdist_name
+
+    path_to_sdist = tmpdir.join(sdist_name)
+    assert path_to_sdist.check()
+
+    # Unpack the tarball and do some sanity checks to make sure the
+    # sdist looks correct.
+    shutil.unpack_archive(path_to_sdist, tmpdir)
+    unpacked_sdist = tmpdir.join(f'awscli-{awscli.__version__}')
+    assert unpacked_sdist.join('setup.cfg').check()
+    assert unpacked_sdist.join('awscli', '__init__.py').check()
+
+    # Make sure the backends package is in the sdist so users can build
+    # a wheel from an sdist using PEP 517.
+    assert unpacked_sdist.join('backends', 'pep517.py').check()
+
+    # We do not build the ac.index in building the sdist. So we want to make
+    # sure it is not being included.
+    assert not unpacked_sdist.join('awscli', 'data', 'ac.index').check()
+
+
+def test_build_wheel(tmpdir, config_settings):
+    wheel_name = backends.pep517.build_wheel(str(tmpdir), config_settings)
+    expected_wheel_name = f'awscli-{awscli.__version__}-py3-none-any.whl'
+    assert wheel_name == expected_wheel_name
+
+    path_to_wheel = tmpdir.join(wheel_name)
+    assert path_to_wheel.check()
+
+    # Unpack the wheel and do some sanity checks to make sure the
+    # sdist looks correct.
+    unpacked_wheel_dir = tmpdir.join('unpacked_wheel')
+    unpacked_wheel_dist_info = unpacked_wheel_dir.join(
+        f'awscli-{awscli.__version__}.dist-info')
+    shutil.unpack_archive(path_to_wheel, unpacked_wheel_dir, 'zip')
+    assert unpacked_wheel_dir.join('awscli', '__init__.py').check()
+    assert_dist_info_correctness(unpacked_wheel_dist_info)
+
+    # We do not want the backends package included as part of the
+    # environment's site-packages so it should not exist in the wheel
+    assert not unpacked_wheel_dir.join('backends', 'pep517.py').check()
+
+    # The wheel should have built the auto-complete index and repacked it
+    # into the wheel.
+    assert unpacked_wheel_dir.join('awscli', 'data', 'ac.index').check()
+    records_content = unpacked_wheel_dist_info.join('RECORD').read()
+    assert '/'.join(['awscli', 'data', 'ac.index']) in records_content
+
+
+def test_prepare_metadata_for_build_wheel(tmpdir, config_settings):
+    dist_info_dirname = backends.pep517.prepare_metadata_for_build_wheel(
+        str(tmpdir), config_settings)
+    assert dist_info_dirname == 'awscli.dist-info'
+    assert_dist_info_correctness(tmpdir.join(dist_info_dirname))
+
+
+def test_get_requires_for_build_sdist(config_settings):
+    requirements = backends.pep517.get_requires_for_build_sdist(
+        config_settings)
+    assert requirements == []
+
+
+def test_get_requires_for_build_wheel(config_settings, repo_root):
+    requirements = backends.pep517.get_requires_for_build_wheel(
+        config_settings)
+    expected_requirements = []
+    # Setuptools relies on wheel under the hood to generate the wheel. So it
+    # specifies wheel as a build requirement.
+    expected_requirements += ['wheel']
+    # Generation of the auto-complete index requires importing from the
+    # awscli package and iterating over the commands from the clidriver. In
+    # order to be able to do this, it requires all of the CLI's runtime
+    # dependencies to be present to avoid import errors. So we want to make
+    # sure whatever is being returned from the PEP 517 hook matches the runtime
+    # dependencies declared in the setup.cfg
+    expected_requirements += setuptools.config.read_configuration(
+        os.path.join(repo_root, 'setup.cfg'))['options']['install_requires']
+
+    assert requirements == expected_requirements
+    # Also assert that some of the runtime dependencies we expect are actually
+    # being from the setup.cfg
+    assert_dependency_in_requirements('botocore', requirements)
+    assert_dependency_in_requirements('awscrt', requirements)

--- a/tests/functional/autocomplete/test_generator.py
+++ b/tests/functional/autocomplete/test_generator.py
@@ -10,27 +10,34 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import glob
 import os
 import tempfile
 
-from awscli.testutils import unittest, create_clidriver
+from awscli.testutils import unittest
 from awscli.autocomplete import generator
-from awscli.autocomplete.local import model, indexer
-from awscli.autocomplete.serverside.indexer import create_apicall_indexer
+from awscli.autocomplete.local import model
 
 
 class TestCanGenerateEntireIndex(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.tempfile = os.path.join(self.temp_dir, 'temp.db')
-        self.model_indexer = indexer.create_model_indexer(self.tempfile)
-        self.api_call_indexer = create_apicall_indexer(self.tempfile)
         self.model_index = model.ModelIndex(self.tempfile)
 
     def tearDown(self):
-        self.model_indexer._db_connection.close()
-        self.api_call_indexer._db_connection.close()
         self.model_index._db_connection.close()
+
+    def assert_no_temp_index_files(self):
+        # When generating the index, it generates it in a file different from
+        # its final location so that only a completely built index is ever at
+        # the final location. This intermediary file shares the same name as
+        # final location except it has an additional suffix extension (e.g.,
+        # ``.temp`` at the end). So this check ensures there are no lingering
+        # intermediary files from building the index (even if the suffix
+        # extension changes in the future).
+        possible_matches = glob.glob(f'{self.tempfile}.*')
+        self.assertEqual(possible_matches, [])
 
     def test_can_generate_entire_index(self):
         # The point of this test is to make sure generating the index
@@ -38,16 +45,14 @@ class TestCanGenerateEntireIndex(unittest.TestCase):
         # generation are tested in tests/unit/autocomplete.  Here we just
         # generate the entire index and perform basic sanity checks.  It's
         # just a functional smoke test.
-        driver = create_clidriver()
-        index_generator = generator.IndexGenerator([
-            self.model_indexer,
-            self.api_call_indexer,
-        ])
-        index_generator.generate_index(driver)
+        generator.generate_index(self.tempfile)
 
         # Basic sanity checks.  Index generation for the entire CLI
         # takes a while so all the sanity checks are combined in a single
         # test method.
+        self.assertTrue(os.path.exists(self.tempfile))
+        self.assert_no_temp_index_files()
+
         commands = self.model_index.command_names(lineage=['aws'])
         self.assertIn('ec2', commands)
         self.assertIn('s3', commands)

--- a/tests/functional/autocomplete/test_main.py
+++ b/tests/functional/autocomplete/test_main.py
@@ -10,54 +10,26 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.autocomplete import main, generator
-from awscli.autocomplete.local import indexer
-from awscli import clidriver
-from awscli import testutils
-
-
-def _ec2_and_dynamo_only_command_table(command_table, **kwargs):
-    for key in list(command_table):
-        if key not in ['ec2', 'dynamodb']:
-            del command_table[key]
+from awscli.autocomplete import main
 
 
 def test_smoke_test_completer():
-    # Verify we can:
-    # 1. Generate part of the completion index
-    # 2. Create a completer with the factory function
-    # 3. Generate completions using this index.
-    #
-    # We don't generate the entire completion index for all commands.
-    # We're more interested in the end to end flow.  The test_generator.py
-    # file verifies that we can generate the entire index so we don't need
-    # to do this twice (it takes a while).
-    with testutils.temporary_file('w') as f:
-        _generate_index(f.name)
-        completions = _autocomplete(f.name, 'aws ec2 desc')
-        # The API can change so we won't assert a specific list, but we'll
-        # pick a few operations that we know will always be there.
-        completion_strings = [c.name for c in completions]
-        assert 'describe-instances' in completion_strings
-        assert 'describe-regions' in completion_strings
+    # Verify we can use the completer using the default auto-complete index
+    # that should have been built and installed as part of building the
+    # CLI distribution.
+    completions = _autocomplete('aws ec2 desc')
+    # The API can change so we won't assert a specific list, but we'll
+    # pick a few operations that we know will always be there.
+    completion_strings = [c.name for c in completions]
+    assert 'describe-instances' in completion_strings
+    assert 'describe-regions' in completion_strings
 
-        completions = _autocomplete(f.name, 'aws dynamodb describe-tab')
-        completion_strings = [c.name for c in completions]
-        assert all(completion.startswith('describe-table')
-                   for completion in completion_strings)
+    completions = _autocomplete('aws dynamodb describe-tab')
+    completion_strings = [c.name for c in completions]
+    assert all(completion.startswith('describe-table')
+               for completion in completion_strings)
 
 
-def _autocomplete(filename, command_line):
-    completer = main.create_autocompleter(filename)
+def _autocomplete(command_line):
+    completer = main.create_autocompleter()
     return completer.autocomplete(command_line)
-
-
-def _generate_index(filename):
-    # This will eventually be moved into some utility function.
-    index_generator = generator.IndexGenerator(
-        [indexer.create_model_indexer(filename)],
-    )
-    driver = clidriver.create_clidriver()
-    driver.session.register('building-command-table.main',
-                            _ec2_and_dynamo_only_command_table)
-    index_generator.generate_index(driver)


### PR DESCRIPTION
This allows the auto-complete index to be automatically built as part of building the wheel so that you no longer have to run the `gen-ac-index script` in order to get a completely functional AWS CLI when installing from source. This implements one of the aspects of the source distribution specification (generating the auto-complete index): https://github.com/aws/aws-cli/pull/6352 in order to make the CLI v2 completely buildable and installable by tools that abide by PEP 517. For rationale on most of the changes, see the commit messages. I tried to break the changes into logical commits and added rationale to the message as needed.

### ⚠️  Note for consumers directly installing from the v2 branch

If you are currently installing v2 from source (e.g.):
```bash
git checkout v2
pip install -r requirements.txt
pip install .
```
You will likely need to update your logic to include the `--no-build-isolation` flag:
```bash
git checkout v2
pip install -r requirements.txt
pip install . --no-build-isolation
```
By default, `pip` will build the wheel in in isolated virtualenv, which now requires installing all of the AWS CLI's runtime dependencies in order to build the auto-complete index. However, because the CLI's botocore implementation is not on PyPI, it will fail to install it in the isolated virtualenv. The `--no-build-isolation` flag disables this behavior and uses the current environment as is when building the wheel. In the future, as we implement more of the source distribution proposal, the requirement for needing `--no-build-isolation` will go away and the flag will be more of a build/install optimization that you can use to avoid installing the AWS CLI v2's dependencies twice (once for the build environment and once for the runtime environment).


