### PR TITLE
Update example output for S3 presigned URL max expiration

### DIFF
--- a/awscli/examples/s3/presign.rst
+++ b/awscli/examples/s3/presign.rst
@@ -17,6 +17,6 @@ The following ``presign`` command generates a pre-signed URL for a specified buc
 
 Output::
 
-    https://DOC-EXAMPLE-BUCKET.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
+    https://DOC-EXAMPLE-BUCKET.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
 
 For more information, see `Share an Object with Others <https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html>`__ in the *S3 Developer Guide* guide.


### PR DESCRIPTION
*Description of changes:*

This PR modifies the output URL for a presigned S3 object when the max expiration date is provided. Admittedly I haven't used this API before but the output URLs to both example commands are identical and I assume that the `X-Amz-Expires` query parameter is supposed to reflect the provided expiration date, so I altered the latter output to reflect this. Apologies if the outputs are indeed identical for both command!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
