### PR TITLE
Change to using the codecov github action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install codecov
         python scripts/ci/install
         python scripts/ci/install-check
     - name: Run tests
@@ -31,7 +30,6 @@ jobs:
     - name: Run checks
       run: python scripts/ci/run-check
     - name: codecov
-      run: |
-        rm tests/coverage.xml
-        mv tests/.coverage ./
-        codecov
+      uses: codecov/codecov-action@v3
+      with:
+        directory: tests

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -328,6 +328,8 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
             'AWS_CONFIG_FILE': '',
             'AWS_SHARED_CREDENTIALS_FILE': '',
         }
+        if os.environ.get('ComSpec'):
+            self.environ['ComSpec'] = os.environ['ComSpec']
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
         self.http_response = AWSResponse(None, 200, {}, None)


### PR DESCRIPTION
codecov yanked their pypi package breaking all of our CI. In the short term this unblocks us by using the github action.

https://about.codecov.io/blog/message-regarding-the-pypi-package/

Also updates our tests to pass with the changes to `subprocess.run` in the most recent versions of python:
https://github.com/python/cpython/pull/101708/files
