### PR TITLE
[v2] Update a couple of botocore modules

### DIFF
--- a/.changes/next-release/enhancement-HTTP-91272.json
+++ b/.changes/next-release/enhancement-HTTP-91272.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "HTTP",
+  "description": "Update HTTP session configurations to match v1 configurations (`#7107 <https://github.com/aws/aws-cli/issues/7107>`__)"
+}

--- a/awscli/botocore/httpsession.py
+++ b/awscli/botocore/httpsession.py
@@ -5,21 +5,36 @@ import socket
 import sys
 from base64 import b64encode
 
-from urllib3 import PoolManager, ProxyManager, Timeout, proxy_from_url
+from urllib3 import PoolManager, Timeout, proxy_from_url
 from urllib3.exceptions import (
     ConnectTimeoutError as URLLib3ConnectTimeoutError,
 )
-from urllib3.exceptions import NewConnectionError, ProtocolError, ProxyError
+from urllib3.exceptions import (
+    LocationParseError,
+    NewConnectionError,
+    ProtocolError,
+    ProxyError,
+)
 from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 from urllib3.exceptions import SSLError as URLLib3SSLError
 from urllib3.util.retry import Retry
 from urllib3.util.ssl_ import (
     DEFAULT_CIPHERS,
     OP_NO_COMPRESSION,
+    PROTOCOL_TLS,
     OP_NO_SSLv2,
     OP_NO_SSLv3,
+    is_ipaddress,
     ssl,
 )
+from urllib3.util.url import parse_url
+
+try:
+    from urllib3.util.ssl_ import OP_NO_TICKET, PROTOCOL_TLS_CLIENT
+except ImportError:
+    # Fallback directly to ssl for version of urllib3 before 1.26.
+    # They are available in the standard library starting in Python 3.6.
+    from ssl import OP_NO_TICKET, PROTOCOL_TLS_CLIENT
 
 try:
     # Always import the original SSLContext, even if it has been patched
@@ -28,7 +43,12 @@ except ImportError:
     from urllib3.util.ssl_ import SSLContext
 
 import botocore.awsrequest
