### PR TITLE
Use h3 tags for admonition titles

### DIFF
--- a/doc/source/guzzle_sphinx_theme/__init__.py
+++ b/doc/source/guzzle_sphinx_theme/__init__.py
@@ -17,6 +17,7 @@ def setup(app):
     app.connect('html-page-context', add_html_link)
     app.connect('build-finished', create_sitemap)
     app.sitemap_links = []
+    app.set_translator('html', HTMLTranslator)
 
 
 def add_html_link(app, pagename, templatename, context, doctree):
@@ -51,28 +52,17 @@ def html_theme_path():
 
 
 class HTMLTranslator(SphinxHTMLTranslator):
-    """
-    Handle translating to bootstrap structure.
-    """
-    def visit_table(self, node, name=''):
-        """
-        Override docutils default table formatter to not include a border
-        and to use Bootstrap CSS
-        See: http://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/writers/html4css1/__init__.py#l1550
-        """
-        self.context.append(self.compact_p)
-        self.compact_p = True
-        classes = ' '.join(['table', 'table-bordered',
-            self.settings.table_style]).strip()
-        self.body.append(
-            self.starttag(node, 'table', CLASS=classes))
-
-    def depart_table(self, node):
-        """
-        This needs overridin' too
-        """
-        self.compact_p = self.context.pop()
-        self.body.append('</table>\n')
+    def visit_admonition(self, node, name=''):
+        """Uses the h3 tag for admonition titles instead of the p tag"""
+        self.body.append(self.starttag(
+            node, 'div', CLASS=('admonition ' + name)))
+        if name:
+            title = (
+                f"<h3 class='admonition-title'>"
+                f"{admonitionlabels[name]}</h3>"
+            )
+            self.body.append(title)
+        self.set_first_last(node)
 
 
 class GuzzleStyle(Style):

--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -93,7 +93,7 @@
             <div class="body">
                 <div class="well">
                     <p>
-                        <strong>Note:</strong>
+                        <h3 style="margin-top: 0px;">Note:</h3>
                         You are viewing the documentation for an older major version of the AWS CLI (version 1).
                     </p>
                     <p>

--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/static/guzzle.css_t
@@ -481,16 +481,6 @@ div.admonition dl {
   margin-bottom: 0;
 }
 
-p.admonition-title {
-  margin: 0px 10px 5px 0px;
-  font-weight: bold;
-  display: inline;
-}
-
-p.admonition-title:after {
-  content: ":";
-}
-
 div.body p.centered {
   text-align: center;
   margin-top: 25px;
@@ -510,14 +500,6 @@ dd div.admonition {
   padding-left: 60px;
 }
 
-div.admonition p.admonition-title {
-  font-weight: bold;
-  font-size: 15px;
-  margin: 0 0 10px 0;
-  padding: 0;
-  line-height: 1;
-}
-
 div.admonition p.last {
   margin-bottom: 0;
 }
@@ -526,6 +508,14 @@ div.note {
   background-color: #f8f8f8;
   border: 1px solid #ccc;
   border-radius: 3px;
+}
+
+div.body h3.admonition-title {
+  margin-top: 0px;
+}
+
+div.body h3.admonition-title:after {
+  content: ":";
 }
 
 /* -- other body styles ----------------------------------------------------- */


### PR DESCRIPTION
This PR overrides Sphinx's default `HTMLTranslator` method for admonitions so that admonition titles have the `h3` tag rather than the `p` tag. This should make it more obvious for people using screen readers that admonitions such as notes and warnings are their own sections.