### PR TITLE
Remove random behavior when using cli-generate-skeleton

### DIFF
--- a/.changes/next-release/enhancement-generatecliskeleton-45373.json
+++ b/.changes/next-release/enhancement-generatecliskeleton-45373.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``--generate-cli-skeleton``",
+  "description": "Argument populates enums in JSON skeleton with stable enum value, fixes (`#6695 <https://github.com/aws/aws-cli/issues/6695>`__)."
+}

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -970,7 +970,7 @@ class ArgumentGenerator(object):
                 if self._use_member_names:
                     return name
                 if shape.enum:
-                    return random.choice(shape.enum)
+                    return shape.enum[0]
                 return ''
             elif shape.type_name in ['integer', 'long']:
                 return 0

--- a/awscli/customizations/generatecliskeleton.py
+++ b/awscli/customizations/generatecliskeleton.py
@@ -54,7 +54,10 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
             '``yaml-input`` it will print a sample input YAML that can be '
             'used with ``--cli-input-yaml``. If provided with the value '
             '``output``, it validates the command inputs and returns a '
-            'sample output JSON for that command.'
+            'sample output JSON for that command. '
+            'The generated JSON skeleton is not stable between versions '
+            'of the AWS CLI and there are no backwards compatibility '
+            'guarantees in the JSON skeleton generated.'
         ),
         'nargs': '?',
         'const': 'input',

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -546,14 +546,14 @@ class TestArgumentGenerator(unittest.TestCase):
 
     def test_generate_string_enum(self):
         enum_values = ['A', 'B', 'C']
-        model = {
-            'A': {'type': 'string', 'enum': enum_values}
-        }
-        shape = DenormalizedStructureBuilder().with_members(
-            model).build_model()
-        actual = self.arg_generator.generate_skeleton(shape)
-
-        self.assertIn(actual['A'], enum_values)
+        self.assert_skeleton_from_model_is(
+            model={
+                'A': {'type': 'string', 'enum': enum_values}
+            },
+            generated_skeleton={
+                'A': enum_values[0]
+            }
+        )
 
     def test_generate_scalars(self):
         self.assert_skeleton_from_model_is(


### PR DESCRIPTION
Related issue: https://github.com/aws/aws-cli/issues/6695

Currently, if a shape object has the enum attribute, then it'll return a randomly sampled element from the list when using the `generate-cli-argument`. This is confusing users who expect consistent outputs from their inputs. This PR takes the first element of the list instead in order to provide consistent reproducibility. It also auto-generates a note in docs whenever `generate-cli-argument` is a valid argument that lets users know that the change in behavior is only in v2 and there's no backwards-compatibility guarantee since v1's behavior is random.

Preview of doc note:
<img width="751" alt="image" src="https://user-images.githubusercontent.com/106777148/184448246-12e1e098-0d8e-4920-a917-a2f4c6160080.png">
