### PR TITLE
Deprecate datapipeline create-default-roles

### DIFF
--- a/.changes/next-release/enhancement-datapipeline-86652.json
+++ b/.changes/next-release/enhancement-datapipeline-86652.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "datapipeline",
+  "description": "Deprecated support for the datapipeline create-default-roles command"
+}

--- a/awscli/customizations/datapipeline/createdefaultroles.py
+++ b/awscli/customizations/datapipeline/createdefaultroles.py
@@ -14,6 +14,7 @@
 # Class to create default roles for datapipeline
 
 import logging
+import warnings
 from awscli.customizations.datapipeline.constants \
     import DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME, \
     DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME, \
@@ -29,19 +30,37 @@ from botocore.exceptions import ClientError
 LOG = logging.getLogger(__name__)
 
 
+_DEPRECATION_NOTICE = """
+Support for this command has been deprecated and may fail to create these roles
+if they do not already exist. For more information on managing these policies
+manually see the following documentation:
+
+https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-iam-roles.html
+"""
+
+_DESCRIPTION = """
+NOTE: {}
+
+Creates the default IAM role "{}" and "{}" which are used while creating an EMR
+cluster.
+
+If these roles do not exist, create-default-roles will automatically create
+them and set their policies.
+
+If these roles have already been created create-default-roles will not update
+their policies.
+"""
+
+
 class CreateDefaultRoles(BasicCommand):
 
     NAME = "create-default-roles"
-    DESCRIPTION = ('Creates the default IAM role ' +
-                   DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME + ' and ' +
-                   DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME +
-                   ' which are used while creating an EMR cluster.\n'
-                   'If the roles do not exist, create-default-roles '
-                   'will automatically create them and set their policies.'
-                   ' If these roles are already '
-                   'created create-default-roles'
-                   ' will not update their policies.'
-                   '\n')
+    _UNDOCUMENTED = True
+    DESCRIPTION = _DESCRIPTION.format(
+        _DEPRECATION_NOTICE,
+        DATAPIPELINE_DEFAULT_SERVICE_ROLE_NAME,
+        DATAPIPELINE_DEFAULT_RESOURCE_ROLE_NAME,
+    )
 
     def __init__(self, session, formatter=None):
         super(CreateDefaultRoles, self).__init__(session)
@@ -56,6 +75,7 @@ class CreateDefaultRoles(BasicCommand):
             endpoint_url=self._endpoint_url,
             verify=parsed_globals.verify_ssl
         )
+        warnings.warn(_DEPRECATION_NOTICE)
         return self._create_default_roles(parsed_args, parsed_globals)
 
     def _create_role(self, role_name, role_arn, role_policy):

--- a/tests/unit/customizations/datapipeline/test_create_default_role.py
+++ b/tests/unit/customizations/datapipeline/test_create_default_role.py
@@ -1,3 +1,5 @@
+import pytest
+
 import awscli.customizations.datapipeline.createdefaultroles \
     as createdefaultroles
 from awscli.customizations.datapipeline.constants\
@@ -12,6 +14,7 @@ from awscli.customizations.datapipeline.translator import dict_to_string
 from botocore.compat import json
 
 
+@pytest.mark.filterwarnings('ignore::UserWarning')
 class TestCreateDefaultRole(BaseAWSCommandParamsTest):
     prefix = 'datapipeline create-default-roles'
 


### PR DESCRIPTION
Support for the underlying managed policies will be deprecated with no replacement meaning this custom command will no longer function properly if the roles do not already exist. This removes the command from the documentation and prints a warning notice that the command has been deprecated.