### PR TITLE
Add a Global Options section to help docs

### DIFF
--- a/awscli/bcdoc/docevents.py
+++ b/awscli/bcdoc/docevents.py
@@ -23,6 +23,9 @@ DOC_EVENTS = {
     'doc-option': '.%s.%s',
     'doc-option-example': '.%s.%s',
     'doc-options-end': '.%s',
+    'doc-global-options-start': '.%s',
+    'doc-global-option': '.%s.%s',
+    'doc-global-options-end': '.%s',
     'doc-examples': '.%s',
     'doc-output': '.%s',
     'doc-subitems-start': '.%s',
@@ -57,6 +60,15 @@ def generate_events(session, help_command):
                 'doc-synopsis-option.%s.%s' % (help_command.event_class,
                                                arg_name),
                 arg_name=arg_name, help_command=help_command)
+    if help_command.global_arg_table:
+        for arg_name in help_command.global_arg_table:
+            if getattr(help_command.global_arg_table[arg_name],
+                       '_UNDOCUMENTED', False):
+                continue
+            session.emit(
+                'doc-synopsis-option.%s.%s' % (help_command.event_class,
+                                               arg_name),
+                arg_name=arg_name, help_command=help_command)
     session.emit('doc-synopsis-end.%s' % help_command.event_class,
                  help_command=help_command)
     session.emit('doc-options-start.%s' % help_command.event_class,
@@ -73,6 +85,18 @@ def generate_events(session, help_command):
                          (help_command.event_class, arg_name),
                          arg_name=arg_name, help_command=help_command)
     session.emit('doc-options-end.%s' % help_command.event_class,
+                 help_command=help_command)
+    if help_command.global_arg_table:
+        session.emit('doc-global-options-start.%s' % help_command.event_class,
+                    help_command=help_command)
+        for arg_name in help_command.global_arg_table:
+            if getattr(help_command.global_arg_table[arg_name],
+                    '_UNDOCUMENTED', False):
+                continue
+            session.emit('doc-global-option.%s.%s' % (help_command.event_class,
+                                                    arg_name),
+                        arg_name=arg_name, help_command=help_command)
+    session.emit('doc-global-options-end.%s' % help_command.event_class,
                  help_command=help_command)
     session.emit('doc-subitems-start.%s' % help_command.event_class,
                  help_command=help_command)

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -124,7 +124,11 @@ class CLIDocumentEventHandler(object):
 
     def doc_synopsis_option(self, arg_name, help_command, **kwargs):
         doc = help_command.doc
-        argument = help_command.arg_table[arg_name]
+        if arg_name in help_command.global_arg_table:
+            arg_table = help_command.global_arg_table
+        else:
+            arg_table = help_command.arg_table
+        argument = arg_table[arg_name]
         if argument.group_name in self._arg_groups:
             if argument.group_name in self._documented_arg_groups:
                 # This arg is already documented so we can move on.
@@ -178,6 +182,22 @@ class CLIDocumentEventHandler(object):
             self._document_nested_structure(argument.argument_model, doc)
         doc.style.dedent()
         doc.style.new_paragraph()
+    
+    def doc_global_options_start(self, help_command, **kwargs):
+        doc = help_command.doc
+        doc.style.h2('Global Options')
+
+    def doc_global_option(self, arg_name, help_command, **kwargs):
+        doc = help_command.doc
+        argument = help_command.global_arg_table[arg_name]
+        doc.writeln('``%s`` (%s)' % (argument.cli_name,
+                                     argument.cli_type_name))
+        doc.include_doc_string(argument.documentation)
+        if argument.choices:
+            doc.style.start_ul()
+            for choice in argument.choices:
+                doc.style.li(choice)
+            doc.style.end_ul()
 
     def doc_relateditems_start(self, help_command, **kwargs):
         if help_command.related_items:
@@ -283,21 +303,13 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
         doc = help_command.doc
         doc.style.new_paragraph()
 
+    # A provider document's options are provided by
+    # the global option methods.
     def doc_options_start(self, help_command, **kwargs):
-        doc = help_command.doc
-        doc.style.h2('Options')
+        pass
 
     def doc_option(self, arg_name, help_command, **kwargs):
-        doc = help_command.doc
-        argument = help_command.arg_table[arg_name]
-        doc.writeln('``%s`` (%s)' % (argument.cli_name,
-                                     argument.cli_type_name))
-        doc.include_doc_string(argument.documentation)
-        if argument.choices:
-            doc.style.start_ul()
-            for choice in argument.choices:
-                doc.style.li(choice)
-            doc.style.end_ul()
+        pass
 
     def doc_subitems_start(self, help_command, **kwargs):
         doc = help_command.doc
@@ -333,6 +345,12 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
         pass
 
     def doc_options_end(self, help_command, **kwargs):
