### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -94,7 +94,7 @@ def _should_contain_zip_content(value):
     try:
         with closing(zipfile.ZipFile(fileobj)) as f:
             f.infolist()
-    except zipfile.BadZipfile:
+    except zipfile.BadZipFile:
         raise ValueError(ERROR_MSG)
 
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

`BadZipfile` (with a small `f`) has been deprecated since Python 3.2, use `BadZipFile` (big `F`) instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
