### PR TITLE
[v2] Import and adapt s3transfer 0.5.1

### DIFF
--- a/awscli/s3transfer/compat.py
+++ b/awscli/s3transfer/compat.py
@@ -10,14 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import inspect
-import sys
-import os
 import errno
+import inspect
+import os
 import socket
+import sys
 
 from botocore.compat import six
-
 
 if sys.platform.startswith('win'):
     def rename_file(current_filename, new_filename):
@@ -34,24 +33,17 @@ if sys.platform.startswith('win'):
 else:
     rename_file = os.rename
 
-if six.PY3:
-    def accepts_kwargs(func):
-        # In python3.4.1, there's backwards incompatible
-        # changes when using getargspec with functools.partials.
-        return inspect.getfullargspec(func)[2]
 
-    # In python3, socket.error is OSError, which is too general
-    # for what we want (i.e FileNotFoundError is a subclass of OSError).
-    # In py3 all the socket related errors are in a newly created
-    # ConnectionError
-    SOCKET_ERROR = ConnectionError
-    MAXINT = None
-else:
-    def accepts_kwargs(func):
-        return inspect.getargspec(func)[2]
+def accepts_kwargs(func):
+    return inspect.getfullargspec(func)[2]
 
-    SOCKET_ERROR = socket.error
-    MAXINT = sys.maxint
+
+# In python 3, socket.error is OSError, which is too general
+# for what we want (i.e FileNotFoundError is a subclass of OSError).
+# In python 3, all the socket related errors are in a newly created
+# ConnectionError.
+SOCKET_ERROR = ConnectionError
+MAXINT = None
 
 
 def seekable(fileobj):
@@ -71,7 +63,7 @@ def seekable(fileobj):
         try:
             fileobj.seek(0, 1)
             return True
-        except (OSError, IOError):
+        except OSError:
             # If an io related error was thrown then it is not seekable.
             return False
     # Else, the fileobj is not seekable

--- a/awscli/s3transfer/constants.py
+++ b/awscli/s3transfer/constants.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import s3transfer
 
-
 KB = 1024
 MB = KB * KB
 GB = MB * KB

--- a/awscli/s3transfer/delete.py
+++ b/awscli/s3transfer/delete.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
+from s3transfer.tasks import SubmissionTask, Task
 
 
 class DeleteSubmissionTask(SubmissionTask):
@@ -48,8 +47,8 @@ class DeleteSubmissionTask(SubmissionTask):
                     'key': call_args.key,
                     'extra_args': call_args.extra_args,
                 },
-                is_final=True
-            )
+                is_final=True,
+            ),
         )
 
 

--- a/awscli/s3transfer/exceptions.py
+++ b/awscli/s3transfer/exceptions.py
@@ -15,7 +15,7 @@ from concurrent.futures import CancelledError
 
 class RetriesExceededError(Exception):
     def __init__(self, last_exception, msg='Max Retries Exceeded'):
-        super(RetriesExceededError, self).__init__(msg)
+        super().__init__(msg)
         self.last_exception = last_exception
 
 
@@ -33,4 +33,5 @@ class TransferNotDoneError(Exception):
 
 class FatalError(CancelledError):
     """A CancelledError raised from an error in the TransferManager"""
+
     pass

--- a/awscli/s3transfer/manager.py
+++ b/awscli/s3transfer/manager.py
@@ -15,51 +15,51 @@ import logging
 import re
 import threading
 
-from botocore.compat import six
-
-from s3transfer.constants import KB, MB
-from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import signal_transferring
-from s3transfer.utils import signal_not_transferring
-from s3transfer.utils import CallArgs
-from s3transfer.utils import OSUtils
-from s3transfer.utils import TaskSemaphore
-from s3transfer.utils import SlidingWindowSemaphore
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import FatalError
-from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
-from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
-from s3transfer.futures import BoundedExecutor
-from s3transfer.futures import TransferFuture
-from s3transfer.futures import TransferMeta
-from s3transfer.futures import TransferCoordinator
-from s3transfer.download import DownloadSubmissionTask
-from s3transfer.upload import UploadSubmissionTask
+from s3transfer.bandwidth import BandwidthLimiter, LeakyBucket
+from s3transfer.constants import ALLOWED_DOWNLOAD_ARGS, KB, MB
 from s3transfer.copies import CopySubmissionTask
 from s3transfer.delete import DeleteSubmissionTask
-from s3transfer.bandwidth import LeakyBucket
-from s3transfer.bandwidth import BandwidthLimiter
-
+from s3transfer.download import DownloadSubmissionTask
+from s3transfer.exceptions import CancelledError, FatalError
+from s3transfer.futures import (
+    IN_MEMORY_DOWNLOAD_TAG,
+    IN_MEMORY_UPLOAD_TAG,
+    BoundedExecutor,
+    TransferCoordinator,
+    TransferFuture,
+    TransferMeta,
+)
+from s3transfer.upload import UploadSubmissionTask
+from s3transfer.utils import (
+    CallArgs,
+    OSUtils,
+    SlidingWindowSemaphore,
+    TaskSemaphore,
+    get_callbacks,
+    signal_not_transferring,
+    signal_transferring,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class TransferConfig(object):
-    def __init__(self,
-                 multipart_threshold=8 * MB,
-                 multipart_chunksize=8 * MB,
-                 max_request_concurrency=10,
-                 max_submission_concurrency=5,
-                 max_request_queue_size=1000,
-                 max_submission_queue_size=1000,
-                 max_io_queue_size=1000,
-                 io_chunksize=256 * KB,
-                 num_download_attempts=5,
-                 max_in_memory_upload_chunks=10,
-                 max_in_memory_download_chunks=10,
-                 max_bandwidth=None):
-        """Configurations for the transfer mangager
+class TransferConfig:
+    def __init__(
+        self,
+        multipart_threshold=8 * MB,
+        multipart_chunksize=8 * MB,
+        max_request_concurrency=10,
+        max_submission_concurrency=5,
+        max_request_queue_size=1000,
+        max_submission_queue_size=1000,
+        max_io_queue_size=1000,
+        io_chunksize=256 * KB,
+        num_download_attempts=5,
+        max_in_memory_upload_chunks=10,
+        max_in_memory_download_chunks=10,
+        max_bandwidth=None,
+    ):
+        """Configurations for the transfer manager
 
         :param multipart_threshold: The threshold for which multipart
             transfers occur.
@@ -94,7 +94,7 @@ class TransferConfig(object):
 
         :param num_download_attempts: The number of download attempts that
             will be tried upon errors with downloading an object in S3. Note
-            that these retries account for errors that occur when streamming
+            that these retries account for errors that occur when streaming
             down the data from s3 (i.e. socket errors and read timeouts that
             occur after receiving an OK response from s3).
             Other retryable exceptions such as throttling errors and 5xx errors
@@ -120,7 +120,7 @@ class TransferConfig(object):
 
         :param max_in_memory_download_chunks: The number of chunks that can
             be buffered in memory and **not** in the io queue at a time for all
-            ongoing dowload requests. This pertains specifically to file-like
+            ongoing download requests. This pertains specifically to file-like
             objects that cannot be seeked. The total maximum memory footprint
             due to a in-memory download chunks is roughly equal to:
 
@@ -145,14 +145,15 @@ class TransferConfig(object):
         self._validate_attrs_are_nonzero()
 
     def _validate_attrs_are_nonzero(self):
-        for attr, attr_val, in self.__dict__.items():
+        for attr, attr_val in self.__dict__.items():
             if attr_val is not None and attr_val <= 0:
                 raise ValueError(
                     'Provided parameter %s of value %s must be greater than '
-                    '0.' % (attr, attr_val))
+                    '0.' % (attr, attr_val)
+                )
 
 
-class TransferManager(object):
+class TransferManager:
     ALLOWED_DOWNLOAD_ARGS = ALLOWED_DOWNLOAD_ARGS
 
     ALLOWED_UPLOAD_ARGS = [
@@ -178,7 +179,7 @@ class TransferManager(object):
         'SSEKMSKeyId',
         'SSEKMSEncryptionContext',
         'Tagging',
-        'WebsiteRedirectLocation'
+        'WebsiteRedirectLocation',
     ]
 
     ALLOWED_COPY_ARGS = ALLOWED_UPLOAD_ARGS + [
@@ -197,7 +198,7 @@ class TransferManager(object):
         'MFA',
         'VersionId',
         'RequestPayer',
-        'ExpectedBucketOwner'
+        'ExpectedBucketOwner',
     ]
 
     VALIDATE_SUPPORTED_BUCKET_VALUES = True
@@ -238,11 +239,13 @@ class TransferManager(object):
             max_num_threads=self._config.max_request_concurrency,
             tag_semaphores={
                 IN_MEMORY_UPLOAD_TAG: TaskSemaphore(
-                    self._config.max_in_memory_upload_chunks),
+                    self._config.max_in_memory_upload_chunks
+                ),
                 IN_MEMORY_DOWNLOAD_TAG: SlidingWindowSemaphore(
-                    self._config.max_in_memory_download_chunks)
+                    self._config.max_in_memory_download_chunks
+                ),
             },
-            executor_cls=executor_cls
+            executor_cls=executor_cls,
         )
 
         # The executor responsible for submitting the necessary tasks to
@@ -250,8 +253,7 @@ class TransferManager(object):
         self._submission_executor = BoundedExecutor(
             max_size=self._config.max_submission_queue_size,
             max_num_threads=self._config.max_submission_concurrency,
-            executor_cls=executor_cls
-
+            executor_cls=executor_cls,
         )
 
         # There is one thread available for writing to disk. It will handle
@@ -259,7 +261,7 @@ class TransferManager(object):
         self._io_executor = BoundedExecutor(
             max_size=self._config.max_io_queue_size,
             max_num_threads=1,
-            executor_cls=executor_cls
+            executor_cls=executor_cls,
         )
 
         # The component responsible for limiting bandwidth usage if it
@@ -267,7 +269,8 @@ class TransferManager(object):
         self._bandwidth_limiter = None
         if self._config.max_bandwidth is not None:
             logger.debug(
-                'Setting max_bandwidth to %s', self._config.max_bandwidth)
+                'Setting max_bandwidth to %s', self._config.max_bandwidth
+            )
             leaky_bucket = LeakyBucket(self._config.max_bandwidth)
             self._bandwidth_limiter = BandwidthLimiter(leaky_bucket)
 
@@ -314,17 +317,22 @@ class TransferManager(object):
         self._validate_all_known_args(extra_args, self.ALLOWED_UPLOAD_ARGS)
         self._validate_if_bucket_supported(bucket)
         call_args = CallArgs(
-            fileobj=fileobj, bucket=bucket, key=key, extra_args=extra_args,
-            subscribers=subscribers
+            fileobj=fileobj,
+            bucket=bucket,
+            key=key,
+            extra_args=extra_args,
+            subscribers=subscribers,
         )
         extra_main_kwargs = {}
         if self._bandwidth_limiter:
             extra_main_kwargs['bandwidth_limiter'] = self._bandwidth_limiter
         return self._submit_transfer(
-            call_args, UploadSubmissionTask, extra_main_kwargs)
+            call_args, UploadSubmissionTask, extra_main_kwargs
+        )
 
-    def download(self, bucket, key, fileobj, extra_args=None,
-                 subscribers=None):
+    def download(
+        self, bucket, key, fileobj, extra_args=None, subscribers=None
+    ):
         """Downloads a file from S3
 
         :type bucket: str
@@ -357,17 +365,28 @@ class TransferManager(object):
         self._validate_all_known_args(extra_args, self.ALLOWED_DOWNLOAD_ARGS)
         self._validate_if_bucket_supported(bucket)
         call_args = CallArgs(
-            bucket=bucket, key=key, fileobj=fileobj, extra_args=extra_args,
-            subscribers=subscribers
+            bucket=bucket,
+            key=key,
+            fileobj=fileobj,
+            extra_args=extra_args,
+            subscribers=subscribers,
         )
         extra_main_kwargs = {'io_executor': self._io_executor}
         if self._bandwidth_limiter:
             extra_main_kwargs['bandwidth_limiter'] = self._bandwidth_limiter
         return self._submit_transfer(
-            call_args, DownloadSubmissionTask, extra_main_kwargs)
+            call_args, DownloadSubmissionTask, extra_main_kwargs
+        )
 
-    def copy(self, copy_source, bucket, key, extra_args=None,
-             subscribers=None, source_client=None):
+    def copy(
+        self,
+        copy_source,
+        bucket,
+        key,
+        extra_args=None,
+        subscribers=None,
+        source_client=None,
+    ):
         """Copies a file in S3
 
         :type copy_source: dict
@@ -413,9 +432,12 @@ class TransferManager(object):
             self._validate_if_bucket_supported(copy_source.get('Bucket'))
         self._validate_if_bucket_supported(bucket)
         call_args = CallArgs(
-            copy_source=copy_source, bucket=bucket, key=key,
-            extra_args=extra_args, subscribers=subscribers,
-            source_client=source_client
+            copy_source=copy_source,
+            bucket=bucket,
+            key=key,
+            extra_args=extra_args,
+            subscribers=subscribers,
+            source_client=source_client,
         )
         return self._submit_transfer(call_args, CopySubmissionTask)
 
@@ -448,8 +470,10 @@ class TransferManager(object):
         self._validate_all_known_args(extra_args, self.ALLOWED_DELETE_ARGS)
         self._validate_if_bucket_supported(bucket)
         call_args = CallArgs(
-            bucket=bucket, key=key, extra_args=extra_args,
-            subscribers=subscribers
+            bucket=bucket,
+            key=key,
+            extra_args=extra_args,
+            subscribers=subscribers,
         )
         return self._submit_transfer(call_args, DeleteSubmissionTask)
 
@@ -471,17 +495,19 @@ class TransferManager(object):
             if kwarg not in allowed:
                 raise ValueError(
                     "Invalid extra_args key '%s', "
-                    "must be one of: %s" % (
-                        kwarg, ', '.join(allowed)))
+                    "must be one of: %s" % (kwarg, ', '.join(allowed))
+                )
 
-    def _submit_transfer(self, call_args, submission_task_cls,
-                         extra_main_kwargs=None):
+    def _submit_transfer(
+        self, call_args, submission_task_cls, extra_main_kwargs=None
+    ):
         if not extra_main_kwargs:
             extra_main_kwargs = {}
 
         # Create a TransferFuture to return back to the user
         transfer_future, components = self._get_future_with_components(
-            call_args)
+            call_args
+        )
 
         # Add any provided done callbacks to the created transfer future
         # to be invoked on the transfer future being complete.
