### PR TITLE
[v2] Add protocol support for lists in headers

### DIFF
--- a/.changes/next-release/enhancement-protocol-77528.json
+++ b/.changes/next-release/enhancement-protocol-77528.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "protocol",
+  "description": "Add support for lists in headers"
+}

--- a/awscli/botocore/parsers.py
+++ b/awscli/botocore/parsers.py
@@ -941,6 +941,13 @@ class BaseRestParser(ResponseParser):
             parsed = json.loads(decoded)
         return parsed
 
+    def _handle_list(self, shape, node):
+        location = shape.serialization.get('location')
+        if location == 'header' and not isinstance(node, list):
+            # List in headers may be a comma separated string as per RFC7230
+            node = [e.strip() for e in node.split(',')]
+        return super(BaseRestParser, self)._handle_list(shape, node)
+
 
 class RestJSONParser(BaseRestParser, BaseJSONParser):
 

--- a/awscli/botocore/serialize.py
+++ b/awscli/botocore/serialize.py
@@ -616,6 +616,12 @@ class BaseRestSerializer(Serializer):
             timestamp_format = shape.serialization.get(
                 'timestampFormat', self.HEADER_TIMESTAMP_FORMAT)
             return self._convert_timestamp_to_str(timestamp, timestamp_format)
+        elif shape.type_name == 'list':
+            converted_value = [
+                self._convert_header_value(shape.member, v)
+                for v in value if v is not None
+            ]
+            return ",".join(converted_value)
         elif is_json_value_header(shape):
             # Serialize with no spaces after separators to save space in
             # the header.

--- a/awscli/botocore/serialize.py
+++ b/awscli/botocore/serialize.py
@@ -585,6 +585,9 @@ class BaseRestSerializer(Serializer):
                 partitioned['query_string_kwargs'][key_name] = param_value
         elif location == 'header':
             shape = shape_members[param_name]
+            if not param_value and shape.type_name == 'list':
+                # Empty lists should not be set on the headers
+                return
             value = self._convert_header_value(shape, param_value)
             partitioned['headers'][key_name] = str(value)
         elif location == 'headers':

--- a/tests/unit/botocore/protocols/input/rest-json.json
+++ b/tests/unit/botocore/protocols/input/rest-json.json
@@ -2107,5 +2107,65 @@
         }
       }
     ]
+  },
+  {
+    "description": "List in header",
+    "metadata": {
+      "protocol": "rest-json",
+      "apiVersion": "2014-01-01"
+    },
+    "clientEndpoint": "https://rest-json-test.amazonaws.com",
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "ListParam": {
+            "shape": "ListShape",
+            "location": "header",
+            "locationName": "x-amz-list-param"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "EnumType"
+        }
+      },
+      "EnumType": {
+        "type": "string",
+        "enum": ["one", "two", "three"]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/example"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListParam": [
+            "one",
+            "two",
+            "three"
+          ]
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/2014-01-01/example",
+          "headers": {
+            "x-amz-list-param": "one,two,three"
+          }
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/botocore/protocols/input/rest-json.json
+++ b/tests/unit/botocore/protocols/input/rest-json.json
@@ -2165,6 +2165,29 @@
             "x-amz-list-param": "one,two,three"
           }
         }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/example"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest"
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListParam": []
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/2014-01-01/example",
+          "headers": {},
+          "forbidHeaders": ["x-amz-list-param"]
+        }
       }
     ]
   }

--- a/tests/unit/botocore/protocols/input/rest-xml.json
+++ b/tests/unit/botocore/protocols/input/rest-xml.json
@@ -1888,5 +1888,65 @@
         }
       }
     ]
+  },
+  {
+    "description": "List in header",
+    "metadata": {
+      "protocol": "rest-xml",
+      "apiVersion": "2014-01-01"
+    },
+    "shapes": {
+      "InputShape": {
+        "type": "structure",
+        "members": {
+          "ListParam": {
+            "shape": "ListShape",
+            "location": "header",
+            "locationName": "x-amz-list-param"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "EnumType"
+        }
+      },
+      "EnumType": {
+        "type": "string",
+        "enum": ["one", "two", "three"]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/example"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest",
+            "xmlNamespace": {"uri": "https://foo/"}
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListParam": [
+            "one",
+            "two",
+            "three"
+          ]
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/2014-01-01/example",
+          "headers": {
+            "x-amz-list-param": "one,two,three"
+          }
+        }
+      }
+    ]
   }
 ]

--- a/tests/unit/botocore/protocols/input/rest-xml.json
+++ b/tests/unit/botocore/protocols/input/rest-xml.json
@@ -1946,6 +1946,30 @@
             "x-amz-list-param": "one,two,three"
           }
         }
+      },
+      {
+        "given": {
+          "http": {
+            "method": "POST",
+            "requestUri": "/2014-01-01/example"
+          },
+          "input": {
+            "shape": "InputShape",
+            "locationName": "OperationRequest",
+            "xmlNamespace": {"uri": "https://foo/"}
+          },
+          "name": "OperationName"
+        },
+        "params": {
+          "ListParam": []
+        },
+        "serialized": {
+          "method": "POST",
+          "body": "",
+          "uri": "/2014-01-01/example",
+          "headers": {},
+          "forbidHeaders": ["x-amz-list-param"]
+        }
       }
     ]
   }

