### PR TITLE
Add note for Tagged Unions

### DIFF
--- a/.changes/next-release/enhancement-docs-3408.json
+++ b/.changes/next-release/enhancement-docs-3408.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "docs",
+  "description": "Generate a usage note for Tagged Union structures."
+}

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -159,6 +159,11 @@ def is_streaming_blob_type(shape):
             shape.serialization.get('streaming', False))
 
 
+def is_tagged_union_type(shape):
+    """Check if the shape is a tagged union structure."""
+    return getattr(shape, 'is_tagged_union', False)
+
+
 def operation_uses_document_types(operation_model):
     """Check if document types are ever used in the operation"""
     recording_visitor = ShapeRecordingVisitor()

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -13,7 +13,7 @@
 import json
 
 from botocore.model import ShapeResolver, StructureShape, StringShape, \
-    ListShape, MapShape, Shape
+    ListShape, MapShape, Shape, DenormalizedStructureBuilder
 
 from awscli.testutils import mock, unittest, FileCreator
 from awscli.clidocs import OperationDocumentEventHandler, \
@@ -149,6 +149,15 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         operation_model.service_model.operation_names = []
         help_command.obj = operation_model
         return help_command
+
+    def create_tagged_union_shape(self):
+        shape_model = {
+            'type': 'structure',
+            'union': True,
+            'members': {}
+        }
+        tagged_union = StructureShape('tagged_union', shape_model)
+        return tagged_union
 
     def get_help_docs_for_argument(self, shape):
         arg_table = {'arg-name': mock.Mock(argument_model=shape)}
@@ -390,6 +399,50 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
                                      help_command=help_command)
         rendered = help_command.doc.getvalue().decode('utf-8')
         self.assertRegex(rendered, r'FooBar[\s\S]*streaming blob')
+
+    def test_includes_tagged_union_options(self):
+        help_command = self.create_help_command()
+        tagged_union = self.create_tagged_union_shape()
+        arg = CustomArgument(name='tagged_union',
+                             argument_model=tagged_union)
+        help_command.arg_table = {'tagged_union': arg}
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_option(arg_name='tagged_union',
+                                     help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertIn('(tagged union structure)', rendered)
+
+    def test_tagged_union_comes_after_docstring_options(self):
+        help_command = self.create_help_command()
+        tagged_union = self.create_tagged_union_shape()
+        arg = CustomArgument(name='tagged_union',
+                             argument_model=tagged_union,
+                             help_text='FooBar')
+        help_command.arg_table = {'tagged_union': arg}
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_option(arg_name='tagged_union',
+                                     help_command=help_command)
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertRegex(rendered, r'FooBar[\s\S]*Tagged Union')
+
+    def test_tagged_union_comes_after_docstring_output(self):
+        help_command = self.create_help_command()
+        tagged_union = self.create_tagged_union_shape()
+        tagged_union.documentation = "FooBar"
+        shape = DenormalizedStructureBuilder().with_members({
+            'foo': {
+                'type': 'structure',
+                'union': True,
+                'documentation': 'FooBar',
+                'members': {}
+            }
+        }).build_model()
+        help_command.obj.output_shape = shape
+        operation_handler = OperationDocumentEventHandler(help_command)
+        operation_handler.doc_output(help_command=help_command,
+                                     event_name='foobar')
+        rendered = help_command.doc.getvalue().decode('utf-8')
+        self.assertRegex(rendered, r'FooBar[\s\S]*Tagged Union')
 
 
 class TestTopicDocumentEventHandlerBase(unittest.TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,8 +22,8 @@ from awscli.testutils import unittest, skip_if_windows, mock
 from awscli.utils import (
     split_on_commas, ignore_ctrl_c, find_service_and_method_in_event_name,
     is_document_type, is_document_type_container, is_streaming_blob_type,
-    operation_uses_document_types, ShapeWalker, ShapeRecordingVisitor,
-    OutputStreamFactory
+    is_tagged_union_type, operation_uses_document_types, ShapeWalker,
+    ShapeRecordingVisitor, OutputStreamFactory
 )
 
 
@@ -433,3 +433,13 @@ class TestStreamingBlob:
         argument_model.type_name = 'string'
         argument_model.serialization = {}
         assert not is_streaming_blob_type(argument_model)
+
+
+@pytest.mark.usefixtures('argument_model')
+class TestTaggedUnion:
+    def test_shape_is_tagged_union(self, argument_model):
+        setattr(argument_model, 'is_tagged_union', True)
+        assert is_tagged_union_type(argument_model)
+    
+    def test_shape_is_not_tagged_union(self, argument_model):
+        assert not is_tagged_union_type(argument_model)


### PR DESCRIPTION
Services and `botocore` support Tagged Union structures. The purpose of this PR is to enhance the CLI docs by generating a usage note for Tagged Union structures. Because Tagged Union structures can be nested under other complex types, the change needed to be made for nested options, in addition to top level options.

Preview of changes:
<img width="769" alt="image" src="https://user-images.githubusercontent.com/106777148/185487385-9af34860-0726-46e2-b431-9109db560c10.png">
