### PR TITLE
Add support for S3 GLACIER_IR storage class

### DIFF
--- a/.changes/next-release/bugfix-s3-42238.json
+++ b/.changes/next-release/bugfix-s3-42238.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Add support for S3 GLACIER_IR storage class. Fix `#6587 <https://github.com/aws/aws-cli/issues/6587>`__"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -249,12 +249,12 @@ SSE_C_COPY_SOURCE_KEY = {
 STORAGE_CLASS = {'name': 'storage-class',
                  'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA',
                              'ONEZONE_IA', 'INTELLIGENT_TIERING', 'GLACIER',
-                             'DEEP_ARCHIVE'],
+                             'DEEP_ARCHIVE', 'GLACIER_IR'],
                  'help_text': (
                      "The type of storage to use for the object. "
                      "Valid choices are: STANDARD | REDUCED_REDUNDANCY "
                      "| STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING "
-                     "| GLACIER | DEEP_ARCHIVE. "
+                     "| GLACIER | DEEP_ARCHIVE | GLACIER_IR. "
                      "Defaults to 'STANDARD'")}
 
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -174,6 +174,21 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(args['Bucket'], 'bucket')
         self.assertEqual(args['StorageClass'], 'DEEP_ARCHIVE')
 
+    def test_upload_glacier_ir(self):
+        full_path = self.files.create_file('foo.txt', 'mycontent')
+        cmdline = ('%s %s s3://bucket/key.txt --storage-class GLACIER_IR' %
+                   (self.prefix, full_path))
+        self.parsed_responses = \
+            [{'ETag': '"c8afdb36c52cf4727836669019e69222"'}]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 1,
+                         self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        args = self.operations_called[0][1]
+        self.assertEqual(args['Key'], 'key.txt')
+        self.assertEqual(args['Bucket'], 'bucket')
+        self.assertEqual(args['StorageClass'], 'GLACIER_IR')
+
     def test_operations_used_in_download_file(self):
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},

--- a/tests/unit/customizations/s3/test_fileinfo.py
+++ b/tests/unit/customizations/s3/test_fileinfo.py
@@ -18,6 +18,27 @@ class TestIsGlacierCompatible(unittest.TestCase):
     def setUp(self):
         self.file_info = FileInfo('bucket/key')
         self.file_info.associated_response_data = {'StorageClass': 'GLACIER'}
+        self._glacier_ir_response_data = {'StorageClass': 'GLACIER_IR'}
+
+    def test_copy_operation_is_glacier_ir_compatible(self):
+        self.file_info.operation_name = 'copy'
+        self.file_info.associated_response_data = self._glacier_ir_response_data
+        self.assertTrue(self.file_info.is_glacier_compatible())
+
+    def test_download_operation_is_glacier_ir_compatible(self):
+        self.file_info.operation_name = 'download'
+        self.file_info.associated_response_data = self._glacier_ir_response_data
+        self.assertTrue(self.file_info.is_glacier_compatible())
+
+    def test_delete_operation_is_glacier_ir_compatible(self):
+        self.file_info.operation_name = 'delete'
+        self.file_info.associated_response_data = self._glacier_ir_response_data
+        self.assertTrue(self.file_info.is_glacier_compatible())
+
+    def test_move_operation_is_glacier_ir_compatible(self):
+        self.file_info.operation_name = 'move'
+        self.file_info.associated_response_data = self._glacier_ir_response_data
+        self.assertTrue(self.file_info.is_glacier_compatible())
 
     def test_operation_is_glacier_compatible(self):
         self.file_info.operation_name = 'delete'


### PR DESCRIPTION
Add support for S3 GLACIER_IR storage class in various sub commands

*Issue #, if available:*

#6587

*Description of changes:*

Add support for S3 GLACIER_IR storage class
Update fileinfo logic for GLACIER_IR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
