### PR TITLE
Add SES create/update CVE template URL parameters to paramfile disabled

### DIFF
--- a/.changes/next-release/bugfix-ses-17094.json
+++ b/.changes/next-release/bugfix-ses-17094.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "ses",
+  "description": "SES create and update custom verification email template operations don't send the custom redirection URL content anymore but send the URL as a string instead (as expected)"
+}

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -110,7 +110,11 @@ PARAMFILE_DISABLED = set([
     'service-catalog.create-product.support-url',
     'service-catalog.update-product.support-url',
 
+    'ses.create-custom-verification-email-template.failure-redirection-url',
+    'ses.create-custom-verification-email-template.success-redirection-url',
     'ses.put-account-details.website-url',
+    'ses.update-custom-verification-email-template.failure-redirection-url',
+    'ses.update-custom-verification-email-template.success-redirection-url',
 
     'sqs.add-permission.queue-url',
     'sqs.change-message-visibility.queue-url',

--- a/tests/functional/ses/test_create_custom_verification_email_template.py
+++ b/tests/functional/ses/test_create_custom_verification_email_template.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateCustomVerificationEmailTemplate(BaseAWSCommandParamsTest):
+    prefix = 'ses create-custom-verification-email-template'
+    template_name = 'test-template-name'
+    from_email_address = 'from@example.com'
+    template_subject = 'template-subject'
+    template_content = 'template-content'
+    success_redirection_url = 'https://aws.amazon.com/ses/verifysuccess'
+    failure_redirection_url = 'https://aws.amazon.com/ses/verifyfailure'
+
+    def test_create_custom_verification_email_template(self):
+        cmdline = self.prefix
+        cmdline += ' --template-name ' + self.template_name
+        cmdline += ' --from-email-address ' + self.from_email_address
+        cmdline += ' --template-subject ' + self.template_subject
+        cmdline += ' --template-content ' + self.template_content
+        cmdline += ' --success-redirection-url ' + self.success_redirection_url
+        cmdline += ' --failure-redirection-url ' + self.failure_redirection_url
+
+        result = {
+            'TemplateName': self.template_name,
+            'FromEmailAddress': self.from_email_address,
+            'TemplateSubject': self.template_subject,
+            'TemplateContent': self.template_content,
+            'SuccessRedirectionURL': self.success_redirection_url,
+            'FailureRedirectionURL': self.failure_redirection_url
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/ses/test_update_custom_verification_email_template.py
+++ b/tests/functional/ses/test_update_custom_verification_email_template.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestUpdateCustomVerificationEmailTemplate(BaseAWSCommandParamsTest):
+    prefix = 'ses update-custom-verification-email-template'
+    template_name = 'test-template-name'
+    from_email_address = 'from@example.com'
+    template_subject = 'template-subject'
+    template_content = 'template-content'
+    success_redirection_url = 'https://aws.amazon.com/ses/verifysuccess'
+    failure_redirection_url = 'https://aws.amazon.com/ses/verifyfailure'
+
+    def test_update_custom_verification_email_template(self):
+        cmdline = self.prefix
+        cmdline += ' --template-name ' + self.template_name
+        cmdline += ' --from-email-address ' + self.from_email_address
+        cmdline += ' --template-subject ' + self.template_subject
+        cmdline += ' --template-content ' + self.template_content
+        cmdline += ' --success-redirection-url ' + self.success_redirection_url
+        cmdline += ' --failure-redirection-url ' + self.failure_redirection_url
+
+        result = {
+            'TemplateName': self.template_name,
+            'FromEmailAddress': self.from_email_address,
+            'TemplateSubject': self.template_subject,
+            'TemplateContent': self.template_content,
+            'SuccessRedirectionURL': self.success_redirection_url,
+            'FailureRedirectionURL': self.failure_redirection_url
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/sesv2/test_create_custom_verification_email_template.py
+++ b/tests/functional/sesv2/test_create_custom_verification_email_template.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestCreateCustomVerificationEmailTemplate(BaseAWSCommandParamsTest):
+    prefix = 'sesv2 create-custom-verification-email-template'
+    template_name = 'test-template-name'
+    from_email_address = 'from@example.com'
+    template_subject = 'template-subject'
+    template_content = 'template-content'
+    success_redirection_url = 'https://aws.amazon.com/ses/verifysuccess'
+    failure_redirection_url = 'https://aws.amazon.com/ses/verifyfailure'
+
+    def test_create_custom_verification_email_template(self):
+        cmdline = self.prefix
+        cmdline += ' --template-name ' + self.template_name
+        cmdline += ' --from-email-address ' + self.from_email_address
+        cmdline += ' --template-subject ' + self.template_subject
+        cmdline += ' --template-content ' + self.template_content
+        cmdline += ' --success-redirection-url ' + self.success_redirection_url
+        cmdline += ' --failure-redirection-url ' + self.failure_redirection_url
+
+        result = {
+            'TemplateName': self.template_name,
+            'FromEmailAddress': self.from_email_address,
+            'TemplateSubject': self.template_subject,
+            'TemplateContent': self.template_content,
+            'SuccessRedirectionURL': self.success_redirection_url,
+            'FailureRedirectionURL': self.failure_redirection_url
+        }
+        self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/sesv2/test_update_custom_verification_email_template.py
+++ b/tests/functional/sesv2/test_update_custom_verification_email_template.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestUpdateCustomVerificationEmailTemplate(BaseAWSCommandParamsTest):
+    prefix = 'sesv2 update-custom-verification-email-template'
+    template_name = 'test-template-name'
+    from_email_address = 'from@example.com'
+    template_subject = 'template-subject'
+    template_content = 'template-content'
+    success_redirection_url = 'https://aws.amazon.com/ses/verifysuccess'
+    failure_redirection_url = 'https://aws.amazon.com/ses/verifyfailure'
+
+    def test_update_custom_verification_email_template(self):
+        cmdline = self.prefix
+        cmdline += ' --template-name ' + self.template_name
+        cmdline += ' --from-email-address ' + self.from_email_address
+        cmdline += ' --template-subject ' + self.template_subject
+        cmdline += ' --template-content ' + self.template_content
+        cmdline += ' --success-redirection-url ' + self.success_redirection_url
+        cmdline += ' --failure-redirection-url ' + self.failure_redirection_url
+
+        result = {
+            'TemplateName': self.template_name,
+            'FromEmailAddress': self.from_email_address,
+            'TemplateSubject': self.template_subject,
+            'TemplateContent': self.template_content,
+            'SuccessRedirectionURL': self.success_redirection_url,
+            'FailureRedirectionURL': self.failure_redirection_url
+        }
+        self.assert_params_for_cmd(cmdline, result)


### PR DESCRIPTION
*Issue #, if available:*
For these parameters, the content of the URL is fetched and sent instead of the URL string. As these are required parameters for the `create-custom-verification-email-template` operation, this makes it unusable.

*Description of changes:*
Added the following attributes to `paramfile.py` disable:
- `success-redirection-url`
- `failure-redirection-url`

For `ses` (and `sesv2`) operations:
- `create-custom-verification-email-template`
- `update-custom-verification-email-template`

Added tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
