### PR TITLE
Add export-creds command to the CLI

### DIFF
--- a/.changes/next-release/feature-credentials-32931.json
+++ b/.changes/next-release/feature-credentials-32931.json
@@ -1,5 +1,5 @@
 {
   "type": "feature",
   "category": "credentials",
-  "description": "Add ``aws configure export-creds`` command (`issue 7388 <https://github.com/aws/aws-cli/issues/7388>`__)"
+  "description": "Add ``aws configure export-credentials`` command (`issue 7388 <https://github.com/aws/aws-cli/issues/7388>`__)"
 }

--- a/.changes/next-release/feature-credentials-32931.json
+++ b/.changes/next-release/feature-credentials-32931.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "credentials",
+  "description": "Add ``aws configure export-creds`` command (`issue 7388 <https://github.com/aws/aws-cli/issues/7388>`__)"
+}

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -26,7 +26,7 @@ from awscli.customizations.configure.importer import ConfigureImportCommand
 from awscli.customizations.configure.listprofiles import ListProfilesCommand
 from awscli.customizations.configure.sso import ConfigureSSOCommand
 from awscli.customizations.configure.exportcreds import \
-    ConfigureExportCredsCommand
+    ConfigureExportCredentialsCommand
 
 from . import mask_value, profile_to_section
 
@@ -82,7 +82,8 @@ class ConfigureCommand(BasicCommand):
         {'name': 'import', 'command_class': ConfigureImportCommand},
         {'name': 'list-profiles', 'command_class': ListProfilesCommand},
         {'name': 'sso', 'command_class': ConfigureSSOCommand},
-        {'name': 'export-creds', 'command_class': ConfigureExportCredsCommand},
+        {'name': 'export-credentials',
+         'command_class': ConfigureExportCredentialsCommand},
     ]
 
     # If you want to add new values to prompt, update this list here.

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -25,6 +25,8 @@ from awscli.customizations.configure.writer import ConfigFileWriter
 from awscli.customizations.configure.importer import ConfigureImportCommand
 from awscli.customizations.configure.listprofiles import ListProfilesCommand
 from awscli.customizations.configure.sso import ConfigureSSOCommand
+from awscli.customizations.configure.exportcreds import \
+    ConfigureExportCredsCommand
 
 from . import mask_value, profile_to_section
 
@@ -80,6 +82,7 @@ class ConfigureCommand(BasicCommand):
         {'name': 'import', 'command_class': ConfigureImportCommand},
         {'name': 'list-profiles', 'command_class': ListProfilesCommand},
         {'name': 'sso', 'command_class': ConfigureSSOCommand},
+        {'name': 'export-creds', 'command_class': ConfigureExportCredsCommand},
     ]
 
     # If you want to add new values to prompt, update this list here.

--- a/awscli/customizations/configure/exportcreds.py
+++ b/awscli/customizations/configure/exportcreds.py
@@ -69,6 +69,10 @@ class BashEnvVarFormatter(BaseCredentialFormatter):
         )
         if credentials.token is not None:
             output += f'export AWS_SESSION_TOKEN={credentials.token}\n'
+        if credentials.expiry_time is not None:
+            output += (
+                f'export AWS_CREDENTIAL_EXPIRATION={credentials.expiry_time}\n'
+            )
         self._stream.write(output)
 
 
@@ -83,6 +87,10 @@ class PowershellFormatter(BaseCredentialFormatter):
         )
         if credentials.token is not None:
             output += f'$Env:AWS_SESSION_TOKEN="{credentials.token}"\n'
+        if credentials.expiry_time is not None:
+            output += (
+                f'$Env:AWS_CREDENTIAL_EXPIRATION={credentials.expiry_time}\n'
+            )
         self._stream.write(output)
 
 
@@ -97,6 +105,10 @@ class WindowsCmdFormatter(BaseCredentialFormatter):
         )
         if credentials.token is not None:
             output += f'set AWS_SESSION_TOKEN={credentials.token}\n'
