### PR TITLE
Update awscrt version to 0.12.4

### DIFF
--- a/.changes/next-release/enhancement-s3-3942.json
+++ b/.changes/next-release/enhancement-s3-3942.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``s3``",
+  "description": "Update awscrt version to 0.12.4, which adds proxy support for the ``crt`` S3 transfer client"
+}

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -22,4 +22,4 @@ s3transfer>=0.4.2,<0.5.0
 wcwidth<0.2.0
 prompt-toolkit>=2.0.0,<3.0.0
 distro>=1.5.0,<1.6.0
-awscrt==0.11.24
+awscrt==0.12.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     wcwidth<0.2.0
     prompt-toolkit>=2.0.0,<3.0.0
     distro>=1.5.0,<1.6.0
-    awscrt==0.11.24
+    awscrt==0.12.4
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
This awscrt version adds proxy support for the ``crt`` s3transfer client 
*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
