### PR TITLE
fixes typo in repository-name

### DIFF
--- a/awscli/examples/ecr/create-repository.rst
+++ b/awscli/examples/ecr/create-repository.rst
@@ -3,7 +3,7 @@
 The following ``create-repository`` example creates a repository inside the specified namespace in the default registry for an account. ::
 
     aws ecr create-repository \
-        --repository-name project-a/nginx-web-app
+        --repository-name sample-repo
 
 Output::
 


### PR DESCRIPTION
the argument repository-name does not match the response's ("Output") repositoryName

*Issue #, if available:*

*Description of changes:*
fixes type with repository name in example


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
