### PR TITLE
Fix sso-session to include source_profile

### DIFF
--- a/.changes/next-release/bugfix-SSO-16681.json
+++ b/.changes/next-release/bugfix-SSO-16681.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "SSO",
+  "description": "Fixes `#7496 <https://github.com/aws/aws-cli/issues/7496>`__ by including source_profile when looking for the SSO session name."
+}

--- a/awscli/botocore/tokens.py
+++ b/awscli/botocore/tokens.py
@@ -205,10 +205,13 @@ class SSOTokenProvider:
             profile_name = "default"
         profile_config = profiles.get(profile_name, {})
 
-        if "sso_session" not in profile_config:
+        sso_session = profile_config.get('sso_session', None)
+        sso_source_profile = profile_config.get('source_profile', None)
+        sso_source_session = profiles.get(
+            sso_source_profile, {}).get('sso_session', None)
+        sso_session_name = sso_session or sso_source_session
+        if not sso_session_name:
             return
-
-        sso_session_name = profile_config["sso_session"]
         sso_config = sso_sessions.get(sso_session_name, None)
 
         if not sso_config:

--- a/tests/unit/botocore/test_tokens.py
+++ b/tests/unit/botocore/test_tokens.py
@@ -33,9 +33,25 @@ def parametrize(cases):
 
 sso_provider_resolution_cases = [
     {
-        "documentation": "Full valid profile",
+        "documentation": "Full valid profile via sso_session",
         "config": {
             "profiles": {"test": {"sso_session": "admin"}},
+            "sso_sessions": {
+                "admin": {
+                    "sso_region": "us-east-1",
+                    "sso_start_url": "https://d-abc123.awsapps.com/start",
+                }
+            },
+        },
+        "resolves": True,
+    },
+    {
+        "documentation": "Full valid profile via source_profile",
+        "config": {
+            "profiles": {
+                "test": {"source_profile": "test2"},
+                "test2": {"sso_session": "admin"},
+            },
             "sso_sessions": {
                 "admin": {
                     "sso_region": "us-east-1",
@@ -82,9 +98,25 @@ sso_provider_resolution_cases = [
         "expectedException": InvalidConfigError,
     },
     {
-        "documentation": "The sso_session must be specified",
+        "documentation": "sso_session or source_profile must be specified",
         "config": {
             "profiles": {"test": {"region": "us-west-2"}},
+            "sso_sessions": {
+                "admin": {
+                    "sso_region": "us-east-1",
+                    "sso_start_url": "https://d-abc123.awsapps.com/start",
+                }
+            },
+        },
+        "resolves": False,
+    },
+    {
+        "documentation": "source_profile must specify sso_session",
+        "config": {
+            "profiles": {
+                "test": {"source_profile": "test2"},
+                "test2": {},
+            },
             "sso_sessions": {
                 "admin": {
                     "sso_region": "us-east-1",


### PR DESCRIPTION
A profile's sso-session can be referenced either directly by specifying `sso_session` or indirectly by specifying `source_profile` that specifies `sso_session`. The current implementation only looks for `sso_session` and returns `None` if not found in the profile.
This commit aligns the implementation with the intended behavior by also looking for `sso_session` via a specified `source_profile`.

Example of a valid config that is currently failing to resolve:
```
[profile test]
role_arn = arn:aws:iam:XXXXXXXXXXXX:role/testrole-1
source_profile = AdministratorAccess-XXXXXXXXXXXX
region = us-west-2

[profile AdministratorAccess-XXXXXXXXXXXX]
sso_session = dev
sso_account_id = XXXXXXXXXXXX
sso_role_name = AdministratorAccess
region = us-west-2
output = json

[sso-session dev]
sso_start_url = https://d-XXXXXXXXX.awsapps.com/start
sso_region = us-west-2
sso_registration_scopes = sso:account:access
```