### PR TITLE
Fix tests and code to avoid ruamel deprecation warnings

### DIFF
--- a/awscli/customizations/cliinput.py
+++ b/awscli/customizations/cliinput.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
 
 from awscli.paramfile import get_paramfile, LOCAL_PREFIX_MAP
@@ -145,7 +145,9 @@ class CliInputYAMLArgument(CliInputArgument):
     }
 
     def _load_parameters(self, arg_value):
+        yaml = YAML(typ='safe', pure=True)
+
         try:
-            return yaml.safe_load(arg_value)
+            return yaml.load(arg_value)
         except YAMLError:
             raise ParamError(self.name, "Invalid YAML received.")

--- a/awscli/customizations/ecs/filehelpers.py
+++ b/awscli/customizations/ecs/filehelpers.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 from awscli.customizations.ecs import exceptions
 
@@ -77,4 +77,5 @@ def parse_appspec(appspec_str):
     try:
         return json.loads(appspec_str)
     except ValueError:
-        return yaml.safe_load(appspec_str)
+        yaml = YAML(typ='safe', pure=True)
+        return yaml.load(appspec_str)

--- a/awscli/customizations/wizard/devcommands.py
+++ b/awscli/customizations/wizard/devcommands.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.wizard.factory import create_wizard_app
 
@@ -29,7 +29,8 @@ def create_default_wizard_dev_runner(session):
 
 class WizardLoader(object):
     def load(self, contents):
-        data = yaml.load(contents, Loader=yaml.RoundTripLoader)
+        yaml = YAML(typ="rt")
+        data = yaml.load(contents)
         return data
 
 

--- a/awscli/customizations/wizard/loader.py
+++ b/awscli/customizations/wizard/loader.py
@@ -39,7 +39,7 @@ exists, then a usage error will be printed.
 
 """
 import os
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 
 WIZARD_SPEC_DIR = os.path.join(
@@ -56,6 +56,8 @@ class WizardLoader(object):
         if spec_dir is None:
             spec_dir = WIZARD_SPEC_DIR
         self._spec_dir = spec_dir
+
+        self._yaml = YAML(typ='rt')
 
     def list_commands_with_wizards(self):
         """Returns a list of commands with at least one wizard.
@@ -90,7 +92,7 @@ class WizardLoader(object):
                                                             wizard_name))
 
     def _load_yaml(self, contents):
-        data = yaml.load(contents, Loader=yaml.RoundTripLoader)
+        data = self._yaml.load(contents)
         return data
 
     def wizard_exists(self, command_name, wizard_name):

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -37,6 +37,8 @@ import unittest
 
 from awscli.compat import StringIO
 
+from ruamel.yaml import YAML
+
 try:
     import mock
 except ImportError as e:
@@ -359,6 +361,7 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         self.http_responses = None
         self.driver = create_clidriver()
         self.entry_point = awscli.clidriver.AWSCLIEntryPoint(self.driver)
+        self.yaml = YAML(typ="safe", pure=True)
 
     def tearDown(self):
         # This clears all the previous registrations.
@@ -1005,3 +1008,22 @@ class ConsistencyWaiter(object):
     def _fail_message(self, attempts, successes):
         format_args = (attempts, successes)
         return 'Failed after %s attempts, only had %s successes' % format_args
+
+
+class YAMLStdoutDump(YAML):
+    """YAML class that can dump output as a string.
+
+    Taken from:
+
+    https://yaml.readthedocs.io/en/latest/example.html#output-of-dump-as-a-string
+
+    """
+
+    def dump(self, data, stream=None, **kwargs):
+        to_stdout = False
+        if stream is None:
+            to_stdout = True
+            stream = StringIO()
+        YAML.dump(self, data, stream, **kwargs)
+        if to_stdout:
+            return stream.getvalue()

--- a/tests/functional/ddb/test_select.py
+++ b/tests/functional/ddb/test_select.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 from awscli.testutils import BaseAWSCommandParamsTest
 
@@ -21,7 +21,7 @@ class BaseSelectTest(BaseAWSCommandParamsTest):
     def assert_yaml_response_equal(self, response, expected):
         with self.assertRaises(ValueError):
             json.loads(response)
-        loaded = yaml.safe_load(response)
+        loaded = self.yaml.load(response)
         self.assertEqual(loaded, expected)
 
 

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -12,9 +12,10 @@
 # language governing permissions and limitations under the License.
 import os
 
-import ruamel.yaml as yaml
+from awscli.testutils import \
+    BaseAWSCommandParamsTest, FileCreator, YAMLStdoutDump
 
-from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+yaml = YAMLStdoutDump(typ="safe", pure=True)
 
 
 class BaseCLIInputArgumentTest(BaseAWSCommandParamsTest):

--- a/tests/functional/test_generatecliskeleton.py
+++ b/tests/functional/test_generatecliskeleton.py
@@ -12,8 +12,6 @@
 # language governing permissions and limitations under the License.
 import json
 
-from ruamel import yaml
-
 from awscli.testutils import BaseAWSCommandParamsTest
 
 
@@ -52,7 +50,7 @@ class TestGenerateCliSkeletonYamlInput(BaseAWSCommandParamsTest):
         cmdline = 's3api delete-object --generate-cli-skeleton yaml-input'
         stdout, _, rc = self.run_cmd(cmdline)
         self.assertEqual(rc, 0)
-        loaded_skeleton = yaml.safe_load(stdout)
+        loaded_skeleton = self.yaml.load(stdout)
         self.assertEqual(loaded_skeleton['Bucket'], '')
         self.assertEqual(loaded_skeleton['BypassGovernanceRetention'], True)
         self.assertEqual(loaded_skeleton['Key'], '')
