### PR TITLE
Ignore errors setting always-auth in npm config set

### DIFF
--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -78,20 +78,26 @@ class BaseLogin(object):
             return
 
         for command in commands:
-            try:
-                self.subprocess_utils.check_call(
-                    command,
-                    stdout=self.subprocess_utils.PIPE,
-                    stderr=self.subprocess_utils.PIPE,
-                )
-            except OSError as ex:
-                if ex.errno == errno.ENOENT:
-                    raise ValueError(
-                        self._TOOL_NOT_FOUND_MESSAGE % tool
-                    )
-                raise ex
+            self._run_command(tool, command)
 
         self._write_success_message(tool)
+
+    def _run_command(self, tool, command, *, ignore_errors=False):
+        try:
+            self.subprocess_utils.check_call(
+                command,
+                stdout=self.subprocess_utils.PIPE,
+                stderr=self.subprocess_utils.PIPE
+            )
+        except subprocess.CalledProcessError as ex:
+            if not ignore_errors:
+                raise ex
+        except OSError as ex:
+            if ex.errno == errno.ENOENT:
+                raise ValueError(
+                    self._TOOL_NOT_FOUND_MESSAGE % tool
+                )
+            raise ex
 
     @classmethod
     def get_commands(cls, endpoint, auth_token, **kwargs):
@@ -302,6 +308,12 @@ class NpmLogin(BaseLogin):
             self.repository_endpoint, self.auth_token, scope=scope
         )
         self._run_commands('npm', commands, dry_run)
+
+    def _run_command(self, tool, command):
+        if any('always-auth' in arg for arg in command):
+            super()._run_command(tool, command, ignore_errors=True)
+        else:
+            super()._run_command(tool, command)
 
     @classmethod
     def get_scope(cls, namespace):

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -310,7 +310,7 @@ class NpmLogin(BaseLogin):
         self._run_commands('npm', commands, dry_run)
 
     def _run_command(self, tool, command):
-        if any('always-auth' in arg for arg in command):
+        if any("always-auth" in arg for arg in command):
             super()._run_command(tool, command, ignore_errors=True)
         else:
             super()._run_command(tool, command)

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -452,30 +452,26 @@ class TestNpmLogin(unittest.TestCase):
         )
 
     def test_login_always_auth_not_allowed(self):
-        def side_effect(command, stdout, stderr):
-            if any('always-auth' in arg for arg in command):
-                raise subprocess.CalledProcessError(
-                    returncode=1,
-                    cmd=command
-                )
+        self.test_subject.login()
 
-            return mock.DEFAULT
-
-        self.subprocess_utils.check_call.side_effect = side_effect
         expected_calls = []
-
+        mock_subprocess = mock.Mock()
         for command in self.commands:
+            if any("always-auth" in arg for arg in command):
+                mock_subprocess.check_output.side_effect = subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=["Invalid"]
+                )
             expected_calls.append(mock.call(
                     command,
                     stdout=self.subprocess_utils.PIPE,
                     stderr=self.subprocess_utils.PIPE,
                 )
             )
-        self.test_subject.login()
 
         self.subprocess_utils.check_call.assert_has_calls(
-                expected_calls, any_order=True
-            )
+            expected_calls, any_order=True
+        )
 
     def test_get_scope(self):
         expected_value = '@{}'.format(self.namespace)

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import subprocess
 
 from datetime import datetime
 from dateutil.tz import tzlocal, tzutc
@@ -449,6 +450,32 @@ class TestNpmLogin(unittest.TestCase):
         self.subprocess_utils.check_call.assert_has_calls(
             expected_calls, any_order=True
         )
+
+    def test_login_always_auth_not_allowed(self):
+        def side_effect(command, stdout, stderr):
+            if any('always-auth' in arg for arg in command):
+                raise subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=command
+                )
+
+            return mock.DEFAULT
+
+        self.subprocess_utils.check_call.side_effect = side_effect
+        expected_calls = []
+
+        for command in self.commands:
+            expected_calls.append(mock.call(
+                    command,
+                    stdout=self.subprocess_utils.PIPE,
+                    stderr=self.subprocess_utils.PIPE,
+                )
+            )
+        self.test_subject.login()
+
+        self.subprocess_utils.check_call.assert_has_calls(
+                expected_calls, any_order=True
+            )
 
     def test_get_scope(self):
         expected_value = '@{}'.format(self.namespace)


### PR DESCRIPTION
*Issue #, if available:*

#7434 

*Description of changes:*

The release of NPM 9 has dropped the support of deprecated or unsupported parameters in the `npm config set` command. This includes the `always-auth` parameter. Since `always-auth=true` is being set internally via the `aws codeartifact login --tool npm` command, this results in users of NPM 9 getting an exception. this blocks users to use login command entirely with NPM 9. This flag is ignored by NPM 7 and 8. Since the NPM login command is also used for yarn users, it was not previously removed.

This change is to catch and ignore an exception while setting `always-auth` flag for the `npm config set` command. Users with NPM < 9 will still set the parameter in their `.npmrc` file, while users with NPM >= 9 will not.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
