### PR TITLE
Register disable_signing first to ensure proper usage

### DIFF
--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -86,8 +86,11 @@ def no_sign_request(parsed_args, session, **kwargs):
     if not parsed_args.sign_request:
         # In order to make signing disabled for all requests
         # we need to use botocore's ``disable_signing()`` handler.
-        session.register(
-            'choose-signer', disable_signing, unique_id='disable-signing')
+        # Register this first to override other handlers.
+        emitter = session.get_component('event_emitter')
+        emitter.register_first(
+            'choose-signer', disable_signing, unique_id='disable-signing',
+        )
 
 
 def resolve_cli_connect_timeout(parsed_args, session, **kwargs):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import collections
 import copy
 import os
 import sys
+import unittest
 
 # Both nose and py.test will add the first parent directory it
 # encounters that does not have a __init__.py to the sys.path. In
@@ -27,7 +28,7 @@ import botocore.loaders
 import botocore.model
 import botocore.serialize
 import botocore.validate
-
+from botocore.compat import HAS_CRT
 
 # A shared loader to use for classes in this module. This allows us to
 # load models outside of influence of a session and take advantage of
@@ -323,3 +324,13 @@ class CaseInsensitiveDict(collections_abc.MutableMapping):
 
     def __repr__(self):
         return str(dict(self.items()))
+
+
+def requires_crt(reason=None):
+    if reason is None:
+        reason = "Test requires awscrt to be installed"
+
+    def decorator(func):
+        return unittest.skipIf(not HAS_CRT, reason)(func)
+
+    return decorator

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -18,6 +18,7 @@ from awscli.testutils import capture_input
 from awscli.testutils import mock 
 from awscli.compat import six
 from tests.functional.s3 import BaseS3TransferCommandTest
+from tests import requires_crt
 
 
 class BufferedBytesIO(six.BytesIO):
@@ -1147,6 +1148,7 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
             ]
         )
 
+    @requires_crt()
     def test_accepts_mrap_arns(self):
         mrap_arn = (
             'arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap'
@@ -1162,6 +1164,7 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
             ]
         )
 
+    @requires_crt()
     def test_accepts_mrap_arns_with_slash(self):
         mrap_arn = (
             'arn:aws:s3::123456789012:accesspoint/mfzwi23gnjvgw.mrap'

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -135,7 +135,8 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         session = mock.Mock()
 
         globalargs.no_sign_request(args, session)
-        session.register.assert_called_with(
+        emitter = session.get_component('event_emitter')
+        emitter.register_first.assert_called_with(
             'choose-signer', disable_signing, unique_id='disable-signing')
 
     def test_request_signed_by_default(self):


### PR DESCRIPTION
This PR will ensure we register the `disable_signing` event handler first when the flag `--no-sign-request` global arg is passed. This is to avoid race conditions with other handlers for a response when choosing an appropriate signer.