### PR TITLE
Add "-NoProfile" to powershell.exe subprocess

### DIFF
--- a/awscli/customizations/codedeploy/systems.py
+++ b/awscli/customizations/codedeploy/systems.py
@@ -60,6 +60,7 @@ class Windows(System):
         process = subprocess.Popen(
             [
                 'powershell.exe',
+                '-NoProfile',
                 '-Command', 'Stop-Service',
                 '-Name', 'codedeployagent'
             ],
@@ -89,6 +90,7 @@ class Windows(System):
         )
         subprocess.check_call([
             'powershell.exe',
+            '-NoProfile',
             '-Command', 'Restart-Service',
             '-Name', 'codedeployagent'
         ])
@@ -96,6 +98,7 @@ class Windows(System):
         process = subprocess.Popen(
             [
                 'powershell.exe',
+                '-NoProfile',
                 '-Command', 'Get-Service',
                 '-Name', 'codedeployagent'
             ],
@@ -112,6 +115,7 @@ class Windows(System):
         process = subprocess.Popen(
             [
                 'powershell.exe',
+                '-NoProfile',
                 '-Command', 'Stop-Service',
                 '-Name', 'codedeployagent'
             ],

--- a/tests/unit/customizations/codedeploy/test_systems.py
+++ b/tests/unit/customizations/codedeploy/test_systems.py
@@ -84,6 +84,7 @@ class TestWindows(unittest.TestCase):
             mock.call(
                 [
                     'powershell.exe',
+                    '-NoProfile',
                     '-Command', 'Stop-Service',
                     '-Name', 'codedeployagent'
                 ],
@@ -94,6 +95,7 @@ class TestWindows(unittest.TestCase):
             mock.call(
                 [
                     'powershell.exe',
+                    '-NoProfile',
                     '-Command', 'Get-Service',
                     '-Name', 'codedeployagent'
                 ],
@@ -113,6 +115,7 @@ class TestWindows(unittest.TestCase):
             ),
             mock.call([
                 'powershell.exe',
+                '-NoProfile',
                 '-Command', 'Restart-Service',
                 '-Name', 'codedeployagent'
             ])
@@ -130,6 +133,7 @@ class TestWindows(unittest.TestCase):
             mock.call(
                 [
                     'powershell.exe',
+                    '-NoProfile',
                     '-Command', 'Stop-Service',
                     '-Name', 'codedeployagent'
                 ],


### PR DESCRIPTION
It is recommended and best practice to execute PowerShell with NoProfile parameter. Using NoProfile doesn’t load windows PowerShell profile and ensures no changes in environment. It also speeds up PowerShell load time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.