### PR TITLE
Remove extra bracket from feedback URL

### DIFF
--- a/doc/source/_templates/feedback.html
+++ b/doc/source/_templates/feedback.html
@@ -1,6 +1,6 @@
 <div class="left-bar-other">
   <h3>Feedback</h3>
-  <p class="feedback">Did you find this page useful? Do you have a suggestion to improve the documentation? <a href="https://docs.aws.amazon.com/forms/aws-doc-feedback?hidden_service_name=AWS%20Command%20Line%20Interface&hidden_guide_name=Reference}&topic_url=https%3A%2F%2Fdocs.aws.amazon.com%2Fcli%2Flatest%2F{{ pagename }}.html">Give us feedback</a>.
+  <p class="feedback">Did you find this page useful? Do you have a suggestion to improve the documentation? <a href="https://docs.aws.amazon.com/forms/aws-doc-feedback?hidden_service_name=AWS%20Command%20Line%20Interface&hidden_guide_name=Reference&topic_url=https%3A%2F%2Fdocs.aws.amazon.com%2Fcli%2Flatest%2F{{ pagename }}.html">Give us feedback</a>.
     <br />
     If you would like to suggest an improvement or fix for the AWS CLI, check out our <a href="https://github.com/aws/aws-cli/blob/develop/CONTRIBUTING.md">contributing guide</a> on GitHub.</p>
 </div>


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Feedback link returns 400 error. Removing extra bracket to fix the URL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
