### PR TITLE
[v2] Add usage of pytest-xdist plugin

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ mock==1.3.0
 pytest==6.2.5
 coverage==5.5
 pytest-cov==2.12.1
+pytest-xdist==2.4.0

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -44,6 +44,7 @@ def process_args(args):
             f"--cov-config={os.path.join(REPO_ROOT, '.coveragerc')} "
             f"--cov-report xml "
         )
+    test_args += '--numprocesses=auto --dist=loadfile --maxprocesses=4 '
     dirs = " ".join(args.test_dirs)
 
     return runner, test_args, dirs

--- a/tests/functional/botocore/test_endpoints.py
+++ b/tests/functional/botocore/test_endpoints.py
@@ -107,7 +107,7 @@ def known_endpoint_prefixes():
     # ``metadata`` section.
     session = get_session()
     loader = session.get_component('data_loader')
-    known_services = loader.list_available_services('service-2')
+    known_services = sorted(loader.list_available_services('service-2'))
     return [
         session.get_service_model(service_name).endpoint_prefix
         for service_name in known_services
@@ -138,7 +138,7 @@ def _computed_endpoint_prefixes():
     # Now we go through every known endpoint prefix in the endpoints.json
     # file and ensure it maps to an endpoint prefix we've seen
     # in a service model.
-    for endpoint_prefix in services_in_endpoints_file:
+    for endpoint_prefix in sorted(list(services_in_endpoints_file)):
         # Check for an override where we know that an entry
         # in the endpoints.json actually maps to a different endpoint
         # prefix.
@@ -160,7 +160,7 @@ def _available_services():
     # will become the client names.
     session = get_session()
     loader = session.get_component('data_loader')
-    return loader.list_available_services('service-2')
+    return sorted(loader.list_available_services('service-2'))
 
 
 @pytest.mark.parametrize("service_name", _available_services())

--- a/tests/functional/botocore/test_rds.py
+++ b/tests/functional/botocore/test_rds.py
@@ -10,13 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-from contextlib import contextmanager
-
-import botocore.session
 from tests import BaseSessionTest, ClientHTTPStubber
-from botocore.stub import Stubber
-from tests import unittest
 
 
 class TestRDSPresignUrlInjection(BaseSessionTest):
@@ -83,12 +77,10 @@ class TestRDSPresignUrlInjection(BaseSessionTest):
             self.assert_presigned_url_injected_in_request(sent_request.body)
 
 
-class TestRDS(unittest.TestCase):
+class TestRDS(BaseSessionTest):
     def setUp(self):
-        self.session = botocore.session.get_session()
+        super(TestRDS, self).setUp()
         self.client = self.session.create_client('rds', 'us-west-2')
-        self.stubber = Stubber(self.client)
-        self.stubber.activate()
 
     def test_generate_db_auth_token(self):
         hostname = 'host.us-east-1.rds.amazonaws.com'


### PR DESCRIPTION
The plugin spawns workers in subprocesses to run tests in order to speed up running all of the tests at once. With regards to performance improvements when comparing it to the [most recent CI run](https://github.com/aws/aws-cli/runs/4040934996), I was seeing about 5 to 10 minutes in improvement across each job. This should give us quicker feedback on if tests are failing and speed up how long we need to wait to merge a PR. 


Some tests needed to be updated so that the parameterized cases have a stable order as the workers will collect
all of the cases upfront and make sure the collected tests and order is the same tests before running.

With regards to configuration:

* The number of processes is set to `auto` so it spawns workers based on the number of CPU cores. We cap this to four processes to make sure too much memory is not consumed in the case the environment has a lot of cores.

* The tests are configured to be distributed by test file to minimize the number of duplicate setups/teardowns of tests across the workers.

I also had to update an RDS test that was not appropriately mocking out the environment which caused credential not being found exceptions. 