### PR TITLE
Improve incorrect access policy in s3api example

### DIFF
--- a/awscli/examples/s3api/put-bucket-notification-configuration.rst
+++ b/awscli/examples/s3api/put-bucket-notification-configuration.rst
@@ -30,7 +30,7 @@ The SNS topic must have an IAM policy attached to it that allows Amazon S3 to pu
      "Action": [
       "SNS:Publish"
      ],
-     "Resource": "arn:aws:sns:us-west-2:123456789012:my-bucket",
+     "Resource": "arn:aws:sns:us-west-2:123456789012:s3-notification-topic",
      "Condition": {
         "ArnLike": {          
         "aws:SourceArn": "arn:aws:s3:*:*:my-bucket"    

--- a/awscli/examples/s3api/put-bucket-notification.rst
+++ b/awscli/examples/s3api/put-bucket-notification.rst
@@ -26,7 +26,7 @@ The SNS topic must have an IAM policy attached to it that allows Amazon S3 to pu
      "Action": [
       "SNS:Publish"
      ],
-     "Resource": "arn:aws:sns:us-west-2:123456789012:my-bucket",
+     "Resource": "arn:aws:sns:us-west-2:123456789012:s3-notification-topic",
      "Condition": {
         "ArnLike": {          
         "aws:SourceArn": "arn:aws:s3:*:*:my-bucket"    


### PR DESCRIPTION
*Description of changes:* Fix the "Resource" key in an SNS Access Policy so that it correctly reflects an SNS topic ARN, not an S3 bucket.

To confirm that this is correct, see the relevant [AWS docs](https://docs.aws.amazon.com/sns/latest/dg/sns-access-policy-use-cases.html#sns-grant-aws-account-access-to-topic).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.