### PR TITLE
Update S3 sync examples

### DIFF
--- a/awscli/examples/s3/sync.rst
+++ b/awscli/examples/s3/sync.rst
@@ -1,9 +1,14 @@
-The following ``sync`` command syncs objects under a specified prefix and bucket to files in a local directory by
-uploading the local files to s3.  A local file will require uploading if the size of the local file is different than
-the size of the s3 object, the last modified time of the local file is newer than the last modified time of the s3
-object, or the local file does not exist under the specified bucket and prefix.  In this example, the user syncs the
-bucket ``mybucket`` to the local current directory.  The local current directory contains the files ``test.txt`` and
-``test2.txt``.  The bucket ``mybucket`` contains no objects::
+**Sync from local directory to S3 bucket**
+
+The following ``sync`` command syncs objects to a specified bucket and prefix from files in a local directory by
+uploading the local files to s3.  A local file will require uploading if one of the following conditions is true:
+
+* The local file does not exist under the specified bucket and prefix.
+* The size of the local file is different than the size of the s3 object.
+* The last modified time of the local file is newer than the last modified time of the s3 object.
+
+In this example, the user syncs the bucket ``mybucket`` to the local current directory.  The local current directory 
+contains the files ``test.txt`` and ``test2.txt``.  The bucket ``mybucket`` contains no objects::
 
     aws s3 sync . s3://mybucket
 
@@ -11,12 +16,18 @@ Output::
 
     upload: test.txt to s3://mybucket/test.txt
     upload: test2.txt to s3://mybucket/test2.txt
+    
+**Sync from S3 bucket to another S3 bucket**
 
-The following ``sync`` command syncs objects under a specified prefix and bucket to objects under another specified
-prefix and bucket by copying s3 objects.  A s3 object will require copying if the sizes of the two s3 objects differ,
-the last modified time of the source is newer than the last modified time of the destination, or the s3 object does not
-exist under the specified bucket and prefix destination.  In this example, the user syncs the bucket ``mybucket`` to
-the bucket ``mybucket2``.  The bucket ``mybucket`` contains the objects ``test.txt`` and ``test2.txt``.  The bucket
+The following ``sync`` command syncs objects to a specified bucket and prefix from objects in another specified
+bucket and prefix by copying s3 objects.  An s3 object will require copying if one of the following conditions is true:
+
+* The s3 object does not exist in the specified bucket and prefix destination.
+* The sizes of the two s3 objects differ.
+* The last modified time of the source is newer than the last modified time of the destination.
+
+In this example, the user syncs the bucket ``mybucket`` to the bucket ``mybucket2``.  
+The bucket ``mybucket`` contains the objects ``test.txt`` and ``test2.txt``.  The bucket
 ``mybucket2`` contains no objects::
 
     aws s3 sync s3://mybucket s3://mybucket2
@@ -25,14 +36,19 @@ Output::
 
     copy: s3://mybucket/test.txt to s3://mybucket2/test.txt
     copy: s3://mybucket/test2.txt to s3://mybucket2/test2.txt
+    
+**Sync from S3 bucket to local directory**
 
-The following ``sync`` command syncs files in a local directory to objects under a specified prefix and bucket by
-downloading s3 objects.  A s3 object will require downloading if the size of the s3 object differs from the size of the
-local file, the last modified time of the s3 object is newer than the last modified time of the local file, or the s3
-object does not exist in the local directory.  Take note that when objects are downloaded from s3, the last modified
-time of the local file is changed to the last modified time of the s3 object.  In this example, the user syncs the
-current local directory to the bucket ``mybucket``.  The bucket ``mybucket`` contains the objects ``test.txt`` and
-``test2.txt``.  The current local directory has no files::
+The following ``sync`` command syncs files to a local directory from objects in a specified bucket and prefix by
+downloading s3 objects.  An s3 object will require downloading if one of the following conditions is true:
+
+* The s3 object does not exist in the local directory.
+* The size of the s3 object differs from the size of the local file. 
+* The last modified time of the s3 object is older than the last modified time of the local file.  
+
+Take note that when objects are downloaded from s3, the last modified time of the local file is changed to the last modified time of the s3 object.  
+In this example, the user syncs the current local directory to the bucket ``mybucket``.  The bucket ``mybucket`` contains 
+the objects ``test.txt`` and ``test2.txt``.  The current local directory has no files::
 
     aws s3 sync s3://mybucket .
 
