### PR TITLE
Bump ruamel.yaml version ceiling to <=0.17.21

### DIFF
--- a/.changes/next-release/enhancement-dependency-89337.json
+++ b/.changes/next-release/enhancement-dependency-89337.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "dependency",
+  "description": "Bump upper bound of ruamel.yaml to <=0.17.21; fixes `#6756 <https://github.com/aws/aws-cli/issues/6756>`__"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     colorama>=0.2.5,<0.4.4
     docutils>=0.10,<0.16
     cryptography>=3.3.2,<37.0.0
-    ruamel.yaml>=0.15.0,<0.16.0
+    ruamel.yaml>=0.15.0,<=0.17.21
     wcwidth<0.2.0
     prompt-toolkit>=3.0.24,<3.0.29
     distro>=1.5.0,<1.6.0


### PR DESCRIPTION
*Issue #, if available:*

Fixes #6756.

*Description of changes:*

Bump the ceiling of ruamel.yaml to <=0.17.21.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
