### PR TITLE
[v2] Fix pyproject version pin

### DIFF
--- a/.changes/next-release/bugfix-Source-30131.json
+++ b/.changes/next-release/bugfix-Source-30131.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Source",
+  "description": "Fix invalid dependency specification in pyproject.toml (`#6513 <https://github.com/aws/aws-cli/pull/6513>`__)."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools>=40.6.0<59.0.0", "wheel<=0.37.0"]
+requires = ["setuptools>=40.6.0,<59.0.0", "wheel<=0.37.0"]
 build-backend = "backends.pep517"
 backend-path = ["."]


### PR DESCRIPTION
The dependency specification was missing a comma. For tools like pip and build, they just ignored the version ceiling requirement. but for other tools such as building an RPM for Fedora, it will error out: https://github.com/davdunc/awscli-2-rpm/issues/3.