### PR TITLE
add support for mandoc

### DIFF
--- a/awscli/help.py
+++ b/awscli/help.py
@@ -106,9 +106,12 @@ class PosixHelpRenderer(PagingHelpRenderer):
 
     def _convert_doc_content(self, contents):
         man_contents = publish_string(contents, writer=manpage.Writer())
-        if not self._exists_on_path('groff'):
-            raise ExecutableNotFoundError('groff')
-        cmdline = ['groff', '-m', 'man', '-T', 'ascii']
+        if self._exists_on_path('groff'):
+            cmdline = ['groff', '-m', 'man', '-T', 'ascii']
+        elif self._exists_on_path('mandoc'):
+            cmdline = ['mandoc', '-T', 'ascii']
+        else:
+            raise ExecutableNotFoundError('groff or mandoc')
         LOG.debug("Running command: %s", cmdline)
         p3 = self._popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         groff_output = p3.communicate(input=man_contents)[0]

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -79,7 +79,7 @@ def skip_if_windows(reason):
     """
     def decorator(func):
         return unittest.skipIf(
-            platform.system() not in ['Darwin', 'Linux'], reason)(func)
+            platform.system() not in ['Darwin', 'Linux', 'FreeBSD', 'NetBSD', 'OpenBSD'], reason)(func)
     return decorator
 
 

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -99,7 +99,7 @@ class TestHelpPager(unittest.TestCase):
     def test_no_groff_exists(self):
         renderer = FakePosixHelpRenderer()
         renderer.exists_on_path['groff'] = False
-        expected_error = 'Could not find executable named "groff"'
+        expected_error = 'Could not find executable named "groff or mandoc"'
         with self.assertRaisesRegex(ExecutableNotFoundError, expected_error):
             renderer.render('foo')
 


### PR DESCRIPTION
Issue #, if available: #6918

- simple merge conflict resolution of pull/2635
- original pr comment:
> Issue #, if available: #6918
>
> Hi.
>
> This will allow Linux distros and BSDs systems that use mandoc instead of groff to display 'help' without the need to install additional software. More information about the mandoc formatter is available at: http://mdocml.bsd.lv/ Thanks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Co-authored-by: Antoine Jacoutot <ajacoutot@openbsd.org>
