### PR TITLE
Better sso url

### DIFF
--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -137,6 +137,9 @@ class OpenBrowserHandler(BaseAuthorizationhandler):
             f'\n{verificationUri}\n'
             f'\nThen enter the code:\n'
             f'\n{userCode}\n'
+            f'\nAlternatively, you may visit the following URL which will '
+            f'autofill the code upon loading:'
+            f'\n{verificationUriComplete}\n'
         )
         uni_print(opening_msg, self._outfile)
         if self._open_browser:


### PR DESCRIPTION
*Description of changes:*

I have a workflow where I SSH to a remote box and use `aws sso login`.  Currently, it outputs the URL and the code separately,  which means I have to manually copy and paste the code.

I've modified the output to be similar to the ```--no-browser``` output so you can click on the auto code entering URL

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
