### PR TITLE
Appsync codes3location artifact support

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -332,6 +332,14 @@ class GraphQLSchemaResource(Resource):
     PACKAGE_NULL_PROPERTY = False
 
 
+class AppSyncResolverCodeResource(Resource):
+    RESOURCE_TYPE = "AWS::AppSync::Resolver"
+    PROPERTY_NAME = "CodeS3Location"
+    # Don't package the directory if CodeS3Location is omitted.
+    # Necessary to support Code
+    PACKAGE_NULL_PROPERTY = False
+
+
 class AppSyncResolverRequestTemplateResource(Resource):
     RESOURCE_TYPE = "AWS::AppSync::Resolver"
     PROPERTY_NAME = "RequestMappingTemplateS3Location"
@@ -345,6 +353,14 @@ class AppSyncResolverResponseTemplateResource(Resource):
     PROPERTY_NAME = "ResponseMappingTemplateS3Location"
     # Don't package the directory if ResponseMappingTemplateS3Location is omitted.
     # Necessary to support ResponseMappingTemplate
+    PACKAGE_NULL_PROPERTY = False
+
+
+class AppSyncFunctionConfigurationCodeResource(Resource):
+    RESOURCE_TYPE = "AWS::AppSync::FunctionConfiguration"
+    PROPERTY_NAME = "CodeS3Location"
+    # Don't package the directory if CodeS3Location is omitted.
+    # Necessary to support Code
     PACKAGE_NULL_PROPERTY = False
 
 

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -18,8 +18,9 @@ This command can upload local artifacts referenced in the following places:
     - ``ContentUri`` property for the ``AWS::Serverless::LayerVersion`` resource
     - ``Location`` property for the ``AWS::Serverless::Application`` resource
     - ``DefinitionS3Location`` property for the ``AWS::AppSync::GraphQLSchema`` resource
+    - ``CodeS3Location`` property for the ``AWS::AppSync::Resolver`` resource
     - ``RequestMappingTemplateS3Location`` property for the ``AWS::AppSync::Resolver`` resource
-    - ``ResponseMappingTemplateS3Location`` property for the ``AWS::AppSync::Resolver`` resource
+    - ``CodeS3Location`` property for the ``AWS::AppSync::FunctionConfiguration`` resource
     - ``RequestMappingTemplateS3Location`` property for the ``AWS::AppSync::FunctionConfiguration`` resource
     - ``ResponseMappingTemplateS3Location`` property for the ``AWS::AppSync::FunctionConfiguration`` resource
     - ``DefinitionUri`` property for the ``AWS::Serverless::Api`` resource

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -20,6 +20,7 @@ This command can upload local artifacts referenced in the following places:
     - ``DefinitionS3Location`` property for the ``AWS::AppSync::GraphQLSchema`` resource
     - ``CodeS3Location`` property for the ``AWS::AppSync::Resolver`` resource
     - ``RequestMappingTemplateS3Location`` property for the ``AWS::AppSync::Resolver`` resource
+    - ``ResponseMappingTemplateS3Location`` property for the ``AWS::AppSync::Resolver`` resource
     - ``CodeS3Location`` property for the ``AWS::AppSync::FunctionConfiguration`` resource
     - ``RequestMappingTemplateS3Location`` property for the ``AWS::AppSync::FunctionConfiguration`` resource
     - ``ResponseMappingTemplateS3Location`` property for the ``AWS::AppSync::FunctionConfiguration`` resource

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -88,12 +88,22 @@ RESOURCE_EXPORT_TEST_CASES = [
     },
 
     {
+        "class": AppSyncResolverCodeTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
+
+    {
         "class": AppSyncResolverRequestTemplateResource,
         "expected_result": UPLOADED_S3_URL
     },
 
     {
         "class": AppSyncResolverResponseTemplateResource,
+        "expected_result": UPLOADED_S3_URL
+    },
+
+    {
+        "class": AppSyncFunctionConfigurationCodeTemplateResource,
         "expected_result": UPLOADED_S3_URL
     },
 


### PR DESCRIPTION
 Fix for #7469

Update the cloudformation package artifact generation to include the `CodeS3Location` propertices on `AWS::AppSync::Resolver` and `AWS::AppSync::FunctionConfiguration` objects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
