### PR TITLE
[docs] Fixing broken literal code block in DynamoDb create table example

### DIFF
--- a/awscli/examples/dynamodb/create-table.rst
+++ b/awscli/examples/dynamodb/create-table.rst
@@ -518,7 +518,7 @@ For more information, see `Basic Operations for Tables <https://docs.aws.amazon.
 
 **Example 7: To create a table with Streams enabled**
 
-The following example creates a table called ``GameScores`` with DynamoDB Streams enabled. Both new and old images of each item will be written to the stream.
+The following example creates a table called ``GameScores`` with DynamoDB Streams enabled. Both new and old images of each item will be written to the stream. ::
 
     aws dynamodb create-table \
         --table-name GameScores \


### PR DESCRIPTION
*Description of changes:*

It seems that the doc doesn't introduce literal code block well for DynamoDb create-table command example.
<img width="832" alt="image" src="https://user-images.githubusercontent.com/9458203/154693905-e7a30381-6470-4aba-97f6-a4409c5b576d.png">
I just added "::" to make it work 👍

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
