### PR TITLE
Remove global options from topic tags

### DIFF
--- a/.changes/next-release/bugfix-docs-61070.json
+++ b/.changes/next-release/bugfix-docs-61070.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "docs",
+  "description": "Fixes `#7338 <https://github.com/aws/aws-cli/issues/7338>`__. Remove global options from topic tags."
+}

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -655,6 +655,9 @@ class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     def doc_options_end(self, help_command, **kwargs):
         pass
 
+    def doc_global_option(self, help_command, **kwargs):
+        pass
+
     def doc_subitems_start(self, help_command, **kwargs):
         doc = help_command.doc
         doc.style.h2('Available Topics')

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -652,6 +652,11 @@ class TestTopicDocumentEventHandler(TestTopicDocumentEventHandlerBase):
         contents = self.cmd.doc.getvalue().decode('utf-8')
         self.assertIn(ref_body, contents)
 
+    def test_excludes_global_options(self):
+        self.doc_handler.doc_global_option(self.cmd)
+        global_options = self.cmd.doc.getvalue().decode('utf-8')
+        self.assertNotIn('Global Options', global_options)
+
 
 class TestGlobalOptionsDocumenter(unittest.TestCase):
     def create_help_command(self):


### PR DESCRIPTION
Fixes #7338 

Remove the global options section from topic tags to avoid sphinx hierarchy rule violations. This removal is okay since the topic tags help commands don't make use of global options.