--- a/tests/unit/botocore/protocols/output/rest-json.json
+++ b/tests/unit/botocore/protocols/output/rest-json.json
@@ -1127,87 +1127,135 @@
       }
     ]
   },
-    {
-        "description": "Tagged Unions",
-        "metadata": {
-            "protocol": "rest-json"
+  {
+    "description": "Tagged Unions",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "UnionMember": {
+            "shape": "UnionType"
+          }
+        }
+      },
+      "UnionType": {
+        "type": "structure",
+        "members": {
+          "S":{"shape":"StringType"},
+          "L": {"shape": "ListType"}
         },
-        "shapes": {
-            "OutputShape": {
-                "type": "structure",
-                "members": {
-                    "UnionMember": {
-                        "shape": "UnionType"
-                    }
-                }
-            },
-            "UnionType": {
-                "type": "structure",
-                "members": {
-                    "S":{"shape":"StringType"},
-                    "L": {"shape": "ListType"}
-                },
-                "union": true
-            },
-            "ListType": {
-                "type": "list",
-                "member": {
-                    "shape": "StringType"
-                }
-            },
-            "StringType": {
-                "type": "string"
-            }
+        "union": true
+      },
+      "ListType": {
+        "type": "list",
+        "member": {
+          "shape": "StringType"
+        }
+      },
+      "StringType": {
+        "type": "string"
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
         },
-        "cases": [
-            {
-                "given": {
-                    "output": {
-                        "shape": "OutputShape"
-                    },
-                    "name": "OperationName"
-                },
-                "result": {
-                    "UnionMember": {"S":  "mystring"}
-                },
-                "response": {
-                    "status_code": 200,
-                    "headers": {},
-                    "body": "{\"UnionMember\": {\"S\": \"mystring\"}}"
-                }
-            },
-            {
-                "given": {
-                    "output": {
-                        "shape": "OutputShape"
-                    },
-                    "name": "OperationName"
-                },
-                "result": {
-                    "UnionMember": {"L":  ["a", "b"]}
-                },
-                "response": {
-                    "status_code": 200,
-                    "headers": {},
-                    "body": "{\"UnionMember\": {\"L\": [\"a\", \"b\"]}}"
-                }
-            },
-            {
-                "given": {
-                    "output": {
-                        "shape": "OutputShape"
-                    },
-                    "name": "OperationName"
-                },
-                "result": {
-                    "UnionMember": {"SDK_UNKNOWN_MEMBER":  {"name": "SomeUnknownMember"}}
-                },
-                "response": {
-                    "status_code": 200,
-                    "headers": {},
-                    "body": "{\"UnionMember\": {\"SomeUnknownMember\": \"foo\"}}"
-                }
-            }
-        ]
-    }
+        "result": {
+          "UnionMember": {"S":  "mystring"}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"S\": \"mystring\"}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "UnionMember": {"L":  ["a", "b"]}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"L\": [\"a\", \"b\"]}}"
+        }
+      },
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "UnionMember": {"SDK_UNKNOWN_MEMBER":  {"name": "SomeUnknownMember"}}
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {},
+          "body": "{\"UnionMember\": {\"SomeUnknownMember\": \"foo\"}}"
+        }
+      }
+    ]
+  },
+  {
+    "description": "List in header",
+    "metadata": {
+      "protocol": "rest-json"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape",
+            "location": "header",
+            "locationName": "x-amz-list-member"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "EnumType"
+        }
+      },
+      "EnumType": {
+        "type": "string",
+        "enum": ["one", "two", "three"]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["one", "two", "three"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+              "x-amz-list-member": " one,two , three "
+          },
+          "body": ""
+        }
+      }
+    ]
+  }
 ]

--- a/tests/unit/botocore/protocols/output/rest-xml.json
+++ b/tests/unit/botocore/protocols/output/rest-xml.json
@@ -1221,5 +1221,53 @@
               }
           }
       ]
+  },
+  {
+    "description": "List in header",
+    "metadata": {
+      "protocol": "rest-xml"
+    },
+    "shapes": {
+      "OutputShape": {
+        "type": "structure",
+        "members": {
+          "ListMember": {
+            "shape": "ListShape",
+            "location": "header",
+            "locationName": "x-amz-list-member"
+          }
+        }
+      },
+      "ListShape": {
+        "type": "list",
+        "member": {
+          "shape": "EnumType"
+        }
+      },
+      "EnumType": {
+        "type": "string",
+        "enum": ["one", "two", "three"]
+      }
+    },
+    "cases": [
+      {
+        "given": {
+          "output": {
+            "shape": "OutputShape"
+          },
+          "name": "OperationName"
+        },
+        "result": {
+          "ListMember": ["one", "two", "three"]
+        },
+        "response": {
+          "status_code": 200,
+          "headers": {
+              "x-amz-list-member": " one,two , three "
+          },
+          "body": ""
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This pull requests includes the following:

* The original commit that added protocol support for lists in headers in botocore: https://github.com/boto/botocore/pull/2566
* The subsequent fix that avoids serializing empty lists to empty strings and instead just omit the header all together: https://github.com/boto/botocore/pull/2594
