### PR TITLE
add s3 GLACIER_IR storage class

### DIFF
--- a/.changes/next-release/bugfix-s3-66408.json
+++ b/.changes/next-release/bugfix-s3-66408.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Support for S3 Glacer Instant Retrieval storage class.  Fixes `#6587 <https://github.com/aws/aws-cli/issues/6587>`__"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -249,12 +249,12 @@ SSE_C_COPY_SOURCE_KEY = {
 STORAGE_CLASS = {'name': 'storage-class',
                  'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA',
                              'ONEZONE_IA', 'INTELLIGENT_TIERING', 'GLACIER',
-                             'DEEP_ARCHIVE'],
+                             'DEEP_ARCHIVE', 'GLACIER_IR'],
                  'help_text': (
                      "The type of storage to use for the object. "
                      "Valid choices are: STANDARD | REDUCED_REDUNDANCY "
                      "| STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING "
-                     "| GLACIER | DEEP_ARCHIVE. "
+                     "| GLACIER | DEEP_ARCHIVE | GLACIER_IR. "
                      "Defaults to 'STANDARD'")}
 
 

--- a/tests/unit/customizations/s3/test_copy_params.py
+++ b/tests/unit/customizations/s3/test_copy_params.py
@@ -80,6 +80,15 @@ class TestGetObject(BaseAWSCommandParamsTest):
                   'StorageClass': u'STANDARD_IA'}
         self.assert_params(cmdline, result)
 
+    def test_glacier_ir_storage_class(self):
+        cmdline = self.prefix
+        cmdline += self.file_path
+        cmdline += ' s3://mybucket/mykey'
+        cmdline += ' --storage-class GLACIER_IR'
+        result = {'Bucket': u'mybucket', 'Key': u'mykey',
+                  'StorageClass': u'GLACIER_IR'}
+        self.assert_params(cmdline, result)
+
     def test_website_redirect(self):
         cmdline = self.prefix
         cmdline += self.file_path


### PR DESCRIPTION
Closes #6587

Description of changes:

S3 recently introduced the Glacier Instant Retrieval storage class. Added the option to subcommands for use with cp, as this already works with standard S3 APIs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.