### PR TITLE
Add --server-sdk-version parameter to upload-build

### DIFF
--- a/.changes/next-release/enhancement-gameliftuploadbuild-67304.json
+++ b/.changes/next-release/enhancement-gameliftuploadbuild-67304.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``gamelift upload-build``",
+  "description": "Add ``--server-sdk-version`` parameter to the ``upload-build`` command"
+}

--- a/awscli/customizations/gamelift/uploadbuild.py
+++ b/awscli/customizations/gamelift/uploadbuild.py
@@ -34,6 +34,10 @@ class UploadBuildCommand(BasicCommand):
         {'name': 'build-root', 'required': True,
          'help_text':
          'The path to the directory containing the build to upload'},
+        {'name': 'server-sdk-version', 'required': False,
+         'help_text':
+             'The version of the GameLift server SDK used to '
+             'create the game server'},
         {'name': 'operating-system', 'required': False,
          'help_text': 'The operating system the build runs on'}
     ]
@@ -60,7 +64,8 @@ class UploadBuildCommand(BasicCommand):
         }
         if args.operating_system:
             create_build_kwargs['OperatingSystem'] = args.operating_system
-
+        if args.server_sdk_version:
+            create_build_kwargs['ServerSdkVersion'] = args.server_sdk_version
         response = gamelift_client.create_build(**create_build_kwargs)
         build_id = response['Build']['BuildId']
 

--- a/awscli/examples/gamelift/upload-build.rst
+++ b/awscli/examples/gamelift/upload-build.rst
@@ -7,6 +7,7 @@ The following ``upload-build`` example uploads Linux game server build files fro
         --build-version 2.0.1 \
         --build-root ~/MegaFrogRace_Server/release-na \
         --operating-system AMAZON_LINUX_2
+        --server-sdk-version 4.0.2
 
 Output::
 
@@ -27,6 +28,7 @@ The following ``upload-build`` example uploads Windows game server build files f
         --build-version 2.0.1 \
         --build-root C:\MegaFrogRace_Server\release-na \
         --operating-system WINDOWS_2012
+        --server-sdk-version 4.0.2
 
 Output::
 

--- a/tests/functional/gamelift/test_upload_build.py
+++ b/tests/functional/gamelift/test_upload_build.py
@@ -198,3 +198,52 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
             'The build root directory is empty or does not exist.\n'
             % '""',
             stderr)
+
+    def test_upload_build_with_server_sdk_version_param(self):
+        self.files.create_file('tmpfile', 'Some contents')
+        cmdline = self.prefix
+        cmdline += ' --name mybuild --build-version myversion'
+        cmdline += ' --build-root %s' % self.files.rootdir
+        cmdline += ' --server-sdk-version 4.0.2'
+
+        self.parsed_responses = [
+            {'Build': {'BuildId': 'myid'}},
+            {'StorageLocation': {
+                'Bucket': 'mybucket',
+                'Key': 'mykey'},
+                'UploadCredentials': {
+                    'AccessKeyId': 'myaccesskey',
+                    'SecretAccessKey': 'mysecretkey',
+                    'SessionToken': 'mytoken'}},
+            {}
+        ]
+
+        stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
+
+        # First the build is created.
+        self.assertEqual(len(self.operations_called), 3)
+        self.assertEqual(self.operations_called[0][0].name, 'CreateBuild')
+        self.assertEqual(
+            self.operations_called[0][1],
+            {'Name': 'mybuild', 'Version': 'myversion',
+             'ServerSdkVersion': '4.0.2'}
+        )
+
+        # Second the credentials are requested.
+        self.assertEqual(
+            self.operations_called[1][0].name, 'RequestUploadCredentials')
+        self.assertEqual(
+            self.operations_called[1][1], {'BuildId': 'myid'})
+
+        # The build is then uploaded to S3.
+        self.assertEqual(self.operations_called[2][0].name, 'PutObject')
+        self.assertEqual(
+            self.operations_called[2][1],
+            {'Body': mock.ANY, 'Bucket': 'mybucket', 'Key': 'mykey'}
+        )
+
+        # Check the output of the command.
+        self.assertIn(
+            'Successfully uploaded %s to AWS GameLift' % self.files.rootdir,
+            stdout)
+        self.assertIn('Build ID: myid', stdout)

--- a/tests/unit/customizations/gamelift/test_uploadbuild.py
+++ b/tests/unit/customizations/gamelift/test_uploadbuild.py
@@ -194,6 +194,21 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             # Make sure the temporary file is removed.
             self.assertFalse(os.path.exists(tempfile_path))
 
+    def test_upload_build_when_server_sdk_version_is_provided(self):
+        server_sdk_version = '4.0.2'
+        self.file_creator.create_file('tmpfile', 'Some contents')
+        self.args = [
+            '--name', self.build_name, '--build-version', self.build_version,
+            '--build-root', self.build_root,
+            '--server-sdk-version', server_sdk_version
+        ]
+        self.cmd(self.args, self.global_args)
+
+        # Ensure the GameLift client was called correctly.
+        self.gamelift_client.create_build.assert_called_once_with(
+            Name=self.build_name, Version=self.build_version,
+            ServerSdkVersion=server_sdk_version)
+
 
 class TestZipDirectory(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add the `--server-sdk-version` parameter to the `gamelift upload-build` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