@@ -490,14 +516,15 @@ class TransferManager(object):
 
         # Get the main kwargs needed to instantiate the submission task
         main_kwargs = self._get_submission_task_main_kwargs(
-            transfer_future, extra_main_kwargs)
+            transfer_future, extra_main_kwargs
+        )
 
         # Submit a SubmissionTask that will submit all of the necessary
         # tasks needed to complete the S3 transfer.
         self._submission_executor.submit(
             submission_task_cls(
                 transfer_coordinator=components['coordinator'],
-                main_kwargs=main_kwargs
+                main_kwargs=main_kwargs,
             )
         )
 
@@ -512,27 +539,30 @@ class TransferManager(object):
         transfer_coordinator = TransferCoordinator(transfer_id=transfer_id)
         # Track the transfer coordinator for transfers to manage.
         self._coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Also make sure that the transfer coordinator is removed once
         # the transfer completes so it does not stick around in memory.
         transfer_coordinator.add_done_callback(
             self._coordinator_controller.remove_transfer_coordinator,
-            transfer_coordinator)
+            transfer_coordinator,
+        )
         components = {
             'meta': TransferMeta(call_args, transfer_id=transfer_id),
-            'coordinator': transfer_coordinator
+            'coordinator': transfer_coordinator,
         }
         transfer_future = TransferFuture(**components)
         return transfer_future, components
 
     def _get_submission_task_main_kwargs(
-            self, transfer_future, extra_main_kwargs):
+        self, transfer_future, extra_main_kwargs
+    ):
         main_kwargs = {
             'client': self._client,
             'config': self._config,
             'osutil': self._osutil,
             'request_executor': self._request_executor,
-            'transfer_future': transfer_future
+            'transfer_future': transfer_future,
         }
         main_kwargs.update(extra_main_kwargs)
         return main_kwargs
@@ -541,11 +571,13 @@ class TransferManager(object):
         # Register handlers to enable/disable callbacks on uploads.
         event_name = 'request-created.s3'
         self._client.meta.events.register_first(
-            event_name, signal_not_transferring,
-            unique_id='s3upload-not-transferring')
+            event_name,
+            signal_not_transferring,
+            unique_id='s3upload-not-transferring',
+        )
         self._client.meta.events.register_last(
-            event_name, signal_transferring,
-            unique_id='s3upload-transferring')
+            event_name, signal_transferring, unique_id='s3upload-transferring'
+        )
 
     def __enter__(self):
         return self
@@ -558,7 +590,7 @@ class TransferManager(object):
         # all of the inprogress futures in the shutdown.
         if exc_type:
             cancel = True
-            cancel_msg = six.text_type(exc_value)
+            cancel_msg = str(exc_value)
             if not cancel_msg:
                 cancel_msg = repr(exc_value)
             # If it was a KeyboardInterrupt, the cancellation was initiated
@@ -609,7 +641,7 @@ class TransferManager(object):
             self._io_executor.shutdown()
 
 
-class TransferCoordinatorController(object):
+class TransferCoordinatorController:
     def __init__(self):
         """Abstraction to control all transfer coordinators
 
@@ -668,7 +700,7 @@ class TransferCoordinatorController(object):
     def wait(self):
         """Wait until there are no more inprogress transfers
 
-        This will not stop when failures are encountered and not propogate any
+        This will not stop when failures are encountered and not propagate any
         of these errors from failed transfers, but it can be interrupted with
         a KeyboardInterrupt.
         """
@@ -684,7 +716,8 @@ class TransferCoordinatorController(object):
             if transfer_coordinator:
                 logger.debug(
                     'On KeyboardInterrupt was waiting for %s',
-                    transfer_coordinator)
+                    transfer_coordinator,
+                )
             raise
         except Exception:
             # A general exception could have been thrown because

--- a/awscli/s3transfer/subscribers.py
+++ b/awscli/s3transfer/subscribers.py
@@ -10,41 +10,38 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.compat import six
-
 from s3transfer.compat import accepts_kwargs
 from s3transfer.exceptions import InvalidSubscriberMethodError
 
 
-class BaseSubscriber(object):
+class BaseSubscriber:
     """The base subscriber class
 
     It is recommended that all subscriber implementations subclass and then
     override the subscription methods (i.e. on_{subsribe_type}() methods).
     """
-    VALID_SUBSCRIBER_TYPES = [
-        'queued',
-        'progress',
-        'done'
-    ]
+
+    VALID_SUBSCRIBER_TYPES = ['queued', 'progress', 'done']
 
     def __new__(cls, *args, **kwargs):
         cls._validate_subscriber_methods()
-        return super(BaseSubscriber, cls).__new__(cls)
+        return super().__new__(cls)
 
     @classmethod
     def _validate_subscriber_methods(cls):
         for subscriber_type in cls.VALID_SUBSCRIBER_TYPES:
             subscriber_method = getattr(cls, 'on_' + subscriber_type)
-            if not six.callable(subscriber_method):
+            if not callable(subscriber_method):
                 raise InvalidSubscriberMethodError(
-                    'Subscriber method %s must be callable.' %
-                    subscriber_method)
+                    'Subscriber method %s must be callable.'
+                    % subscriber_method
+                )
 
             if not accepts_kwargs(subscriber_method):
                 raise InvalidSubscriberMethodError(
                     'Subscriber method %s must accept keyword '
-                    'arguments (**kwargs)' % subscriber_method)
+                    'arguments (**kwargs)' % subscriber_method
+                )
 
     def on_queued(self, future, **kwargs):
         """Callback to be invoked when transfer request gets queued

--- a/awscli/s3transfer/upload.py
+++ b/awscli/s3transfer/upload.py
@@ -11,21 +11,25 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import math
+from io import BytesIO
 
-from botocore.compat import six
-
-from s3transfer.compat import seekable, readable
+from s3transfer.compat import readable, seekable
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
-from s3transfer.tasks import Task
-from s3transfer.tasks import SubmissionTask
-from s3transfer.tasks import CreateMultipartUploadTask
-from s3transfer.tasks import CompleteMultipartUploadTask
-from s3transfer.utils import get_callbacks
-from s3transfer.utils import get_filtered_dict
-from s3transfer.utils import DeferredOpenFile, ChunksizeAdjuster
+from s3transfer.tasks import (
+    CompleteMultipartUploadTask,
+    CreateMultipartUploadTask,
+    SubmissionTask,
+    Task,
+)
+from s3transfer.utils import (
+    ChunksizeAdjuster,
+    DeferredOpenFile,
+    get_callbacks,
+    get_filtered_dict,
+)
 
 
-class AggregatedProgressCallback(object):
+class AggregatedProgressCallback:
     def __init__(self, callbacks, threshold=1024 * 256):
         """Aggregates progress updates for every provided progress callback
 
@@ -58,7 +62,7 @@ class AggregatedProgressCallback(object):
         self._bytes_seen = 0
 
 
-class InterruptReader(object):
+class InterruptReader:
     """Wrapper that can interrupt reading using an error
 
     It uses a transfer coordinator to propagate an error if it notices
@@ -71,6 +75,7 @@ class InterruptReader(object):
     :param transfer_coordinator: The transfer coordinator to use if the
         reader needs to be interrupted.
     """
+
     def __init__(self, fileobj, transfer_coordinator):
         self._fileobj = fileobj
         self._transfer_coordinator = transfer_coordinator
@@ -101,7 +106,7 @@ class InterruptReader(object):
         self.close()
 
 
-class UploadInputManager(object):
+class UploadInputManager:
     """Base manager class for handling various types of files for uploads
 
     This class is typically used for the UploadSubmissionTask class to help
@@ -116,6 +121,7 @@ class UploadInputManager(object):
     that may be accepted. All implementations must subclass and override
     public methods from this class.
     """
+
     def __init__(self, osutil, transfer_coordinator, bandwidth_limiter=None):
         self._osutil = osutil
         self._transfer_coordinator = transfer_coordinator
@@ -167,7 +173,7 @@ class UploadInputManager(object):
 
         :rtype: boolean
         :returns: True, if the upload should be multipart based on
-            configuartion and size. False, otherwise.
+            configuration and size. False, otherwise.
         """
         raise NotImplementedError('must implement requires_multipart_upload()')
 
@@ -206,7 +212,8 @@ class UploadInputManager(object):
         fileobj = InterruptReader(fileobj, self._transfer_coordinator)
         if self._bandwidth_limiter:
             fileobj = self._bandwidth_limiter.get_bandwith_limited_stream(
-                fileobj, self._transfer_coordinator, enabled=False)
+                fileobj, self._transfer_coordinator, enabled=False
+            )
         return fileobj
 
     def _get_progress_callbacks(self, transfer_future):
@@ -224,17 +231,18 @@ class UploadInputManager(object):
 
 class UploadFilenameInputManager(UploadInputManager):
     """Upload utility for filenames"""
+
     @classmethod
     def is_compatible(cls, upload_source):
-        return isinstance(upload_source, six.string_types)
+        return isinstance(upload_source, str)
 
     def stores_body_in_memory(self, operation_name):
         return False
 
     def provide_transfer_size(self, transfer_future):
         transfer_future.meta.provide_transfer_size(
-            self._osutil.get_file_size(
-                transfer_future.meta.call_args.fileobj))
+            self._osutil.get_file_size(transfer_future.meta.call_args.fileobj)
+        )
 
     def requires_multipart_upload(self, transfer_future, config):
         return transfer_future.meta.size >= config.multipart_threshold
@@ -242,7 +250,8 @@ class UploadFilenameInputManager(UploadInputManager):
     def get_put_object_body(self, transfer_future):
         # Get a file-like object for the given input
         fileobj, full_size = self._get_put_object_fileobj_with_full_size(
-            transfer_future)
+            transfer_future
+        )
 
         # Wrap fileobj with interrupt reader that will quickly cancel
         # uploads if needed instead of having to wait for the socket
@@ -255,8 +264,12 @@ class UploadFilenameInputManager(UploadInputManager):
         # Return the file-like object wrapped into a ReadFileChunk to get
         # progress.
         return self._osutil.open_file_chunk_reader_from_fileobj(
-            fileobj=fileobj, chunk_size=size, full_file_size=full_size,
-            callbacks=callbacks, close_callbacks=close_callbacks)
+            fileobj=fileobj,
+            chunk_size=size,
+            full_file_size=full_size,
+            callbacks=callbacks,
+            close_callbacks=close_callbacks,
+        )
 
     def yield_upload_part_bodies(self, transfer_future, chunksize):
         full_file_size = transfer_future.meta.size
@@ -268,8 +281,11 @@ class UploadFilenameInputManager(UploadInputManager):
             # Get a file-like object for that part and the size of the full
             # file size for the associated file-like object for that part.
             fileobj, full_size = self._get_upload_part_fileobj_with_full_size(
-                transfer_future.meta.call_args.fileobj, start_byte=start_byte,
-                part_size=chunksize, full_file_size=full_file_size)
+                transfer_future.meta.call_args.fileobj,
+                start_byte=start_byte,
+                part_size=chunksize,
+                full_file_size=full_file_size,
+            )
 
             # Wrap fileobj with interrupt reader that will quickly cancel
             # uploads if needed instead of having to wait for the socket
@@ -278,14 +294,18 @@ class UploadFilenameInputManager(UploadInputManager):
 
             # Wrap the file-like object into a ReadFileChunk to get progress.
             read_file_chunk = self._osutil.open_file_chunk_reader_from_fileobj(
-                fileobj=fileobj, chunk_size=chunksize,
-                full_file_size=full_size, callbacks=callbacks,
-                close_callbacks=close_callbacks)
+                fileobj=fileobj,
+                chunk_size=chunksize,
+                full_file_size=full_size,
+                callbacks=callbacks,
+                close_callbacks=close_callbacks,
+            )
             yield part_number, read_file_chunk
 
     def _get_deferred_open_file(self, fileobj, start_byte):
         fileobj = DeferredOpenFile(
-            fileobj, start_byte, open_function=self._osutil.open)
+            fileobj, start_byte, open_function=self._osutil.open
+        )
         return fileobj
 
     def _get_put_object_fileobj_with_full_size(self, transfer_future):
@@ -299,12 +319,12 @@ class UploadFilenameInputManager(UploadInputManager):
         return self._get_deferred_open_file(fileobj, start_byte), full_size
 
     def _get_num_parts(self, transfer_future, part_size):
-        return int(
-            math.ceil(transfer_future.meta.size / float(part_size)))
+        return int(math.ceil(transfer_future.meta.size / float(part_size)))
 
 
 class UploadSeekableInputManager(UploadFilenameInputManager):
     """Upload utility for an open file object"""
+
     @classmethod
     def is_compatible(cls, upload_source):
         return readable(upload_source) and seekable(upload_source)
@@ -325,7 +345,8 @@ class UploadSeekableInputManager(UploadFilenameInputManager):
         end_position = fileobj.tell()
         fileobj.seek(start_position)
         transfer_future.meta.provide_transfer_size(
-            end_position - start_position)
+            end_position - start_position
+        )
 
     def _get_upload_part_fileobj_with_full_size(self, fileobj, **kwargs):
         # Note: It is unfortunate that in order to do a multithreaded
@@ -340,7 +361,7 @@ class UploadSeekableInputManager(UploadFilenameInputManager):
         # meaning the BytesIO object has no knowledge of its start position
         # relative the input source nor access to the rest of the input
         # source. So we must treat it as its own standalone file.
-        return six.BytesIO(data), len(data)
+        return BytesIO(data), len(data)
 
     def _get_put_object_fileobj_with_full_size(self, transfer_future):
         fileobj = transfer_future.meta.call_args.fileobj
@@ -352,9 +373,9 @@ class UploadSeekableInputManager(UploadFilenameInputManager):
 
 class UploadNonSeekableInputManager(UploadInputManager):
     """Upload utility for a file-like object that cannot seek."""
+
     def __init__(self, osutil, transfer_coordinator, bandwidth_limiter=None):
-        super(UploadNonSeekableInputManager, self).__init__(
-            osutil, transfer_coordinator, bandwidth_limiter)
+        super().__init__(osutil, transfer_coordinator, bandwidth_limiter)
         self._initial_data = b''
 
     @classmethod
@@ -392,7 +413,8 @@ class UploadNonSeekableInputManager(UploadInputManager):
         fileobj = transfer_future.meta.call_args.fileobj
 
         body = self._wrap_data(
-            self._initial_data + fileobj.read(), callbacks, close_callbacks)
+            self._initial_data + fileobj.read(), callbacks, close_callbacks
+        )
 
         # Zero out the stored data so we don't have additional copies
         # hanging around in memory.
