### PR TITLE
Added deprecation notice for debugging tool in help text

### DIFF
--- a/awscli/customizations/emr/helptext.py
+++ b/awscli/customizations/emr/helptext.py
@@ -283,7 +283,8 @@ DEBUGGING = (
     ' which allows you to browse log files using the Amazon EMR console.'
     ' Turning debugging on requires that you specify <code>--log-uri</code>'
     ' because log files must be stored in Amazon S3 so that'
-    ' Amazon EMR can index them for viewing in the console.</p>')
+    ' Amazon EMR can index them for viewing in the console.'
+    ' Effective January 23, 2023, Amazon EMR will discontinue the debugging tool for all versions.</p>')
 
 TAGS = (
     '<p>A list of tags to associate with a cluster, which apply to'


### PR DESCRIPTION
Added 1/23/23 deprecation notice for debugging tool in help create-cluster help text.

*Issue #, if available:*
Debugging tool will no longer be supported.

*Description of changes:*
Added 1/23/23 deprecation notice for debugging tool in help create-cluster help text.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
