### PR TITLE
Consistently remove ResponseMetadata field in output

### DIFF
--- a/.changes/next-release/bugfix-Output-98295.json
+++ b/.changes/next-release/bugfix-Output-98295.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Output",
+  "description": "Consistently remove ResponseMetadata field for all commands (`#7829 <https://github.com/aws/aws-cli/pull/7829>`__)"
+}

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -35,16 +35,11 @@ class Formatter(object):
         self._args = args
 
     def _remove_request_id(self, response_data):
-        # We only want to display the ResponseMetadata (which includes
-        # the request id) if there is an error in the response.
-        # Since all errors have been unified under the Errors key,
-        # this should be a reasonable way to filter.
-        if 'Errors' not in response_data:
-            if 'ResponseMetadata' in response_data:
-                if 'RequestId' in response_data['ResponseMetadata']:
-                    request_id = response_data['ResponseMetadata']['RequestId']
-                    LOG.debug('RequestId: %s', request_id)
-                del response_data['ResponseMetadata']
+        if 'ResponseMetadata' in response_data:
+            if 'RequestId' in response_data['ResponseMetadata']:
+                request_id = response_data['ResponseMetadata']['RequestId']
+                LOG.debug('RequestId: %s', request_id)
+            del response_data['ResponseMetadata']
 
     def _get_default_stream(self):
         return compat.get_stdout_text_writer()

--- a/tests/functional/test_response_metadata.py
+++ b/tests/functional/test_response_metadata.py
@@ -1,0 +1,56 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestResponseMetadata(BaseAWSCommandParamsTest):
+    def test_excludes_response_metadata_when_errors_key_present(self):
+        # The ResponseMetadata key should never be present in output. For this
+        # test case, we are using an arbitrary command, s3api delete-objects,
+        # to ensure generally that the ResponseMetadata does not appear in the
+        # output even if the parsed response contains an Errors key.
+        self.parsed_response = {
+            "ResponseMetadata": {
+                "RequestId": "REQUEST-ID",
+                "HTTPStatusCode": 200,
+                "HTTPHeaders": {
+                    "x-amz-id-2": "REQUEST-ID-2",
+                    "x-amz-request-id": "REQUEST-ID",
+                    "date": "Thu, 13 Apr 2023 15:31:52 GMT",
+                    "content-type": "application/xml",
+                    "transfer-encoding": "chunked",
+                    "server": "AmazonS3",
+                    "connection": "close",
+                },
+                "RetryAttempts": 0,
+            },
+            "Errors": [
+                {
+                    "Key": "key",
+                    "VersionId": "version-id",
+                    "Code": "NoSuchVersion",
+                    "Message": "The specified version does not exist.",
+                }
+            ],
+        }
+        stdout, _, _ = self.run_cmd(
+            [
+                "s3api",
+                "delete-objects",
+                "--bucket",
+                "bucket",
+                "--delete",
+                "Objects=[{Key=key,VersionId=version-id}]",
+            ]
+        )
+        self.assertNotIn("ResponseMetadata", stdout)


### PR DESCRIPTION
The CLI contains logic that removes the `ResponseMetadata` field that is always populated in a botocore client response dictionary. This `ResponseMetadata` field is never supposed to be present in the output from the CLI command as it clutters command output with metadata information not particularly useful to the general command invocation, all which can be located in debug logs.

However, there was a small edge case where the output would leak the `ResponseMetadata` field if an `Errors` field was present in a successful API response. This behavior as it is today is unintentional and undocumented. Originally, the logic was intended to target a pre-GA interfaces of botocore that did not raise client exceptions for non-2xx responses and therefore has not been applicable to CLI output formatting since 2015.

**Before this change**
If any parsed response included an `Errors` key, then the `ResponseMetadata` would be unintentionally present in the output:
```
$ aws s3api delete-objects --bucket some-bucket --delete 'Objects=[{Key=some-key,VersionId=5}]'
{
 "ResponseMetadata": {
     "RequestId": "REQUEST-ID",
     "HostId": "HOST-ID",
     "HTTPStatusCode": 200,
     "HTTPHeaders": {
         "x-amz-id-2": "REQUEST-ID-2",
         "x-amz-request-id": "REQUEST-ID",
         "date": "Thu, 13 Apr 2023 15:31:52 GMT",
         "content-type": "application/xml",
         "transfer-encoding": "chunked",
         "server": "AmazonS3",
         "connection": "close"
     },
     "RetryAttempts": 0
 },
 "Errors": [
     {
         "Key": "some-key",
         "VersionId": "5",
         "Code": "NoSuchVersion",
         "Message": "The specified version does not exist."
     }
 ]
}
```


**With this change**
The CLI consistently removes the `ResponseMetadata` in the output even if there is an `Errors` key:
```
$ aws s3api delete-objects --bucket some-bucket --delete 'Objects=[{Key=some-key,VersionId=5}]'
{
 "Errors": [
     {
         "Key": "some-key",
         "VersionId": "5",
         "Code": "NoSuchVersion",
         "Message": "The specified version does not exist."
     }
 ]
}
```