### PR TITLE
Add support for per sub-command aliases

### DIFF
--- a/.changes/next-release/feature-alias-21534.json
+++ b/.changes/next-release/feature-alias-21534.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "alias",
+  "description": "Add support for per-command aliases (`#7386 <https://github.com/aws/aws-cli/issues/7386>`__)"
+}

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -25,6 +25,17 @@ from awscli.utils import emit_top_level_args_parsed_event
 LOG = logging.getLogger(__name__)
 
 
+def register_alias_commands(event_handlers, alias_filename=None):
+    kwargs = {}
+    if alias_filename is not None:
+        kwargs['alias_filename'] = alias_filename
+    alias_injector = AliasSubCommandInjector(AliasLoader(**kwargs))
+    event_handlers.register(
+        'building-command-table',
+        alias_injector.on_building_command_table
+    )
+
+
 class InvalidAliasException(Exception):
     pass
 
@@ -43,27 +54,61 @@ class AliasLoader(object):
 
     def _build_aliases(self):
         self._aliases = self._load_aliases()
-        self._cleanup_alias_values(self._aliases.get('toplevel', {}))
+        self._cleanup_alias_values(self._aliases)
 
     def _load_aliases(self):
+        parsed = {}
         if os.path.exists(self._filename):
-            return raw_config_parse(
+            parsed = raw_config_parse(
                 self._filename, parse_subsections=False)
-        return {'toplevel': {}}
+        self._normalize_key_names(parsed)
+        return parsed
 
-    def _cleanup_alias_values(self, aliases):
-        for alias in aliases:
-            # Beginning and end line separators should not be included
-            # in the internal representation of the alias value.
-            aliases[alias] = aliases[alias].strip()
+    def _normalize_key_names(self, parsed):
+        for key in list(parsed):
+            if key.startswith('command '):
+                new_key = tuple(key.split())
+                value = parsed.pop(key)
+                parsed[new_key] = value
 
-    def get_aliases(self):
+    def _cleanup_alias_values(self, all_aliases):
+        for section_aliases in all_aliases.values():
+            for alias in section_aliases:
+                # Beginning and end line separators should not be included
+                # in the internal representation of the alias value.
+                section_aliases[alias] = section_aliases[alias].strip()
+
+    def get_aliases(self, command=None):
+        # To preserve existing behavior, get_alises() with no args
+        # will return the top level aliases, i.e `[topleve]`.
+        # However, you can now get aliases for a specific section by
+        # providing a command key which is a tuple of the command
+        # lineage, i.e. `('ec2', 'wait',)`.
+        if command is None:
+            key = 'toplevel'
+        else:
+            key = ('command',) + tuple(command)
         if self._aliases is None:
             self._build_aliases()
-        return self._aliases.get('toplevel', {})
+        return self._aliases.get(key, {})
 
 
-class AliasCommandInjector(object):
+class BaseAliasCommandInjector(object):
+    def __init__(self, alias_loader):
+        self._alias_loader = alias_loader
+
+    def _get_alias_items(self, command=None):
+        return self._alias_loader.get_aliases(command=command).items()
+
+    def _is_external_alias(self, alias_value):
+        return alias_value.startswith('!')
+
+    def _inject_external_alias(self, alias_name, alias_value, command_table):
+        command_table[alias_name] = ExternalAliasCommand(
+            alias_name, alias_value)
+
+
+class AliasCommandInjector(BaseAliasCommandInjector):
     def __init__(self, session, alias_loader):
         """Injects alias commands for a command table
 
@@ -73,14 +118,14 @@ class AliasCommandInjector(object):
         :type alias_loader: awscli.alias.AliasLoader
         :param alias_loader: The alias loader to use
         """
+        super(AliasCommandInjector, self).__init__(alias_loader)
         self._session = session
-        self._alias_loader = alias_loader
 
     def inject_aliases(self, command_table, parser):
-        for alias_name, alias_value in \
-                self._alias_loader.get_aliases().items():
-            if alias_value.startswith('!'):
-                alias_cmd = ExternalAliasCommand(alias_name, alias_value)
+        for alias_name, alias_value in self._get_alias_items():
+            if self._is_external_alias(alias_value):
+                self._inject_external_alias(alias_name, alias_value,
+                                            command_table)
             else:
                 service_alias_cmd_args = [
                     alias_name, alias_value, self._session, command_table,
@@ -94,7 +139,44 @@ class AliasCommandInjector(object):
                     service_alias_cmd_args.append(
                         command_table[alias_name])
                 alias_cmd = ServiceAliasCommand(*service_alias_cmd_args)
-            command_table[alias_name] = alias_cmd
+                command_table[alias_name] = alias_cmd
+
+
+class AliasSubCommandInjector(BaseAliasCommandInjector):
+    def __init__(self, alias_loader):
+        super(AliasSubCommandInjector, self).__init__(alias_loader)
+        self._global_cmd_driver = None
+        self._global_args_parser = None
+
+    def _retrieve_global_args_parser(self):
+        if self._global_args_parser is None:
+            if self._global_cmd_driver is not None:
+                command_table = self._global_cmd_driver.subcommand_table
+                self._global_args_parser = \
+                    self._global_cmd_driver.create_parser(command_table)
+        return self._global_args_parser
+
+    def on_building_command_table(self, command_table, event_name,
+                                  command_object, session, **kwargs):
+        if not isinstance(command_object, CLICommand) and \
+                event_name == 'building-command-table.main':
+            self._global_cmd_driver = command_object
+            return
+        key_name = tuple(event_name.split('.', 1)[1].split('_'))
+        aliases_for_cmd = self._alias_loader.get_aliases(command=key_name)
+        if not aliases_for_cmd:
+            return
+        for alias_name, alias_value in aliases_for_cmd.items():
+            if self._is_external_alias(alias_value):
+                self._inject_external_alias(
+                    alias_name, alias_value, command_table)
+            else:
+                proxied_sub_command = command_table.get(alias_name)
+                command_table[alias_name] = InternalAliasSubCommand(
+                    alias_name, alias_value, command_object,
+                    self._retrieve_global_args_parser(),
+                    session=session,
+                    proxied_sub_command=proxied_sub_command)
 
 
 class BaseAliasCommand(CLICommand):
@@ -112,6 +194,7 @@ class BaseAliasCommand(CLICommand):
         """
         self._alias_name = alias_name
         self._alias_value = alias_value
+        self._lineage = [self]
 
     def __call__(self, args, parsed_args):
         raise NotImplementedError('__call__')
@@ -124,13 +207,79 @@ class BaseAliasCommand(CLICommand):
     def name(self, value):
         self._alias_name = value
 
+    @property
+    def lineage(self):
+        return self._lineage
 
-class ServiceAliasCommand(BaseAliasCommand):
+    @lineage.setter
+    def lineage(self, value):
+        self._lineage = value
+
+
+class BaseInternalAliasCommand(BaseAliasCommand):
     UNSUPPORTED_GLOBAL_PARAMETERS = [
         'debug',
         'profile'
     ]
 
+    def __init__(self, alias_name, alias_value, session):
+        super(BaseInternalAliasCommand, self).__init__(alias_name, alias_value)
+        self._session = session
+
+    def _get_alias_args(self):
+        try:
+            alias_args = shlex.split(self._alias_value)
+        except ValueError as e:
+            raise InvalidAliasException(
+                'Value of alias "%s" could not be parsed. '
+                'Received error: %s when parsing:\n%s' % (
+                    self._alias_name, e, self._alias_value)
+            )
+
+        alias_args = [arg.strip(os.linesep) for arg in alias_args]
+        LOG.debug(
+            'Expanded subcommand alias %r with value: %r to: %r',
+            self._alias_name, self._alias_value, alias_args
+        )
+        return alias_args
+
+    def _update_parsed_globals(self, arg_parser, parsed_alias_args,
+                               parsed_globals):
+        global_params_to_update = self._get_global_parameters_to_update(
+            arg_parser, parsed_alias_args)
+        # Emit the top level args parsed event to ensure all possible
+        # customizations that typically get applied are applied to the
+        # global parameters provided in the alias before updating
+        # the original provided global parameter values
+        # and passing those onto subsequent commands.
+        emit_top_level_args_parsed_event(self._session, parsed_alias_args)
+        for param_name in global_params_to_update:
+            updated_param_value = getattr(parsed_alias_args, param_name)
+            setattr(parsed_globals, param_name, updated_param_value)
+
+    def _get_global_parameters_to_update(self, arg_parser, parsed_alias_args):
+        # Retrieve a list of global parameters that the newly parsed args
+        # from the alias will have to clobber from the originally provided
+        # parsed globals.
+        global_params_to_update = []
+        for parsed_param, value in vars(parsed_alias_args).items():
+            # To determine which parameters in the alias were global values
+            # compare the parsed alias parameters to the default as
+            # specified by the parser. If the parsed values from the alias
+            # differs from the default value in the parser,
+            # that global parameter must have been provided in the alias.
+            if arg_parser.get_default(parsed_param) != value:
+                if parsed_param in self.UNSUPPORTED_GLOBAL_PARAMETERS:
+                    raise InvalidAliasException(
+                        'Global parameter "--%s" detected in alias "%s" '
+                        'which is not support in subcommand aliases.' % (
+                            parsed_param, self._alias_name))
+                else:
+                    global_params_to_update.append(parsed_param)
+        return global_params_to_update
+
+
+class ServiceAliasCommand(BaseInternalAliasCommand):
     def __init__(self, alias_name, alias_value, session, command_table,
                  parser, shadow_proxy_command=None):
         """Command for a `toplevel` subcommand alias
@@ -163,8 +312,8 @@ class ServiceAliasCommand(BaseAliasCommand):
             to this command as opposed to proxy to itself in the command
             table
         """
-        super(ServiceAliasCommand, self).__init__(alias_name, alias_value)
-        self._session = session
+        super(ServiceAliasCommand, self).__init__(
+            alias_name, alias_value, session)
         self._command_table = command_table
         self._parser = parser
         self._shadow_proxy_command = shadow_proxy_command
@@ -173,7 +322,8 @@ class ServiceAliasCommand(BaseAliasCommand):
         alias_args = self._get_alias_args()
         parsed_alias_args, remaining = self._parser.parse_known_args(
             alias_args)
-        self._update_parsed_globals(parsed_alias_args, parsed_globals)
+        self._update_parsed_globals(self._parser, parsed_alias_args,
+                                    parsed_globals)
         # Take any of the remaining arguments that were not parsed out and
         # prepend them to the remaining args provided to the alias.
         remaining.extend(args)
@@ -197,57 +347,6 @@ class ServiceAliasCommand(BaseAliasCommand):
                 command = self._shadow_proxy_command
         return command(remaining, parsed_globals)
 
-    def _get_alias_args(self):
-        try:
-            alias_args = shlex.split(self._alias_value)
-        except ValueError as e:
-            raise InvalidAliasException(
-                'Value of alias "%s" could not be parsed. '
-                'Received error: %s when parsing:\n%s' % (
-                    self._alias_name, e, self._alias_value)
-            )
-
-        alias_args = [arg.strip(os.linesep) for arg in alias_args]
-        LOG.debug(
-            'Expanded subcommand alias %r with value: %r to: %r',
-            self._alias_name, self._alias_value, alias_args
-        )
-        return alias_args
-
-    def _update_parsed_globals(self, parsed_alias_args, parsed_globals):
-        global_params_to_update = self._get_global_parameters_to_update(
-            parsed_alias_args)
-        # Emit the top level args parsed event to ensure all possible
-        # customizations that typically get applied are applied to the
-        # global parameters provided in the alias before updating
-        # the original provided global parameter values
-        # and passing those onto subsequent commands.
-        emit_top_level_args_parsed_event(self._session, parsed_alias_args)
-        for param_name in global_params_to_update:
-            updated_param_value = getattr(parsed_alias_args, param_name)
-            setattr(parsed_globals, param_name, updated_param_value)
-
-    def _get_global_parameters_to_update(self, parsed_alias_args):
-        # Retrieve a list of global parameters that the newly parsed args
-        # from the alias will have to clobber from the originally provided
-        # parsed globals.
-        global_params_to_update = []
-        for parsed_param, value in vars(parsed_alias_args).items():
-            # To determine which parameters in the alias were global values
-            # compare the parsed alias parameters to the default as
-            # specified by the parser. If the parsed values from the alias
-            # differs from the default value in the parser,
-            # that global parameter must have been provided in the alias.
-            if self._parser.get_default(parsed_param) != value:
-                if parsed_param in self.UNSUPPORTED_GLOBAL_PARAMETERS:
-                    raise InvalidAliasException(
-                        'Global parameter "--%s" detected in alias "%s" '
-                        'which is not support in subcommand aliases.' % (
-                            parsed_param, self._alias_name))
-                else:
-                    global_params_to_update.append(parsed_param)
-        return global_params_to_update
-
 
 class ExternalAliasCommand(BaseAliasCommand):
     def __init__(self, alias_name, alias_value, invoker=subprocess.call):
@@ -267,8 +366,7 @@ class ExternalAliasCommand(BaseAliasCommand):
         :param invoker: Callable to run arguments of external alias. The
             signature should match that of ``subprocess.call``
         """
-        self._alias_name = alias_name
-        self._alias_value = alias_value
+        super(ExternalAliasCommand, self).__init__(alias_name, alias_value)
         self._invoker = invoker
 
     def __call__(self, args, parsed_globals):
@@ -281,3 +379,46 @@ class ExternalAliasCommand(BaseAliasCommand):
             'Using external alias %r with value: %r to run: %r',
             self._alias_name, self._alias_value, command)
         return self._invoker(command, shell=True)
+
+
+class InternalAliasSubCommand(BaseInternalAliasCommand):
+
+    def __init__(self, alias_name, alias_value, command_object,
+                 global_args_parser, session,
+                 proxied_sub_command=None):
+        super(InternalAliasSubCommand, self).__init__(
+            alias_name, alias_value, session)
+        self._command_object = command_object
+        self._global_args_parser = global_args_parser
+        self._proxied_sub_command = proxied_sub_command
+
+    def _process_global_args(self, arg_parser, alias_args, parsed_globals):
+        globally_parseable_args = [parsed_globals.command] + alias_args
+        alias_globals, remaining = arg_parser\
+            .parse_known_args(globally_parseable_args)
+        self._update_parsed_globals(arg_parser, alias_globals, parsed_globals)
+        return remaining
+
+    def __call__(self, args, parsed_globals):
+        # args - Args explicitly provided by the user when
+        #   invoking this command.
+        # parsed_globals - Global args explicitly provided by the user
+        #  that we've already parsed.
+        # alias_args - Any args (including the command name) that are
+        #  embedded as part of the alias value (i.e defined in the alias file)
+        alias_args = self._get_alias_args()
+        cmd_specific_args = self._process_global_args(
+            self._global_args_parser, alias_args, parsed_globals)
+        cmd_specific_args.extend(args)
+        if self._proxied_sub_command is not None:
+            # If we overwrote an existing command, we just delegate to that
+            # command we proxied to.  We know that when this happens, the
+            # first argument will match the command associated with this
+            # command so we remove that value before delegating to the
+            # proxied command.
+            cmd_specific_args = cmd_specific_args[1:]
+            LOG.debug("Delegating to proxy sub-command with new alias "
+                      "args: %s", alias_args)
+            return self._proxied_sub_command(cmd_specific_args, parsed_globals)
+        else:
+            return self._command_object(cmd_specific_args, parsed_globals)

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -32,7 +32,8 @@ def register_alias_commands(event_handlers, alias_filename=None):
     alias_injector = AliasSubCommandInjector(AliasLoader(**kwargs))
     event_handlers.register(
         'building-command-table',
-        alias_injector.on_building_command_table
+        alias_injector.on_building_command_table,
+        unique_id='cli-alias-injector',
     )
 
 
@@ -398,6 +399,11 @@ class InternalAliasSubCommand(BaseInternalAliasCommand):
             .parse_known_args(globally_parseable_args)
         self._update_parsed_globals(arg_parser, alias_globals, parsed_globals)
         return remaining
+
+    def create_help_command(self):
+        # In the future we could create a custom help command
+        # that documents that this is an alias with more info.
+        return self._command_object.create_help_command()
 
     def __call__(self, args, parsed_globals):
         # args - Args explicitly provided by the user when

--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -163,6 +163,21 @@ class AliasSubCommandInjector(BaseAliasCommandInjector):
                 event_name == 'building-command-table.main':
             self._global_cmd_driver = command_object
             return
+        # We have to transform the event name to figure out what the
+        # hierarchy of commands actually is.  Normally the hierarchical
+        # events are separated by dots:
+        #
+        # some-event.cloudformation.wait.stack-exists
+        #
+        # But specifically for the `building-command-table` event, this
+        # was purposefully avoided to workaround a specific bug.
+        # As a result the actual event name for
+        #
+        # "aws cloudformation wait stack-exists" would be:
+        #
+        # building-command-table.cloudformation_wait_stack-exists
+        #
+        # See https://github.com/aws/aws-cli/pull/5714 for more details.
         key_name = tuple(event_name.split('.', 1)[1].split('_'))
         aliases_for_cmd = self._alias_loader.get_aliases(command=key_name)
         if not aliases_for_cmd:

--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -275,8 +275,6 @@ class SubCommandArgParser(ArgTableArgParser):
         return arg_table_copy
 
 
-
-
 class FirstPassGlobalArgParser(CLIArgParser):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -683,7 +683,6 @@ class ServiceOperation(object):
         self._operation_model = operation_model
         self._session = session
         self._subcommand_table = None
-        self._subcommand_delegated = False
         if operation_model.deprecated:
             self._UNDOCUMENTED = True
 
@@ -734,7 +733,7 @@ class ServiceOperation(object):
         return self._arg_table
 
     def _parse_potential_subcommand(self, args, subcommand_table):
-        if subcommand_table and not self._subcommand_delegated:
+        if subcommand_table:
             parser = SubCommandArgParser(self.arg_table, subcommand_table)
             return parser.parse_known_args(args)
         return None
@@ -751,7 +750,6 @@ class ServiceOperation(object):
             args, subcommand_table)
         if maybe_parsed_subcommand is not None:
             new_args, subcommand_name = maybe_parsed_subcommand
