### PR TITLE
[v2] Address additional escape sequence deprecation warnings

### DIFF
--- a/awscli/autocomplete/local/basic.py
+++ b/awscli/autocomplete/local/basic.py
@@ -546,7 +546,7 @@ class QueryCompleter(BaseCompleter):
         # user enters query like Groups[2] jmespath will return "null"
         # and we won't be able to prompting so we change all the numbers
         # in brackets to 0 to be able to get the shape of the nested structure
-        query = re.sub(r'([\{\[])\d+?([\}\]])', '\g<1>0\g<2>', query)
+        query = re.sub(r'([\{\[])\d+?([\}\]])', r'\g<1>0\g<2>', query)
         return query.rsplit('.', 1)
 
     def _create_completions(self, results, last_key, fragment):

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -129,9 +129,9 @@ class ShorthandParser(object):
 
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
-    _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
-    _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
-    _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
+    _START_WORD = r'\!\#-&\(-\+\--\<\>-Z\\-z' + '\u007c-\uffff'
+    _FIRST_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\\\^-\|~-' + '\uffff'
+    _SECOND_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\<\>-' + '\uffff'
     _ESCAPED_COMMA = '(\\\\,)'
     _FIRST_VALUE = _NamedRegex(
         'first',


### PR DESCRIPTION
The strings in general are intended to be used as regex's, but these values are only a non-raw string to allow use of the unicode escape sequences when handing unicode in shorthand syntax.

To fix the deprecation warning, I broke up the string so that normal strings are only used if needed. The one subtle part of this change was that I converted `\\\\` to `\\` under the raw string so that we maintain matching literal backslashes as part of the regex. See the Python docs for more about this: https://docs.python.org/3/library/re.html#raw-string-notation
