### PR TITLE
Fix params in `ec2 modify-security-group-rules` example: use dict instead of strings

### DIFF
--- a/awscli/examples/ec2/modify-security-group-rules.rst
+++ b/awscli/examples/ec2/modify-security-group-rules.rst
@@ -4,7 +4,7 @@ The following ``modify-security-group-rules`` example updates the description, t
 
     aws ec2 modify-security-group-rules \
         --group-id sg-1234567890abcdef0 \
-        --security-group-rules SecurityGroupRuleId=sgr-abcdef01234567890,SecurityGroupRule={Description=test,IpProtocol=-1,CidrIpv4=0.0.0.0/0}
+        --security-group-rules SecurityGroupRuleId=sgr-abcdef01234567890,SecurityGroupRule={{Description=test},{IpProtocol=-1},{CidrIpv4=0.0.0.0/0}}
 
 Output::
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-cli/issues/7227

*Description of changes:*
Change string to dict in example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