@@ -412,7 +434,8 @@ class UploadNonSeekableInputManager(UploadInputManager):
             if not part_content:
                 break
             part_object = self._wrap_data(
-                part_content, callbacks, close_callbacks)
+                part_content, callbacks, close_callbacks
+            )
 
             # Zero out part_content to avoid hanging on to additional data.
             part_content = None
@@ -476,10 +499,14 @@ class UploadNonSeekableInputManager(UploadInputManager):
 
         :return: Fully wrapped data.
         """
-        fileobj = self._wrap_fileobj(six.BytesIO(data))
+        fileobj = self._wrap_fileobj(BytesIO(data))
         return self._osutil.open_file_chunk_reader_from_fileobj(
-            fileobj=fileobj, chunk_size=len(data), full_file_size=len(data),
-            callbacks=callbacks, close_callbacks=close_callbacks)
+            fileobj=fileobj,
+            chunk_size=len(data),
+            full_file_size=len(data),
+            callbacks=callbacks,
+            close_callbacks=close_callbacks,
+        )
 
 
 class UploadSubmissionTask(SubmissionTask):
@@ -490,13 +517,10 @@ class UploadSubmissionTask(SubmissionTask):
         'SSECustomerAlgorithm',
         'SSECustomerKeyMD5',
         'RequestPayer',
-        'ExpectedBucketOwner'
+        'ExpectedBucketOwner',
     ]
 
-    COMPLETE_MULTIPART_ARGS = [
-        'RequestPayer',
-        'ExpectedBucketOwner'
-    ]
+    COMPLETE_MULTIPART_ARGS = ['RequestPayer', 'ExpectedBucketOwner']
 
     def _get_upload_input_manager_cls(self, transfer_future):
         """Retrieves a class for managing input for an upload based on file type
@@ -511,7 +535,7 @@ class UploadSubmissionTask(SubmissionTask):
         upload_manager_resolver_chain = [
             UploadFilenameInputManager,
             UploadSeekableInputManager,
-            UploadNonSeekableInputManager
+            UploadNonSeekableInputManager,
         ]
 
         fileobj = transfer_future.meta.call_args.fileobj
@@ -519,11 +543,20 @@ class UploadSubmissionTask(SubmissionTask):
             if upload_manager_cls.is_compatible(fileobj):
                 return upload_manager_cls
         raise RuntimeError(
-            'Input %s of type: %s is not supported.' % (
-                fileobj, type(fileobj)))
+            'Input {} of type: {} is not supported.'.format(
+                fileobj, type(fileobj)
+            )
+        )
 
-    def _submit(self, client, config, osutil, request_executor,
-                transfer_future, bandwidth_limiter=None):
+    def _submit(
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        transfer_future,
+        bandwidth_limiter=None,
+    ):
         """
         :param client: The client associated with the transfer manager
 
@@ -543,8 +576,8 @@ class UploadSubmissionTask(SubmissionTask):
             transfer request that tasks are being submitted for
         """
         upload_input_manager = self._get_upload_input_manager_cls(
-            transfer_future)(
-                osutil, self._transfer_coordinator, bandwidth_limiter)
+            transfer_future
+        )(osutil, self._transfer_coordinator, bandwidth_limiter)
 
         # Determine the size if it was not provided
         if transfer_future.meta.size is None:
@@ -552,22 +585,41 @@ class UploadSubmissionTask(SubmissionTask):
 
         # Do a multipart upload if needed, otherwise do a regular put object.
         if not upload_input_manager.requires_multipart_upload(
-                transfer_future, config):
+            transfer_future, config
+        ):
             self._submit_upload_request(
-                client, config, osutil, request_executor, transfer_future,
-                upload_input_manager)
+                client,
+                config,
+                osutil,
+                request_executor,
+                transfer_future,
+                upload_input_manager,
+            )
         else:
             self._submit_multipart_request(
-                client, config, osutil, request_executor, transfer_future,
-                upload_input_manager)
+                client,
+                config,
+                osutil,
+                request_executor,
+                transfer_future,
+                upload_input_manager,
+            )
 
-    def _submit_upload_request(self, client, config, osutil, request_executor,
-                               transfer_future, upload_input_manager):
+    def _submit_upload_request(
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        transfer_future,
+        upload_input_manager,
+    ):
         call_args = transfer_future.meta.call_args
 
         # Get any tags that need to be associated to the put object task
         put_object_tag = self._get_upload_task_tag(
-            upload_input_manager, 'put_object')
+            upload_input_manager, 'put_object'
+        )
 
         # Submit the request of a single upload.
         self._transfer_coordinator.submit(
@@ -577,19 +629,26 @@ class UploadSubmissionTask(SubmissionTask):
                 main_kwargs={
                     'client': client,
                     'fileobj': upload_input_manager.get_put_object_body(
-                        transfer_future),
+                        transfer_future
+                    ),
                     'bucket': call_args.bucket,
                     'key': call_args.key,
-                    'extra_args': call_args.extra_args
+                    'extra_args': call_args.extra_args,
                 },
-                is_final=True
+                is_final=True,
             ),
-            tag=put_object_tag
+            tag=put_object_tag,
         )
 
-    def _submit_multipart_request(self, client, config, osutil,
-                                  request_executor, transfer_future,
-                                  upload_input_manager):
+    def _submit_multipart_request(
+        self,
+        client,
+        config,
+        osutil,
+        request_executor,
+        transfer_future,
+        upload_input_manager,
+    ):
         call_args = transfer_future.meta.call_args
 
         # Submit the request to create a multipart upload.
@@ -602,8 +661,8 @@ class UploadSubmissionTask(SubmissionTask):
                     'bucket': call_args.bucket,
                     'key': call_args.key,
                     'extra_args': call_args.extra_args,
-                }
-            )
+                },
+            ),
         )
 
         # Submit requests to upload the parts of the file.
@@ -613,13 +672,15 @@ class UploadSubmissionTask(SubmissionTask):
         # Get any tags that need to be associated to the submitted task
         # for upload the data
         upload_part_tag = self._get_upload_task_tag(
-            upload_input_manager, 'upload_part')
+            upload_input_manager, 'upload_part'
+        )
 
         size = transfer_future.meta.size
         adjuster = ChunksizeAdjuster()
         chunksize = adjuster.adjust_chunksize(config.multipart_chunksize, size)
         part_iterator = upload_input_manager.yield_upload_part_bodies(
-            transfer_future, chunksize)
+            transfer_future, chunksize
+        )
 
         for part_number, fileobj in part_iterator:
             part_futures.append(
@@ -633,18 +694,19 @@ class UploadSubmissionTask(SubmissionTask):
                             'bucket': call_args.bucket,
                             'key': call_args.key,
                             'part_number': part_number,
-                            'extra_args': extra_part_args
+                            'extra_args': extra_part_args,
                         },
                         pending_main_kwargs={
                             'upload_id': create_multipart_future
-                        }
+                        },
                     ),
-                    tag=upload_part_tag
+                    tag=upload_part_tag,
                 )
             )
 
         complete_multipart_extra_args = self._extra_complete_multipart_args(
-            call_args.extra_args)
+            call_args.extra_args
+        )
         # Submit the request to complete the multipart upload.
         self._transfer_coordinator.submit(
             request_executor,
@@ -658,10 +720,10 @@ class UploadSubmissionTask(SubmissionTask):
                 },
                 pending_main_kwargs={
                     'upload_id': create_multipart_future,
-                    'parts': part_futures
+                    'parts': part_futures,
                 },
-                is_final=True
-            )
+                is_final=True,
+            ),
         )
 
     def _extra_upload_part_args(self, extra_args):
@@ -681,6 +743,7 @@ class UploadSubmissionTask(SubmissionTask):
 
 class PutObjectTask(Task):
     """Task to do a nonmultipart upload"""
+
     def _main(self, client, fileobj, bucket, key, extra_args):
         """
         :param client: The client to use when calling PutObject
@@ -696,8 +759,10 @@ class PutObjectTask(Task):
 
 class UploadPartTask(Task):
     """Task to upload a part in a multipart upload"""
-    def _main(self, client, fileobj, bucket, key, upload_id, part_number,
-              extra_args):
+
+    def _main(
+        self, client, fileobj, bucket, key, upload_id, part_number, extra_args
+    ):
         """
         :param client: The client to use when calling PutObject
         :param fileobj: The file to upload.
