### PR TITLE
Fix: adjust cloudformation package behaviour to disable uploading when inline code provided

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -424,7 +424,7 @@ class LambdaFunctionResource(ResourceWithS3UrlDict):
     def do_export(self, resource_id, resource_dict, parent_dir):
         code_value = jmespath.search(self.PROPERTY_NAME, resource_dict)
         if code_value: 
-            if isinstance(code_value, dict) and code_value.get(INLINE_CODE):
+            if isinstance(code_value, dict) and code_value.get(self.INLINE_CODE):
                 return
 
         artifact_s3_url = \

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -390,10 +390,8 @@ class LambdaFunctionResource(ResourceWithS3UrlDict):
             if isinstance(code_value, dict) and code_value.get(INLINE_CODE):
                 return
 
-        uploaded_url = upload_local_artifacts(resource_id, resource_dict,
-                                   self.PROPERTY_NAME,
-                                   parent_dir, self.uploader)
-        set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, uploaded_url)
+        super().do_export(resource_id, resource_dict, parent_dir)
+
 
 class ApiGatewayRestApiResource(ResourceWithS3UrlDict):
     RESOURCE_TYPE = "AWS::ApiGateway::RestApi"

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -394,7 +394,7 @@ class LambdaFunctionResource(ResourceWithS3UrlDict):
             return
 
         if isinstance(property_value, dict):
-            if INLINE_CODE not in property_value:
+            if self.INLINE_CODE not in property_value:
                 LOG.debug("Property {0} of {1} resource is not a URL"
                         .format(self.PROPERTY_NAME, resource_id))
                 return

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -384,13 +384,60 @@ class LambdaFunctionResource(ResourceWithS3UrlDict):
     INLINE_CODE = "ZipFile"
     FORCE_ZIP = True
 
+    def export(self, resource_id, resource_dict, parent_dir):
+        if resource_dict is None:
+            return
+
+        property_value = jmespath.search(self.PROPERTY_NAME, resource_dict)
+
+        if not property_value and not self.PACKAGE_NULL_PROPERTY:
+            return
+
+        if isinstance(property_value, dict):
+            if INLINE_CODE not in property_value:
+                LOG.debug("Property {0} of {1} resource is not a URL"
+                        .format(self.PROPERTY_NAME, resource_id))
+                return
+
+        # If property is a file but not a zip file, place file in temp
+        # folder and send the temp folder to be zipped
+        temp_dir = None
+        if is_local_file(property_value) and not \
+                is_zip_file(property_value) and self.FORCE_ZIP:
+            temp_dir = copy_to_temp_dir(property_value)
+            set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, temp_dir)
+
+        try:
+            self.do_export(resource_id, resource_dict, parent_dir)
+
+        except Exception as ex:
+            LOG.debug("Unable to export", exc_info=ex)
+            raise exceptions.ExportFailedError(
+                    resource_id=resource_id,
+                    property_name=self.PROPERTY_NAME,
+                    property_value=property_value,
+                    ex=ex)
+        finally:
+            if temp_dir:
+                shutil.rmtree(temp_dir)
+
     def do_export(self, resource_id, resource_dict, parent_dir):
         code_value = jmespath.search(self.PROPERTY_NAME, resource_dict)
         if code_value: 
             if isinstance(code_value, dict) and code_value.get(INLINE_CODE):
                 return
 
-        super().do_export(resource_id, resource_dict, parent_dir)
+        artifact_s3_url = \
+            upload_local_artifacts(resource_id, resource_dict,
+                                   self.PROPERTY_NAME,
+                                   parent_dir, self.uploader)
+
+        parsed_url = parse_s3_url(
+                artifact_s3_url,
+                bucket_name_property=self.BUCKET_NAME_PROPERTY,
+                object_key_property=self.OBJECT_KEY_PROPERTY,
+                version_property=self.VERSION_PROPERTY)
+        set_value_from_jmespath(resource_dict, self.PROPERTY_NAME, parsed_url)
 
 
 class ApiGatewayRestApiResource(ResourceWithS3UrlDict):

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -387,7 +387,7 @@ class LambdaFunctionResource(ResourceWithS3UrlDict):
     def do_export(self, resource_id, resource_dict, parent_dir):
         code_value = jmespath.search(self.PROPERTY_NAME, resource_dict)
         if code_value: 
-            if code_value.get(INLINE_CODE):
+            if isinstance(code_value, dict) and code_value.get(INLINE_CODE):
                 return
 
         uploaded_url = upload_local_artifacts(resource_id, resource_dict,

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -1069,7 +1069,7 @@ class TestArtifactExporter(unittest.TestCase):
         template_path = os.path.join(template_dir, 'path')
         template_str = self.example_yaml_template()
 
-        resource_type1_class = ServerlessFunctionResource
+        resource_type1_class = LambdaFunctionResource
         resource_type1_class.RESOURCE_TYPE = "AWS::Lambda::Function"
         resource_type1_instance = mock.Mock()
         resource_type1_class.return_value = resource_type1_instance

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -1078,7 +1078,7 @@ class TestArtifactExporter(unittest.TestCase):
             resource_type1_class
         ]
 
-        properties = {"Handler": "index.handler", "Runtime": "nodejs10.x", "Code": {"ZipFIle": "'code'"}}
+        properties = {"Handler": "index.handler", "Runtime": "nodejs10.x", "Code": {"ZipFile": "'code'"}}
         template_dict = {
             "Resources": {
                 "Resource1": {

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -1082,7 +1082,7 @@ class TestArtifactExporter(unittest.TestCase):
         template_dict = {
             "Resources": {
                 "Resource1": {
-                    "Type": "AWS::Serverless::Function",
+                    "Type": "AWS::Lambda::Function",
                     "Properties": properties
                 }
             }
@@ -1102,7 +1102,7 @@ class TestArtifactExporter(unittest.TestCase):
             exported_template = template_exporter.export()
             self.assertTrue(
                 "Zipfile" in exported_template.get("Resources").get("Resource1").get("Properties").get("Code")
-                )
+            )
 
             open_mock.assert_called_once_with(
                     make_abs_path(parent_dir, template_path), "r")

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -1101,7 +1101,7 @@ class TestArtifactExporter(unittest.TestCase):
                 resources_to_export)
             exported_template = template_exporter.export()
             self.assertTrue(
-                "Zipfile" in exported_template.get("Resources").get("Resource1").get("Properties").get("Code")
+                "ZipFile" in exported_template.get("Resources").get("Resource1").get("Properties").get("Code")
             )
 
             open_mock.assert_called_once_with(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-cli/pull/7359

*Description of changes:*
22/11/10 Rebasing the latest changes and creating a new PR.

"The root cause of the issue above is how AWS CLI disregards inline code properties and creates a url to upload. This pr aims to fix the behaviour and treat serverless function resource with InlineCode property and lambda function resource with ZipFile property as special cases to skip the upload and set property process. The mirroring fixes in SAM CLI were released in v1.16.0."

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
