### PR TITLE
Force timezone info to fix test failure

### DIFF
--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -19,7 +19,7 @@ import time
 import mock
 import tempfile
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import sys
 
 import pytest
@@ -47,8 +47,8 @@ from botocore.stub import Stubber
 from botocore.tokens import SSOTokenProvider
 from botocore.utils import datetime2timestamp
 
-TIME_IN_ONE_HOUR = datetime.utcnow() + timedelta(hours=1)
-TIME_IN_SIX_MONTHS = datetime.utcnow() + timedelta(hours=4320)
+TIME_IN_ONE_HOUR = datetime.now(tz=timezone.utc) + timedelta(hours=1)
+TIME_IN_SIX_MONTHS = datetime.now(tz=timezone.utc) + timedelta(hours=4320)
 
 
 class TestCredentialRefreshRaces(unittest.TestCase):


### PR DESCRIPTION
This commit will affects the test
`test_credentials.py::SSOSessionTest::test_token_chosen_from_provider`. This test will throw a `RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired` because the [timestamp call here](https://github.com/aws/aws-cli/blob/v2/tests/functional/botocore/test_credentials.py#L1055) uses system local time, which is different from UTC time. And this will cause an unexpected failure if the test is not run in a system configured with `TZ=UTC`.

To reproduce the bug, try to input the below code in python REPL:

```python
from datetime import datetime, timezone

datetime.now(tz=timezone.utc).timestamp()

# datetime.utcnow() returned datetime object doesn't have tzinfo
datetime.utcnow().timestamp()
```

*Description of changes:*

This PR force the test to use UTC tz as default timezone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
