### PR TITLE
Fixes multiple issues with autogenerated docs

### DIFF
--- a/awscli/bcdoc/docstringparser.py
+++ b/awscli/bcdoc/docstringparser.py
@@ -12,6 +12,9 @@
 # language governing permissions and limitations under the License.
 from botocore.compat import six
 
+PRIORITY_PARENT_TAGS = ('code', 'a')
+OMIT_NESTED_TAGS = ('span', 'i', 'code', 'a')
+OMIT_SELF_TAGS = ('i', 'b')
 
 class DocStringParser(six.moves.html_parser.HTMLParser):
     """
@@ -132,7 +135,23 @@ class TagNode(StemNode):
         self.attrs = attrs
         self.tag = tag
 
+    def _has_nested_tags(self):
+        # Returns True if any children are TagNodes and False otherwise.
+        return any(isinstance(child, TagNode) for child in self.children)
+
     def write(self, doc, next_child=None):
+        prioritize_nested_tags = (
+            self.tag in OMIT_SELF_TAGS and self._has_nested_tags()
+        )
+        prioritize_parent_tag = (
+            isinstance(self.parent, TagNode)
+            and self.parent.tag in PRIORITY_PARENT_TAGS
+            and self.tag in OMIT_NESTED_TAGS
+        )
+        if prioritize_nested_tags or prioritize_parent_tag:
+            self._write_children(doc)
+            return
+
         self._write_start(doc)
         self._write_children(doc)
         self._write_end(doc, next_child)
@@ -198,6 +217,11 @@ class DataNode(Node):
 
         if self.data.isspace():
             str_data = ' '
+            if isinstance(self.parent, TagNode) and self.parent.tag == 'code':
+                # Inline markup content may not start or end with whitespace.
+                # When provided <code> Test </code>, we want to
+                # generate ``Test`` instead of `` Test ``.
+                str_data = ''
         else:
             end_space = self.data[-1].isspace()
             words = self.data.split()

--- a/awscli/bcdoc/restdoc.py
+++ b/awscli/bcdoc/restdoc.py
@@ -59,7 +59,7 @@ class ReSTDocument(object):
         """
         Removes and returns the last content written to the stack.
         """
-        return self._writes.pop()
+        return self._writes.pop() if len(self._writes) > 0 else None
 
     def push_write(self, s):
         """

--- a/awscli/bcdoc/style.py
+++ b/awscli/bcdoc/style.py
@@ -64,6 +64,16 @@ class BaseStyle(object):
     def italics(self, s):
         return s
 
+    def add_trailing_space_to_previous_write(self):
+        # Adds a trailing space if none exists. This is mainly used for
+        # ensuring inline code and links are separated from surrounding text.
+        last_write = self.doc.pop_write()
+        if last_write is None:
+            last_write = ''
+        if last_write != '' and last_write[-1] != ' ':
+            last_write += ' '
+        self.doc.push_write(last_write)
+
 
 class ReSTStyle(BaseStyle):
 
@@ -163,6 +173,7 @@ class ReSTStyle(BaseStyle):
 
     def start_code(self, attrs=None):
         self.doc.do_translation = True
+        self.add_trailing_space_to_previous_write()
         self._start_inline('``')
 
     def end_code(self):
@@ -206,10 +217,15 @@ class ReSTStyle(BaseStyle):
         self.new_paragraph()
 
     def start_a(self, attrs=None):
+        # Write an empty space to guard against zero whitespace
+        # before an "a" tag. Example: hi<a>Example</a>
+        self.add_trailing_space_to_previous_write()
         if attrs:
             for attr_key, attr_value in attrs:
                 if attr_key == 'href':
-                    self.a_href = attr_value
+                    # Removes unnecessary whitespace around the href link.
+                    # Example: <a href=" http://example.com ">Example</a>
+                    self.a_href = attr_value.strip()
                     self.doc.write('`')
         else:
             # There are some model documentation that
@@ -230,9 +246,23 @@ class ReSTStyle(BaseStyle):
         else:
             self.doc.write(text)
 
+    def _clean_link_text(self):
+        doc = self.doc
+        # Pop till we reach the link start character to retrieve link text.
+        last_write = doc.pop_write()
+        while not last_write.startswith('`'):
+            last_write = doc.pop_write() + last_write
+        doc.push_write('`')
+
+        # Remove whitespace from the start of link text.
+        last_write = last_write[1:].lstrip(' ')
+        if last_write != '':
+            doc.push_write(last_write)
+
     def end_a(self, next_child=None):
         self.doc.do_translation = False
         if self.a_href:
+            self._clean_link_text()
             last_write = self.doc.pop_write()
             last_write = last_write.rstrip(' ')
             if last_write and last_write != '`':

--- a/awscli/bcdoc/style.py
+++ b/awscli/bcdoc/style.py
@@ -14,7 +14,8 @@
 import logging
 
 logger = logging.getLogger('bcdocs')
-
+# Terminal punctuation where a space is not needed before.
+PUNCTUATION_CHARACTERS = ('.', ',', '?', '!', ':', ';')
 
 class BaseStyle(object):
 
@@ -229,7 +230,7 @@ class ReSTStyle(BaseStyle):
         else:
             self.doc.write(text)
 
