### PR TITLE
Allow non-interactive configuration of sso-session

### DIFF
--- a/awscli/customizations/configure/get.py
+++ b/awscli/customizations/configure/get.py
@@ -86,6 +86,13 @@ class ConfigureGetCommand(BasicCommand):
                     section, {}).get(config_name)
             return value
 
+        if parts[0] == 'sso-session':
+            session_name = parts[1]
+            config_name = parts[2]
+            value = self._session.full_config['sso_sessions'].get(
+                session_name, {}).get(config_name)
+            return value
+
         if parts[0] == 'profile':
             profile_name = parts[1]
             config_name = parts[2]

--- a/tests/functional/configure/test_configure.py
+++ b/tests/functional/configure/test_configure.py
@@ -114,6 +114,24 @@ class TestConfigureCommand(BaseAWSCommandParamsTest):
         )
         self.assertEqual(stdout.strip(), "testing_access_key")
 
+    def test_get_with_sso_session_name(self):
+        self.set_config_file_contents(
+            "\n"
+            "[default]\n"
+            "aws_access_key_id=default_access_key\n"
+            "\n"
+            "[profile testing]\n"
+            "sso_session=testing_session\n"
+            "\n"
+            "[sso-session testing_session]\n"
+            "sso_region=us-east-2\n"
+        )
+        stdout, _, _ = self.run_cmd(
+            "configure get sso-session.testing_session.sso_region "
+            "--profile default",
+        )
+        self.assertEqual(stdout.strip(), "us-east-2")
+
     def test_get_fq_with_quoted_profile_name(self):
         self.set_config_file_contents(
             "\n"
@@ -237,6 +255,16 @@ class TestConfigureCommand(BaseAWSCommandParamsTest):
         self.assertEqual(
             "[profile testing]\n"
             "region = us-west-2\n",
+            self.get_config_file_contents(),
+        )
+
+    def test_set_with_session_name(self):
+        self.run_cmd(
+            "configure set sso-session.testing.sso_region us-west-2",
+        )
+        self.assertEqual(
+            "[sso-session testing]\n"
+            "sso_region = us-west-2\n",
             self.get_config_file_contents(),
         )
 

--- a/tests/unit/customizations/configure/test_get.py
+++ b/tests/unit/customizations/configure/test_get.py
@@ -84,6 +84,18 @@ class TestConfigureGetCommand(unittest.TestCase):
         rendered = stream.getvalue()
         self.assertEqual(rendered.strip(), 's3v4')
 
+    def test_get_from_sso_session(self):
+        session = FakeSession({})
+        session.full_config = {
+            'profiles': {'testing': {'sso_session': 'test-session'}},
+            'sso_sessions': {'test-session': {'sso_region': 'us-east-2'}}}
+        stream, error_stream, config_get = self.create_command(session)
+        config_get = ConfigureGetCommand(session, stream)
+        config_get(args=['sso-session.test-session.sso_region'],
+                   parsed_globals=None)
+        rendered = stream.getvalue()
+        self.assertEqual(rendered.strip(), 'us-east-2')
+
     def test_get_nested_attribute_from_default(self):
         session = FakeSession({})
         session.full_config = {

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -100,6 +100,16 @@ class TestConfigureSetCommand(unittest.TestCase):
             {'__section__': 'profile foo',
              's3': {'signature_version': 's3v4'}}, 'myconfigfile')
 
+    def test_configure_set_with_sso_session(self):
+        # aws configure set sso-session.testing.sso_region us-east-2
+        set_command = ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(args=['sso-session.testing.sso_region', 'us-east-2'],
+                    parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'sso-session testing',
+             'sso_region': 'us-east-2'}, 'myconfigfile')
+
     def test_access_key_written_to_shared_credentials_file(self):
         set_command = ConfigureSetCommand(
             self.session, self.config_writer)


### PR DESCRIPTION
Resolves #7835.

The client supports configuring reusable SSO sessions using the command:

    aws configure sso-session

However, there is no way to set or get the sso-session configuration
programmatically.

This updates the `configure set` and `configure get` commands to support
specifying an sso-session by using the prefix `sso-session.NAME`.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
