### PR TITLE
Remap Eventbridge events for Sigv4a signing

### DIFF
--- a/.changes/next-release/bugfix-events-79390.json
+++ b/.changes/next-release/bugfix-events-79390.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``events``",
+  "description": "Fixed a bug causing signing to fail for put-events"
+}

--- a/awscli/botocore/exceptions.py
+++ b/awscli/botocore/exceptions.py
@@ -65,6 +65,14 @@ class UnknownServiceError(DataNotFoundError):
         "{known_service_names}")
 
 
+class UnknownRegionError(BotoCoreError):
+    """Raised when trying to load data for an unknown region.
+    :ivar region_name: The name of the unknown region.
+    """
+
+    fmt = "Unknown region: '{region_name}'. {error_msg}"
+
+
 class ApiVersionNotFoundError(BotoCoreError):
     """
     The data associated with either the API version or a compatible one

--- a/awscli/botocore/regions.py
+++ b/awscli/botocore/regions.py
@@ -19,7 +19,11 @@ in a specific AWS partition.
 import logging
 import re
 
-from botocore.exceptions import EndpointVariantError, NoRegionError
+from botocore.exceptions import (
+    EndpointVariantError,
+    NoRegionError,
+    UnknownRegionError
+)
 
 LOG = logging.getLogger(__name__)
 DEFAULT_URI_TEMPLATE = '{service}.{region}.{dnsSuffix}' # noqa
@@ -195,6 +199,15 @@ class EndpointResolver(BaseEndpointResolver):
             )
             if result:
                 return result
+
+    def get_partition_for_region(self, region_name):
+        for partition in self._endpoint_data['partitions']:
+            if self._region_match(partition, region_name):
+                return partition['partition']
+        raise UnknownRegionError(
+            region_name=region_name,
+            error_msg='No partition found for provided region_name.',
+        )
 
     def _endpoint_for_partition(self, partition, service_name, region_name,
                                 use_dualstack_endpoint, use_fips_endpoint,

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -2720,11 +2720,11 @@ class EventbridgeSignerSetter:
 
     def register(self, event_emitter):
         event_emitter.register(
-            'before-parameter-build.events.PutEvents',
+            'before-parameter-build.eventbridge.PutEvents',
             self.check_for_global_endpoint
         )
         event_emitter.register(
-            'before-call.events.PutEvents',
+            'before-call.eventbridge.PutEvents',
             self.set_endpoint_url
         )
 
@@ -2744,13 +2744,6 @@ class EventbridgeSignerSetter:
         if len(endpoint) == 0:
             raise InvalidEndpointConfigurationError(
                 msg='EndpointId must not be a zero length string'
-            )
-
-        if not HAS_CRT:
-            raise MissingDependencyException(
-                msg="Using EndpointId requires an additional "
-                    "dependency. You will need to pip install "
-                    "botocore[crt] before proceeding."
             )
 
         config = context.get('client_config')

--- a/tests/functional/botocore/test_eventbridge.py
+++ b/tests/functional/botocore/test_eventbridge.py
@@ -4,7 +4,7 @@ import pytest
 
 from botocore.config import Config
 from botocore.exceptions import InvalidEndpointConfigurationError
-from tests import BaseSessionTest, ClientHTTPStubber, requires_crt
+from tests import BaseSessionTest, ClientHTTPStubber
 
 
 class TestClientEvents(BaseSessionTest):
@@ -81,7 +81,6 @@ class TestClientEvents(BaseSessionTest):
         assert stubber.requests[0].url == "https://events.us-east-1.amazonaws.com/"
         assert b"EndpointId" not in stubber.requests[0].body
 
-    @requires_crt()
     def test_put_event_endpoint_id(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -101,7 +100,6 @@ class TestClientEvents(BaseSessionTest):
         self._assert_multi_region_endpoint(stubber.requests[0], endpoint_id)
         self._assert_sigv4a_headers(stubber.requests[0])
 
-    @requires_crt()
     def test_put_event_endpoint_id_explicit_config(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -125,7 +123,6 @@ class TestClientEvents(BaseSessionTest):
         self._assert_multi_region_endpoint(stubber.requests[0], endpoint_id)
         self._assert_sigv4a_headers(stubber.requests[0])
 
-    @requires_crt()
     def test_put_event_bad_endpoint_id(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -137,7 +134,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(EndpointId=endpoint_id, **default_args)
         assert "EndpointId is not a valid hostname component" in str(e.value)
 
-    @requires_crt()
     def test_put_event_bad_endpoint_id_explicit_config(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -153,7 +149,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(EndpointId=endpoint_id, **default_args)
         assert "EndpointId is not a valid hostname component" in str(e.value)
 
-    @requires_crt()
     def test_put_event_empty_endpoint_id(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -165,7 +160,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(EndpointId=endpoint_id, **default_args)
         assert "EndpointId must not be a zero length string" in str(e.value)
 
-    @requires_crt()
     def test_put_event_empty_endpoint_id_explicit_config(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -192,7 +186,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(**default_args)
         assert stubber.requests[0].url == "https://events.us-east-1.api.aws/"
 
-    @requires_crt()
     def test_put_events_endpoint_id_dualstack(self):
         config = Config(use_dualstack_endpoint=True, use_fips_endpoint=False)
         client, stubber = self.create_stubbed_eventbridge_client(
@@ -226,7 +219,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(**default_args)
         assert stubber.requests[0].url == "https://events-fips.us-east-1.amazonaws.com/"
 
-    @requires_crt()
     def test_put_events_endpoint_id_fips(self):
         config = Config(use_dualstack_endpoint=False, use_fips_endpoint=True)
         client, stubber = self.create_stubbed_eventbridge_client(
@@ -252,7 +244,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(**default_args)
         assert stubber.requests[0].url == "https://events-fips.us-east-1.api.aws/"
 
-    @requires_crt()
     def test_put_events_endpoint_id_dualstack_fips(self):
         config = Config(use_dualstack_endpoint=True, use_fips_endpoint=True)
         client, stubber = self.create_stubbed_eventbridge_client(
@@ -278,7 +269,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(**default_args)
         assert stubber.requests[0].url == "https://events.us-iso-east-1.c2s.ic.gov/"
 
-    @requires_crt()
     def test_put_events_endpoint_id_gov(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True,
@@ -311,7 +301,6 @@ class TestClientEvents(BaseSessionTest):
             client.put_events(**default_args)
         assert stubber.requests[0].url == "https://example.org/"
 
-    @requires_crt()
     def test_put_events_endpoint_id_custom(self):
         client, stubber = self.create_stubbed_eventbridge_client(
             with_default_responses=True, endpoint_url="https://example.org"

--- a/tests/functional/eventbridge/test_put_events.py
+++ b/tests/functional/eventbridge/test_put_events.py
@@ -1,0 +1,41 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestPutEventsCommand(BaseAWSCommandParamsTest):
+
+    def run_put_events(self, cmd):
+        response, _, _ = self.run_cmd(cmd)
+        return response
+
+    def test_put_events_with_endpoint_id(self):
+        """Verify SigV4a signer has been loaded for put-events with
+        an endpoint-id provided.
+        """
+        self.patch_make_request()
+        cmd = [
+            "events",
+            "put-events",
+            "--entries",
+            "[{}]",
+            "--endpoint-id",
+            "123abcdefg.abc",
+        ]
+        response = self.run_put_events(cmd)
+        self.assertEqual(
+            self.last_request_dict["url"],
+            "https://123abcdefg.abc.endpoint.events.amazonaws.com/",
+        )
+        self.assertEqual(self.last_request_dict["context"]["auth_type"], "v4a")


### PR DESCRIPTION
This PR will port forward some of the changes from the CLI v1 that are currently missing and remaps the `EventbridgeSignerSetter` to the correct service name in the CLI v2. There's a variance between `v1` where the name is `events` and v2 where it's `eventbridge` in some parts of the code base.