-            self._subcommand_delegated = True
             return subcommand_table[subcommand_name](new_args, parsed_globals)
         operation_parser = self._create_operation_parser(
             self.arg_table, subcommand_table)

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -793,8 +793,6 @@ class ServiceOperation(object):
                 # method of the operation caller. It represents the return
                 # code of the operation.
                 return override
-        elif getattr(parsed_args, 'subcommand', None) is not None:
-            return subcommand_table[parsed_args.subcommand](remaining, parsed_globals)
         else:
             # No override value was supplied.
             return self._operation_caller.invoke(

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -207,9 +207,6 @@ class BasicCommand(CLICommand):
                 return 0
             else:
                 return rc
-        else:
-            return self.subcommand_table[parsed_args.subcommand](remaining,
-                                                                 parsed_globals)
 
     def _validate_value_against_schema(self, model, value):
         validate_parameters(value, model)

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -125,11 +125,10 @@ class BasicCommand(CLICommand):
         self._session = session
         self._arg_table = None
         self._subcommand_table = None
-        self._subcommand_delegated = False
         self._lineage = [self]
 
     def _parse_potential_subcommand(self, args, subcommand_table):
-        if subcommand_table and not self._subcommand_delegated:
+        if subcommand_table:
             parser = SubCommandArgParser(self.arg_table, subcommand_table)
             return parser.parse_known_args(args)
         return None
@@ -149,7 +148,6 @@ class BasicCommand(CLICommand):
         )
         if maybe_parsed_subcommand is not None:
             new_args, subcommand_name = maybe_parsed_subcommand
