### PR TITLE
Fix FIPS resoultion for non-default partitions

### DIFF
--- a/.changes/next-release/bugfix-endpoints-56982.json
+++ b/.changes/next-release/bugfix-endpoints-56982.json
@@ -1,0 +1,5 @@
+{
+  "category": "endpoints", 
+  "type": "bugfix", 
+  "description": "Fix FIPS endpoint resolution for non-default partitions"
+}

--- a/awscli/botocore/regions.py
+++ b/awscli/botocore/regions.py
@@ -289,6 +289,7 @@ class EndpointResolver(BaseEndpointResolver):
                     service_name, endpoint_name
                 ))
                 raise EndpointVariantError(tags=tags, error_msg=error_msg)
+            self._merge_keys(endpoint_data, result)
         else:
             result = endpoint_data
 

--- a/tests/unit/botocore/test_regions.py
+++ b/tests/unit/botocore/test_regions.py
@@ -1172,3 +1172,11 @@ def _verify_expected_endpoint(service, region, fips, dualstack,
             use_fips_endpoint=fips
         )
     assert resolved['hostname'] == endpoint
+
+
+def test_additional_endpoint_data_exists_with_variants():
+    resolver = regions.EndpointResolver(_modeled_variants_template())
+    resolved = resolver.construct_endpoint(
+        'global-service', 'aws-global', use_fips_endpoint=True,
+    )
+    assert resolved['credentialScope'] == {'region': 'us-east-1'}


### PR DESCRIPTION
This is a port of this PR to v2: https://github.com/boto/botocore/pull/2625
