### PR TITLE
Retain LastModified timetsamp accuracy while setting access and modified times of written files.

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -747,9 +747,7 @@ class ProvideLastModifiedTimeSubscriber(OnDoneFilteredSubscriber):
     def _on_success(self, future, **kwargs):
         filename = future.meta.call_args.fileobj
         try:
-            last_update_tuple = self._last_modified_time.timetuple()
-            mod_timestamp = time.mktime(last_update_tuple)
-            set_file_utime(filename, int(mod_timestamp))
+            set_file_utime(filename, self._last_modified_time.timestamp())
         except Exception as e:
             warning_message = (
                 'Successfully Downloaded %s but was unable to update the '


### PR DESCRIPTION
`s3 sync --exact-timestamps` does not work when the LastModified response includes subsecond precision.
Milli/microseconds are returned by some implementations, eg Ceph Object Gateway.

The current code uses `datetime.timetuple()` to convert the datetime object to a `time.struct_time`, and loses any sub-second precision.  Instead `datetime.timestamp()` can be used, where the float result can be passed as-is, without any need for useless conversions using `time.mktime()`. 

#5369
#5730

For AWS customers this is a no-op change, plus it would future-proof aws-cli should AWS ever introduce subsecond precisions.

Thanks

```
MainThread - botocore.parsers - DEBUG - Response body:
b'<?xml version="1.0" encoding="UTF-8"?><ListBucketResult>... 
<LastModified>2021-10-20T03:43:55.144Z</LastModified>...

stat output of file written to disk:
Access: 2021-10-20 03:43:55.000000000 +0000
Modify: 2021-10-20 03:43:55.000000000 +0000
Change: 2023-01-13 09:25:21.663876917 +0000

subsequent calls of s3 sync --exact-timestamps result in file always 
being re-downloaded because last modified time =! on-disk time.

MainThread - awscli.customizations.s3.syncstrategy.base - DEBUG - syncing: ... 
modified time: 2021-10-20 03:43:55.144000+00:00 -> 2021-10-20 03:43:55+00:00

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
