### PR TITLE
Fix typos in s3

### DIFF
--- a/awscli/customizations/s3/comparator.py
+++ b/awscli/customizations/s3/comparator.py
@@ -44,7 +44,7 @@ class Comparator(object):
         the ``S3Handler``.
 
         :param src_files: The generated FileInfo objects from the source.
-        :param dest_files: The genereated FileInfo objects from the dest.
+        :param dest_files: The generated FileInfo objects from the dest.
 
         :returns: Yields the FilInfo objects of the files that need to be
             operated on
@@ -61,7 +61,7 @@ class Comparator(object):
             but not the source file.  If the source list is empty delete the
             rest of the files in the dest list from the destination.  If the
             dest list is empty add the rest of the file in source list to
-            the destionation.
+            the destination.
         """
         # :var src_done: True if there are no more files from the source left.
         src_done = False

--- a/awscli/customizations/s3/fileformat.py
+++ b/awscli/customizations/s3/fileformat.py
@@ -65,7 +65,7 @@ class FileFormat(object):
         the editted path.
         Formatting Rules:
             1) If a destination file is taking on a source name, it must end
-               with the apporpriate operating system seperator
+               with the appropriate operating system seperator
 
         General Options:
             1) If the operation is on a directory, the destination file will
@@ -124,7 +124,7 @@ class FileFormat(object):
         """
         It identifies whether the path is from local or s3.  Returns the
         adjusted pathname and a string stating whether the file is from local
-        or s3.  If from s3 it strips off the s3:// from the beginnning of the
+        or s3.  If from s3 it strips off the s3:// from the beginning of the
         path
         """
         if path.startswith('s3://'):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -200,7 +200,7 @@ class BaseResultHandler(object):
 
 
 class ResultRecorder(BaseResultHandler):
-    """Records and track transfer statistics based on results receieved"""
+    """Records and track transfer statistics based on results received"""
     def __init__(self):
         self.bytes_transferred = 0
         self.bytes_failed_to_transfer = 0
@@ -286,7 +286,7 @@ class ResultRecorder(BaseResultHandler):
         # gets created that the timestamp on the progress result is less
         # than the timestamp of when the result processor actually
         # processes that initial queued result. So this will avoid
-        # negative progress being displayed or zero divison occurring.
+        # negative progress being displayed or zero division occurring.
         if result.timestamp > self.start_time:
             self.bytes_transfer_speed = self.bytes_transferred / (
                 result.timestamp - self.start_time)

--- a/awscli/customizations/s3/s3.py
+++ b/awscli/customizations/s3/s3.py
@@ -22,7 +22,7 @@ from awscli.customizations.s3.syncstrategy.register import \
 def awscli_initialize(cli):
     """
     This function is require to use the plugin.  It calls the functions
-    required to add all neccessary commands and parameters to the CLI.
+    required to add all necessary commands and parameters to the CLI.
     This function is necessary to install the plugin using a configuration
     file
     """
@@ -33,7 +33,7 @@ def awscli_initialize(cli):
 def s3_plugin_initialize(event_handlers):
     """
     This is a wrapper to make the plugin built-in to the cli as opposed
-    to specifiying it in the configuration file.
+    to specifying it in the configuration file.
     """
     awscli_initialize(event_handlers)
 

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1100,7 +1100,7 @@ class CommandArchitecture(object):
         )
 
     def _map_sse_c_params(self, request_parameters, paths_type):
-        # SSE-C may be neaded for HeadObject for copies/downloads/deletes
+        # SSE-C may be needed for HeadObject for copies/downloads/deletes
         # If the operation is s3 to s3, the FileGenerator should use the
         # copy source key and algorithm. Otherwise, use the regular
         # SSE-C key and algorithm. Note the reverse FileGenerator does

--- a/awscli/customizations/s3/syncstrategy/base.py
+++ b/awscli/customizations/s3/syncstrategy/base.py
@@ -93,8 +93,8 @@ class BaseSync(object):
         that this method must return a Boolean as documented below.
 
         :type src_file: ``FileStat`` object
-        :param src_file: A representation of the opertaion that is to be
-            performed on a specfic file existing in the source.  Note if
+        :param src_file: A representation of the operation that is to be
+            performed on a specific file existing in the source.  Note if
             the file does not exist at the source, ``src_file`` is None.
 
         :type dest_file: ``FileStat`` object

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -134,7 +134,7 @@ class AppendFilter(argparse.Action):
     --exclude and the value will be the rule to apply.  This will
     format all of the rules inputted into the command line
     in a way compatible with the Filter class.  Note that rules that
-    appear later in the command line take preferance over rulers that
+    appear later in the command line take preference over rulers that
     appear earlier.
     """
     def __call__(self, parser, namespace, values, option_string=None):
@@ -338,9 +338,9 @@ def guess_content_type(filename):
     """
     try:
         return mimetypes.guess_type(filename)[0]
-    # This catches a bug in the mimetype libary where some MIME types
+    # This catches a bug in the mimetype library where some MIME types
     # specifically on windows machines cause a UnicodeDecodeError
-    # because the MIME type in the Windows registery has an encoding
+    # because the MIME type in the Windows registry has an encoding
     # that cannot be properly encoded using the default system encoding.
     # https://bugs.python.org/issue9291
     #


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I noticed there were some typos in the docstrings and comments, so fixed them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
