### PR TITLE
Adding a sorting process for s3 objects when "aws s3 sync --delete" is executed.

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -319,9 +319,11 @@ class FileGenerator(object):
         else:
             lister = BucketLister(self._client)
             extra_args = self.request_parameters.get('ListObjectsV2', {})
-            for key in lister.list_objects(bucket=bucket, prefix=prefix,
-                                           page_size=self.page_size,
-                                           extra_args=extra_args):
+            objects = lister.list_objects(bucket=bucket, prefix=prefix,
+                                          page_size=self.page_size,
+                                          extra_args=extra_args)
+            for key in sorted(
+                    objects, key=lambda item: item[0].replace(os.sep, '/')):
                 source_path, response_data = key
                 if response_data['Size'] == 0 and source_path.endswith('/'):
                     if self.operation_name == 'delete':


### PR DESCRIPTION
*Issue #, if available:*

(A similar issue: https://github.com/aws/aws-cli/issues/440 )

When "aws s3 sync <local_directory> <s3_url> --delete" command is executed, under certain conditions, both upload and delete requests are executed for a same file in local_directory.
That's because the result of list_files() for local_directory is sorted but the result of list_objects() for s3_url is not sorted.
Therefore, some files in s3_url synced from local_directory is deleted after uploaded sometimes.
```
$ aws --version
aws-cli/2.5.1 Python/3.9.11 Linux/3.10.0-1127.19.1.el7.x86_64 exe/x86_64.centos.7 prompt/off


// case 1: problem is reproduced
$ ls data/ -1
dir/
dir-2/

$ aws <endpoint_option> s3 ls \
    s3://bucket/data/
                           PRE dir-2/
                           PRE dir/
=> all files are already synced

$ aws <endpoint_option> s3 sync --delete \
    data \
    s3://bucket/data
upload: data/dir-2/file2.txt to s3://bucket/data/dir-2/file2.txt
delete: s3://bucket/data/dir-2/file2.txt
=> files in dir-2/ are always uploaded and deleted parallelly
   (when files are deleted after uploaded, corresponding objects in s3 disappear)


// case 2: problem is not reproduced
$ ls data/ -1
dir/
dir_2/

$ aws <endpoint_option> s3 ls \
    s3://bucket/data/
                           PRE dir/
                           PRE dir_2/
=> all files are already synced

$ aws <endpoint_option> s3 sync --delete \
    data \
    s3://bucket/data
=> no output, no problem
```

*Description of changes:*

In order to solve this problem, I added a sort process for the result of list_objects() for s3_url.
I checked this problem does not happen when I use fixed AWS CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.