### PR TITLE
Support the --no-browser flag on sso login commands

### DIFF
--- a/.changes/next-release/enhancement-sso-39498.json
+++ b/.changes/next-release/enhancement-sso-39498.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``sso``",
+  "description": "Implements `#5301 <https://github.com/aws/aws-cli/issues/5301>`__. Added support for the ``--no-browser`` flag to the ``aws sso login`` and ``aws configure sso`` commands."
+}

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -11,7 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.customizations.commands import BasicCommand
-from awscli.customizations.sso.utils import do_sso_login
+from awscli.customizations.sso.utils import (
+    do_sso_login, PrintOnlyHandler, LOGIN_ARGS,
+)
 from awscli.customizations.utils import uni_print
 from awscli.customizations.exceptions import ConfigurationError
 
@@ -31,7 +33,7 @@ class LoginCommand(BasicCommand):
         'and creating multiple profiles does not allow for multiple users to '
         'be authenticated against the same SSO Start URL.'
     )
-    ARG_TABLE = []
+    ARG_TABLE = LOGIN_ARGS
     _REQUIRED_SSO_CONFIG_VARS = [
         'sso_start_url',
         'sso_region',
@@ -39,10 +41,14 @@ class LoginCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         sso_config = self._get_sso_config()
+        on_pending_authorization = None
+        if parsed_args.no_browser:
+            on_pending_authorization = PrintOnlyHandler()
         do_sso_login(
             session=self._session,
             sso_region=sso_config['sso_region'],
             start_url=sso_config['sso_start_url'],
+            on_pending_authorization=on_pending_authorization,
             force_refresh=True
         )
         success_msg = 'Successully logged into Start URL: %s\n'

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -124,6 +124,17 @@ class TestLoginCommand(BaseSSOTest):
             expected_token=self.access_token
         )
 
+    def test_login_no_browser(self):
+        self.add_oidc_workflow_responses(self.access_token)
+        stdout, _, _ = self.run_cmd('sso login --no-browser')
+        self.assertIn('Browser will not be automatically opened.', stdout)
+        self.open_browser_mock.assert_not_called()
+        self.assert_used_expected_sso_region(expected_region=self.sso_region)
+        self.assert_cache_contains_token(
+            start_url=self.start_url,
+            expected_token=self.access_token
+        )
+
     def test_login_forces_refresh(self):
         self.add_oidc_workflow_responses(self.access_token)
         self.run_cmd('sso login')


### PR DESCRIPTION
Added support for the `--no-browser` flag on the `aws confgure sso` and `aws sso` login commands.

Closes #5301.