### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.changes/next-release/feature-Python-26513.json
+++ b/.changes/next-release/feature-Python-26513.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Python",
+  "description": "Dropped support for Python 3.6"
+}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ The list below are guidelines to use when submitting pull requests. These are th
 - The SDK is released under the [Apache license](http://aws.amazon.com/apache2.0/). Any code you submit will be released under that license.
 - We maintain a high percentage of code coverage in our unit tests. As a general rule of thumb, code changes should not lower the overall code coverage percentage for the project. In practice, this means that **every bug fix and feature addition should include tests.**
 - Code should follow [pep8](https://www.python.org/dev/peps/pep-0008/), although if you are modifying an existing module, it is more important for the code to be consistent if there are any discrepancies. Using [`flake8`](https://flake8.pycqa.org/en/latest/) can assist in identifying `pep8` compliance issues.
-- Code must work on `python3.6` and higher.
+- Code must work on `python3.7` and higher.
 - The AWS CLI is cross platform and code must work on at least Linux, Windows, and Mac OS X. Avoid platform specific behavior.
 - If you would like to implement support for a significant feature that is not yet available in the AWS CLI, please talk to us beforehand to avoid any duplication of effort. You can file an [issue](https://github.com/aws/aws-cli/issues) to discuss the feature request further.
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,6 @@ Requirements
 
 The aws-cli package works on Python versions:
 
--  3.6.x and greater
 -  3.7.x and greater
 -  3.8.x and greater
 -  3.9.x and greater
@@ -40,7 +39,7 @@ on 2021-07-15. To avoid disruption, customers using the AWS CLI on Python 2.7 ma
 need to upgrade their version of Python or pin the version of the AWS CLI. For
 more information, see this `blog post <https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/>`__.
 
-On 2022-05-30, we will be dropping support for Python 3.6. This follows the
+On 2022-05-30, support for Python 3.6 was ended. This follows the
 Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
 for the runtime which occurred on 2021-12-23.
 For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.

--- a/UPGRADE_PY3.md
+++ b/UPGRADE_PY3.md
@@ -15,13 +15,14 @@ v1. You can upgrade to the AWS CLI v2 to avoid these deprecations in the future.
 ----
 ## Timeline
 
-Going forward, customers using the CLI v1 should transition to using Python 3, with Python 3.6 becoming 
+Going forward, customers using the CLI v1 should transition to using Python 3, with Python 3.7 becoming
 the minimum by the end of the transition. The deprecation dates for the affected versions of Python are:
 
 |Python version|Deprecation date|
 |--------------|----------------|
 | Python 2.7|          7/15/2021|
 | Python 3.4 and 3.5|   2/1/2021|
+| Python 3.6|          5/30/2022|
 
 ## Impact on the AWS CLI
 
@@ -47,7 +48,7 @@ $ aws --version
 aws-cli/1.18.191 Python/2.7.18 Darwin/19.6.0 botocore/1.19.31
 ```
 
-If the second portion of the version string, starting with **Python/** isn’t Python/3.6.x 
+If the second portion of the version string, starting with **Python/** isn’t Python/3.7.x
 or higher, you should review the options below.
 
 ### Installing CLI with Python 3
@@ -60,7 +61,7 @@ Otherwise, upgrading Python versions isn’t difficult.
 
 1. To begin, uninstall your existing copy of the AWS CLI. You can find instructions in the 
 [CLI v1 installation guide](https://docs.aws.amazon.com/cli/latest/userguide/install-linux.html).
-2. Now we’ll install Python 3.6 or later. You can get Python from 
+2. Now we’ll install Python 3.7 or later. You can get Python from
 [Python.org](https://www.python.org/downloads) or using your local package manager. 
 In this example, we’ll use a recent version, Python 3.8.7, to ensure the longest support window. 
 3. Next, depending on your installation method, the new Python installation should be available at 
@@ -87,7 +88,7 @@ $ python awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
 7. If you wish, you may verify that the newly installed copy of the AWS CLI tool, **aws**, is 
 using the correct version of Python. The **aws --version** command reports the **aws** tool's 
 version number, followed by the version of Python it's running under, then the operating system 
-version and the version of botocore. As long as the Python version is at least 3.6, 
+version and the version of botocore. As long as the Python version is at least 3.7,
 you're ready to go:
 ```bash
     $ aws --version

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -2,7 +2,7 @@
 Building The Documentation
 ==========================
 
-Before building the documentation, make sure you have Python 3.6,
+Before building the documentation, make sure you have Python 3.7,
 the awscli, and all the necessary dependencies installed.  You can
 install dependencies by using the requirements-docs.txt file at the
 root of this repo::

--- a/scripts/install
+++ b/scripts/install
@@ -20,13 +20,13 @@ PACKAGES_DIR = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'packages')
 INSTALL_DIR = os.path.expanduser(os.path.join(
     '~', '.local', 'lib', 'aws'))
-GTE_PY37 = sys.version_info[:2] >= (3, 7)
 UNSUPPORTED_PYTHON = (
     (2,6),
     (2,7),
     (3,3),
     (3,4),
     (3,5),
+    (3,6),
 )
 INSTALL_ARGS = (
     '--no-binary :all: --no-build-isolation --no-cache-dir --no-index '
@@ -59,7 +59,8 @@ def _build_deprecations():
     }
 
     return {
-        (3, 6): py_36_params
+        # Example for future deprecations
+        # (3, 6): py_36_params
     }
 
 
@@ -112,24 +113,6 @@ def _create_virtualenv_internal(location, working_dir):
     # There's a bug with sys.executable on external virtualenv
     # that causes installation failures.
     run('%s -m venv %s' % (sys.executable, location))
-
-
-def _create_virtualenv_external(location, working_dir):
-    # working_dir is used (generally somewhere in /tmp) so that we
-    # don't modify the install/packages directories.
-    with cd(PACKAGES_DIR):
-        venv = _get_venv_package_tarball('.')
-        compressed = tarfile.open(venv)
-        compressed.extractall(path=working_dir)
-        compressed.close()
-    with cd(working_dir):
-        # We know that virtualenv is the only dir in this directory
-        # so we can listdir()[0] it.
-        with cd(os.listdir('.')[0]):
-            run(('%s virtualenv.py --no-download '
-                 '--python %s %s') % (sys.executable,
-                                      sys.executable,
-                                      location))
 
 
 def _get_package_tarball(package_dir, package_prefix):
@@ -215,7 +198,7 @@ def main():
     if py_version in UNSUPPORTED_PYTHON:
         unsupported_python_msg = (
             "Unsupported Python version detected: Python {}.{}\n"
-            "To continue using this installer you must use Python 3.6 "
+            "To continue using this installer you must use Python 3.7 "
             "or later.\n"
             "For more information see the following blog post: "
             "https://aws.amazon.com/blogs/developer/announcing-end-"
@@ -258,10 +241,7 @@ def main():
         shutil.rmtree(working_dir)
 
 
-if GTE_PY37:
-    create_virtualenv = _create_virtualenv_internal
-else:
-    create_virtualenv = _create_virtualenv_external
+create_virtualenv = _create_virtualenv_internal
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup_options = dict(
     install_requires=install_requires,
     extras_require={},
     license="Apache License 2.0",
-    python_requires=">= 3.6",
+    python_requires=">= 3.7",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -60,7 +60,6 @@ setup_options = dict(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 
 skipsdist = True
 


### PR DESCRIPTION
**DO NOT MERGE PRIOR TO 5/30**

This PR will end support for Python 3.6 in awscli as [announced](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/#:~:text=Overview,deprecations%20which%20started%20in%202021) earlier this year. This PR will remove the testing scaffolding, update documentation, and remove any Python 3.6 specific code paths. This will need to be merged in conjunction with the other PRs in boto3, botocore, and s3transfer.