### PR TITLE
Address DeprecationWarning for configparser.readfp()

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -19,6 +19,7 @@ import platform
 import zipfile
 import signal
 import contextlib
+from configparser import RawConfigParser
 
 from botocore.compat import six
 #import botocore.compat
@@ -36,7 +37,6 @@ StringIO = six.StringIO
 BytesIO = six.BytesIO
 urlopen = six.moves.urllib.request.urlopen
 binary_type = six.binary_type
-RawConfigParser = six.moves.configparser.RawConfigParser
 
 
 # Most, but not all, python installations will have zlib. This is required to

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -459,7 +459,7 @@ password: {auth_token}'''
                 sys.stdout.write(os.linesep)
                 raise e
         else:
-            pypi_rc.readfp(StringIO(default_pypi_rc))
+            pypi_rc.read_string(default_pypi_rc)
 
         pypi_rc_stream = StringIO()
         pypi_rc.write(pypi_rc_stream)

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -218,7 +218,7 @@ password: {auth_token}'''
             pypi_rc.set('codeartifact', 'username', 'aws')
             pypi_rc.set('codeartifact', 'password', self.auth_token)
         else:
-            pypi_rc.readfp(StringIO(default_pypi_rc))
+            pypi_rc.read_string(default_pypi_rc)
 
         pypi_rc_stream = StringIO()
         pypi_rc.write(pypi_rc_stream)
@@ -302,7 +302,7 @@ password: {auth_token}'''
         self, pypi_rc_str, server, repo_url=None, username=None, password=None
     ):
         pypi_rc = RawConfigParser()
-        pypi_rc.readfp(StringIO(pypi_rc_str))
+        pypi_rc.read_string(pypi_rc_str)
 
         self.assertIn('distutils', pypi_rc.sections())
         self.assertIn('index-servers', pypi_rc.options('distutils'))

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -6,7 +6,7 @@ from dateutil.tz import tzlocal, tzutc
 from dateutil.relativedelta import relativedelta
 
 from awscli.testutils import unittest, mock, FileCreator
-from awscli.compat import urlparse, RawConfigParser, StringIO
+from awscli.compat import urlparse, RawConfigParser
 from awscli.customizations.codeartifact.login import (
     BaseLogin, NuGetLogin, DotNetLogin, NpmLogin, PipLogin, TwineLogin,
     get_relative_expiration_time
@@ -590,7 +590,7 @@ class TestTwineLogin(unittest.TestCase):
         self, pypi_rc_str, server, repo_url=None, username=None, password=None
     ):
         pypi_rc = RawConfigParser()
-        pypi_rc.readfp(StringIO(pypi_rc_str))
+        pypi_rc.read_string(pypi_rc_str)
 
         self.assertIn('distutils', pypi_rc.sections())
         self.assertIn('index-servers', pypi_rc.options('distutils'))


### PR DESCRIPTION
*Issue #, if available:* No related issue

*Description of changes:*

Running `scripts/ci/run-tests` results in 20 instances of this deprecation warning from Python's [configparser](https://docs.python.org/3/library/configparser.html):

```
DeprecationWarning: This method will be removed in Python 3.12. Use 'parser.read_file()' instead.
```

All lines of code that trigger this warning follow this pattern:

```python
configparser.readfp(StringIO(some_string))
```

Since Python 3.2, `configparser` has a [`read_string`](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_string) method that can be used instead:

```python
configparser.read_string(some_string)
```

After the changes in this PR, the unit and functional tests still pass and the deprecation warnings are gone.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
