### PR TITLE
make hotkey bindings configurable in aws-cli

### DIFF
--- a/awscli/autoprompt/core.py
+++ b/awscli/autoprompt/core.py
@@ -84,12 +84,14 @@ class AutoPrompter:
     the UI prompt backend easily if needed.
 
     """
+
     def __init__(self, completion_source, driver, prompter=None):
         self._completion_source = completion_source
         self._driver = driver
+        self._session = driver.session
         if prompter is None:
             prompter = PromptToolkitPrompter(self._completion_source,
-                                             self._driver)
+                                             self._driver,self._session)
         self._prompter = prompter
 
     def prompt_for_values(self, original_args):

--- a/awscli/autoprompt/factory.py
+++ b/awscli/autoprompt/factory.py
@@ -34,9 +34,6 @@ from awscli.autoprompt.filters import (
     input_buffer_has_focus, doc_window_has_focus, is_history_mode
 )
 
-keys = {"F1": Keys.F1, "F2": Keys.F2,
-        "F3": Keys.F3, "F4": Keys.F4, "F5": Keys.F5}
-
 
 class PrompterKeyboardInterrupt(KeyboardInterrupt):
     pass
@@ -240,7 +237,7 @@ class PromptToolkitKeyBindings:
                 buffer.switch_history_mode()
             buffer.insert_text(' ')
 
-        @self._kb.add(keys[self._session.get_config_variable('hide_show_docs')])
+        @self._kb.add(self._session.get_config_variable('hide_show_docs'))
         def _(event):
             current_buffer = event.app.current_buffer
             if current_buffer.name == 'doc_buffer':
@@ -249,11 +246,11 @@ class PromptToolkitKeyBindings:
                 layout.focus(input_buffer)
             event.app.show_doc = not getattr(event.app, 'show_doc')
 
-        @self._kb.add(keys["F4"])
+        @self._kb.add(Keys.F4)
         def _(event):
             event.app.multi_column = not event.app.multi_column
 
-        @self._kb.add(keys[self._session.get_config_variable('hide_show_output')])
+        @self._kb.add(self._session.get_config_variable('hide_show_output'))
         def _(event):
             event.app.show_output = not event.app.show_output
             if event.app.current_buffer.name == 'output_buffer':
@@ -261,7 +258,7 @@ class PromptToolkitKeyBindings:
                 input_buffer = layout.get_buffer_by_name('input_buffer')
                 layout.focus(input_buffer)
 
-        @self._kb.add(keys[self._session.get_config_variable('show_shortkey_help')])
+        @self._kb.add(self._session.get_config_variable('show_shortkey_help'))
         def _(event):
             event.app.show_help = not event.app.show_help
 
@@ -279,7 +276,7 @@ class PromptToolkitKeyBindings:
             text = f'> aws {input_buffer.document.text}'
             event.app.exit(exception=PrompterKeyboardInterrupt(text))
 
-        @self._kb.add(keys[self._session.get_config_variable('focus_on_next_panel')])
+        @self._kb.add(self._session.get_config_variable('focus_on_next_panel'))
         def _(event):
             focus_next(event)
 

--- a/awscli/autoprompt/factory.py
+++ b/awscli/autoprompt/factory.py
@@ -34,6 +34,9 @@ from awscli.autoprompt.filters import (
     input_buffer_has_focus, doc_window_has_focus, is_history_mode
 )
 
+keys = {"F1": Keys.F1, "F2": Keys.F2,
+        "F3": Keys.F3, "F4": Keys.F4, "F5": Keys.F5}
+
 
 class PrompterKeyboardInterrupt(KeyboardInterrupt):
     pass
@@ -236,7 +239,7 @@ class PromptToolkitKeyBindings:
                 buffer.switch_history_mode()
             buffer.insert_text(' ')
 
-        @self._kb.add(Keys.F3)
+        @self._kb.add(keys["F3"])
         def _(event):
             current_buffer = event.app.current_buffer
             if current_buffer.name == 'doc_buffer':
@@ -245,11 +248,11 @@ class PromptToolkitKeyBindings:
                 layout.focus(input_buffer)
             event.app.show_doc = not getattr(event.app, 'show_doc')
 
-        @self._kb.add(Keys.F4)
+        @self._kb.add(keys["F4"])
         def _(event):
             event.app.multi_column = not event.app.multi_column
 
-        @self._kb.add(Keys.F5)
+        @self._kb.add(keys["F5"])
         def _(event):
             event.app.show_output = not event.app.show_output
             if event.app.current_buffer.name == 'output_buffer':
@@ -257,7 +260,7 @@ class PromptToolkitKeyBindings:
                 input_buffer = layout.get_buffer_by_name('input_buffer')
                 layout.focus(input_buffer)
 
-        @self._kb.add(Keys.F1)
+        @self._kb.add(keys["F1"])
         def _(event):
             event.app.show_help = not event.app.show_help
 
@@ -275,7 +278,7 @@ class PromptToolkitKeyBindings:
             text = f'> aws {input_buffer.document.text}'
             event.app.exit(exception=PrompterKeyboardInterrupt(text))
 
-        @self._kb.add(Keys.F2)
+        @self._kb.add(keys["F2"])
         def _(event):
             focus_next(event)
 

--- a/awscli/autoprompt/factory.py
+++ b/awscli/autoprompt/factory.py
@@ -35,7 +35,7 @@ from awscli.autoprompt.filters import (
 )
 
 keys = {"F1": Keys.F1, "F2": Keys.F2,
-        "F3": Keys.F3, "F4": Keys.F4, "F5": Keys.F5}
+        "F3": Keys.F3, "F4": Keys.F4, "F5": Keys.F5, "F9": Keys.F9}
 
 
 class PrompterKeyboardInterrupt(KeyboardInterrupt):
@@ -186,12 +186,13 @@ class PromptToolkitFactory:
             ])
         )
 
-    def create_key_bindings(self):
-        return PromptToolkitKeyBindings()
+    def create_key_bindings(self, session):
+        return PromptToolkitKeyBindings(session=session)
 
 
 class PromptToolkitKeyBindings:
-    def __init__(self, keybindings=None):
+    def __init__(self, keybindings=None, session=None):
+        self._session = session
         if keybindings is None:
             keybindings = KeyBindings()
         self._kb = keybindings
@@ -260,7 +261,7 @@ class PromptToolkitKeyBindings:
                 input_buffer = layout.get_buffer_by_name('input_buffer')
                 layout.focus(input_buffer)
 
-        @self._kb.add(keys["F1"])
+        @self._kb.add(keys[self._session.get_config_variable('show_shortkey_help')])
         def _(event):
             event.app.show_help = not event.app.show_help
 

--- a/awscli/autoprompt/factory.py
+++ b/awscli/autoprompt/factory.py
@@ -193,6 +193,10 @@ class PromptToolkitKeyBindings:
         if keybindings is None:
             keybindings = KeyBindings()
         self._kb = keybindings
+        self.hide_show_docs = self._session.get_config_variable('hide_show_docs')
+        self.hide_show_output = self._session.get_config_variable('hide_show_output')
+        self.show_shortkey_help = self._session.get_config_variable('show_shortkey_help')
+        self.focus_on_next_panel = self._session.get_config_variable('focus_on_next_panel')
 
         @self._kb.add(Keys.Enter, filter=input_buffer_has_focus)
         def _(event):
@@ -237,7 +241,7 @@ class PromptToolkitKeyBindings:
                 buffer.switch_history_mode()
             buffer.insert_text(' ')
 
-        @self._kb.add(self._session.get_config_variable('hide_show_docs'))
+        @self._kb.add(self.hide_show_docs if self.hide_show_docs else Keys.F3)
         def _(event):
             current_buffer = event.app.current_buffer
             if current_buffer.name == 'doc_buffer':
@@ -250,7 +254,7 @@ class PromptToolkitKeyBindings:
         def _(event):
             event.app.multi_column = not event.app.multi_column
 
-        @self._kb.add(self._session.get_config_variable('hide_show_output'))
+        @self._kb.add(self.hide_show_output if self.hide_show_output else Keys.F5)
         def _(event):
             event.app.show_output = not event.app.show_output
             if event.app.current_buffer.name == 'output_buffer':
@@ -258,7 +262,7 @@ class PromptToolkitKeyBindings:
                 input_buffer = layout.get_buffer_by_name('input_buffer')
                 layout.focus(input_buffer)
 
-        @self._kb.add(self._session.get_config_variable('show_shortkey_help'))
+        @self._kb.add(self.show_shortkey_help if self.show_shortkey_help else Keys.F1)
         def _(event):
             event.app.show_help = not event.app.show_help
 
@@ -276,7 +280,7 @@ class PromptToolkitKeyBindings:
             text = f'> aws {input_buffer.document.text}'
             event.app.exit(exception=PrompterKeyboardInterrupt(text))
 
-        @self._kb.add(self._session.get_config_variable('focus_on_next_panel'))
+        @self._kb.add(self.focus_on_next_panel if self.focus_on_next_panel else Keys.F2)
         def _(event):
             focus_next(event)
 

--- a/awscli/autoprompt/factory.py
+++ b/awscli/autoprompt/factory.py
@@ -35,7 +35,7 @@ from awscli.autoprompt.filters import (
 )
 
 keys = {"F1": Keys.F1, "F2": Keys.F2,
-        "F3": Keys.F3, "F4": Keys.F4, "F5": Keys.F5, "F9": Keys.F9}
+        "F3": Keys.F3, "F4": Keys.F4, "F5": Keys.F5}
 
 
 class PrompterKeyboardInterrupt(KeyboardInterrupt):
@@ -240,7 +240,7 @@ class PromptToolkitKeyBindings:
                 buffer.switch_history_mode()
             buffer.insert_text(' ')
 
-        @self._kb.add(keys["F3"])
+        @self._kb.add(keys[self._session.get_config_variable('hide_show_docs')])
         def _(event):
             current_buffer = event.app.current_buffer
             if current_buffer.name == 'doc_buffer':
@@ -253,7 +253,7 @@ class PromptToolkitKeyBindings:
         def _(event):
             event.app.multi_column = not event.app.multi_column
 
-        @self._kb.add(keys["F5"])
+        @self._kb.add(keys[self._session.get_config_variable('hide_show_output')])
         def _(event):
             event.app.show_output = not event.app.show_output
             if event.app.current_buffer.name == 'output_buffer':
@@ -279,7 +279,7 @@ class PromptToolkitKeyBindings:
             text = f'> aws {input_buffer.document.text}'
             event.app.exit(exception=PrompterKeyboardInterrupt(text))
 
-        @self._kb.add(keys["F2"])
+        @self._kb.add(keys[self._session.get_config_variable('focus_on_next_panel')])
         def _(event):
             focus_next(event)
 

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -57,7 +57,8 @@ class PromptToolkitPrompter:
     """Handles the actual prompting in the autoprompt workflow.
 
     """
-    def __init__(self, completion_source, driver, completer=None,
+
+    def __init__(self, completion_source, driver, session, completer=None,
                  factory=None, app=None, cli_parser=None, output=None,
                  app_input=None):
         self._completion_source = completion_source
@@ -78,13 +79,14 @@ class PromptToolkitPrompter:
         self.input_buffer = None
         self.doc_buffer = None
         self.output_buffer = None
-        if app is None:
-            app = self.create_application()
-        self.app = app
         self._args = []
         self._driver = driver
         self._docs_getter = DocsGetter(self._driver)
         self._output_getter = OutputGetter(self._driver)
+        self._session = session
+        if app is None:
+            app = self.create_application()
+        self.app = app
 
     def args(self, value):
         self._args = value
@@ -109,13 +111,13 @@ class PromptToolkitPrompter:
     def create_application(self):
         self._create_buffers()
         input_buffer_container, \
-                doc_window, output_window = self._create_containers()
+            doc_window, output_window = self._create_containers()
         layout = self._factory.create_layout(
             on_input_buffer_text_changed=self.update_bottom_buffers_text,
             input_buffer_container=input_buffer_container,
             doc_window=doc_window, output_window=output_window
         )
-        kb_manager = self._factory.create_key_bindings()
+        kb_manager = self._factory.create_key_bindings(session=self._session)
         kb = kb_manager.keybindings
         app = Application(layout=layout, key_bindings=kb, full_screen=False,
                           output=self._output, erase_when_done=True,
@@ -240,6 +242,7 @@ class PromptToolkitCompleter(Completer):
     `prompt_toolkit.Completion` objects.
 
     """
