### PR TITLE
Add waiter config override option for cloudformation deploy

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import os
 import sys
 import time
 import logging
@@ -209,8 +210,8 @@ class Deployer(object):
         # Poll every 30 seconds. Polling too frequently risks hitting rate limits
         # on CloudFormation's DescribeStacks API
         waiter_config = {
-            'Delay': 30,
-            'MaxAttempts': 120,
+            'Delay': int(os.environ.get("AWS_WAITER_DELAY", 30)),
+            'MaxAttempts': int(os.environ.get("AWS_WAITER_MAXATTEMPTS", 120)),
         }
 
         try:


### PR DESCRIPTION
*Description of changes:*

This PR adds an option to override waiter config with env vars for cloudformation deploy. Sometimes, some stacks take over 1 hour to provision which makes deploy command exit with failure after 1h although deploy itself remains running. 

Mentioned here: https://github.com/aws/aws-cli/issues/2831

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
