### PR TITLE
Fix KeyError for name

### DIFF
--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -65,7 +65,7 @@ class Kubeconfig(object):
         if 'clusters' not in self.content:
             return False
         return name in [cluster['name']
-                        for cluster in self.content['clusters']]
+                        for cluster in self.content['clusters'] if 'name' in cluster]
 
 
 class KubeconfigValidator(object):


### PR DESCRIPTION
2022-10-18 09:11:17,688 - MainThread - awscli.clidriver - DEBUG - Exception caught in main() Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/awscli/clidriver.py", line 217, in main
    return command_table[parsed_args.command](remaining, parsed_args)
  File "/usr/lib/python3/dist-packages/awscli/clidriver.py", line 361, in __call__
    return command_table[parsed_args.operation](remaining, parsed_globals)
  File "/usr/lib/python3/dist-packages/awscli/customizations/commands.py", line 187, in __call__
    return self._run_main(parsed_args, parsed_globals)
  File "/usr/lib/python3/dist-packages/awscli/customizations/eks/update_kubeconfig.py", line 126, in _run_main
    config = config_selector.choose_kubeconfig(
  File "/usr/lib/python3/dist-packages/awscli/customizations/eks/update_kubeconfig.py", line 213, in choose_kubeconfig
    if loaded_config.has_cluster(cluster_name):
  File "/usr/lib/python3/dist-packages/awscli/customizations/eks/kubeconfig.py", line 71, in has_cluster
    return name in [cluster['name']
  File "/usr/lib/python3/dist-packages/awscli/customizations/eks/kubeconfig.py", line 71, in <listcomp>
    return name in [cluster['name']
KeyError: 'name'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
