### PR TITLE
Make changes to avoid deprecation warnings for cf yamlhelper

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     colorama>=0.2.5,<0.4.4
     docutils>=0.10,<0.16
     cryptography>=3.3.2,<37.0.0
-    ruamel.yaml>=0.15.0,<0.16.0
+    ruamel.yaml>=0.15.0,<=0.17.21
     wcwidth<0.2.0
     prompt-toolkit>=3.0.24,<3.0.29
     distro>=1.5.0,<1.6.0


### PR DESCRIPTION
*Issue #, if available:*

Test out changes to use new ruamel API with CloudFormation customization. Updates the `yamlhelper.py`.

The tests need to be changed because the new API's `dump` does not output to a string, which our tests use. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
