### PR TITLE
Loosen SSO login requirements

### DIFF
--- a/.changes/next-release/enhancement-SSO-16533.json
+++ b/.changes/next-release/enhancement-SSO-16533.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "SSO",
+  "description": "Fixes `#5727 <https://github.com/aws/aws-cli/issues/5727>`__. Loosens the requirements to perform an ``aws sso login`` command to just the ``sso_start_url`` and ``sso_region``."
+}

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -26,14 +26,15 @@ class LoginCommand(BasicCommand):
         'Retrieves and caches an AWS SSO access token to exchange for AWS '
         'credentials. To login, the requested profile must have first been '
         'setup using ``aws configure sso``. Each time the ``login`` command '
-        'is called, a new SSO access token will be retrieved.'
+        'is called, a new SSO access token will be retrieved. Please note '
+        'that only one login session can be active for a given SSO Start URL '
+        'and creating multiple profiles does not allow for multiple users to '
+        'be authenticated against the same SSO Start URL.'
     )
     ARG_TABLE = []
     _REQUIRED_SSO_CONFIG_VARS = [
         'sso_start_url',
         'sso_region',
-        'sso_role_name',
-        'sso_account_id',
     ]
 
     def _run_main(self, parsed_args, parsed_globals):

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -145,6 +145,21 @@ class TestLoginCommand(BaseSSOTest):
             stderr
         )
 
+    def test_login_minimal_sso_configuration(self):
+        content = (
+            '[default]\n'
+            'sso_start_url={start_url}\n'
+            'sso_region={sso_region}\n'
+        ).format(start_url=self.start_url, sso_region=self.sso_region)
+        self.set_config_file_content(content=content)
+        self.add_oidc_workflow_responses(self.access_token)
+        self.run_cmd('sso login')
+        self.assert_used_expected_sso_region(expected_region=self.sso_region)
+        self.assert_cache_contains_token(
+            start_url=self.start_url,
+            expected_token=self.access_token
+        )
+
     def test_login_partially_missing_sso_configuration(self):
         content = (
             '[default]\n'
@@ -158,6 +173,8 @@ class TestLoginCommand(BaseSSOTest):
         )
         self.assertIn('sso_region', stderr)
         self.assertNotIn('sso_start_url', stderr)
+        self.assertNotIn('sso_account_id', stderr)
+        self.assertNotIn('sso_role_name', stderr)
 
     def test_token_cache_datetime_format(self):
         self.add_oidc_workflow_responses(self.access_token)


### PR DESCRIPTION
Fixes #5727

Fundamentally, the `aws sso login` command derives an access token for the given `sso_start_url` and is cached globally for that `sso_start_url`. The particular `sso_account_id` / `sso_role_name` are irrelevant to actually performing the OIDC device authorization flow and aren't true requirements to perform the `aws sso login`.
