### PR TITLE
Add CLI parameters for `aws configure sso` to skip prompted value 

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -129,23 +129,14 @@ class ConfigureSSOCommand(BasicCommand):
         {
             'name': 'sso-start-url',
             'required': False,
-            'help_text': (
-                'help get fucked'
-            )
         },
         {
             'name': 'sso-role-name',
             'required': False,
-            'help_text': (
-                'help get fucked'
-            )
         },
         {
             'name': 'sso-account-id',
             'required': False,
-            'help_text': (
-                'help get fucked'
-            )
         },
         {
             'name': 'sso-region',
@@ -155,23 +146,14 @@ class ConfigureSSOCommand(BasicCommand):
         {
             'name': 'default-region',
             'required': False,
-            'help_text': (
-                'help get fucked'
-            )
         },
         {
             'name': 'default-output',
             'required': False,
-            'help_text': (
-                'help get fucked'
-            )
         },
         {
             'name': 'dry-run',
             'action': 'store_true',
-            'help_text': (
-                'help get fucked'
-            )
         }
     ]
 

--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -141,7 +141,6 @@ class ConfigureSSOCommand(BasicCommand):
         {
             'name': 'sso-region',
             'required': False,
-            'default': 'us-east-1'
         },
         {
             'name': 'default-region',


### PR DESCRIPTION
*Description of changes:*

Adds some flags to allow the use of `aws configure sso` non-interactively.

NOTE: This is a work in progress. Hoping I can get some preliminary approval before I actually clean it up.

This has been marked TODO since at least 2019-11-06, which is part of why I'm hesitant to submit a 100% cleaned-up PR; maybe there's some reason why previous PRs were rejected.

Anyway, my use-case is: In my org, we want to write some scripts that automate things across a range of aws accounts (e.g. the "prod" account, the "dev" account, the "dmr-fucking-around-with-k8s" account). However, we've never been consistent about how people name profiles, and as the number of accounts gets bigger we're never going to fix this. So we'd rather have a second script to create any script-required profiles so we don't have to worry about whether the user has done `aws configure sso` already or what profile naming convention they have.

> By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Sure