### PR TITLE
Expand tox range to Python 3.11

### DIFF
--- a/.changes/next-release/feature-Python-78138.json
+++ b/.changes/next-release/feature-Python-78138.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "Python",
+  "description": "Upgrade the embedded Python version to 3.11."
+}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39
+envlist = py38,py39,py310,py311
 
 skipsdist = True
 
@@ -10,7 +10,7 @@ commands =
 
 
 [testenv:exe]
-basepython = python3.9
+basepython = python3.11
 install_command =
     python -m pip install --no-build-isolation {opts} {packages}
 deps =
@@ -20,7 +20,7 @@ commands =
 
 
 [testenv:macpkg]
-basepython = python3.9
+basepython = python3.11
 install_command =
     python -m pip install --no-build-isolation  {opts} {packages}
 deps =
@@ -30,7 +30,7 @@ commands =
 
 
 [testenv:test-exe]
-basepython = python3.9
+basepython = python3.11
 install_command =
     python -m pip install --no-build-isolation  {opts} {packages}
 deps =
@@ -41,6 +41,6 @@ commands =
 
 
 [testenv:sign-exe]
-basepython = python3.9
+basepython = python3.11
 commands =
     {envpython} {toxinidir}/scripts/installers/sign-exe {posargs}


### PR DESCRIPTION
Add Python 3.10 and Python 3.11 to tox range and use Python 3.11 as the base version when running tox.