-from botocore.compat import ensure_bytes, filter_ssl_warnings, urlparse
+from botocore.compat import (
+    IPV6_ADDRZ_RE,
+    ensure_bytes,
+    filter_ssl_warnings,
+    urlparse,
+)
 from botocore.exceptions import (
     ConnectionClosedError,
     ConnectTimeoutError,
@@ -39,7 +59,6 @@ from botocore.exceptions import (
     ReadTimeoutError,
     SSLError,
 )
-from botocore.vendored import six
 from botocore.vendored.six.moves.urllib_parse import unquote
 
 filter_ssl_warnings()
@@ -51,6 +70,7 @@ DEFAULT_CA_BUNDLE = os.path.join(os.path.dirname(__file__), 'cacert.pem')
 try:
     from certifi import where
 except ImportError:
+
     def where():
         return DEFAULT_CA_BUNDLE
 
@@ -60,19 +80,26 @@ def get_cert_path(verify):
         return verify
 
     cert_path = where()
-    logger.debug("Certificate path: {0}".format(cert_path))
+    logger.debug(f"Certificate path: {cert_path}")
 
     return cert_path
 
 
-def create_urllib3_context(ssl_version=None, cert_reqs=None,
-                           options=None, ciphers=None):
-    """ This function is a vendored version of the same function in urllib3
+def create_urllib3_context(
+    ssl_version=None, cert_reqs=None, options=None, ciphers=None
+):
+    """This function is a vendored version of the same function in urllib3
 
-        We vendor this function to ensure that the SSL contexts we construct
-        always use the std lib SSLContext instead of pyopenssl.
+    We vendor this function to ensure that the SSL contexts we construct
+    always use the std lib SSLContext instead of pyopenssl.
     """
-    context = SSLContext(ssl_version or ssl.PROTOCOL_SSLv23)
+    # PROTOCOL_TLS is deprecated in Python 3.10
+    if not ssl_version or ssl_version == PROTOCOL_TLS:
+        ssl_version = PROTOCOL_TLS_CLIENT
+
+    context = SSLContext(ssl_version)
+
+    context.set_ciphers(ciphers or DEFAULT_CIPHERS)
 
     # Setting the default here, as we may have no ssl module on import
     cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs
@@ -86,26 +113,51 @@ def create_urllib3_context(ssl_version=None, cert_reqs=None,
         # Disable compression to prevent CRIME attacks for OpenSSL 1.0+
         # (issue urllib3#309)
         options |= OP_NO_COMPRESSION
+        # TLSv1.2 only. Unless set explicitly, do not request tickets.
+        # This may save some bandwidth on wire, and although the ticket is encrypted,
+        # there is a risk associated with it being on wire,
+        # if the server is not rotating its ticketing keys properly.
+        options |= OP_NO_TICKET
 
     context.options |= options
 
-    if getattr(context, 'supports_set_ciphers', True):
-        # Platform-specific: Python 2.6
-        context.set_ciphers(ciphers or DEFAULT_CIPHERS)
+    # Enable post-handshake authentication for TLS 1.3, see GH #1634. PHA is
+    # necessary for conditional client cert authentication with TLS 1.3.
+    # The attribute is None for OpenSSL <= 1.1.0 or does not exist in older
+    # versions of Python.  We only enable on Python 3.7.4+ or if certificate
+    # verification is enabled to work around Python issue #37428
+    # See: https://bugs.python.org/issue37428
+    if (
+        cert_reqs == ssl.CERT_REQUIRED or sys.version_info >= (3, 7, 4)
+    ) and getattr(context, "post_handshake_auth", None) is not None:
+        context.post_handshake_auth = True
 
-    context.verify_mode = cert_reqs
-    if getattr(context, 'check_hostname', None) is not None:
-        # Platform-specific: Python 3.2
-        # We do our own verification, including fingerprints and alternative
-        # hostnames. So disable it here
-        context.check_hostname = False
+    def disable_check_hostname():
+        if (
+            getattr(context, "check_hostname", None) is not None
+        ):  # Platform-specific: Python 3.2
+            # We do our own verification, including fingerprints and alternative
+            # hostnames. So disable it here
+            context.check_hostname = False
+
+    # The order of the below lines setting verify_mode and check_hostname
+    # matter due to safe-guards SSLContext has to prevent an SSLContext with
+    # check_hostname=True, verify_mode=NONE/OPTIONAL. This is made even more
+    # complex because we don't know whether PROTOCOL_TLS_CLIENT will be used
+    # or not so we don't know the initial state of the freshly created SSLContext.
+    if cert_reqs == ssl.CERT_REQUIRED:
+        context.verify_mode = cert_reqs
+        disable_check_hostname()
+    else:
+        disable_check_hostname()
+        context.verify_mode = cert_reqs
 
     # Enable logging of TLS session keys via defacto standard environment variable
     # 'SSLKEYLOGFILE', if the feature is available (Python 3.8+). Skip empty values.
-    if hasattr(context, 'keylog_filename'):
-        keylogfile = os.environ.get('SSLKEYLOGFILE')
-        if keylogfile and not sys.flags.ignore_environment:
-            context.keylog_filename = keylogfile
+    if hasattr(context, "keylog_filename"):
+        sslkeylogfile = os.environ.get("SSLKEYLOGFILE")
+        if sslkeylogfile and not sys.flags.ignore_environment:
+            context.keylog_filename = sslkeylogfile
 
     return context
 
@@ -121,13 +173,37 @@ def ensure_boolean(val):
         return val.lower() == 'true'
 
 
-class ProxyConfiguration(object):
+def mask_proxy_url(proxy_url):
+    """
+    Mask proxy url credentials.
+
+    :type proxy_url: str
+    :param proxy_url: The proxy url, i.e. https://username:password@proxy.com
+
+    :return: Masked proxy url, i.e. https://***:***@proxy.com
+    """
+    mask = '*' * 3
+    parsed_url = urlparse(proxy_url)
+    if parsed_url.username:
+        proxy_url = proxy_url.replace(parsed_url.username, mask, 1)
+    if parsed_url.password:
+        proxy_url = proxy_url.replace(parsed_url.password, mask, 1)
+    return proxy_url
+
+
+def _is_ipaddress(host):
+    """Wrap urllib3's is_ipaddress to support bracketed IPv6 addresses."""
+    return is_ipaddress(host) or bool(IPV6_ADDRZ_RE.match(host))
+
+
+class ProxyConfiguration:
     """Represents a proxy configuration dictionary and additional settings.
 
     This class represents a proxy configuration dictionary and provides utility
     functions to retreive well structured proxy urls and proxy headers from the
     proxy configuration dictionary.
     """
+
     def __init__(self, proxies=None, proxies_settings=None):
         if proxies is None:
             proxies = {}
@@ -138,7 +214,7 @@ class ProxyConfiguration(object):
         self._proxies_settings = proxies_settings
 
     def proxy_url_for(self, url):
-        """Retrieves the corresponding proxy url for a given url. """
+        """Retrieves the corresponding proxy url for a given url."""
         parsed_url = urlparse(url)
         proxy = self._proxies.get(parsed_url.scheme)
         if proxy:
@@ -146,7 +222,7 @@ class ProxyConfiguration(object):
         return proxy
 
     def proxy_headers_for(self, proxy_url):
-        """Retrieves the corresponding proxy headers for a given proxy url. """
+        """Retrieves the corresponding proxy headers for a given proxy url."""
         headers = {}
         username, password = self._get_auth_from_url(proxy_url)
         if username and password:
@@ -167,9 +243,9 @@ class ProxyConfiguration(object):
             return 'http://' + proxy_url
 
     def _construct_basic_auth(self, username, password):
-        auth_str = '{0}:{1}'.format(username, password)
+        auth_str = f'{username}:{password}'
         encoded_str = b64encode(auth_str.encode('ascii')).strip().decode()
-        return 'Basic {0}'.format(encoded_str)
+        return f'Basic {encoded_str}'
 
     def _get_auth_from_url(self, url):
         parsed_url = urlparse(url)
@@ -179,7 +255,7 @@ class ProxyConfiguration(object):
             return None, None
 
 
-class URLLib3Session(object):
+class URLLib3Session:
     """A basic HTTP client that supports connection pooling and proxies.
 
     This class is inspired by requests.adapters.HTTPAdapter, but has been
@@ -190,18 +266,21 @@ class URLLib3Session(object):
     v2.7.0 implemented this themselves, later version urllib3 support this
     directly via a flag to urlopen so enabling it if needed should be trivial.
     """
-    def __init__(self,
-                 verify=True,
-                 proxies=None,
-                 timeout=None,
-                 max_pool_connections=MAX_POOL_CONNECTIONS,
-                 socket_options=None,
-                 client_cert=None,
-                 proxies_config=None,
+
+    def __init__(
+        self,
+        verify=True,
+        proxies=None,
+        timeout=None,
+        max_pool_connections=MAX_POOL_CONNECTIONS,
+        socket_options=None,
+        client_cert=None,
+        proxies_config=None,
     ):
         self._verify = verify
-        self._proxy_config = ProxyConfiguration(proxies=proxies,
-                                                proxies_settings=proxies_config)
+        self._proxy_config = ProxyConfiguration(
+            proxies=proxies, proxies_settings=proxies_config
+        )
         self._pool_classes_by_scheme = {
             'http': botocore.awsrequest.AWSHTTPConnectionPool,
             'https': botocore.awsrequest.AWSHTTPSConnectionPool,
@@ -227,14 +306,13 @@ class URLLib3Session(object):
         self._manager = PoolManager(**self._get_pool_manager_kwargs())
         self._manager.pool_classes_by_scheme = self._pool_classes_by_scheme
 
-    @property
-    def _proxies_kwargs(self):
+    def _proxies_kwargs(self, **kwargs):
         proxies_settings = self._proxy_config.settings
-        proxy_ssl_context = self._setup_proxy_ssl_context(proxies_settings)
         proxies_kwargs = {
-            'proxy_ssl_context': proxy_ssl_context,
             'use_forwarding_for_https': proxies_settings.get(
-                'proxy_use_forwarding_for_https'),
+                'proxy_use_forwarding_for_https'
+            ),
+            **kwargs,
         }
         return {k: v for k, v in proxies_kwargs.items() if v is not None}
 
@@ -257,9 +335,13 @@ class URLLib3Session(object):
     def _get_proxy_manager(self, proxy_url):
         if proxy_url not in self._proxy_managers:
             proxy_headers = self._proxy_config.proxy_headers_for(proxy_url)
+            proxy_ssl_context = self._setup_proxy_ssl_context(proxy_url)
             proxy_manager_kwargs = self._get_pool_manager_kwargs(
-                proxy_headers=proxy_headers)
-            proxy_manager_kwargs.update(**self._proxies_kwargs)
+                proxy_headers=proxy_headers
+            )
+            proxy_manager_kwargs.update(
+                self._proxies_kwargs(proxy_ssl_context=proxy_ssl_context)
+            )
             proxy_manager = proxy_from_url(proxy_url, **proxy_manager_kwargs)
             proxy_manager.pool_classes_by_scheme = self._pool_classes_by_scheme
             self._proxy_managers[proxy_url] = proxy_manager
@@ -283,7 +365,8 @@ class URLLib3Session(object):
             conn.cert_reqs = 'CERT_NONE'
             conn.ca_certs = None
 
-    def _setup_proxy_ssl_context(self, proxies_settings):
+    def _setup_proxy_ssl_context(self, proxy_url):
+        proxies_settings = self._proxy_config.settings
         proxy_ca_bundle = proxies_settings.get('proxy_ca_bundle')
         proxy_cert = proxies_settings.get('proxy_client_cert')
         if proxy_ca_bundle is None and proxy_cert is None:
@@ -291,9 +374,11 @@ class URLLib3Session(object):
 
         context = self._get_ssl_context()
         try:
-            # urllib3 disables this by default but we need
-            # it for proper proxy tls negotiation.
-            context.check_hostname = True
+            url = parse_url(proxy_url)
+            # urllib3 disables this by default but we need it for proper
+            # proxy tls negotiation when proxy_url is not an IP Address
+            if not _is_ipaddress(url.host):
+                context.check_hostname = True
             if proxy_ca_bundle is not None:
                 context.load_verify_locations(cafile=proxy_ca_bundle)
 
@@ -303,7 +388,7 @@ class URLLib3Session(object):
                 context.load_cert_chain(proxy_cert)
 
             return context
-        except (IOError, URLLib3SSLError) as e:
+        except (OSError, URLLib3SSLError, LocationParseError) as e:
             raise InvalidProxiesConfigError(error=e)
 
     def _get_connection_manager(self, url, proxy_url=None):
@@ -324,8 +409,8 @@ class URLLib3Session(object):
         # forwarding for HTTPS through the 'use_forwarding_for_https' parameter.
         proxy_scheme = urlparse(proxy_url).scheme
         using_https_forwarding_proxy = (
-            proxy_scheme == 'https' and
-            self._proxies_kwargs.get('use_forwarding_for_https', False)
+            proxy_scheme == 'https'
+            and self._proxies_kwargs().get('use_forwarding_for_https', False)
         )
 
         if using_https_forwarding_proxy or url.startswith('http:'):
@@ -337,6 +422,11 @@ class URLLib3Session(object):
         transfer_encoding = headers.get('Transfer-Encoding', b'')
         transfer_encoding = ensure_bytes(transfer_encoding)
         return transfer_encoding.lower() == b'chunked'
+
+    def close(self):
+        self._manager.clear()
+        for manager in self._proxy_managers.values():
+            manager.clear()
 
     def send(self, request):
         try:
@@ -386,16 +476,16 @@ class URLLib3Session(object):
         except (NewConnectionError, socket.gaierror) as e:
             raise EndpointConnectionError(endpoint_url=request.url, error=e)
         except ProxyError as e:
-            raise ProxyConnectionError(proxy_url=proxy_url, error=e)
+            raise ProxyConnectionError(
+                proxy_url=mask_proxy_url(proxy_url), error=e
+            )
         except URLLib3ConnectTimeoutError as e:
             raise ConnectTimeoutError(endpoint_url=request.url, error=e)
         except URLLib3ReadTimeoutError as e:
             raise ReadTimeoutError(endpoint_url=request.url, error=e)
         except ProtocolError as e:
             raise ConnectionClosedError(
-                error=e,
-                request=request,
-                endpoint_url=request.url
+                error=e, request=request, endpoint_url=request.url
             )
         except Exception as e:
             message = 'Exception received when sending urllib3 HTTP request'


### PR DESCRIPTION
This PR is meant to replace this one: https://github.com/aws/aws-cli/pull/7040 for addressing deprecation warnings.

The motivation for the new PR is that the `httpsession` module in general should match what we are using in v1. There were no backwards incompatible changes between v1 and v2 for this module. So this change just copies over the file into v2 and there are no longer any difference between the two.

In addition, this required updating the botocore `compat` module to pull in some constants now used in `httpsession`. For that I copied over the `compat` from v1 and removed a couple checks that are not needed in v2. Below is the diff now between v1 and v2:
```diff
$ diff -u compat.py ~/GitHub/botocore/botocore/compat.py 
--- compat.py	2022-07-14 11:21:53.000000000 -0700
+++ /Users/kyleknap/GitHub/botocore/botocore/compat.py	2022-07-14 11:21:18.000000000 -0700
@@ -289,6 +289,17 @@
         return (tzlocal,)
 
 
+# Detect if CRT is available for use
+try:
+    import awscrt.auth
+
+    # Allow user opt-out if needed
+    disabled = os.environ.get('BOTO_DISABLE_CRT', "false")
+    HAS_CRT = not disabled.lower() == 'true'
+except ImportError:
+    HAS_CRT = False
+
+
 ########################################################
 #              urllib3 compat backports                #
 ########################################################
@@ -331,3 +342,9 @@
 # These are the characters that are stripped by post-bpo-43882 urlparse().
 UNSAFE_URL_CHARS = frozenset('\t\r\n')
 
+# Detect if gzip is available for use
+try:
+    import gzip
+    HAS_GZIP = True
+except ImportError:
+    HAS_GZIP = False
```
