### PR TITLE
Silence ecs execute-command session manager plugin check

### DIFF
--- a/awscli/customizations/ecs/executecommand.py
+++ b/awscli/customizations/ecs/executecommand.py
@@ -13,6 +13,7 @@
 import logging
 import json
 import errno
+import os
 
 from subprocess import check_call
 from awscli.compat import ignore_user_entered_signals
@@ -83,7 +84,7 @@ class ExecuteCommandCaller(CLIOperationCaller):
             # before calling execute-command to ensure that
             # session-manager-plugin is installed
             # before execute-command-command is made
-            check_call(["session-manager-plugin"])
+            check_call(["session-manager-plugin"], stdout=open(os.devnull, 'wb'))
             client = self._session.create_client(
                 service_name, region_name=parsed_globals.region,
                 endpoint_url=parsed_globals.endpoint_url,


### PR DESCRIPTION
When running ` aws ecs execute-command`, it  unnecessarily outputs:

```
The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.
```

This is because within the `ExecuteCommandCaller` Class, `check_call(["session-manager-plugin"])` is used

`check_call` in this case is only used to ensure that the command exists

Changing `stddout` to devnull, will still exit if the command errors (eg. if `session-manager-plugin` doesn't exist)