### PR TITLE
[v2] Enforce deprecation and collection warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,10 @@ filterwarnings = [
     # Prevents use of functionality that is deprecated or pending deprecation
     "error::DeprecationWarning",
     "error::PendingDeprecationWarning",
+
+    # Do not error out on deprecation warnings stemming from our current
+    # version of setuptools (57.5.0) in a Python 3.10 environment. When we add
+    # support for the latest version of setuptools, we should be able to remove
+    # these filters.
+    'default:The distutils\.sysconfig module is deprecated:DeprecationWarning'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,19 @@
 requires = ["setuptools>=40.6.0,<59.0.0", "wheel<=0.37.0"]
 build-backend = "backends.pep517"
 backend-path = ["."]
+
+
+[tool.pytest.ini_options]
+# We set error warning filters in order to enforce that particular
+# undesired warnings are not emitted as part of the codebase. If you
+# want to override these filters with pytest's default warning filters
+# (i.e. print out deprecation warnings instead of erroring out on them),
+# you can run pytest with the -Wd flag.
+filterwarnings = [
+    # Prevents declaring tests that cannot be collected by pytest
+    "error::pytest.PytestCollectionWarning",
+
+    # Prevents use of functionality that is deprecated or pending deprecation
+    "error::DeprecationWarning",
+    "error::PendingDeprecationWarning",
+]


### PR DESCRIPTION
By enforcing these warnings to be treated as errors, it:

* Ensures contributors do not inadvertently use functionality that is deprecated or is soon to be deprecated.
* Forces code is migrated off of deprecated functionality when upgrading dependency or adding support for a new Python version.
* Ensures tests that are written that cannot be collected by pytest

If you want to override these filters with pytest's default warning filters (i.e. print out deprecation warnings instead of erroring out on them), you can run pytest with the `-Wd` flag. See here if you want to read more about pytest filter warning integration: https://docs.pytest.org/en/7.1.x/how-to/capture-warnings.html#controlling-warnings

In general, I see this check as somewhat experimental; if we find it too difficult to maintain/work with, we can always remove it. However, for now, hopefully this can help us stay on top of the warnings that are emitted from the codebase and make sure we do our due diligence when updating support for a Python version/dependency.

In order to see these checks in action, I pushed up this [branch](https://github.com/kyleknap/aws-cli/tree/enforce-warnings-test) and verified in [the CI that we got errors](https://github.com/kyleknap/aws-cli/runs/7365836502) for previous warnings that we addressed.




