### PR TITLE
Enable dependabot for v2 branch

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,8 +1,0 @@
-version: 1
-update_configs:
-  - package_manager: python
-    directory: /
-    update_schedule: daily
-    allowed_updates:
-      - match:
-          dependency_name: colorama

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "v2"
+    labels:
+      - "dependencies"
+    allow:
+      - dependency-name: "PyInstaller"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ requires_dist =
 ignore =
     .github
     .github/*
-    .dependabot
-    .dependabot/*
     .coveragerc
     CHANGELOG.rst
     CONTRIBUTING.md


### PR DESCRIPTION
The plan is to enable dependabot updates for each of our dependencies one at a time until all dependencies are accounted for starting with pyinstaller. At that time, we can move away from an allow list.

Note that even though this is for v2, the commit is on the develop branch because it is the default GitHub branch and GitHub only pulls dependabot configuration from the default branch.

In the future, when we make v2 the default branch, we should be able to just remove the target-branch setting.

Here is a sample PR that got sent to my fork: https://github.com/kyleknap/aws-cli/pull/2. I ended up sending the PyInstaller update as a separate PR: https://github.com/aws/aws-cli/pull/7250 in order to decouple this change and the version update, but note that the two resulted in the same change in updating the `requirements-build.txt` 