+        pass
+
+    def doc_global_option_start(self, help_command, **kwargs):
+        pass
+
+    def doc_global_option(self, help_command, **kwargs):
         pass
 
     def doc_description(self, help_command, **kwargs):

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -206,7 +206,8 @@ class HelpCommand(object):
     EventHandler class used by this HelpCommand.
     """
 
-    def __init__(self, session, obj, command_table, arg_table):
+    def __init__(self, session, obj, command_table, arg_table,
+                 global_arg_table={}):
         self.session = session
         self.obj = obj
         if command_table is None:
@@ -215,6 +216,7 @@ class HelpCommand(object):
         if arg_table is None:
             arg_table = {}
         self.arg_table = arg_table
+        self.global_arg_table = global_arg_table
         self._subcommand_table = {}
         self._related_items = []
         self.renderer = get_renderer()
@@ -284,7 +286,7 @@ class ProviderHelpCommand(HelpCommand):
     def __init__(self, session, command_table, arg_table,
                  description, synopsis, usage):
         HelpCommand.__init__(self, session, None,
-                             command_table, arg_table)
+                             command_table, arg_table, arg_table)
         self.description = description
         self.synopsis = synopsis
         self.help_usage = usage
@@ -336,7 +338,7 @@ class ServiceHelpCommand(HelpCommand):
     def __init__(self, session, obj, command_table, arg_table, name,
                  event_class):
         super(ServiceHelpCommand, self).__init__(session, obj, command_table,
-                                                 arg_table)
+                                                 arg_table, {})
         self._name = name
         self._event_class = event_class
 
@@ -358,9 +360,10 @@ class OperationHelpCommand(HelpCommand):
     """
     EventHandlerClass = OperationDocumentEventHandler
 
-    def __init__(self, session, operation_model, arg_table, name,
-                 event_class):
-        HelpCommand.__init__(self, session, operation_model, None, arg_table)
+    def __init__(self, session, operation_model, arg_table,
+                 global_arg_table, name, event_class):
+        HelpCommand.__init__(self, session, operation_model,
+                             None, arg_table, global_arg_table)
         self.param_shorthand = ParamShorthandParser()
         self._name = name
         self._event_class = event_class
@@ -378,7 +381,7 @@ class TopicListerCommand(HelpCommand):
     EventHandlerClass = TopicListerDocumentEventHandler
 
     def __init__(self, session):
-        super(TopicListerCommand, self).__init__(session, None, {}, {})
+        super(TopicListerCommand, self).__init__(session, None, {}, {}, {})
 
     @property
     def event_class(self):
@@ -393,7 +396,7 @@ class TopicHelpCommand(HelpCommand):
     EventHandlerClass = TopicDocumentEventHandler
 
     def __init__(self, session, topic_name):
-        super(TopicHelpCommand, self).__init__(session, None, {}, {})
+        super(TopicHelpCommand, self).__init__(session, None, {}, {}, {})
         self._topic_name = topic_name
 
     @property

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -121,8 +121,8 @@ class TestBasicCommandHooks(unittest.TestCase):
         driver.main('s3 foo'.split())
 
         self.assert_events_fired_in_order([
-            'building-command-table.main',
             'building-top-level-params',
+            'building-command-table.main',
             'top-level-args-parsed',
             'session-initialized',
             'building-command-table.s3',

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -103,7 +103,8 @@ class TestHelpDocumentationModifications(TestPaginateBase):
         with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value={'result_key': 'abc'}):
             help_command = OperationHelpCommand(
-                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+                mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(),
+                'foo', OperationDocumentEventHandler)
             help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
@@ -116,7 +117,8 @@ class TestHelpDocumentationModifications(TestPaginateBase):
         with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value={'result_key': ['abc', '123']}):
             help_command = OperationHelpCommand(
-                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+                mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(),
+                'foo', OperationDocumentEventHandler)
             help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
@@ -127,7 +129,8 @@ class TestHelpDocumentationModifications(TestPaginateBase):
         with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value={'limit_key': 'aaa'}):
             help_command = OperationHelpCommand(
-                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+                mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(),
+                'foo', OperationDocumentEventHandler)
             help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
@@ -140,7 +143,8 @@ class TestHelpDocumentationModifications(TestPaginateBase):
         with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value=None):
             help_command = OperationHelpCommand(
-                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+                mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(),
+                'foo', OperationDocumentEventHandler)
             help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -368,8 +368,8 @@ class TestCliDriverHooks(unittest.TestCase):
         driver.main('s3 list-objects --bucket foo'.split())
         self.assert_events_fired_in_order([
             # Events fired while parser is being created.
-            'building-command-table.main',
             'building-top-level-params',
+            'building-command-table.main',
             'top-level-args-parsed',
             'session-initialized',
             'building-command-table.s3',
@@ -398,8 +398,8 @@ class TestCliDriverHooks(unittest.TestCase):
         command.create_help_command()
         self.assert_events_fired_in_order([
             # Events fired while parser is being created.
-            'building-command-table.main',
             'building-top-level-params',
+            'building-command-table.main',
             'building-command-table.s3',
         ])
 


### PR DESCRIPTION
We get a lot of requests from users to include global options in a command's help page. The changes in this PR passes the global args table created once by the `CLIDriver` to the help commands that generate help docs. The global args table is used to generate a new `Global Options` section in the help docs.
The changes are currently only applied to standard commands, and does not include customizations.

![image](https://user-images.githubusercontent.com/106777148/182201988-4235a3a7-b900-450b-a4eb-8ef4b1db7f89.png)
