### PR TITLE
Add environment variable to configure assume-role-with-web-identity credential cache directory

### DIFF
--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -5,7 +5,9 @@ from botocore.exceptions import ProfileNotFound
 from botocore.credentials import JSONFileCache
 
 LOG = logging.getLogger(__name__)
-CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
+CACHE_DIR = os.environ.get("AWS_CREDENTIAL_CACHE_DIR",
+                           os.path.expanduser(
+                               os.path.join('~', '.aws', 'cli', 'cache')))
 
 
 def register_assume_role_provider(event_handlers):

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -303,9 +303,10 @@ STS on your behalf.
 
 When you specify a profile that has IAM role configuration, the AWS CLI will
 make an ``AssumeRoleWithWebIdentity`` call to retrieve temporary credentials.
-These credentials are then stored (in ``~/.aws/cli/cache``).  Subsequent AWS
-CLI commands will use the cached temporary credentials until they expire, in
-which case the AWS CLI will automatically refresh credentials.
+These credentials are then stored (in ``~/.aws/cli/cache``, or the directory
+specified by the ``AWS_CREDENTIAL_CACHE_DIR`` environment variable).
+Subsequent AWS CLI commands will use the cached temporary credentials until
+they expire, in which case the AWS CLI will automatically refresh credentials.
 
 You can specify the following configuration values for configuring an
 assume role with web identity profile in the shared config:
@@ -342,6 +343,10 @@ This provider can also be configured via the environment:
 
 ``AWS_ROLE_SESSION_NAME``
     The name applied to this assume-role session.
+
+``AWS_CREDENTIAL_CACHE_DIR```
+    The directory in which to cache temporary credentials. Defaults to
+    ``~/.aws/cli/cache`` if unset.
 
 .. note::
 


### PR DESCRIPTION
*Issue #, if available:*
A description of the problem was discussed in #4374, which was closed by the author because they had a workaround. This addresses the problem directly.

*Description of changes:*
This makes the credential cache directory (default: `~/.aws/cli/cache`) used to store temporary credentials obtained using `AssumeRoleWithWebIdentity` configurable using the environment variable `AWS_CREDENTIAL_CACHE_DIR`. The use case is environments where the home directory is mounted as read-only. The cache directory being configurable means it can be pointed at a writable volume.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
