### PR TITLE
Change file:// to fileb:// for apigateway put-rest-api v2 example

### DIFF
--- a/awscli/examples/apigateway/put-rest-api.rst
+++ b/awscli/examples/apigateway/put-rest-api.rst
@@ -2,10 +2,10 @@
 
 Command::
 
-  aws apigateway put-rest-api --rest-api-id 1234123412 --mode overwrite --body 'file:///path/to/API_Swagger_template.json'
+  aws apigateway put-rest-api --rest-api-id 1234123412 --mode overwrite --body 'fileb:///path/to/API_Swagger_template.json'
 
 **To merge a Swagger template into an existing API**
 
 Command::
 
-  aws apigateway put-rest-api --rest-api-id 1234123412 --mode merge --body 'file:///path/to/API_Swagger_template.json'
+  aws apigateway put-rest-api --rest-api-id 1234123412 --mode merge --body 'fileb:///path/to/API_Swagger_template.json'


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/6523

*Description of changes:* Change file:// to fileb:// for apigateway put-rest-api v2 example to make consistent with import-rest-api example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
