### PR TITLE
Use JSON only when getting user entries in kubeconfig

### DIFF
--- a/.changes/next-release/bugfix-eks-56963.json
+++ b/.changes/next-release/bugfix-eks-56963.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "eks",
+  "description": "Output JSON only for user entry in kubeconfig fixes `#7719 <https://github.com/aws/aws-cli/issues/7719>`__, fixes `#7723 <https://github.com/aws/aws-cli/issues/7723>`__, fixes `#7724 <https://github.com/aws/aws-cli/issues/7724>`__"
+}

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -143,7 +143,9 @@ class GetTokenCommand(BasicCommand):
             },
         }
 
-        output = self._session.get_config_variable('output')
+        output = parsed_globals.output
+        if output is None:
+            output = self._session.get_config_variable('output')
         formatter = get_formatter(output, parsed_globals)
         formatter.query = parsed_globals.query
 

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -313,6 +313,8 @@ class EKSClient(object):
                             "get-token",
                             cluster_identification_parameter,
                             cluster_identification_value,
+                            "--output",
+                            "json",
                         ]),
                     ("command", "aws"),
                 ]))

--- a/tests/functional/eks/testdata/output_combined
+++ b/tests/functional/eks/testdata/output_combined
@@ -32,6 +32,8 @@ users:
       - get-token
       - --cluster-name
       - Existing
+      - --output
+      - json
       command: aws
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
@@ -44,5 +46,7 @@ users:
       - get-token
       - --cluster-name
       - ExampleCluster
+      - --output
+      - json
       command: aws
 

--- a/tests/functional/eks/testdata/output_combined_changed_ordering
+++ b/tests/functional/eks/testdata/output_combined_changed_ordering
@@ -10,6 +10,8 @@ users:
       - get-token
       - --cluster-name
       - Existing
+      - --output
+      - json
       command: aws
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:
@@ -22,6 +24,8 @@ users:
       - get-token
       - --cluster-name
       - ExampleCluster
+      - --output
+      - json
       command: aws
 clusters:
 - cluster:

--- a/tests/functional/eks/testdata/output_single
+++ b/tests/functional/eks/testdata/output_single
@@ -24,4 +24,6 @@ users:
       - get-token
       - --cluster-name
       - ExampleCluster
+      - --output
+      - json
       command: aws

--- a/tests/functional/eks/testdata/valid_changed_ordering
+++ b/tests/functional/eks/testdata/valid_changed_ordering
@@ -10,6 +10,8 @@ users:
       - get-token
       - --cluster-name
       - Existing
+      - --output
+      - json
       command: aws
 clusters:
 - cluster:

--- a/tests/functional/eks/testdata/valid_existing
+++ b/tests/functional/eks/testdata/valid_existing
@@ -24,5 +24,7 @@ users:
       - get-token
       - --cluster-name
       - Existing
+      - --output
+      - json
       command: aws
 

--- a/tests/functional/eks/testdata/valid_old_api_version
+++ b/tests/functional/eks/testdata/valid_old_api_version
@@ -24,4 +24,6 @@ users:
       - get-token
       - --cluster-name
       - ExampleCluster
+      - --output
+      - json
       command: aws

--- a/tests/functional/eks/testdata/valid_old_api_version_updated
+++ b/tests/functional/eks/testdata/valid_old_api_version_updated
@@ -24,4 +24,6 @@ users:
       - get-token
       - --cluster-name
       - ExampleCluster
+      - --output
+      - json
       command: aws

--- a/tests/functional/eks/testdata/valid_old_data
+++ b/tests/functional/eks/testdata/valid_old_data
@@ -32,6 +32,8 @@ users:
       - get-token
       - --cluster-name
       - Existing
+      - --output
+      - json
       command: aws
 - name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
   user:

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -179,7 +179,9 @@ class TestEKSClient(unittest.TestCase):
                             "eks",
                             "get-token",
                             "--cluster-name",
-                            "ExampleCluster"
+                            "ExampleCluster",
+                            "--output",
+                            "json",
                         ]),
                     ("command", "aws")
                 ]))
@@ -198,7 +200,9 @@ class TestEKSClient(unittest.TestCase):
                             "eks",
                             "get-token",
                             "--cluster-id",
-                            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                            "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                            "--output",
+                            "json",
                         ]),
                     ("command", "aws")
                 ]))


### PR DESCRIPTION
*Issue #, if available:*
#7719, #7723, #7724

*Description of changes:*
Hard-code `json` as the output format when getting user entry in kubeconfig. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
