### PR TITLE
refactor ddb `select` output error message

### DIFF
--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -156,7 +156,8 @@ class SelectCommand(PaginatedDDBCommand):
     DESCRIPTION = (
         '``select`` searches a table or index.\n\n'
         'Under the hood, this operation will use ``query`` if '
-        '``--key-condition`` is specified, or ``scan`` otherwise.'
+        '``--key-condition`` is specified, or ``scan`` otherwise.\n\n'
+        'Only YAML output is supported for this operation.'
     )
     ARG_TABLE = [
         parameters.TABLE_NAME,

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -157,7 +157,7 @@ class SelectCommand(PaginatedDDBCommand):
         '``select`` searches a table or index.\n\n'
         'Under the hood, this operation will use ``query`` if '
         '``--key-condition`` is specified, or ``scan`` otherwise.\n\n'
-        'Only YAML output is supported for this operation.'
+        'Only ``yaml`` output is supported for this operation.'
     )
     ARG_TABLE = [
         parameters.TABLE_NAME,

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -85,7 +85,8 @@ class DDBCommand(BasicCommand):
         return response
 
     def _dump_yaml(self, operation_name, data, parsed_globals):
-        if parsed_globals.output == 'yaml-stream':
+        output_type = parsed_globals.output
+        if output_type != 'yaml':
             # TODO: In the future, we should support yaml-stream. However, it
             #  would require a larger refactoring. Right now we always build
             #  the full result when paginating prior to sending it to the
@@ -96,7 +97,7 @@ class DDBCommand(BasicCommand):
             #  For example, botocore cannot serialize our Binary types into
             #  a resume token when --max-items gets set.
             raise ParamValidationError(
-                'yaml-stream output format is not supported for ddb commands'
+                f'{output_type} output format is not supported for ddb commands'
             )
         formatter = YAMLFormatter(parsed_globals, DynamoYAMLDumper())
         with self._output_stream_factory.get_output_stream() as stream:

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -86,7 +86,7 @@ class DDBCommand(BasicCommand):
 
     def _dump_yaml(self, operation_name, data, parsed_globals):
         output_type = parsed_globals.output
-        if output_type != 'yaml':
+        if output_type is not None and output_type != 'yaml':
             # TODO: In the future, we should support yaml-stream. However, it
             #  would require a larger refactoring. Right now we always build
             #  the full result when paginating prior to sending it to the

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -460,18 +460,22 @@ class TestSelect(BaseSelectTest):
             command, expected, expected_rc=0
         )
 
-    def test_select_does_not_support_yaml_stream(self):
-        cmdline = 'ddb select mytable --output yaml-stream'
-        stdout, _, _ = self.assert_params_for_cmd(
-            cmdline, expected_rc=252,
-            stderr_contains='yaml-stream output format is not supported',
-        )
+    def test_select_unsupported_output(self):
+        unsupported_output = ['yaml-stream', 'json', 'text', 'table']
+        for output_type in unsupported_output:
+            cmdline=f'ddb select mytable --output {output_type}'
+            stdout, _, _ = self.assert_params_for_cmd(
+                cmdline, expected_rc=252,
+                stderr_contains=f'{output_type} output format is not supported',
+            )
 
     def test_select_parsing_error_rc(self):
         cmdline = 'ddb select mytable --filter a=?!f'
         stdout, _, _ = self.assert_params_for_cmd(
             cmdline, expected_rc=252,
         )
+
+
 
 
 class TestSelectPagination(BaseSelectTest):

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -476,8 +476,6 @@ class TestSelect(BaseSelectTest):
         )
 
 
-
-
 class TestSelectPagination(BaseSelectTest):
     def setUp(self):
         super(TestSelectPagination, self).setUp()

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
+import pytest
 
 import ruamel.yaml as yaml
 
@@ -460,14 +461,16 @@ class TestSelect(BaseSelectTest):
             command, expected, expected_rc=0
         )
 
-    def test_select_unsupported_output(self):
-        unsupported_output = ['yaml-stream', 'json', 'text', 'table']
-        for output_type in unsupported_output:
-            cmdline=f'ddb select mytable --output {output_type}'
-            stdout, _, _ = self.assert_params_for_cmd(
-                cmdline, expected_rc=252,
-                stderr_contains=f'{output_type} output format is not supported',
-            )
+    @pytest.mark.parametrize(
+        "output_type", 
+        ['json', 'table', 'text', 'yaml-stream']
+    ) 
+    def test_select_unsupported_output(self, output_type):
+        cmdline = f'ddb select mytable --output {output_type}'
+        stdout, _, _ = self.assert_params_for_cmd(
+            cmdline, expected_rc=252,
+            stderr_contains = f'{output_type} output format is not supported',
+        )
 
     def test_select_parsing_error_rc(self):
         cmdline = 'ddb select mytable --filter a=?!f'


### PR DESCRIPTION
Closes #6387

*Description of changes:*

Because we already check for parsed global output type in the YAML formatter, refactored check to raise an error if any output type other than `yaml` is provided as an argument.

Also added a line to the `select` command reference page to call out that YAML is the only output type supported for the operation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
