### PR TITLE
Update supported cryptography range

### DIFF
--- a/.changes/next-release/enhancement-dependency-81152.json
+++ b/.changes/next-release/enhancement-dependency-81152.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "dependency",
+  "description": "bump cryptography version"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ include_package_data = True
 install_requires =
     colorama>=0.2.5,<0.4.4
     docutils>=0.10,<0.16
-    cryptography>=3.3.2,<3.4.0
+    cryptography>=3.3.2,<37.0.0
     ruamel.yaml>=0.15.0,<0.16.0
     wcwidth<0.2.0
     prompt-toolkit>=3.0.24,<3.1.0


### PR DESCRIPTION
*Issue #, if available:*  #5943

*Description of changes:*

This PR raises the supported version of `cryptography` to <37.0.0 allowing the CLI v2 to distribute a more recent version of the dependency. According to the changelog, there shouldn't be any backwards incompatible changes for the pieces we use.