-    def end_a(self):
+    def end_a(self, next_child=None):
         self.doc.do_translation = False
         if self.a_href:
             last_write = self.doc.pop_write()
@@ -251,7 +252,15 @@ class ReSTStyle(BaseStyle):
                 self.doc.hrefs[self.a_href] = self.a_href
                 self.doc.write('`__')
             self.a_href = None
-        self.doc.write(' ')
+
+        if (
+            next_child is None
+            or next_child.data[0] not in PUNCTUATION_CHARACTERS
+        ):
+            # We only want to add a trailing space if the link is
+            # not followed by a period, comma, or other gramatically
+            # correct special character.
+            self.doc.write(' ')
 
     def start_i(self, attrs=None):
         self.doc.do_translation = True

--- a/tests/unit/bcdoc/test_docstringparser.py
+++ b/tests/unit/bcdoc/test_docstringparser.py
@@ -71,6 +71,42 @@ class TestDocStringParser(unittest.TestCase):
             result, [b'This is a test `Link <https://testing.com>`__.']
         )
 
+    def test_code_with_empty_link(self):
+        html = "<code> <a>Link</a> </code>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [b'``Link`` '])
+
+    def test_code_with_link_spaces(self):
+        html = "<code> <a href=\"https://testing.com\">Link</a> </code>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [b'``Link`` '])
+
+    def test_code_with_link_no_spaces(self):
+        html = "<code><a href=\"https://testing.com\">Link</a></code>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(result, [b'``Link`` '])
+
+    def test_href_with_spaces(self):
+        html = "<p><a href=\" https://testing.com\">Link</a></p>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b' `Link <https://testing.com>`__ ']
+        )
+
+    def test_bold_with_nested_formatting(self):
+        html = "<b><code>Test</code>test<a href=\" https://testing.com\">Link</a></b>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'``Test`` test `Link <https://testing.com>`__ ']
+        )
+
+    def test_link_with_nested_formatting(self):
+        html = "<a href=\"https://testing.com\"><code>Test</code></a>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'`Test <https://testing.com>`__ ']
+        )
+
 
 class TestHTMLTree(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/bcdoc/test_docstringparser.py
+++ b/tests/unit/bcdoc/test_docstringparser.py
@@ -57,6 +57,20 @@ class TestDocStringParser(unittest.TestCase):
             b'  * Horld'
         ])
 
+    def test_link_with_no_period(self):
+        html = "<p>This is a test <a href='https://testing.com'>Link</a></p>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'This is a test `Link <https://testing.com>`__ ']
+        )
+
+    def test_link_with_period(self):
+        html = "<p>This is a test <a href='https://testing.com'>Link</a>.</p>"
+        result = self.parse(html)
+        self.assert_contains_exact_lines_in_order(
+            result, [b'This is a test `Link <https://testing.com>`__.']
+        )
+
 
 class TestHTMLTree(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Problem
1. Extra Whitespace: When auto-generating awscli documentation, an additional whitespace is hardcoded after every hyperlink is created. This may have been done under the assumption that a hyperlink would always be followed by a word but fails to consider cases where a space wouldn't be needed such as before the following characters `['.', ',', '?', '!', ':', ';']`.
    * [Example 1](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-traffic-mirror-target.html#:~:text=CreateTrafficMirrorSession%20.)
    * [Example 2](https://docs.aws.amazon.com/cli/latest/reference/kms/generate-random.html#:~:text=Management%20Service%20Cryptographic-,Details%20.,-Cross%2Daccount%20use)

2. Formatting Issues: Missing or necessary white space causes links to render incorrectly (explained [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#external-links:~:text=in%20ordinary%20text.-,Important,-There%20must%20be)).  Nested formatting not being supported by Sphinx and causes a combination such as making an italicized link to render incorrectly.
    * [Example 1](https://docs.aws.amazon.com/cli/latest/reference/kms/index.html#cli-aws-kms:~:text=%60%20Key%20Management%20Service%20Developer%20Guide%20https%3A//docs.aws.amazon.com/kms/latest/developerguide/%60__%20.)
    * [Example 2](https://docs.aws.amazon.com/cli/latest/reference/sqs/send-message.html#:~:text=system%20attribute%20value.%20For%20string%20data%20types%2C%20the-,Value%20attribute%20has%20the%20same%20restrictions%20on%20the%20content%20as%20the%20message%20body.%20For%20more%20information%2C%20see%20%60%60%20SendMessage%20.%60%60,-Name%20%2C%20type%20%2C%20value%20and%20the%20message)

## Solution
1. This PR addresses the first issue by providing a look-ahead (`next`) when possible, and if either of these characters is detected, a space is omitted.
2. The second issue is addressed by ignoring nested formats and choosing one to display. 

## Validation
1. Generated documentation HTML files before and after changes and validated the only changes were whitespace by running diff -rw old_cli_html remove_spaces_cli_html and returning no changes. Some cases were also manually validated.
2. Running `grep -ro '``' <CLI_DIR>/ | wc -l` before and after changes decreased from `1791 --> 33`
3. Running ``grep -ro '`__' <CLI_DIR>/ | wc -l`` before and after changes decreased from `480 --> 38`

## Notes
* Remaining detected issues come from manually written examples.
* Relevant botocore PR's [2817](https://github.com/boto/botocore/pull/2817) and [2809](https://github.com/boto/botocore/pull/2809/files).