### PR TITLE
Updated s3_cleanup to use waiters, paginators, and batch delete_objects

### DIFF
--- a/tests/integration/customizations/s3/__init__.py
+++ b/tests/integration/customizations/s3/__init__.py
@@ -10,17 +10,17 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, WaiterError
 from awscli.testutils import create_bucket
 
 
-def make_s3_files(session, key1='text1.txt', key2='text2.txt', size=None):
+def make_s3_files(session, key1="text1.txt", key2="text2.txt", size=None):
     """
     Creates a randomly generated bucket in s3 with the files text1.txt and
     another_directory/text2.txt inside. The directory is manually created
     as it tests the ability to handle directories when generating s3 files.
     """
-    region = 'us-west-2'
+    region = "us-west-2"
     bucket = create_bucket(session)
 
     if size:
@@ -30,12 +30,13 @@ def make_s3_files(session, key1='text1.txt', key2='text2.txt', size=None):
         string1 = "This is a test."
         string2 = "This is another test."
 
-    client = session.create_client('s3', region_name=region)
+    client = session.create_client("s3", region_name=region)
     client.put_object(Bucket=bucket, Key=key1, Body=string1)
     if key2 is not None:
-        client.put_object(Bucket=bucket, Key='another_directory/')
-        client.put_object(Bucket=bucket, Key='another_directory/%s' % key2,
-                          Body=string2)
+        client.put_object(Bucket=bucket, Key="another_directory/")
+        client.put_object(
+            Bucket=bucket, Key="another_directory/%s" % key2, Body=string2
+        )
     return bucket
 
 
@@ -43,15 +44,39 @@ def s3_cleanup(bucket, session):
     """
     Function to cleanup generated s3 bucket and files.
     """
-    region = 'us-west-2'
-    client = session.create_client('s3', region_name=region)
-    try:
-        client.head_bucket(Bucket=bucket)
-    except ClientError:
-        return
-    response = client.list_objects(Bucket=bucket)
-    contents = response.get('Contents', {})
-    keys = [content['Key'] for content in contents]
-    for key in keys:
-        client.delete_object(Bucket=bucket, Key=key)
-    client.delete_bucket(Bucket=bucket)
+    region = "us-west-2"
+    client = session.create_client("s3", region_name=region)
+    # Ensure the bucket exists before attempting to wipe it out
+    bucket_exists_waiter = client.get_waiter("bucket_exists")
+    bucket_exists_waiter.wait(Bucket=bucket)
+
+    page = client.get_paginator("list_objects")
+    # Use pages paired with batch delete_objects().
+    for page in page.paginate(Bucket=bucket):
+        keys = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+        if keys:
+            client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+            for _ in range(5):
+                try:
+                    client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+                    break
+                except client.exceptions.NoSuchBucket:
+                    bucket_exists_waiter.wait(Bucket=bucket)
+                except WaiterError:
+                    continue
+
+    for _ in range(5):
+        try:
+            client.delete_bucket(Bucket=bucket)
+            break
+        except client.exceptions.NoSuchBucket:
+            bucket_exists_waiter.wait(Bucket=bucket)
+        except Exception:
+            # We can sometimes get exceptions when trying to
+            # delete a bucket.  We'll let the waiter make
+            # the final call as to whether the bucket was able
+            # to be deleted.
+            bucket_not_exists_waiter = client.get_waiter("bucket_not_exists")
+            bucket_not_exists_waiter.wait(Bucket=bucket)
+        except WaiterError:
+            continue

--- a/tests/integration/customizations/s3/__init__.py
+++ b/tests/integration/customizations/s3/__init__.py
@@ -10,17 +10,17 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.exceptions import ClientError, WaiterError
+from botocore.exceptions import WaiterError
 from awscli.testutils import create_bucket
 
 
-def make_s3_files(session, key1="text1.txt", key2="text2.txt", size=None):
+def make_s3_files(session, key1='text1.txt', key2='text2.txt', size=None):
     """
     Creates a randomly generated bucket in s3 with the files text1.txt and
     another_directory/text2.txt inside. The directory is manually created
     as it tests the ability to handle directories when generating s3 files.
     """
-    region = "us-west-2"
+    region = 'us-west-2'
     bucket = create_bucket(session)
 
     if size:
@@ -30,13 +30,12 @@ def make_s3_files(session, key1="text1.txt", key2="text2.txt", size=None):
         string1 = "This is a test."
         string2 = "This is another test."
 
-    client = session.create_client("s3", region_name=region)
+    client = session.create_client('s3', region_name=region)
     client.put_object(Bucket=bucket, Key=key1, Body=string1)
     if key2 is not None:
-        client.put_object(Bucket=bucket, Key="another_directory/")
-        client.put_object(
-            Bucket=bucket, Key="another_directory/%s" % key2, Body=string2
-        )
+        client.put_object(Bucket=bucket, Key='another_directory/')
+        client.put_object(Bucket=bucket, Key='another_directory/%s' % key2,
+                          Body=string2)
     return bucket
 
 
@@ -44,21 +43,21 @@ def s3_cleanup(bucket, session):
     """
     Function to cleanup generated s3 bucket and files.
     """
-    region = "us-west-2"
-    client = session.create_client("s3", region_name=region)
+    region = 'us-west-2'
+    client = session.create_client('s3', region_name=region)
     # Ensure the bucket exists before attempting to wipe it out
-    bucket_exists_waiter = client.get_waiter("bucket_exists")
+    bucket_exists_waiter = client.get_waiter('bucket_exists')
     bucket_exists_waiter.wait(Bucket=bucket)
 
-    page = client.get_paginator("list_objects")
+    page = client.get_paginator('list_objects')
     # Use pages paired with batch delete_objects().
     for page in page.paginate(Bucket=bucket):
-        keys = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+        keys = [{'Key': obj['Key']} for obj in page.get('Contents', [])]
         if keys:
-            client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+            client.delete_objects(Bucket=bucket, Delete={'Objects': keys})
             for _ in range(5):
                 try:
-                    client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+                    client.delete_objects(Bucket=bucket, Delete={'Objects': keys})
                     break
                 except client.exceptions.NoSuchBucket:
                     bucket_exists_waiter.wait(Bucket=bucket)
@@ -76,7 +75,7 @@ def s3_cleanup(bucket, session):
             # delete a bucket.  We'll let the waiter make
             # the final call as to whether the bucket was able
             # to be deleted.
-            bucket_not_exists_waiter = client.get_waiter("bucket_not_exists")
+            bucket_not_exists_waiter = client.get_waiter('bucket_not_exists')
             bucket_not_exists_waiter.wait(Bucket=bucket)
         except WaiterError:
             continue


### PR DESCRIPTION
## Updated s3_cleanup to use waiters, paginators, and batch delete_objects


*Description of changes:*
Modernized the `s3_cleanup` function using waiters to solve the `NoSuchBucket` errors. I also implemented the use of paginators to iterate over bucket keys and batch `delete_objects` to empty them out. 

*Performance Changes*
Before these changes, the `tests/integration/customizations/s3/__init__.py` file on average seemed to run in `20-25 seconds` as compared to `23-30 seconds` after the changes. There is an obvious decrease in performance, however, the changes should save time by preventing future test failures. 
