### PR TITLE
Ignore errors setting always-auth in npm config set

### DIFF
--- a/.changes/next-release/bugfix-codeartifactlogin-60905.json
+++ b/.changes/next-release/bugfix-codeartifactlogin-60905.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``codeartifact login``",
+  "description": "Ignore always-auth errors for CodeArtifact login command; fixes `#7434 <https://github.com/aws/aws-cli/issues/7434>`__"
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -78,20 +78,26 @@ class BaseLogin(object):
             return
 
         for command in commands:
-            try:
-                self.subprocess_utils.check_call(
-                    command,
-                    stdout=self.subprocess_utils.PIPE,
-                    stderr=self.subprocess_utils.PIPE,
-                )
-            except OSError as ex:
-                if ex.errno == errno.ENOENT:
-                    raise ValueError(
-                        self._TOOL_NOT_FOUND_MESSAGE % tool
-                    )
-                raise ex
+            self._run_command(tool, command)
 
         self._write_success_message(tool)
+
+    def _run_command(self, tool, command, *, ignore_errors=False):
+        try:
+            self.subprocess_utils.check_call(
+                command,
+                stdout=self.subprocess_utils.PIPE,
+                stderr=self.subprocess_utils.PIPE
+            )
+        except subprocess.CalledProcessError as ex:
+            if not ignore_errors:
+                raise ex
+        except OSError as ex:
+            if ex.errno == errno.ENOENT:
+                raise ValueError(
+                    self._TOOL_NOT_FOUND_MESSAGE % tool
+                )
+            raise ex
 
     @classmethod
     def get_commands(cls, endpoint, auth_token, **kwargs):
@@ -302,6 +308,10 @@ class NpmLogin(BaseLogin):
             self.repository_endpoint, self.auth_token, scope=scope
         )
         self._run_commands('npm', commands, dry_run)
+
+    def _run_command(self, tool, command):
+        ignore_errors = any('always-auth' in arg for arg in command)
+        super()._run_command(tool, command, ignore_errors=ignore_errors)
 
     @classmethod
     def get_scope(cls, namespace):

--- a/tests/functional/codeartifact/test_codeartifact_login.py
+++ b/tests/functional/codeartifact/test_codeartifact_login.py
@@ -587,6 +587,30 @@ password: {auth_token}'''
         self._assert_operations_called(package_format='npm', result=result)
         self._assert_dry_run_execution(self._get_npm_commands(), result.stdout)
 
+    def test_npm_login_always_auth_error_ignored(self):
+        """Test login ignores error for always-auth.
+
+        This test is for NPM version >= 9 where the support of 'always-auth'
+        has been dropped. Running the command to set config gives a non-zero
+        exit code. This is to make sure that login ignores that error and all
+        other commands executes successfully.
+        """
+        def side_effect(command, stdout, stderr):
+            if any('always-auth' in arg for arg in command):
+                raise subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd=command
+                )
+
+            return mock.DEFAULT
+
+        self.subprocess_mock.side_effect = side_effect
+        cmdline = self._setup_cmd(tool='npm')
+        result = self.cli_runner.run(cmdline)
+        self.assertEqual(result.rc, 0)
+        self._assert_expiration_printed_to_stdout(result.stdout)
+        self._assert_subprocess_execution(self._get_npm_commands())
+
     def test_npm_login_with_domain_owner(self):
         cmdline = self._setup_cmd(tool='npm', include_domain_owner=True)
         result = self.cli_runner.run(cmdline)


### PR DESCRIPTION
*Issue #, if available:*

#7434 

*Description of changes:*

The release of NPM 9 has dropped the support of deprecated or unsupported parameters in the `npm config set` command. This includes the `always-auth` parameter. Since `always-auth=true` is being set internally via the `aws codeartifact login --tool npm` command, this results in users of NPM 9 getting an exception. This blocks users to use login command entirely with NPM 9. This flag is ignored by NPM 7 and 8. Since the NPM login command is also used for yarn users, it was not previously removed.

This change is to catch and ignore an exception while setting `always-auth` flag for the `npm config set` command. Users with NPM < 9 will still set the parameter in their `.npmrc` file, while users with NPM >= 9 will not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
