### PR TITLE
Refactor set_operation_specific_signer handler  to support sv4a

### DIFF
--- a/tests/unit/botocore/test_handlers.py
+++ b/tests/unit/botocore/test_handlers.py
@@ -19,6 +19,8 @@ import copy
 import os
 import json
 
+import pytest
+
 import botocore
 import botocore.session
 from botocore.compat import OrderedDict
@@ -961,12 +963,33 @@ class TestHandlers(BaseSessionTest):
             context=context, signing_name=signing_name)
         self.assertEqual(response, 'v4')
 
-    def test_set_operation_specific_signer_s3v4(self):
-        signing_name = 's3'
-        context = {'auth_type': 'v4'}
+    def test_set_operation_specific_signer_v4a(self):
+        signing_name = 'myservice'
+        context = {'auth_type': 'v4a'}
         response = handlers.set_operation_specific_signer(
-            context=context, signing_name=signing_name)
-        self.assertEqual(response, 's3v4')
+            context=context, signing_name=signing_name
+        )
+        self.assertEqual(response, 'v4a')
+        # for v4a, context gets updated in place
+        self.assertIsNotNone(context.get('signing'))
+        self.assertEqual(context['signing']['region'], '*')
+        self.assertEqual(context['signing']['signing_name'], signing_name)
+
+    def test_set_operation_specific_signer_v4a_existing_signing_context(self):
+        signing_name = 'myservice'
+        context = {
+            'auth_type': 'v4a',
+            'signing': {'foo': 'bar', 'region': 'abc'},
+        }
+        handlers.set_operation_specific_signer(
+            context=context, signing_name=signing_name
+        )
+        # region has been updated
+        self.assertEqual(context['signing']['region'], '*')
+        # signing_name has been added
+        self.assertEqual(context['signing']['signing_name'], signing_name)
+        # foo remained untouched
+        self.assertEqual(context['signing']['foo'], 'bar')
 
     def test_set_operation_specific_signer_v4_unsinged_payload(self):
         signing_name = 'myservice'
@@ -983,6 +1006,18 @@ class TestHandlers(BaseSessionTest):
             context=context, signing_name=signing_name)
         self.assertEqual(response, 's3v4')
         self.assertEqual(context.get('payload_signing_enabled'), False)
+
+
+@pytest.mark.parametrize(
+    'auth_type, expected_response', [('v4', 's3v4'), ('v4a', 's3v4a')]
+)
+def test_set_operation_specific_signer_s3v4(auth_type, expected_response):
+    signing_name = 's3'
+    context = {'auth_type': auth_type}
+    response = handlers.set_operation_specific_signer(
+        context=context, signing_name=signing_name
+    )
+    assert response == expected_response
 
 
 class TestConvertStringBodyToFileLikeObject(BaseSessionTest):


### PR DESCRIPTION
Based off of this pr: https://github.com/boto/botocore/pull/2741