### PR TITLE
Remove __pycache__ folders from source tree when building

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -17,7 +17,7 @@ DOWNLOAD_DEPS_FLAG = @DOWNLOAD_DEPS_FLAG@
 all: build
 
 build:
-	"$(PYTHON)" "$(build_backend)" \
+	PYTHONDONTWRITEBYTECODE=1 "$(PYTHON)" "$(build_backend)" \
 		build \
 		--artifact "$(INSTALL_TYPE)" \
 		--build-dir "$(aws_cli_builddir)" $(DOWNLOAD_DEPS_FLAG)

--- a/configure
+++ b/configure
@@ -2084,7 +2084,7 @@ else $as_nop
 fi
 
 if test "$with_download_deps" = no; then
-     ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || as_fn_error $? "\"Python dependencies not met.\"" "$LINENO" 5
+     PYTHONDONTWRITEBYTECODE=1 ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || as_fn_error $? "\"Python dependencies not met.\"" "$LINENO" 5
      DOWNLOAD_DEPS_FLAG=""
 else
      DOWNLOAD_DEPS_FLAG=--download-deps

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_ARG_WITH(download_deps,
 [with_download_deps=no]
 )
 if test "$with_download_deps" = no; then
-     ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || AC_MSG_ERROR("Python dependencies not met.")
+     PYTHONDONTWRITEBYTECODE=1 ${PYTHON} ${srcdir}/backends/build_system validate-env --artifact $with_install_type || AC_MSG_ERROR("Python dependencies not met.")
      DOWNLOAD_DEPS_FLAG=""
 else
      DOWNLOAD_DEPS_FLAG=--download-deps

--- a/tests/backends/build_system/integration/__init__.py
+++ b/tests/backends/build_system/integration/__init__.py
@@ -63,6 +63,20 @@ class BaseArtifactTest:
         assert f"Python/{self.expected_python_version()}" in version_string
         assert f"source-{dist_type}" in version_string
 
+    def assert_no_pycache(self, directory: Path):
+        failures = []
+        for root, dirs, files in os.walk(directory):
+            # Do not check the build directory since that is expected to have
+            # __pycache__ folders generated inside it.
+            if 'build' in dirs:
+                dirs.remove('build')
+            # If we are not in a build directory there should not be
+            # any pycache directories.
+            if '__pycache__' in dirs:
+                failures.append(os.path.join(root, '__pycache__'))
+
+        assert failures == [], f"Expected no __pycache__ directories, found {failures}"
+
     def assert_built_venv_is_correct(self, venv_dir):
         self.assert_venv_is_correct(venv_dir)
         files = os.listdir(venv_dir)
@@ -124,7 +138,12 @@ class VEnvWorkspace:
         shutil.copytree(
             ROOT,
             self.cli_path,
-            ignore=shutil.ignore_patterns(".git", "build", ".tox"),
+            ignore=shutil.ignore_patterns(
+                ".git",
+                "build",
+                ".tox",
+                "__pycache__",
+            ),
         )
 
     def _init_venv_directory(self):

--- a/tests/backends/build_system/integration/test_makefile.py
+++ b/tests/backends/build_system/integration/test_makefile.py
@@ -124,6 +124,7 @@ class TestMake(BaseArtifactTest):
         workspace.make()
 
         self.assert_built_exe_is_correct(workspace.cli_path)
+        self.assert_no_pycache(workspace.cli_path)
 
     @skip_if_windows(WINDOWS_SKIP_REASON)
     def test_exe_without_deps(self, workspace: VEnvWorkspace):
@@ -132,6 +133,7 @@ class TestMake(BaseArtifactTest):
         workspace.configure(install_type="portable-exe")
         workspace.make()
 
+        self.assert_no_pycache(workspace.cli_path)
         self.assert_built_exe_is_correct(workspace.cli_path)
 
     @skip_if_windows(WINDOWS_SKIP_REASON)
@@ -142,6 +144,7 @@ class TestMake(BaseArtifactTest):
         )
         workspace.make()
 
+        self.assert_no_pycache(workspace.cli_path)
         self.assert_built_venv_is_correct(workspace.build_path)
 
     @skip_if_windows(WINDOWS_SKIP_REASON)
@@ -152,4 +155,5 @@ class TestMake(BaseArtifactTest):
         )
         workspace.make()
 
+        self.assert_no_pycache(workspace.cli_path)
         self.assert_built_venv_is_correct(workspace.build_path)


### PR DESCRIPTION
This prevents __pycache__ folders from being generated in the source tree. They will still be generated in the build/ directory, however for out-of-tree builds this will prevent files from littering the source directory.
