### PR TITLE
Add --use-json to cloudformation package example

### DIFF
--- a/awscli/examples/cloudformation/package.rst
+++ b/awscli/examples/cloudformation/package.rst
@@ -2,5 +2,5 @@ Following command exports a template named ``template.json`` by uploading local
 artifacts to S3 bucket ``bucket-name`` and writes the exported template to
 ``packaged-template.json``::
 
-    aws cloudformation package --template-file /path_to_template/template.json --s3-bucket bucket-name --output-template-file packaged-template.json
+    aws cloudformation package --template-file /path_to_template/template.json --s3-bucket bucket-name --output-template-file packaged-template.json --use-json
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/2308

*Description of changes:* Add `--use-json` to example here: https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/package.html

If `--use-json` isn't used then it outputs YAML to a JSON file.

This would bring consistency with example here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-package.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
