### PR TITLE
Fix help message when using `--help`

### DIFF
--- a/.changes/next-release/bugfix-argumentparsing-97824.json
+++ b/.changes/next-release/bugfix-argumentparsing-97824.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "argument parsing",
+  "description": "Fixes issue reported in `#303 <https://github.com/aws/aws-cli/issues/303>`__ involving -h/--help output"
+}

--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -277,6 +277,7 @@ class SubCommandArgParser(ArgTableArgParser):
 
 class FirstPassGlobalArgParser(CLIArgParser):
     def __init__(self, *args, **kwargs):
+        kwargs['add_help'] = False
         super().__init__(*args, **kwargs)
         self._build()
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -749,7 +749,9 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
         self.assertIn(HELP_BLURB, self.stderr.getvalue())
 
     def test_help_blurb_in_unknown_argument_error_message(self):
-        rc = self.driver.main(['s3api', 'list-objects', '--help'])
+        args = ['s3api', 'list-objects', '--help']
+        driver = create_clidriver(args)
+        rc = driver.main(args)
         self.assertEqual(rc, 252)
         self.assertIn(HELP_BLURB, self.stderr.getvalue())
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/303 

*Description of changes:*
https://github.com/aws/aws-cli/issues/303 has two distinct issues:
1. The AWS CLI uses `help` rather than `-h/--help` conventions.
2. Currently, adding `-h/--help` does not return the correct text.

The first issue is unlikely to change due to design decisions. The second issue is very confusing, because currently the `-h/--help` commands return the default [argparse output](https://docs.python.org/3/library/argparse.html#add-help) which is misleading. The built-in AWS CLI [help command](https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-help.html#cli-usage-help-command) should be referenced instead.

This behavior began in v2.1.0. Prior to v2.1.0, adding `--help` resulted in `Unknown options: --help` . There is a [help blurb](https://github.com/aws/aws-cli/blob/72fe46161f7d4e253b0d5eb103d7d34cabb64132/awscli/argparser.py#L20) specifically designed to direct users to the intended command usage. The `print_help` function can be used to output the correct usage text.

Current behavior:

<img width="377" alt="wrong" src="https://user-images.githubusercontent.com/87778557/226660399-91e705ea-cd6e-421e-b4b9-7db2e29ad1e4.png">

New behavior:

<img width="483" alt="correct" src="https://user-images.githubusercontent.com/87778557/226660507-4f5588da-3da5-425b-a0ce-a1d3a65f29b3.png">

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.