### PR TITLE
[v2] Update EKS customization yaml operations

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -35,8 +35,6 @@ from pprint import pformat
 from subprocess import Popen, PIPE
 import unittest
 
-from awscli.compat import StringIO
-
 from ruamel.yaml import YAML
 
 try:
@@ -1008,22 +1006,3 @@ class ConsistencyWaiter(object):
     def _fail_message(self, attempts, successes):
         format_args = (attempts, successes)
         return 'Failed after %s attempts, only had %s successes' % format_args
-
-
-class YAMLStdoutDump(YAML):
-    """YAML class that can dump output as a string.
-
-    Taken from:
-
-    https://yaml.readthedocs.io/en/latest/example.html#output-of-dump-as-a-string
-
-    """
-
-    def dump(self, data, stream=None, **kwargs):
-        to_stdout = False
-        if stream is None:
-            to_stdout = True
-            stream = StringIO()
-        YAML.dump(self, data, stream, **kwargs)
-        if to_stdout:
-            return stream.getvalue()

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -35,6 +35,8 @@ from pprint import pformat
 from subprocess import Popen, PIPE
 import unittest
 
+from awscli.compat import StringIO
+
 from ruamel.yaml import YAML
 
 try:
@@ -360,6 +362,7 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         self.driver = create_clidriver()
         self.entry_point = awscli.clidriver.AWSCLIEntryPoint(self.driver)
         self.yaml = YAML(typ="safe", pure=True)
+        self.yaml.representer.default_flow_style = False
 
     def tearDown(self):
         # This clears all the previous registrations.

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -453,6 +453,20 @@ def original_ld_library_path(env=None):
             env['LD_LIBRARY_PATH'] = value_to_put_back
 
 
+def dump_yaml_to_str(yaml, data):
+    """Dump a Python object to a YAML-formatted string.
+
+    :type yaml: ruamel.yaml.YAML
+    :param yaml: An instance of ruamel.yaml.YAML.
+
+    :type data: object
+    :param data: A Python object that can be dumped to YAML.
+    """
+    stream = StringIO()
+    yaml.dump(data, stream)
+    return stream.getvalue()
+
+
 class ShapeWalker(object):
     def walk(self, shape, visitor):
         """Walk through and visit shapes for introspection
@@ -511,17 +525,3 @@ class ShapeRecordingVisitor(BaseShapeVisitor):
 
     def visit_shape(self, shape):
         self.visited.append(shape)
-
-
-def dump_yaml_to_str(yaml, data):
-    """Dump a Python object to a YAML-formatted string.
-
-    :type yaml: ruamel.yaml.YAML
-    :param yaml: An instance of ruamel.yaml.YAML.
-
-    :type data: object
-    :param data: A Python object that can be dumped to YAML.
-    """
-    stream = StringIO()
-    yaml.dump(data, stream)
-    return stream.getvalue()

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -23,6 +23,7 @@ import logging
 from awscli.compat import six
 from awscli.compat import get_stdout_text_writer
 from awscli.compat import get_popen_kwargs_for_pager_cmd
+from awscli.compat import StringIO
 from botocore.utils import resolve_imds_endpoint_mode
 from botocore.utils import IMDSFetcher
 from botocore.configprovider import BaseProvider
@@ -510,3 +511,17 @@ class ShapeRecordingVisitor(BaseShapeVisitor):
 
     def visit_shape(self, shape):
         self.visited.append(shape)
+
+
+def dump_yaml_to_str(yaml, data):
+    """Dump a Python object to a YAML-formatted string.
+
+    :type yaml: ruamel.yaml.YAML
+    :param yaml: An instance of ruamel.yaml.YAML.
+
+    :type data: object
+    :param data: A Python object that can be dumped to YAML.
+    """
+    stream = StringIO()
+    yaml.dump(data, stream)
+    return stream.getvalue()

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -13,9 +13,8 @@
 import os
 
 from awscli.testutils import \
-    BaseAWSCommandParamsTest, FileCreator, YAMLStdoutDump
-
-yaml = YAMLStdoutDump(typ="safe", pure=True)
+    BaseAWSCommandParamsTest, FileCreator
+from awscli.utils import dump_yaml_to_str
 
 
 class BaseCLIInputArgumentTest(BaseAWSCommandParamsTest):
@@ -121,7 +120,7 @@ class TestCLIInputYAML(BaseCLIInputArgumentTest):
             'Body': b'foo',
         }
         command = [
-            's3api', 'put-object', '--cli-input-yaml', yaml.dump(expected_args)
+            's3api', 'put-object', '--cli-input-yaml', dump_yaml_to_str(self.yaml, expected_args)
         ]
         self.run_cmd(command)
         self.assertEqual(self.last_kwargs['Body'].getvalue(), b'foo')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,12 +27,14 @@ from awscli.compat import is_windows
 from awscli.utils import (
     split_on_commas, ignore_ctrl_c, find_service_and_method_in_event_name,
     is_document_type, is_document_type_container,
-    operation_uses_document_types, ShapeWalker, ShapeRecordingVisitor,
-    OutputStreamFactory, LazyPager
+    operation_uses_document_types, dump_yaml_to_str, ShapeWalker,
+    ShapeRecordingVisitor, OutputStreamFactory, LazyPager
 )
 from awscli.utils import InstanceMetadataRegionFetcher
 from awscli.utils import IMDSRegionProvider
 from tests import RawResponse
+
+import ruamel.yaml
 
 
 class TestCSVSplit(unittest.TestCase):
@@ -716,6 +718,18 @@ class TestOperationUsesDocumentTypes(BaseShapeTest):
 
     def test_operation_uses_document_types_is_false_when_no_doc_types(self):
         self.assertFalse(operation_uses_document_types(self.operation_model))
+
+
+class TestDumpYamlToStr(unittest.TestCase):
+    def setUp(self):
+        self.yaml = ruamel.yaml.YAML(typ="safe", pure=True)
+        self.yaml.representer.default_flow_style = False
+
+    def test_dump_to_str(self):
+        obj = {'A': 1, 'parameter': "something"}
+        expected_result = "A: 1\nparameter: something\n"
+        result = dump_yaml_to_str(self.yaml, obj)
+        self.assertEqual(result, expected_result)
 
 
 class TestShapeWalker(BaseShapeTest):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove usage of top level YAML loaders and dumpers as they will be deprecated in the future.

The EKS customization makes use of ordered dicts; moving the changes to the constructor and representer of the YAML object has the same effect as before.

There is room for potential improvement to abstract this to something like what DynamoDB uses:

https://github.com/aws/aws-cli/blob/v2/awscli/customizations/dynamodb/formatter.py#L22

However, that implementation is specifically for a dumper, not a loader.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
