### PR TITLE
Use kwargs to simplify adding optional flags to `eks update-kubeconfig`

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -242,7 +242,8 @@ class EKSClient(object):
         self._cluster_description = None
         self._globals = parsed_globals
 
-    def _get_cluster_description(self):
+    @property
+    def cluster_description(self):
         """
         Use an eks describe-cluster call to get the cluster description
         Cache the response in self._cluster_description.
@@ -276,10 +277,9 @@ class EKSClient(object):
         the previously obtained description.
         """
 
-        cert_data = self._get_cluster_description().get("certificateAuthority",
-                                                        {"data": ""})["data"]
-        endpoint = self._get_cluster_description().get("endpoint")
-        arn = self._get_cluster_description().get("arn")
+        cert_data = self.cluster_description.get("certificateAuthority", {}).get("data", "")
+        endpoint = self.cluster_description.get("endpoint")
+        arn = self.cluster_description.get("arn")
 
         return OrderedDict([
             ("cluster", OrderedDict([
@@ -294,9 +294,8 @@ class EKSClient(object):
         Return a user entry generated using
         the previously obtained description.
         """
-        cluster_description = self._get_cluster_description()
-        region = cluster_description.get("arn").split(":")[3]
-        outpost_config = cluster_description.get("outpostConfig")
+        region = self.cluster_description.get("arn").split(":")[3]
+        outpost_config = self.cluster_description.get("outpostConfig")
 
         if outpost_config is None:
             cluster_identification_parameter = "--cluster-name"
@@ -304,10 +303,10 @@ class EKSClient(object):
         else:
             # If cluster contains outpostConfig, use id for identification
             cluster_identification_parameter = "--cluster-id"
-            cluster_identification_value = cluster_description.get("id")
+            cluster_identification_value = self.cluster_description.get("id")
 
         generated_user = OrderedDict([
-            ("name", user_alias or self._get_cluster_description().get("arn", "")),
+            ("name", user_alias or self.cluster_description.get("arn", "")),
             ("user", OrderedDict([
                 ("exec", OrderedDict([
                     ("apiVersion", API_VERSION),

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -220,7 +220,7 @@ class TestEKSClient(unittest.TestCase):
         self._client = EKSClient(self._session, "ExampleCluster", None)
 
     def test_get_cluster_description(self):
-        self.assertEqual(self._client._get_cluster_description(),
+        self.assertEqual(self._client.cluster_description,
                          describe_cluster_response()["cluster"])
         self._mock_client.describe_cluster.assert_called_once_with(
             name="ExampleCluster"
@@ -230,8 +230,8 @@ class TestEKSClient(unittest.TestCase):
     def test_get_cluster_description_no_status(self):
         self._mock_client.describe_cluster.return_value = \
             describe_cluster_no_status_response()
-        self.assertRaises(EKSClusterError,
-                          self._client._get_cluster_description)
+        with self.assertRaises(EKSClusterError):
+            self._client.cluster_description
         self._mock_client.describe_cluster.assert_called_once_with(
             name="ExampleCluster"
         )
@@ -276,8 +276,8 @@ class TestEKSClient(unittest.TestCase):
     def test_cluster_creating(self):
         self._mock_client.describe_cluster.return_value =\
                                            describe_cluster_creating_response()
-        self.assertRaises(EKSClusterError,
-                          self._client._get_cluster_description)
+        with self.assertRaises(EKSClusterError):
+            self._client.cluster_description
         self._mock_client.describe_cluster.assert_called_once_with(
             name="ExampleCluster"
         )
@@ -286,8 +286,8 @@ class TestEKSClient(unittest.TestCase):
     def test_cluster_deleting(self):
         self._mock_client.describe_cluster.return_value =\
                                            describe_cluster_deleting_response()
-        self.assertRaises(EKSClusterError,
-                          self._client._get_cluster_description)
+        with self.assertRaises(EKSClusterError):
+            self._client.cluster_description
         self._mock_client.describe_cluster.assert_called_once_with(
             name="ExampleCluster"
         )

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -13,27 +13,27 @@
 
 import glob
 import os
-import tempfile
 import shutil
 import sys
+import tempfile
+from argparse import Namespace
+
 import botocore
 from botocore.compat import OrderedDict
 
-from awscli.testutils import mock, unittest
-from awscli.customizations.utils import uni_print
 import awscli.customizations.eks.kubeconfig as kubeconfig
-from awscli.customizations.eks.update_kubeconfig import (KubeconfigSelector,
-                                                         EKSClient,
-                                                         API_VERSION)
-from awscli.customizations.eks.exceptions import (EKSError,
-                                                  EKSClusterError)
+from awscli.customizations.eks.exceptions import EKSClusterError, EKSError
 from awscli.customizations.eks.ordered_yaml import ordered_yaml_load
-from tests.functional.eks.test_util import get_testdata
-from tests.functional.eks.test_util import (describe_cluster_response,
-                                            describe_cluster_response_outpost_cluster,
-                                            describe_cluster_no_status_response,
-                                            describe_cluster_creating_response,
-                                            describe_cluster_deleting_response)
+from awscli.customizations.eks.update_kubeconfig import (API_VERSION,
+                                                         EKSClient,
+                                                         KubeconfigSelector)
+from awscli.customizations.utils import uni_print
+from awscli.testutils import mock, unittest
+from tests.functional.eks.test_util import (
+    describe_cluster_creating_response, describe_cluster_deleting_response,
+    describe_cluster_no_status_response, describe_cluster_response,
+    describe_cluster_response_outpost_cluster, get_testdata)
+
 
 def generate_env_variable(files):
     """
@@ -217,7 +217,7 @@ class TestEKSClient(unittest.TestCase):
         self._session.create_client.return_value = self._mock_client
         self._session.profile = None
 
-        self._client = EKSClient(self._session, "ExampleCluster", None)
+        self._client = EKSClient(self._session, parsed_args=Namespace(cluster_name="ExampleCluster", role_arn=None))
 
     def test_get_cluster_description(self):
         self.assertEqual(self._client.cluster_description,


### PR DESCRIPTION
**Issue #, if available:**
No issues, general refactoring to prepare for feature requests like #7623 #7845 #7879

**Description of changes:**
Methods are at risk of getting bloated as more and more parameters are added. Use a variable number of keyword-only arguments allow additional parsed args to be passed without changing the method signature every time. 

[x] By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
