### PR TITLE
Update tox version to 3.24.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tox>=2.3.1,<3.0.0
+tox==3.24.3
 setuptools==57.5.0
 wheel==0.37.0
 build==0.7.0


### PR DESCRIPTION
Fixes dependency conflict between pytest and tox

*Issue #, if available:*

*Description of changes:*
Update tox version to 3.24.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
