### PR TITLE
Fix typos in awscli source files

### DIFF
--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -153,7 +153,7 @@ class ServiceAliasCommand(BaseAliasCommand):
         :type parser: awscli.argparser.MainArgParser
         :param parser: The parser to parse commands provided at the top level
             of a CLI command which includes service commands and global
-            parameters. This is used to parse the service commmand and any
+            parameters. This is used to parse the service command and any
             global parameters from the alias's value.
 
         :type shadow_proxy_command: CLICommand
@@ -180,7 +180,7 @@ class ServiceAliasCommand(BaseAliasCommand):
         LOG.debug(
             'Alias %r passing on arguments: %r to %r command',
             self._alias_name, remaining, parsed_alias_args.command)
-        # Pass the update remaing args and global args to the service command
+        # Pass the update remaining args and global args to the service command
         # the alias proxied to.
         command = self._command_table[parsed_alias_args.command]
         if self._shadow_proxy_command:

--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -494,7 +494,7 @@ class BooleanArgument(CLIArgument):
 
         aws foo bar --enabled
 
-    For cases wher the boolean parameter is required we need to add
+    For cases where the boolean parameter is required we need to add
     two parameters::
 
         aws foo bar --enabled

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -77,7 +77,7 @@ class NonTranslatedStdout(object):
 
     It is deliberately set to binary mode so that `\r` does not get added to
     the line ending. This can be useful when printing commands where a
-    windows style line ending would casuse errors.
+    windows style line ending would cause errors.
     """
 
     def __enter__(self):

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -109,7 +109,7 @@ class DuplicateKeyInObjectError(ShorthandParseError):
     def _construct_msg(self):
         msg = (
             "Second instance of key \"%s\" encountered for input:\n%s\n"
-            "This is often because there is a preceeding \",\" instead of a "
+            "This is often because there is a preceding \",\" instead of a "
             "space."
         ) % (self.key, self._error_location())
         return msg
@@ -162,7 +162,7 @@ class ShorthandParser(object):
             parser.parse('a=b')  # {'a': 'b'}
             parser.parse('a=b,c')  # {'a': ['b', 'c']}
 
-        :tpye value: str
+        :type value: str
         :param value: Any value that needs to be parsed.
 
         :return: Parsed value, which will be a dictionary.

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -281,7 +281,7 @@ class TopicTagDB(object):
 
         :param topic_name: The name of the topic
         :param tag: The name of the tag to retrieve
-        :raises VauleError: Raised if there is not exactly one value
+        :raises ValueError: Raised if there is not exactly one value
             in the list value.
         """
         value = self.get_tag_value(topic_name, tag)


### PR DESCRIPTION
*Description of changes:*
This PR fixes a few small typos in the comment blocks of awscli source code. I stumbled upon them when reading the code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
