### PR TITLE
fix: docs related issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -9,6 +9,7 @@ body:
       value: |
         Developer guide? Raise an issue/pr here: https://github.com/awsdocs/aws-cli-user-guide
 
+  - type: textarea  
     id: description
     attributes:
       label: Describe the issue


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
GitHub Issue creation for Documentation (related) template was missing due to a problem with documentation.yaml markdown. This PR should fix the yaml file and allow users to open docs related GH issues.

<img width="1389" alt="Screen Shot 2022-09-14 at 2 20 14 PM" src="https://user-images.githubusercontent.com/47447266/190264679-589486ce-86f0-45e8-bd26-ab3712e8dcb1.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
