### PR TITLE
make aws logs tail --follow ~2x faster

### DIFF
--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -333,7 +333,7 @@ class NoFollowLogEventsGenerator(BaseLogEventsGenerator):
 
 
 class FollowLogEventsGenerator(BaseLogEventsGenerator):
-    _TIME_TO_SLEEP = 5
+    _TIME_TO_SLEEP = 1
 
     def __init__(self, client, timestamp_utils, sleep=None):
         super(FollowLogEventsGenerator, self).__init__(client, timestamp_utils)


### PR DESCRIPTION
Reduce sleep time which makes aws logs tail --follow ~2x faster (for lambdas that emit frequently enough, eg every second); before this PR, you often had a ~10s latency between the time a log is written to some lambda's stdout and the time it appears in terminal (5s buffer time for cloudwatch logs + _TIME_TO_SLEEP); after this PR this becomes ~6 seconds.
