### PR TITLE
Move to git+https:// for requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # botocore and the awscli packages are typically developed
 # in tandem, so we're requiring the latest develop
 # branch of botocore and s3transfer when working on the awscli.
--e git://github.com/boto/botocore.git@develop#egg=botocore
--e git://github.com/boto/s3transfer.git@develop#egg=s3transfer
+-e git+https://github.com/boto/botocore.git@develop#egg=botocore
+-e git+https://github.com/boto/s3transfer.git@develop#egg=s3transfer


### PR DESCRIPTION
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Github started a brownout today for users still on git:// for their repository links. We're moving to HTTPS to make sure we're using proper cipher suites when cloning.