### PR TITLE
Pull Amazon Linux image from ECR

### DIFF
--- a/.changes/next-release/enhancement-Dockerfile-3223.json
+++ b/.changes/next-release/enhancement-Dockerfile-3223.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Dockerfile",
+  "description": "This update pulls the base Amazon Linux image from ECR Public rather than Docker Hub."
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2 as installer
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 as installer
 ARG EXE_FILENAME=awscli-exe-linux-x86_64.zip
 COPY $EXE_FILENAME .
 RUN yum update -y \
@@ -11,7 +11,7 @@ RUN yum update -y \
   # may be present in /usr/local/bin of the installer stage.
   && ./aws/install --bin-dir /aws-cli-bin/
 
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y \
   && yum install -y less groff \
   && yum clean all


### PR DESCRIPTION
This PR modifies the Dockerfile to pull its base image from ECR Public rather than Docker Hub, since both Amazon Linux and ECR Public are Amazon-owned. We still continue to pull the tag that tracks the major version (2), so the Dockerfile effectively does not change behavior.