### PR TITLE
Pin Jinja2<3.1 to avoid breakages in Sphinx

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,8 @@
+# Newer versions of Jinja break our current copy of Sphinx
+# See https://github.com/sphinx-doc/sphinx/issues/10306 for details
+jinja2<3.1
+
+
 docutils>=0.10,<0.16
 Sphinx==1.2.3
 -e .


### PR DESCRIPTION
It appears the doc requirements no longer work as of the release of Jinja2 3.1.x.

```python
 File "/tmp/venv/lib/python3.8/site-packages/sphinx/jinja2glue.py", line 15, in <module>
    from jinja2 import BaseLoader, FileSystemLoader, TemplateNotFound, contextfunction
ImportError: cannot import name 'contextfunction' from 'jinja2' (/tmp/venv/lib/python3.8/site-packages/jinja2/__init__.py)
```
This appears to be the same issue as https://github.com/sphinx-doc/sphinx/issues/10306. We're going to pin Jinja2<3.1 for the time being until we have a path to upgrading to a version of Sphinx with support.