+
     def __init__(self, completion_source):
         self._completion_source = completion_source
 

--- a/awscli/autoprompt/widgets.py
+++ b/awscli/autoprompt/widgets.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 from functools import partial
+import awscli.clidriver
 
 from prompt_toolkit.application import get_app
 from prompt_toolkit.filters import has_focus
@@ -196,13 +197,19 @@ class InputToolbarView(BaseToolbarView):
 
     @property
     def help_text(self):
+        driver = awscli.clidriver.create_clidriver()
+        session = driver.session
+        hide_show_docs=session.get_config_variable('hide_show_docs') if session.get_config_variable('hide_show_docs') else "F3"
+        hide_show_output=session.get_config_variable('hide_show_output') if session.get_config_variable('hide_show_output') else "F5"
+        show_shortkey_help= session.get_config_variable('show_shortkey_help') if session.get_config_variable('show_shortkey_help') else "F1"
+        focus_on_next_panel=session.get_config_variable('focus_on_next_panel') if session.get_config_variable('focus_on_next_panel') else "F2"
         return (
             f'{self.STYLE}[ENTER]</style> Autocomplete '
             f'Choice/Execute Command{self.SPACING}'
-            f'{self.STYLE}[F1]</style> Show Shortkey Help{self.SPACING}'
-            f'{self.STYLE}[F2]</style> Focus on next panel{self.SPACING}'
-            f'{self.STYLE}[F3]</style> Hide/Show Docs{self.SPACING}'
-            f'{self.STYLE}[F5]</style> Hide/Show Output'
+            f'{self.STYLE}[{show_shortkey_help.upper()}]</style> Show Shortkey Help{self.SPACING}'
+            f'{self.STYLE}[{focus_on_next_panel.upper()}]</style> Focus on next panel{self.SPACING}'
+            f'{self.STYLE}[{hide_show_docs.upper()}]</style> Hide/Show Docs{self.SPACING}'
+            f'{self.STYLE}[{hide_show_output.upper()}]</style> Hide/Show Output'
             )
 
 

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -9,7 +9,7 @@
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
+# language governing permissions and limitations under the Licenscae.
 """This module contains the inteface for controlling how configuration
 is loaded.
 """
