### PR TITLE
[v2] Update awscrt version range to include 0.13.5

### DIFF
--- a/.changes/next-release/enhancement-Dependency-55326.json
+++ b/.changes/next-release/enhancement-Dependency-55326.json
@@ -1,0 +1,5 @@
+{
+  "category": "Dependency", 
+  "type": "enhancement", 
+  "description": "Update ``awscrt`` version range to include 0.13.5"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     wcwidth<0.2.0
     prompt-toolkit>=3.0.24,<3.1.0
     distro>=1.5.0,<1.6.0
-    awscrt==0.12.4
+    awscrt>=0.12.4,<=0.13.5
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
     urllib3>=1.25.4,<1.27


### PR DESCRIPTION
This changed the version pin to be a range to be more flexible with what version of CRT you need to install v2 from source.