### PR TITLE
docs: Fix a few typos

### DIFF
--- a/awscli/examples/autoscaling/describe-instance-refreshes.rst
+++ b/awscli/examples/autoscaling/describe-instance-refreshes.rst
@@ -1,6 +1,6 @@
 **To list instance refreshes**
 
-The following ``describe-instance-refreshes`` example returns a description of all instance refresh requests for the specified Auto Scaling group, including the status messsage and (if available) the status reason. ::
+The following ``describe-instance-refreshes`` example returns a description of all instance refresh requests for the specified Auto Scaling group, including the status message and (if available) the status reason. ::
 
     aws autoscaling describe-instance-refreshes \
         --auto-scaling-group-name my-asg 

--- a/awscli/examples/elasticache/start-migration.rst
+++ b/awscli/examples/elasticache/start-migration.rst
@@ -1,6 +1,6 @@
 **To start a migration**
 
-The following ``start-migratio`` migrates your data from self-hosted Redis on Amazon EC2 to Amazon ElastiCache, using the Redis engine. ::
+The following ``start-migration`` migrates your data from self-hosted Redis on Amazon EC2 to Amazon ElastiCache, using the Redis engine. ::
 
     aws elasticache start-migration \
        --replication-group-id test \

--- a/awscli/examples/guardduty/list-findings.rst
+++ b/awscli/examples/guardduty/list-findings.rst
@@ -1,6 +1,6 @@
 **Example 1: To list all findings for the current region**
 
-The following ``list-findings`` example displays a list of all findingIds for the current region sorted by severit from highest to lowest. ::
+The following ``list-findings`` example displays a list of all findingIds for the current region sorted by severity from highest to lowest. ::
 
     aws guardduty list-findings \
         --detector-id 12abc34d567e8fa901bc2d34eexample \ 

--- a/tests/functional/history/test_db.py
+++ b/tests/functional/history/test_db.py
@@ -413,7 +413,7 @@ class TestDatabaseHistoryHandler(unittest.TestCase):
 
     def test_can_emit_http_request_record(self):
         # HTTP_REQUEST records have have their entire body field as a binary
-        # blob, howver it will all be utf-8 valid since the binary fields
+        # blob, however it will all be utf-8 valid since the binary fields
         # from the api call will have been b64 encoded.
         payload = {
             'url': ('https://lambda.us-west-2.amazonaws.com/2015-03-31/'


### PR DESCRIPTION
There are small typos in:
- awscli/examples/autoscaling/describe-instance-refreshes.rst
- awscli/examples/elasticache/start-migration.rst
- awscli/examples/guardduty/list-findings.rst
- tests/functional/history/test_db.py

Fixes:
- Should read `severity` rather than `severit`.
- Should read `migration` rather than `migratio`.
- Should read `message` rather than `messsage`.
- Should read `however` rather than `howver`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md