### PR TITLE
Set endpoint url for s3_client about `aws cloudformation deploy`

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -300,6 +300,7 @@ class DeployCommand(BasicCommand):
                 "s3",
                 config=Config(signature_version='s3v4'),
                 region_name=parsed_globals.region,
+                endpoint_url=parsed_globals.endpoint_url,
                 verify=parsed_globals.verify_ssl)
 
             s3_uploader = S3Uploader(s3_client,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR addresses a fix for the `--endpoint-url` option in [`aws cloudformation deploy`](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudformation/deploy/index.html).
In the previous information, the effect of `--endpoint-url` was lost midway when the `--s3-bucket` & `--s3-prefix` options were specified. This has corrected to ensure proper functioning.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
