### PR TITLE
Remove or rename duplicate tests

### DIFF
--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -312,16 +312,6 @@ class TestS3ClientConfigResolution(BaseS3ClientConfigurationTest):
             }
         )
 
-    def test_use_arn_region_is_case_insensitive(self):
-        self.environ['AWS_S3_USE_ARN_REGION'] = 'True'
-        client = self.create_s3_client()
-        self.assertEqual(
-            client.meta.config.s3,
-            {
-                'use_arn_region': True,
-            }
-        )
-
     def test_client_region_defaults_to_aws_global(self):
         client = self.create_s3_client(region_name=None)
         self.assertEqual(client.meta.region_name, 'aws-global')
@@ -653,7 +643,7 @@ class TestAccesspointArn(BaseS3ClientConfigurationTest):
         self.assertIsNotNone(sha_header)
         self.assertNotEqual(sha_header, b"UNSIGNED-PAYLOAD")
 
-    def test_basic_outpost_arn(self):
+    def test_basic_outpost_arn_custom_endpoint(self):
         outpost_arn = (
             'arn:aws:s3-outposts:us-west-2:123456789012:outpost:'
             'op-01234567890123456:accesspoint:myaccesspoint'

--- a/tests/functional/route53/test_resource_id.py
+++ b/tests/functional/route53/test_resource_id.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -2226,7 +2226,7 @@ class TestCpWithCRTClient(BaseCRTTransferClientTest):
         self.assertEqual(tls_context_options.ca_buffer, fake_ca_contents)
 
     @mock.patch('s3transfer.crt.ClientTlsContext')
-    def test_respects_ca_bundle_parameter(self, mock_client_tls_context_options):
+    def test_respects_ca_bundle_parameter_no_verify(self, mock_client_tls_context_options):
         filename = self.files.create_file('myfile', 'mycontent')
         ca_bundle = self.files.create_file('fake_ca', 'mycontent')
         cmdline = [

--- a/tests/unit/botocore/test_client.py
+++ b/tests/unit/botocore/test_client.py
@@ -1702,16 +1702,6 @@ class TestClientEndpointBridge(unittest.TestCase):
         resolved = bridge.resolve('myservice', 'us-foo-baz', is_secure=False)
         self.assertEqual('http://host.com', resolved['endpoint_url'])
 
-    def test_can_create_http_urls(self):
-        resolver = mock.Mock()
-        resolver.construct_endpoint.return_value = {
-            'partition': 'aws', 'hostname': 'host.com',
-            'signatureVersions': ['v4'],
-            'endpointName': 'us-foo-baz'}
-        bridge = ClientEndpointBridge(resolver)
-        resolved = bridge.resolve('myservice', 'us-foo-baz', is_secure=False)
-        self.assertEqual('http://host.com', resolved['endpoint_url'])
-
     def test_credential_scope_overrides_signing_region(self):
         resolver = mock.Mock()
         resolver.construct_endpoint.return_value = {

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -138,7 +138,7 @@ class TestResolveIMDSEndpointMode(unittest.TestCase):
         session = self.create_session_with_config('IPv6', None)
         self.assertEqual(resolve_imds_endpoint_mode(session), 'ipv6')
 
-    def test_resolve_endpoint_mode_IPv6(self):
+    def test_resolve_endpoint_mode_IPv4(self):
         session = self.create_session_with_config('IPv4', None)
         self.assertEqual(resolve_imds_endpoint_mode(session), 'ipv4')
 

--- a/tests/unit/test_topictags.py
+++ b/tests/unit/test_topictags.py
@@ -309,17 +309,6 @@ class TestTopicTagDBQuery(TestTopicTagDB):
         self.assertEqual(query_dict,
                          {'foo': ['topic-name-1'], 'bar': ['topic-name-1']})
 
-    def test_query_tag_multi_values(self):
-        tag_dict = {
-            'topic-name-1': {
-                'related topic': ['foo', 'bar']
-            }
-        }
-        self.topic_tag_db = TopicTagDB(tag_dict)
-        query_dict = self.topic_tag_db.query('related topic')
-        self.assertEqual(query_dict,
-                         {'foo': ['topic-name-1'], 'bar': ['topic-name-1']})
-
     def test_query_multiple_topics(self):
         tag_dict = {
             'topic-name-1': {


### PR DESCRIPTION
A few tests were shadowing other tests. Some were simple copy pastes
of other tests, which I removed. Others had unique functionality but
their name was being shadowed so they were never getting run, these I
renamed.