### PR TITLE
Connect and read timeouts customization with providers

### DIFF
--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -17,8 +17,6 @@ import logging
 import os
 
 from botocore import utils
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -105,6 +103,8 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         'auto', None),
     'retry_mode': ('retry_mode', 'AWS_RETRY_MODE', 'standard', None),
     'max_attempts': ('max_attempts', 'AWS_MAX_ATTEMPTS', 3, int),
+    'connect_timeout': ('connect_timeout', 'AWS_CONNECT_TIMEOUT', 60, int),
+    'read_timeout': ('read_timeout', 'AWS_READ_TIMEOUT', 60, int),
 }
 # A mapping for the s3 specific configuration vars. These are the configuration
 # vars that typically go in the s3 section of the config file. This mapping

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -182,6 +182,7 @@ class AWSCLIEntryPoint:
         driver = self._driver
         if driver is None:
             driver = create_clidriver(args)
+        driver._set_connect_timeout()
         autoprompt_driver = AutoPromptDriver(driver)
         auto_prompt_mode = autoprompt_driver.resolve_mode(args)
         if auto_prompt_mode == 'on':
@@ -218,7 +219,7 @@ class CLIDriver(object):
         self._command_table = None
         self._argument_table = None
         self.alias_loader = AliasLoader()
-        self._set_connect_timeout()
+        
 
 
     def _update_config_chain(self):

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -228,8 +228,6 @@ class CLIDriver(object):
         self._command_table = None
         self._argument_table = None
         self.alias_loader = AliasLoader()
-        
-
 
     def _update_config_chain(self):
         config_store = self.session.get_component('config_store')

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -19,7 +19,7 @@ import jmespath
 
 from awscli.compat import urlparse
 from awscli.customizations.exceptions import ParamValidationError
-
+from awscli.clidriver import _update_default_client_config
 
 def register_parse_global_args(cli):
     cli.register('top-level-args-parsed', resolve_types,
@@ -115,11 +115,4 @@ def _resolve_timeout(session, parsed_args, arg_name):
         setattr(parsed_args, arg_name, arg_value)
         _update_default_client_config(session, arg_name, arg_value)
 
-def _update_default_client_config(session, arg_name, arg_value):
-    # Update in the default client config so that the timeout will be used
-    # by all clients created from then on.
-    current_default_config = session.get_default_client_config()
-    new_default_config = Config(**{arg_name: arg_value})
-    if current_default_config is not None:
-        new_default_config = current_default_config.merge(new_default_config)
-    session.set_default_client_config(new_default_config)
+

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -109,7 +109,6 @@ def _resolve_timeout(session, parsed_args, arg_name):
     # The CLI gets the timeout from Providers, if there is a parsed arg from
     # the command line, it has priority over the Providers
     arg_value = getattr(parsed_args, arg_name, None)
-    print(arg_value)
     if arg_value is not None:    
         arg_value = int(arg_value)
         setattr(parsed_args, arg_name, arg_value)

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -14,7 +14,6 @@ import sys
 import os
 
 from botocore.client import Config
-from botocore.endpoint import DEFAULT_TIMEOUT
 from botocore.handlers import disable_signing
 import jmespath
 
@@ -111,13 +110,10 @@ def _resolve_timeout(session, parsed_args, arg_name):
     arg_value = getattr(parsed_args, arg_name, None)
     if arg_value is not None:    
         arg_value = int(arg_value)
+        if arg_value == 0:
+            arg_value = None
         setattr(parsed_args, arg_name, arg_value)
         _update_default_client_config(session, arg_name, arg_value)
-    if arg_value == 0:
-        arg_value = None
-        setattr(parsed_args, arg_name, arg_value)
-        _update_default_client_config(session, arg_name, arg_value)
-
 
 def _update_default_client_config(session, arg_name, arg_value):
     # Update in the default client config so that the timeout will be used

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -106,19 +106,23 @@ def resolve_cli_read_timeout(parsed_args, session, **kwargs):
 
 
 def _resolve_timeout(session, parsed_args, arg_name):
+    # The CLI gets the timeout from Providers, if there is a parsed arg from
+    # the command line, it has priority over the Providers
     arg_value = getattr(parsed_args, arg_name, None)
-    if arg_value is None:
-        arg_value = DEFAULT_TIMEOUT
-    arg_value = int(arg_value)
+    print(arg_value)
+    if arg_value is not None:    
+        arg_value = int(arg_value)
+        setattr(parsed_args, arg_name, arg_value)
+        _update_default_client_config(session, arg_name, arg_value)
     if arg_value == 0:
         arg_value = None
-    setattr(parsed_args, arg_name, arg_value)
-    # Update in the default client config so that the timeout will be used
-    # by all clients created from then on.
-    _update_default_client_config(session, arg_name, arg_value)
+        setattr(parsed_args, arg_name, arg_value)
+        _update_default_client_config(session, arg_name, arg_value)
 
 
 def _update_default_client_config(session, arg_name, arg_value):
+    # Update in the default client config so that the timeout will be used
+    # by all clients created from then on.
     current_default_config = session.get_default_client_config()
     new_default_config = Config(**{arg_name: arg_value})
     if current_default_config is not None:


### PR DESCRIPTION
*Issue #, if available:*

Fixes #5754.

*Description of changes:*
Implementation of the timeout customization from the CLI by creating a config chain with Providers. If the user type `--cli-connect-timeout` or `--cli-read-timeout` in the CLI it as has priority over the providers.
- With an env var I tried with the following: `export AWS_CONNECT_TIMEOUT=X` and `export AWS_READ_TIMEOUT=Y`
- For the config file I did the following: `aws configure set connect_timeout X` and `aws configure set read_timeout Y`
- The ConstantProvider is 60, as always. 
- The debug logs changed accordingly to my changes `MainThread - botocore.endpoint - DEBUG - Setting s3 timeout as (X, Y)`, I tried it by uploading a file to an S3 bucket

Also, I included a debug log to let the user know that a timeout was found within the providers (if he ever forgets it he can see the debug logs)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
