### PR TITLE
[v2] Port logic to prompt-toolkit 3

### DIFF
--- a/.changes/next-release/Depedency-prompttoolkit-97207.json
+++ b/.changes/next-release/Depedency-prompttoolkit-97207.json
@@ -1,0 +1,5 @@
+{
+  "type": "Depedency",
+  "category": "prompt-toolkit",
+  "description": "Update to prompt-toolkit dependency to 3.x (`#6507 <https://github.com/aws/aws-cli/issues/6507>`__)."
+}

--- a/awscli/autoprompt/history.py
+++ b/awscli/autoprompt/history.py
@@ -61,15 +61,15 @@ class HistoryCompleter(Completer):
 
     def __init__(self, buffer):
         self.buffer = buffer
-        self.working_lines = buffer.history.get_strings()
 
     def get_completions(self, document, *args):
+        working_lines = self.buffer.history.get_strings()
         found_completions = set()
         completions = []
         current_line = document.current_line_before_cursor.lstrip()
         try:
             # going backwards from newest commands to oldest
-            for line in self.working_lines[::-1]:
+            for line in working_lines[::-1]:
                 s_line = line.strip()
                 if s_line and s_line not in found_completions:
                     found_completions.add(s_line)

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -80,7 +80,7 @@ class PromptToolkitPrompter:
         self.output_buffer = None
         if app is None:
             app = self.create_application()
-        self._app = app
+        self.app = app
         self._args = []
         self._driver = driver
         self._docs_getter = DocsGetter(self._driver)
@@ -161,7 +161,7 @@ class PromptToolkitPrompter:
 
     def _set_debug_mode(self):
         if '--debug' in self._args:
-            self._app.debug = True
+            self.app.debug = True
 
     def pre_run(self):
         if '--cli-auto-prompt' in self._args:
@@ -212,7 +212,7 @@ class PromptToolkitPrompter:
         self._args = self._quote_args_with_spaces(original_args)
         self._set_debug_mode()
         logging_manager = nullcontext
-        if self._app.debug:
+        if self.app.debug:
             # NOTE: The CRT library is not integrated with the Python stdlib
             # logger and only allows you to write to file names and
             # stdout/stderr. Therefore we currently are unable to switch it
@@ -223,7 +223,7 @@ class PromptToolkitPrompter:
             disable_crt_logging()
             logging_manager = loggers_handler_switcher
         with logging_manager():
-            self._app.run(pre_run=self.pre_run)
+            self.app.run(pre_run=self.pre_run)
         cmd_line_text = self.input_buffer.document.text
         # Once the application is finished running, the screen is cleared.
         # Here, we display the command to be run so that the user knows what

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     cryptography>=3.3.2,<3.4.0
     ruamel.yaml>=0.15.0,<0.16.0
     wcwidth<0.2.0
-    prompt-toolkit>=2.0.0,<3.0.0
+    prompt-toolkit>=3.0.24,<3.1.0
     distro>=1.5.0,<1.6.0
     awscrt==0.12.4
     python-dateutil>=2.1,<3.0.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -432,7 +432,7 @@ class PromptToolkitAppRunner:
             self._wait_until_app_is_done_updating()
 
     def wait_for_completions_on_current_buffer(self):
-        if self.app.current_buffer.complete_state:
+        if self._current_buffer_has_completions():
             return
         self.app.current_buffer.on_completions_changed.add_handler(
             self._notify_done_completing
@@ -460,6 +460,12 @@ class PromptToolkitAppRunner:
 
     def _notify_done_completing(self, app):
         self._done_completing_event.set()
+
+    def _current_buffer_has_completions(self):
+        return (
+            self.app.current_buffer.complete_state and
+            self.app.current_buffer.complete_state.completions
+        )
 
     def _convert_key_to_vt100_data(self, key):
         return REVERSE_ANSI_SEQUENCES.get(key, key)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import contextlib
 import logging
+import threading
 
+from prompt_toolkit.application import create_app_session
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
 import pytest
 
 import awscli.logger
@@ -31,3 +36,14 @@ def clear_loggers():
         logger.handlers = []
         logger.setLevel(logging.NOTSET)
     awscli.logger.disable_crt_logging()
+
+
+@pytest.fixture
+def ptk_app_session():
+    pipe_input = create_pipe_input()
+    output = DummyOutput()
+    try:
+        with create_app_session(input=pipe_input, output=output) as session:
+            yield session
+    finally:
+        pipe_input.close()

--- a/tests/functional/autoprompt/test_prompttoolkit.py
+++ b/tests/functional/autoprompt/test_prompttoolkit.py
@@ -27,7 +27,7 @@ from awscli.autoprompt.prompttoolkit import (
 )
 from awscli.autoprompt.history import HistoryDriver
 from awscli.testutils import mock, FileCreator, cd
-from tests import ThreadedAppRunner
+from tests import PromptToolkitAppRunner
 
 
 def _ec2_only_command_table(command_table, **kwargs):
@@ -107,7 +107,7 @@ def prompter(model_index, history_file, ptk_app_session):
 
 @pytest.fixture
 def app_runner(prompter):
-    return ThreadedAppRunner(
+    return PromptToolkitAppRunner(
         app=prompter.app, pre_run=prompter.pre_run)
 
 
@@ -276,6 +276,7 @@ class TestHistoryMode(BasicPromptToolkitTest):
             self.assert_selected_history_completion(
                 app_runner.app, 's3 ls')
             app_runner.feed_input(Keys.Enter)
+            self.assert_history_mode_is_disabled(app_runner.app)
             self.assert_current_buffer(app_runner.app, 'input_buffer')
             self.assert_current_buffer_text(app_runner.app, 's3 ls')
 
@@ -299,6 +300,7 @@ class TestCompletions(BasicPromptToolkitTest):
     def test_service_full_name_shown(self, app_runner, prompter):
         prompter.args = ['e']
         with app_runner.run_app_in_thread():
+            app_runner.wait_for_completions_on_current_buffer()
             first_completion = app_runner.app.current_buffer.\
                 complete_state.completions[0]
             assert 'Elastic Compute' in first_completion.display_meta_text

--- a/tests/functional/autoprompt/test_prompttoolkit.py
+++ b/tests/functional/autoprompt/test_prompttoolkit.py
@@ -10,13 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import contextlib
-import io
 import json
 import os
 
 import awscrt.io
-from prompt_toolkit import Application
+import pytest
 from prompt_toolkit.keys import Keys
 
 from awscli.autocomplete.main import create_autocompleter
@@ -28,9 +26,8 @@ from awscli.autoprompt.prompttoolkit import (
     PromptToolkitCompleter, PromptToolkitPrompter
 )
 from awscli.autoprompt.history import HistoryDriver
-from awscli.testutils import unittest, mock, FileCreator, cd
-from tests import PromptToolkitApplicationStubber as ApplicationStubber
-from tests import FakeApplicationOutput, FakeApplicationInput
+from awscli.testutils import mock, FileCreator, cd
+from tests import ThreadedAppRunner
 
 
 def _ec2_only_command_table(command_table, **kwargs):
@@ -59,84 +56,73 @@ def _index_has_been_generated(db_connection):
     return any(result.fetchall())
 
 
-class FakeApplication:
-    debug = False
+@pytest.fixture()
+def files():
+    files = FileCreator()
+    yield files
+    files.remove_all()
 
-    def run(self, pre_run):
-        pre_run()
+
+@pytest.fixture(scope='module')
+def model_index():
+    index_filename = 'file::memory:?cache=shared'
+    db_connection = db.DatabaseConnection(index_filename)
+    _generate_index_if_needed(db_connection)
+    yield index_filename
+    db_connection.close()
 
 
-class BasicPromptToolkitTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.test_file_creator = FileCreator()
-        index_filename = 'file::memory:?cache=shared'
-        cls.db_connection = db.DatabaseConnection(index_filename)
-        _generate_index_if_needed(cls.db_connection)
-        cls.cli_parser = parser.CLIParser(model.ModelIndex(index_filename))
-        cls.completion_source = create_autocompleter(
-            index_filename, response_filter=filters.fuzzy_filter)
+@pytest.fixture
+def history_file(files):
+    history = {
+        'version': 1,
+        'commands': [
+            'accessanalyzer update-findings',
+            'ec2 describe-instances',
+            's3 ls'
+        ]
+    }
+    return files.create_file(
+        'prompt_history.json', json.dumps(history))
 
-        history = {
-            'version': 1,
-            'commands': [
-                'accessanalyzer update-findings',
-                'ec2 describe-instances',
-                's3 ls'
-            ]
-        }
-        cls.history_filename = cls.test_file_creator.create_file(
-            'prompt_history.json', json.dumps(history))
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.db_connection.close()
-        cls.test_file_creator.remove_all()
+@pytest.fixture
+def prompter(model_index, history_file, ptk_app_session):
+    cli_parser = parser.CLIParser(model.ModelIndex(model_index))
+    completion_source = create_autocompleter(
+        model_index, response_filter=filters.fuzzy_filter)
+    completer = PromptToolkitCompleter(completion_source)
+    history_driver = HistoryDriver(history_file)
+    driver = create_clidriver()
+    factory = PromptToolkitFactory(completer, history_driver=history_driver)
+    return PromptToolkitPrompter(
+        completion_source=completion_source,
+        driver=driver,
+        factory=factory,
+        cli_parser=cli_parser,
+        output=ptk_app_session.output,
+        app_input=ptk_app_session.input,
+    )
 
-    def setUp(self):
-        self.completer = PromptToolkitCompleter(self.completion_source)
-        self.history_driver = HistoryDriver(self.history_filename)
-        self.driver = create_clidriver()
-        self.factory = PromptToolkitFactory(
-            self.completer,
-            history_driver=self.history_driver
-        )
-        self.prompter = PromptToolkitPrompter(
-            completion_source=self.completion_source,
-            driver=self.driver,
-            factory=self.factory,
-            cli_parser=self.cli_parser,
-            output=FakeApplicationOutput(),
-            app_input=FakeApplicationInput(),
-        )
-        self.prompter.args = []
-        self.prompter.input_buffer = self.factory.create_input_buffer()
-        self.prompter.doc_buffer = self.factory.create_doc_buffer()
-        self.prompter.output_buffer = self.factory.create_output_buffer()
 
-    def create_application(self):
-        layout = self.factory.create_layout()
-        return Application(layout=layout)
+@pytest.fixture
+def app_runner(prompter):
+    return ThreadedAppRunner(
+        app=prompter.app, pre_run=prompter.pre_run)
 
-    def get_current_buffer_assertion(self, buffer_name):
-        return lambda app: self.assertEqual(
-            app.current_buffer.name, buffer_name)
 
-    def get_current_buffer_content_assertion(self, expected_content):
-        return lambda app: self.assertEqual(
-            app.current_buffer.text, expected_content)
+class BasicPromptToolkitTest:
+    def assert_current_buffer(self, app, expected_current_buffer_name):
+        assert app.current_buffer.name == expected_current_buffer_name
 
-    def get_buffer_is_visible_assertion(self, buffer_name):
-        return lambda app: self.assertIn(
-            buffer_name,
-            self.get_all_visible_buffers(app)
-        )
+    def assert_current_buffer_text(self, app, expected):
+        assert app.current_buffer.text == expected
 
-    def get_buffer_not_visible_assertion(self, buffer_name):
-        return lambda app: self.assertNotIn(
-            buffer_name,
-            self.get_all_visible_buffers(app)
-        )
+    def assert_buffer_is_visible(self, app, buffer_name):
+        assert buffer_name in self.get_all_visible_buffers(app)
+
+    def assert_buffer_is_not_visible(self, app, buffer_name):
+        assert buffer_name not in self.get_all_visible_buffers(app)
 
     def get_all_visible_buffers(self, app):
         return [
@@ -146,529 +132,313 @@ class BasicPromptToolkitTest(unittest.TestCase):
         ]
 
 
-class TestPromptToolkitPrompterBuffer(BasicPromptToolkitTest):
+class TestPromptToolkitPrompterBuffer:
     """This set of tests tests that we set the buffer (aka "construction zone")
     correctly. Some of these tests test against specific edge cases that have
     previously been known to produce unexpected behavior.
 
     """
+    @pytest.mark.parametrize(
+        'args,expected_input_buffer_text',
+        [
+            (['ec2', 'fake'], 'ec2 fake'),
+            (['ec2'], 'ec2 '),
+            (['s3', 'mv', '/path/to/file/1', 's3://path/to/file/2'],
+             's3 mv /path/to/file/1 s3://path/to/file/2 '),
+            (['s3', 'ls'], 's3 ls '),
+            (['ec2', 'desc'], 'ec2 desc'),
+            (['s3', 'ls '], 's3 ls '),
+            (['ec2', 'fake', '--output'],
+             'ec2 fake --output '),
+            (['ec2', 'describe-instances', '--output'],
+             'ec2 describe-instances --output '),
+            ([' '], ' '),
+        ]
+    )
+    def test_input_buffer_initialization(
+            self, prompter, args, expected_input_buffer_text):
+        prompter.args = args
+        prompter.pre_run()
+        actual_input_text = prompter.input_buffer.document.text
+        assert actual_input_text == expected_input_buffer_text
 
-    def get_updated_input_buffer_text(self, original_args):
-        self.prompter.args = original_args
-        self.prompter.pre_run()
-        return self.prompter.input_buffer.document.text
-
-    def test_preserve_buffer_text_if_invalid_command_entered(self):
-        original_args = ['ec2', 'fake']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 'ec2 fake')
-
-    def test_dont_reset_buffer_text_if_complete_command_entered(self):
-        original_args = ['ec2']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 'ec2 ')
-
-    def test_dont_reset_buffer_text_if_file_path_entered(self):
-        original_args = ['s3', 'mv', '/path/to/file/1', 's3://path/to/file/2']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 's3 mv /path/to/file/1 s3://path/to/file/2 ')
-
-    def test_add_trailing_space_if_s3_ls_entered(self):
-        original_args = ['s3', 'ls']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 's3 ls ')
-
-    def test_dont_add_trailing_space_if_incomplete_command(self):
-        original_args = ['ec2', 'desc']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 'ec2 desc')
-
-    def test_dont_reset_buffer_text_if_s3_ls_space_entered(self):
-        original_args = ['s3', 'ls ']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 's3 ls ')
-
-    def test_preserve_buffer_text_if_invalid_command_with_option_entered(self):
-        original_args = ['ec2', 'fake', '--output']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 'ec2 fake --output ')
-
-    def test_add_trailing_space_if_valid_command_with_option_entered(self):
-        original_args = ['ec2', 'describe-instances', '--output']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, 'ec2 describe-instances --output ')
-
-    def test_reset_buffer_text_if_empty_aws_command_entered(self):
-        original_args = [' ']
-        buffer_text = self.get_updated_input_buffer_text(original_args)
-        self.assertEqual(buffer_text, ' ')
-
-    def test_handle_args_with_spaces(self):
+    def test_handle_args_with_spaces(self, app_runner, prompter):
         original_args = ['iam', 'create-role', '--description', 'With spaces']
