### PR TITLE
ddb `select` output error handling

### DIFF
--- a/.changes/next-release/bugfix-ddb-13616.json
+++ b/.changes/next-release/bugfix-ddb-13616.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ddb",
+  "description": "fixes `#6387 <https://github.com/aws/aws-cli/issues/6387>`__"
+}

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -166,6 +166,7 @@ class SelectCommand(PaginatedDDBCommand):
         parameters.RETURN_CONSUMED_CAPACITY,
         parameters.NO_RETURN_CONSUMED_CAPACITY,
     ]
+    _SUPPORTED_OUTPUT_TYPES = ('yaml',)
 
     def _run_main(self, parsed_args, parsed_globals):
         super(SelectCommand, self)._run_main(parsed_args, parsed_globals)
@@ -174,7 +175,7 @@ class SelectCommand(PaginatedDDBCommand):
 
     def _select(self, parsed_args, parsed_globals):
         output_type = parsed_globals.output
-        if output_type is not None and output_type != 'yaml':
+        if output_type is not None and output_type not in self._SUPPORTED_OUTPUT_TYPES:
             raise ParamValidationError(
                 f'{output_type} output format is not supported for ddb commands'
             )

--- a/awscli/customizations/dynamodb/subcommands.py
+++ b/awscli/customizations/dynamodb/subcommands.py
@@ -85,19 +85,15 @@ class DDBCommand(BasicCommand):
         return response
 
     def _dump_yaml(self, operation_name, data, parsed_globals):
-        if parsed_globals.output == 'yaml-stream':
-            # TODO: In the future, we should support yaml-stream. However, it
-            #  would require a larger refactoring. Right now we always build
-            #  the full result when paginating prior to sending it to the
-            #  formatter. We need to instead pass the page iterator and
-            #  deserialize in the formatter. We cannot necessarily just
-            #  convert these to client handlers because the DDB types we
-            #  introduce do not play nicely with the pagination interfaces.
-            #  For example, botocore cannot serialize our Binary types into
-            #  a resume token when --max-items gets set.
-            raise ParamValidationError(
-                'yaml-stream output format is not supported for ddb commands'
-            )
+        # TODO: In the future, we should support yaml-stream. However, it
+        #  would require a larger refactoring. Right now we always build
+        #  the full result when paginating prior to sending it to the
+        #  formatter. We need to instead pass the page iterator and
+        #  deserialize in the formatter. We cannot necessarily just
+        #  convert these to client handlers because the DDB types we
+        #  introduce do not play nicely with the pagination interfaces.
+        #  For example, botocore cannot serialize our Binary types into
+        #  a resume token when --max-items gets set.
         formatter = YAMLFormatter(parsed_globals, DynamoYAMLDumper())
         with self._output_stream_factory.get_output_stream() as stream:
             formatter(operation_name, data, stream)
@@ -155,7 +151,8 @@ class SelectCommand(PaginatedDDBCommand):
     DESCRIPTION = (
         '``select`` searches a table or index.\n\n'
         'Under the hood, this operation will use ``query`` if '
-        '``--key-condition`` is specified, or ``scan`` otherwise.'
+        '``--key-condition`` is specified, or ``scan`` otherwise.\n\n'
+        'Only ``yaml`` output is supported for this operation.'
     )
     ARG_TABLE = [
         parameters.TABLE_NAME,
@@ -176,6 +173,12 @@ class SelectCommand(PaginatedDDBCommand):
         return 0
 
     def _select(self, parsed_args, parsed_globals):
+        output_type = parsed_globals.output
+        if output_type is not None and output_type != 'yaml':
+            raise ParamValidationError(
+                f'{output_type} output format is not supported for ddb commands'
+            )
+
         if parsed_args.key_condition:
             LOGGER.debug(
                 "select command using query because --key-condition was "

--- a/awscli/topics/return-codes.rst
+++ b/awscli/topics/return-codes.rst
@@ -26,24 +26,24 @@ of a CLI command:
   other files marked for transfer were successfully transferred.
   Files that are skipped during the transfer process include:
   files that do not exist, files that are character special devices,
-  block special device, FIFO's, or sockets, and files that the user cannot
+  block special device, FIFOs, or sockets, and files that the user cannot
   read from.
 
 * ``130`` -- The process received a SIGINT (Ctrl-C).
 
 * ``252`` -- Command syntax was invalid, an unknown parameter was provided, or
-  a paramter value was incorrect and prevented the command from running.
+  a parameter value was incorrect and prevented the command from running.
 
 * ``253`` -- The system environment or configuration was invalid. While the
   command provided may be syntactically valid, missing configuration or
   credentials prevented the command from running.
 
-* ``254`` -- The command was succesfully parsed and a request was made to the
+* ``254`` -- The command was successfully parsed and a request was made to the
   specified service but the service returned an error. This will generally
   indicate incorrect API usage or other service specific issues.
 
 * ``255`` -- General catch-all error. The command may have parsed correctly but
-  an unspecified runtime error occured when running the command. Because this
+  an unspecified runtime error occurred when running the command. Because this
   is a general error code, an error may change from 255 to a more specific
   return code. A return code of 255 should not be relied on to determine a
   specific error case.

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -460,12 +460,15 @@ class TestSelect(BaseSelectTest):
             command, expected, expected_rc=0
         )
 
-    def test_select_does_not_support_yaml_stream(self):
-        cmdline = 'ddb select mytable --output yaml-stream'
-        stdout, _, _ = self.assert_params_for_cmd(
-            cmdline, expected_rc=252,
-            stderr_contains='yaml-stream output format is not supported',
-        )
+    def test_select_unsupported_output(self):
+        unsupported_output = ['json', 'table', 'text', 'yaml-stream']
+        for output in unsupported_output:
+            with self.subTest(output):
+                cmdline = f'ddb select mytable --output {output}'
+                stdout, _, _ = self.assert_params_for_cmd(
+                    cmdline, expected_rc=252,
+                    stderr_contains=f'{output} output format is not supported for ddb commands',
+                )
 
     def test_select_parsing_error_rc(self):
         cmdline = 'ddb select mytable --filter a=?!f'


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/6387

Description of changes:

Refactored `select` to throw exception if an unsupported output type is provided as a command line argument.  Previously, a request was made regardless of whether or not the output type was supported and only a YAML formatted response output was displayed. Added a note to the command reference page that only YAML output is supported. Also fixed some typos in the return code documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
