### PR TITLE
Update copy-image.rst

### DIFF
--- a/awscli/examples/ec2/copy-image.rst
+++ b/awscli/examples/ec2/copy-image.rst
@@ -4,6 +4,7 @@ The following ``copy-image`` example command copies the specified AMI from the `
 
     aws ec2 copy-image \
         --region us-east-1 \
+        --name ami-name \
         --source-region us-west-2 \
         --source-image-id ami-066877671789bd71b \
         --description "This is my copied image."
@@ -22,7 +23,8 @@ The following ``copy-image`` command copies the specified AMI from the ``us-west
 
     aws ec2 copy-image \
         --source-region us-west-2 \
-        --source-image-id snap-066877671789bd71b \
+        --name ami-name \
+        --source-image-id ami-066877671789bd71b \
         --encrypted \
         --kms-key-id alias/my-kms-key
 


### PR DESCRIPTION
Corrections: `name` is mandatory in both examples and `source-image-id` was incorrectly using a snapshot ID in the second example. Once these are changed the commands work as intended.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