@@ -53,6 +53,8 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
     'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
+    # This is a session variable to make AWS CLI shortcut keys configureable
+    'show_shortkey_help': ('show_shortkey_help', ['AWS_SHOW_SHORTKEY_HELP'], None, None),
 
     # This is the shared credentials file amongst sdks.
     'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',
@@ -95,7 +97,7 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     # Note: These configurations are considered internal to botocore.
     # Do not use them until publicly documented.
     'csm_enabled': (
-            'csm_enabled', 'AWS_CSM_ENABLED', False, utils.ensure_boolean),
+        'csm_enabled', 'AWS_CSM_ENABLED', False, utils.ensure_boolean),
     'csm_host': ('csm_host', 'AWS_CSM_HOST', '127.0.0.1', None),
     'csm_port': ('csm_port', 'AWS_CSM_PORT', 31000, int),
     'csm_client_id': ('csm_client_id', 'AWS_CSM_CLIENT_ID', '', None),
@@ -141,6 +143,7 @@ DEFAULT_PROXIES_CONFIG_VARS = {
         'proxy_use_forwarding_for_https', None, None, utils.normalize_boolean),
 }
 
+
 def create_botocore_default_config_mapping(session):
     chain_builder = ConfigChainFactory(session=session)
     config_mapping = _create_config_chain_mapping(
@@ -176,6 +179,7 @@ class ConfigChainFactory(object):
     our most common pattern. This is to prevent ordering them incorrectly,
     and to make the config chain construction more readable.
     """
+
     def __init__(self, session, environ=None):
         """Initialize a ConfigChainFactory.
 
@@ -280,6 +284,7 @@ class ConfigChainFactory(object):
 
 class ConfigValueStore(object):
     """The ConfigValueStore object stores configuration values."""
+
     def __init__(self, mapping=None):
         """Initialize a ConfigValueStore.
 
@@ -375,6 +380,7 @@ class BaseProvider(object):
     A configuration provider has some method of providing a configuration
     value.
     """
+
     def provide(self):
         """Provide a config value."""
         raise NotImplementedError('provide')
@@ -386,6 +392,7 @@ class ChainProvider(BaseProvider):
     Each provider in the chain is called, the first one returning a non-None
     value is then returned.
     """
+
     def __init__(self, providers=None, conversion_func=None):
         """Initalize a ChainProvider.
 
@@ -427,6 +434,7 @@ class ChainProvider(BaseProvider):
 
 class InstanceVarProvider(BaseProvider):
     """This class loads config values from the session instance vars."""
+
     def __init__(self, instance_var, session):
         """Initialize InstanceVarProvider.
 
@@ -489,6 +497,7 @@ class ScopedConfigProvider(BaseProvider):
 
 class EnvironmentProvider(BaseProvider):
     """This class loads config values from environment variables."""
+
     def __init__(self, name, env):
         """Initialize with the keys in the dictionary to check.
 
@@ -517,6 +526,7 @@ class SectionConfigProvider(BaseProvider):
     This is useful for retrieving scoped config variables (i.e. s3) that have
     their own set of config variables and resolving logic.
     """
+
     def __init__(self, section_name, session, override_providers=None):
         self._section_name = section_name
         self._session = session
@@ -553,6 +563,7 @@ class SectionConfigProvider(BaseProvider):
 
 class ConstantProvider(BaseProvider):
     """This provider provides a constant value."""
+
     def __init__(self, value):
         self._value = value
 

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -53,8 +53,11 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
     'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
-    # This is a session variable to make AWS CLI shortcut keys configureable
+    # Following 4 are the session variables to make AWS CLI shortcut keys configureable
     'show_shortkey_help': ('show_shortkey_help', ['AWS_SHOW_SHORTKEY_HELP'], None, None),
+    'focus_on_next_panel': ('focus_on_next_panel', ['AWS_FOCUS_ON_NEXT_PANEL'], None, None),
+    'hide_show_docs': ('hide_show_docs', ['AWS_HIDE_SHOW_DOCS'], None, None),
+    'hide_show_output': ('hide_show_output', ['AWS_HIDE_SHOW_OUTPUT'], None, None),
 
     # This is the shared credentials file amongst sdks.
     'credentials_file': (None, 'AWS_SHARED_CREDENTIALS_FILE',

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -9,7 +9,7 @@
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the Licenscae.
+# language governing permissions and limitations under the License.
 """This module contains the inteface for controlling how configuration
 is loaded.
 """

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -53,7 +53,7 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
     'data_path': ('data_path', 'AWS_DATA_PATH', None, None),
     'config_file': (None, 'AWS_CONFIG_FILE', '~/.aws/config', None),
     'ca_bundle': ('ca_bundle', 'AWS_CA_BUNDLE', None, None),
-    # Following 4 are the session variables to make AWS CLI shortcut keys configureable
+    # Following are the 4 session variables to make AWS CLI shortcut keys configureable
     'show_shortkey_help': ('show_shortkey_help', ['AWS_SHOW_SHORTKEY_HELP'], None, None),
     'focus_on_next_panel': ('focus_on_next_panel', ['AWS_FOCUS_ON_NEXT_PANEL'], None, None),
     'hide_show_docs': ('hide_show_docs', ['AWS_HIDE_SHOW_DOCS'], None, None),


### PR DESCRIPTION
*Issue #, if available:*
Change hotkey bindings https://github.com/aws/aws-cli/issues/5715

*Description of changes:*
- Overall goal of this PR is to make the aws-cli shortcut keys configurable.
- The first commit is hard-coding a python dictionary to map the key bindings to the existing operations. Plan is to make these key-bindings configurable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
