### PR TITLE
Fix parsing of dotnet output for `aws codeartifact login` command.

### DIFF
--- a/.changes/next-release/bugfix-codeartifactlogin-92237.json
+++ b/.changes/next-release/bugfix-codeartifactlogin-92237.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``codeartifact login``",
+  "description": "Fix parsing of dotnet output for aws codeartifact login command; fixes `#6197 <https://github.com/aws/aws-cli/issues/6197>`__"
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -116,6 +116,9 @@ class NuGetBaseLogin(BaseLogin):
     # source in whichever NuGet.Config file the source was found.
     _SOURCE_ADDED_MESSAGE = 'Added source %s to the user level NuGet.Config\n'
     _SOURCE_UPDATED_MESSAGE = 'Updated source %s in the NuGet.Config\n'
+    # Example line the below regex should match:
+    # 1.  nuget.org [Enabled]
+    _SOURCE_REGEX = re.compile(r'^\d+\.\s+(?P<source_name>.*)\s+\[.*\]')
 
     def login(self, dry_run=False):
         try:
@@ -162,58 +165,42 @@ class NuGetBaseLogin(BaseLogin):
         self._write_success_message('nuget')
 
     def _get_source_to_url_dict(self):
-        # The response from listing sources takes the following form:
-        #
-        # Registered Sources:
-        #   1.  Source Name 1 [Enabled]
-        #       https://source1.com/index.json
-        #   2.  Source Name 2 [Disabled]
-        #       https://source2.com/index.json
-        # ...
-        #   100. Source Name 100
-        #       https://source100.com/index.json
+        """
+        Parses the output of the nuget sources list command.
 
-       # Or it can be (blank line after Registered Sources:)
+        A dict is created where the keys are the source names
+        and the values the corresponding URL.
 
-       # Registered Sources:
+        The output of the command can contain header and footer information
+        around the 'Registered Sources' section, which is ignored.
 
-       #   1.  Source Name 1 [Enabled]
-       #       https://source1.com/index.json
-       #   2.  Source Name 2 [Disabled]
-       #       https://source2.com/index.json
-       # ...
-       #   100. Source Name 100
-       #       https://source100.com/index.json
+        Example output that is parsed:
 
+        Registered Sources:
+
+        1. Source Name 1 [Enabled]
+           https://source1.com/index.json
+        2. Source Name 2 [Disabled]
+           https://source2.com/index.json
+        100. Source Name 100 [Activé]
+             https://source100.com/index.json
+        """
         response = self.subprocess_utils.check_output(
             self._get_list_command(),
             stderr=self.subprocess_utils.PIPE
         )
 
-        lines = response.decode("utf-8").splitlines()
+        lines = response.decode(os.device_encoding(1) or "utf-8").splitlines()
         lines = [line for line in lines if line.strip() != '']
 
         source_to_url_dict = {}
-        for i in range(1, len(lines), 2):
-            source_to_url_dict[self._parse_source_name(lines[i])] = \
-                self._parse_source_url(lines[i + 1])
+        for i in range(len(lines)):
+            result = self._SOURCE_REGEX.match(lines[i].strip())
+            if result:
+                source_to_url_dict[result["source_name"]] = \
+                    lines[i + 1].strip()
 
         return source_to_url_dict
-
-    def _parse_source_name(self, line):
-        # A source name line takes the following form:
-        #   1.  NuGet Source [Enabled]
-
-        # Remove the Enabled/Disabled tag.
-        line_without_tag = line.strip().rsplit(' [', 1)[0]
-
-        # Remove the leading number.
-        return line_without_tag.split(None, 1)[1]
-
-    def _parse_source_url(self, line):
-        # A source url line takes the following form:
-        #       https://source.com/index.json
-        return line.strip()
 
     def _get_source_name(self, codeartifact_url, source_dict):
         default_name = '{}/{}'.format(self.domain, self.repository)


### PR DESCRIPTION
*Issue #, if available:*

Fixes #6197.

*Description of changes:*

The login command for dotnet is unable to parse the output from the command `dotnet nuget list source --format detailed`, resulting in an index out of range error. This is because with dotnet tool version 6.0.402, a warning message was added in the end of the output.

Additionally, if `DOTNET_NOLOGO=true` is set, a header message at the start of `welcome to dotnet 1.0!` is added, which breaks the parsing.

Finally, responses from the `dotnet nuget list` command do not always come in utf-8 format.

This PR addresses these issues to make parsing independent of any lines other than those that appear in the Registered Sources section from the command output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
