### PR TITLE
add a batch presign URL

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -654,7 +654,7 @@ class PresignCommand(S3Command):
         "configured explicitly."
     )
     USAGE = "<S3Uri>"
-    ARG_TABLE = [{'name': 'path',
+    ARG_TABLE = [{'name': 'paths','nargs': '+',
                   'positional_arg': True, 'synopsis': USAGE},
                  {'name': 'expires-in', 'default': 3600,
                   'cli_type_name': 'integer',
@@ -664,17 +664,17 @@ class PresignCommand(S3Command):
 
     def _run_main(self, parsed_args, parsed_globals):
         super(PresignCommand, self)._run_main(parsed_args, parsed_globals)
-        path = parsed_args.path
-        if path.startswith('s3://'):
-            path = path[5:]
-        bucket, key = find_bucket_key(path)
-        url = self.client.generate_presigned_url(
-            'get_object',
-            {'Bucket': bucket, 'Key': key},
-            ExpiresIn=parsed_args.expires_in
-        )
-        uni_print(url)
-        uni_print('\n')
+        for path in  parsed_args.paths:
+            if path.startswith('s3://'):
+                path = path[5:]
+            bucket, key = find_bucket_key(path)
+            url = self.client.generate_presigned_url(
+                'get_object',
+                {'Bucket': bucket, 'Key': key},
+                ExpiresIn=parsed_args.expires_in
+            )
+            uni_print(url)
+            uni_print('\n')
         return 0
 
 

--- a/awscli/examples/s3/presign.rst
+++ b/awscli/examples/s3/presign.rst
@@ -20,3 +20,25 @@ Output::
     https://DOC-EXAMPLE-BUCKET.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
 
 For more information, see `Share an Object with Others <https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html>`__ in the *S3 Developer Guide* guide.
+
+
+**Example 3: To create a batch pre-signed URL with the default one hour lifetime that links to an object in an S3 bucket**
+
+The following ``presign`` command generates a pre-signed URL for a specified bucket and key that is valid for one hour. ::
+
+    aws s3 presign s3://DOC-EXAMPLE-BUCKET/test2.txt  s3://DOC-EXAMPLE-BUCKET/test2.txt
+
+Output::
+
+    https://DOC-EXAMPLE-BUCKET.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
+    https://DOC-EXAMPLE-BUCKET.s3.us-west-2.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAEXAMPLE123456789%2F20210621%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20210621T041609Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=EXAMBLE1234494d5fba3fed607f98018e1dfc62e2529ae96d844123456
+
+
+Accept the results after execution:
+```python
+import subprocess
+
+output = subprocess.getstatusoutput('aws s3 presign s3://DOC-EXAMPLE-BUCKET/test2.txt  s3://DOC-EXAMPLE-BUCKET/test2.txt')
+print(output[1].split('\n'))
+
+```

--- a/awscli/examples/s3/presign.rst
+++ b/awscli/examples/s3/presign.rst
@@ -35,10 +35,11 @@ Output::
 
 
 Accept the results after execution:
-```python
-import subprocess
 
-output = subprocess.getstatusoutput('aws s3 presign s3://DOC-EXAMPLE-BUCKET/test2.txt  s3://DOC-EXAMPLE-BUCKET/test2.txt')
-print(output[1].split('\n'))
+Output::
+    import subprocess
 
-```
+    output = subprocess.getstatusoutput('aws s3 presign s3://DOC-EXAMPLE-BUCKET/test2.txt  s3://DOC-EXAMPLE-BUCKET/test2.txt')
+    print(output[1].split('\n'))
+
+


### PR DESCRIPTION
I have a batch of link signatures, but the execution one by one is time-consuming. I want to save some time, so I will pass in a batch of signatures and accept the execution results

I think it's very useful

I hope it can be added to the current version

