### PR TITLE
Update eks-kubeconfig for better null checks

### DIFF
--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -62,10 +62,11 @@ class Kubeconfig(object):
         Return true if this kubeconfig contains an entry
         For the passed cluster name.
         """
-        if 'clusters' not in self.content:
+        if 'clusters' not in self.content or \
+                self.content['clusters'] is None:
             return False
         return name in [cluster['name']
-                        for cluster in self.content['clusters']]
+                        for cluster in self.content['clusters'] if 'name' in cluster]
 
 
 class KubeconfigValidator(object):
@@ -211,7 +212,8 @@ class KubeconfigAppender(object):
         :param config: The kubeconfig to insert an entry into
         :type config: Kubeconfig
         """
-        if key not in config.content:
+        if key not in config.content or \
+                config.content[key] is None:
             config.content[key] = []
         array = config.content[key]
         if not isinstance(array, list):

--- a/tests/functional/eks/testdata/valid_null_cluster
+++ b/tests/functional/eks/testdata/valid_null_cluster
@@ -1,0 +1,24 @@
+apiVersion: v1
+clusters: null
+contexts:
+- context:
+    cluster: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+    user: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+  name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+current-context: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+kind: Config
+preferences: {}
+users:
+- name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args:
+      - --region
+      - us-west-2
+      - eks
+      - get-token
+      - --cluster-name
+      - Existing
+      command: aws
+

--- a/tests/functional/eks/testdata/valid_null_context
+++ b/tests/functional/eks/testdata/valid_null_context
@@ -1,0 +1,24 @@
+apiVersion: v1
+contexts: null
+clusters:
+- cluster:
+    certificate-authority-data: DATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATA=
+    server: https://existingEndpoint.eks.amazonaws.com
+  name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+current-context: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+kind: Config
+preferences: {}
+users:
+- name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args:
+      - --region
+      - us-west-2
+      - eks
+      - get-token
+      - --cluster-name
+      - Existing
+      command: aws
+

--- a/tests/functional/eks/testdata/valid_null_user
+++ b/tests/functional/eks/testdata/valid_null_user
@@ -1,0 +1,16 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: DATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATADATA=
+    server: https://existingEndpoint.eks.amazonaws.com
+  name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+contexts:
+- context:
+    cluster: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+    user: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+  name: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+current-context: arn:aws:eks:us-west-2:111222333444:cluster/Existing
+users: null
+kind: Config
+preferences: {}
+

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -65,6 +65,31 @@ class TestKubeconfig(unittest.TestCase):
         config = Kubeconfig(self._path, self._content)
         self.assertFalse(config.has_cluster("clustername"))
 
+    def test_has_cluster_with_none_clusters(self):
+        self._content["clusters"] = None
+
+        config = Kubeconfig(self._path, self._content)
+        self.assertFalse(config.has_cluster("anyclustername"))
+
+    def test_has_cluster_with_cluster_no_name(self):
+        self._content["clusters"] = [
+            OrderedDict([
+                ("cluster", None),
+                ("name", "clustername")
+            ]),
+            OrderedDict([
+                ("cluster", None),
+                ("name", None),
+            ]),
+            OrderedDict([
+                ("cluster", None),
+            ]),
+        ]
+
+        config = Kubeconfig(self._path, self._content)
+        self.assertTrue(config.has_cluster("clustername"))
+        self.assertFalse(config.has_cluster("othercluster"))
+
 
 class TestKubeconfigWriter(unittest.TestCase):
 
@@ -251,6 +276,45 @@ class TestKubeconfigAppender(unittest.TestCase):
                     ("name", "clustername")
                 ])
             ])
+        ])
+        updated = self._appender.insert_entry(Kubeconfig(None, initial),
+                                              "clusters",
+                                              cluster)
+        self.assertDictEqual(updated.content, correct)
+
+    def test_key_none(self):
+        initial = OrderedDict([
+            ("apiVersion", "v1"),
+            ("clusters", None),
+            ("contexts", []),
+            ("current-context", None),
+            ("kind", "Config"),
+            ("preferences", OrderedDict()),
+            ("users", [])
+        ])
+        cluster = OrderedDict([
+            ("cluster", OrderedDict([
+                ("certificate-authority-data", "data"),
+                ("server", "endpoint")
+            ])),
+            ("name", "clustername")
+        ])
+        correct = OrderedDict([
+            ("apiVersion", "v1"),
+            ("clusters", [
+                OrderedDict([
+                    ("cluster", OrderedDict([
+                        ("certificate-authority-data", "data"),
+                        ("server", "endpoint")
+                    ])),
+                    ("name", "clustername")
+                ])
+            ]),
+            ("contexts", []),
+            ("current-context", None),
+            ("kind", "Config"),
+            ("preferences", OrderedDict()),
+            ("users", []),
         ])
         updated = self._appender.insert_entry(Kubeconfig(None, initial),
                                               "clusters",


### PR DESCRIPTION
*Issue #, if available:*
- #4843 
- #5532

*Description of changes:*
Updates eks-kubeconfig to better handle null checks and missing required properties.
- When inserting entry to arrays, initialize an empty array if the target property is null.
- When checking `has_cluster`, skip bad `clusters` which does not have `name` property.

*Tests*
Tested with kubeconfigs provided in above issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
