### PR TITLE
Update 3.6 deprecation notice with blog post

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,17 +35,15 @@ The aws-cli package works on Python versions:
 Notices
 ~~~~~~~
 
-On 01/15/2021, deprecation for Python 2.7 was announced and support was dropped
-on 07/15/2021. To avoid disruption, customers using the AWS CLI on Python 2.7 may
+On 2021-01-15, deprecation for Python 2.7 was announced and support was dropped
+on 2021-07-15. To avoid disruption, customers using the AWS CLI on Python 2.7 may
 need to upgrade their version of Python or pin the version of the AWS CLI. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
-On 10/29/2020, support for Python 3.4 and Python 3.5 was deprecated and
-support was dropped on 02/01/2021. Customers using the AWS CLI on
-Python 3.4 or 3.5 will need to upgrade their version of Python to
-continue receiving feature and security updates. For more information,
-see this `blog
-post <https://aws.amazon.com/blogs/developer/announcing-the-end-of-support-for-python-3-4-and-3-5-in-the-aws-sdk-for-python-and-aws-cli-v1/>`__.
+On 2022-05-30, we will be dropping support for Python 3.6. This follows the
+Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
+for the runtime which occurred on 2021-12-23.
+For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 *Attention!*
 


### PR DESCRIPTION
Adding link to [blog post](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/) and cleaning up date format mismatches from previous campaigns.