+        if credentials.expiry_time is not None:
+            output += (
+                f'set AWS_CREDENTIAL_EXPIRATION={credentials.expiry_time}\n'
+            )
         self._stream.write(output)
 
 

--- a/awscli/customizations/configure/exportcreds.py
+++ b/awscli/customizations/configure/exportcreds.py
@@ -58,22 +58,35 @@ class BaseCredentialFormatter(object):
         pass
 
 
-class BashEnvVarFormatter(BaseCredentialFormatter):
+class BaseEnvVarFormatter(BaseCredentialFormatter):
 
-    FORMAT = 'env'
+    _VAR_PREFIX = ''
 
     def display_credentials(self, credentials):
+        prefix = self._VAR_PREFIX
         output = (
-            f'export AWS_ACCESS_KEY_ID={credentials.access_key}\n'
-            f'export AWS_SECRET_ACCESS_KEY={credentials.secret_key}\n'
+            f'{prefix}AWS_ACCESS_KEY_ID={credentials.access_key}\n'
+            f'{prefix}AWS_SECRET_ACCESS_KEY={credentials.secret_key}\n'
         )
         if credentials.token is not None:
-            output += f'export AWS_SESSION_TOKEN={credentials.token}\n'
+            output += f'{prefix}AWS_SESSION_TOKEN={credentials.token}\n'
         if credentials.expiry_time is not None:
             output += (
-                f'export AWS_CREDENTIAL_EXPIRATION={credentials.expiry_time}\n'
+                f'{prefix}AWS_CREDENTIAL_EXPIRATION={credentials.expiry_time}\n'
             )
         self._stream.write(output)
+
+
+class BashEnvVarFormatter(BaseEnvVarFormatter):
+
+    FORMAT = 'env'
+    _VAR_PREFIX = 'export '
+
+
+class BashNoExportEnvFormatter(BaseEnvVarFormatter):
+
+    FORMAT = 'env-no-export'
+    _VAR_PREFIX = ''
 
 
 class PowershellFormatter(BaseCredentialFormatter):
@@ -134,8 +147,8 @@ class CredentialProcessFormatter(BaseCredentialFormatter):
 
 SUPPORTED_FORMATS = {
     format_cls.FORMAT: format_cls for format_cls in
-    [BashEnvVarFormatter, CredentialProcessFormatter, PowershellFormatter,
-     WindowsCmdFormatter]
+    [BashEnvVarFormatter, BashNoExportEnvFormatter, CredentialProcessFormatter,
+     PowershellFormatter, WindowsCmdFormatter]
 }
 
 

--- a/awscli/customizations/configure/exportcreds.py
+++ b/awscli/customizations/configure/exportcreds.py
@@ -139,9 +139,9 @@ SUPPORTED_FORMATS = {
 }
 
 
