### PR TITLE
[v2] Fix ARN parsing behavior for endpoint provider

### DIFF
--- a/.changes/next-release/bugfix-Endpointprovider-32427.json
+++ b/.changes/next-release/bugfix-Endpointprovider-32427.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Endpoint provider",
+  "description": "Updates ARN parsing ``resourceId`` delimiters"
+}

--- a/awscli/botocore/endpoint_provider.py
+++ b/awscli/botocore/endpoint_provider.py
@@ -236,8 +236,7 @@ class RuleSetStandardLibary:
         arn_dict["accountId"] = arn_dict.pop("account")
 
         resource = arn_dict.pop("resource")
-        delimiter = ":" if ":" in resource else "/"
-        arn_dict["resourceId"] = resource.split(delimiter)
+        arn_dict["resourceId"] = resource.replace(":", "/").split("/")
 
         return arn_dict
 

--- a/tests/unit/botocore/test_endpoint_provider.py
+++ b/tests/unit/botocore/test_endpoint_provider.py
@@ -217,6 +217,47 @@ def test_invalid_arn_returns_none(rule_lib):
     assert rule_lib.aws_parse_arn("arn:aws:this-is-not-an-arn:foo") is None
 
 
+@pytest.mark.parametrize(
+    "arn, expected_resource_id",
+    [
+        (
+            "arn:aws:s3:::myBucket/key",
+            {
+                "partition": "aws",
+                "service": "s3",
+                "region": "",
+                "accountId": "",
+                "resourceId": ["myBucket", "key"],
+            },
+        ),
+        (
+            "arn:aws:kinesis:us-east-1:1234567890:stream/mystream:foo",
+            {
+                "partition": "aws",
+                "service": "kinesis",
+                "region": "us-east-1",
+                "accountId": "1234567890",
+                "resourceId": ["stream", "mystream", "foo"],
+            },
+        ),
+        (
+            "arn:aws:s3:::myBucket",
+            {
+                "partition": "aws",
+                "service": "s3",
+                "region": "",
+                "accountId": "",
+                "region": "",
+                "resourceId": ["myBucket"],
+            },
+        ),
+    ],
+)
+def test_parse_arn_delimiters(rule_lib, arn, expected_resource_id):
+    parsed_arn = rule_lib.aws_parse_arn(arn)
+    assert parsed_arn == expected_resource_id
+
+
 def test_uri_encode_none_returns_none(rule_lib):
     assert rule_lib.uri_encode(None) is None
 


### PR DESCRIPTION
Specifically, the previous implementation did not handle ARNs that use both colon and slashes as delimeters. This is a port from the original implementation across the following PRs:

* https://github.com/boto/botocore/pull/2831
* https://github.com/boto/botocore/pull/2834