### PR TITLE
Fix key condition parameter name.

### DIFF
--- a/awscli/examples/ddb/select.rst
+++ b/awscli/examples/ddb/select.rst
@@ -29,7 +29,7 @@ One You Know".
 Command::
 
     aws ddb select MusicCollection --projection SongTitle \
-        --key-condition-expression 'Artist = "No One You Know"'
+        --key-condition 'Artist = "No One You Know"'
 
 Output::
 


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Fix documentation example for `aws ddb select` `--key-condition` parameter. Confirmed the parameter name in the code:

https://github.com/aws/aws-cli/blob/3ec6c1a2bdbdac265ad05c3b309e8e158a655b22/awscli/customizations/dynamodb/params.py#L113

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
