### PR TITLE
Include changelog for OpenSSL upgrade

### DIFF
--- a/.changes/next-release/enhancement-openssl-31169.json
+++ b/.changes/next-release/enhancement-openssl-31169.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "openssl",
+  "description": "The bundled OpenSSL versions for the Linux installers have been upgraded from 1.0.2 to 1.1.1"
+}


### PR DESCRIPTION
This commit adds a changelog for upgrading OpenSSL from 1.0.2 to 1.1.1 in the CLI v2 Linux installers.