### PR TITLE
[v2] Allow custom event pattern for new-rule wizard

### DIFF
--- a/.changes/next-release/enhancement-newrule-67599.json
+++ b/.changes/next-release/enhancement-newrule-67599.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``new-rule``",
+  "description": "Add support for specifying custom event pattern for new-rule EventBridge wizard (`#6573 <https://github.com/aws/aws-cli/issues/6573>`__)."
+}

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -283,6 +283,36 @@ class SharedConfigStep(BaseStep):
             )
 
 
+class LoadDataStep(BaseStep):
+    NAME = 'load-data'
+
+    def run_step(self, step_definition, parameters):
+        var_resolver = VariableResolver()
+        value = var_resolver.resolve_variables(
+            parameters, step_definition['value'],
+        )
+        load_type = step_definition['load_type']
+        if load_type == 'json':
+            return json.loads(value)
+        else:
+            raise ValueError(f'Unsupported load_type: {load_type}')
+
+
+class DumpDataStep(BaseStep):
+    NAME = 'dump-data'
+
+    def run_step(self, step_definition, parameters):
+        var_resolver = VariableResolver()
+        value = var_resolver.resolve_variables(
+            parameters, step_definition['value'],
+        )
+        dump_type = step_definition['dump_type']
+        if dump_type == 'json':
+            return json.dumps(value)
+        else:
+            raise ValueError(f'Unsupported load_type: {dump_type}')
+
+
 class VariableResolver(object):
 
     _VAR_MATCH = re.compile(r'^{(.*?)}$')
@@ -591,33 +621,17 @@ class MergeDictStep(ExecutorStep):
             return newvalue
 
 
-class LoadDataStep(ExecutorStep):
+class LoadDataExecutorStep(ExecutorStep):
     NAME = 'load-data'
 
     def run_step(self, step_definition, parameters):
-        var_resolver = VariableResolver()
-        value = var_resolver.resolve_variables(
-            parameters, step_definition['value'],
-        )
-        load_type = step_definition['load_type']
-        if load_type == 'json':
-            loaded_value = json.loads(value)
-            parameters[step_definition['output_var']] = loaded_value
-        else:
-            raise ValueError(f'Unsupported load_type: {load_type}')
+        loaded_value = LoadDataStep().run_step(step_definition, parameters)
+        parameters[step_definition['output_var']] = loaded_value
 
 
-class DumpDataStep(ExecutorStep):
+class DumpDataExecutorStep(ExecutorStep):
     NAME = 'dump-data'
 
     def run_step(self, step_definition, parameters):
-        var_resolver = VariableResolver()
-        value = var_resolver.resolve_variables(
-            parameters, step_definition['value'],
-        )
-        dump_type = step_definition['dump_type']
-        if dump_type == 'json':
-            dumped_value = json.dumps(value)
-            parameters[step_definition['output_var']] = dumped_value
-        else:
-            raise ValueError(f'Unsupported load_type: {dump_type}')
+        dumped_value = DumpDataStep().run_step(step_definition, parameters)
+        parameters[step_definition['output_var']] = dumped_value

--- a/awscli/customizations/wizard/factory.py
+++ b/awscli/customizations/wizard/factory.py
@@ -27,8 +27,8 @@ def create_default_executor(api_invoker, shared_config):
                 shared_config),
             core.DefineVariableStep.NAME: core.DefineVariableStep(),
             core.MergeDictStep.NAME: core.MergeDictStep(),
-            core.LoadDataStep.NAME: core.LoadDataStep(),
-            core.DumpDataStep.NAME: core.DumpDataStep(),
+            core.LoadDataExecutorStep.NAME: core.LoadDataExecutorStep(),
+            core.DumpDataExecutorStep.NAME: core.DumpDataExecutorStep(),
         }
     )
 
@@ -71,6 +71,8 @@ def create_wizard_app(definition, session, output=None, app_input=None):
             core.SharedConfigStep.NAME: core.SharedConfigStep(
                 config_api=shared_config),
             core.TemplateStep.NAME: core.TemplateStep(),
+            core.LoadDataStep.NAME: core.LoadDataStep(),
+            core.DumpDataStep.NAME: core.DumpDataStep(),
         },
         exception_handler=layout.error_bar.display_error
     )

--- a/awscli/customizations/wizard/wizards/events/new-rule.yml
+++ b/awscli/customizations/wizard/wizards/events/new-rule.yml
@@ -25,10 +25,24 @@ plan:
             actual_value: schedule
 
       # Event pattern related prompts
-      service_for_event_pattern:
+      event_pattern_input_type:
+        type: prompt
         condition:
           variable: pattern_type
           equals: event_pattern
+        description: Select method to choose the event pattern
+        choices:
+          - display: Use pre-defined pattern by service
+            actual_value: predefined
+          - display: Use custom pattern
+            actual_value: custom
+
+      service_for_event_pattern:
+        condition:
+          - variable: pattern_type
+            equals: event_pattern
+          - variable: event_pattern_input_type
+            equals: predefined
         type: prompt
         description: Select a service to match events for
         choices:
@@ -47,9 +61,35 @@ plan:
         details:
           value: event_pattern_value
           description: "Event pattern"
+
+      custom_event_pattern_filename:
+        condition:
+          - variable: pattern_type
+            equals: event_pattern
+          - variable: event_pattern_input_type
+            equals: custom
+        type: prompt
+        description: Enter the filename with the custom event pattern
+        completer: file_completer
+
+      custom_event_pattern:
+        type: load-data
+        load_type: json
+        value:
+          __wizard__:File:
+            path: "{custom_event_pattern_filename}"
+
+      custom_event_pattern_as_normalized_json:
+        type: dump-data
+        dump_type: json
+        value: "{custom_event_pattern}"
+
       event_pattern_value:
         type: template
-        value: "{{\"source\": [\"aws.{service_for_event_pattern}\"]}}"
+        value: |
+          {% if {event_pattern_input_type} == predefined %}{{"source": ["aws.{service_for_event_pattern}"]}}{% endif %}
+          {% if {event_pattern_input_type} == custom %}{custom_event_pattern_as_normalized_json}{% endif %}
+
       # Schedule related prompts
       schedule_type:
         condition:
@@ -330,9 +370,7 @@ plan:
                 ScheduleExpression: {schedule_expression}
                 {% endif %}
                 {%if {pattern_type} == event_pattern %}
-                EventPattern:
-                  source:
-                    - aws.{service_for_event_pattern}
+                EventPattern: {event_pattern_value}
                 {% endif %}
                 Targets:
                   - Id: cli-wizard-0


### PR DESCRIPTION
You can now specify the path to a file for an event pattern instead of using the pre-defined pattern.

This also required adding support for data dumping and loading steps outside of the executor.

