### PR TITLE
Fix collections imports for Mapping, MutableSequence and Set

### DIFF
--- a/awscli/customizations/dynamodb/transform.py
+++ b/awscli/customizations/dynamodb/transform.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from collections import Mapping, MutableSequence
+from collections.abc import Mapping, MutableSequence
 
 from awscli.customizations.dynamodb.types import (
     TypeSerializer, TypeDeserializer

--- a/awscli/customizations/dynamodb/types.py
+++ b/awscli/customizations/dynamodb/types.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from collections import Mapping, Set
+from collections.abc import Mapping, Set
 from decimal import Decimal, Context, Clamped
 from decimal import Overflow, Inexact, Underflow, Rounded
 


### PR DESCRIPTION
This patch will fix outdated import calls. In Python 3.3, `collections.abc` was created with the abstract base classes that used to exist in the top-level `collections` module. These were aliased for backwards compatibility until Python 3.10 when the alias was removed.