### PR TITLE
Replace file:// with fileb:// in kafka create-configuration documentation

### DIFF
--- a/awscli/examples/kafka/create-configuration.rst
+++ b/awscli/examples/kafka/create-configuration.rst
@@ -6,7 +6,7 @@ The following ``create-configuration`` example creates a custom MSK configuratio
         --name "CustomConfiguration" \
         --description "Topic autocreation enabled; Apache ZooKeeper timeout 2000 ms; Log rolling 604800000 ms." \
         --kafka-versions "2.2.1" \
-        --server-properties file://configuration.txt
+        --server-properties fileb://configuration.txt
 
 Contents of ``configuration.txt``::
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/5001

*Description of changes:* Replace file:// with fileb:// in kafka create-configuration documentation for `--server-properties` example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
