### PR TITLE
Point v2 branch links to the latest docs

### DIFF
--- a/awscli/customizations/addexamples.py
+++ b/awscli/customizations/addexamples.py
@@ -47,13 +47,13 @@ def add_examples(help_command, **kwargs):
         help_command.doc.style.start_note()
         msg = ("<p>To use the following examples, you must have the AWS "
                "CLI installed and configured. See the "
-               "<a href='https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-quickstart.html'>"
+               "<a href='https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html'>"
                "Getting started guide</a> in the <i>AWS CLI User Guide</i> "
                "for more information.</p>"
                "<p>Unless otherwise stated, all examples have unix-like "
                "quotation rules. These examples will need to be adapted "
                "to your terminal's quoting rules. See "
-               "<a href='https://docs.aws.amazon.com/cli/v1/userguide/cli-usage-parameters-quoting-strings.html'>"
+               "<a href='https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-quoting-strings.html'>"
                "Using quotation marks with strings</a> "
                "in the <i>AWS CLI User Guide</i>.</p>")
         help_command.doc.include_doc_string(msg)


### PR DESCRIPTION
Updating the `Examples` note links to docs for the `v2` branch.