### PR TITLE
[v2] Update Python version range support to 3.8 to 3.9

### DIFF
--- a/.changes/next-release/enhancement-Python-48960.json
+++ b/.changes/next-release/enhancement-Python-48960.json
@@ -1,0 +1,5 @@
+{
+  "category": "Python", 
+  "type": "enhancement", 
+  "description": "Update Python interpreter version range support to 3.8 to 3.9"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ This package provides a unified command line interface to Amazon Web Services.
 
 The aws-cli package works on Python versions:
 
-* 3.7.x and greater
 * 3.8.x and greater
+* 3.9.x and greater
 
 .. attention::
    We recommend that all customers regularly monitor the

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -541,7 +541,7 @@ To enable plugin support, create ``[plugins]`` section in your
 ``~/.aws/config`` file::
 
      [plugins]
-     cli_legacy_plugin_path = <path-to-plugins>/python3.7/site-packages
+     cli_legacy_plugin_path = <path-to-plugins>/python3.8/site-packages
      <plugin-name> = <plugin-module>
 
 

--- a/exe/assets/THIRD_PARTY_LICENSES
+++ b/exe/assets/THIRD_PARTY_LICENSES
@@ -1263,7 +1263,7 @@ LICENSE ISSUES
 
 ------
 
-** Python 3.7.2; version 3.7.2 -- https://github.com/python/cpython/tree/v3.7.2
+** Python 3.8.8; version 3.8.8 -- https://github.com/python/cpython/tree/v3.8.8
 Copyright © 2001-2020 Python Software Foundation. All rights reserved.
 
 PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2

--- a/exe/tests/install.bats
+++ b/exe/tests/install.bats
@@ -42,7 +42,7 @@ create_exes() {
 }
 
 aws_version_output() {
-  echo "aws-cli/$1 Python/3.7.2 Darwin/17.7.0 botocore/1.12.48"
+  echo "aws-cli/$1 Python/3.8.8 Darwin/17.7.0 botocore/1.12.48"
 }
 
 run_install() {

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,8 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
 
 [options]
 scripts =
@@ -25,7 +25,7 @@ scripts =
     bin/aws_zsh_completer.sh
     bin/aws_bash_completer
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 include_package_data = True
 install_requires =
     colorama>=0.2.5,<0.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38
+envlist = py38,py39
 
 skipsdist = True
 
@@ -26,7 +26,7 @@ commands =
 
 
 [testenv:test-exe]
-basepython = python3.7
+basepython = python3.8
 deps =
     -r{toxinidir}/requirements.txt
     {toxinidir}
@@ -35,6 +35,6 @@ commands =
 
 
 [testenv:sign-exe]
-basepython = python3.7
+basepython = python3.8
 commands =
     {envpython} {toxinidir}/scripts/installers/sign-exe {posargs}


### PR DESCRIPTION
Python3.7 was dropped in accordance with the accepted installing from source proposal: https://github.com/aws/aws-cli/pull/6352. Furthermore, none of the official installers currently use Python 3.7 and the project being installable on Python 3.7 (along with CI continuing to be ran) is just an artifact that was never cleaned up from when the installers were migrated from 3.7 to 3.8. Python3.8 will be the minimal Python version required once installing from source is officially supported.

The codebase will be updated to support Python 3.10 in a subsequent update.
