### PR TITLE
Fix map shorthand docs issue, struct in a map should be wrapped in cu…

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -503,7 +503,11 @@ class ParamShorthandDocGen(ParamShorthand):
 
     def _map_docs(self, argument_model, stack):
         k = argument_model.key
-        value_docs = self._shorthand_docs(argument_model.value, stack)
+        stack.append(argument_model.key)
+        try:
+            value_docs = self._shorthand_docs(argument_model.value, stack)
+        finally:
+            stack.pop()
         start = 'KeyName1=%s,KeyName2=%s' % (value_docs, value_docs)
         if k.enum and not stack:
             start += '\n\nWhere valid key names are:\n'

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -556,6 +556,14 @@ class TestDocGen(BaseArgProcessTest):
         )
         self.assert_generated_example_contains(argument, expected_example_str)
 
+    def test_gen_struct_in_map_type_docs(self):
+        argument = self.get_param_model('sns.Publish.MessageAttributes')
+        expected_example_str = (
+            'KeyName1={DataType=string,StringValue=string,BinaryValue=blob},'
+            'KeyName2={DataType=string,StringValue=string,BinaryValue=blob}'
+        )
+        self.assert_generated_example_contains(argument, expected_example_str)
+
     def test_gen_list_scalar_docs(self):
         self.service_name = 'elb'
         self.service_id = 'elastic-load-balancing'


### PR DESCRIPTION
*Issue #:* #3637

*Description of changes:*

This PR is to fix a shorthand doc issue. The struct type in the map should be wrapped in curly braces {}. 

Doc url: https://docs.aws.amazon.com/cli/latest/reference/sqs/send-message.html

Before the change: 
`KeyName1=DataType=string,StringValue=string,BinaryValue=blob`

After the change:
`KeyName1={DataType=string,StringValue=string,BinaryValue=blob}`