### PR TITLE
Support mandoc

### DIFF
--- a/.changes/next-release/enhancement-docs-15168.json
+++ b/.changes/next-release/enhancement-docs-15168.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "docs",
+  "description": "Fixes `#6918 <https://github.com/aws/aws-cli/issues/6918>`__ and `#7400 <https://github.com/aws/aws-cli/issues/7400>`__. The CLI falls back on mandoc if groff isn't available."
+}

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -106,9 +106,12 @@ class PosixHelpRenderer(PagingHelpRenderer):
 
     def _convert_doc_content(self, contents):
         man_contents = publish_string(contents, writer=manpage.Writer())
-        if not self._exists_on_path('groff'):
-            raise ExecutableNotFoundError('groff')
-        cmdline = ['groff', '-m', 'man', '-T', 'ascii']
+        if self._exists_on_path('groff'):
+            cmdline = ['groff', '-m', 'man', '-T', 'ascii']
+        elif self._exists_on_path('mandoc'):
+            cmdline = ['mandoc', '-T', 'ascii']
+        else:
+            raise ExecutableNotFoundError('groff or mandoc')
         LOG.debug("Running command: %s", cmdline)
         p3 = self._popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         groff_output = p3.communicate(input=man_contents)[0]

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -114,8 +114,8 @@ class PosixHelpRenderer(PagingHelpRenderer):
             raise ExecutableNotFoundError('groff or mandoc')
         LOG.debug("Running command: %s", cmdline)
         p3 = self._popen(cmdline, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        groff_output = p3.communicate(input=man_contents)[0]
-        return groff_output
+        output = p3.communicate(input=man_contents)[0]
+        return output
 
     def _send_output_to_pager(self, output):
         cmdline = self.get_pager_cmdline()

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -96,12 +96,24 @@ class TestHelpPager(unittest.TestCase):
                          pager_cmd.split())
 
     @skip_if_windows('Requires posix system.')
-    def test_no_groff_exists(self):
+    def test_no_groff_or_mandoc_exists(self):
         renderer = FakePosixHelpRenderer()
         renderer.exists_on_path['groff'] = False
+        renderer.exists_on_path['mandoc'] = False
         expected_error = 'Could not find executable named "groff or mandoc"'
-        with self.assertRaisesRegexp(ExecutableNotFoundError, expected_error):
+        with self.assertRaisesRegex(ExecutableNotFoundError, expected_error):
             renderer.render('foo')
+
+    @skip_if_windows('Requires POSIX system.')
+    def test_renderer_falls_back_to_mandoc(self):
+        stdout = six.StringIO()
+        renderer = FakePosixHelpRenderer(output_stream=stdout)
+
+        renderer.exists_on_path['groff'] = False
+        renderer.exists_on_path['mandoc'] = True
+        renderer.mock_popen.communicate.return_value = (b'foo', '')
+        renderer.render('foo')
+        self.assertEqual(stdout.getvalue(), 'foo\n')
 
     @skip_if_windows('Requires POSIX system.')
     def test_no_pager_exists(self):

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -99,8 +99,8 @@ class TestHelpPager(unittest.TestCase):
     def test_no_groff_exists(self):
         renderer = FakePosixHelpRenderer()
         renderer.exists_on_path['groff'] = False
-        expected_error = 'Could not find executable named "groff"'
-        with self.assertRaisesRegex(ExecutableNotFoundError, expected_error):
+        expected_error = 'Could not find executable named "groff or mandoc"'
+        with self.assertRaisesRegexp(ExecutableNotFoundError, expected_error):
             renderer.render('foo')
 
     @skip_if_windows('Requires POSIX system.')


### PR DESCRIPTION
Fixes #6918 and #7400.
This PR was built on top of a commit contributed by [ajacoutot](https://github.com/ajacoutot) in #2635.

The CLI's help commands are currently broken on macOS Ventura because Ventura has replaced `groff` with `mandoc`. This PR fixes the issue by falling back on `mandoc` if `groff` doesn't exist in the path.