### PR TITLE
making colors for auto prompt mode configureable

### DIFF
--- a/awscli/autoprompt/core.py
+++ b/awscli/autoprompt/core.py
@@ -87,9 +87,10 @@ class AutoPrompter:
     def __init__(self, completion_source, driver, prompter=None):
         self._completion_source = completion_source
         self._driver = driver
+        self._session = driver.session
         if prompter is None:
             prompter = PromptToolkitPrompter(self._completion_source,
-                                             self._driver)
+                                             self._driver,self._session)
         self._prompter = prompter
 
     def prompt_for_values(self, original_args):

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -109,8 +109,8 @@ class PromptToolkitPrompter:
         return input_buffer_container, doc_window, output_window
 
     def create_application(self):
-        colorDepth = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,
-                      "256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
+        _colorDepth = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,"256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
+
         self._create_buffers()
         input_buffer_container, \
             doc_window, output_window = self._create_containers()
@@ -123,7 +123,7 @@ class PromptToolkitPrompter:
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
                           output=self._output, erase_when_done=True,
-                          input=self._input, color_depth=colorDepth["true_colors"])
+                          input=self._input, color_depth=_colorDepth["true_colors"])
         self._set_app_defaults(app)
         return app
 

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -114,8 +114,9 @@ class PromptToolkitPrompter:
         # which can be used to configure different color schemes in aws cli. You can read more
         # about it in the documentation linked below:
         # https://python-prompt-toolkit.readthedocs.io/en/master/pages/advanced_topics/styling.html?highlight=classes#color-depths
-        cliColorPalette = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,"256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
-        cliColorDepth = self._session.get_config_variable('color_palette')
+        cliColorDepth = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,"256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
+        depthLevel = self._session.get_config_variable('color_palette')
+        depthLevel = depthLevel if depthLevel else "256_colors"
         self._create_buffers()
         input_buffer_container, doc_window, output_window = self._create_containers()
         layout = self._factory.create_layout(
@@ -127,7 +128,7 @@ class PromptToolkitPrompter:
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
                           output=self._output, erase_when_done=True,
-                          input=self._input, color_depth=cliColorPalette[cliColorDepth])
+                          input=self._input, color_depth=cliColorDepth[depthLevel])
         self._set_app_defaults(app)
         return app
 

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -19,6 +19,7 @@ from prompt_toolkit.application import Application
 from prompt_toolkit.completion import Completer, ThreadedCompleter
 from prompt_toolkit.completion import Completion
 from prompt_toolkit.document import Document
+from prompt_toolkit.output.color_depth import ColorDepth
 
 from awscli.logger import LOG_FORMAT, disable_crt_logging
 from awscli.autocomplete import parser
@@ -57,6 +58,7 @@ class PromptToolkitPrompter:
     """Handles the actual prompting in the autoprompt workflow.
 
     """
+
     def __init__(self, completion_source, driver, completer=None,
                  factory=None, app=None, cli_parser=None, output=None,
                  app_input=None):
@@ -107,9 +109,11 @@ class PromptToolkitPrompter:
         return input_buffer_container, doc_window, output_window
 
     def create_application(self):
+        colorDepth = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,
+                      "256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
         self._create_buffers()
         input_buffer_container, \
-                doc_window, output_window = self._create_containers()
+            doc_window, output_window = self._create_containers()
         layout = self._factory.create_layout(
             on_input_buffer_text_changed=self.update_bottom_buffers_text,
             input_buffer_container=input_buffer_container,
@@ -119,7 +123,7 @@ class PromptToolkitPrompter:
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
                           output=self._output, erase_when_done=True,
-                          input=self._input)
+                          input=self._input, color_depth=colorDepth["true_colors"])
         self._set_app_defaults(app)
         return app
 
@@ -240,6 +244,7 @@ class PromptToolkitCompleter(Completer):
     `prompt_toolkit.Completion` objects.
 
     """
+
     def __init__(self, completion_source):
         self._completion_source = completion_source
 

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -114,9 +114,9 @@ class PromptToolkitPrompter:
         # which can be used to configure different color schemes in aws cli. You can read more
         # about it in the documentation linked below:
         # https://python-prompt-toolkit.readthedocs.io/en/master/pages/advanced_topics/styling.html?highlight=classes#color-depths
-        cliColorDepth = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,"256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
-        depthLevel = self._session.get_config_variable('color_palette')
-        depthLevel = depthLevel if depthLevel else "256_colors"
+        cli_color_depth = {"black_and_white": ColorDepth.MONOCHROME, "ansi_colors": ColorDepth.ANSI_COLORS_ONLY,"256_colors": ColorDepth.DEFAULT, "true_colors": ColorDepth.TRUE_COLOR}
+        depth_level = self._session.get_config_variable('color_palette')
+        depth_level = depth_level if depth_level else "256_colors"
         self._create_buffers()
         input_buffer_container, doc_window, output_window = self._create_containers()
         layout = self._factory.create_layout(
@@ -128,7 +128,7 @@ class PromptToolkitPrompter:
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
                           output=self._output, erase_when_done=True,
-                          input=self._input, color_depth=cliColorDepth[depthLevel])
+                          input=self._input, color_depth=cli_color_depth[depth_level])
         self._set_app_defaults(app)
         return app
 

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -53,6 +53,8 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
     'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
+    # This is a session variable to make AWS CLI color configureable
+    'color_palette': ('color_palette', ['AWS_COLOR_PALETTE'], None, None),
 
     # This is the shared credentials file amongst sdks.
     'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',


### PR DESCRIPTION
*Issue #, if available:*
Configurable colors for auto prompt mode #6086

*Description of changes:*
- Overall goal of this PR is to make the `aws-cli` colors configurable. 
- The first commit is hardcoding[ 4 different color-pallettes ](https://python-prompt-toolkit.readthedocs.io/en/master/pages/advanced_topics/styling.html?highlight=classes#color-depths)which are available via `prompt_toolkit`. Plan is to make these color-pallettes configurable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
