### PR TITLE
[v2] Add save details dialog

### DIFF
--- a/.changes/next-release/enhancement-Wizards-78551.json
+++ b/.changes/next-release/enhancement-Wizards-78551.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Wizards",
+  "description": "Add save to file option for more details panel (`#6574 <https://github.com/aws/aws-cli/issues/6574>`__)."
+}

--- a/awscli/customizations/wizard/app.py
+++ b/awscli/customizations/wizard/app.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
+import os
 from collections.abc import MutableMapping
 
 from prompt_toolkit.application import Application
@@ -42,7 +43,7 @@ class WizardAppRunner(object):
 class WizardApp(Application):
     def __init__(self, layout, values, traverser, executor, style=None,
                  key_bindings=None, full_screen=True, output=None,
-                 app_input=None):
+                 app_input=None, file_io=None):
         self.values = values
         self.traverser = traverser
         self.executor = executor
@@ -52,6 +53,10 @@ class WizardApp(Application):
             key_bindings = get_default_keybindings()
         self.details_visible = False
         self.error_bar_visible = None
+        self.save_details_visible = False
+        if file_io is None:
+            file_io = FileIO()
+        self.file_io = file_io
         super().__init__(
             layout=layout, style=style, key_bindings=key_bindings,
             full_screen=full_screen, output=output, input=app_input,
@@ -105,7 +110,7 @@ class WizardTraverser:
     def current_prompt_has_details(self):
         return 'details' in self._prompt_definitions.get(
             self._current_prompt, {})
-    
+
     def submit_prompt_answer(self, answer):
         definition = self._prompt_definitions[self._current_prompt]
         if 'choices' in definition:
@@ -333,3 +338,9 @@ class WizardValues(MutableMapping):
         return new_vars
 
     copy = __copy__
+
+
+class FileIO:
+    def write_file_contents(self, filename, contents):
+        with open(os.path.expanduser(filename), 'w') as f:
+            f.write(contents)

--- a/awscli/customizations/wizard/ui/keybindings.py
+++ b/awscli/customizations/wizard/ui/keybindings.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from prompt_toolkit.application import get_app
-from prompt_toolkit.filters import Condition
+from prompt_toolkit.filters import has_focus, Condition
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
 
@@ -25,6 +25,11 @@ from awscli.customizations.wizard.exceptions import BaseWizardException
 @Condition
 def details_visible():
     return get_app().details_visible
+
+
+@Condition
+def save_details_visible():
+    return get_app().save_details_visible
 
 
 @Condition
@@ -107,6 +112,17 @@ def get_default_keybindings():
             layout.focus(current_control)
         else:
             refresh_details_view(event.app, current_prompt)
+
+    @kb.add(Keys.ControlS, filter=prompt_has_details)
+    def show_save_details_dialogue(event):
+        if not event.app.details_visible:
+            event.app.details_visible = True
+            current_prompt = event.app.traverser.get_current_prompt()
+            refresh_details_view(event.app, current_prompt)
+        event.app.save_details_visible = True
+        save_dialogue = get_ui_control_by_buffer_name(
+            event.app.layout, 'save_details_dialogue')
+        event.app.layout.focus(save_dialogue)
 
     @kb.add(Keys.F4, filter=error_bar_enabled)
     def show_details(event):

--- a/awscli/customizations/wizard/ui/style.py
+++ b/awscli/customizations/wizard/ui/style.py
@@ -28,6 +28,7 @@ def get_default_style():
             ('wizard.section.tab.visited', ''),
             ('wizard.dialog', ''),
             ('wizard.dialog frame.label', 'white bold'),
+            ('wizard.dialog.save frame.label', 'black bold'),
             ('wizard.dialog.body', 'bg:#aaaaaa black'),
             ('wizard.error', 'bg:#550000 #ffffff'),
 


### PR DESCRIPTION
This allows you to save any details pane contents
with the `<Ctrl-S>` keybinding for wizards.