### PR TITLE
[v2] Rename utility class to avoid PytestCollectionWarning

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -934,11 +934,10 @@ class StringIOWithFileNo(StringIO):
         return 0
 
 
-class TestEventHandler(object):
+class EventCaptureHandler(object):
     def __init__(self, handler=None):
         self._handler = handler
         self._called = False
-        self.__test__ = False
 
     @property
     def called(self):

--- a/tests/functional/elb/test_register_instances_with_load_balancer.py
+++ b/tests/functional/elb/test_register_instances_with_load_balancer.py
@@ -11,7 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import BaseAWSCommandParamsTest, TestEventHandler
+from awscli.testutils import BaseAWSCommandParamsTest, EventCaptureHandler
 import os
 
 
@@ -82,7 +82,7 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
         cmdline += ' --instances {"InstanceId":"i-12345678"}'
-        handler = TestEventHandler()
+        handler = EventCaptureHandler()
         event = 'process-cli-arg.elb.register-instances-with-load-balancer'
         self.driver.session.register(event, handler.handler)
         self.run_cmd(cmdline)


### PR DESCRIPTION
Eliminates warnings from py.test output such as:
```
PytestCollectionWarning: cannot collect test class 'TestEventHandler' because it has a __init__ constructor (from: tests/functional/elb/test_register_instances_with_load_balancer.py)
    class TestEventHandler(object):
```
