### PR TITLE
[v2] Wait an invalidation cycle after app is running in ptk tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -403,7 +403,7 @@ class PromptToolkitAppRunner:
             target=self._do_run_app, args=(target, args, run_context))
         try:
             thread.start()
-            self._wait_until_app_is_done_rendering()
+            self._wait_until_app_is_done_updating()
             yield run_context
         finally:
             if self._app_is_exitable():


### PR DESCRIPTION
Some of the tests assert the app state right after it is running. However for the UI changes to propagate, especially around conditional containers, it requires at least an additional rendering cycle. So by manually calling invalidate() before yielding to make assertions we can be more confident the changes have been propagated to the UI.