-        prompter = PromptToolkitPrompter(
-            completion_source=self.completion_source, driver=self.driver,
-            app=FakeApplication(), cli_parser=self.cli_parser)
-        prompter.input_buffer = self.factory.create_input_buffer()
-        prompter.doc_buffer = self.factory.create_doc_buffer()
-        prompter.output_buffer = self.factory.create_output_buffer()
-        args = prompter.prompt_for_args(original_args)
-        self.assertEqual(prompter.input_buffer.document.text,
-                         "iam create-role --description 'With spaces' ")
-        self.assertEqual(args, original_args)
+        prompter.args = original_args
+        with app_runner.run_app_in_thread(
+                target=prompter.prompt_for_args, args=(original_args,)) as ctx:
+            assert prompter.input_buffer.document.text == (
+                "iam create-role --description 'With spaces' "
+            )
+        assert ctx.return_value == original_args
 
 
 class TestPromptToolkitDocBuffer(BasicPromptToolkitTest):
-    def get_doc_panel_visibility_assertion(self, is_visible):
-        return lambda app: self.assertEqual(app.show_doc, is_visible)
+    def assert_doc_panel_is_visible(self, app):
+        assert app.show_doc
 
-    def get_doc_panel_cursor_position_assertion(self, expected_row):
-        return lambda app: self.assertEqual(
-            app.layout.get_buffer_by_name(
-                'doc_buffer').document.cursor_position_row,
-            expected_row
-        )
+    def assert_doc_panel_is_not_visible(self, app):
+        assert not app.show_doc
 
-    def get_updated_doc_buffer_text(self, original_args):
-        self.prompter.args = original_args
-        self.prompter.pre_run()
-        return self.prompter.doc_buffer.document.text
+    def assert_doc_panel_cursor_position(self, app, expected_row):
+        assert app.layout.get_buffer_by_name(
+            'doc_buffer').document.cursor_position_row == expected_row
 
