### PR TITLE
Default to beta API for eks get-token

### DIFF
--- a/.changes/next-release/bugfix-eks-27483.json
+++ b/.changes/next-release/bugfix-eks-27483.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``eks get-token``",
+  "description": "Correctly fallback to client.authentication.k8s.io/v1beta1 API if KUBERNETES_EXEC_INFO is undefined"
+}

--- a/.changes/next-release/feature-eksgettoken-97938.json
+++ b/.changes/next-release/feature-eksgettoken-97938.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``eks get-token``",
+  "description": "All eks get-token commands default to api version v1beta1."
+}

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -86,7 +86,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             response,
             {
                 "kind": "ExecCredential",
-                "apiVersion": "client.authentication.k8s.io/v1alpha1",
+                "apiVersion": "client.authentication.k8s.io/v1beta1",
                 "spec": {},
                 "status": {
                     "expirationTimestamp": "2019-10-23T23:14:00Z",
@@ -185,13 +185,13 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
         self.assertEqual(
             response["apiVersion"],
-            "client.authentication.k8s.io/v1alpha1",
+            "client.authentication.k8s.io/v1beta1",
         )
 
         self.assertEqual(
             stderr,
             (
-                "Error parsing KUBERNETES_EXEC_INFO, defaulting to client.authentication.k8s.io/v1alpha1. "
+                "Error parsing KUBERNETES_EXEC_INFO, defaulting to client.authentication.k8s.io/v1beta1. "
                 "This is likely a bug in your Kubernetes client. Please update your Kubernetes client.\n"
             ),
         )
@@ -203,16 +203,10 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
         self.assertEqual(
             response["apiVersion"],
-            "client.authentication.k8s.io/v1alpha1",
+            "client.authentication.k8s.io/v1beta1",
         )
 
-        self.assertEqual(
-            stderr,
-            (
-                "Empty KUBERNETES_EXEC_INFO, defaulting to client.authentication.k8s.io/v1alpha1. "
-                "This is likely a bug in your Kubernetes client. Please update your Kubernetes client.\n"
-            ),
-        )
+        self.assertEqual(stderr, "",)
 
     def test_api_version_discovery_v1(self):
         self.set_kubernetes_exec_info('v1')
@@ -248,13 +242,13 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
         self.assertEqual(
             response["apiVersion"],
-            "client.authentication.k8s.io/v1alpha1",
+            "client.authentication.k8s.io/v1beta1",
         )
 
         self.assertEqual(
             stderr,
             (
-                "Unrecognized API version in KUBERNETES_EXEC_INFO, defaulting to client.authentication.k8s.io/v1alpha1. "
+                "Unrecognized API version in KUBERNETES_EXEC_INFO, defaulting to client.authentication.k8s.io/v1beta1. "
                 "This is likely due to an outdated AWS CLI. Please update your AWS CLI.\n"
             ),
         )


### PR DESCRIPTION
* Default to beta API for eks get-token
* Stop logging a warning on an empty KUBERNETES_EXEC_INFO
* Respond with correct deprecated version in warning message

Signed-off-by: Micah Hausler <mhausler@amazon.com>

*Issue #, if available:*

Resolves #6935
Resolves aws/containers-roadmap#1736

*Description of changes:*

From Kubernetes 1.11 trough 1.19, client-go (so kubectl, kubelet, etc) accepted client.authentication.k8s.io API version v1alpha1 or v1beta1, but only provided `KUBERNETES_EXEC_INFO`  if the v1alpha1 API version was specified in a kubeconfig (fixed in kubernetes/kubernetes#95489). This leaves client binaries (such as `aws-iam-authenticator` or `aws eks get-token`) having to guess what version of the API to respond with. If they guess wrong (which the AWS CLI currently does by falling back to v1alpha1), the user gets an error (observed in comment on [#6476](https://github.com/aws/aws-cli/pull/6476#issuecomment-1122315050)).

For 1.11-1.19 clients, if their kubeconfig specifies:
* `v1alpha` (the old default) - Everything works. `v1alpha1` is specified in `KUBERNETES_EXEC_INFO`, the CLI will correctly provide the right response,  and they'll get a warning to upgrade and run `aws eks update-kubeconfig`
* `v1beta1` (the new default) - Everything works. The CLI will now correctly guess that an empty `KUBERNETES_EXEC_INFO` means that client-go handled a `v1beta1` kubeconfig, but isn't telling the CLI about it.
* `v1` (they would have to manually set this) - They will get a failure before ever executing the AWS CLI. 

For 1.20-1.23 clients (EKS only supports up to 1.22 today), if their kubeconfig specifies:
* `v1alpha` (the old default) - Everything works. `v1alpha1` is specified in `KUBERNETES_EXEC_INFO`, the CLI will correctly provide the right response,  and they'll get a warning to upgrade and run `aws eks update-kubeconfig`
* `v1beta1` (the new default) - Everything works. `v1beta1` is specified in `KUBERNETES_EXEC_INFO`, the CLI will correctly provide the right response

For clients <= 1.21, if their kubeconfig specifies `v1`, they will get a failure before ever executing the AWS CLI. 

For 1.24+ clients (if someone installs kubectl with homebrew), if their kubeconfig specifies:
* `v1alpha` (the old default) - They will get a failure before ever executing the AWS CLI. (Observed in #6920 and #6921)
* `v1beta1` (the new default) - Everything works. `v1beta1` is specified in `KUBERNETES_EXEC_INFO`, the CLI will correctly provide the right response
* `v1` (they would have to manually set this) - Everything works. `v1` is specified in `KUBERNETES_EXEC_INFO`, the CLI will correctly provide the right response

|Kubectl version	|Supports Alpha API	|can accept beta API	|Provides EXEC_INFO for non-alpha kubeconfigs	|Supports v1 API	|Available for new EKS clusters	|
|---	|---	|---	|---	|---	|---	|
|v1.17	|yes	|yes	|no	|no	|no	|
|v1.18	|yes	|yes	|no	|no	|no	|
|v1.19	|yes	|yes	|no	|no	|yes	|
|v1.20	|yes	|yes	|yes	|no	|yes	|
|v1.21	|yes	|yes	|yes	|no	|yes	|
|v1.22	|yes	|yes	|yes	|yes	|yes	|
|v1.23	|yes	|yes	|yes	|yes	|no	|
|v1.24	|no	|yes	|yes	|yes	|no	|

Once EKS no longer supports 1.19 (or previous) clusters, we can add back a warning about the empty `KUBERNETES_EXEC_INFO`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


<details>
  <summary>Test code used to validate the above</summary>

  ```bash
  #!/usr/bin/env bash
  set -euo pipefail
  
  # gleaned from https://kubernetes.io/releases/patch-releases/#support-period
  versions=(
    v1.17.17
    v1.18.20
    v1.19.16
    v1.20.15
    v1.21.12
    v1.22.9
    v1.23.6
    v1.24.0
  )
  
  
  # get_client downloads kubectl
  get_client() {
      local version="$1"
      local download="kubernetes-client-darwin-amd64.tar.gz"
      local minor=$(echo $version | cut -c 2-5 | tr '.' '-')
      if [ -f "./kubectl-$minor" ]; then
          return
      fi
      URL=https://dl.k8s.io/${version}/${download}
      wget $URL
      tar xvf $download
      mv kubernetes/client/bin/kubectl ./kubectl-${minor}
      rm -rf ./kubernetes ./$download
  }
  
  for version in "${versions[@]}"; do
      get_client $version
  done
  
  try_version() {
      local version="$1"
      local minor=$(echo $version | cut -c 2-5 | tr '.' '-')
      local kcli="kubectl-${minor}"
  
      # copy kubeconfig
      local kubeconfig="kubeconfig-${minor}"
      kubectl config view --minify --raw | sed -e 's,client\.authentication\.k8s\.io/.*,client.authentication.k8s.io/v1alpha1,g' > $kubeconfig
  
      echo "Testing kubectl version $version with alpha"
      set +e
      KUBECONFIG=${kubeconfig} ./$kcli version
      set -e
      echo
  
      echo "Testing kubectl version $version with beta"
      kubectl config view --minify --raw | sed -e 's,client\.authentication\.k8s\.io/.*,client.authentication.k8s.io/v1beta1,g' > $kubeconfig
      set +e
      KUBECONFIG=${kubeconfig} ./$kcli version
      set -e
      echo
  
      echo "Testing kubectl version $version with v1"
      kubectl config view --minify --raw | sed -e 's,client\.authentication\.k8s\.io/.*,client.authentication.k8s.io/v1,g' > $kubeconfig
      set +e
      KUBECONFIG=${kubeconfig} ./$kcli version
      set -e
      echo
  }
  
  for version in "${versions[@]}"; do
      try_version $version
  done
  ```

</details>