### PR TITLE
Add s3 ls --short to display the files or objects names without times…

### DIFF
--- a/awscli/examples/s3/ls.rst
+++ b/awscli/examples/s3/ls.rst
@@ -81,3 +81,22 @@ Output::
 
                                PRE somePrefix/
     2013-07-25 17:06:27         88 test.txt
+
+**Example 7: Recursively listing all prefixes and objects in a bucket without the timestamp and file sizes**
+
+The following ``ls`` command will recursively list objects in a bucket without the timestamp and file sizes.  Rather than showing ``PRE dirname/`` in the output, all the content in a bucket will be listed in order::
+
+    aws s3 ls s3://mybucket --short
+
+Output::
+
+    a.txt
+    foo.zip
+    foo/bar/.baz/a
+    foo/bar/.baz/b
+    foo/bar/.baz/c
+    foo/bar/.baz/d
+    foo/bar/.baz/e
+    foo/bar/.baz/hooks/bar
+    foo/bar/.baz/hooks/foo
+    z.txt


### PR DESCRIPTION
…tamp or size

*Issue #, if    ###available:* #6582 

*Description of changes:*
Currently the command aws s3 ls --recursive mybucket gives long-form results with timestamp, filesize, and key, so added "aws s3 ls --short" to display only the key without displaying the timestamp or file size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
