### PR TITLE
Changed order of values in STORAGE_CLASS

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -247,14 +247,14 @@ SSE_C_COPY_SOURCE_KEY = {
 
 
 STORAGE_CLASS = {'name': 'storage-class',
-                 'choices': ['STANDARD', 'REDUCED_REDUNDANCY', 'STANDARD_IA',
-                             'ONEZONE_IA', 'INTELLIGENT_TIERING', 'GLACIER',
-                             'DEEP_ARCHIVE', 'GLACIER_IR'],
+                 'choices': ['STANDARD', 'INTELLIGENT_TIERING', 'STANDARD_IA',
+                             'ONEZONE_IA', 'GLACIER_IR', 'GLACIER',
+                             'DEEP_ARCHIVE', 'REDUCED_REDUNDANCY'],
                  'help_text': (
                      "The type of storage to use for the object. "
-                     "Valid choices are: STANDARD | REDUCED_REDUNDANCY "
-                     "| STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING "
-                     "| GLACIER | DEEP_ARCHIVE | GLACIER_IR. "
+                     "Valid choices are: STANDARD | INTELLIGENT_TIERING "
+                     "| STANDARD_IA | ONEZONE_IA | GLACIER_IR "
+                     "| GLACIER | DEEP_ARCHIVE | REDUCED_REDUNDANCY. "
                      "Defaults to 'STANDARD'")}
 
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-cli/issues/6608

*Description of changes:*
I think the storage classes options should be sorted according to their order on https://aws.amazon.com/s3/storage-classes/?nc=sn&loc=3, and not as they are currently sorted. Specifically, `GLACIER_IR` should come before `GLACIER`.

Please note, I didn't find `REDUCED_REDUNDANCY` on https://aws.amazon.com/s3/storage-classes/?nc=sn&loc=3, so I put it last. Was it removed?

I checked and the same order of classes appears also on https://aws.amazon.com/s3/pricing/?nc=sn&loc=4.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