@@ -719,8 +784,12 @@ class UploadPartTask(Task):
         """
         with fileobj as body:
             response = client.upload_part(
-                Bucket=bucket, Key=key,
-                UploadId=upload_id, PartNumber=part_number,
-                Body=body, **extra_args)
+                Bucket=bucket,
+                Key=key,
+                UploadId=upload_id,
+                PartNumber=part_number,
+                Body=body,
+                **extra_args
+            )
         etag = response['ETag']
         return {'ETag': etag, 'PartNumber': part_number}

--- a/tests/functional/s3transfer/test_copy.py
+++ b/tests/functional/s3transfer/test_copy.py
@@ -13,30 +13,25 @@
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
 
-from tests import BaseGeneralInterfaceTest
-from tests import FileSizeProvider
-from s3transfer.manager import TransferManager
-from s3transfer.manager import TransferConfig
+from s3transfer.manager import TransferConfig, TransferManager
 from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE
+from tests import BaseGeneralInterfaceTest, FileSizeProvider
 
 
 class BaseCopyTest(BaseGeneralInterfaceTest):
     def setUp(self):
-        super(BaseCopyTest, self).setUp()
+        super().setUp()
         self.config = TransferConfig(
             max_request_concurrency=1,
             multipart_chunksize=MIN_UPLOAD_CHUNKSIZE,
-            multipart_threshold=MIN_UPLOAD_CHUNKSIZE * 4
+            multipart_threshold=MIN_UPLOAD_CHUNKSIZE * 4,
         )
         self._manager = TransferManager(self.client, self.config)
 
         # Initialize some default arguments
         self.bucket = 'mybucket'
         self.key = 'mykey'
-        self.copy_source = {
-            'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
-        }
+        self.copy_source = {'Bucket': 'mysourcebucket', 'Key': 'mysourcekey'}
         self.extra_args = {}
         self.subscribers = []
 
@@ -59,22 +54,15 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         }
 
     def create_invalid_extra_args(self):
-        return {
-            'Foo': 'bar'
-        }
+        return {'Foo': 'bar'}
 
     def create_stubbed_responses(self):
         return [
             {
                 'method': 'head_object',
-                'service_response': {
-                    'ContentLength': len(self.content)
-                }
+                'service_response': {'ContentLength': len(self.content)},
             },
-            {
-                'method': 'copy_object',
-                'service_response': {}
-            }
+            {'method': 'copy_object', 'service_response': {}},
         ]
 
     def create_expected_progress_callback_info(self):
@@ -91,8 +79,11 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         stubber.add_response(**head_response)
 
     def add_successful_copy_responses(
-            self, expected_copy_params=None, expected_create_mpu_params=None,
-            expected_complete_mpu_params=None):
+        self,
+        expected_copy_params=None,
+        expected_create_mpu_params=None,
+        expected_complete_mpu_params=None,
+    ):
 
         # Add all responses needed to do the copy of the object.
         # Should account for both ranged and nonranged downloads.
@@ -107,7 +98,8 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         # Add the expected create multipart upload params.
         if expected_create_mpu_params:
             stubbed_responses[0][
-                'expected_params'] = expected_create_mpu_params
+                'expected_params'
+            ] = expected_create_mpu_params
 
         # Add any expected copy parameters.
         if expected_copy_params:
@@ -120,7 +112,8 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         # Add the expected complete multipart upload params.
         if expected_complete_mpu_params:
             stubbed_responses[-1][
-                'expected_params'] = expected_complete_mpu_params
+                'expected_params'
+            ] = expected_complete_mpu_params
 
         # Add the responses to the stubber.
         for stubbed_response in stubbed_responses:
@@ -144,7 +137,7 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
         expected_params = {
             'Bucket': 'mysourcebucket',
             'Key': 'mysourcekey',
-            'VersionId': 'mysourceversionid'
+            'VersionId': 'mysourceversionid',
         }
 
         self.add_head_object_response(expected_params=expected_params)
@@ -162,8 +155,11 @@ class BaseCopyTest(BaseGeneralInterfaceTest):
 
     def test_provide_copy_source_client(self):
         source_client = self.session.create_client(
-            's3', 'eu-central-1', aws_access_key_id='foo',
-            aws_secret_access_key='bar')
+            's3',
+            'eu-central-1',
+            aws_access_key_id='foo',
+            aws_secret_access_key='bar',
+        )
         source_stubber = Stubber(source_client)
         source_stubber.activate()
         self.addCleanup(source_stubber.deactivate)
@@ -188,16 +184,17 @@ class TestNonMultipartCopy(BaseCopyTest):
     def test_copy(self):
         expected_head_params = {
             'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
+            'Key': 'mysourcekey',
         }
         expected_copy_object = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'CopySource': self.copy_source
+            'CopySource': self.copy_source,
         }
         self.add_head_object_response(expected_params=expected_head_params)
         self.add_successful_copy_responses(
-            expected_copy_params=expected_copy_object)
+            expected_copy_params=expected_copy_object
+        )
 
         future = self.manager.copy(**self.create_call_kwargs())
         future.result()
@@ -208,18 +205,19 @@ class TestNonMultipartCopy(BaseCopyTest):
 
         expected_head_params = {
             'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
+            'Key': 'mysourcekey',
         }
         expected_copy_object = {
             'Bucket': self.bucket,
             'Key': self.key,
             'CopySource': self.copy_source,
-            'MetadataDirective': 'REPLACE'
+            'MetadataDirective': 'REPLACE',
         }
 
         self.add_head_object_response(expected_params=expected_head_params)
         self.add_successful_copy_responses(
-            expected_copy_params=expected_copy_object)
+            expected_copy_params=expected_copy_object
+        )
 
         call_kwargs = self.create_call_kwargs()
         call_kwargs['extra_args'] = self.extra_args
@@ -233,18 +231,19 @@ class TestNonMultipartCopy(BaseCopyTest):
         expected_head_params = {
             'Bucket': 'mysourcebucket',
             'Key': 'mysourcekey',
-            'SSECustomerAlgorithm': 'AES256'
+            'SSECustomerAlgorithm': 'AES256',
         }
         expected_copy_object = {
             'Bucket': self.bucket,
             'Key': self.key,
             'CopySource': self.copy_source,
-            'CopySourceSSECustomerAlgorithm': 'AES256'
+            'CopySourceSSECustomerAlgorithm': 'AES256',
         }
 
         self.add_head_object_response(expected_params=expected_head_params)
         self.add_successful_copy_responses(
-            expected_copy_params=expected_copy_object)
+            expected_copy_params=expected_copy_object
+        )
 
         call_kwargs = self.create_call_kwargs()
         call_kwargs['extra_args'] = self.extra_args
@@ -258,9 +257,7 @@ class TestNonMultipartCopy(BaseCopyTest):
             self.assertIn(allowed_upload_arg, op_model.input_shape.members)
 
     def test_copy_with_tagging(self):
-        extra_args = {
-            'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'
-        }
+        extra_args = {'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'}
         self.add_head_object_response()
         self.add_successful_copy_responses(
             expected_copy_params={
@@ -268,11 +265,12 @@ class TestNonMultipartCopy(BaseCopyTest):
                 'Key': self.key,
                 'CopySource': self.copy_source,
                 'Tagging': 'tag1=val1',
-                'TaggingDirective': 'REPLACE'
+                'TaggingDirective': 'REPLACE',
             }
         )
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key, extra_args)
+            self.copy_source, self.bucket, self.key, extra_args
+        )
         future.result()
         self.stubber.assert_no_pending_responses()
 
@@ -285,8 +283,10 @@ class TestNonMultipartCopy(BaseCopyTest):
             self.manager.copy(self.copy_source, s3_object_lambda_arn, self.key)
 
     def test_raise_exception_on_s3_object_lambda_resource_as_source(self):
-        source = {'Bucket': 'arn:aws:s3-object-lambda:us-west-2:123456789012:'
-                            'accesspoint:my-accesspoint'}
+        source = {
+            'Bucket': 'arn:aws:s3-object-lambda:us-west-2:123456789012:'
+            'accesspoint:my-accesspoint'
+        }
         with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.copy(source, self.bucket, self.key)
 
@@ -295,54 +295,37 @@ class TestMultipartCopy(BaseCopyTest):
     __test__ = True
 
     def setUp(self):
-        super(TestMultipartCopy, self).setUp()
+        super().setUp()
         self.config = TransferConfig(
-            max_request_concurrency=1, multipart_threshold=1,
-            multipart_chunksize=4)
+            max_request_concurrency=1,
+            multipart_threshold=1,
+            multipart_chunksize=4,
+        )
         self._manager = TransferManager(self.client, self.config)
 
     def create_stubbed_responses(self):
         return [
             {
                 'method': 'head_object',
-                'service_response': {
-                    'ContentLength': len(self.content)
-                }
+                'service_response': {'ContentLength': len(self.content)},
             },
             {
                 'method': 'create_multipart_upload',
-                'service_response': {
-                    'UploadId': 'my-upload-id'
-                }
+                'service_response': {'UploadId': 'my-upload-id'},
             },
             {
                 'method': 'upload_part_copy',
-                'service_response': {
-                    'CopyPartResult': {
-                        'ETag': 'etag-1'
-                    }
-                }
+                'service_response': {'CopyPartResult': {'ETag': 'etag-1'}},
             },
             {
                 'method': 'upload_part_copy',
-                'service_response': {
-                    'CopyPartResult': {
-                        'ETag': 'etag-2'
-                    }
-                }
+                'service_response': {'CopyPartResult': {'ETag': 'etag-2'}},
             },
             {
                 'method': 'upload_part_copy',
-                'service_response': {
-                    'CopyPartResult': {
-                        'ETag': 'etag-3'
-                    }
-                }
+                'service_response': {'CopyPartResult': {'ETag': 'etag-3'}},
             },
-            {
-                'method': 'complete_multipart_upload',
-                'service_response': {}
-            }
+            {'method': 'complete_multipart_upload', 'service_response': {}},
         ]
 
     def create_expected_progress_callback_info(self):
@@ -351,7 +334,7 @@ class TestMultipartCopy(BaseCopyTest):
         return [
             {'bytes_transferred': MIN_UPLOAD_CHUNKSIZE},
             {'bytes_transferred': MIN_UPLOAD_CHUNKSIZE},
-            {'bytes_transferred': self.half_chunksize}
+            {'bytes_transferred': self.half_chunksize},
         ]
 
     def add_create_multipart_upload_response(self):
@@ -374,8 +357,11 @@ class TestMultipartCopy(BaseCopyTest):
 
         expected_copy_params = []
         # Add expected parameters to the copy part
-        ranges = ['bytes=0-5242879', 'bytes=5242880-10485759',
-                  'bytes=10485760-13107199']
+        ranges = [
+            'bytes=0-5242879',
+            'bytes=5242880-10485759',
+            'bytes=10485760-13107199',
+        ]
         for i, range_val in enumerate(ranges):
             expected_copy_params.append(
                 {
@@ -384,21 +370,22 @@ class TestMultipartCopy(BaseCopyTest):
                     'CopySource': self.copy_source,
                     'UploadId': upload_id,
                     'PartNumber': i + 1,
-                    'CopySourceRange': range_val
+                    'CopySourceRange': range_val,
                 }
             )
 
         # Add expected parameters for the complete multipart
         expected_complete_mpu_params = {
             'Bucket': self.bucket,
-            'Key': self.key, 'UploadId': upload_id,
+            'Key': self.key,
+            'UploadId': upload_id,
             'MultipartUpload': {
                 'Parts': [
                     {'ETag': 'etag-1', 'PartNumber': 1},
                     {'ETag': 'etag-2', 'PartNumber': 2},
-                    {'ETag': 'etag-3', 'PartNumber': 3}
+                    {'ETag': 'etag-3', 'PartNumber': 3},
                 ]
-            }
+            },
         }
 
         return expected_head_params, {
@@ -408,7 +395,8 @@ class TestMultipartCopy(BaseCopyTest):
         }
 
     def _add_params_to_expected_params(
-            self, add_copy_kwargs, operation_types, new_params):
+        self, add_copy_kwargs, operation_types, new_params
+    ):
 
         expected_params_to_update = []
         for operation_type in operation_types:
@@ -441,8 +429,10 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu', 'copy', 'complete_mpu'],
-            self.extra_args)
+            add_copy_kwargs,
+            ['create_mpu', 'copy', 'complete_mpu'],
+            self.extra_args,
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -472,7 +462,8 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu'], self.extra_args)
+            add_copy_kwargs, ['create_mpu'], self.extra_args
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -490,7 +481,8 @@ class TestMultipartCopy(BaseCopyTest):
         self.add_head_object_response(expected_params=head_params)
 
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['create_mpu', 'copy'], self.extra_args)
+            add_copy_kwargs, ['create_mpu', 'copy'], self.extra_args
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -511,7 +503,8 @@ class TestMultipartCopy(BaseCopyTest):
 
         # However, it needs to remain the same for UploadPartCopy.
         self._add_params_to_expected_params(
-            add_copy_kwargs, ['copy'], self.extra_args)
+            add_copy_kwargs, ['copy'], self.extra_args
+        )
         self.add_successful_copy_responses(**add_copy_kwargs)
 
         call_kwargs = self.create_call_kwargs()
@@ -535,8 +528,8 @@ class TestMultipartCopy(BaseCopyTest):
             expected_params={
                 'Bucket': self.bucket,
                 'Key': self.key,
-                'UploadId': 'my-upload-id'
-            }
+                'UploadId': 'my-upload-id',
+            },
         )
 
         future = self.manager.copy(**self.create_call_kwargs())
@@ -545,9 +538,7 @@ class TestMultipartCopy(BaseCopyTest):
         self.stubber.assert_no_pending_responses()
 
     def test_mp_copy_with_tagging_directive(self):
-        extra_args = {
-            'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'
-        }
+        extra_args = {'Tagging': 'tag1=val1', 'TaggingDirective': 'REPLACE'}
         self.add_head_object_response()
         self.add_successful_copy_responses(
             expected_create_mpu_params={
@@ -557,6 +548,7 @@ class TestMultipartCopy(BaseCopyTest):
             }
         )
         future = self.manager.copy(
-            self.copy_source, self.bucket, self.key, extra_args)
+            self.copy_source, self.bucket, self.key, extra_args
+        )
         future.result()
         self.stubber.assert_no_pending_responses()

--- a/tests/functional/s3transfer/test_crt.py
+++ b/tests/functional/s3transfer/test_crt.py
@@ -18,14 +18,12 @@ from concurrent.futures import Future
 from botocore.session import Session
 
 from s3transfer.subscribers import BaseSubscriber
-
-from tests import (
-    FileCreator, requires_crt, HAS_CRT, unittest, mock
-)
+from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest
 
 if HAS_CRT:
-    import s3transfer.crt
     import awscrt
+
+    import s3transfer.crt
 
 
 class submitThread(threading.Thread):
@@ -72,10 +70,12 @@ class TestCRTTransferManager(unittest.TestCase):
         self.session = Session()
         self.session.set_config_variable('region', self.region)
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
-            self.session)
+            self.session
+        )
         self.transfer_manager = s3transfer.crt.CRTTransferManager(
             crt_s3_client=self.s3_crt_client,
-            crt_request_serializer=self.request_serializer)
+            crt_request_serializer=self.request_serializer,
+        )
         self.record_subscriber = RecordingSubscriber()
 
     def tearDown(self):
@@ -86,11 +86,11 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertTrue(self.record_subscriber.on_done_called)
         if expected_future:
             self.assertIs(
-                self.record_subscriber.on_queued_future,
-                expected_future)
+                self.record_subscriber.on_queued_future, expected_future
+            )
             self.assertIs(
-                self.record_subscriber.on_done_future,
-                expected_future)
+                self.record_subscriber.on_done_future, expected_future
+            )
 
     def _invoke_done_callbacks(self, **kwargs):
         callargs = self.s3_crt_client.make_request.call_args
@@ -99,7 +99,7 @@ class TestCRTTransferManager(unittest.TestCase):
         on_done(error=None)
 
     def _simulate_file_download(self, recv_filepath):
-        self.files.create_file(recv_filepath, "fake resopnse")
+        self.files.create_file(recv_filepath, "fake response")
 
     def _simulate_make_request_side_effect(self, **kwargs):
         if kwargs.get('recv_filepath'):
@@ -108,17 +108,21 @@ class TestCRTTransferManager(unittest.TestCase):
         return mock.DEFAULT
 
     def test_upload(self):
-        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         future = self.transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [self.record_subscriber])
+            self.filename, self.bucket, self.key, {}, [self.record_subscriber]
+        )
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
         callargs_kwargs = callargs[1]
         self.assertEqual(callargs_kwargs["send_filepath"], self.filename)
         self.assertIsNone(callargs_kwargs["recv_filepath"])
-        self.assertEqual(callargs_kwargs["type"],
-                         awscrt.s3.S3RequestType.PUT_OBJECT)
+        self.assertEqual(
+            callargs_kwargs["type"], awscrt.s3.S3RequestType.PUT_OBJECT
+        )
         crt_request = callargs_kwargs["request"]
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
@@ -126,9 +130,12 @@ class TestCRTTransferManager(unittest.TestCase):
         self._assert_subscribers_called(future)
 
     def test_download(self):
-        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         future = self.transfer_manager.download(
-            self.bucket, self.key, self.filename, {}, [self.record_subscriber])
+            self.bucket, self.key, self.filename, {}, [self.record_subscriber]
+        )
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
@@ -137,12 +144,14 @@ class TestCRTTransferManager(unittest.TestCase):
         # random suffix
         self.assertTrue(
             fnmatch.fnmatch(
-                callargs_kwargs["recv_filepath"], f'{self.filename}.*',
+                callargs_kwargs["recv_filepath"],
+                f'{self.filename}.*',
             )
         )
         self.assertIsNone(callargs_kwargs["send_filepath"])
-        self.assertEqual(callargs_kwargs["type"],
-                         awscrt.s3.S3RequestType.GET_OBJECT)
+        self.assertEqual(
+            callargs_kwargs["type"], awscrt.s3.S3RequestType.GET_OBJECT
+        )
         crt_request = callargs_kwargs["request"]
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
@@ -150,20 +159,24 @@ class TestCRTTransferManager(unittest.TestCase):
         self._assert_subscribers_called(future)
         with open(self.filename, 'rb') as f:
             # Check the fake response overwrites the file because of download
-            self.assertEqual(f.read(), b'fake resopnse')
+            self.assertEqual(f.read(), b'fake response')
 
     def test_delete(self):
-        self.s3_crt_client.make_request.side_effect = self._simulate_make_request_side_effect
+        self.s3_crt_client.make_request.side_effect = (
+            self._simulate_make_request_side_effect
+        )
         future = self.transfer_manager.delete(
-            self.bucket, self.key, {}, [self.record_subscriber])
+            self.bucket, self.key, {}, [self.record_subscriber]
+        )
         future.result()
 
         callargs = self.s3_crt_client.make_request.call_args
         callargs_kwargs = callargs[1]
         self.assertIsNone(callargs_kwargs["send_filepath"])
         self.assertIsNone(callargs_kwargs["recv_filepath"])
-        self.assertEqual(callargs_kwargs["type"],
-                         awscrt.s3.S3RequestType.DEFAULT)
+        self.assertEqual(
+            callargs_kwargs["type"], awscrt.s3.S3RequestType.DEFAULT
+        )
         crt_request = callargs_kwargs["request"]
         self.assertEqual("DELETE", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
@@ -184,8 +197,8 @@ class TestCRTTransferManager(unittest.TestCase):
         while len(futures) < max_request_processes:
             time.sleep(0.05)
         self.assertLessEqual(
-            self.s3_crt_client.make_request.call_count,
-            max_request_processes)
+            self.s3_crt_client.make_request.call_count, max_request_processes
+        )
         # Release lock
         callargs = self.s3_crt_client.make_request.call_args
         callargs_kwargs = callargs[1]
@@ -194,13 +207,14 @@ class TestCRTTransferManager(unittest.TestCase):
         for thread in threads:
             thread.join()
         self.assertEqual(
-            self.s3_crt_client.make_request.call_count,
-            all_concurrent)
+            self.s3_crt_client.make_request.call_count, all_concurrent
+        )
 
     def _cancel_function(self):
         self.cancel_called = True
         self.s3_request.finished_future.set_exception(
-            awscrt.exceptions.from_code(0))
+            awscrt.exceptions.from_code(0)
+        )
         self._invoke_done_callbacks()
 
     def test_cancel(self):
@@ -210,7 +224,8 @@ class TestCRTTransferManager(unittest.TestCase):
         try:
             with self.transfer_manager:
                 future = self.transfer_manager.upload(
-                    self.filename, self.bucket, self.key, {}, [])
+                    self.filename, self.bucket, self.key, {}, []
+                )
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass
@@ -220,28 +235,33 @@ class TestCRTTransferManager(unittest.TestCase):
         self.assertTrue(self.cancel_called)
 
     def test_serializer_error_handling(self):
-
         class SerializationException(Exception):
             pass
 
-        class ExceptionRaisingSerializer(s3transfer.crt.BaseCRTRequestSerializer):
+        class ExceptionRaisingSerializer(
+            s3transfer.crt.BaseCRTRequestSerializer
+        ):
             def serialize_http_request(self, transfer_type, future):
                 raise SerializationException()
 
         not_impl_serializer = ExceptionRaisingSerializer()
         transfer_manager = s3transfer.crt.CRTTransferManager(
             crt_s3_client=self.s3_crt_client,
-            crt_request_serializer=not_impl_serializer)
+            crt_request_serializer=not_impl_serializer,
+        )
         future = transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [])
+            self.filename, self.bucket, self.key, {}, []
+        )
 
         with self.assertRaises(SerializationException):
             future.result()
 
     def test_crt_s3_client_error_handling(self):
-        self.s3_crt_client.make_request.side_effect = awscrt.exceptions.from_code(
-            0)
+        self.s3_crt_client.make_request.side_effect = (
+            awscrt.exceptions.from_code(0)
+        )
         future = self.transfer_manager.upload(
-            self.filename, self.bucket, self.key, {}, [])
+            self.filename, self.bucket, self.key, {}, []
+        )
         with self.assertRaises(awscrt.exceptions.AwsCrtError):
             future.result()

--- a/tests/functional/s3transfer/test_delete.py
+++ b/tests/functional/s3transfer/test_delete.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import BaseGeneralInterfaceTest
 from s3transfer.manager import TransferManager
+from tests import BaseGeneralInterfaceTest
 
 
 class TestDeleteObject(BaseGeneralInterfaceTest):
@@ -19,7 +19,7 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
     __test__ = True
 
     def setUp(self):
-        super(TestDeleteObject, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
         self.manager = TransferManager(self.client)
@@ -49,18 +49,21 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
 
             [{'method': 'put_object', 'service_response': {}}]
         """
