### PR TITLE
[v2] Copy env vars when injecting fake creds for botocore memory leak test

### DIFF
--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -160,10 +160,10 @@ class BaseClientDriverTest(unittest.TestCase):
 
     def setUp(self):
         self.driver = ClientDriver()
-        env = None
+        env = os.environ.copy()
         if self.INJECT_DUMMY_CREDS:
-            env = {'AWS_ACCESS_KEY_ID': 'foo',
-                   'AWS_SECRET_ACCESS_KEY': 'bar'}
+            env['AWS_ACCESS_KEY_ID'] = 'foo'
+            env['AWS_SECRET_ACCESS_KEY'] = 'bar'
         self.driver.start(env=env)
 
     def cmd(self, *args):


### PR DESCRIPTION
Without providing a copy of the current environment variables, the `cmd-runner` may not work as we are not proxying over environment variables that are needed to function correctly. For example, the environment can be setting the `PYTHONPATH` in order to find additional Python packages that are not installed in the default site packages.


