### PR TITLE
Add a pip install command to the error ouput with unmet dependencies

### DIFF
--- a/backends/build_system/utils.py
+++ b/backends/build_system/utils.py
@@ -27,10 +27,10 @@ PACKAGE_NAME = re.compile(r"(?P<name>[A-Za-z][A-Za-z0-9_\.\-]+)(?P<rest>.+)")
 CONSTRAINT = re.compile(r"(?P<comparison>[=\<\>]+)(?P<version>.+)")
 COMPARISONS: Dict[str, Callable[[List[int], List[int]], bool]] = {
     '==': lambda a, b: a == b,
-    '>':  lambda a, b: a > b,
-    '>=':  lambda a, b: a >= b,
-    '<':  lambda a, b: a < b,
-    '<=':  lambda a, b: a <= b,
+    '>': lambda a, b: a > b,
+    '>=': lambda a, b: a >= b,
+    '<': lambda a, b: a < b,
+    '<=': lambda a, b: a <= b,
 }
 
 
@@ -84,6 +84,9 @@ class Requirement:
         if other is None:
             return False
         return (self.name == other.name and self.constraints == other.constraints)
+
+    def string_constraints(self):
+        return ','.join(self.constraints)
 
 
 class ParseError(Exception):

--- a/configure
+++ b/configure
@@ -2066,7 +2066,7 @@ else $as_nop
 fi
 
 if test "$with_download_deps" = no; then
-     ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || as_fn_error $? "\"Python dependencies not met. Consider using the --with-download-deps flag.\"" "$LINENO" 5
+     ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || as_fn_error $? "\"Python dependencies not met.\"" "$LINENO" 5
      DOWNLOAD_DEPS_FLAG=""
 else
      DOWNLOAD_DEPS_FLAG=--download-deps

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_ARG_WITH(download_deps,
 [with_download_deps=no]
 )
 if test "$with_download_deps" = no; then
-     ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || AC_MSG_ERROR("Python dependencies not met. Consider using the --with-download-deps flag.")
+     ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || AC_MSG_ERROR("Python dependencies not met.")
      DOWNLOAD_DEPS_FLAG=""
 else
      DOWNLOAD_DEPS_FLAG=--download-deps

--- a/tests/backends/build_system/unit/test_validate_env.py
+++ b/tests/backends/build_system/unit/test_validate_env.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+
+from backends.build_system.validate_env import UnmetDependenciesException
+from backends.build_system.utils import Requirement
+
+
+
+@pytest.fixture
+def unmet_error(request):
+    error = UnmetDependenciesException([
+        ('colorama', '1.0', Requirement('colorama', '>=2.0', '<3.0')),
+    ], in_venv=request.param)
+    return str(error)
+
+
+
+class TestUnmetDependencies:
+    @pytest.mark.parametrize('unmet_error', [False], indirect=True)
+    def test_in_error_message(self, unmet_error):
+        assert (
+            "colorama (required: ('>=2.0', '<3.0')) (version installed: 1.0)"
+        ) in unmet_error
+        assert (
+            f"{sys.executable} -m pip install 'colorama>=2.0,<3.0'"
+        ) in unmet_error
+
+    @pytest.mark.parametrize('unmet_error', [False], indirect=True)
+    def test_not_in_venv(self, unmet_error):
+        assert 'We noticed you are not in a virtualenv.' in unmet_error
+
+    @pytest.mark.parametrize('unmet_error', [True], indirect=True)
+    def test_in_venv(self, unmet_error):
+        assert 'We noticed you are not in a virtualenv.' not in unmet_error


### PR DESCRIPTION
This makes it easier to install all of the dependencies if you do not want to --use-download-deps.

```
$ ./configure
checking for a Python interpreter with version >= 3.8... python
checking for python... /Users/jcarlyl/.envs/env3.9.3/bin/python
checking for python version... 3.9
checking for python platform... darwin
checking for GNU default python prefix... ${prefix}
checking for GNU default python exec_prefix... ${exec_prefix}
checking for python script directory (pythondir)... ${PYTHON_PREFIX}/lib/python3.9/site-packages
checking for python extension module directory (pyexecdir)... ${PYTHON_EXEC_PREFIX}/lib/python3.9/site-packages
checking for --with-install-type... system-sandbox
checking for --with-download-deps... Traceback (most recent call last):
...
validate_env.UnmetDependenciesException: Environment requires following Python dependencies:

flit_core (required: ('>=3.7.1', '<3.7.2')) (version installed: 3.8.0)
colorama (required: ('>=0.2.5', '<0.4.4')) (version installed: None)

Run the following pip command to install manually:
/Users/jcarlyl/.envs/env3.9.3/bin/python -m pip install "flit_core>=3.7.1,<3.7.2" "colorama>=0.2.5,<0.4.4"

configure: error: "Python dependencies not met. Consider using the --with-download-deps flag."


$ /Users/jcarlyl/.envs/env3.9.3/bin/python -m pip install "flit_core>=3.7.1,<3.7.2" "colorama>=0.2.5,<0.4.4"
Collecting flit_core<3.7.2,>=3.7.1
  Using cached flit_core-3.7.1-py3-none-any.whl (60 kB)
Collecting colorama<0.4.4,>=0.2.5
  Using cached colorama-0.4.3-py2.py3-none-any.whl (15 kB)
Installing collected packages: flit_core, colorama
  Attempting uninstall: flit_core
    Found existing installation: flit_core 3.8.0
    Uninstalling flit_core-3.8.0:
      Successfully uninstalled flit_core-3.8.0
Successfully installed colorama-0.4.3 flit_core-3.7.1
(env3.9.3) ➜  aws-cli git:(usable-pip-error) ✗ ./configure
checking for a Python interpreter with version >= 3.8... python
checking for python... /Users/jcarlyl/.envs/env3.9.3/bin/python
checking for python version... 3.9
checking for python platform... darwin
checking for GNU default python prefix... ${prefix}
checking for GNU default python exec_prefix... ${exec_prefix}
checking for python script directory (pythondir)... ${PYTHON_PREFIX}/lib/python3.9/site-packages
checking for python extension module directory (pyexecdir)... ${PYTHON_EXEC_PREFIX}/lib/python3.9/site-packages
checking for --with-install-type... system-sandbox
checking for --with-download-deps... no
configure: creating ./config.status
config.status: creating Makefile
```