-        return [{
-            'method': 'delete_object',
-            'service_response': {},
-            'expected_params': {'Bucket': self.bucket, 'Key': self.key},
-        }]
+        return [
+            {
+                'method': 'delete_object',
+                'service_response': {},
+                'expected_params': {'Bucket': self.bucket, 'Key': self.key},
+            }
+        ]
 
     def create_expected_progress_callback_info(self):
         return []
 
     def test_known_allowed_args_in_input_shape(self):
         op_model = self.client.meta.service_model.operation_model(
-            'DeleteObject')
+            'DeleteObject'
+        )
         for allowed_arg in self.manager.ALLOWED_DELETE_ARGS:
             self.assertIn(allowed_arg, op_model.input_shape.members)
 

--- a/tests/functional/s3transfer/test_utils.py
+++ b/tests/functional/s3transfer/test_utils.py
@@ -15,9 +15,8 @@ import shutil
 import socket
 import tempfile
 
-from tests import unittest
-from tests import skip_if_windows
 from s3transfer.utils import OSUtils
+from tests import skip_if_windows, unittest
 
 
 @skip_if_windows('Windows does not support UNIX special files')

--- a/tests/integration/s3transfer/__init__.py
+++ b/tests/integration/s3transfer/__init__.py
@@ -14,12 +14,9 @@ import botocore
 import botocore.session
 from botocore.exceptions import WaiterError
 
-from tests import unittest
-from tests import FileCreator
-from tests import S3Utils
-from tests import random_bucket_name
 from s3transfer.manager import TransferManager
 from s3transfer.subscribers import BaseSubscriber
+from tests import FileCreator, S3Utils, random_bucket_name, unittest
 
 
 class BaseTransferManagerIntegTest(unittest.TestCase):
@@ -45,16 +42,12 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
         cls.s3_utils.delete_bucket(cls.bucket_name)
 
     def create_client(self, **override_kwargs):
-        kwargs = {
-            'region_name': self.region
-        }
+        kwargs = {'region_name': self.region}
         kwargs.update(override_kwargs)
         return self.session.create_client('s3', **kwargs)
 
     def delete_object(self, key):
-        self.client.delete_object(
-            Bucket=self.bucket_name,
-            Key=key)
+        self.client.delete_object(Bucket=self.bucket_name, Key=key)
 
     def object_exists(self, key, extra_args=None):
         try:
@@ -68,9 +61,7 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             extra_args = {}
         try:
             self.client.get_waiter('object_not_exists').wait(
-                Bucket=self.bucket_name,
-                Key=key,
-                **extra_args
+                Bucket=self.bucket_name, Key=key, **extra_args
             )
             return True
         except WaiterError:
@@ -81,9 +72,7 @@ class BaseTransferManagerIntegTest(unittest.TestCase):
             extra_args = {}
         for _ in range(5):
             self.client.get_waiter('object_exists').wait(
-                Bucket=self.bucket_name,
-                Key=key,
-                **extra_args
+                Bucket=self.bucket_name, Key=key, **extra_args
             )
 
     def create_transfer_manager(self, config=None, client=None):

--- a/tests/integration/s3transfer/test_copy.py
+++ b/tests/integration/s3transfer/test_copy.py
@@ -10,31 +10,31 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from s3transfer.manager import TransferConfig
 from tests import RecordingSubscriber
 from tests.integration.s3transfer import BaseTransferManagerIntegTest
-from s3transfer.manager import TransferConfig
 
 
 class TestCopy(BaseTransferManagerIntegTest):
     def setUp(self):
-        super(TestCopy, self).setUp()
+        super().setUp()
         self.multipart_threshold = 5 * 1024 * 1024
         self.config = TransferConfig(
-            multipart_threshold=self.multipart_threshold)
+            multipart_threshold=self.multipart_threshold
+        )
 
     def test_copy_below_threshold(self):
         transfer_manager = self.create_transfer_manager(self.config)
         key = '1mb.txt'
         new_key = '1mb-copy.txt'
 
-        filename = self.files.create_file_with_size(
-            key, filesize=1024 * 1024)
+        filename = self.files.create_file_with_size(key, filesize=1024 * 1024)
         self.upload_file(filename, key)
 
         future = transfer_manager.copy(
             copy_source={'Bucket': self.bucket_name, 'Key': key},
             bucket=self.bucket_name,
-            key=new_key
+            key=new_key,
         )
 
         future.result()
@@ -46,13 +46,14 @@ class TestCopy(BaseTransferManagerIntegTest):
         new_key = '20mb-copy.txt'
 
         filename = self.files.create_file_with_size(
-            key, filesize=20 * 1024 * 1024)
+            key, filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, key)
 
         future = transfer_manager.copy(
             copy_source={'Bucket': self.bucket_name, 'Key': key},
             bucket=self.bucket_name,
-            key=new_key
+            key=new_key,
         )
 
         future.result()
@@ -65,14 +66,15 @@ class TestCopy(BaseTransferManagerIntegTest):
         new_key = '20mb-copy.txt'
 
         filename = self.files.create_file_with_size(
-            key, filesize=20 * 1024 * 1024)
+            key, filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, key)
 
         future = transfer_manager.copy(
             copy_source={'Bucket': self.bucket_name, 'Key': key},
             bucket=self.bucket_name,
             key=new_key,
-            subscribers=[subscriber]
+            subscribers=[subscriber],
         )
 
         future.result()

--- a/tests/integration/s3transfer/test_crt.py
+++ b/tests/integration/s3transfer/test_crt.py
@@ -10,19 +10,18 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import os
 import glob
-from s3transfer.utils import OSUtils
-
-from tests.integration.s3transfer import BaseTransferManagerIntegTest
-from tests import assert_files_equal
+import os
 
 from s3transfer.subscribers import BaseSubscriber
-from tests import requires_crt, HAS_CRT
+from s3transfer.utils import OSUtils
+from tests import HAS_CRT, assert_files_equal, requires_crt
+from tests.integration.s3transfer import BaseTransferManagerIntegTest
 
 if HAS_CRT:
-    import s3transfer.crt
     from awscrt.exceptions import AwsCrtError
+
+    import s3transfer.crt
 
 
 class RecordingSubscriber(BaseSubscriber):
@@ -47,19 +46,25 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
 
     def _create_s3_transfer(self):
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
-            self.session, client_kwargs={'region_name': self.region})
+            self.session, client_kwargs={'region_name': self.region}
+        )
         credetial_resolver = self.session.get_component('credential_provider')
         self.s3_crt_client = s3transfer.crt.create_s3_crt_client(
-            self.region, credetial_resolver)
+            self.region, credetial_resolver
+        )
         self.record_subscriber = RecordingSubscriber()
         self.osutil = OSUtils()
         return s3transfer.crt.CRTTransferManager(
-            self.s3_crt_client, self.request_serializer)
+            self.s3_crt_client, self.request_serializer
+        )
 
     def _assert_has_public_read_acl(self, response):
         grants = response['Grants']
-        public_read = [g['Grantee'].get('URI', '') for g in grants
-                       if g['Permission'] == 'READ']
+        public_read = [
+            g['Grantee'].get('URI', '')
+            for g in grants
+            if g['Permission'] == 'READ'
+        ]
         self.assertIn('groups/global/AllUsers', public_read[0])
 
     def _assert_subscribers_called(self, expected_bytes_transferred=None):
@@ -68,19 +73,24 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         if expected_bytes_transferred:
             self.assertEqual(
                 self.record_subscriber.bytes_transferred,
-                expected_bytes_transferred)
+                expected_bytes_transferred,
+            )
 
     def test_upload_below_multipart_chunksize(self):
         transfer = self._create_s3_transfer()
         file_size = 1024 * 1024
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=file_size)
+            'foo.txt', filesize=file_size
+        )
         self.addCleanup(self.delete_object, 'foo.txt')
 
         with transfer:
             future = transfer.upload(
-                filename, self.bucket_name, 'foo.txt',
-                subscribers=[self.record_subscriber])
+                filename,
+                self.bucket_name,
+                'foo.txt',
+                subscribers=[self.record_subscriber],
+            )
             future.result()
 
         self.assertTrue(self.object_exists('foo.txt'))
@@ -90,13 +100,17 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         transfer = self._create_s3_transfer()
         file_size = 20 * 1024 * 1024
         filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=file_size)
+            '20mb.txt', filesize=file_size
+        )
         self.addCleanup(self.delete_object, '20mb.txt')
 
         with transfer:
             future = transfer.upload(
-                filename, self.bucket_name, '20mb.txt',
-                subscribers=[self.record_subscriber])
+                filename,
+                self.bucket_name,
+                '20mb.txt',
+                subscribers=[self.record_subscriber],
+            )
             future.result()
         self.assertTrue(self.object_exists('20mb.txt'))
         self._assert_subscribers_called(file_size)
@@ -105,20 +119,25 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         transfer = self._create_s3_transfer()
         file_size = 6 * 1024 * 1024
         filename = self.files.create_file_with_size(
-            '6mb.txt', filesize=file_size)
+            '6mb.txt', filesize=file_size
+        )
         extra_args = {'ACL': 'public-read'}
         self.addCleanup(self.delete_object, '6mb.txt')
 
         with transfer:
             future = transfer.upload(
-                filename, self.bucket_name,
-                '6mb.txt', extra_args=extra_args,
-                subscribers=[self.record_subscriber])
+                filename,
+                self.bucket_name,
+                '6mb.txt',
+                extra_args=extra_args,
+                subscribers=[self.record_subscriber],
+            )
             future.result()
 
         self.assertTrue(self.object_exists('6mb.txt'))
         response = self.client.get_object_acl(
-            Bucket=self.bucket_name, Key='6mb.txt')
+            Bucket=self.bucket_name, Key='6mb.txt'
+        )
         self._assert_has_public_read_acl(response)
         self._assert_subscribers_called(file_size)
 
@@ -131,13 +150,17 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         file_size = 6 * 1024 * 1024
         transfer = self._create_s3_transfer()
         filename = self.files.create_file_with_size(
-            '6mb.txt', filesize=file_size)
+            '6mb.txt', filesize=file_size
+        )
         self.addCleanup(self.delete_object, '6mb.txt')
         with transfer:
             future = transfer.upload(
-                filename, self.bucket_name,
-                '6mb.txt', extra_args=extra_args,
-                subscribers=[self.record_subscriber])
+                filename,
+                self.bucket_name,
+                '6mb.txt',
+                extra_args=extra_args,
+                subscribers=[self.record_subscriber],
+            )
             future.result()
         # A head object will fail if it has a customer key
         # associated with it and it's not provided in the HeadObject
@@ -148,8 +171,8 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         }
         self.wait_object_exists('6mb.txt', oringal_extra_args)
         response = self.client.head_object(
-            Bucket=self.bucket_name,
-            Key='6mb.txt', **oringal_extra_args)
+            Bucket=self.bucket_name, Key='6mb.txt', **oringal_extra_args
+        )
         self.assertEqual(response['SSECustomerAlgorithm'], 'AES256')
         self._assert_subscribers_called(file_size)
 
@@ -169,9 +192,12 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
         with transfer:
             future = transfer.download(
-                self.bucket_name, 'foo.txt',
-                download_path, extra_args=extra_args,
-                subscribers=[self.record_subscriber])
+                self.bucket_name,
+                'foo.txt',
+                download_path,
+                extra_args=extra_args,
+                subscribers=[self.record_subscriber],
+            )
             future.result()
         file_size = self.osutil.get_file_size(download_path)
         self._assert_subscribers_called(file_size)
@@ -181,14 +207,18 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     def test_download_below_threshold(self):
         transfer = self._create_s3_transfer()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, 'foo.txt')
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
         with transfer:
-            future = transfer.download(self.bucket_name, 'foo.txt',
-                                       download_path,
-                                       subscribers=[self.record_subscriber])
+            future = transfer.download(
+                self.bucket_name,
+                'foo.txt',
+                download_path,
+                subscribers=[self.record_subscriber],
+            )
             future.result()
         file_size = self.osutil.get_file_size(download_path)
         self._assert_subscribers_called(file_size)
@@ -197,14 +227,18 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     def test_download_above_threshold(self):
         transfer = self._create_s3_transfer()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, 'foo.txt')
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
         with transfer:
-            future = transfer.download(self.bucket_name, 'foo.txt',
-                                       download_path,
-                                       subscribers=[self.record_subscriber])
+            future = transfer.download(
+                self.bucket_name,
+                'foo.txt',
+                download_path,
+                subscribers=[self.record_subscriber],
+            )
             future.result()
         assert_files_equal(filename, download_path)
         file_size = self.osutil.get_file_size(download_path)
@@ -213,7 +247,8 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     def test_delete(self):
         transfer = self._create_s3_transfer()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=1024 * 1024)
