### PR TITLE
Allow for `~` for the specified cfn template path

### DIFF
--- a/.changes/next-release/enhancement-cloudformation-20774.json
+++ b/.changes/next-release/enhancement-cloudformation-20774.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``cloudformation``",
+  "description": "Expand the ``~`` character for the template file argument in the ``aws cloudformation deploy`` command."
+}


### PR DESCRIPTION
This allows a user to specify paths such as `~/foo/mytemplate.yml`.  I ended up refactoring the code a bit to create a separate `load_template_file` so I could test it directly.