### PR TITLE
[v2] fix escape sequence deprecation warnings

### DIFF
--- a/tests/functional/cloudformation/test_create_stack.py
+++ b/tests/functional/cloudformation/test_create_stack.py
@@ -41,7 +41,7 @@ class TestCreateStack(BaseAWSCommandParamsTest):
         # we need to be able to quote the value or escape the comma.
         cmdline = self.prefix
         cmdline += ' --stack-name test-stack --template-url http://foo'
-        cmdline += ' --parameters ParameterKey=foo,ParameterValue=one\,two'
+        cmdline += r' --parameters ParameterKey=foo,ParameterValue=one\,two'
         result = {'StackName': 'test-stack', 'TemplateURL': 'http://foo',
                   'Parameters': [{'ParameterKey': 'foo',
                                   'ParameterValue': 'one,two'}]}

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -32,7 +32,7 @@ class RegionCapture(object):
     def __call__(self, request, **kwargs):
         url = request.url
         region = re.match(
-            'https://.*?\.(.*?)\.amazonaws\.com', url).groups(1)[0]
+            r'https://.*?\.(.*?)\.amazonaws\.com', url).groups(1)[0]
         self.region = region
 
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -146,7 +146,7 @@ def test_display_error_message(cmd):
     result = _aws(cmd, target_rc=254)
     assert result.rc == 254
     error_message = re.compile(
-        'An error occurred \(.+\) when calling the \w+ operation: \w+')
+        r'An error occurred \(.+\) when calling the \w+ operation: \w+')
     match = error_message.search(result.stderr)
     assert match, (
         f'Error message was not displayed for command "{cmd}": {result.stderr}'

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -119,7 +119,7 @@ class TestConfigureListCommand(unittest.TestCase):
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
-        self.assertRegex(rendered, 'region\s+from-imds\s+imds')
+        self.assertRegex(rendered, r'region\s+from-imds\s+imds')
 
     def test_configure_from_args(self):
         parsed_globals = Namespace(profile='foo')

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -208,11 +208,11 @@ class TestAddSteps(BaseAWSCommandParamsTest):
 
     def test_custom_jar_step_with_all_fields(self):
         cmd = self.prefix + (
-            'Name=Custom,Type=Custom_jar,'
-            'Jar=s3://mybucket/mytest.jar,'
-            'Args=arg1,arg2,MainClass=mymainclass,'
-            'ActionOnFailure=TERMINATE_CLUSTER,'
-            'Properties=k1=v1\,k2=v2\,k3')
+            r'Name=Custom,Type=Custom_jar,'
+            r'Jar=s3://mybucket/mytest.jar,'
+            r'Args=arg1,arg2,MainClass=mymainclass,'
+            r'ActionOnFailure=TERMINATE_CLUSTER,'
+            r'Properties=k1=v1\,k2=v2\,k3')
         expected_result = {
             'JobFlowId': 'j-ABC',
             'Steps': [

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -617,7 +617,7 @@ class TestPayloadSerialzier(unittest.TestCase):
             'list': ['foo', b'\xfe\xed'],
             'more_nesting': {
                 'bytes': b'\xfe\xed',
-                'tuple': ('bar', 'baz', b'\xfe\ed')
+                'tuple': ('bar', 'baz', b'\xfe\xed')
             }
         }
         encoded = {

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -771,7 +771,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         machine = platform.machine()
         driver = create_clidriver()
         user_agent_extra_pattern = re.compile(
-            '^source/%s(\.[a-z_]+)?(\.[0-9]+)?$' % machine
+            fr'^source/{machine}(\.[a-z_]+)?(\.[0-9]+)?$'
         )
         self.assertIsNotNone(user_agent_extra_pattern.match(
             driver.session.user_agent_extra))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -70,7 +70,7 @@ class TestCSVSplit(unittest.TestCase):
                          ['foo', 'bar=BAR', 'baz'])
 
     def test_escape_quotes(self):
-        self.assertEqual(split_on_commas('foo,bar=1\,2\,3,baz'),
+        self.assertEqual(split_on_commas(r'foo,bar=1\,2\,3,baz'),
                          ['foo', 'bar=1,2,3', 'baz'])
 
     def test_no_commas(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix `DeprecationWarning`s for invalid escape sequences.

All but one are converted to raw strings; one had a typo in the byte string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
