### PR TITLE
fix unicode escaped JSON log

### DIFF
--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -95,7 +95,7 @@ class PrettyJSONLogEventsFormatter(BaseLogEventsFormatter):
     def _format_pretty_json(self, log_message):
         try:
             loaded_json = json.loads(log_message)
-            return '\n%s' % json.dumps(loaded_json, indent=4)
+            return '\n%s' % json.dumps(loaded_json, indent=4, ensure_ascii=False)
         except json.decoder.JSONDecodeError:
             pass
         return log_message


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

#### Current state:

```aws logs tail``` CLI command with ```--format json``` for tailing the JSON log events containing Japanese characters results in characters encoded in unicode rather than actual characters.

```
$ aws logs tail test --format json
2023-01-29T17:49:40.180000+00:00 test 
{
    "key": "\u3053\u3093\u306b\u3061\u306f\u4e16\u754c"
}
```

#### Proposed improvements:

Display log messages without escaping.

```
$ aws logs tail test --format json
2023-01-29T17:49:40.180000+00:00 test 
{
    "key": "こんにちは世界"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.