### PR TITLE
[v2] Add support for crytography 38.0.1

### DIFF
--- a/.changes/next-release/enhancement-dependency-38685.json
+++ b/.changes/next-release/enhancement-dependency-38685.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "dependency",
+  "description": "Update dependency on cryptography to 38.0.1"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "colorama>=0.2.5,<0.4.4",
     "docutils>=0.10,<0.16",
-    "cryptography>=3.3.2,<37.0.0",
+    "cryptography>=3.3.2,<=38.0.1",
     "ruamel.yaml>=0.15.0,<=0.17.21",
     "wcwidth<0.2.0",
     "prompt-toolkit>=3.0.24,<3.0.29",


### PR DESCRIPTION
Going through the [changelog](https://cryptography.io/en/latest/changelog/), I did not find any breaking changes across the 37.x.x and 38.x.x versions that impact functionality in the CLI. Most of the backwards compatible changes were around the OpenSSL/Python version supported, wheels that are provided, and some methods were removed (but we were already using the correct methods to start).
