### PR TITLE
Remove BOM from import csv file

### DIFF
--- a/awscli/customizations/configure/importer.py
+++ b/awscli/customizations/configure/importer.py
@@ -160,9 +160,6 @@ class CSVCredentialParser(object):
             raise CredentialParserError(self._EMPTY_CSV)
 
         lines = csv.splitlines()
-        # Remove the BOM if it exists
-        if lines[0].startswith(u'\ufeff'):
-            lines[0] = lines[0][1:]
         parsed_headers = self._parse_csv_headers(lines[0])
         header_indices = self._extract_expected_header_indices(parsed_headers)
         return self._parse_csv_rows(lines[1:], header_indices)

--- a/awscli/customizations/configure/importer.py
+++ b/awscli/customizations/configure/importer.py
@@ -160,6 +160,9 @@ class CSVCredentialParser(object):
             raise CredentialParserError(self._EMPTY_CSV)
 
         lines = csv.splitlines()
+        # Remove the BOM if it exists
+        if lines[0].startswith(u'\ufeff'):
+            lines[0] = lines[0][1:]
         parsed_headers = self._parse_csv_headers(lines[0])
         header_indices = self._extract_expected_header_indices(parsed_headers)
         return self._parse_csv_rows(lines[1:], header_indices)


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/aws-cli/issues/7721

*Description of changes:*
Several users reported receiving the following error:
 `awscli.customizations.configure.importer.CredentialParserError: Expected header "User Name" not found`

This occurs when attempting the command `aws configure import --csv file://<filename>.csv` (even when User Name exists in the .csv file.)

_(Note: users do need to manually add User Name to the .csv file provided in the IAM console as noted here in the User Guide: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds-import)_

After some community feedback and testing, we found that a Byte Order Mark ([BOM](https://unicode.org/faq/utf_bom.html#bom1)) was getting added to the beginning of the .csv file when users edited/saved the file in certain applications (for example, Excel but not TextEdit). The BOM breaks the credential parser, resulting in the previously referenced error. The change in this PR removes the BOM from the CSV file if it exists, prior to processing the file.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