+            'foo.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, 'foo.txt')
 
         with transfer:
@@ -225,7 +260,8 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         transfer = self._create_s3_transfer()
 
         filename = self.files.create_file_with_size(
-            '1mb.txt', filesize=1024 * 1024)
+            '1mb.txt', filesize=1024 * 1024
+        )
         self.upload_file(filename, '1mb.txt')
 
         filenames = []
@@ -235,8 +271,7 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
 
         with transfer:
             for filename in filenames:
-                transfer.download(
-                    self.bucket_name, '1mb.txt', filename)
+                transfer.download(self.bucket_name, '1mb.txt', filename)
         for download_path in filenames:
             assert_files_equal(filename, download_path)
 
@@ -250,13 +285,13 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
             key = base_key + str(i) + sufix
             keys.append(key)
             filename = self.files.create_file_with_size(
-                key, filesize=1024 * 1024)
+                key, filesize=1024 * 1024
+            )
             filenames.append(filename)
             self.addCleanup(self.delete_object, key)
         with transfer:
             for filename, key in zip(filenames, keys):
-                transfer.upload(
-                    filename, self.bucket_name, key)
+                transfer.upload(filename, self.bucket_name, key)
 
         for key in keys:
             self.assertTrue(self.object_exists(key))
@@ -267,7 +302,8 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
         base_key = 'foo'
         sufix = '.txt'
         filename = self.files.create_file_with_size(
-            '1mb.txt', filesize=1024 * 1024)
+            '1mb.txt', filesize=1024 * 1024
+        )
         for i in range(10):
             key = base_key + str(i) + sufix
             keys.append(key)
@@ -282,12 +318,14 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     def test_upload_cancel(self):
         transfer = self._create_s3_transfer()
         filename = self.files.create_file_with_size(
-            '20mb.txt', filesize=20 * 1024 * 1024)
+            '20mb.txt', filesize=20 * 1024 * 1024
+        )
         future = None
         try:
             with transfer:
                 future = transfer.upload(
-                    filename, self.bucket_name, '20mb.txt')
+                    filename, self.bucket_name, '20mb.txt'
+                )
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass
@@ -300,16 +338,20 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     def test_download_cancel(self):
         transfer = self._create_s3_transfer()
         filename = self.files.create_file_with_size(
-            'foo.txt', filesize=20 * 1024 * 1024)
+            'foo.txt', filesize=20 * 1024 * 1024
+        )
         self.upload_file(filename, 'foo.txt')
 
         download_path = os.path.join(self.files.rootdir, 'downloaded.txt')
         future = None
         try:
             with transfer:
-                future = transfer.download(self.bucket_name, 'foo.txt',
-                                           download_path,
-                                           subscribers=[self.record_subscriber])
+                future = transfer.download(
+                    self.bucket_name,
+                    'foo.txt',
+                    download_path,
+                    subscribers=[self.record_subscriber],
+                )
                 raise KeyboardInterrupt()
         except KeyboardInterrupt:
             pass

--- a/tests/integration/s3transfer/test_delete.py
+++ b/tests/integration/s3transfer/test_delete.py
@@ -14,16 +14,15 @@ from tests.integration.s3transfer import BaseTransferManagerIntegTest
 
 
 class TestDeleteObject(BaseTransferManagerIntegTest):
-
     def test_can_delete_object(self):
         key_name = 'mykey'
-        self.client.put_object(Bucket=self.bucket_name,
-                               Key=key_name, Body=b'hello world')
+        self.client.put_object(
+            Bucket=self.bucket_name, Key=key_name, Body=b'hello world'
+        )
         self.assertTrue(self.object_exists(key_name))
 
         transfer_manager = self.create_transfer_manager()
-        future = transfer_manager.delete(bucket=self.bucket_name,
-                                         key=key_name)
+        future = transfer_manager.delete(bucket=self.bucket_name, key=key_name)
         future.result()
 
         self.assertTrue(self.object_not_exists(key_name))

--- a/tests/unit/s3transfer/test_compat.py
+++ b/tests/unit/s3transfer/test_compat.py
@@ -11,24 +11,21 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import tempfile
 import shutil
-import signal
+import tempfile
+from io import BytesIO
 
-from botocore.compat import six
-
+from s3transfer.compat import readable, seekable
 from tests import unittest
-from tests import skip_if_windows
-from s3transfer.compat import seekable, readable
-from s3transfer.compat import BaseManager
 
 
-class ErrorRaisingSeekWrapper(object):
+class ErrorRaisingSeekWrapper:
     """An object wrapper that throws an error when seeked on
 
     :param fileobj: The fileobj that it wraps
-    :param execption: The exception to raise when seeked on.
+    :param exception: The exception to raise when seeked on.
     """
+
     def __init__(self, fileobj, exception):
         self._fileobj = fileobj
         self._exception = exception
@@ -53,7 +50,7 @@ class TestSeekable(unittest.TestCase):
             self.assertTrue(seekable(f))
 
     def test_non_file_like_obj(self):
-        # Fails becase there is no seekable(), seek(), nor tell()
+        # Fails because there is no seekable(), seek(), nor tell()
         self.assertFalse(seekable(object()))
 
     def test_non_seekable_ioerror(self):
@@ -73,7 +70,7 @@ class TestReadable(unittest.TestCase):
             self.assertTrue(readable(f))
 
     def test_readable_file_like_obj(self):
-        self.assertTrue(readable(six.BytesIO()))
+        self.assertTrue(readable(BytesIO()))
 
     def test_non_file_like_obj(self):
         self.assertFalse(readable(object()))

--- a/tests/unit/s3transfer/test_copies.py
+++ b/tests/unit/s3transfer/test_copies.py
@@ -10,21 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import BaseTaskTest
-from tests import RecordingSubscriber
-from s3transfer.copies import CopyObjectTask
-from s3transfer.copies import CopyPartTask
+from s3transfer.copies import CopyObjectTask, CopyPartTask
+from tests import BaseTaskTest, RecordingSubscriber
 
 
 class BaseCopyTaskTest(BaseTaskTest):
     def setUp(self):
-        super(BaseCopyTaskTest, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
-        self.copy_source = {
-            'Bucket': 'mysourcebucket',
-            'Key': 'mysourcekey'
-        }
+        self.copy_source = {'Bucket': 'mysourcebucket', 'Key': 'mysourcekey'}
         self.extra_args = {}
         self.callbacks = []
         self.size = 5
@@ -33,21 +28,26 @@ class BaseCopyTaskTest(BaseTaskTest):
 class TestCopyObjectTask(BaseCopyTaskTest):
     def get_copy_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'copy_source': self.copy_source,
-            'bucket': self.bucket, 'key': self.key,
-            'extra_args': self.extra_args, 'callbacks': self.callbacks,
-            'size': self.size
+            'client': self.client,
+            'copy_source': self.copy_source,
+            'bucket': self.bucket,
+            'key': self.key,
+            'extra_args': self.extra_args,
+            'callbacks': self.callbacks,
+            'size': self.size,
         }
         default_kwargs.update(kwargs)
         return self.get_task(CopyObjectTask, main_kwargs=default_kwargs)
 
     def test_main(self):
         self.stubber.add_response(
-            'copy_object', service_response={},
+            'copy_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+            },
         )
         task = self.get_copy_task()
         task()
@@ -57,11 +57,14 @@ class TestCopyObjectTask(BaseCopyTaskTest):
     def test_extra_args(self):
         self.extra_args['ACL'] = 'private'
         self.stubber.add_response(
-            'copy_object', service_response={},
+            'copy_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'ACL': 'private'
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'ACL': 'private',
+            },
         )
         task = self.get_copy_task()
         task()
@@ -72,11 +75,13 @@ class TestCopyObjectTask(BaseCopyTaskTest):
         subscriber = RecordingSubscriber()
         self.callbacks.append(subscriber.on_progress)
         self.stubber.add_response(
-            'copy_object', service_response={},
+            'copy_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+            },
         )
         task = self.get_copy_task()
         task()
@@ -87,7 +92,7 @@ class TestCopyObjectTask(BaseCopyTaskTest):
 
 class TestCopyPartTask(BaseCopyTaskTest):
     def setUp(self):
-        super(TestCopyPartTask, self).setUp()
+        super().setUp()
         self.copy_source_range = 'bytes=5-9'
         self.extra_args['CopySourceRange'] = self.copy_source_range
         self.upload_id = 'myuploadid'
@@ -96,73 +101,77 @@ class TestCopyPartTask(BaseCopyTaskTest):
 
     def get_copy_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'copy_source': self.copy_source,
-            'bucket': self.bucket, 'key': self.key,
-            'upload_id': self.upload_id, 'part_number': self.part_number,
-            'extra_args': self.extra_args, 'callbacks': self.callbacks,
-            'size': self.size
+            'client': self.client,
+            'copy_source': self.copy_source,
+            'bucket': self.bucket,
+            'key': self.key,
+            'upload_id': self.upload_id,
+            'part_number': self.part_number,
+            'extra_args': self.extra_args,
+            'callbacks': self.callbacks,
+            'size': self.size,
         }
         default_kwargs.update(kwargs)
         return self.get_task(CopyPartTask, main_kwargs=default_kwargs)
 
     def test_main(self):
         self.stubber.add_response(
-            'upload_part_copy', service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag
-                }
-            },
+            'upload_part_copy',
+            service_response={'CopyPartResult': {'ETag': self.result_etag}},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'UploadId': self.upload_id,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
                 'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range
-            }
+                'CopySourceRange': self.copy_source_range,
+            },
         )
         task = self.get_copy_task()
         self.assertEqual(
-            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag})
+            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
         self.stubber.assert_no_pending_responses()
 
     def test_extra_args(self):
         self.extra_args['RequestPayer'] = 'requester'
         self.stubber.add_response(
-            'upload_part_copy', service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag
-                }
-            },
+            'upload_part_copy',
+            service_response={'CopyPartResult': {'ETag': self.result_etag}},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'UploadId': self.upload_id,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
                 'PartNumber': self.part_number,
                 'CopySourceRange': self.copy_source_range,
-                'RequestPayer': 'requester'
-            }
+                'RequestPayer': 'requester',
+            },
         )
         task = self.get_copy_task()
         self.assertEqual(
-            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag})
+            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
         self.stubber.assert_no_pending_responses()
 
     def test_callbacks_invoked(self):
         subscriber = RecordingSubscriber()
         self.callbacks.append(subscriber.on_progress)
         self.stubber.add_response(
-            'upload_part_copy', service_response={
-                'CopyPartResult': {
-                    'ETag': self.result_etag
-                }
-            },
+            'upload_part_copy',
+            service_response={'CopyPartResult': {'ETag': self.result_etag}},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-                'CopySource': self.copy_source, 'UploadId': self.upload_id,
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.upload_id,
                 'PartNumber': self.part_number,
-                'CopySourceRange': self.copy_source_range
-            }
+                'CopySourceRange': self.copy_source_range,
+            },
         )
         task = self.get_copy_task()
         self.assertEqual(
-            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag})
+            task(), {'PartNumber': self.part_number, 'ETag': self.result_etag}
+        )
         self.stubber.assert_no_pending_responses()
         self.assertEqual(subscriber.calculate_bytes_seen(), self.size)

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -10,17 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.session import Session
 from botocore.credentials import CredentialResolver, ReadOnlyCredentials
+from botocore.session import Session
+
 from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.utils import CallArgs
-
-from tests import (
-    FileCreator, requires_crt, HAS_CRT, mock, unittest
-)
+from tests import HAS_CRT, FileCreator, mock, requires_crt, unittest
 
 if HAS_CRT:
     import awscrt.s3
+
     import s3transfer.crt
 
 
@@ -35,7 +34,8 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.session = Session()
         self.session.set_config_variable('region', self.region)
         self.request_serializer = s3transfer.crt.BotocoreCRTRequestSerializer(
-            self.session)
+            self.session
+        )
         self.bucket = "test_bucket"
         self.key = "test_key"
         self.files = FileCreator()
@@ -48,14 +48,19 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
     def test_upload_request(self):
         callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
+            bucket=self.bucket,
+            key=self.key,
+            fileobj=self.filename,
+            extra_args={},
+            subscribers=[],
+        )
         coordinator = s3transfer.crt.CRTTransferCoordinator()
         future = s3transfer.crt.CRTTransferFuture(
-            s3transfer.crt.CRTTransferMeta(call_args=callargs),
-            coordinator)
+            s3transfer.crt.CRTTransferMeta(call_args=callargs), coordinator
+        )
         crt_request = self.request_serializer.serialize_http_request(
-            "put_object", future)
+            "put_object", future
+        )
         self.assertEqual("PUT", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
@@ -63,14 +68,19 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
     def test_download_request(self):
         callargs = CallArgs(
-            bucket=self.bucket, key=self.key, fileobj=self.filename,
-            extra_args={}, subscribers=[])
+            bucket=self.bucket,
+            key=self.key,
+            fileobj=self.filename,
+            extra_args={},
+            subscribers=[],
+        )
         coordinator = s3transfer.crt.CRTTransferCoordinator()
         future = s3transfer.crt.CRTTransferFuture(
-            s3transfer.crt.CRTTransferMeta(call_args=callargs),
-            coordinator)
+            s3transfer.crt.CRTTransferMeta(call_args=callargs), coordinator
+        )
         crt_request = self.request_serializer.serialize_http_request(
-            "get_object", future)
+            "get_object", future
+        )
         self.assertEqual("GET", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
@@ -78,14 +88,15 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
     def test_delete_request(self):
         callargs = CallArgs(
-            bucket=self.bucket, key=self.key,
-            extra_args={}, subscribers=[])
+            bucket=self.bucket, key=self.key, extra_args={}, subscribers=[]
+        )
         coordinator = s3transfer.crt.CRTTransferCoordinator()
         future = s3transfer.crt.CRTTransferFuture(
-            s3transfer.crt.CRTTransferMeta(call_args=callargs),
-            coordinator)
+            s3transfer.crt.CRTTransferMeta(call_args=callargs), coordinator
+        )
         crt_request = self.request_serializer.serialize_http_request(
-            "delete_object", future)
+            "delete_object", future
+        )
         self.assertEqual("DELETE", crt_request.method)
         self.assertEqual(self.expected_path, crt_request.path)
         self.assertEqual(self.expected_host, crt_request.headers.get("host"))
@@ -94,15 +105,14 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
 
 @requires_crt
 class TestCRTCredentialProviderAdapter(unittest.TestCase):
-
     def setUp(self):
         self.botocore_credential_provider = mock.Mock(CredentialResolver)
         self.access_key = "access_key"
         self.secret_key = "secret_key"
         self.token = "token"
