### PR TITLE
Add support for a system-wide aws config file.

### DIFF
--- a/awscli/botocore/session.py
+++ b/awscli/botocore/session.py
@@ -367,7 +367,7 @@ class Session(object):
         if self._config is None:
             try:
                 config_file = self.get_config_variable('config_file')
-                self._config = botocore.configloader.load_config(config_file)
+                self._config = botocore.configloader.multi_file_load_config(config_file, "/etc/aws/config")
             except ConfigNotFound:
                 self._config = {'profiles': {}}
             try:


### PR DESCRIPTION
Issue #7720

*Description of changes:*

It's beneficial in an enterprise to have centrally managed settings for certain applications live in a system-wide location. All of the plumbing for this already exists, so just add /etc/aws/config as a default, lower priority config file location.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
