### PR TITLE
Fix eks get-token --query --output

### DIFF
--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta
 from botocore.signers import RequestSigner
 from botocore.model import ServiceId
 
+from awscli.formatter import get_formatter
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import uni_print
 from awscli.customizations.utils import validate_mutually_exclusive
@@ -141,10 +142,12 @@ class GetTokenCommand(BasicCommand):
                 "token": token,
             },
         }
-        if parsed_globals.query is not None:
-            uni_print(parsed_globals.query.search(full_object))
-        else:
-            uni_print(json.dumps(full_object))
+
+        output = self._session.get_config_variable('output')
+        formatter = get_formatter(output, parsed_globals)
+        formatter.query = parsed_globals.query
+
+        formatter(self.NAME, full_object)
         uni_print('\n')
         return 0
 

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -141,8 +141,10 @@ class GetTokenCommand(BasicCommand):
                 "token": token,
             },
         }
-
-        uni_print(json.dumps(full_object))
+        if parsed_globals.query is not None:
+            uni_print(parsed_globals.query.search(full_object))
+        else:
+            uni_print(json.dumps(full_object))
         uni_print('\n')
         return 0
 

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -95,6 +95,28 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             },
         )
 
+    @mock.patch('awscli.customizations.eks.get_token.datetime')
+    def test_query_nested_object(self, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --query status'
+        response = self.run_get_token(cmd)
+        self.assertEqual(
+            response,
+            {
+                "expirationTimestamp": "2019-10-23T23:14:00Z",
+                "token": mock.ANY,  # This is asserted in later cases
+            },
+        )
+
+    def test_query_value(self):
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --query apiVersion'
+        response = self.run_get_token(cmd)
+        self.assertEqual(
+            response, "client.authentication.k8s.io/v1beta1",
+        )
+
     def test_url(self):
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         response = self.run_get_token(cmd)

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -117,6 +117,26 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             response, "client.authentication.k8s.io/v1beta1",
         )
 
+    @mock.patch('awscli.customizations.eks.get_token.datetime')
+    def test_output_text(self, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --output text'
+        stdout, _, _ = self.run_cmd(cmd)
+        self.assertIn("ExecCredential", stdout)
+        self.assertIn("client.authentication.k8s.io/v1beta1", stdout)
+        self.assertIn("2019-10-23T23:14:00Z", stdout)
+
+    @mock.patch('awscli.customizations.eks.get_token.datetime')
+    def test_output_table(self, mock_datetime):
+        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd += ' --output table'
+        stdout, _, _ = self.run_cmd(cmd)
+        self.assertIn("ExecCredential", stdout)
+        self.assertIn("client.authentication.k8s.io/v1beta1", stdout)
+        self.assertIn("2019-10-23T23:14:00Z", stdout)
+
     def test_url(self):
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         response = self.run_get_token(cmd)


### PR DESCRIPTION
*Issue #, if available:*
Fixes #4490

*Description of changes:*
* Use parsed global JMESPath expression to filter response object (--query)
* Use Formatter to change output format (--output)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
