### PR TITLE
[Fix issue #6012] Prevent sending HEAD request with sse params

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -352,6 +352,8 @@ class FileGenerator(object):
         try:
             params = {'Bucket': bucket, 'Key': key}
             params.update(self.request_parameters.get('HeadObject', {}))
+            del params['SSECustomerAlgorithm']
+            del params['SSECustomerKey']
             response = self._client.head_object(**params)
         except ClientError as e:
             # We want to try to give a more helpful error message.

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -352,8 +352,9 @@ class FileGenerator(object):
         try:
             params = {'Bucket': bucket, 'Key': key}
             params.update(self.request_parameters.get('HeadObject', {}))
-            del params['SSECustomerAlgorithm']
-            del params['SSECustomerKey']
+            for key in ['SSECustomerAlgorithm', 'SSECustomerKey']:
+                if key in params.keys():
+                    del params[key] 
             response = self._client.head_object(**params)
         except ClientError as e:
             # We want to try to give a more helpful error message.


### PR DESCRIPTION
*Issue #, if available:*
[aws s3 cp bucket to bucket copy fails when sse-c is set #6012](https://github.com/aws/aws-cli/issues/6012)

*Description of changes:*
I fixed the codes not to send HEAD request with sse params.

Test for this change
https://github.com/aws/aws-cli/blob/47ccc20ae74fce359adb7a661aacf033b9d85cbb/tests/functional/s3/test_cp_command.py#L440


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