@@ -64,7 +62,7 @@ class TestGenerateCliSkeletonYamlInput(BaseAWSCommandParamsTest):
             'sqs change-message-visibility --generate-cli-skeleton yaml-input'
         )
         self.assertEqual(rc, 0)
-        loaded_skeleton = yaml.safe_load(stdout)
+        loaded_skeleton = self.yaml.load(stdout)
         self.assertEqual(loaded_skeleton['QueueUrl'], '')
         self.assertEqual(loaded_skeleton['ReceiptHandle'], '')
         self.assertEqual(loaded_skeleton['VisibilityTimeout'], 0)
@@ -73,7 +71,7 @@ class TestGenerateCliSkeletonYamlInput(BaseAWSCommandParamsTest):
         cmdline = 'iam create-group --generate-cli-skeleton yaml-input'
         stdout, _, rc = self.run_cmd(cmdline)
         self.assertEqual(rc, 0)
-        loaded_skeleton = yaml.safe_load(stdout)
+        loaded_skeleton = self.yaml.load(stdout)
         self.assertEqual(loaded_skeleton['Path'], '')
         self.assertEqual(loaded_skeleton['GroupName'], '')
 

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -196,7 +196,7 @@ class TestYAMLStream(BaseAWSCommandParamsTest):
     def assert_yaml_response_equal(self, response, expected):
         with self.assertRaises(ValueError):
             json.loads(response)
-        loaded = yaml.safe_load(response)
+        loaded = self.yaml.load(response)
         self.assertEqual(loaded, expected)
 
     def test_yaml_stream_single_response(self):

--- a/tests/integration/customizations/test_generatecliskeleton.py
+++ b/tests/integration/customizations/test_generatecliskeleton.py
@@ -17,7 +17,7 @@ import logging
 
 import mock
 import pytest
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 from awscli.clidriver import create_clidriver
 
@@ -46,6 +46,9 @@ def clean_environ():
     with patch_environ():
         yield
 
+@pytest.fixture
+def yaml_safe_loader():
+    return YAML(typ="safe", pure=True)
 
 def get_all_cli_skeleton_commands():
     skeleton_commands = []
@@ -84,12 +87,12 @@ def test_gen_input_skeleton(cmd, capsys, clean_environ):
 
 
 @pytest.mark.parametrize('cmd', SKELETON_COMMANDS)
-def test_gen_yaml_input_skeleton(cmd, capsys, clean_environ):
+def test_gen_yaml_input_skeleton(cmd, capsys, clean_environ, yaml_safe_loader):
     stdout, stderr, _ = _run_cmd(
         cmd + ' --generate-cli-skeleton yaml-input', capsys
     )
     try:
-        yaml.safe_load(stdout)
+        yaml_safe_loader.load(stdout)
     except ValueError:
         raise AssertionError(
             f"Could not generate CLI YAML skeleton for command: {cmd}\n"

--- a/tests/unit/customizations/wizard/test_core.py
+++ b/tests/unit/customizations/wizard/test_core.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 from botocore.session import Session
 from botocore.paginate import Paginator
@@ -25,7 +25,8 @@ from awscli.testutils import unittest, mock, temporary_file
 
 
 def load_wizard(yaml_str):
-    data = yaml.load(yaml_str, Loader=yaml.RoundTripLoader)
+    yaml = YAML(typ="rt")
+    data = yaml.load(yaml_str)
     return data
 
 

--- a/tests/unit/output/test_yaml_output.py
+++ b/tests/unit/output/test_yaml_output.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 import datetime
 
-import ruamel.yaml as yaml
+from ruamel.yaml import YAML
 
 from awscli.compat import ensure_text_type
 from awscli.testutils import BaseAWSCommandParamsTest
@@ -42,6 +42,8 @@ class TestYAMLOutput(BaseAWSCommandParamsTest):
                 },
             ]
         }
+        
+        self.yaml = YAML(typ="safe", pure=True)
 
     def test_yaml_response(self):
         stdout, _, _ = self.run_cmd(
@@ -61,7 +63,7 @@ class TestYAMLOutput(BaseAWSCommandParamsTest):
             "  UserName: testuser-51\n"
         )
         self.assertEqual(stdout, expected)
-        parsed_output = yaml.safe_load(stdout)
+        parsed_output = self.yaml.load(stdout)
         self.assertEqual(self.parsed_response, parsed_output)
 
     def test_empty_dict_response_prints_nothing(self):
@@ -92,7 +94,7 @@ class TestYAMLOutput(BaseAWSCommandParamsTest):
             'iam list-users --output yaml --query %s' % jmespath_query,
             expected_rc=0
         )
-        parsed_output = yaml.safe_load(stdout)
+        parsed_output = self.yaml.load(stdout)
         self.assertEqual(parsed_output, ['testuser-50', 'testuser-51'])
 
     def test_print_int(self):


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

~Update the ceiling to `ruamel.yaml<=0.17.21`, the most recent version at time of writing.~ (This was completed with https://github.com/aws/aws-cli/pull/7059).

Use the new `ruamel.yaml` API to avoid deprecationwarnings of top level load/dump functions present since version 0.17.10. 

Everywhere the top level `yaml.load` or `yaml.dump` is used, replace it with a YAML object with the correct `typ` set (e.g., `typ='safe'` to replace `yaml.safe_load`). This is common across the test suite and a few modules.

In the test suite, we used to use the top-level dump function to get back a string representation to pass to command line calls. This implementation uses the suggested custom YAML class discussed here to be able to dump YAML to a string for other uses, so I added it in the test utils:

https://yaml.readthedocs.io/en/latest/example.html#output-of-dump-as-a-string

Separate pull requests will address the CloudFormation and EKS customizations, which also use top level methods but have more alterations to the way YAML is processed. This pull request fixes the changes to the ECS customization as they were the same as other straightforward uses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
