### PR TITLE
Add get total size of all buckets's Objects Info

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -475,7 +475,7 @@ class ListCommand(S3Command):
             path = path[5:]
         bucket, key = find_bucket_key(path)
         if not bucket:
-            self._list_all_buckets()
+            self._list_all_buckets(parsed_args.summarize)
         elif parsed_args.dir_op:
             # Then --recursive was specified.
             self._list_all_objects_recursive(
@@ -539,13 +539,18 @@ class ListCommand(S3Command):
             uni_print(print_str)
         self._at_first_page = False
 
-    def _list_all_buckets(self):
+    def _list_all_buckets(self, summarize):
         response_data = self.client.list_buckets()
         buckets = response_data['Buckets']
         for bucket in buckets:
             last_mod_str = self._make_last_mod_str(bucket['CreationDate'])
             print_str = last_mod_str + ' ' + bucket['Name'] + '\n'
             uni_print(print_str)
+
+            if summarize:
+                bucket, key = find_bucket_key(bucket['Name'])
+                self._list_all_objects(
+                    bucket, key, None, None)
 
     def _list_all_objects_recursive(self, bucket, key, page_size=None,
                                     request_payer=None):


### PR DESCRIPTION
* Issue #6799

* Description of changes: `aws s3 ls --summarize` to return the Total Objects and Total Size of all buckets:


The verification log in the local environment is described below

```
 ~/De/O/aws-cli  Feature-tota..l-s3-buckets !1  python awscli s3 ls --summarize
2022-07-13 13:11:01       4645 xxxxx.template
2022-07-04 14:34:44 xxxxx2
2022-07-04 14:34:44       5583 xxxxx2.json
2022-07-01 13:46:59 xxxxx3
                           PRE xxxxxLog/
2022-07-16 22:40:19 xxxxx4
2022-07-14 18:01:49 xxxxx5
                           PRE xxxxx6/
2022-07-14 18:02:53 xxxxx7
                           PRE xxxxx6/
2022-07-14 18:16:59     155595 xxxxx8
2022-07-13 10:40:32 test-s3-hands-on
                           PRE prefix/
2022-07-13 10:13:33     155595 IMG_3799.PNG
2022-07-13 10:26:10 test-s3-hands-on-2

Total Objects: 4
   Total Size: 321418

 ~/De/O/aws-cli  Feature-tota..l-s3-buckets !1  python awscli s3 ls
2022-07-13 13:11:00 xxxxx1
2022-07-04 14:34:44 xxxxx2
2022-07-01 13:46:59 xxxxx3
2022-07-16 22:40:19 xxxxx4
2022-07-14 18:01:49 xxxxx5
2022-07-14 18:02:53 xxxxx7
2022-07-13 10:40:32 test-s3-hands-on
2022-07-13 10:26:10 test-s3-hands-on-2

 ~/De/O/aws-cli  Feature-tota..l-s3-buckets !1  python awscli s3 ls --summarize --human-readable
2022-07-13 13:11:00 xxxxx1
2022-07-13 13:11:01    4.5 KiB xxxxx.template
2022-07-04 14:34:44 xxxxx2
2022-07-04 14:34:44    5.5 KiB xxxxx2.json
2022-07-01 13:46:59 xxxxx3
                           PRE xxxxxLog/
2022-07-16 22:40:19 xxxxx4
2022-07-14 18:01:49 xxxxx5
                           PRE dump/
2022-07-14 18:02:53 xxxxx7
                           PRE dump/
2022-07-14 18:16:59  151.9 KiB tmp
2022-07-13 10:40:32 test-s3-hands-on
                           PRE prefix/
2022-07-13 10:13:33  151.9 KiB IMG_3799.PNG
2022-07-13 10:26:10 test-s3-hands-on-2

Total Objects: 4
   Total Size: 313.9 KiB
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