-    def test_doc_buffer_not_shown_on_start_and_not_focusable(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_doc_panel_visibility_assertion(is_visible=False)
-        )
-        stubber.add_keypress(
-            Keys.F1,
-            app_assertion=self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_doc_buffer_not_shown_on_start_and_not_focusable(self, app_runner):
+        with app_runner.run_app_in_thread():
+            self.assert_doc_panel_is_not_visible(app_runner.app)
+            app_runner.feed_input(Keys.F1)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
 
-    def test_doc_buffer_shows_hides_on_F3(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_keypress(
-            Keys.F3,
-            app_assertion=self.get_doc_panel_visibility_assertion(
-                is_visible=True
-            )
-        )
-        stubber.add_keypress(
-            Keys.F3,
-            app_assertion=self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_doc_buffer_shows_hides_on_F3(self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F3)
+            self.assert_doc_panel_is_visible(app_runner.app)
+            app_runner.feed_input(Keys.F3)
+            self.assert_doc_panel_is_not_visible(app_runner.app)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
 
-    def test_doc_buffer_gets_and_removes_focus(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_keypress(
-            Keys.F3,
-            app_assertion=self.get_doc_panel_visibility_assertion(
-                is_visible=True
-            )
-        )
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_current_buffer_assertion('doc_buffer')
-        )
-        stubber.add_keypress(
-            'q',
-            app_assertion=self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_doc_buffer_gets_and_removes_focus(self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F3)
+            self.assert_doc_panel_is_visible(app_runner.app)
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'doc_buffer')
+            app_runner.feed_input('q')
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
 
-    def test_doc_buffer_keeps_position_if_content_dont_change(self):
-        original_args = ['ec2', 'describe-instances']
-        self.prompter.args = original_args
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_keypress(Keys.F3)
-        stubber.add_keypress(Keys.F2)
-        # go to the top row
-        stubber.add_keypress(
-            'g',
-            app_assertion=self.get_doc_panel_cursor_position_assertion(
-                expected_row=0
-            )
-        )
-        # go three rows down
-        stubber.add_keypress('j')
-        stubber.add_keypress('j')
-        stubber.add_keypress(
-            'j',
-            app_assertion=self.get_doc_panel_cursor_position_assertion(
-                expected_row=3
-            )
-        )
-        # get back to input
-        stubber.add_keypress('q')
-        # go on enter the rest of the command and  check that cursor in doc
-        # panel remains on the same place
-        for k in ' --instances':
-            stubber.add_keypress(
-                k,
-                app_assertion=self.get_doc_panel_cursor_position_assertion(
-                    expected_row=3
-                )
-            )
-        stubber.run(self.prompter.pre_run)
+    def test_doc_buffer_keeps_position_if_content_dont_change(
+            self, prompter, app_runner):
+        prompter.args = ['ec2', 'describe-instances']
+        with app_runner.run_app_in_thread():
+            # Open the doc panel, focus on it, and go to its top
+            app_runner.feed_input(Keys.F3, Keys.F2, 'g')
+            self.assert_doc_panel_cursor_position(
+                app_runner.app, expected_row=0)
+            # Move three rows down
+            app_runner.feed_input('j', 'j', 'j')
+            self.assert_doc_panel_cursor_position(
+                app_runner.app, expected_row=3)
+            # Focus on the input buffer
+            app_runner.feed_input('q')
+            # Add parameters to the currently inputted command
+            app_runner.feed_input('--instances')
+            # The doc position should not have moved
+            self.assert_doc_panel_cursor_position(
+                app_runner.app, expected_row=3)
 
-    def test_show_general_help_on_empty_input(self):
-        original_args = [' ']
-        buffer_text = self.get_updated_doc_buffer_text(original_args)
-        self.assertIn('AWS Command Line Interface', buffer_text)
-
-    def test_show_general_help_on_incorrect_command(self):
-        original_args = ['fake']
-        buffer_text = self.get_updated_doc_buffer_text(original_args)
-        self.assertIn('AWS Command Line Interface', buffer_text)
-
-    def test_show_command_help_on_command_without_subcommand(self):
-        original_args = ['ec2']
-        buffer_text = self.get_updated_doc_buffer_text(original_args)
-        self.assertIn('Elastic Compute Cloud', buffer_text)
-
-    def test_show_command_help_on_command_with_incorrect_subcommand(self):
-        original_args = ['ec2', 'fake']
-        buffer_text = self.get_updated_doc_buffer_text(original_args)
-        self.assertIn('Elastic Compute Cloud', buffer_text)
-
-    def test_show_subcommand_help_on_command_with_subcommand(self):
-        original_args = ['ec2', 'describe-instances']
-        buffer_text = self.get_updated_doc_buffer_text(original_args)
-        self.assertIn('Describes the specified', buffer_text)
-
-    def test_show_subcommand_help_on_command_with_subcommand_and_option(self):
-        original_args = ['ec2', 'describe-instances', '--instance-ids']
-        buffer_text = self.get_updated_doc_buffer_text(original_args)
-        self.assertIn('Describes the specified', buffer_text)
+    @pytest.mark.parametrize(
+        'args,expected_docs',
+        [
+            ([' '], 'AWS Command Line Interface'),
+            (['fake'], 'AWS Command Line Interface'),
+            (['ec2'], 'Elastic Compute Cloud'),
+            (['ec2', 'fake'], 'Elastic Compute Cloud'),
+            (['ec2', 'describe-instances'], 'Describes the specified'),
+            (['ec2', 'describe-instances', '--instance-ids'],
+             'Describes the specified'),
+        ]
+    )
+    def test_doc_panel_content(self, prompter, args, expected_docs):
+        prompter.args = args
+        prompter.pre_run()
+        assert expected_docs in prompter.doc_buffer.document.text
 
 
 class TestHistoryMode(BasicPromptToolkitTest):
-    def get_history_mode_enabled_assertion(self, is_enabled):
-        return lambda app: self.assertEqual(
-            app.current_buffer.history_mode, is_enabled
-        )
+    def assert_history_mode_is_enabled(self, app):
+        assert app.current_buffer.history_mode
 
-    def get_selected_history_completion_assertion(self, expected_completion):
-        return lambda app: self.assertEqual(
-            app.current_buffer.complete_state.current_completion.text,
-            expected_completion
-        )
+    def assert_history_mode_is_disabled(self, app):
+        assert not app.current_buffer.history_mode
 
-    def test_history_mode_disabled_on_start_and_switched_by_control_R(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_history_mode_enabled_assertion(is_enabled=False)
-        )
-        stubber.add_keypress(
-            Keys.ControlR,
-            app_assertion=self.get_history_mode_enabled_assertion(
-                is_enabled=True
-            )
-        )
-        stubber.add_keypress(
-            Keys.ControlR,
-            app_assertion=self.get_history_mode_enabled_assertion(
-                is_enabled=False
-            )
-        )
-        stubber.run(self.prompter.pre_run)
+    def assert_selected_history_completion(self, app, expected):
+        actual = app.current_buffer.complete_state.current_completion.text
+        assert actual == expected
 
-    def test_choose_and_disable_history_mode_with_enter(self):
-        self.prompter.args = ['s']
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_history_mode_enabled_assertion(is_enabled=False)
-        )
-        stubber.add_keypress(
-            Keys.ControlR,
-            app_assertion=self.get_history_mode_enabled_assertion(
-                is_enabled=True
-            )
-        )
-        # for some reason in this mode first click down chooses the original
-        # input and only the second one gets to the completions
-        stubber.add_keypress(Keys.Down)
-        stubber.add_keypress(
-            Keys.Down,
-            app_assertion=self.get_selected_history_completion_assertion(
-                's3 ls'
-            )
-        )
-        stubber.add_keypress(Keys.Enter)
-        stubber.add_app_assertion(
-            self.get_history_mode_enabled_assertion(is_enabled=False)
-        )
-        stubber.add_app_assertion(
-            self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.add_app_assertion(
-            self.get_current_buffer_content_assertion(expected_content='s3 ls')
-        )
+    def test_history_mode_disabled_on_start_and_switched_by_control_R(
+            self, app_runner):
+        with app_runner.run_app_in_thread():
+            self.assert_history_mode_is_disabled(app_runner.app)
+            app_runner.feed_input(Keys.ControlR)
+            self.assert_history_mode_is_enabled(app_runner.app)
+            app_runner.feed_input(Keys.ControlR)
+            self.assert_history_mode_is_disabled(app_runner.app)
 
-    def test_choose_and_disable_history_mode_with_space(self):
-        self.prompter.args = ['s']
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_history_mode_enabled_assertion(is_enabled=False)
-        )
-        stubber.add_keypress(
-            Keys.ControlR,
-            app_assertion=self.get_history_mode_enabled_assertion(
-                is_enabled=True
-            )
-        )
-        # for some reason in this mode first click down chooses the original
-        # input and only the second one gets to the completions
-        stubber.add_keypress(Keys.Down)
-        stubber.add_keypress(
-            Keys.Down,
-            app_assertion=self.get_selected_history_completion_assertion(
-                's3 ls'
-            )
-        )
-        stubber.add_keypress(' ')
-        stubber.add_app_assertion(
-            self.get_history_mode_enabled_assertion(is_enabled=False)
-        )
-        stubber.add_app_assertion(
-            self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.add_app_assertion(
-            self.get_current_buffer_content_assertion(
-                expected_content='s3 ls ')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_choose_and_disable_history_mode_with_enter(
+            self, app_runner, prompter):
+        prompter.args = ['s3']
+        with app_runner.run_app_in_thread():
+            self.assert_history_mode_is_disabled(app_runner.app)
+            app_runner.feed_input(Keys.ControlR)
+            self.assert_history_mode_is_enabled(app_runner.app)
+            app_runner.feed_input(Keys.Down)
+            self.assert_selected_history_completion(
+                app_runner.app, 's3 ls')
+            app_runner.feed_input(Keys.Enter)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
+            self.assert_current_buffer_text(app_runner.app, 's3 ls')
+
+    def test_choose_and_disable_history_mode_with_space(
+            self, app_runner, prompter):
+        prompter.args = ['s3']
+        with app_runner.run_app_in_thread():
+            self.assert_history_mode_is_disabled(app_runner.app)
+            app_runner.feed_input(Keys.ControlR)
+            self.assert_history_mode_is_enabled(app_runner.app)
+            app_runner.feed_input(Keys.Down)
+            self.assert_selected_history_completion(
+                app_runner.app, 's3 ls')
+            app_runner.feed_input(' ')
+            self.assert_history_mode_is_disabled(app_runner.app)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
+            self.assert_current_buffer_text(app_runner.app, 's3 ls ')
 
 
 class TestCompletions(BasicPromptToolkitTest):
-    def test_service_full_name_shown(self):
-        self.prompter.args = ['e']
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            lambda app: self.assertIn(
-                'Elastic Compute',
-                app.current_buffer.complete_state.completions[
-                    0].display_meta_text
-            )
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_service_full_name_shown(self, app_runner, prompter):
+        prompter.args = ['e']
+        with app_runner.run_app_in_thread():
+            first_completion = app_runner.app.current_buffer.\
+                complete_state.completions[0]
+            assert 'Elastic Compute' in first_completion.display_meta_text
 
-    def test_switch_to_multicolumn_mode(self):
-        self.prompter.args = ['ec2 d']
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_keypress(
-            Keys.F4,
-            app_assertion=lambda app: self.assertTrue(app.multi_column)
-        )
-        stubber.add_keypress(
-            Keys.F4,
-            app_assertion=lambda app: self.assertFalse(app.multi_column)
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_switch_to_multicolumn_mode(self, app_runner, prompter):
+        prompter.args = ['ec2']
+        with app_runner.run_app_in_thread():
+            assert not app_runner.app.multi_column
+            app_runner.feed_input(Keys.F4)
+            assert app_runner.app.multi_column
+            app_runner.feed_input(Keys.F4)
+            assert not app_runner.app.multi_column
 
 
 class TestHelpPanel(BasicPromptToolkitTest):
-    def test_help_panel_disabled_on_start_and_appear_on_F1(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(lambda app: self.assertFalse(app.show_help))
-        stubber.add_keypress(
-            Keys.F1,
-            app_assertion=lambda app: self.assertTrue(app.show_help)
-        )
-        stubber.add_keypress(
-            Keys.F1,
-            app_assertion=lambda app: self.assertFalse(app.show_help)
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_help_panel_disabled_on_start_and_appear_on_F1(
+            self, app_runner, prompter):
+        with app_runner.run_app_in_thread():
+            assert not app_runner.app.show_help
+            app_runner.feed_input(Keys.F1)
+            assert app_runner.app.show_help
+            app_runner.feed_input(Keys.F1)
+            assert not app_runner.app.show_help
 
-    def test_show_correct_help_panel(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_keypress(
-            Keys.F1,
-            app_assertion=self.get_buffer_is_visible_assertion('help_input')
-        )
-        stubber.add_app_assertion(
-            self.get_buffer_not_visible_assertion('help_doc'))
-        stubber.add_keypress(Keys.F3)
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_buffer_is_visible_assertion('help_doc')
-        )
-        stubber.add_app_assertion(
-            self.get_buffer_not_visible_assertion('help_input'))
-        stubber.run(self.prompter.pre_run)
+    def test_show_correct_help_panel(
+            self, app_runner, prompter):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F1)
+            self.assert_buffer_is_visible(app_runner.app, 'help_input')
+            self.assert_buffer_is_not_visible(app_runner.app, 'help_doc')
+            # Open doc panel and focus on it
+            app_runner.feed_input(Keys.F3, Keys.F2)
+            # The help for the doc panel should now be visible instead of
+            # the help for the main input buffer
+            self.assert_buffer_is_visible(app_runner.app, 'help_doc')
+            self.assert_buffer_is_not_visible(app_runner.app, 'help_input')
 
-    def test_toolbar_hides_when_help_panel_visible(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_buffer_is_visible_assertion('toolbar_input'))
-        stubber.add_keypress(
-            Keys.F1,
-            app_assertion=self.get_buffer_not_visible_assertion(
-                'toolbar_input')
-        )
-        stubber.add_app_assertion(
-            self.get_buffer_not_visible_assertion('toolbar_doc'))
-        stubber.run(self.prompter.pre_run)
+    def test_toolbar_hides_when_help_panel_visible(
+            self, app_runner, prompter):
+        with app_runner.run_app_in_thread():
+            self.assert_buffer_is_visible(app_runner.app, 'toolbar_input')
+            app_runner.feed_input(Keys.F1)
+            self.assert_buffer_is_not_visible(app_runner.app, 'toolbar_input')
+            self.assert_buffer_is_not_visible(app_runner.app, 'toolbar_doc')
 
 
 class TestDebugPanel(BasicPromptToolkitTest):
-    def test_debug_panel_not_visible_in_non_debug_mode(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_buffer_not_visible_assertion('debug_buffer'))
-        stubber.run(self.prompter.pre_run)
+    def test_debug_panel_not_visible_in_non_debug_mode(
+            self, app_runner, prompter):
+        with app_runner.run_app_in_thread():
+            self.assert_buffer_is_not_visible(app_runner.app, 'debug_buffer')
 
-    def test_debug_panel_visible_in_debug_mode(self):
-        app = self.prompter.create_application()
-        app.debug = True
-        stubber = ApplicationStubber(app)
-        stubber.add_app_assertion(
-            self.get_buffer_is_visible_assertion('debug_buffer'))
-        stubber.run(self.prompter.pre_run)
+    def test_debug_panel_visible_in_debug_mode(
+            self, app_runner, prompter):
+        prompter.app.debug = True
+        with app_runner.run_app_in_thread():
+            self.assert_buffer_is_visible(app_runner.app, 'debug_buffer')
 
-    def test_open_save_dialog_on_control_s(self):
-        app = self.prompter.create_application()
-        app.debug = True
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(
-            Keys.ControlS,
-            app_assertion=lambda app: self.assertEqual(
-                app.current_buffer.text, 'prompt_debug.log')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_open_save_dialog_on_control_s(
+            self, app_runner, prompter):
+        prompter.app.debug = True
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.ControlS)
+            self.assert_current_buffer_text(app_runner.app, 'prompt_debug.log')
 
-    def test_can_save_log_file(self):
-        app = self.prompter.create_application()
-        app.debug = True
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(Keys.ControlS)
-        stubber.add_keypress(Keys.Enter)
-        log_file_path = self.test_file_creator.full_path('prompt_debug.log')
-        with cd(self.test_file_creator.rootdir):
-            stubber.run(self.prompter.pre_run)
-            self.assertTrue(os.path.exists(log_file_path))
+    def test_can_save_log_file(
+            self, app_runner, prompter, files):
+        prompter.app.debug = True
+        log_file_path = files.full_path('prompt_debug.log')
+        with cd(files.rootdir):
+            with app_runner.run_app_in_thread():
+                app_runner.feed_input(Keys.ControlS)
+                app_runner.feed_input(Keys.Enter)
+        assert os.path.exists(log_file_path)
 
-    def test_can_switch_focus_between_panels(self):
-        app = self.prompter.create_application()
-        app.debug = True
-        stubber = ApplicationStubber(app)
-        stubber.add_app_assertion(
-            self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F2,
-            self.get_current_buffer_assertion('debug_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F2,
-            self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_can_switch_focus_between_panels(
+            self, app_runner, prompter):
+        prompter.app.debug = True
+        with app_runner.run_app_in_thread():
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'debug_buffer')
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
 
     @mock.patch('awscrt.io.init_logging')
-    def test_debug_mode_does_not_allow_crt_logging(self, mock_init_logging):
-        app = FakeApplication()
-        prompter = PromptToolkitPrompter(
-            completion_source=self.completion_source, driver=self.driver,
-            app=app, cli_parser=self.cli_parser)
-        prompter.input_buffer = self.factory.create_input_buffer()
-        prompter.doc_buffer = self.factory.create_doc_buffer()
-        prompter.output_buffer = self.factory.create_output_buffer()
-        with contextlib.redirect_stderr(io.StringIO()):
-            prompter.prompt_for_args(['ec2', 'describe-instances', '--debug'])
-        self.assertTrue(app.debug)
+    def test_debug_mode_does_not_allow_crt_logging(
+            self, mock_init_logging, app_runner, prompter):
+        args = ['ec2', 'describe-instances', '--debug']
+        with app_runner.run_app_in_thread(
+                target=prompter.prompt_for_args, args=(args,)):
+            assert app_runner.app.debug
         mock_init_logging.assert_called_with(
             awscrt.io.LogLevel.NoLogs, 'stderr'
         )
 
 
 class TestOutputPanel(BasicPromptToolkitTest):
-    def test_output_panel_not_visible_on_start(self):
-        stubber = ApplicationStubber(self.prompter.create_application())
-        stubber.add_app_assertion(
-            self.get_buffer_not_visible_assertion('output_buffer'))
-        stubber.run(self.prompter.pre_run)
+    def test_output_panel_not_visible_on_start(self, app_runner):
+        with app_runner.run_app_in_thread():
+            self.assert_buffer_is_not_visible(app_runner.app, 'output_buffer')
 
-    def test_output_panel_switches_on_F5(self):
-        app = self.prompter.create_application()
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(
-            Keys.F5,
-            app_assertion=self.get_buffer_is_visible_assertion(
-                'output_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F5,
-            app_assertion=self.get_buffer_not_visible_assertion(
-                'output_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_output_panel_switches_on_F5(self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F5)
+            self.assert_buffer_is_visible(app_runner.app, 'output_buffer')
+            app_runner.feed_input(Keys.F5)
+            self.assert_buffer_is_not_visible(app_runner.app, 'output_buffer')
 
-    def test_output_panel_and_doc_panel_can_be_visible_together(self):
-        app = self.prompter.create_application()
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(
-            Keys.F5,
-            app_assertion=self.get_buffer_is_visible_assertion('output_buffer')
-        )
-        stubber.add_app_assertion(
-            self.get_buffer_not_visible_assertion('doc_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F3,
-            app_assertion=self.get_buffer_is_visible_assertion('doc_buffer'))
-        stubber.add_app_assertion(
-            self.get_buffer_is_visible_assertion('doc_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_output_panel_and_doc_panel_can_be_visible_together(
+            self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F5)
+            self.assert_buffer_is_visible(app_runner.app, 'output_buffer')
+            self.assert_buffer_is_not_visible(app_runner.app, 'doc_buffer')
+            app_runner.feed_input(Keys.F3)
+            self.assert_buffer_is_visible(app_runner.app, 'doc_buffer')
+            self.assert_buffer_is_visible(app_runner.app, 'output_buffer')
 
-    def test_can_switch_focus_between_panels(self):
-        app = self.prompter.create_application()
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(Keys.F5)
-        stubber.add_keypress(Keys.F3)
-        stubber.add_app_assertion(
-            self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_current_buffer_assertion('doc_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_current_buffer_assertion('output_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_can_switch_focus_between_panels(self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F5, Keys.F3)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'doc_buffer')
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'output_buffer')
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
 
-    def test_can_quit_output_panel(self):
-        app = self.prompter.create_application()
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(Keys.F5)
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_current_buffer_assertion('output_buffer')
-        )
-        stubber.add_keypress(
-            'q',
-            app_assertion=self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_can_quit_output_panel(self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F5, Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'output_buffer')
+            app_runner.feed_input('q')
+            self.assert_current_buffer(app_runner.app, 'input_buffer')
 
-    def test_return_focus_on_input_buffer(self):
-        app = self.prompter.create_application()
-        stubber = ApplicationStubber(app)
-        stubber.add_keypress(Keys.F5)
-        stubber.add_keypress(
-            Keys.F2,
-            app_assertion=self.get_current_buffer_assertion('output_buffer')
-        )
-        stubber.add_keypress(
-            Keys.F5,
-            app_assertion=self.get_current_buffer_assertion('input_buffer')
-        )
-        stubber.run(self.prompter.pre_run)
+    def test_return_focus_on_input_buffer(self, app_runner):
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F5, Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'output_buffer')
+            app_runner.feed_input(Keys.F5)
+            self.assert_current_buffer(app_runner.app, 'input_buffer')

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -19,7 +19,7 @@ from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import walk
 import pytest
 
-from tests import ThreadedAppRunner
+from tests import PromptToolkitAppRunner
 from awscli.customizations.wizard.factory import create_wizard_app
 from awscli.customizations.wizard.app import (
     WizardAppRunner, WizardTraverser, WizardValues, FileIO
@@ -74,7 +74,7 @@ def make_stubbed_wizard_runner(ptk_app_session, mock_botocore_session):
             app_input=ptk_app_session.input,
         )
         ptk_app_session.app = app
-        return ThreadedAppRunner(app=app)
+        return PromptToolkitAppRunner(app=app)
     yield _make_stubbed_wizard_runner
 
 

--- a/tests/unit/customizations/wizard/test_app.py
+++ b/tests/unit/customizations/wizard/test_app.py
@@ -10,21 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from io import BytesIO, TextIOWrapper
 from awscli.testutils import unittest, mock
 
 from botocore.session import Session
 from prompt_toolkit.application import Application
 from prompt_toolkit.completion import PathCompleter, Completion
-from prompt_toolkit.eventloop import Future
-from prompt_toolkit.input.defaults import create_pipe_input
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.layout import walk
+import pytest
 
-from tests import (
-    PromptToolkitApplicationStubber as ApplicationStubber,
-    FakeApplicationOutput, FakeApplicationInput
-)
+from tests import ThreadedAppRunner
 from awscli.customizations.wizard.factory import create_wizard_app
 from awscli.customizations.wizard.app import (
     WizardAppRunner, WizardTraverser, WizardValues, FileIO
@@ -36,12 +31,482 @@ from awscli.customizations.wizard.exceptions import (
 from awscli.customizations.wizard.core import BaseStep, Executor
 
 
+@pytest.fixture
+def mock_botocore_session():
+    return mock.Mock(spec=Session)
+
+
+@pytest.fixture
+def mock_iam_client(mock_botocore_session):
+    mock_client = mock.Mock()
+    mock_botocore_session.create_client.return_value = mock_client
+    mock_client.list_policies.return_value = {
+        'Policies': [
+            {
+                'PolicyName': 'policy1',
+                'Arn': 'policy1_arn'
+            },
+            {
+                'PolicyName': 'policy2',
+                'Arn': 'policy2_arn'
+            }
+        ]
+    }
+    mock_client.get_policy.return_value = {
+        'Policy': {'DefaultVersionId': 'policy_id'}
+    }
+    mock_client.get_policy_version.return_value = {
+        'PolicyVersion': {'Document': {'policy': 'policy_document'}}
+    }
+    mock_client.create_role.return_value = {
+        'Role': {'Arn': 'returned-role-arn'}
+    }
+    return mock_client
+
+
+@pytest.fixture
+def make_stubbed_wizard_runner(ptk_app_session, mock_botocore_session):
+    def _make_stubbed_wizard_runner(definition):
+        app = create_wizard_app(
+            definition=definition,
+            session=mock_botocore_session,
+            output=ptk_app_session.output,
+            app_input=ptk_app_session.input,
+        )
+        ptk_app_session.app = app
+        return ThreadedAppRunner(app=app)
+    yield _make_stubbed_wizard_runner
+
+
+@pytest.fixture
+def patch_path_completer():
+    with mock.patch(
+            'awscli.customizations.wizard.ui.prompt.PathCompleter',
+            FakePathCompleter) as completer:
+        yield completer
+
+
+class FakePathCompleter(PathCompleter):
+    def get_completions(self, document, complete_event):
+        prefix_len = len(document.text)
+        yield from [
+            Completion('file1'[prefix_len:], 0, display='file1'),
+            Completion('file2'[prefix_len:], 0, display='file2'),
+        ]
+
+
+@pytest.fixture
+def empty_definition():
+    return {
+        'title': 'Wizard title',
+        'plan': {
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def basic_definition():
+    return {
+        'title': 'Basic Wizard',
+        'plan': {
+            'first_section': {
+                'shortname': 'First',
+                'values': {
+                    'prompt1': {
+                        'description': 'Description of first prompt',
+                        'type': 'prompt'
+                    },
+                    'prompt2': {
+                        'description': 'Description of second prompt',
+                        'type': 'prompt',
+                        'default_value': 'foo'
+                    },
+                }
+            },
+            'second_section': {
+                'shortname': 'Second',
+                'values': {
+                    'second_section_prompt': {
+                        'description': 'Description of prompt',
+                        'type': 'prompt'
+                    },
+                    'template_section': {
+                        'type': 'template',
+                        'value': 'some text',
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {},
+        '__OUTPUT__': {'value': 'output: {template_section}'}
+    }
+
+
+@pytest.fixture
+def conditional_definition():
+    return {
+        'title': 'Conditional wizard',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'before_conditional': {
+                        'description': 'Description of first prompt',
+                        'type': 'prompt'
+                    },
+                    'conditional': {
+                        'description': 'Description of second prompt',
+                        'type': 'prompt',
+                        'condition': {
+                            'variable': 'before_conditional',
+                            'equals': 'condition-met'
+                        }
+                    },
+                    'after_conditional': {
+                        'description': 'Description of second prompt',
+                        'type': 'prompt',
+                    },
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def choices_definition():
+    return {
+        'title': 'Conditional wizard',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'choices_prompt': {
+                        'description': 'Description of first prompt',
+                        'type': 'prompt',
+                        'choices': [
+                            {
+                                'display': 'Option 1',
+                                'actual_value': 'actual_option_1'
+                            },
+                            {
+                                'display': 'Option 2',
+                                'actual_value': 'actual_option_2'
+                            }
+                        ]
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def corrupted_choice_definition():
+    return {
+        'title': 'Conditional wizard',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'choices_prompt': {
+                        'description': 'Description of first prompt',
+                        'type': 'prompt',
+                        'choices': 'corrupted_choice'
+                    },
+                    'corrupted_choice': {
+                        'description': 'Description of first prompt',
+                        'type': 'apicall',
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def mixed_prompt_definition():
+    return {
+        'title': 'Wizard with both buffer inputs and select inputs',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'buffer_input_prompt': {
+                        'description': 'Type answer',
+                        'type': 'prompt',
+                    },
+                    'select_prompt': {
+                        'description': 'Select answer',
+                        'type': 'prompt',
+                        'choices': [
+                            'select_answer_1',
+                            'select_answer_2'
+                        ]
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def data_convert_definition():
+    return {
+        'title': 'Wizard with both buffer inputs and select inputs',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'buffer_input_int': {
+                        'description': 'Type answer',
+                        'type': 'prompt',
+                        'datatype': 'int'
+                    },
+                    'buffer_input_bool': {
+                        'description': 'Type answer',
+                        'type': 'prompt',
+                        'datatype': 'bool'
+                    },
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def api_call_definition():
+    return {
+        'title': 'Uses API call in prompting stage',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'existing_policies': {
+                        'type': 'apicall',
+                        'operation': 'iam.ListPolicies',
+                        'params': {},
+                        'query': (
+                            'sort_by(Policies[].{display: PolicyName, '
+                            'actual_value: Arn}, &display)'
+                        )
+                    },
+                    'choose_policy': {
+                        'description': 'Choose policy',
+                        'type': 'prompt',
+                        'choices': 'existing_policies'
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def details_definition():
+    return {
+        'title': 'Show details in prompting stage',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'version_id': {
+                        'type': 'apicall',
+                        'operation': 'iam.GetPolicy',
+                        'params': {
+                            'PolicyArn': '{policy_arn}'
+                        },
+                        'query': 'Policy.DefaultVersionId',
+                        'cache': True
+                    },
+                    'policy_document': {
+                        'type': 'apicall',
+                        'operation': 'iam.GetPolicyVersion',
+                        'params': {
+                            'PolicyArn': '{policy_arn}',
+                            'VersionId': '{version_id}'
+                        },
+                        'query': 'PolicyVersion.Document',
+                        'cache': True
+                    },
+                    'existing_policies': {
+                        'type': 'apicall',
+                        'operation': 'iam.ListPolicies',
+                        'params': {},
+                        'query': (
+                            'sort_by(Policies[].{display: PolicyName, '
+                            'actual_value: Arn}, &display)'
+                        )
+                    },
+                    'policy_arn': {
+                        'description': 'Choose policy',
+                        'type': 'prompt',
+                        'choices': 'existing_policies',
+                        'details': {
+                            'value': 'policy_document',
+                            'description': 'Policy Document',
+                            'output': 'json'
+                        },
+                    },
+                    'some_prompt': {
+                        'description': 'Choose something',
+                        'type': 'prompt',
+                        'choices': [1, 2, 3],
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
+@pytest.fixture
+def preview_definition():
+    return {
+        'title': 'Show details in prompting stage',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'option1': {
+                        'type': 'template',
+                        'value': "First option details"
+                    },
+                    'option2': {
+                        'type': 'template',
+                        'value': "Second option details"
+                    },
+                    'some_prompt': {
+                        'description': 'Choose something',
+                        'type': 'prompt',
+                        'choices': [{
+                            'display': '1', 'actual_value': '2'
+                        }],
+                    },
+                    'choose_option': {
+                        'description': 'Choose option',
+                        'type': 'prompt',
+                        'choices': [
+                            {'display': 'Option 1',
+                             'actual_value': 'option1'},
+                            {'display': 'Option 2',
+                             'actual_value': 'option2'},
+                        ],
+                        'details': {
+                            'visible': True,
+                            'value': '__selected_choice__',
+                            'description': 'Option details',
+                        },
+                    },
+                }
+            },
+            '__DONE__': {},
+        }
+    }
+
+
+@pytest.fixture
+def shared_config_definition():
+    return {
+        'title': 'Uses shared config API in prompting stage',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'existing_profiles': {
+                        'type': 'sharedconfig',
+                        'operation': 'ListProfiles',
+                    },
+                    'choose_profile': {
+                        'description': 'Choose profile',
+                        'type': 'prompt',
+                        'choices': 'existing_profiles'
+                    }
+                }
+            },
+            '__DONE__': {},
+        }
+    }
+
+
+@pytest.fixture
+def run_wizard_definition():
+    return {
+        'title': 'For running execute step',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'role_name': {
+                        'type': 'prompt',
+                        'description': 'Enter role name'
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {
+            'default': [
+                {
+                    'type': 'apicall',
+                    'operation': 'iam.CreateRole',
+                    'params': {
+                        'RoleName': "{role_name}"
+                    },
+                    'output_var': 'role_arn',
+                    'query': 'Role.Arn',
+                }
+
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def file_prompt_definition():
+    return {
+        'title': 'Uses API call in prompting stage',
+        'plan': {
+            'section': {
+                'shortname': 'Section',
+                'values': {
+                    'choose_file': {
+                        'description': 'Choose file',
+                        'type': 'prompt',
+                        'completer': 'file_completer'
+                    },
+                    'second_prompt': {
+                        'description': 'Second prompt',
+                        'type': 'prompt',
+                    }
+                }
+            },
+            '__DONE__': {},
+        },
+        'execute': {}
+    }
+
+
 class TestWizardAppRunner(unittest.TestCase):
     def setUp(self):
         self.session = mock.Mock(Session)
         self.app_factory = mock.Mock(create_wizard_app)
         self.app = mock.Mock(Application)
-        self.app.future = mock.Mock(Future)
         self.app.traverser = mock.Mock(WizardTraverser)
         self.app_factory.return_value = self.app
         self.definition = {}
@@ -52,111 +517,61 @@ class TestWizardAppRunner(unittest.TestCase):
     def test_run_calls_expected_app_interfaces(self):
         self.runner.run(self.definition)
         self.app.run.assert_called_with()
-        self.app.future.result.assert_called_with()
         self.app.traverser.get_output.assert_called_with()
 
-    def test_run_propagates_error_from_app_future(self):
+    def test_run_propagates_error_from_app_run(self):
         expected_exception = KeyboardInterrupt
-        self.app.future.result.side_effect = KeyboardInterrupt
+        self.app.run.side_effect = KeyboardInterrupt
         with self.assertRaises(expected_exception):
             self.runner.run(self.definition)
 
 
-class BaseWizardApplicationTest(unittest.TestCase):
-    def setUp(self):
-        self.definition = self.get_definition()
-        self.session = mock.Mock(spec=Session)
-        self.app = create_wizard_app(
-            self.definition, self.session, FakeApplicationOutput(),
-            app_input=FakeApplicationInput()
-        )
-        self.stubbed_app = ApplicationStubber(self.app)
+class BaseWizardApplicationTest:
+    def assert_app_values(self, app, **expected_values):
+        assert dict(app.values) == expected_values
 
-    def get_definition(self):
-        return {
-            'title': 'Wizard title',
-            'plan': {
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
+    def assert_buffer_text(self, app, buffer_name, expected_text):
+        buffer = app.layout.get_buffer_by_name(buffer_name)
+        assert buffer.document.text == expected_text
 
-    def add_answer_submission(self, answer):
-        self.stubbed_app.add_text_to_current_buffer(answer)
-        self.stubbed_app.add_keypress(Keys.Enter)
+    def assert_current_buffer(self, app, buffer_name):
+        assert app.layout.current_buffer.name, buffer_name
 
-    def add_app_values_assertion(self, **expected_values):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(dict(app.values), expected_values)
-        )
+    def assert_expected_buffer_completions(
+            self, app, buffer_name, expected_completions):
+        buffer = app.layout.get_buffer_by_name(buffer_name)
+        assert buffer.complete_state.completions == expected_completions
 
-    def add_buffer_text_assertion(self, buffer_name, text):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(
-                app.layout.get_buffer_by_name(buffer_name).document.text,
-                text)
-        )
+    def assert_prompt_is_visible(self, app, prompt_name):
+        assert prompt_name in self.get_visible_buffers(app)
 
-    def add_current_buffer_assertion(self, buffer_name):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(
-                app.layout.current_buffer.name, buffer_name)
+    def assert_prompt_is_not_visible(self, app, prompt_name):
+        assert prompt_name not in self.get_visible_buffers(app)
+
+    def assert_run_wizard_dialog_is_visible(self, app):
+        dialog_container = app.layout.run_wizard_dialog.container
+        assert dialog_container in self.get_visible_containers(app)
+
+    def assert_run_wizard_dialog_is_not_visible(self, app):
+        dialog_container = app.layout.run_wizard_dialog.container
+        assert dialog_container not in self.get_visible_containers(app)
+
+    def assert_toolbar_has_text(self, app, text):
+        assert any(
+            [text in tip[1]
+             for tip in list(filter(
+                lambda x: getattr(x, 'name', '') == 'toolbar_panel',
+                app.layout.find_all_controls())
+            )[0].text()()]
         )
 
-    def add_buffer_completions_assertion(self, buffer_name, completions):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(
-                app.layout.get_buffer_by_name(
-                    buffer_name).complete_state.completions,
-                completions)
-        )
-
-    def add_prompt_is_visible_assertion(self, name):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertIn(name, self.get_visible_buffers(app))
-        )
-
-    def add_prompt_is_not_visible_assertion(self, name):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertNotIn(name, self.get_visible_buffers(app))
-        )
-
-    def add_run_wizard_dialog_is_visible(self):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertIn(
-                app.layout.run_wizard_dialog.container,
-                self.get_visible_containers(app)
-            )
-        )
-
-    def add_run_wizard_dialog_is_not_visible(self):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertNotIn(
-                app.layout.run_wizard_dialog.container,
-                self.get_visible_containers(app)
-            )
-        )
-
-    def add_toolbar_has_text_assertion(self, text):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertTrue(any(
-                [text in tip[1]
-                 for tip in list(filter(
-                    lambda x: getattr(x, 'name', '') == 'toolbar_panel',
-                    app.layout.find_all_controls())
-                 )[0].text()()]
-            ))
-        )
-
-    def add_toolbar_has_not_text_assertion(self, text):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertFalse(any(
-                [text in tip[1]
-                 for tip in list(filter(
-                    lambda x: getattr(x, 'name', '') == 'toolbar_panel',
-                    app.layout.find_all_controls())
-                 )[0].text()()]
-            ))
+    def assert_toolbar_does_not_have_text(self, app, text):
+        assert not any(
+            [text in tip[1]
+             for tip in list(filter(
+                lambda x: getattr(x, 'name', '') == 'toolbar_panel',
+                app.layout.find_all_controls())
+            )[0].text()()]
         )
 
     def get_visible_buffers(self, app):
@@ -171,859 +586,533 @@ class BaseWizardApplicationTest(unittest.TestCase):
 
 
 class TestBasicWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Basic Wizard',
-            'plan': {
-                'first_section': {
-                    'shortname': 'First',
-                    'values': {
-                        'prompt1': {
-                            'description': 'Description of first prompt',
-                            'type': 'prompt'
-                        },
-                        'prompt2': {
-                            'description': 'Description of second prompt',
-                            'type': 'prompt',
-                            'default_value': 'foo'
-                        },
-                    }
-                },
-                'second_section': {
-                    'shortname': 'Second',
-                    'values': {
-                        'second_section_prompt': {
-                            'description': 'Description of prompt',
-                            'type': 'prompt'
-                        },
-                        'template_section': {
-                            'type': 'template',
-                            'value': 'some text',
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {},
-            '__OUTPUT__': {'value': 'output: {template_section}'}
-        }
+    def test_can_answer_single_prompt(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('val1\n')
+            self.assert_app_values(app_runner.app, prompt1='val1')
 
-    def test_can_answer_single_prompt(self):
-        self.stubbed_app.add_text_to_current_buffer('val1')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(prompt1='val1')
-        self.stubbed_app.run()
+    def test_can_answer_multiple_prompts(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('val1\n')
+            # This is to remove the default answer of foo for prompt 2
+            app_runner.feed_input(
+                Keys.Backspace, Keys.Backspace, Keys.Backspace)
+            app_runner.feed_input('val2\n')
+            self.assert_app_values(
+                app_runner.app, prompt1='val1', prompt2='val2')
 
-    def test_can_answer_multiple_prompts(self):
-        self.stubbed_app.add_text_to_current_buffer('val1')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.stubbed_app.add_text_to_current_buffer('val2')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(prompt1='val1', prompt2='val2')
-        self.stubbed_app.run()
+    def test_can_use_tab_to_submit_answer(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('val1')
+            app_runner.feed_input(Keys.Tab)
+            self.assert_app_values(app_runner.app, prompt1='val1')
 
-    def test_can_use_tab_to_submit_answer(self):
-        self.stubbed_app.add_text_to_current_buffer('val1')
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.add_app_values_assertion(prompt1='val1')
-        self.stubbed_app.run()
+    def test_can_use_prompt_default_value(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Tab)
+            app_runner.feed_input(Keys.Tab)
+            self.assert_app_values(app_runner.app, prompt1='', prompt2='foo')
 
-    def test_can_use_prompt_default_value(self):
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.add_app_values_assertion(prompt1='', prompt2='foo')
-        self.stubbed_app.run()
+    def test_can_use_shift_tab_to_toggle_backwards_and_change_answer(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('1\n')
+            app_runner.feed_input(Keys.BackTab)
+            app_runner.feed_input(Keys.Backspace)
+            app_runner.feed_input('override1\n')
+            self.assert_app_values(
+                app_runner.app, prompt1='override1', prompt2='foo')
 
-    def test_can_use_shift_tab_to_toggle_backwards_and_change_answer(self):
-        self.add_answer_submission('orig1')
-        self.stubbed_app.add_keypress(Keys.BackTab)
-        self.add_answer_submission('override1')
-        self.add_app_values_assertion(prompt1='override1', prompt2='foo')
-        self.stubbed_app.run()
+    def test_can_answer_prompts_across_sections(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('val1\n')
+            app_runner.feed_input('\n')
+            app_runner.feed_input('second_section_val1\n')
+            self.assert_app_values(
+                app_runner.app, prompt1='val1', prompt2='foo',
+                second_section_prompt='second_section_val1'
+            )
 
-    def test_can_answer_prompts_across_sections(self):
-        self.add_answer_submission('val1')
-        self.add_answer_submission('val2')
-        self.add_answer_submission('second_section_val1')
-        self.add_app_values_assertion(
-            prompt1='val1', prompt2='val2',
-            second_section_prompt='second_section_val1'
-        )
-        self.stubbed_app.run()
+    def test_can_move_back_to_a_prompt_in_previous_section(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('val1\n')
+            app_runner.feed_input('\n')
+            app_runner.feed_input('second_section_val1\n')
+            # At DONE step, hit back tab to select "Go back" button
+            # and enter to select that button.
+            app_runner.feed_input(Keys.BackTab, Keys.Enter)
+            app_runner.feed_input(Keys.BackTab)
+            # This is to remove the default answer of foo for prompt 2
+            app_runner.feed_input(
+                Keys.Backspace, Keys.Backspace, Keys.Backspace)
+            app_runner.feed_input('override2\n')
+            self.assert_app_values(
+                app_runner.app, prompt1='val1', prompt2='override2',
+                second_section_prompt='second_section_val1'
+            )
 
-    def test_can_move_back_to_a_prompt_in_previous_section(self):
-        self.add_answer_submission('val1')
-        self.add_answer_submission('val2')
-        self.add_answer_submission('second_section_val1')
-        self.stubbed_app.add_keypress(Keys.BackTab)  # At DONE step
-        self.stubbed_app.add_keypress(Keys.BackTab)
-        self.add_answer_submission('override2')
-        self.add_app_values_assertion(
-            prompt1='val1', prompt2='override2',
-            second_section_prompt='second_section_val1'
-        )
-        self.stubbed_app.run()
+    def test_prompts_are_not_visible_across_sections(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            self.assert_prompt_is_visible(app_runner.app, 'prompt1')
+            self.assert_prompt_is_visible(app_runner.app, 'prompt2')
+            self.assert_prompt_is_not_visible(
+                app_runner.app, 'second_section_prompt')
 
-    def test_prompts_are_not_visible_across_sections(self):
-        self.add_prompt_is_visible_assertion('prompt1')
-        self.add_prompt_is_visible_assertion('prompt2')
-        self.add_prompt_is_not_visible_assertion('second_section_prompt')
+            app_runner.feed_input('val1\n')
+            app_runner.feed_input('val2\n')
 
-        self.add_answer_submission('val1')
-        self.add_answer_submission('val2')
+            self.assert_prompt_is_not_visible(app_runner.app, 'prompt1')
+            self.assert_prompt_is_not_visible(app_runner.app, 'prompt2')
+            self.assert_prompt_is_visible(
+                app_runner.app, 'second_section_prompt')
 
-        self.add_prompt_is_not_visible_assertion('prompt1')
-        self.add_prompt_is_not_visible_assertion('prompt2')
-        self.add_prompt_is_visible_assertion('second_section_prompt')
-        self.stubbed_app.run()
+    def test_run_wizard_dialog_appears_only_at_end_of_wizard(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
 
-    def test_run_wizard_dialog_appears_only_at_end_of_wizard(self):
-        self.add_run_wizard_dialog_is_not_visible()
-        self.add_answer_submission('val1')
-        self.add_run_wizard_dialog_is_not_visible()
-        self.add_answer_submission('val2')
-        self.add_run_wizard_dialog_is_not_visible()
-        self.add_answer_submission('second_section_val1')
-        self.add_run_wizard_dialog_is_visible()
-        self.stubbed_app.run()
+        with app_runner.run_app_in_thread():
+            self.assert_run_wizard_dialog_is_not_visible(app_runner.app)
+            app_runner.feed_input('val1\n')
+            self.assert_run_wizard_dialog_is_not_visible(app_runner.app)
+            app_runner.feed_input('val2\n')
+            self.assert_run_wizard_dialog_is_not_visible(app_runner.app)
+            app_runner.feed_input('second_section_val1\n')
+            self.assert_run_wizard_dialog_is_visible(app_runner.app)
 
-    def test_enter_at_wizard_dialog_exits_app_with_zero_rc(self):
-        self.add_answer_submission('val1')
-        self.add_answer_submission('val2')
-        self.add_answer_submission('second_section_val1')
-        self.add_run_wizard_dialog_is_visible()
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.stubbed_app.run()
-        self.assertEqual(self.app.future.result(), 0)
+    def test_enter_at_wizard_dialog_exits_app_with_zero_rc(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread() as ctx:
+            app_runner.feed_input('val1\n')
+            app_runner.feed_input('val2\n')
+            app_runner.feed_input('second_section_val1\n')
+            self.assert_run_wizard_dialog_is_visible(app_runner.app)
+            app_runner.feed_input(Keys.Enter)
+        assert ctx.return_value == 0
 
-    def test_can_go_back_from_run_wizard_dialog(self):
-        self.add_answer_submission('val1')
-        self.add_answer_submission('val2')
-        self.add_answer_submission('second_section_val1')
-        self.add_run_wizard_dialog_is_visible()
-        self.stubbed_app.add_keypress(Keys.Right)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_answer_submission('override_second_section_val1')
-        self.add_app_values_assertion(
-            prompt1='val1', prompt2='val2',
-            second_section_prompt='override_second_section_val1'
-        )
-        self.stubbed_app.run()
+    def test_can_go_back_from_run_wizard_dialog(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('val1\n')
+            app_runner.feed_input('\n')
+            app_runner.feed_input('second_section_val1\n')
+            self.assert_run_wizard_dialog_is_visible(app_runner.app)
+            app_runner.feed_input(Keys.Right, Keys.Enter)
+            app_runner.feed_input('_override\n')
+            self.assert_app_values(
+                app_runner.app, prompt1='val1', prompt2='foo',
+                second_section_prompt='second_section_val1_override'
+            )
 
-    def test_traverser_get_output(self):
-        self.assertEqual('output: some text',
-                         self.app.traverser.get_output())
+    def test_traverser_get_output(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        assert app_runner.app.traverser.get_output() == 'output: some text'
 
-    def test_can_exit_and_propagate_ctrl_c_from_wizard(self):
-        self.stubbed_app.add_keypress(Keys.ControlC)
-        with self.assertRaises(KeyboardInterrupt):
-            self.stubbed_app.run()
-            self.app.future.result()
+    def test_can_exit_and_propagate_ctrl_c_from_wizard(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread() as ctx:
+            app_runner.feed_input(Keys.ControlC)
+        assert isinstance(ctx.raised_exception, KeyboardInterrupt)
 
-    def test_captures_unexpected_errors_when_processing_input(self):
+    def test_captures_unexpected_errors_when_processing_input(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
         unexpected_error = ValueError('Not expected')
 
-        @self.app.key_bindings.add('a')
+        @app_runner.app.key_bindings.add('a')
         def trigger_unexpected_error(event):
             raise unexpected_error
 
-        self.app.output.stdout = TextIOWrapper(BytesIO(), encoding="utf-8")
+        with app_runner.run_app_in_thread() as ctx:
+            app_runner.feed_input('a')
+        assert isinstance(ctx.raised_exception, UnexpectedWizardException)
+        assert ctx.raised_exception.original_exception is unexpected_error
 
-        pipe_input = create_pipe_input()
-        captured_exception = None
-        try:
-            pipe_input.send_text('a')
-            self.app.input = pipe_input
-            self.app.run()
-        except UnexpectedWizardException as e:
-            captured_exception = e
-        finally:
-            pipe_input.close()
-        self.assertIsInstance(captured_exception, UnexpectedWizardException)
-        self.assertIs(captured_exception.original_exception, unexpected_error)
-
-    def test_cant_open_save_panel_if_no_details_available(self):
-        self.stubbed_app.add_keypress(
-            Keys.ControlS,
-            lambda app: self.assertNotIn(
-                'save_details_dialogue', self.get_visible_buffers(app))
-        )
-        self.stubbed_app.run()
+    def test_cant_open_save_panel_if_no_details_available(
+            self, make_stubbed_wizard_runner, basic_definition):
+        app_runner = make_stubbed_wizard_runner(basic_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.ControlS)
+            assert 'save_details_dialogue' not in self.get_visible_buffers(
+                app_runner.app)
 
 
 class TestConditionalWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Conditional wizard',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'before_conditional': {
-                            'description': 'Description of first prompt',
-                            'type': 'prompt'
-                        },
-                        'conditional': {
-                            'description': 'Description of second prompt',
-                            'type': 'prompt',
-                            'condition': {
-                                'variable': 'before_conditional',
-                                'equals': 'condition-met'
-                            }
-                        },
-                        'after_conditional': {
-                            'description': 'Description of second prompt',
-                            'type': 'prompt',
-                        },
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
+    def test_conditional_prompt_is_skipped_when_condition_not_met(
+            self, make_stubbed_wizard_runner, conditional_definition):
+        app_runner = make_stubbed_wizard_runner(conditional_definition)
+        with app_runner.run_app_in_thread():
+            self.assert_prompt_is_not_visible(app_runner.app, 'conditional')
+            app_runner.feed_input('condition-not-met\n')
+            self.assert_prompt_is_not_visible(app_runner.app, 'conditional')
+            app_runner.feed_input('after-conditional-val\n')
+            self.assert_app_values(
+                app_runner.app, before_conditional='condition-not-met',
+                after_conditional='after-conditional-val',
+            )
 
-    def test_conditional_prompt_is_skipped_when_condition_not_met(self):
-        self.add_prompt_is_not_visible_assertion('conditional')
-        self.add_answer_submission('condition-not-met')
-        self.add_prompt_is_not_visible_assertion('conditional')
-        self.add_answer_submission('after-conditional-val')
-        self.add_app_values_assertion(
-            before_conditional='condition-not-met',
-            after_conditional='after-conditional-val',
-        )
-        self.stubbed_app.run()
-
-    def test_conditional_prompt_appears_when_condition_met(self):
-        self.add_prompt_is_not_visible_assertion('conditional')
-        self.add_answer_submission('condition-met')
-        self.add_prompt_is_visible_assertion('conditional')
-        self.add_answer_submission('val-at-conditional')
-        self.add_app_values_assertion(
-            before_conditional='condition-met',
-            conditional='val-at-conditional',
-        )
-        self.stubbed_app.run()
+    def test_conditional_prompt_appears_when_condition_met(
+            self, make_stubbed_wizard_runner, conditional_definition):
+        app_runner = make_stubbed_wizard_runner(conditional_definition)
+        with app_runner.run_app_in_thread():
+            self.assert_prompt_is_not_visible(app_runner.app, 'conditional')
+            app_runner.feed_input('condition-met\n')
+            self.assert_prompt_is_visible(app_runner.app, 'conditional')
+            app_runner.feed_input('val-at-conditional\n')
+            self.assert_app_values(
+                app_runner.app, before_conditional='condition-met',
+                conditional='val-at-conditional',
+            )
 
 
 class TestChoicesWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Conditional wizard',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'choices_prompt': {
-                            'description': 'Description of first prompt',
-                            'type': 'prompt',
-                            'choices': [
-                                {
-                                    'display': 'Option 1',
-                                    'actual_value': 'actual_option_1'
-                                },
-                                {
-                                    'display': 'Option 2',
-                                    'actual_value': 'actual_option_2'
-                                }
-                            ]
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
+    def test_immediately_pressing_enter_selects_first_choice(
+            self, make_stubbed_wizard_runner, choices_definition):
+        app_runner = make_stubbed_wizard_runner(choices_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Enter)
+            self.assert_app_values(
+                app_runner.app, choices_prompt='actual_option_1')
 
-    def test_immediately_pressing_enter_selects_first_choice(self):
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(choices_prompt='actual_option_1')
-        self.stubbed_app.run()
-
-    def test_can_select_choice_in_prompt(self):
-        self.stubbed_app.add_keypress(Keys.Down)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(choices_prompt='actual_option_2')
-        self.stubbed_app.run()
+    def test_can_select_choice_in_prompt(
+            self, make_stubbed_wizard_runner, choices_definition):
+        app_runner = make_stubbed_wizard_runner(choices_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Down, Keys.Enter)
+            self.assert_app_values(
+                app_runner.app, choices_prompt='actual_option_2')
 
 
 class TestCorruptedChoicesWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Conditional wizard',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'choices_prompt': {
-                            'description': 'Description of first prompt',
-                            'type': 'prompt',
-                            'choices': 'corrupted_choice'
-                        },
-                        'corrupted_choice': {
-                            'description': 'Description of first prompt',
-                            'type': 'apicall',
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
+    def test_can_handle_corrupted_choices(
+            self, make_stubbed_wizard_runner, corrupted_choice_definition):
+        app_runner = make_stubbed_wizard_runner(corrupted_choice_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Down, Keys.Enter)
+            self.assert_app_values(
+                app_runner.app, choices_prompt=None)
 
-    def test_can_handle_corrupted_choices(self):
-        self.stubbed_app.add_keypress(Keys.Down)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(choices_prompt=None)
-        self.stubbed_app.run()
+    def test_show_error_message_on_get_value_exception(
+            self, make_stubbed_wizard_runner, corrupted_choice_definition):
+        app_runner = make_stubbed_wizard_runner(corrupted_choice_definition)
+        with app_runner.run_app_in_thread():
+            self.assert_buffer_text(
+                app_runner.app,
+                'error_bar',
+                'Encountered following error in wizard:\n\n\'operation\''
+            )
 
-    def test_show_error_message_on_get_value_exception(self):
-        self.add_buffer_text_assertion(
-            'error_bar',
-            'Encountered following error in wizard:\n\n\'operation\''
-        )
-        self.stubbed_app.run()
-
-    def test_toolbar_text_on_get_value_exception(self):
-        self.add_toolbar_has_text_assertion('error message')
-        self.stubbed_app.run()
+    def test_toolbar_text_on_get_value_exception(
+            self, make_stubbed_wizard_runner, corrupted_choice_definition):
+        app_runner = make_stubbed_wizard_runner(corrupted_choice_definition)
+        with app_runner.run_app_in_thread():
+            self.assert_toolbar_has_text(app_runner.app, 'error message')
 
 
 class TestMixedPromptTypeWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Wizard with both buffer inputs and select inputs',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'buffer_input_prompt': {
-                            'description': 'Type answer',
-                            'type': 'prompt',
-                        },
-                        'select_prompt': {
-                            'description': 'Select answer',
-                            'type': 'prompt',
-                            'choices': [
-                                'select_answer_1',
-                                'select_answer_2'
-                            ]
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
-
-    def test_can_answer_buffer_prompt_followed_by_select_prompt(self):
-        self.add_answer_submission('buffer_answer')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(
-            buffer_input_prompt='buffer_answer',
-            select_prompt='select_answer_1'
-        )
-        self.stubbed_app.run()
+    def test_can_answer_buffer_prompt_followed_by_select_prompt(
+            self, make_stubbed_wizard_runner, mixed_prompt_definition):
+        app_runner = make_stubbed_wizard_runner(mixed_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('buffer_answer\n')
+            app_runner.feed_input(Keys.Enter)
+            self.assert_app_values(
+                app_runner.app, buffer_input_prompt='buffer_answer',
+                select_prompt='select_answer_1'
+            )
 
 
 class TestPromptWithDataConvertWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Wizard with both buffer inputs and select inputs',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'buffer_input_int': {
-                            'description': 'Type answer',
-                            'type': 'prompt',
-                            'datatype': 'int'
-                        },
-                        'buffer_input_bool': {
-                            'description': 'Type answer',
-                            'type': 'prompt',
-                            'datatype': 'bool'
-                        },
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
+    def test_can_convert_integers(
+            self, make_stubbed_wizard_runner, data_convert_definition):
+        app_runner = make_stubbed_wizard_runner(data_convert_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('100\n')
+            self.assert_app_values(app_runner.app, buffer_input_int=100)
 
-    def test_can_convert_integers(self):
-        self.add_answer_submission('100')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(
-            buffer_input_int=100,
-            buffer_input_bool=False
-        )
-        self.stubbed_app.run()
+    def test_can_convert_bool(
+            self, make_stubbed_wizard_runner, data_convert_definition):
+        app_runner = make_stubbed_wizard_runner(data_convert_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('0\n')
+            app_runner.feed_input('true\n')
+            self.assert_app_values(
+                app_runner.app, buffer_input_int=0, buffer_input_bool=True
+            )
 
-    def test_can_convert_bool(self):
-        self.add_answer_submission('0')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_answer_submission('true')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(
-            buffer_input_int=100,
-            buffer_input_bool=True
-        )
-        self.stubbed_app.run()
+    def test_show_error_and_stop_on_incorrect_input(
+            self, make_stubbed_wizard_runner, data_convert_definition):
+        app_runner = make_stubbed_wizard_runner(data_convert_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('foo\n')
+            self.assert_buffer_text(
+                app_runner.app,
+                'error_bar',
+                'Encountered following error in wizard:\n\n'
+                'Invalid value foo for datatype int'
+            )
+            self.assert_current_buffer(app_runner.app, 'buffer_input_int')
 
-    def test_show_error_and_stop_on_incorrect_input(self):
-        self.add_answer_submission('foo')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_buffer_text_assertion(
-            'error_bar',
-            'Encountered following error in wizard:\n\n'
-            'Invalid value foo for datatype int'
-        )
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(
-                app.layout.current_buffer.name, 'buffer_input_int')
-        )
-        self.stubbed_app.run()
-
-    def test_clear_error_and_go_on_after_correction(self):
-        self.add_answer_submission('foo')
-        self.add_buffer_text_assertion(
-            'error_bar',
-            'Encountered following error in wizard:\n\n'
-            'Invalid value foo for datatype int'
-        )
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(
-                app.layout.current_buffer.name, 'buffer_input_int')
-        )
-        self.add_answer_submission('100')
-        self.add_buffer_text_assertion('error_bar', '')
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(
-                app.layout.current_buffer.name, 'buffer_input_bool')
-        )
-        self.stubbed_app.run()
+    def test_clear_error_and_go_on_after_correction(
+            self, make_stubbed_wizard_runner, data_convert_definition):
+        app_runner = make_stubbed_wizard_runner(data_convert_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('foo\n')
+            self.assert_buffer_text(
+                app_runner.app,
+                'error_bar',
+                'Encountered following error in wizard:\n\n'
+                'Invalid value foo for datatype int'
+            )
+            self.assert_current_buffer(app_runner.app, 'buffer_input_int')
+            app_runner.feed_input(
+                Keys.Backspace, Keys.Backspace, Keys.Backspace)
+            app_runner.feed_input('100\n')
+            self.assert_buffer_text(
+                app_runner.app, 'error_bar', ''
+            )
+            self.assert_current_buffer(app_runner.app, 'buffer_input_bool')
 
 
 class TestApiCallWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Uses API call in prompting stage',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'existing_policies': {
-                            'type': 'apicall',
-                            'operation': 'iam.ListPolicies',
-                            'params': {},
-                            'query': (
-                                'sort_by(Policies[].{display: PolicyName, '
-                                'actual_value: Arn}, &display)'
-                            )
-                        },
-                        'choose_policy': {
-                            'description': 'Choose policy',
-                            'type': 'prompt',
-                            'choices': 'existing_policies'
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
-
-    def test_uses_choices_from_api_call(self):
-        mock_client = mock.Mock()
-        self.session.create_client.return_value = mock_client
-        mock_client.list_policies.return_value = {
-            'Policies': [
-                {
-                    'PolicyName': 'policy1',
-                    'Arn': 'policy1_arn'
-                },
-                {
-                    'PolicyName': 'policy2',
-                    'Arn': 'policy2_arn'
-                }
-            ]
-        }
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(choose_policy='policy1_arn')
-        self.stubbed_app.run()
+    def test_uses_choices_from_api_call(
+            self, make_stubbed_wizard_runner, api_call_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(api_call_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Enter)
+            self.assert_app_values(app_runner.app, choose_policy='policy1_arn')
 
 
 class TestDetailsWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Show details in prompting stage',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'version_id': {
-                            'type': 'apicall',
-                            'operation': 'iam.GetPolicy',
-                            'params': {
-                                'PolicyArn': '{policy_arn}'
-                            },
-                            'query': 'Policy.DefaultVersionId',
-                            'cache': True
-                        },
-                        'policy_document': {
-                            'type': 'apicall',
-                            'operation': 'iam.GetPolicyVersion',
-                            'params': {
-                                'PolicyArn': '{policy_arn}',
-                                'VersionId': '{version_id}'
-                            },
-                            'query': 'PolicyVersion.Document',
-                            'cache': True
-                        },
-                        'existing_policies': {
-                            'type': 'apicall',
-                            'operation': 'iam.ListPolicies',
-                            'params': {},
-                            'query': (
-                                'sort_by(Policies[].{display: PolicyName, '
-                                'actual_value: Arn}, &display)'
-                            )
-                        },
-                        'policy_arn': {
-                            'description': 'Choose policy',
-                            'type': 'prompt',
-                            'choices': 'existing_policies',
-                            'details': {
-                                'value': 'policy_document',
-                                'description': 'Policy Document',
-                                'output': 'json'
-                            },
-                        },
-                        'some_prompt': {
-                            'description': 'Choose something',
-                            'type': 'prompt',
-                            'choices': [1, 2, 3],
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
-
-    def setUp(self):
-        super(TestDetailsWizardApplication, self).setUp()
-        self.mock_client = mock.Mock()
-        self.session.create_client.return_value = self.mock_client
-        self.mock_client.list_policies.return_value = {
-            'Policies': [
-                {
-                    'PolicyName': 'policy1',
-                    'Arn': 'policy1_arn'
-                },
-                {
-                    'PolicyName': 'policy2',
-                    'Arn': 'policy2_arn'
-                }
-            ]
-        }
-        self.mock_client.get_policy.return_value = {
-            'Policy': {'DefaultVersionId': 'policy_id'}
-        }
-        self.mock_client.get_policy_version.return_value = {
-            'PolicyVersion': {'Document': {'policy': 'policy_document'}}
-        }
-
-    def test_get_details_for_choice(self):
-        self.stubbed_app.add_keypress(Keys.F3)
-        self.add_buffer_text_assertion(
-            'details_buffer',
-            '{\n    "policy": "policy_document"\n}'
-        )
-        self.stubbed_app.run()
-
-    def test_details_disabled_for_choice_wo_details(self):
-        self.add_prompt_is_visible_assertion('toolbar_details')
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.add_prompt_is_not_visible_assertion('toolbar_details')
-        self.stubbed_app.add_keypress(Keys.F3)
-        self.add_prompt_is_not_visible_assertion('details_buffer')
-
-    def test_can_switch_focus_to_details_panel(self):
-        self.stubbed_app.add_keypress(Keys.F3)
-        self.stubbed_app.add_keypress(
-            Keys.F2,
-            lambda app: self.assertEqual(
-                app.layout.current_buffer.name, 'details_buffer')
-        )
-        self.stubbed_app.add_keypress(
-            Keys.F3,
-            lambda app: self.assertIsNone(app.layout.current_buffer)
-        )
-        self.stubbed_app.run()
-
-    def test_can_toggle_save_panel(self):
-        self.stubbed_app.add_keypress(
-            Keys.ControlS,
-            lambda app: self.assertEqual(
-                app.layout.current_buffer.name, 'save_details_dialogue'
+    def test_get_details_for_choice(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F3)
+            self.assert_buffer_text(
+                app_runner.app,
+                'details_buffer',
+                '{\n    "policy": "policy_document"\n}'
             )
-        )
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertIn(
-                'save_details_dialogue', self.get_visible_buffers(app))
-        )
-        # The details panel will automatically be visible when
-        # Ctrl-S is pressed.
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertTrue(app.details_visible)
-        )
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertTrue(app.save_details_visible)
-        )
-        self.stubbed_app.run()
 
-    def test_can_not_switch_focus_to_details_panel_if_it_not_visible(self):
-        self.stubbed_app.add_keypress(
-            Keys.F2,
-            lambda app: self.assertIsNone(app.layout.current_buffer)
-        )
-        self.stubbed_app.run()
+    def test_details_disabled_for_choice_wo_details(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Tab)
+            self.assert_prompt_is_not_visible(
+                app_runner.app, 'toolbar_details')
+            app_runner.feed_input(Keys.F3)
+            self.assert_prompt_is_not_visible(app_runner.app, 'details_buffer')
 
-    def test_can_set_details_panel_title(self):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertEqual(app.details_title, 'Policy Document')
-        )
-        self.stubbed_app.add_keypress(
-            Keys.F3,
-            lambda app: self.assertEqual(app.details_title, 'Policy Document')
-        )
-        self.stubbed_app.run()
+    def test_can_switch_focus_to_details_panel(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F3)
+            app_runner.feed_input(Keys.F2)
+            self.assert_current_buffer(app_runner.app, 'details_buffer')
+            app_runner.feed_input(Keys.F3)
+            assert app_runner.app.layout.current_buffer is None
 
-    def test_can_set_details_toolbar_text(self):
-        self.add_toolbar_has_text_assertion('Policy Document')
-        self.stubbed_app.run()
+    def test_can_toggle_save_panel(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.ControlS)
+            self.assert_current_buffer(app_runner.app, 'save_details_dialogue')
+            self.assert_prompt_is_visible(
+                app_runner.app, 'save_details_dialogue')
+            assert app_runner.app.details_visible
+            assert app_runner.app.save_details_visible
+
+    def test_can_not_switch_focus_to_details_panel_if_it_not_visible(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F2)
+            assert app_runner.app.layout.current_buffer is None
+
+    def test_can_set_details_panel_title(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            assert app_runner.app.details_title == 'Policy Document'
+            app_runner.feed_input(Keys.F3)
+            assert app_runner.app.details_title == 'Policy Document'
+
+    def test_can_set_details_toolbar_text(
+            self, make_stubbed_wizard_runner, details_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(details_definition)
+        with app_runner.run_app_in_thread():
+            self.assert_toolbar_has_text(app_runner.app, 'Policy Document')
 
 
 class TestPreviewWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Show details in prompting stage',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'option1': {
-                            'type': 'template',
-                            'value': "First option details"
-                        },
-                        'option2': {
-                            'type': 'template',
-                            'value': "Second option details"
-                        },
-                        'some_prompt': {
-                            'description': 'Choose something',
-                            'type': 'prompt',
-                            'choices': [{
-                                'display': '1', 'actual_value': '2'
-                            }],
-                        },
-                        'choose_option': {
-                            'description': 'Choose option',
-                            'type': 'prompt',
-                            'choices': [
-                                {'display': 'Option 1',
-                                 'actual_value': 'option1'},
-                                {'display': 'Option 2',
-                                 'actual_value': 'option2'},
-                            ],
-                            'details': {
-                                'visible': True,
-                                'value': '__selected_choice__',
-                                'description': 'Option details',
-                            },
-                        },
-                    }
-                },
-                '__DONE__': {},
-            }
-        }
+    def test_details_panel_visible_by_default(
+            self, make_stubbed_wizard_runner, preview_definition):
+        app_runner = make_stubbed_wizard_runner(preview_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Tab)
+            self.assert_prompt_is_visible(app_runner.app, 'details_buffer')
 
-    def test_details_panel_visible_by_default(self):
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.add_prompt_is_visible_assertion('details_buffer')
-        self.stubbed_app.run()
+    def test_get_details_for_choice(
+            self, make_stubbed_wizard_runner, preview_definition):
+        app_runner = make_stubbed_wizard_runner(preview_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Tab)
+            self.assert_buffer_text(
+                app_runner.app,
+                'details_buffer',
+                'First option details'
+            )
 
-    def test_get_details_for_choice(self):
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.add_buffer_text_assertion(
-            'details_buffer',
-            'First option details'
-        )
-        self.stubbed_app.run()
-
-    def test_get_details_for_second_choice(self):
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.stubbed_app.add_keypress(Keys.Down)
-        self.add_buffer_text_assertion(
-            'details_buffer',
-            'Second option details'
-        )
-        self.stubbed_app.run()
+    def test_get_details_for_second_choice(
+            self, make_stubbed_wizard_runner, preview_definition):
+        app_runner = make_stubbed_wizard_runner(preview_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Tab)
+            app_runner.feed_input(Keys.Down)
+            self.assert_buffer_text(
+                app_runner.app,
+                'details_buffer',
+                'Second option details'
+            )
 
 
 class TestSharedConfigWizardApplication(BaseWizardApplicationTest):
-    def get_definition(self):
-        return {
-            'title': 'Uses shared config API in prompting stage',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'existing_profiles': {
-                            'type': 'sharedconfig',
-                            'operation': 'ListProfiles',
-                        },
-                        'choose_profile': {
-                            'description': 'Choose profile',
-                            'type': 'prompt',
-                            'choices': 'existing_profiles'
-                        }
-                    }
-                },
-                '__DONE__': {},
-            }
-        }
-
-    def test_uses_choices_from_api_call(self):
-        self.session.available_profiles = ['profile1', 'profile2']
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_app_values_assertion(choose_profile='profile1')
-        self.stubbed_app.run()
+    def test_uses_choices_from_api_call(
+            self, make_stubbed_wizard_runner, shared_config_definition,
+            mock_botocore_session):
+        mock_botocore_session.available_profiles = ['profile1', 'profile2']
+        app_runner = make_stubbed_wizard_runner(shared_config_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.Enter)
+            self.assert_app_values(app_runner.app, choose_profile='profile1')
 
 
 class TestRunWizardApplication(BaseWizardApplicationTest):
-    def setUp(self):
-        super().setUp()
-        self.client = mock.Mock()
-        self.session.create_client.return_value = self.client
-        self.role_arn = 'returned-role-arn'
-        self.create_role_response = {
-            'Role': {
-                'Arn': self.role_arn
-            }
-        }
+    def assert_error_bar_is_visible(self, app):
+        assert 'error_bar' in self.get_visible_buffers(app)
 
-    def get_definition(self):
-        return {
-            'title': 'For running execute step',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'role_name': {
-                            'type': 'prompt',
-                            'description': 'Enter role name'
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {
-                'default': [
-                    {
-                        'type': 'apicall',
-                        'operation': 'iam.CreateRole',
-                        'params': {
-                            'RoleName': "{role_name}"
-                        },
-                        'output_var': 'role_arn',
-                        'query': 'Role.Arn',
-                    }
+    def assert_error_bar_is_not_visible(self, app):
+        assert 'error_bar' not in self.get_visible_buffers(app)
 
-                ]
-            }
-        }
+    def test_run_wizard_execute(
+            self, make_stubbed_wizard_runner, run_wizard_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(run_wizard_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('role-name\n')
+            app_runner.feed_input(Keys.Enter)
+        mock_iam_client.create_role.assert_called_with(RoleName='role-name')
+        assert app_runner.app.values['role_arn'] == 'returned-role-arn'
 
-    def add_error_bar_is_not_visible_assertion(self):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertNotIn(
-                'error_bar', self.get_visible_buffers(app))
-        )
+    def test_run_wizard_captures_and_displays_errors(
+            self, make_stubbed_wizard_runner, run_wizard_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(run_wizard_definition)
+        mock_iam_client.create_role.side_effect = Exception(
+            'Error creating role')
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('role-name\n')
+            app_runner.feed_input(Keys.Enter)
+            self.assert_buffer_text(
+                app_runner.app,
+                'error_bar',
+                'Encountered following error in wizard:\n\nError creating role'
+            )
 
-    def add_error_bar_is_visible_assertion(self):
-        self.stubbed_app.add_app_assertion(
-            lambda app: self.assertIn(
-                'error_bar', self.get_visible_buffers(app))
-        )
-
-    def test_run_wizard_execute(self):
-        self.client.create_role.return_value = self.create_role_response
-        self.add_answer_submission('role-name')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.stubbed_app.run()
-        self.client.create_role.assert_called_with(RoleName='role-name')
-        self.assertEqual(self.app.values['role_arn'], self.role_arn)
-
-    def test_run_wizard_captures_and_displays_errors(self):
-        self.client.create_role.side_effect = Exception('Error creating role')
-        self.add_answer_submission('role-name')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_buffer_text_assertion(
-            'error_bar',
-            'Encountered following error in wizard:\n\nError creating role'
-        )
-        self.stubbed_app.run()
-
-    def test_can_change_answers_on_run_wizard_failure(self):
-        self.client.create_role.side_effect = [
+    def test_can_change_answers_on_run_wizard_failure(
+            self, make_stubbed_wizard_runner, run_wizard_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(run_wizard_definition)
+        mock_iam_client.create_role.side_effect = [
             Exception('Initial error'),
-            self.create_role_response
+            mock_iam_client.create_role.return_value,
         ]
-        self.add_answer_submission('role-name')
-        self.add_error_bar_is_not_visible_assertion()
-        self.add_run_wizard_dialog_is_visible()
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_buffer_text_assertion(
-            'error_bar',
-            'Encountered following error in wizard:\n\nInitial error'
-        )
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('role-name\n')
+            self.assert_error_bar_is_not_visible(app_runner.app)
+            self.assert_run_wizard_dialog_is_visible(app_runner.app)
+            app_runner.feed_input(Keys.Enter)
+            self.assert_buffer_text(
+                app_runner.app,
+                'error_bar',
+                'Encountered following error in wizard:\n\nInitial error'
+            )
 
-        # Make sure dialog closed on error but error message is still visible
-        self.add_run_wizard_dialog_is_not_visible()
-        self.add_error_bar_is_visible_assertion()
-        self.add_answer_submission('new-role-name')
+            # Make sure dialog closed on error but error message is visible
+            self.assert_run_wizard_dialog_is_not_visible(app_runner.app)
+            self.assert_error_bar_is_visible(app_runner.app)
+            app_runner.feed_input('-new\n')
 
-        # Make sure we select "Yes" button in dialog
-        self.stubbed_app.add_keypress(Keys.Left)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.stubbed_app.run()
-        self.client.create_role.assert_called_with(RoleName='new-role-name')
-        self.assertEqual(self.app.values['role_arn'], self.role_arn)
+            # Enter "Yes" to the done dialog again
+            app_runner.feed_input(Keys.Enter)
 
-    def test_can_switch_exception_panel(self):
-        self.client.create_role.side_effect = [
+        mock_iam_client.create_role.assert_called_with(
+            RoleName='role-name-new')
+        assert app_runner.app.values['role_arn'] == 'returned-role-arn'
+
+    def test_can_switch_exception_panel(
+            self, make_stubbed_wizard_runner, run_wizard_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(run_wizard_definition)
+        mock_iam_client.create_role.side_effect = [
             Exception('Initial error'),
-            self.create_role_response
+            mock_iam_client.create_role.return_value,
         ]
-        self.add_answer_submission('role-name')
-        self.add_error_bar_is_not_visible_assertion()
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_error_bar_is_visible_assertion()
-        self.stubbed_app.add_keypress(Keys.F2)
-        self.add_error_bar_is_not_visible_assertion()
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('role-name\n')
+            self.assert_error_bar_is_not_visible(app_runner.app)
+            app_runner.feed_input(Keys.Enter)
+            self.assert_error_bar_is_visible(app_runner.app)
+            app_runner.feed_input(Keys.F4)
+            self.assert_error_bar_is_not_visible(app_runner.app)
 
-    def test_toolbar_has_exception_panel_hot_key(self):
-        self.client.create_role.side_effect = [
+    def test_toolbar_has_exception_panel_hot_key(
+            self, make_stubbed_wizard_runner, run_wizard_definition,
+            mock_iam_client):
+        app_runner = make_stubbed_wizard_runner(run_wizard_definition)
+        mock_iam_client.create_role.side_effect = [
             Exception('Initial error'),
-            self.create_role_response
+            mock_iam_client.create_role.return_value,
         ]
-        self.add_answer_submission('role-name')
-        self.add_error_bar_is_not_visible_assertion()
-        self.add_toolbar_has_not_text_assertion('error message')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_error_bar_is_visible_assertion()
-        self.add_toolbar_has_text_assertion('error message')
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('role-name\n')
+            self.assert_error_bar_is_not_visible(app_runner.app)
+            self.assert_toolbar_does_not_have_text(
+                app_runner.app, 'error message')
+            app_runner.feed_input(Keys.Enter)
+            self.assert_error_bar_is_visible(app_runner.app)
+            self.assert_toolbar_has_text(
+                app_runner.app, 'error message')
 
 
 class TestWizardTraverser(unittest.TestCase):
@@ -1575,116 +1664,75 @@ class TestWizardValues(unittest.TestCase):
         self.exception_handler.assert_called_with(e)
 
 
-class FakePathCompleter(PathCompleter):
-    def get_completions(self, document, complete_event):
-        prefix_len = len(document.text)
-
-        yield from [
-            Completion('file1'[prefix_len:], 0, display='file1'),
-            Completion('file2'[prefix_len:], 0, display='file2'),
-        ]
-
-
 class TestPromptCompletionWizardApplication(BaseWizardApplicationTest):
-    def setUp(self):
-        self.patch = mock.patch(
-            'awscli.customizations.wizard.ui.prompt.PathCompleter',
-            FakePathCompleter)
-        self.patch.start()
-        super().setUp()
+    def test_show_completions_for_buffer_text(
+            self, make_stubbed_wizard_runner, file_prompt_definition,
+            patch_path_completer):
+        app_runner = make_stubbed_wizard_runner(file_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('fi')
+            self.assert_expected_buffer_completions(
+                app_runner.app,
+                'choose_file',
+                [
+                    Completion('le1', 0, display='file1'),
+                    Completion('le2', 0, display='file2'),
+                ]
+            )
 
-    def tearDown(self):
-        super().tearDown()
-        self.patch.stop()
+    def test_choose_completion_on_Enter_and_stays_on_the_same_prompt(
+            self, make_stubbed_wizard_runner, file_prompt_definition,
+            patch_path_completer):
+        app_runner = make_stubbed_wizard_runner(file_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('fi')
+            app_runner.feed_input(Keys.Down, Keys.Enter)
+            self.assert_buffer_text(app_runner.app, 'choose_file', 'file1')
+            self.assert_current_buffer(app_runner.app, 'choose_file')
 
-    def get_definition(self):
-        return {
-            'title': 'Uses API call in prompting stage',
-            'plan': {
-                'section': {
-                    'shortname': 'Section',
-                    'values': {
-                        'choose_file': {
-                            'description': 'Choose file',
-                            'type': 'prompt',
-                            'completer': 'file_completer'
-                        },
-                        'second_prompt': {
-                            'description': 'Second prompt',
-                            'type': 'prompt',
-                        }
-                    }
-                },
-                '__DONE__': {},
-            },
-            'execute': {}
-        }
+    def test_choose_completion_on_Enter_and_move_on_second_Enter(
+            self, make_stubbed_wizard_runner, file_prompt_definition,
+            patch_path_completer):
+        app_runner = make_stubbed_wizard_runner(file_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('fi')
+            app_runner.feed_input(Keys.Down, Keys.Enter)
+            app_runner.feed_input(Keys.Enter)
+            self.assert_current_buffer(app_runner.app, 'second_prompt')
 
-    def test_show_completions_for_buffer_text(self):
-        self.stubbed_app.add_text_to_current_buffer('fi')
-        self.stubbed_app.start_completion_for_current_buffer()
-        self.add_buffer_completions_assertion('choose_file',
-            [
-                Completion('le1', 0, display='file1'),
-                Completion('le2', 0, display='file2'),
-            ]
-        )
-        self.stubbed_app.run()
+    def test_switch_completions_on_tab(
+            self, make_stubbed_wizard_runner, file_prompt_definition,
+            patch_path_completer):
+        app_runner = make_stubbed_wizard_runner(file_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('fi')
+            app_runner.feed_input(Keys.Tab, Keys.Tab, Keys.Enter)
+            self.assert_buffer_text(app_runner.app, 'choose_file', 'file2')
+            self.assert_current_buffer(app_runner.app, 'choose_file')
 
-    def test_choose_completion_on_Enter_and_stays_on_the_same_prompt(self):
-        self.stubbed_app.add_text_to_current_buffer('fi')
-        self.stubbed_app.start_completion_for_current_buffer()
-        self.stubbed_app.add_keypress(Keys.Down)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_buffer_text_assertion('choose_file', 'file1')
-        self.add_current_buffer_assertion('choose_file')
-        self.stubbed_app.run()
+    def test_switch_completions_on_back_tab(
+            self, make_stubbed_wizard_runner, file_prompt_definition,
+            patch_path_completer):
+        app_runner = make_stubbed_wizard_runner(file_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('fi')
+            app_runner.feed_input(Keys.Tab, Keys.Tab, Keys.BackTab, Keys.Enter)
+            self.assert_buffer_text(app_runner.app, 'choose_file', 'file1')
+            self.assert_current_buffer(app_runner.app, 'choose_file')
 
-    def test_choose_completion_on_Enter_and_move_on_second_Enter(self):
-        self.stubbed_app.add_text_to_current_buffer('fi')
-        self.stubbed_app.start_completion_for_current_buffer()
-        self.stubbed_app.add_keypress(Keys.Down)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_current_buffer_assertion('second_prompt')
-        self.stubbed_app.run()
-
-    def test_switch_completions_on_tab(self):
-        self.stubbed_app.add_text_to_current_buffer('fi')
-        self.stubbed_app.start_completion_for_current_buffer()
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_buffer_text_assertion('choose_file', 'file2')
-        self.add_current_buffer_assertion('choose_file')
-        self.stubbed_app.run()
-
-    def test_switch_completions_on_back_tab(self):
-        self.stubbed_app.add_text_to_current_buffer('fi')
-        self.stubbed_app.start_completion_for_current_buffer()
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.stubbed_app.add_keypress(Keys.BackTab)
-        self.stubbed_app.add_keypress(Keys.Enter)
-        self.add_buffer_text_assertion('choose_file', 'file1')
-        self.add_current_buffer_assertion('choose_file')
-        self.stubbed_app.run()
-
-    def test_switch_prompt_on_tab_if_it_is_not_completing(self):
-        self.stubbed_app.add_text_to_current_buffer('rrrr')
-        self.stubbed_app.add_keypress(Keys.Tab)
-        self.add_current_buffer_assertion('second_prompt')
-        self.stubbed_app.run()
+    def test_switch_prompt_on_tab_if_it_is_not_completing(
+            self, make_stubbed_wizard_runner, file_prompt_definition,
+            patch_path_completer):
+        app_runner = make_stubbed_wizard_runner(file_prompt_definition)
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input('rrrr')
+            app_runner.feed_input(Keys.Tab)
+            self.assert_current_buffer(app_runner.app, 'second_prompt')
 
 
 class TestSaveDetailsWizard(BaseWizardApplicationTest):
-    def setUp(self):
-        super(TestSaveDetailsWizard, self).setUp()
-        self.mock_file_io = mock.Mock(spec=FileIO)
-        self.app.file_io = self.mock_file_io
-
-    def get_definition(self):
-        return {
+    def test_file_saved_to_disk(self, make_stubbed_wizard_runner):
+        definition = {
             'title': 'Show details in prompting stage',
             'plan': {
                 'section': {
@@ -1706,23 +1754,19 @@ class TestSaveDetailsWizard(BaseWizardApplicationTest):
             },
             'execute': {}
         }
-
-    def test_file_saved_to_disk(self):
-        self.app.values['test_value'] = {'foo': 'bar'}
-        self.stubbed_app.add_keypress(Keys.F3)
-        details_contents = '{\n    "foo": "bar"\n}'
-        self.add_buffer_text_assertion(
-            'details_buffer',
-            details_contents,
-        )
-        self.stubbed_app.add_keypress(Keys.ControlS)
-        self.stubbed_app.add_text_to_current_buffer('/tmp/myfile.json')
-        self.stubbed_app.add_keypress(Keys.Enter)
-        # We should switch back to the control associated with
-        # the current prompt.
-        self.stubbed_app.add_app_assertion(
-            lambda app: app.layout.current_control.buffer.name
-        )
-        self.stubbed_app.run()
-        self.mock_file_io.write_file_contents.assert_called_with(
-            '/tmp/myfile.json', details_contents)
+        app_runner = make_stubbed_wizard_runner(definition)
+        mock_file_io = mock.Mock(spec=FileIO)
+        app_runner.app.file_io = mock_file_io
+        app_runner.app.values['test_value'] = {'foo': 'bar'}
+        details_content = '{\n    "foo": "bar"\n}'
+        with app_runner.run_app_in_thread():
+            app_runner.feed_input(Keys.F3)
+            self.assert_buffer_text(
+                app_runner.app,
+                'details_buffer',
+                details_content
+            )
+            app_runner.feed_input(Keys.ControlS)
+            app_runner.feed_input('/tmp/myfile.json\n')
+            mock_file_io.write_file_contents.assert_called_with(
+                '/tmp/myfile.json', details_content)


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/6507

The main difference is that PTK3 uses the built-in Python asyncio event loop. This required a large refactor of the test scaffolding as some of the synchronous assumptions were no longer valid. With regards to refactoring, I pivoted it to spinning up the application in a thread and then feed input keys to the app and make assertions on it while the app was running. This was also cleaner in that we did not have to add actions and assertions to a queue to be processed and instead can just make the assertion/action directly.
