### PR TITLE
Document differences between regular and streaming blobs

### DIFF
--- a/.changes/next-release/enhancement-docs-84777.json
+++ b/.changes/next-release/enhancement-docs-84777.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "docs",
+  "description": "Differentiate between regular and streaming blobs and generate a usage note when a parameter is of streaming blob type."
+}

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -153,6 +153,12 @@ def is_document_type_container(shape):
     return True
 
 
+def is_streaming_blob_type(shape):
+    """Check if the shape is a streaming blob type."""
+    return (shape and shape.type_name == 'blob' and
+            shape.serialization.get('streaming', False))
+
+
 def operation_uses_document_types(operation_model):
     """Check if document types are ever used in the operation"""
     recording_visitor = ShapeRecordingVisitor()

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -13,7 +13,7 @@
 import json
 
 from botocore.model import ShapeResolver, StructureShape, StringShape, \
-    ListShape, MapShape
+    ListShape, MapShape, Shape
 
 from awscli.testutils import mock, unittest, FileCreator
 from awscli.clidocs import OperationDocumentEventHandler, \
@@ -22,6 +22,7 @@ from awscli.clidocs import OperationDocumentEventHandler, \
 from awscli.bcdoc.restdoc import ReSTDocument
 from awscli.help import ServiceHelpCommand, TopicListerCommand, \
     TopicHelpCommand
+from awscli.arguments import CustomArgument
 
 
 class TestRecursiveShapes(unittest.TestCase):
@@ -405,6 +406,32 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
             "See :doc:`'aws help' </reference/index>` for descriptions of "
             "global parameters", rendered
         )
+
+    def test_includes_streaming_blob_options(self):
+        help_command = self.create_help_command()
+        blob_shape = Shape('blob_shape', {'type': 'blob'})
+        blob_shape.serialization = {'streaming': True}
+        blob_arg = CustomArgument('blob_arg', argument_model=blob_shape)
+        help_command.arg_table = {'blob_arg': blob_arg}
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_option(arg_name='blob_arg',
+                                     help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertIn('streaming blob', rendered)
+
+    def test_streaming_blob_comes_after_docstring(self):
+        help_command = self.create_help_command()
+        blob_shape = Shape('blob_shape', {'type': 'blob'})
+        blob_shape.serialization = {'streaming': True}
+        blob_arg = CustomArgument(name='blob_arg',
+                                  argument_model=blob_shape,
+                                  help_text='FooBar')
+        help_command.arg_table = {'blob_arg': blob_arg}
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_option(arg_name='blob_arg',
+                                     help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertRegex(rendered, r'FooBar[\s\S]*streaming blob')
 
 
 class TestTopicDocumentEventHandlerBase(unittest.TestCase):


### PR DESCRIPTION
The lack of a distinction between regular and streaming blobs in our documentation is causing some confusion among our users. This PR addresses the issue by:
-  Explicitly labeling streaming blobs as `streaming blob`.
- Generating a note that clarifies the usage distinction between regular and streaming blobs if any blob type argument is detected.

Preview of changes:
![image](https://user-images.githubusercontent.com/106777148/183976169-dab9832b-ae59-47db-9fae-af0fe0e5c8b5.png)

![image](https://user-images.githubusercontent.com/106777148/183976211-73b61d55-46cf-43cc-a42d-c345f7632dec.png)
