### PR TITLE
[v2] Use source client for s3 --copy-props subscribers

### DIFF
--- a/.changes/next-release/bugfix-s3-12264.json
+++ b/.changes/next-release/bugfix-s3-12264.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Obey source region when retrieving metadata and tags for cross-region multipart copies (`#7316 <https://github.com/aws/aws-cli/issues/7316>`__)."
+}

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -310,17 +310,17 @@ class BaseS3CLIRunnerTest(unittest.TestCase):
             region = self.region
         return f'{bucket}.s3.{region}.amazonaws.com'
 
-    def add_botocore_head_object_response(self):
+    def add_botocore_head_object_response(self, size=100):
         self.cli_runner.add_response(
             HTTPResponse(
                 headers={
-                    'Content-Length': '100',
+                    'Content-Length': str(size),
                     'Last-Modified': 'Thu, 11 Feb 2021 04:24:23 GMT',
                 }
             )
         )
 
-    def add_botocore_list_objects_response(self, keys):
+    def add_botocore_list_objects_response(self, keys, size=100):
         xml_body = (
             '<?xml version="1.0" ?>'
             '<ListBucketResult xmlns='
@@ -332,7 +332,7 @@ class BaseS3CLIRunnerTest(unittest.TestCase):
                 '<Contents>'
                 '<LastModified>2015-12-08T18:26:43.000Z</LastModified>'
                 f'<Key>{key}</Key>'
-                '<Size>100</Size>'
+                f'<Size>{size}</Size>'
                 '</Contents>'
             )
         xml_body += '</ListBucketResult>'
@@ -352,6 +352,54 @@ class BaseS3CLIRunnerTest(unittest.TestCase):
         )
 
     def add_botocore_delete_object_response(self):
+        self.cli_runner.add_response(HTTPResponse())
+
+    def add_botocore_create_multipart_upload_response(self):
+        self.cli_runner.add_response(
+            HTTPResponse(
+                body=(
+                    '<InitiateMultipartUploadResult>'
+                    '  <Bucket>bucket</Bucket>'
+                    '  <Key>key</Key>'
+                    '  <UploadId>upload-id</UploadId>'
+                    '</InitiateMultipartUploadResult>'
+                )
+            )
+        )
+
+    def add_botocore_upload_part_copy_response(self):
+        self.cli_runner.add_response(
+            HTTPResponse(
+                body=(
+                    '<CopyPartResult>'
+                    '  <LastModified>2022-09-30T17:20:13.000Z</LastModified>'
+                    '  <ETag>&quot;etag&quot;</ETag>'
+                    '</CopyPartResult>'
+                )
+            )
+        )
+
+    def add_botocore_complete_multipart_upload_response(self):
+        self.cli_runner.add_response(
+            HTTPResponse(
+                body=(
+                    '<CompleteMultipartUploadResult>'
+                    '</CompleteMultipartUploadResult>'
+                )
+            )
+        )
+
+    def add_botocore_get_object_tagging_response(self, tags=None):
+        tag_set_xml = '<TagSet>'
+        if tags:
+            for k, v in tags.items():
+                tag_set_xml += f'<Tag><Key>{k}</Key><Value>{v}</Value></Tag>'
+        tag_set_xml += '</TagSet>'
+        self.cli_runner.add_response(
+            HTTPResponse(body=f'<Tagging>{tag_set_xml}</Tagging>')
+        )
+
+    def add_botocore_set_object_tagging_response(self):
         self.cli_runner.add_response(HTTPResponse())
 
     def assert_no_remaining_botocore_responses(self):


### PR DESCRIPTION
When retrieving metadata and tags, the subscribers were using the intended transfer client instead of the source client. This lead to failures when calling GetObjectTags and unnecessary region redirect requests for HeadObject when using an opt-in region (e.g. af-south-1) that did not match the region of the source bucket.

**Before this change:**
If you tried to copy an an individual file that required multipart copy across opt-in regions, you would get an error when the CLI went to describe the object tags it needs to copy over:
```
$ aws s3 cp s3://knapp-us-west-2/some-prefix/10MB-tagged s3://kyleknap-af-south-1/some-prefix/  --source-region us-west-2 --region af-south-1
copy failed: s3://knapp-us-west-2/some-prefix/10MB-tagged to s3://kyleknap-af-south-1/some-prefix/10MB-tagged An error occurred (IllegalLocationConstraintException) when calling the GetObjectTagging operation: The us-west-2 location constraint is incompatible for the region specific endpoint this request was sent to.
```
If you did the same transfer recursively, it would succeed but require additional HTTP (3 extra hops) to handle region redirects:
```
$ aws s3 cp s3://knapp-us-west-2/some-prefix/ s3://kyleknap-af-south-1/some-prefix/ --recursive --source-region us-west-2 --region af-south-1
copy: s3://knapp-us-west-2/some-prefix/10MB-tagged to s3://kyleknap-af-south-1/some-prefix/10MB-tagged
$ aws history show | grep 'HTTP request sent' | wc -l
      10
```
**Note:** Region redirects did not save the non-recursive command because the initial head object was sent to the correct region to start and the subsequent API call was a `GetObjectTagging` call which does not support region redirects for opt-in regions.

**With this change:**
The non-recursive copy succeeds:
```
$ aws s3 cp s3://knapp-us-west-2/some-prefix/10MB-tagged s3://kyleknap-af-south-1/some-prefix/  --source-region us-west-2 --region af-south-1
copy: s3://knapp-us-west-2/some-prefix/10MB-tagged to s3://kyleknap-af-south-1/some-prefix/10MB-tagged
$ aws s3api get-object-tagging --bucket kyleknap-af-south-1 --key some-prefix/10MB-tagged --region af-south-1
{
    "TagSet": [
        {
            "Key": "tag",
            "Value": "value"
        }
    ]
}
```
The expected number of HTTP requests are made for a recursive copy:
```
$ aws s3 cp s3://knapp-us-west-2/some-prefix/ s3://kyleknap-af-south-1/some-prefix/ --recursive --source-region us-west-2 --region af-south-1
$ aws history show | grep 'HTTP request sent' | wc -l
       7
```
specifically the seven calls are:
* 1 ListObjectsV2 call
* 1 HeadObject call
* 1 GetObjectTagging call
* 1 CreateMPU call
* 2 UploadPartCopy calls
* 1 CompleteMPU API call
