### PR TITLE
Fix integration test for public access changes

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -34,8 +34,9 @@ class TestBasicCommandFunctionality(unittest.TestCase):
     def put_object(self, bucket, key, content, extra_args=None):
         session = botocore.session.get_session()
         client = session.create_client('s3', 'us-east-1')
-        client.create_bucket(Bucket=bucket)
+        client.create_bucket(Bucket=bucket, ObjectOwnership='ObjectWriter')
         time.sleep(5)
+        client.delete_public_access_block(Bucket=bucket)
         self.addCleanup(client.delete_bucket, Bucket=bucket)
         call_args = {
             'Bucket': bucket,


### PR DESCRIPTION
Analogous to https://github.com/boto/botocore/pull/2912.

Changes integration test setup code to add necessary S3 API call to deal with changed default in bucket access block settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
