### PR TITLE
Tweak install_requires, now compatible with AL2022

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,12 +28,12 @@ packages = find:
 python_requires = >=3.8
 include_package_data = True
 install_requires =
-    colorama>=0.2.5,<0.4.4
-    docutils>=0.10,<0.16
+    colorama>=0.2.5,<=0.4.4
+    docutils>=0.10,<=0.16
     cryptography>=3.3.2,<37.0.0
-    ruamel.yaml>=0.15.0,<0.16.0
-    wcwidth<0.2.0
-    prompt-toolkit>=3.0.24,<3.0.29
+    ruamel.yaml>=0.15.0,<0.17.0
+    wcwidth<=0.2.5
+    prompt-toolkit>=3.0.24,<3.1.0
     distro>=1.5.0,<1.6.0
     awscrt>=0.12.4,<=0.13.11
     python-dateutil>=2.1,<3.0.0


### PR DESCRIPTION
This is how we are building awscli-2 on Amazon Linux 2022 today.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
