### PR TITLE
docs: use with docker cli in China region

### DIFF
--- a/awscli/examples/ecr/get-login-password.rst
+++ b/awscli/examples/ecr/get-login-password.rst
@@ -15,5 +15,6 @@ To use with the Docker CLI, pipe the output of the ``get-login-password`` comman
     | docker login \
         --username AWS \
         --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com
+        # --password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com.cn for China regions
 
 For more information, see `Registry Authentication <https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries#registry_auth>`__ in the *Amazon ECR User Guide*.


### PR DESCRIPTION
*Issue #, if available:*
should be `--password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com.cn` instead of `--password-stdin <aws_account_id>.dkr.ecr.<region>.amazonaws.com`
the doc in [amazonaws.cn](https://docs.amazonaws.cn/en_us/AmazonECR/latest/userguide/getting-started-cli.html) is wrong, aws-cli's doc also not mention.

It is reasonable to mention the configuration of a specific area.

*Description of changes:*
I add a comment below the `--password-stdin...`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