-            self._subcommand_delegated = True
             return self._subcommand_table[subcommand_name](
                 new_args, parsed_globals)
         parser = ArgTableArgParser(self.arg_table, self.subcommand_table)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -96,6 +96,7 @@ from awscli.customizations.devcommands import register_dev_commands
 from awscli.customizations.wizard.commands import register_wizard_commands
 from awscli.customizations.binaryformat import add_binary_formatter
 from awscli.customizations.lightsail import initialize as lightsail_initialize
+from awscli.alias import register_alias_commands
 
 
 def awscli_initialize(event_handlers):
@@ -192,3 +193,4 @@ def awscli_initialize(event_handlers):
     register_wizard_commands(event_handlers)
     register_sso_commands(event_handlers)
     register_dynamodb_paginator_fix(event_handlers)
+    register_alias_commands(event_handlers)

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -441,6 +441,35 @@ class TestAliases(BaseAWSCommandParamsTest):
                     'TagFilters': [{'Key': 'foo', 'Values': ['bar']}]},
         )
 
+    def test_can_handle_multiple_bag_of_options(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('[command ecs describe-tasks]\n')
+            f.write('mycluster = --cluster mycluster\n')
+            f.write('mytasks = --tasks foo\n')
+
+        cmdline = 'ecs describe-tasks mycluster mytasks'
+        self.assert_single_operation_called(
+            cmdline,
+            service_name='ecs',
+            operation_name='DescribeTasks',
+            params={'cluster': 'mycluster', 'tasks': ['foo']},
+        )
+
+    def test_can_handlle_multiple_bags_of_options_with_overrides(self):
+        with open(self.alias_file, 'a+') as f:
+            f.write('[command ecs describe-tasks]\n')
+            f.write('mycluster = --cluster mycluster\n')
+            f.write('mytasks = --tasks foo\n')
+
+        cmdline = 'ecs describe-tasks mycluster mytasks --include TAGS'
+        self.assert_single_operation_called(
+            cmdline,
+            service_name='ecs',
+            operation_name='DescribeTasks',
+            params={'cluster': 'mycluster', 'tasks': ['foo'],
+                    'include': ['TAGS']},
+        )
+
     def test_can_invoke_custom_test_command(self):
         # Sanity check to ensure the custom test command we're using
         # works properly so we don't waste time debugging a test because

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -19,7 +19,7 @@ def _generate_command_tests():
     driver = create_clidriver()
     help_command = driver.create_help_command()
     top_level_params = set(driver.create_help_command().arg_table)
-    for command_name, command_obj in help_command.command_table.items():
+    for command_name, command_obj in list(help_command.command_table.items()):
         sub_help = command_obj.create_help_command()
         if hasattr(sub_help, 'command_table'):
             yield command_name, sub_help.command_table, top_level_params

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -436,6 +436,7 @@ class TestCliDriverHooks(unittest.TestCase):
             'building-command-table.s3',
             'building-argument-table.s3.list-objects',
             'before-building-argument-table-parser.s3.list-objects',
+            'building-command-table.s3_list-objects',
             'operation-args-parsed.s3.list-objects',
             'load-cli-arg.s3.list-objects.bucket',
             'process-cli-arg.s3.list-objects',


### PR DESCRIPTION
The [CLI alias feature](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-alias.html)
currently supports creating aliases as top level commands, at the
same level that service commands currently reside.  For example,
given this alias file:

```
[toplevel]
iam-roles = iam list-roles
```

you can run `aws iam-roles`, which will be equivalent to
`aws iam list-roles`.  This helps reduce the amount of typing for
commonly used commands.

However, this requires all aliases be in the to level namespace,
which has hundreds of services.  This makes it hard to remember
and look up what aliases you have available.

This PR adds support for creating aliases within namespaces of
existing commands/subcommands.

There is some implementation specific details with respect to
event names that we needed to rely onin order to make aliases of nested
commands work (i.e. `aws foo bar <myalias>`).

The implementation is different from the approach taken by
the `[toplevel]` aliases for several reasons:

* The toplevel aliases make the assumption that a single parser can be
  used for any of the alias values.  This is essentially the "global
  args" parser, so this holds true for top level aliase but isn't
  guaranteed for subcommands, custom commands, etc.
* We need to ensure we scope the alias expansion to the current
  namespace we're traversing so we need an approach that enforces this.
* There may be additional logic that happens when invoking a command,
  even within a given namespace.  The safer option is to re-execute
  all this logic after expanding the alias.

So the high level idea is to take the reference to the parent command
object, and reinvoke it with the expanded alias value, after
picking off, and updating, and global parameters provided in the
alias value.

This approach also has the benefit of not modifying the existing
code (except for extract pieces out into a shared base class) so
it's conservative in terms of the likelihood of
breaking existing aliases.

Closes #7386