@@ -40,10 +56,12 @@ Output::
 
     download: s3://mybucket/test.txt to test.txt
     download: s3://mybucket/test2.txt to test2.txt
+    
+**Sync from local directory to S3 bucket while deleting files that exist in the destination but not in the source**
 
-The following ``sync`` command syncs objects under a specified prefix and bucket to files in a local directory by
-uploading the local files to s3.  Because the ``--delete`` parameter flag is thrown, any files existing under the
-specified prefix and bucket but not existing in the local directory will be deleted.  In this example, the user syncs
+The following ``sync`` command syncs objects to a specified bucket and prefix from files in a local directory by
+uploading the local files to s3.  Because the ``--delete`` parameter flag is used, any files existing in
+specified bucket and prefix but not existing in the local directory will be deleted.  In this example, the user syncs
 the bucket ``mybucket`` to the local current directory.  The local current directory contains the files ``test.txt`` and
 ``test2.txt``.  The bucket ``mybucket`` contains the object ``test3.txt``::
 
@@ -54,9 +72,11 @@ Output::
     upload: test.txt to s3://mybucket/test.txt
     upload: test2.txt to s3://mybucket/test2.txt
     delete: s3://mybucket/test3.txt
+    
+**Sync from local directory to S3 bucket while excluding files that match a specified pattern**
 
-The following ``sync`` command syncs objects under a specified prefix and bucket to files in a local directory by
-uploading the local files to s3.  Because the ``--exclude`` parameter flag is thrown, all files matching the pattern
+The following ``sync`` command syncs objects to a specified bucket and prefix from files in a local directory by
+uploading the local files to s3.  Because the ``--exclude`` parameter flag is used, all files matching the pattern
 existing both in s3 and locally will be excluded from the sync.  In this example, the user syncs the bucket ``mybucket``
 to the local current directory.  The local current directory contains the files ``test.jpg`` and ``test2.txt``.  The
 bucket ``mybucket`` contains the object ``test.jpg`` of a different size than the local ``test.jpg``::
@@ -66,8 +86,10 @@ bucket ``mybucket`` contains the object ``test.jpg`` of a different size than th
 Output::
 
     upload: test2.txt to s3://mybucket/test2.txt
+    
+**Sync from S3 bucket to local directory while excluding objects that match a specified pattern**
 
-The following ``sync`` command syncs files under a local directory to objects under a specified prefix and bucket by
+The following ``sync`` command syncs files to a local directory from objects in a specified bucket and prefix by
 downloading s3 objects.  This example uses the ``--exclude`` parameter flag to exclude a specified directory
 and s3 prefix from the ``sync`` command.  In this example, the user syncs the local current directory to the bucket
 ``mybucket``.  The local current directory contains the files ``test.txt`` and ``another/test2.txt``.  The bucket
@@ -78,6 +100,8 @@ and s3 prefix from the ``sync`` command.  In this example, the user syncs the lo
 Output::
 
     download: s3://mybucket/test1.txt to test1.txt
+    
+**Sync from S3 bucket to another S3 bucket in a different region**
 
 The following ``sync`` command syncs files between two buckets in different regions::
 


### PR DESCRIPTION
*Description of changes:*
Added sub-headings to all examples, re-worded the descriptions, added bullets to upload/download/copy requirements, changed the wording in the "s3 to local" sync example, as it actually appears the opposite is true when it comes to timestamps— for same-sized items, newer s3 objects are not downloaded, but older s3 objects are. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