-class ConfigureExportCredsCommand(BasicCommand):
-    NAME = 'export-creds'
-    SYNOPSIS = 'aws configure export-creds --profile profile-name'
+class ConfigureExportCredentialsCommand(BasicCommand):
+    NAME = 'export-credentials'
+    SYNOPSIS = 'aws configure export-credentials --profile profile-name'
     ARG_TABLE = [
         {'name': 'format',
          'help_text': (
@@ -153,14 +153,14 @@ class ConfigureExportCredsCommand(BasicCommand):
     ]
     _RECURSION_VAR = '_AWS_CLI_PROFILE_CHAIN'
     # Two levels is reasonable because you might explicitly run
-    # "aws configure export-creds" with a profile that is configured
-    # with a credential_process of "aws configure export-creds".
+    # "aws configure export-credentials" with a profile that is configured
+    # with a credential_process of "aws configure export-credentials".
     # So we'll give one more level of recursion for padding and then
     # error out when we hit _MAX_RECURSION.
     _MAX_RECURSION = 4
 
     def __init__(self, session, out_stream=None, error_stream=None, env=None):
-        super(ConfigureExportCredsCommand, self).__init__(session)
+        super(ConfigureExportCredentialsCommand, self).__init__(session)
         if out_stream is None:
             out_stream = sys.stdout
         if error_stream is None:
@@ -211,7 +211,7 @@ class ConfigureExportCredsCommand(BasicCommand):
                 "Try setting an explicit '--profile' value in the "
                 "'credential_process' configuration and ensure there "
                 "are no cycles:\n\n"
-                "credential_process = aws configure export-creds "
+                "credential_process = aws configure export-credentials "
                 "--profile other-profile\n"
             )
             return 2

--- a/awscli/customizations/configure/exportcreds.py
+++ b/awscli/customizations/configure/exportcreds.py
@@ -1,0 +1,183 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import sys
+import json
+from datetime import datetime
+from collections import namedtuple
+
+from awscli.customizations.commands import BasicCommand
+
+
+# Takes botocore's ReadOnlyCredentials and exposes an expiry_time.
+Credentials = namedtuple(
+    'Credentials', ['access_key', 'secret_key', 'token', 'expiry_time'])
+
+
+def convert_botocore_credentials(credentials):
+    # Converts botocore credentials to our `Credentials` type.
+    frozen = credentials.get_frozen_credentials()
+    expiry_time_str = None
+    # Botocore does not expose an attribute for the expiry_time of temporary
+    # credentials, so for the time being we need to access an internal
+    # attribute to retrieve this info.  We're following up to see if botocore
+    # can make this a public attribute.
+    expiry_time = getattr(credentials, '_expiry_time', None)
+    if expiry_time is not None and isinstance(expiry_time, datetime):
+        expiry_time_str = expiry_time.isoformat()
+    return Credentials(
+        access_key=frozen.access_key,
+        secret_key=frozen.secret_key,
+        token=frozen.token,
+        expiry_time=expiry_time_str,
+    )
+
+
+class BaseCredentialFormatter(object):
+
+    FORMAT = None
+
+    def __init__(self, stream=None):
+        if stream is None:
+            stream = sys.stdout
+        self._stream = stream
+
+    def display_credentials(self, credentials):
+        pass
+
+
+class BashEnvVarFormatter(BaseCredentialFormatter):
+
+    FORMAT = 'env'
+
+    def display_credentials(self, credentials):
+        output = (
+            f'export AWS_ACCESS_KEY_ID={credentials.access_key}\n'
+            f'export AWS_SECRET_ACCESS_KEY={credentials.secret_key}\n'
+        )
+        if credentials.token is not None:
+            output += f'export AWS_SESSION_TOKEN={credentials.token}\n'
+        self._stream.write(output)
+
+
+class PowershellFormatter(BaseCredentialFormatter):
+
+    FORMAT = 'powershell'
+
+    def display_credentials(self, credentials):
+        output = (
+            f'$Env:AWS_ACCESS_KEY_ID="{credentials.access_key}"\n'
+            f'$Env:AWS_SECRET_ACCESS_KEY="{credentials.secret_key}"\n'
+        )
+        if credentials.token is not None:
+            output += f'$Env:AWS_SESSION_TOKEN="{credentials.token}"\n'
+        self._stream.write(output)
+
+
+class WindowsCmdFormatter(BaseCredentialFormatter):
+
+    FORMAT = 'windows-cmd'
+
+    def display_credentials(self, credentials):
+        output = (
+            f'set AWS_ACCESS_KEY_ID={credentials.access_key}\n'
+            f'set AWS_SECRET_ACCESS_KEY={credentials.secret_key}\n'
+        )
+        if credentials.token is not None:
+            output += f'set AWS_SESSION_TOKEN={credentials.token}\n'
+        self._stream.write(output)
+
+
+class CredentialProcessFormatter(BaseCredentialFormatter):
+
+    FORMAT = 'process'
+
+    def display_credentials(self, credentials):
+        output = {
+            'Version': 1,
+            'AccessKeyId': credentials.access_key,
+            'SecretAccessKey': credentials.secret_key,
+        }
+        if credentials.token is not None:
+            output['SessionToken'] = credentials.token
+        if credentials.expiry_time is not None:
+            output['Expiration'] = credentials.expiry_time
+        self._stream.write(
+            json.dumps(output, indent=2, separators=(',', ': '))
+        )
+        self._stream.write('\n')
+
+
+SUPPORTED_FORMATS = {
+    format_cls.FORMAT: format_cls for format_cls in
+    [BashEnvVarFormatter, CredentialProcessFormatter, PowershellFormatter,
+     WindowsCmdFormatter]
+}
+
+
+class ConfigureExportCredsCommand(BasicCommand):
+    NAME = 'export-creds'
+    SYNOPSIS = 'aws configure export-creds --profile profile-name'
+    ARG_TABLE = [
+        {'name': 'format',
+         'help_text': (
+             'The output format to display credentials.'
+             'Defaults to "process".'),
+         'action': 'store',
+         'choices': list(SUPPORTED_FORMATS),
+         'default': CredentialProcessFormatter.FORMAT},
+    ]
+    _RECURSION_VAR = '_AWS_CLI_RESOLVING_CREDS'
+
+    def __init__(self, session, out_stream=None, error_stream=None, env=None):
+        super(ConfigureExportCredsCommand, self).__init__(session)
+        if out_stream is None:
+            out_stream = sys.stdout
+        if error_stream is None:
+            error_stream = sys.stderr
+        if env is None:
+            env = os.environ
+        self._out_stream = out_stream
+        self._error_stream = error_stream
+        self._env = env
+
+    def _recursion_detected(self):
+        return self._RECURSION_VAR in self._env
+
+    def _set_recursion_barrier(self):
+        self._env[self._RECURSION_VAR] = 'true'
+
+    def _run_main(self, parsed_args, parsed_globals):
+        if self._recursion_detected():
+            self._error_stream.write(
+                "\n\nRecursive credential resolution process detected.\n"
+                "Try setting an explicit '--profile' value in the "
+                "'credential_process' configuration:\n\n"
+                "credential_process = aws configure export-creds "
+                "--profile other-profile\n"
+            )
+            return 2
+        self._set_recursion_barrier()
+        try:
+            creds = self._session.get_credentials()
+        except Exception as e:
+            self._error_stream.write(
+                "Unable to retrieve credentials: %s\n" % e)
+            return 1
+        if creds is None:
+            self._error_stream.write(
+                "Unable to retrieve credentials: no credentials found\n")
+            return 1
+        creds_with_expiry = convert_botocore_credentials(creds)
+        formatter = SUPPORTED_FORMATS[parsed_args.format](self._out_stream)
+        formatter.display_credentials(creds_with_expiry)

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -53,21 +53,24 @@ class JSONValue:
              'export AWS_SECRET_ACCESS_KEY=secret_key\n'),
             ('export AWS_ACCESS_KEY_ID=access_key\n'
              'export AWS_SECRET_ACCESS_KEY=secret_key\n'
-             'export AWS_SESSION_TOKEN=token\n'),
+             'export AWS_SESSION_TOKEN=token\n'
+             'export AWS_CREDENTIAL_EXPIRATION=2023-01-01T00:00:00Z\n'),
         )),
         (PowershellFormatter, (
             ('$Env:AWS_ACCESS_KEY_ID="access_key"\n'
              '$Env:AWS_SECRET_ACCESS_KEY="secret_key"\n'),
             ('$Env:AWS_ACCESS_KEY_ID="access_key"\n'
              '$Env:AWS_SECRET_ACCESS_KEY="secret_key"\n'
-             '$Env:AWS_SESSION_TOKEN="token"\n'),
+             '$Env:AWS_SESSION_TOKEN="token"\n'
+             '$Env:AWS_CREDENTIAL_EXPIRATION=2023-01-01T00:00:00Z\n'),
         )),
         (WindowsCmdFormatter, (
             ('set AWS_ACCESS_KEY_ID=access_key\n'
              'set AWS_SECRET_ACCESS_KEY=secret_key\n'),
             ('set AWS_ACCESS_KEY_ID=access_key\n'
              'set AWS_SECRET_ACCESS_KEY=secret_key\n'
-             'set AWS_SESSION_TOKEN=token\n'),
+             'set AWS_SESSION_TOKEN=token\n'
+             'set AWS_CREDENTIAL_EXPIRATION=2023-01-01T00:00:00Z\n'),
         )),
         (CredentialProcessFormatter, (
             JSONValue(

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -1,0 +1,210 @@
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import json
+import mock
+import io
+from datetime import datetime, timedelta
+
+from dateutil.tz import tzutc
+import pytest
+from botocore.credentials import RefreshableCredentials
+from botocore.credentials import Credentials as StaticCredentials
+from botocore.credentials import ReadOnlyCredentials
+from botocore.session import Session
+
+from awscli.testutils import unittest
+from awscli.customizations.configure.exportcreds import (
+    Credentials,
+    convert_botocore_credentials,
+    ConfigureExportCredsCommand,
+    BashEnvVarFormatter,
+    PowershellFormatter,
+    WindowsCmdFormatter,
+    CredentialProcessFormatter,
+)
+
+
+class JSONValue:
+    def __init__(self, json_str):
+        self.json_str = json_str
+        self.parsed_json = json.loads(json_str)
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other_parsed = json.loads(other)
+            return self.parsed_json == other_parsed
+        return self.parsed_json == other
+
+
+@pytest.mark.parametrize(
+    'format_cls, expected', [
+        (BashEnvVarFormatter, (
+            ('export AWS_ACCESS_KEY_ID=access_key\n'
+             'export AWS_SECRET_ACCESS_KEY=secret_key\n'),
+            ('export AWS_ACCESS_KEY_ID=access_key\n'
+             'export AWS_SECRET_ACCESS_KEY=secret_key\n'
+             'export AWS_SESSION_TOKEN=token\n'),
+        )),
+        (PowershellFormatter, (
+            ('$Env:AWS_ACCESS_KEY_ID="access_key"\n'
+             '$Env:AWS_SECRET_ACCESS_KEY="secret_key"\n'),
+            ('$Env:AWS_ACCESS_KEY_ID="access_key"\n'
+             '$Env:AWS_SECRET_ACCESS_KEY="secret_key"\n'
+             '$Env:AWS_SESSION_TOKEN="token"\n'),
+        )),
+        (WindowsCmdFormatter, (
+            ('set AWS_ACCESS_KEY_ID=access_key\n'
+             'set AWS_SECRET_ACCESS_KEY=secret_key\n'),
+            ('set AWS_ACCESS_KEY_ID=access_key\n'
+             'set AWS_SECRET_ACCESS_KEY=secret_key\n'
+             'set AWS_SESSION_TOKEN=token\n'),
+        )),
+        (CredentialProcessFormatter, (
+            JSONValue(
+                '{"Version": 1, "AccessKeyId": "access_key", '
+                '"SecretAccessKey": "secret_key"}'),
+            JSONValue(
+                '{"Version": 1, "AccessKeyId": "access_key", '
+                '"SecretAccessKey": "secret_key", "SessionToken": '
+                '"token", "Expiration": "2023-01-01T00:00:00Z"}'),
+        )),
+    ]
+)
+def test_cred_formatter(format_cls, expected):
+    stream = io.StringIO()
+    expected_static, expected_temporary = expected
+    formatter = format_cls(stream)
+
+    # Static case, only access_key/secret_key
+    creds = Credentials('access_key', 'secret_key', None, None)
+    formatter.display_credentials(creds)
+    assert stream.getvalue() == expected_static
+
+    # Refreshable case, access_key/secret_key/token/expiration.
+    # Reset back to an empty stream.
+    stream.truncate(0)
+    stream.seek(0)
+    expiry = '2023-01-01T00:00:00Z'
+    temp_creds = Credentials(
+        'access_key', 'secret_key', 'token', expiry)
+    formatter.display_credentials(temp_creds)
+    assert stream.getvalue() == expected_temporary
+
+
+class TestCanConvertBotocoreCredentials(unittest.TestCase):
+    def test_can_convert_static_creds_with_no_expiry(self):
+        self.assertEqual(
+            convert_botocore_credentials(
+                StaticCredentials('access_key', 'secret_key')
+            ),
+            Credentials('access_key', 'secret_key', token=None,
+                        expiry_time=None)
+        )
+
+    def test_can_convert_creds_with_token_and_no_expiry(self):
+        self.assertEqual(
+            convert_botocore_credentials(
+                StaticCredentials('access_key', 'secret_key', 'token')
+            ),
+            Credentials('access_key', 'secret_key', 'token', expiry_time=None)
+        )
+
+    def test_can_convert_refreshable_with_expiry(self):
+        expiry = datetime.now(tzutc()) + timedelta(hours=12)
+        self.assertEqual(
+            convert_botocore_credentials(
+                RefreshableCredentials(
+                    'access_key',
+                    'secret_key',
+                    'token',
+                    expiry_time=expiry,
+                    refresh_using=None,
+                    method='explicit',
+                )
+            ),
+            Credentials('access_key', 'secret_key', 'token',
+                        expiry_time=expiry.isoformat())
+        )
+
+    def test_no_expiry_time_if_non_datetime_value(self):
+        bad_creds = mock.Mock(spec=StaticCredentials)
+        bad_creds.get_frozen_credentials.return_value = ReadOnlyCredentials(
+            'access_key', 'secret_key', 'token')
+        bad_creds._expiry_time = 'not a datetime'
+        self.assertEqual(
+            convert_botocore_credentials(bad_creds),
+            Credentials('access_key', 'secret_key', 'token',
+                        expiry_time=None)
+        )
+
+
+class TestConfigureExportCredsCommand(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock(spec=Session)
+        self.session.emit_first_non_none_response.return_value = None
+        self.out_stream = io.StringIO()
+        self.err_stream = io.StringIO()
+        self.os_env = {}
+        self.export_creds_cmd = ConfigureExportCredsCommand(
+            self.session, self.out_stream, self.err_stream, env=self.os_env)
+        self.global_args = mock.Mock()
+        self.expiry = '2023-01-01T00:00:00Z'
+        self.creds = StaticCredentials('access_key', 'secret_key')
+
+    def test_can_export_creds(self):
+        self.session.get_credentials.return_value = self.creds
+        rc = self.export_creds_cmd(args=[], parsed_globals=self.global_args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            self.out_stream.getvalue(),
+            JSONValue(
+                '{"Version": 1, "AccessKeyId": "access_key", '
+                '"SecretAccessKey": "secret_key"}')
+        )
+
+    def test_can_export_creds_explicit_format(self):
+        self.session.get_credentials.return_value = self.creds
+        rc = self.export_creds_cmd(
+            args=['--format', 'env'],
+            parsed_globals=self.global_args)
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            self.out_stream.getvalue(),
+            'export AWS_ACCESS_KEY_ID=access_key\n'
+            'export AWS_SECRET_ACCESS_KEY=secret_key\n'
+        )
+
+    def test_show_error_when_no_cred(self):
+        self.session.get_credentials.return_value = None
+        rc = self.export_creds_cmd(args=[], parsed_globals=self.global_args)
+        self.assertIn(
+            'Unable to retrieve credentials', self.err_stream.getvalue()
+        )
+        self.assertEqual(rc, 1)
+
+    def test_show_error_when_cred_resolution_errors(self):
+        self.session.get_credentials.side_effect = Exception("resolution failed")
+        rc = self.export_creds_cmd(args=[], parsed_globals=self.global_args)
+        self.assertIn(
+            'resolution failed', self.err_stream.getvalue()
+        )
+        self.assertEqual(rc, 1)
+
+    def test_can_detect_recursive_resolution(self):
+        self.os_env['_AWS_CLI_RESOLVING_CREDS'] = 'true'
+        rc = self.export_creds_cmd(args=[], parsed_globals=self.global_args)
+        self.assertIn(
+            'Recursive credential resolution process detected',
+            self.err_stream.getvalue()
+        )
+        self.assertEqual(rc, 2)

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -71,7 +71,7 @@ class JSONValue:
             ('$Env:AWS_ACCESS_KEY_ID="access_key"\n'
              '$Env:AWS_SECRET_ACCESS_KEY="secret_key"\n'
              '$Env:AWS_SESSION_TOKEN="token"\n'
-             '$Env:AWS_CREDENTIAL_EXPIRATION=2023-01-01T00:00:00Z\n'),
+             '$Env:AWS_CREDENTIAL_EXPIRATION="2023-01-01T00:00:00Z"\n'),
         )),
         (WindowsCmdFormatter, (
             ('set AWS_ACCESS_KEY_ID=access_key\n'

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -26,7 +26,7 @@ from awscli.testutils import unittest
 from awscli.customizations.configure.exportcreds import (
     Credentials,
     convert_botocore_credentials,
-    ConfigureExportCredsCommand,
+    ConfigureExportCredentialsCommand,
     BashEnvVarFormatter,
     PowershellFormatter,
     WindowsCmdFormatter,
@@ -151,7 +151,7 @@ class TestCanConvertBotocoreCredentials(unittest.TestCase):
         )
 
 
-class TestConfigureExportCredsCommand(unittest.TestCase):
+class TestConfigureExportCredentialsCommand(unittest.TestCase):
     def setUp(self):
         self.session = mock.Mock(spec=Session)
         self.session.emit_first_non_none_response.return_value = None
@@ -159,7 +159,7 @@ class TestConfigureExportCredsCommand(unittest.TestCase):
         self.err_stream = io.StringIO()
         self.os_env = {}
         self.session.get_config_variable.return_value = 'default'
-        self.export_creds_cmd = ConfigureExportCredsCommand(
+        self.export_creds_cmd = ConfigureExportCredentialsCommand(
             self.session, self.out_stream, self.err_stream, env=self.os_env)
         self.global_args = mock.Mock()
         self.expiry = '2023-01-01T00:00:00Z'
@@ -266,7 +266,7 @@ class TestConfigureExportCredsCommand(unittest.TestCase):
         rc = self.export_creds_cmd(args=[], parsed_globals=self.global_args)
         self.assertEqual(rc, 0)
         # Second time, it detects the cycle.
-        second_invoke = ConfigureExportCredsCommand(
+        second_invoke = ConfigureExportCredentialsCommand(
             self.session, self.out_stream, self.err_stream, env=self.os_env)
         rc = second_invoke(args=[], parsed_globals=self.global_args)
         self.assertIn(

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -28,6 +28,7 @@ from awscli.customizations.configure.exportcreds import (
     convert_botocore_credentials,
     ConfigureExportCredentialsCommand,
     BashEnvVarFormatter,
+    BashNoExportEnvFormatter,
     PowershellFormatter,
     WindowsCmdFormatter,
     CredentialProcessFormatter,
@@ -55,6 +56,14 @@ class JSONValue:
              'export AWS_SECRET_ACCESS_KEY=secret_key\n'
              'export AWS_SESSION_TOKEN=token\n'
              'export AWS_CREDENTIAL_EXPIRATION=2023-01-01T00:00:00Z\n'),
+        )),
+        (BashNoExportEnvFormatter, (
+            ('AWS_ACCESS_KEY_ID=access_key\n'
+             'AWS_SECRET_ACCESS_KEY=secret_key\n'),
+            ('AWS_ACCESS_KEY_ID=access_key\n'
+             'AWS_SECRET_ACCESS_KEY=secret_key\n'
+             'AWS_SESSION_TOKEN=token\n'
+             'AWS_CREDENTIAL_EXPIRATION=2023-01-01T00:00:00Z\n'),
         )),
         (PowershellFormatter, (
             ('$Env:AWS_ACCESS_KEY_ID="access_key"\n'


### PR DESCRIPTION
This PR builds on the interface proposed in #6808 and implements the additional features proposed in #7388.

From the original PRs, the additional features are:

* Added support for an explicit `--format` args to control the output format.
* Add support for env vars, powershell/windows vars, and a JSON format that's enables this command to be used as a `credential_process`.
* Detect, and prevent infinite recursion when the credential process resolution results in the CLI calling itself with the same command.

Closes #7388
Closes #5261