### PR TITLE
Pin version of alabaster

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,3 +6,11 @@ jinja2<3.1
 docutils>=0.10,<0.17
 Sphinx==1.3.2
 -e .
+# alabaster version 0.7.13 requires Sphinx>1.6
+alabaster>0.7,<0.7.13
+# Required by Sphinx==1.3.2. (TODO: remove these when upgrading sphinx)
+babel<=2.11.0 # via sphinx
+pygments<=2.14.0 # via sphinx
+pytz<=2022.7 # via babel
+snowballstemmer<=2.2.0 # via sphinx
+sphinx-rtd-theme<=0.5.2 # via sphinx


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Recent version of alabaster (0.7.13) requires sphinx>=1.6. This also pins dependencies of sphinx until we upgrade.

Related PRs for boto/botocore#2849 and boto/boto3#3557.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
