### PR TITLE
Make regex more re-usable

### DIFF
--- a/awscli/botocore/handlers.py
+++ b/awscli/botocore/handlers.py
@@ -74,7 +74,7 @@ REGISTER_LAST = object()
 # to be as long as 255 characters, and bucket names can contain any
 # combination of uppercase letters, lowercase letters, numbers, periods
 # (.), hyphens (-), and underscores (_).
-VALID_BUCKET = re.compile(r'^[a-zA-Z0-9.\-_]{1,255}$')
+VALID_BUCKET = re.compile(r'^[a-zA-Z0-9.\_-]{1,255}$')
 _ACCESSPOINT_ARN = (
     r'^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]*:[0-9]{12}:accesspoint[/:]'
     r'[a-zA-Z0-9\-.]{1,63}$'


### PR DESCRIPTION
In most situations a dash denotes a range
anywhere but the first and last character in a regex

The dash is intended to match literally in this pattern
and is output verbatim due to line 256
which has caused confusion when re-using the pattern with `grep`

*Description of changes:*

Move dash to end of range for better consistency when re-using pattern with other tools. 

When naively copying the current pattern to use with `grep` it unexpectedly did not match "-" but did match "]" and "^" which confused me the first time I saw this pattern. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
