### PR TITLE
Add Y/N boolean YAML test

### DIFF
--- a/tests/functional/cloudformation/deploy_templates/booleans/input.yml
+++ b/tests/functional/cloudformation/deploy_templates/booleans/input.yml
@@ -14,3 +14,8 @@ Resources:
     Type: Custom::YesTester
     Properties:
       Input: !Select [0, ["yes", "no"]]
+  YTester:
+    Type: Custom::YTester
+    Properties:
+      YInput: Y
+      NInput: N

--- a/tests/functional/cloudformation/deploy_templates/booleans/output.yml
+++ b/tests/functional/cloudformation/deploy_templates/booleans/output.yml
@@ -18,3 +18,8 @@ Resources:
         - 0
         - - 'yes'
           - 'no'
+  YTester:
+    Type: Custom::YTester
+    Properties:
+      YInput: Y
+      NInput: N


### PR DESCRIPTION
Ensure that unquoted `Y` and `N` values in YAML files don't get converted into booleans when dumping.