-        self.botocore_credential_provider.load_credentials.return_value.\
-            get_frozen_credentials.return_value = ReadOnlyCredentials(
-                self.access_key, self.secret_key, self.token)
+        self.botocore_credential_provider.load_credentials.return_value.get_frozen_credentials.return_value = ReadOnlyCredentials(
+            self.access_key, self.secret_key, self.token
+        )
 
     def _call_adapter_and_check(self, credentails_provider_adapter):
         credentials = credentails_provider_adapter()
@@ -111,22 +121,27 @@ class TestCRTCredentialProviderAdapter(unittest.TestCase):
         self.assertEqual(credentials.session_token, self.token)
 
     def test_fetch_crt_credentials_successfully(self):
-        credentails_provider_adapter = \
+        credentails_provider_adapter = (
             s3transfer.crt.CRTCredentialProviderAdapter(
-                self.botocore_credential_provider)
+                self.botocore_credential_provider
+            )
+        )
         self._call_adapter_and_check(credentails_provider_adapter)
 
     def test_load_credentials_once(self):
-        credentails_provider_adapter = \
+        credentails_provider_adapter = (
             s3transfer.crt.CRTCredentialProviderAdapter(
-                self.botocore_credential_provider)
+                self.botocore_credential_provider
+            )
+        )
         called_times = 5
         for i in range(called_times):
             self._call_adapter_and_check(credentails_provider_adapter)
         # Assert that the load_credentails of botocore credential provider
         # will only be called once
         self.assertEqual(
-            self.botocore_credential_provider.load_credentials.call_count, 1)
+            self.botocore_credential_provider.load_credentials.call_count, 1
+        )
 
 
 @requires_crt
@@ -138,7 +153,8 @@ class TestCRTTransferFuture(unittest.TestCase):
         self.coordinator = s3transfer.crt.CRTTransferCoordinator()
         self.coordinator.set_s3_request(self.mock_s3_request)
         self.future = s3transfer.crt.CRTTransferFuture(
-            coordinator=self.coordinator)
+            coordinator=self.coordinator
+        )
 
     def test_set_exception(self):
         self.future.set_exception(CustomFutureException())

--- a/tests/unit/s3transfer/test_delete.py
+++ b/tests/unit/s3transfer/test_delete.py
@@ -10,13 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import BaseTaskTest
 from s3transfer.delete import DeleteObjectTask
+from tests import BaseTaskTest
 
 
 class TestDeleteObjectTask(BaseTaskTest):
     def setUp(self):
-        super(TestDeleteObjectTask, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'mykey'
         self.extra_args = {}
@@ -24,7 +24,9 @@ class TestDeleteObjectTask(BaseTaskTest):
 
     def get_delete_task(self, **kwargs):
         default_kwargs = {
-            'client': self.client, 'bucket': self.bucket, 'key': self.key,
+            'client': self.client,
+            'bucket': self.bucket,
+            'key': self.key,
             'extra_args': self.extra_args,
         }
         default_kwargs.update(kwargs)
@@ -32,10 +34,12 @@ class TestDeleteObjectTask(BaseTaskTest):
 
     def test_main(self):
         self.stubber.add_response(
-            'delete_object', service_response={},
+            'delete_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
-            }
+                'Bucket': self.bucket,
+                'Key': self.key,
+            },
         )
         task = self.get_delete_task()
         task()
@@ -46,14 +50,16 @@ class TestDeleteObjectTask(BaseTaskTest):
         self.extra_args['MFA'] = 'mfa-code'
         self.extra_args['VersionId'] = '12345'
         self.stubber.add_response(
-            'delete_object', service_response={},
+            'delete_object',
+            service_response={},
             expected_params={
-                'Bucket': self.bucket, 'Key': self.key,
+                'Bucket': self.bucket,
+                'Key': self.key,
                 # These extra_args should be injected into the
                 # expected params for the delete_object call.
                 'MFA': 'mfa-code',
                 'VersionId': '12345',
-            }
+            },
         )
         task = self.get_delete_task()
         task()

--- a/tests/unit/s3transfer/test_manager.py
+++ b/tests/unit/s3transfer/test_manager.py
@@ -11,16 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import time
-
 from concurrent.futures import ThreadPoolExecutor
 
-from tests import unittest
-from tests import TransferCoordinatorWithInterrupt
-from s3transfer.exceptions import CancelledError
-from s3transfer.exceptions import FatalError
+from s3transfer.exceptions import CancelledError, FatalError
 from s3transfer.futures import TransferCoordinator
-from s3transfer.manager import TransferConfig
-from s3transfer.manager import TransferCoordinatorController
+from s3transfer.manager import TransferConfig, TransferCoordinatorController
+from tests import TransferCoordinatorWithInterrupt, unittest
 
 
 class FutureResultException(Exception):
@@ -49,29 +45,35 @@ class TestTransferCoordinatorController(unittest.TestCase):
         transfer_coordinator = TransferCoordinator()
         # Add the transfer coordinator
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Ensure that is tracked.
         self.assertEqual(
             self.coordinator_controller.tracked_transfer_coordinators,
-            set([transfer_coordinator]))
+            {transfer_coordinator},
+        )
 
     def test_remove_transfer_coordinator(self):
         transfer_coordinator = TransferCoordinator()
         # Add the coordinator
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Now remove the coordinator
         self.coordinator_controller.remove_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Make sure that it is no longer getting tracked.
         self.assertEqual(
-            self.coordinator_controller.tracked_transfer_coordinators, set())
+            self.coordinator_controller.tracked_transfer_coordinators, set()
+        )
 
     def test_cancel(self):
         transfer_coordinator = TransferCoordinator()
         # Add the transfer coordinator
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         # Cancel with the canceler
         self.coordinator_controller.cancel()
         # Check that coordinator got canceled
@@ -81,7 +83,8 @@ class TestTransferCoordinatorController(unittest.TestCase):
         message = 'my cancel message'
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         self.coordinator_controller.cancel(message)
         transfer_coordinator.announce_done()
         with self.assertRaisesRegex(CancelledError, message):
@@ -91,7 +94,8 @@ class TestTransferCoordinatorController(unittest.TestCase):
         message = 'my cancel message'
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
         self.coordinator_controller.cancel(message, exc_type=FatalError)
         transfer_coordinator.announce_done()
         with self.assertRaisesRegex(FatalError, message):
@@ -101,22 +105,23 @@ class TestTransferCoordinatorController(unittest.TestCase):
         # Create a coordinator and add it to the canceler
         transfer_coordinator = TransferCoordinator()
         self.coordinator_controller.add_transfer_coordinator(
-            transfer_coordinator)
+            transfer_coordinator
+        )
 
         sleep_time = 0.02
         with ThreadPoolExecutor(max_workers=1) as executor:
-            # In a seperate thread sleep and then set the transfer coordinator
+            # In a separate thread sleep and then set the transfer coordinator
             # to done after sleeping.
             start_time = time.time()
             executor.submit(
-                self.sleep_then_announce_done, transfer_coordinator,
-                sleep_time)
+                self.sleep_then_announce_done, transfer_coordinator, sleep_time
+            )
             # Now call wait to wait for the transfer coordinator to be done.
             self.coordinator_controller.wait()
             end_time = time.time()
             wait_time = end_time - start_time
         # The time waited should not be less than the time it took to sleep in
-        # the seperate thread because the wait ending should be dependent on
+        # the separate thread because the wait ending should be dependent on
         # the sleeping thread announcing that the transfer coordinator is done.
         self.assertTrue(sleep_time <= wait_time)
 
@@ -132,6 +137,7 @@ class TestTransferCoordinatorController(unittest.TestCase):
     def test_wait_can_be_interrupted(self):
         inject_interrupt_coordinator = TransferCoordinatorWithInterrupt()
         self.coordinator_controller.add_transfer_coordinator(
-            inject_interrupt_coordinator)
+            inject_interrupt_coordinator
+        )
         with self.assertRaises(KeyboardInterrupt):
             self.coordinator_controller.wait()

--- a/tests/unit/s3transfer/test_subscribers.py
+++ b/tests/unit/s3transfer/test_subscribers.py
@@ -10,9 +10,9 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
 from s3transfer.exceptions import InvalidSubscriberMethodError
 from s3transfer.subscribers import BaseSubscriber
+from tests import unittest
 
 
 class ExtraMethodsSubscriber(BaseSubscriber):
@@ -54,7 +54,8 @@ class TestSubscribers(unittest.TestCase):
         except Exception as e:
             self.fail(
                 'Should be able to call base class subscriber method. '
-                'instead got: %s' % e)
+                'instead got: %s' % e
+            )
 
     def test_subclass_can_have_and_call_additional_methods(self):
         subscriber = ExtraMethodsSubscriber()
@@ -62,7 +63,7 @@ class TestSubscribers(unittest.TestCase):
 
     def test_can_subclass_and_override_method_from_base_subscriber(self):
         subscriber = OverrideMethodSubscriber()
-        # Make sure that the overriden method is called
+        # Make sure that the overridden method is called
         self.assertEqual(subscriber.on_queued(foo='bar'), {'foo': 'bar'})
 
     def test_can_subclass_and_override_constructor_from_base_class(self):
@@ -79,10 +80,12 @@ class TestSubscribers(unittest.TestCase):
 
     def test_not_callable_in_subclass_subscriber_method(self):
         with self.assertRaisesRegex(
-                InvalidSubscriberMethodError, 'must be callable'):
+            InvalidSubscriberMethodError, 'must be callable'
+        ):
             NotCallableSubscriber()
 
     def test_no_kwargs_in_subclass_subscriber_method(self):
         with self.assertRaisesRegex(
-                InvalidSubscriberMethodError, 'must accept keyword'):
+            InvalidSubscriberMethodError, 'must accept keyword'
+        ):
             NoKwargsSubscriber()

--- a/tests/unit/s3transfer/test_upload.py
+++ b/tests/unit/s3transfer/test_upload.py
@@ -10,35 +10,37 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from __future__ import division
-import os
-import tempfile
-import shutil
+
 import math
+import os
+import shutil
+import tempfile
+from io import BytesIO
 
 from botocore.stub import ANY
 
-from tests import unittest
-from tests import BaseTaskTest
-from tests import BaseSubmissionTaskTest
-from tests import FileSizeProvider
-from tests import RecordingSubscriber
-from tests import RecordingExecutor
-from tests import NonSeekableReader
-from s3transfer.compat import six
 from s3transfer.futures import IN_MEMORY_UPLOAD_TAG
 from s3transfer.manager import TransferConfig
-from s3transfer.upload import AggregatedProgressCallback
-from s3transfer.upload import InterruptReader
-from s3transfer.upload import UploadFilenameInputManager
-from s3transfer.upload import UploadSeekableInputManager
-from s3transfer.upload import UploadNonSeekableInputManager
-from s3transfer.upload import UploadSubmissionTask
-from s3transfer.upload import PutObjectTask
-from s3transfer.upload import UploadPartTask
-from s3transfer.utils import CallArgs
-from s3transfer.utils import OSUtils
-from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE
+from s3transfer.upload import (
+    AggregatedProgressCallback,
+    InterruptReader,
+    PutObjectTask,
+    UploadFilenameInputManager,
+    UploadNonSeekableInputManager,
+    UploadPartTask,
+    UploadSeekableInputManager,
+    UploadSubmissionTask,
+)
+from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE, CallArgs, OSUtils
+from tests import (
+    BaseSubmissionTaskTest,
+    BaseTaskTest,
+    FileSizeProvider,
+    NonSeekableReader,
+    RecordingExecutor,
+    RecordingSubscriber,
+    unittest,
+)
 
 
 class InterruptionError(Exception):
@@ -48,12 +50,13 @@ class InterruptionError(Exception):
 class OSUtilsExceptionOnFileSize(OSUtils):
     def get_file_size(self, filename):
         raise AssertionError(
-            "The file %s should not have been stated" % filename)
+            "The file %s should not have been stated" % filename
+        )
 
 
 class BaseUploadTest(BaseTaskTest):
     def setUp(self):
-        super(BaseUploadTest, self).setUp()
+        super().setUp()
         self.bucket = 'mybucket'
         self.key = 'foo'
         self.osutil = OSUtils()
@@ -70,10 +73,11 @@ class BaseUploadTest(BaseTaskTest):
         # and their order.
         self.sent_bodies = []
         self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+            'before-parameter-build.s3.*', self.collect_body
+        )
 
     def tearDown(self):
-        super(BaseUploadTest, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tempdir)
 
     def collect_body(self, params, **kwargs):
@@ -86,7 +90,8 @@ class TestAggregatedProgressCallback(unittest.TestCase):
         self.aggregated_amounts = []
         self.threshold = 3
         self.aggregated_progress_callback = AggregatedProgressCallback(
-            [self.callback], self.threshold)
+            [self.callback], self.threshold
+        )
 
     def callback(self, bytes_transferred):
         self.aggregated_amounts.append(bytes_transferred)
@@ -154,7 +159,7 @@ class TestInterruptReader(BaseUploadTest):
 
 class BaseUploadInputManagerTest(BaseUploadTest):
     def setUp(self):
-        super(BaseUploadInputManagerTest, self).setUp()
+        super().setUp()
         self.osutil = OSUtils()
         self.config = TransferConfig()
         self.recording_subscriber = RecordingSubscriber()
@@ -174,26 +179,31 @@ class BaseUploadInputManagerTest(BaseUploadTest):
 
 class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
     def setUp(self):
-        super(TestUploadFilenameInputManager, self).setUp()
+        super().setUp()
         self.upload_input_manager = UploadFilenameInputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator
+        )
         self.call_args = CallArgs(
-            fileobj=self.filename, subscribers=self.subscribers)
+            fileobj=self.filename, subscribers=self.subscribers
+        )
         self.future = self.get_transfer_future(self.call_args)
 
     def test_is_compatible(self):
         self.assertTrue(
             self.upload_input_manager.is_compatible(
-                self.future.meta.call_args.fileobj)
+                self.future.meta.call_args.fileobj
+            )
         )
 
     def test_stores_bodies_in_memory_put_object(self):
         self.assertFalse(
-            self.upload_input_manager.stores_body_in_memory('put_object'))
+            self.upload_input_manager.stores_body_in_memory('put_object')
+        )
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertFalse(
-            self.upload_input_manager.stores_body_in_memory('upload_part'))
+            self.upload_input_manager.stores_body_in_memory('upload_part')
+        )
 
     def test_provide_transfer_size(self):
         self.upload_input_manager.provide_transfer_size(self.future)
