### PR TITLE
Remove repo root from path when running tests

### DIFF
--- a/scripts/ci/run-integ-tests
+++ b/scripts/ci/run-integ-tests
@@ -24,7 +24,9 @@ def cd(path):
 
 
 def run(command):
-    return check_call(command, shell=True)
+    env = os.environ.copy()
+    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    return check_call(command, shell=True, env=env)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -26,7 +26,9 @@ def cd(path):
 
 
 def run(command):
-    return check_call(command, shell=True)
+    env = os.environ.copy()
+    env['TESTS_REMOVE_REPO_ROOT_FROM_PATH'] = 'true'
+    return check_call(command, shell=True, env=env)
 
 
 def process_args(args):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,21 @@
 import collections
 import copy
 import os
+import sys
+
+# Both nose and py.test will add the first parent directory it
+# encounters that does not have a __init__.py to the sys.path. In
+# our case, this is the root of the repository. This means that Python
+# will import the awscli package from source instead of any installed
+# distribution. This environment variable provides the option to remove the
+# repository root from sys.path to be able to rely on the installed
+# distribution when running the tests.
+if os.environ.get('TESTS_REMOVE_REPO_ROOT_FROM_PATH'):
+    rootdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    sys.path = [
+        path for path in sys.path
+        if not os.path.isdir(path) or not os.path.samefile(path, rootdir)
+    ]
 
 import awscli
 from awscli.clidriver import create_clidriver


### PR DESCRIPTION
This is a port back from the v2 branch: https://github.com/aws/aws-cli/pull/6422

Both nose and py.test will add the first parent directory it encounters that does not have a __init__.py to the sys.path. In
our case, this is the root of the repository. This means that Python will import the awscli package from source instead of the installed wheel distribution. So the new environment variable provides the option to remove the repository root from sys.path to be able to rely on the installed distribution when running the tests.

It is also worth noting that nose has --no-path-adjustment to fix this, but py.test does not have an option available without large refactorings of the tests.

I also pushed up a [sample branch](https://github.com/kyleknap/aws-cli/tree/test-remove-root) where GitHub CI missed an issue with our package declaration because the repository was being automatically added to the path and it caught that: https://github.com/kyleknap/aws-cli/runs/7983967043?check_suite_focus=true

