### PR TITLE
[v2] Default to aws partition for no region

### DIFF
--- a/.changes/next-release/bugfix-Endpoints-16572.json
+++ b/.changes/next-release/bugfix-Endpoints-16572.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoints",
+  "description": "Resolve endpoint with default partition when no region is set"
+}

--- a/awscli/botocore/endpoint_provider.py
+++ b/awscli/botocore/endpoint_provider.py
@@ -202,13 +202,12 @@ class RuleSetStandardLibary:
         :type value: str
         :rtype: dict
         """
-        if value is None:
-            return None
-
         partitions = self.partitions_data['partitions']
-        for partition in partitions:
-            if self.is_partition_match(value, partition):
-                return self.format_partition_output(partition)
+
+        if value is not None:
+            for partition in partitions:
+                if self.is_partition_match(value, partition):
+                    return self.format_partition_output(partition)
 
         # return the default partition if no matches were found
         aws_partition = partitions[0]

--- a/tests/functional/botocore/conftest.py
+++ b/tests/functional/botocore/conftest.py
@@ -22,5 +22,6 @@ def patched_session(monkeypatch):
     monkeypatch.setenv('AWS_SECRET_ACCESS_KEY', 'secret_key')
     monkeypatch.setenv('AWS_CONFIG_FILE', 'no-exist-foo')
     monkeypatch.delenv('AWS_PROFILE', raising=False)
+    monkeypatch.delenv('AWS_DEFAULT_REGION', raising=False)
     session = create_session()
     return session

--- a/tests/integration/botocore/test_sts.py
+++ b/tests/integration/botocore/test_sts.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
+from tests import unittest, ClientHTTPStubber
 
 import botocore.session
 from botocore.exceptions import ClientError
@@ -40,3 +40,29 @@ class TestSTS(unittest.TestCase):
         # Signing error will be thrown with the incorrect region name included.
         with self.assertRaisesRegex(ClientError, 'ap-southeast-1') as e:
             sts.get_session_token()
+
+
+def test_assume_role_with_saml_no_region_custom_endpoint(patched_session):
+    # When an endpoint_url and no region are given, AssumeRoleWithSAML should
+    # resolve to the endpoint_url and succeed, not fail in endpoint resolution:
+    # https://github.com/aws/aws-cli/issues/7455
+
+    client = patched_session.create_client(
+        'sts', region_name=None, endpoint_url="https://custom.endpoint.aws"
+    )
+    assert client.meta.region_name is None
+
+    mock_response_body = b"""\
+<AssumeRoleWithSAMLResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+    <AssumeRoleWithSAMLResult></AssumeRoleWithSAMLResult>
+</AssumeRoleWithSAMLResponse>
+"""
+    with ClientHTTPStubber(client) as http_stubber:
+        http_stubber.add_response(body=mock_response_body)
+        client.assume_role_with_saml(
+            RoleArn='arn:aws:iam::123456789:role/RoleA',
+            PrincipalArn='arn:aws:iam::123456789:role/RoleB',
+            SAMLAssertion='xxxx',
+        )
+    captured_request = http_stubber.requests[0]
+    assert captured_request.url == "https://custom.endpoint.aws/"

--- a/tests/unit/botocore/test_endpoint_provider.py
+++ b/tests/unit/botocore/test_endpoint_provider.py
@@ -203,8 +203,9 @@ def test_endpoint_resolution(
     assert endpoint.headers == expected_endpoint.get("headers", {})
 
 
-def test_none_doesnt_use_default_partition(rule_lib):
-    assert rule_lib.aws_partition(None) is None
+def test_none_returns_default_partition(rule_lib):
+    partition_dict = rule_lib.aws_partition(None)
+    assert partition_dict['name'] == "aws"
 
 
 def test_no_match_region_returns_default_partition(rule_lib):


### PR DESCRIPTION
This is a port of this botocore PR: https://github.com/boto/botocore/pull/2818 that allows use of sts commands that have no configured region. I also confirmed locally that it fixes this issue: https://github.com/aws/aws-cli/issues/7455