@@ -208,18 +218,23 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # transfer.
         self.assertFalse(
             self.upload_input_manager.requires_multipart_upload(
-                self.future, self.config))
+                self.future, self.config
+            )
+        )
         # Decreasing the threshold to that of the length of the content of
         # the file should trigger the need for a multipart upload.
         self.config.multipart_threshold = len(self.content)
         self.assertTrue(
             self.upload_input_manager.requires_multipart_upload(
-                self.future, self.config))
+                self.future, self.config
+            )
+        )
 
     def test_get_put_object_body(self):
         self.future.meta.provide_transfer_size(len(self.content))
         read_file_chunk = self.upload_input_manager.get_put_object_body(
-            self.future)
+            self.future
+        )
         read_file_chunk.enable_callback()
         # The file-like object provided back should be the same as the content
         # of the file.
@@ -228,13 +243,14 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # The file-like object should also have been wrapped with the
         # on_queued callbacks to track the amount of bytes being transferred.
         self.assertEqual(
-            self.recording_subscriber.calculate_bytes_seen(),
-            len(self.content))
+            self.recording_subscriber.calculate_bytes_seen(), len(self.content)
+        )
 
     def test_get_put_object_body_is_interruptable(self):
         self.future.meta.provide_transfer_size(len(self.content))
         read_file_chunk = self.upload_input_manager.get_put_object_body(
-            self.future)
+            self.future
+        )
 
         # Set an exception in the transfer coordinator
         self.transfer_coordinator.set_exception(InterruptionError)
@@ -251,7 +267,8 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # Get an iterator that will yield all of the bodies and their
         # respective part number.
         part_iterator = self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config.multipart_chunksize)
+            self.future, self.config.multipart_chunksize
+        )
         expected_part_number = 1
         for part_number, read_file_chunk in part_iterator:
             # Ensure that the part number is as expected
@@ -261,14 +278,15 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
             with read_file_chunk:
                 self.assertEqual(
                     read_file_chunk.read(),
-                    self._get_expected_body_for_part(part_number))
+                    self._get_expected_body_for_part(part_number),
+                )
             expected_part_number += 1
 
         # All of the file-like object should also have been wrapped with the
         # on_queued callbacks to track the amount of bytes being transferred.
         self.assertEqual(
-            self.recording_subscriber.calculate_bytes_seen(),
-            len(self.content))
+            self.recording_subscriber.calculate_bytes_seen(), len(self.content)
+        )
 
     def test_yield_upload_part_bodies_are_interruptable(self):
         # Adjust the chunk size to something more grainular for testing.
@@ -278,7 +296,8 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
         # Get an iterator that will yield all of the bodies and their
         # respective part number.
         part_iterator = self.upload_input_manager.yield_upload_part_bodies(
-            self.future, self.config.multipart_chunksize)
+            self.future, self.config.multipart_chunksize
+        )
 
         # Set an exception in the transfer coordinator
         self.transfer_coordinator.set_exception(InterruptionError)
@@ -291,28 +310,30 @@ class TestUploadFilenameInputManager(BaseUploadInputManagerTest):
 
 class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):
-        super(TestUploadSeekableInputManager, self).setUp()
+        super().setUp()
         self.upload_input_manager = UploadSeekableInputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator
+        )
         self.fileobj = open(self.filename, 'rb')
         self.call_args = CallArgs(
-            fileobj=self.fileobj, subscribers=self.subscribers)
+            fileobj=self.fileobj, subscribers=self.subscribers
+        )
         self.future = self.get_transfer_future(self.call_args)
 
     def tearDown(self):
         self.fileobj.close()
-        super(TestUploadSeekableInputManager, self).tearDown()
+        super().tearDown()
 
     def test_is_compatible_bytes_io(self):
-        self.assertTrue(
-            self.upload_input_manager.is_compatible(six.BytesIO()))
+        self.assertTrue(self.upload_input_manager.is_compatible(BytesIO()))
 
     def test_not_compatible_for_non_filelike_obj(self):
         self.assertFalse(self.upload_input_manager.is_compatible(object()))
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertTrue(
-            self.upload_input_manager.stores_body_in_memory('upload_part'))
+            self.upload_input_manager.stores_body_in_memory('upload_part')
+        )
 
     def test_get_put_object_body(self):
         start_pos = 3
@@ -320,7 +341,8 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
         adjusted_size = len(self.content) - start_pos
         self.future.meta.provide_transfer_size(adjusted_size)
         read_file_chunk = self.upload_input_manager.get_put_object_body(
-            self.future)
+            self.future
+        )
 
         read_file_chunk.enable_callback()
         # The fact that the file was seeked to start should be taken into
@@ -329,17 +351,20 @@ class TestUploadSeekableInputManager(TestUploadFilenameInputManager):
             self.assertEqual(len(read_file_chunk), adjusted_size)
             self.assertEqual(read_file_chunk.read(), self.content[start_pos:])
         self.assertEqual(
-            self.recording_subscriber.calculate_bytes_seen(), adjusted_size)
+            self.recording_subscriber.calculate_bytes_seen(), adjusted_size
+        )
 
 
 class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
     def setUp(self):
-        super(TestUploadNonSeekableInputManager, self).setUp()
+        super().setUp()
         self.upload_input_manager = UploadNonSeekableInputManager(
-            self.osutil, self.transfer_coordinator)
+            self.osutil, self.transfer_coordinator
+        )
         self.fileobj = NonSeekableReader(self.content)
         self.call_args = CallArgs(
-            fileobj=self.fileobj, subscribers=self.subscribers)
+            fileobj=self.fileobj, subscribers=self.subscribers
+        )
         self.future = self.get_transfer_future(self.call_args)
 
     def assert_multipart_parts(self):
@@ -350,12 +375,16 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
         # Assert that a multipart upload is required.
         self.assertTrue(
             self.upload_input_manager.requires_multipart_upload(
-                self.future, self.config))
+                self.future, self.config
+            )
+        )
 
         # Get a list of all the parts that would be sent.
         parts = list(
             self.upload_input_manager.yield_upload_part_bodies(
-                self.future, self.config.multipart_chunksize))
+                self.future, self.config.multipart_chunksize
+            )
+        )
 
         # Assert that the actual number of parts is what we would expect
         # based on the configuration.
@@ -386,11 +415,13 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
 
     def test_stores_bodies_in_memory_upload_part(self):
         self.assertTrue(
-            self.upload_input_manager.stores_body_in_memory('upload_part'))
+            self.upload_input_manager.stores_body_in_memory('upload_part')
+        )
 
     def test_stores_bodies_in_memory_put_object(self):
         self.assertTrue(
-            self.upload_input_manager.stores_body_in_memory('put_object'))
+            self.upload_input_manager.stores_body_in_memory('put_object')
+        )
 
     def test_initial_data_parts_threshold_lesser(self):
         # threshold < size
@@ -413,7 +444,7 @@ class TestUploadNonSeekableInputManager(TestUploadFilenameInputManager):
 
 class TestUploadSubmissionTask(BaseSubmissionTaskTest):
     def setUp(self):
-        super(TestUploadSubmissionTask, self).setUp()
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.filename = os.path.join(self.tempdir, 'myfile')
         self.content = b'0' * (MIN_UPLOAD_CHUNKSIZE * 3)
@@ -432,7 +463,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         # and their order.
         self.sent_bodies = []
         self.client.meta.events.register(
-            'before-parameter-build.s3.*', self.collect_body)
+            'before-parameter-build.s3.*', self.collect_body
+        )
 
         self.call_args = self.get_call_args()
         self.transfer_future = self.get_transfer_future(self.call_args)
@@ -441,13 +473,14 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
             'config': self.config,
             'osutil': self.osutil,
             'request_executor': self.executor,
-            'transfer_future': self.transfer_future
+            'transfer_future': self.transfer_future,
         }
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
 
     def tearDown(self):
-        super(TestUploadSubmissionTask, self).tearDown()
+        super().tearDown()
         shutil.rmtree(self.tempdir)
 
     def collect_body(self, params, **kwargs):
@@ -456,9 +489,11 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
 
     def get_call_args(self, **kwargs):
         default_call_args = {
-            'fileobj': self.filename, 'bucket': self.bucket,
-            'key': self.key, 'extra_args': self.extra_args,
-            'subscribers': self.subscribers
+            'fileobj': self.filename,
+            'bucket': self.bucket,
+            'key': self.key,
+            'extra_args': self.extra_args,
+            'subscribers': self.subscribers,
         }
         default_call_args.update(kwargs)
         return CallArgs(**default_call_args)
@@ -466,23 +501,19 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
     def add_multipart_upload_stubbed_responses(self):
         self.stubber.add_response(
             method='create_multipart_upload',
-            service_response={'UploadId': 'my-id'}
+            service_response={'UploadId': 'my-id'},
         )
         self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': 'etag-1'}
+            method='upload_part', service_response={'ETag': 'etag-1'}
         )
         self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': 'etag-2'}
+            method='upload_part', service_response={'ETag': 'etag-2'}
         )
         self.stubber.add_response(
-            method='upload_part',
-            service_response={'ETag': 'etag-3'}
+            method='upload_part', service_response={'ETag': 'etag-3'}
         )
         self.stubber.add_response(
-            method='complete_multipart_upload',
-            service_response={}
+            method='complete_multipart_upload', service_response={}
         )
 
     def wrap_executor_in_recorder(self):
@@ -495,13 +526,11 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.submission_main_kwargs['transfer_future'] = self.transfer_future
 
     def assert_tag_value_for_put_object(self, tag_value):
-        self.assertEqual(
-            self.executor.submissions[0]['tag'], tag_value)
+        self.assertEqual(self.executor.submissions[0]['tag'], tag_value)
 
     def assert_tag_value_for_upload_parts(self, tag_value):
         for submission in self.executor.submissions[1:-1]:
-            self.assertEqual(
-                submission['tag'], tag_value)
+            self.assertEqual(submission['tag'], tag_value)
 
     def test_provide_file_size_on_put(self):
         self.call_args.subscribers.append(FileSizeProvider(len(self.content)))
@@ -509,9 +538,10 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
             method='put_object',
             service_response={},
             expected_params={
-                'Body': ANY, 'Bucket': self.bucket,
-                'Key': self.key
-            }
+                'Body': ANY,
+                'Bucket': self.bucket,
+                'Key': self.key,
+            },
         )
 
         # With this submitter, it will fail to stat the file if a transfer
@@ -519,7 +549,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.submission_main_kwargs['osutil'] = OSUtilsExceptionOnFileSize()
 
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
         self.submission_task()
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
@@ -530,7 +561,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.stubber.add_response('put_object', {})
 
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
         self.submission_task()
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
@@ -547,7 +579,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         self.config.multipart_threshold = 1
 
         self.submission_task = self.get_task(
-            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+            UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+        )
         self.submission_task()
         self.transfer_future.result()
         self.stubber.assert_no_pending_responses()
@@ -563,7 +596,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         with open(self.filename, 'rb') as f:
             self.use_fileobj_in_call_args(f)
             self.submission_task = self.get_task(
-                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+            )
             self.submission_task()
             self.transfer_future.result()
             self.stubber.assert_no_pending_responses()
@@ -582,7 +616,8 @@ class TestUploadSubmissionTask(BaseSubmissionTaskTest):
         with open(self.filename, 'rb') as f:
             self.use_fileobj_in_call_args(f)
             self.submission_task = self.get_task(
-                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs)
+                UploadSubmissionTask, main_kwargs=self.submission_main_kwargs
+            )
             self.submission_task()
             self.transfer_future.result()
             self.stubber.assert_no_pending_responses()
@@ -604,16 +639,18 @@ class TestPutObjectTask(BaseUploadTest):
                     'fileobj': fileobj,
                     'bucket': self.bucket,
                     'key': self.key,
-                    'extra_args': extra_args
-                }
+                    'extra_args': extra_args,
+                },
             )
             self.stubber.add_response(
                 method='put_object',
                 service_response={},
                 expected_params={
-                    'Body': ANY, 'Bucket': self.bucket, 'Key': self.key,
-                    'Metadata': {'foo': 'bar'}
-                }
+                    'Body': ANY,
+                    'Bucket': self.bucket,
+                    'Key': self.key,
+                    'Metadata': {'foo': 'bar'},
+                },
             )
             task()
             self.stubber.assert_no_pending_responses()
@@ -636,17 +673,20 @@ class TestUploadPartTask(BaseUploadTest):
                     'key': self.key,
                     'upload_id': upload_id,
                     'part_number': part_number,
-                    'extra_args': extra_args
-                }
+                    'extra_args': extra_args,
+                },
             )
             self.stubber.add_response(
                 method='upload_part',
                 service_response={'ETag': etag},
                 expected_params={
-                    'Body': ANY, 'Bucket': self.bucket, 'Key': self.key,
-                    'UploadId': upload_id, 'PartNumber': part_number,
-                    'RequestPayer': 'requester'
-                }
+                    'Body': ANY,
+                    'Bucket': self.bucket,
+                    'Key': self.key,
+                    'UploadId': upload_id,
+                    'PartNumber': part_number,
+                    'RequestPayer': 'requester',
+                },
             )
             rval = task()
             self.stubber.assert_no_pending_responses()


### PR DESCRIPTION
This is a large diff because version `0.5.1` went through major reformatting changes (e.g. `black`, `pyupgrade`, etc.). The changes in this PR should roughly match all of the changes in this range: https://github.com/boto/s3transfer/compare/761cf0fd08552c9deb6f30e5fac93714bfa0f90c..develop

In terms of how I approached this update, I did the following:

* Copied over all of the files from 0.5.1 into their respective paths in the v2 codebase except for anything related to the processpool, integration tests, `tests/unit/test_compat.py`. The tests I did not copy over because they had notable drift from the prior upstream s3transfer release we pulled in.
* For the files that I did not directly copy over, I reapplied the same pre-commit reformatting as the upstream s3transfer repository and made any necessary manual updates to make the checks happy. I have these configuration ports saved as a commit here: https://github.com/kyleknap/aws-cli/commit/70f999e7809e831f52f9744775196f5981a7b298

To validate the correctness, I copied over the entirety of s3transfer 0.5.1 (untouched minus not copying over any processpool files) to another branch and did a diff between that branch and this PR. This should represent the current drift between what is in this pull request and what is in 0.5.1 of s3transfer: https://gist.github.com/kyleknap/005cd671995e61016a48e0e13cf68659

This roughly matches the diff between what is in v2 branch now and the unmodified copy of 0.5.0 s3transfer when it was first added to the v2 branch: https://gist.github.com/kyleknap/44e859d3c4497a11bd08ff5b4fef0bfa (Note the functional test drift was ported back to s3transfer which was why it does not show up in the previous drift diff)
