### PR TITLE
Update awscrt version ceiling to 0.13.11

### DIFF
--- a/.changes/next-release/enhancement-awscrt-28206.json
+++ b/.changes/next-release/enhancement-awscrt-28206.json
@@ -1,0 +1,5 @@
+{
+  "category": "``awscrt``",
+  "type": "enhancement",
+  "description": "Update awscrt version range ceiling to 0.13.11"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     wcwidth<0.2.0
     prompt-toolkit>=3.0.24,<3.0.29
     distro>=1.5.0,<1.6.0
-    awscrt>=0.12.4,<=0.13.5
+    awscrt>=0.12.4,<=0.13.11
     python-dateutil>=2.1,<3.0.0
     jmespath>=0.7.1,<1.0.0
     urllib3>=1.25.4,<1.27


### PR DESCRIPTION
This is needed to support Python 3.10

*Issue #, if available:*
NA

*Description of changes:*
Update `awscrt` version ceiling to [latest version ](https://pypi.org/project/awscrt/) to support Python 3.10

These changes have been tested against all supported platforms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
