### PR TITLE
remove call to print() from the complete() call in completer

### DIFF
--- a/awscli/completer.py
+++ b/awscli/completer.py
@@ -143,4 +143,4 @@ if __name__ == '__main__':
     else:
         print('usage: %s <cmdline> <point>' % sys.argv[0])
         sys.exit(1)
-    print(complete(cmdline, point))
+    complete(cmdline, point)


### PR DESCRIPTION
completer.py contains a function known as complete(). on the last line of completer.py, complete() is printed to the console, but it returns no value. this pull request removes the call to print(), leaving just complete().

alternatively, complete() could be removed from this file and its purpose can be merged into the main function.