### PR TITLE
Update helptext.py to remove visible markup tags

### DIFF
--- a/awscli/customizations/emr/helptext.py
+++ b/awscli/customizations/emr/helptext.py
@@ -48,25 +48,23 @@ HBASE_BACKUP_VERSION = (
 # create-cluster options help text
 
 CREATE_CLUSTER_DESCRIPTION = (
-    '<p>Creates an Amazon EMR cluster with the specified configurations.</p>'
-    '<p>Quick start:</p>'
-    '<p><code>aws emr create-cluster --release-label <release-label>'
-    ' --instance-type <instance-type> --instance-count <instance-count></code></p>'
-    '<p>Values for the following can be set in the AWS CLI'
-    ' config file using the <code>aws configure set</code> command: <code>--service-role, --log-uri,'
-    ' and InstanceProfile and KeyName arguments under --ec2-attributes</code>.</p>')
+    'Creates an Amazon EMR cluster with the specified configurations. '
+    'Quick start: '
+    'aws emr create-cluster --release-label <release-label> '
+    '--instance-type <instance-type> --instance-count <instance-count>'
+    'Values for the following can be set in the AWS CLI. '
+    'config file using the <code>aws configure set</code> command: <code>--service-role, --log-uri, '
+    'and InstanceProfile and KeyName arguments under --ec2-attributes.')
 
 DESCRIBE_CLUSTER_DESCRIPTION = (
-    '<p>Provides  cluster-level details including status, hardware'
-    ' and software configuration, VPC settings, bootstrap'
-    ' actions, instance groups and so on.</p>'
-    '<p>Permissions needed for describe-cluster include:'
-    '<ul><li><code>elasticmapreduce:ListBootstrapActions</code></li>'
-    '<li><code>elasticmapreduce:ListInstanceFleets</code></li>'
-    '<li><code>elasticmapreduce:DescribeCluster</code></li>'
-    '<li><code>elasticmapreduce:ListInstanceGroups</code></li></ul>'
-    'For information about the cluster'
-    ' steps, see <code>list-steps</code>.</p>')
+    'Provides  cluster-level details including status, hardware '
+    'and software configuration, VPC settings, bootstrap '
+    'actions, instance groups and so on. '
+    'Permissions needed for describe-cluster include '
+    'elasticmapreduce:ListBootstrapActions, '
+    'elasticmapreduce:ListInstanceFleets, '
+    'elasticmapreduce:DescribeCluster, '
+    'and elasticmapreduce:ListInstanceGroups.')
 
 CLUSTER_NAME = (
     '<p>The name of the cluster. If not provided, the default is "Development Cluster".</p>')

--- a/awscli/examples/emr/create-cluster-examples.rst
+++ b/awscli/examples/emr/create-cluster-examples.rst
@@ -293,7 +293,7 @@ The following example uses a JSON file, ``instancegroupconfig.json``, to specify
         --release-label emr-5.9.0 \
         --service-role EMR_DefaultRole \
         --ec2-attributes InstanceProfile=EMR_EC2_DefaultRole \
-        --instance-groups s3://mybucket/instancegroupconfig.json \
+        --instance-groups file://myfolder/instancegroupconfig.json \
         --auto-scaling-role EMR_AutoScaling_DefaultRole
 
 Contents of ``instancegroupconfig.json``::


### PR DESCRIPTION
Customer called out that the documentation looked poor because of the markup tags were appearing and causing this to not display as intended.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
