### PR TITLE
[v2] Add support for ssh and open-tunnel commands

### DIFF
--- a/.changes/next-release/feature-ec2instanceconnect-65857.json
+++ b/.changes/next-release/feature-ec2instanceconnect-65857.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``ec2-instance-connect``",
+  "description": "Add ``ssh`` and ``open-tunnel`` commands for connecting to an EC2 instance via an OpenSSH client and a websocket tunnel respectively."
+}

--- a/awscli/customizations/ec2instanceconnect/__init__.py
+++ b/awscli/customizations/ec2instanceconnect/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.ec2instanceconnect.opentunnel import (
+    OpenTunnelCommand,
+)
+from awscli.customizations.ec2instanceconnect.ssh import (
+    SshCommand,
+)
+
+
+def register_ec2_instance_connect_commands(event_handlers):
+    """
+    The entry point for EC2 Instance Connect high level commands.
+    """
+    event_handlers.register(
+        "building-command-table.ec2-instance-connect", inject_commands
+    )
+
+
+def inject_commands(command_table, session, **kwargs):
+    """
+    Called when the EC2 Instance Connect command table is being built.
+    Used to inject new high level commands into the command list.
+    """
+    command_table["open-tunnel"] = OpenTunnelCommand(session)
+    command_table["ssh"] = SshCommand(session)

--- a/awscli/customizations/ec2instanceconnect/eicefetcher.py
+++ b/awscli/customizations/ec2instanceconnect/eicefetcher.py
@@ -1,0 +1,77 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+
+from awscli.customizations.exceptions import ParamValidationError, ConfigurationError
+
+logger = logging.getLogger(__name__)
+
+
+class FipsEndpointUnsupported(ConfigurationError):
+    pass
+
+
+class InstanceConnectEndpointRequestFetcher:
+
+    def get_eice_dns_name(self, eice_info, is_fips_enabled):
+        fips_dns_name = eice_info.get('FipsDnsName')
+
+        if not is_fips_enabled:
+            return eice_info['DnsName']
+        elif is_fips_enabled and fips_dns_name:
+            return fips_dns_name
+        elif is_fips_enabled and not fips_dns_name:
+            raise FipsEndpointUnsupported("Unable to find FIPS Endpoint")
+
+    def get_available_instance_connect_endpoint(self, ec2_client, vpc_id, subnet_id, instance_connect_endpoint_id):
+        if instance_connect_endpoint_id:
+            return self._get_instance_connect_endpoint_by_id(ec2_client, instance_connect_endpoint_id)
+        else:
+            return self._get_instance_connect_endpoint_by_vpc(ec2_client, vpc_id, subnet_id)
+
+    def _get_instance_connect_endpoint_by_id(self, ec2_client, instance_connect_endpoint_id):
+        args = {
+            "Filters": [{"Name": "state", "Values": ["create-complete"]}],
+            "InstanceConnectEndpointIds": [instance_connect_endpoint_id]
+        }
+        describe_eice_response = ec2_client.describe_instance_connect_endpoints(**args)
+        instance_connect_endpoints = describe_eice_response["InstanceConnectEndpoints"]
+        if instance_connect_endpoints:
+            return instance_connect_endpoints[0]
+        raise ParamValidationError(
+            f"There are no available instance connect endpoints with {instance_connect_endpoint_id}")
+
+    def _get_instance_connect_endpoint_by_vpc(self, ec2_client, vpc_id, subnet_id):
+        ## Describe until subnet match and if none match subnet then return the first one based on vpc-id filter
+        args = {"Filters": [
+            {"Name": "state", "Values": ["create-complete"]},
+            {"Name": "vpc-id", "Values": [vpc_id]}
+        ]}
+
+        paginator = ec2_client.get_paginator('describe_instance_connect_endpoints')
+        page_iterator = paginator.paginate(**args)
+        instance_connect_endpoints = []
+        for page in page_iterator:
+            page_result = page["InstanceConnectEndpoints"]
+            instance_connect_endpoints = instance_connect_endpoints + page_result
+            if page_result:
+                for eice in page_result:
+                    if eice['SubnetId'] == subnet_id:
+                        logger.debug(f"Using EICE based on subnet: {instance_connect_endpoints[0]}")
+                        return eice
+
+        if instance_connect_endpoints:
+            logger.debug(f"Using EICE based on vpc: {instance_connect_endpoints[0]}")
+            return instance_connect_endpoints[0]
+
+        raise ParamValidationError("There are no available instance connect endpoints.")

--- a/awscli/customizations/ec2instanceconnect/eicesigner.py
+++ b/awscli/customizations/ec2instanceconnect/eicesigner.py
@@ -1,0 +1,75 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from urllib.parse import urlencode
+
+from botocore.signers import RequestSigner
+
+
+class InstanceConnectEndpointRequestSigner:
+    def __init__(
+            self,
+            session,
+            instance_connect_endpoint_dns_name,
+            instance_connect_endpoint_id,
+            remote_port,
+            instance_private_ip,
+            max_tunnel_duration,
+            request_singer=None,
+    ):
+        service_model = session.get_service_model("ec2-instance-connect")
+
+        if request_singer is None:
+            self._request_signer = RequestSigner(
+                service_model.service_id,
+                session.get_config_variable("region"),
+                service_model.signing_name,
+                service_model.signature_version,
+                session.get_credentials(),
+                session.get_component("event_emitter"),
+            )
+        else:
+            self._request_signer = request_singer
+
+        self.instance_connect_endpoint_dns_name = (
+            instance_connect_endpoint_dns_name
+        )
+        self.instance_connect_endpoint_id = instance_connect_endpoint_id
+        self.remote_port = remote_port
+        self.instance_private_ip = instance_private_ip
+        self.max_tunnel_duration = max_tunnel_duration
+
+    def get_presigned_url(self):
+        qs_components = {
+            "instanceConnectEndpointId": self.instance_connect_endpoint_id,
+            "remotePort": self.remote_port,
+            "privateIpAddress": self.instance_private_ip,
+        }
+        if self.max_tunnel_duration:
+            qs_components["maxTunnelDuration"] = self.max_tunnel_duration
+        query_string = urlencode(qs_components)
+
+        request_dict = {
+            "url": f"wss://{self.instance_connect_endpoint_dns_name}/openTunnel?{query_string}",
+            "body": {},
+            "headers": {"host": self.instance_connect_endpoint_dns_name},
+            "method": "GET",
+            "query_string": "",
+            "url_path": "/",
+            "context": {},
+        }
+        presigned_url = self._request_signer.generate_presigned_url(
+            request_dict=request_dict,
+            operation_name="openTunnel",
+            expires_in=60,
+        )
+        return presigned_url

--- a/awscli/customizations/ec2instanceconnect/opentunnel.py
+++ b/awscli/customizations/ec2instanceconnect/opentunnel.py
@@ -1,0 +1,167 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+import sys
+
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.ec2instanceconnect.eicesigner import (
+    InstanceConnectEndpointRequestSigner,
+)
+from awscli.customizations.ec2instanceconnect.websocket import WebsocketManager
+from awscli.customizations.exceptions import ParamValidationError
+from awscli.customizations.ec2instanceconnect.eicefetcher import InstanceConnectEndpointRequestFetcher
+
+logger = logging.getLogger(__name__)
+
+
+class OpenTunnelCommand(BasicCommand):
+    NAME = "open-tunnel"
+
+    DESCRIPTION = "Opens a websocket tunnel to the specified EC2 Instance or private ip."
+
+    ARG_TABLE = [
+        {
+            "name": "instance-id",
+            "help_text": "Specify the id of the EC2 instance that a tunnel should be opened for.",
+            "required": False,
+        },
+        {
+            "name": "instance-connect-endpoint-id",
+            "help_text": "Specify the EC2 Instance Connect Endpoint Id that should be used to open the tunnel.",
+            "required": False,
+        },
+        {
+            "name": "instance-connect-endpoint-dns-name",
+            "help_text": (
+                "Specify the EC2 Instance Connect Endpoint DNS Name that should be used to open the tunnel. "
+                "If this is specified, you must specify instance-connect-endpoint-id."
+            ),
+            "required": False,
+        },
+        {
+            "name": "private-ip-address",
+            "help_text": (
+                "Specify the private ip address to open a tunnel for. "
+                "If this is specified, you must specify instance-connect-endpoint-id."
+            ),
+            "required": False,
+        },
+        {
+            "name": "remote-port",
+            "help_text": "Specify the remote port to connect to on the instance. This defaults to port 22.",
+            "default": 22,
+            "cli_type_name": "integer",
+            "required": False,
+        },
+        {
+            "name": "local-port",
+            "help_text": (
+                "Specify the local port to listen on. Each new connection will have a separate websocket "
+                "tunnel read and write to it."
+            ),
+            "cli_type_name": "integer",
+            "required": False,
+        },
+        {
+            "name": "max-tunnel-duration",
+            "help_text": (
+                "Specify the maximum time, in seconds, to keep a websocket tunnel alive for. This "
+                "defaults to 3600 seconds."
+            ),
+            "cli_type_name": "integer",
+            "required": False,
+        },
+        {
+            "name": "max-websocket-connections",
+            "help_text": (
+                "Specify the maximum amount of websocket connections allowed when local-port is specified. This value "
+                "defaults to 10. "
+            ),
+            "default": 10,
+            "cli_type_name": "integer",
+            "required": False,
+        },
+    ]
+
+    def _run_main(self, parsed_args, parsed_globals):
+        self._validate_parsed_args(parsed_args)
+        ec2_client = self._session.create_client(
+            "ec2",
+            region_name=parsed_globals.region,
+            verify=parsed_globals.verify_ssl,
+        )
+
+        instance_vpc_id = None
+        instance_subnet_id = None
+        private_ip_address = parsed_args.private_ip_address
+        if not private_ip_address:
+            instance_metadata = ec2_client.describe_instances(
+                InstanceIds=[parsed_args.instance_id]
+            )["Reservations"][0]["Instances"][0]
+            instance_vpc_id = instance_metadata["VpcId"]
+            instance_subnet_id = instance_metadata["SubnetId"]
+            private_ip_address = instance_metadata["PrivateIpAddress"]
+
+        instance_connect_endpoint_id = parsed_args.instance_connect_endpoint_id
+        instance_connect_endpoint_dns_name = (
+            parsed_args.instance_connect_endpoint_dns_name
+        )
+        if not instance_connect_endpoint_dns_name:
+            eice_fetcher = InstanceConnectEndpointRequestFetcher()
+            eice = eice_fetcher.get_available_instance_connect_endpoint(
+                ec2_client,
+                instance_vpc_id,
+                instance_subnet_id,
+                parsed_args.instance_connect_endpoint_id,
+            )
+            instance_connect_endpoint_id = eice["InstanceConnectEndpointId"]
+
+            is_fips_enabled = self._session.get_config_variable('use_fips_endpoint')
+            instance_connect_endpoint_dns_name = eice_fetcher.get_eice_dns_name(eice, is_fips_enabled)
+
+        logger.debug(f"Using endpoint dns: {instance_connect_endpoint_dns_name}")
+        eice_request_signer = InstanceConnectEndpointRequestSigner(
+            self._session,
+            instance_connect_endpoint_dns_name=instance_connect_endpoint_dns_name,
+            instance_connect_endpoint_id=instance_connect_endpoint_id,
+            remote_port=parsed_args.remote_port,
+            instance_private_ip=private_ip_address,
+            max_tunnel_duration=parsed_args.max_tunnel_duration,
+        )
+
+        with WebsocketManager(
+                parsed_args.local_port, parsed_args.max_websocket_connections, eice_request_signer, self._session.user_agent(),
+        ) as websocket_manager:
+            websocket_manager.run()
+        return 0
+
+    def _validate_parsed_args(self, parsed_args):
+        if not parsed_args.instance_id and not parsed_args.private_ip_address:
+            raise ParamValidationError("Specify an instance id or private ip.")
+        if parsed_args.instance_connect_endpoint_dns_name and not parsed_args.instance_connect_endpoint_id:
+            raise ParamValidationError("Specify an instance connect endpoint id when providing a DNS name.")
+        if parsed_args.private_ip_address and not parsed_args.instance_connect_endpoint_id:
+            raise ParamValidationError("Specify an instance connect endpoint id when providing a private ip.")
+        if parsed_args.max_tunnel_duration is not None and (
+                parsed_args.max_tunnel_duration < 1
+                or parsed_args.max_tunnel_duration > 3_600
+        ):
+            raise ParamValidationError(
+                "Invalid max connection timeout specified. Value must be greater than 1 and "
+                "less than 3600."
+            )
+        if parsed_args.local_port is None and sys.stdin.isatty():
+            raise ParamValidationError(
+                "This command does not support interactive mode. You must use this command as a proxy or in listener "
+                "mode. "
+            )

--- a/awscli/customizations/ec2instanceconnect/ssh.py
+++ b/awscli/customizations/ec2instanceconnect/ssh.py
@@ -1,0 +1,382 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import logging
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+from awscli.customizations.commands import BasicCommand
+from awscli.customizations.exceptions import ParamValidationError, ConfigurationError
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import PublicFormat, Encoding, PrivateFormat, NoEncryption
+from awscli.compat import compat_shell_quote
+from awscli.customizations.ec2instanceconnect.eicefetcher import InstanceConnectEndpointRequestFetcher
+
+logger = logging.getLogger(__name__)
+
+
+class SshCommand(BasicCommand):
+    NAME = 'ssh'
+
+    CONNECTION_TYPES = ['auto',
+                        'direct',
+                        'eice']
+
+    ARG_TABLE = [
+        {
+            'name': 'instance-id',
+            'help_text': 'Specify the ID of the EC2 instance to connect to.',
+            'required': True,
+        },
+        {
+            'name': 'instance-ip',
+            'help_text': 'Specify the IP address of the instance to connect to.',
+            'required': False,
+        },
+        {
+            'name': 'private-key-file',
+            'help_text': 'Specify the path to the private key file for login.',
+            'required': False,
+        },
+        {
+            'name': 'os-user',
+            'help_text': 'Specify the OS SSH user. (Default: ec2-user)',
+            'required': False,
+            'default': 'ec2-user',
+        },
+        {
+            'name': 'ssh-port',
+            'help_text': 'Specify the SSH port. (Default: 22)',
+            'required': False,
+            'cli_type_name': 'integer',
+            'default': '22',
+        },
+        {
+            'name': 'local-forwarding',
+            'help_text': 'Specify the local forwarding specification as defined by your OpenSSH client. '
+                         '(Example: 3336:remote.host:3306)',
+            'required': False,
+        },
+        {
+            'name': 'connection-type',
+            'help_text': (
+                'Specify how to SSH into the instance. (Default: auto)'
+                '<ul>'
+                '<li>direct: SSH directly to the instance. '
+                'The CLI tries to connect using the IP addresses in the following order: '
+                    '<ul>'
+                    '<li>Public IPv4</li>'
+                    '<li>IPv6</li>'
+                    '<li>Private IPv4</li>'
+                    '</ul>'
+                '</li>'
+                '<li>eice: SSH using EC2 Instance Connect Endpoint. The CLI always uses the private IPv4 address.</li>'
+                '<li>auto: The CLI automatically determines the connection type (direct or eice) '
+                'to use based on the instance info. Currently the CLI tries to connect using the IP addresses '
+                'in the following order and with the corresponding connection type:'
+                    '<ul>'
+                    '<li>Public IPv4: direct</li>'
+                    '<li>Private IPv4: eice</li>'
+                    '<li>IPv6: direct</li>'
+                    '</ul>'
+                '</li>'
+                '</ul>'
+                'In the future, we might change the behavior of the auto connection type. To ensure that your '
+                'desired connection type is used, we recommend that you explicitly set the --connection-type '
+                'to either direct or eice.'
+            ),
+            'choices': CONNECTION_TYPES,
+            'default': 'auto',
+        },
+        {
+            'name': 'eice-options',
+            'help_text': 'Specify the options for your EC2 Instance Connect Endpoint.',
+            'schema': {
+                'type': 'object',
+                'properties': {
+                    'maxTunnelDuration': {
+                        'type': 'integer',
+                        'description': (
+                            'Specify the maximum duration (in seconds) for an established TCP connection. '
+                            'Default: 3600 seconds (1 hour).'
+                        ),
+                        'required': False,
+                    },
+                    'endpointId': {
+                        'type': 'string',
+                        'description': (
+                            'Specify the EC2 Instance Connect Endpoint ID to use to open the tunnel.'
+                        ),
+                        'required': False,
+                    },
+                    'dnsName': {
+                        'type': 'string',
+                        'description': (
+                            'Specify the EC2 Instance Connect Endpoint DNS name to use to open '
+                            'the tunnel. If this is specified, you must also specify endpointId.'
+                        ),
+                        'required': False,
+                    },
+                }
+            },
+        },
+    ]
+
+    DESCRIPTION = 'Connect to your EC2 instance using your OpenSSH client.'
+
+    def __init__(self, session, key_manager=None):
+        super(SshCommand, self).__init__(session)
+        self._key_manager = KeyManager() if (key_manager is None) else key_manager
+
+    def _run_main(self, parsed_args, parsed_globals):
+        self._validate_parsed_args(parsed_args)
+
+        # Describe instance to validate instance exist
+        ec2_client = self._session.create_client(
+            'ec2',
+            region_name=parsed_globals.region,
+            verify=parsed_globals.verify_ssl,
+            endpoint_url=parsed_globals.endpoint_url,
+        )
+        instance_metadata = ec2_client.describe_instances(
+            InstanceIds=[parsed_args.instance_id]
+        )['Reservations'][0]['Instances'][0]
+
+        private_ip_address = instance_metadata.get('PrivateIpAddress')
+        public_ip_address = instance_metadata.get('PublicIpAddress')
+        ipv6_address = instance_metadata.get('Ipv6Address')
+
+        use_open_tunnel = False
+        ip_address_to_connect = None
+        if parsed_args.instance_ip:
+            use_open_tunnel = parsed_args.connection_type == 'eice'
+            ip_address_to_connect = parsed_args.instance_ip
+        elif parsed_args.connection_type == 'eice' or parsed_args.eice_options:
+            use_open_tunnel = True
+            ip_address_to_connect = private_ip_address
+        elif parsed_args.connection_type == 'direct':
+            use_open_tunnel = False
+            ip_address_to_connect = public_ip_address or ipv6_address or private_ip_address
+        elif parsed_args.connection_type == 'auto':
+            # In case of auto we use IPv4 address first and then IPv6 because right now most instance have these, but
+            # in future we might want to switch this logic to where we select IPv6 first and then fallback to IPv4.
+            if public_ip_address:
+                use_open_tunnel = False
+                ip_address_to_connect = public_ip_address
+            elif private_ip_address:
+                use_open_tunnel = True
+                ip_address_to_connect = private_ip_address
+            elif ipv6_address:
+                use_open_tunnel = False
+                ip_address_to_connect = ipv6_address
+
+        if ip_address_to_connect is None:
+            raise ParamValidationError('Unable to find any IP address on the instance to connect to.')
+
+        instance_connect_endpoint_id = self._get_eice_option(parsed_args.eice_options, 'endpointId')
+        instance_connect_endpoint_dns_name = self._get_eice_option(parsed_args.eice_options, 'dnsName')
+        if use_open_tunnel and not instance_connect_endpoint_dns_name:
+            eice_fetcher = InstanceConnectEndpointRequestFetcher()
+            eice_info = eice_fetcher.get_available_instance_connect_endpoint(
+                ec2_client,
+                instance_metadata["VpcId"],
+                instance_metadata["SubnetId"],
+                instance_connect_endpoint_id
+            )
+            instance_connect_endpoint_id = eice_info["InstanceConnectEndpointId"]
+
+            is_fips_enabled = self._session.get_config_variable('use_fips_endpoint')
+            instance_connect_endpoint_dns_name = eice_fetcher.get_eice_dns_name(eice_info, is_fips_enabled)
+
+        # Validate ssh key exist (either use user defined or create new one)
+        key_file = parsed_args.private_key_file
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            if not key_file:
+                key_file = os.path.join(tmp_dir, 'private-key')
+                logger.debug('Generate new ssh key and upload')
+                private_pem_bytes = self._generate_and_upload_ssh_key(
+                    parsed_args.instance_id, parsed_args.os_user, parsed_globals)
+
+                with open(key_file, 'wb') as fd:
+                    fd.write(private_pem_bytes)
+                    logger.debug('Generated temporary key file: %s', key_file)
+                os.chmod(key_file, 0o400)
+
+            return self._ssh(
+                use_open_tunnel,
+                parsed_args.instance_id,
+                parsed_args.ssh_port,
+                parsed_args.os_user,
+                parsed_args.local_forwarding,
+                key_file,
+                ip_address_to_connect,
+                instance_connect_endpoint_id,
+                instance_connect_endpoint_dns_name,
+                self._get_eice_option(parsed_args.eice_options, 'maxTunnelDuration'),
+                parsed_globals
+            )
+
+    def _validate_parsed_args(self, parsed_args):
+        if parsed_args.instance_id:
+            if not re.search("^i-[0-9a-zA-Z]+$", parsed_args.instance_id):
+                raise ParamValidationError('The specified instance ID is invalid. '
+                                           'Provide the full instance ID in the form i-xxxxxxxxxxxxxxxxx.')
+
+        eice_options = parsed_args.eice_options
+        if parsed_args.connection_type == "direct" and eice_options:
+            raise ParamValidationError('eice-options can\'t be specified when connection type is direct.')
+
+        if self._get_eice_option(eice_options, 'dnsName') and not self._get_eice_option(eice_options, 'endpointId'):
+            raise ParamValidationError('When specifying dnsName, you must specify endpointId.')
+
+        if eice_options and 'maxTunnelDuration' in eice_options:
+            max_tunnel_duration = eice_options['maxTunnelDuration']
+            if max_tunnel_duration is not None and (max_tunnel_duration < 1 or max_tunnel_duration > 3_600):
+                raise ParamValidationError(
+                    'Invalid value specified for maxTunnelDuration. Value must be greater than 1 and '
+                    'less than 3600.'
+                )
+
+        if self._get_eice_option(eice_options, 'endpointId'):
+            if not re.search("^eice-[0-9a-zA-Z_]+$", eice_options['endpointId']):
+                raise ParamValidationError('The specified endpointId is invalid. '
+                                           'Provide the full EC2 Instance Connect Endpoint ID in '
+                                           'the form eice-xxxxxxxxxxxxxxxxx.')
+
+        if self._get_eice_option(eice_options, 'dnsName'):
+            if not re.search('^[0-9a-zA-Z.-]+$', eice_options['dnsName']):
+                raise ParamValidationError('The specified dnsName is invalid.')
+
+        if parsed_args.instance_ip and parsed_args.connection_type == 'auto':
+            raise ParamValidationError('When specifying instance-ip, you must specify connection-type.')
+
+    def _get_eice_option(self, eice_options, option):
+        if eice_options:
+            return eice_options.get(option)
+        return None
+
+    def _generate_and_upload_ssh_key(self, instance_id, os_user, parsed_globals):
+        private_key = self._key_manager.generate_key()
+
+        logger.debug('Upload public ssh key to instance')
+        ec2_instance_connect_client = self._session.create_client(
+            'ec2-instance-connect',
+            region_name=parsed_globals.region,
+            verify=parsed_globals.verify_ssl,
+        )
+        public_key = self._key_manager.get_public_key(private_key)
+        self._key_manager.upload_public_key(ec2_instance_connect_client, instance_id, os_user, public_key)
+
+        return self._key_manager.get_private_pem(private_key)
+
+    def _generate_open_tunnel_command(self, instance_id, private_ip_address, ssh_port, eice_id, eice_dns_name,
+                                      max_tunnel_duration, parsed_globals):
+        aws_cli_path = sys.argv[0]
+        proxy_command = [
+            aws_cli_path, 'ec2-instance-connect', 'open-tunnel',
+            '--instance-id', instance_id,
+            '--private-ip-address', private_ip_address,
+            '--remote-port', str(ssh_port),
+        ]
+        logger.debug(f"Using aws: {aws_cli_path}")
+
+        if parsed_globals.region:
+            proxy_command.append('--region')
+            proxy_command.append(parsed_globals.region)
+        if parsed_globals.profile:
+            proxy_command.append('--profile')
+            proxy_command.append(parsed_globals.profile)
+        if eice_id:
+            proxy_command.append('--instance-connect-endpoint-id')
+            proxy_command.append(eice_id)
+        if eice_dns_name:
+            proxy_command.append('--instance-connect-endpoint-dns-name')
+            proxy_command.append(eice_dns_name)
+        if max_tunnel_duration:
+            proxy_command.append('--max-tunnel-duration')
+            proxy_command.append(str(max_tunnel_duration))
+
+        return proxy_command
+
+    def _ssh(self, use_open_tunnel, instance_id, ssh_port, os_user, local_forwarding, key_file,
+             ip_address, eice_id, eice_dns_name, max_tunnel_duration, parsed_globals):
+
+        proxy_command = self._generate_open_tunnel_command(
+            instance_id, ip_address, ssh_port, eice_id, eice_dns_name, max_tunnel_duration, parsed_globals)
+
+        command = [
+            'ssh',
+            # adding ServerAliveInterval as default because it offers better customer experience as it let customer
+            # know about terminated connections. If we want to allow customer to override this we can add additional
+            # parameter to this cli command
+            '-o', 'ServerAliveInterval=5',
+            '-p', str(ssh_port),
+            '-i', key_file, os_user + '@' + ip_address,
+        ]
+
+        ssh_path = shutil.which('ssh')
+        if ssh_path:
+            command[0] = ssh_path
+            logger.debug(f"Using ssh: {ssh_path}")
+        else:
+            raise ConfigurationError('SSH not available. Please refer to the documentation '
+                                     'at https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Connect-using-EC2-Instance-Connect-Endpoint.html.')
+
+        # Add local-forwarding option if users passed local-forwarding
+        if local_forwarding:
+            command.insert(-1, '-L')
+            command.insert(-1, local_forwarding)
+
+        # If --debug is define lets add '-v' to ssh to generate debug level logs
+        if parsed_globals.debug:
+            command.insert(-1, '-v')
+
+        # If we are trying to connect to instance in private subnet lets use open-tunnel command to use eice
+        if use_open_tunnel:
+            command.insert(-1, '-o')
+            command.insert(-1, f"ProxyCommand={' '.join(compat_shell_quote(a) for a in proxy_command)}")
+
+        logger.debug('Invoking SSH command: %s', command)
+        rc = subprocess.call(command)
+        return rc
+
+
+class KeyManager:
+    def generate_key(self):
+        logger.debug('Generate Ed25519 Key')
+        return Ed25519PrivateKey.generate()
+
+    def get_public_key(self, private_key):
+        return private_key.public_key().public_bytes(
+            encoding=Encoding.OpenSSH,
+            format=PublicFormat.OpenSSH
+        )
+
+    def get_private_pem(self, private_key):
+        return private_key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.OpenSSH,
+            encryption_algorithm=NoEncryption()
+        )
+
+    def upload_public_key(self, ec2_instance_connect_client, instance_id, os_user, public_key):
+        logger.debug('Upload ssh key to instance')
+        ec2_instance_connect_client.send_ssh_public_key(
+            InstanceId=instance_id,
+            InstanceOSUser=os_user,
+            SSHPublicKey=public_key.decode(),
+        )

--- a/awscli/customizations/ec2instanceconnect/websocket.py
+++ b/awscli/customizations/ec2instanceconnect/websocket.py
@@ -1,0 +1,385 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import logging
+import os
+import select
+import socket
+import struct
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from queue import Queue
+from threading import Event
+from urllib.parse import urlparse
+
+from awscrt import websocket
+from awscrt.http import HttpProxyAuthenticationType, HttpProxyOptions
+from awscrt.io import ClientTlsContext, TlsContextOptions
+from awscrt.websocket import (
+    OnConnectionSetupData,
+    OnIncomingFramePayloadData,
+    OnSendFrameCompleteData,
+    Opcode,
+    OnConnectionShutdownData, OnIncomingFrameCompleteData,
+)
+
+from awscli.compat import is_windows
+
+logger = logging.getLogger(__name__)
+
+
+class WebsocketException(RuntimeError):
+    pass
+
+class InputClosedError(RuntimeError):
+    pass
+
+class BaseWebsocketIO:
+    def has_data_to_read(self):
+        raise NotImplementedError("has_data_to_read")
+
+    def read(self, amt) -> bytes:
+        raise NotImplementedError("read")
+
+    def write(self, data):
+        raise NotImplementedError("write")
+
+    def close(self):
+        raise NotImplementedError("close")
+
+
+_SELECT_TIMEOUT = 0.05
+
+
+class StdinStdoutIO(BaseWebsocketIO):
+
+    def has_data_to_read(self):
+        socket_list = [sys.stdin]
+        read_sockets, _, _ = select.select(socket_list, [], [], _SELECT_TIMEOUT)
+        if read_sockets:
+            return True
+        return False
+
+    def read(self, amt) -> bytes:
+        return sys.stdin.buffer.read1(amt)
+
+    def write(self, data):
+        sys.stdout.buffer.write(data)
+        sys.stdout.flush()
+
+    def close(self):
+        pass
+
+
+class WindowsStdinStdoutIO(StdinStdoutIO):
+
+    def has_data_to_read(self):
+        return True
+
+
+class TCPSocketIO(BaseWebsocketIO):
+
+    def __init__(self, conn):
+        self.conn = conn
+
+    def has_data_to_read(self):
+        return True
+
+    def read(self, amt) -> bytes:
+        data = self.conn.recv(amt)
+        # In listener mode use can CTRL+C during host verification that kills the client TCP connect,
+        # when this happens we are able to successfully disconnect because has_data_to_read always return true.
+        # This will check if data is empty and if yes then raise InputCloseError
+        #
+        # recv() relies on the underlying system call which returns empty bytes when the connection is closed.
+        # Linux: https://manpages.debian.org/bullseye/manpages-dev/recv.2.en.html
+        # Windows: https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv
+        if not data:
+            raise InputClosedError()
+        return data
+
+    def write(self, data):
+        self.conn.sendall(data)
+
+    def close(self):
+        try:
+            self.conn.close()
+        # On Windows, we could receive an OSError if the tcp conn is already closed.
+        except OSError:
+            pass
+
+
+class Websocket:
+    def __init__(self, websocketio, websocket_id, tls_connection_options=None, on_connection_event=None,
+                 shutdown_event=None, send_frame_results_queue=None):
+        self.websocketio = websocketio
+        self.websocket_id = websocket_id
+        self._on_connection_event = Event() if (on_connection_event is None) else on_connection_event
+        self._send_frame_results_queue = Queue() if (send_frame_results_queue is None) else send_frame_results_queue
+        self._shutdown_event = Event() if (shutdown_event is None) else shutdown_event
+        self._websocket = None
+        self._exception = None
+        self._close_frame_bytes = bytearray()
+
+        if tls_connection_options is None:
+            self._tls_connection_options = ClientTlsContext(TlsContextOptions()).new_connection_options()
+        else:
+            self._tls_connection_options = tls_connection_options
+
+    _MAX_BYTES_PER_FRAME = 65_000
+    _WAIT_INTERVAL_FOR_INPUT = 0.05
+
+    @property
+    def exception(self):
+        return self._exception
+
+    def connect(self, url, user_agent=None):
+        parsed_url = urlparse(url)
+        path = parsed_url.path + "?" + parsed_url.query
+        request = websocket.create_handshake_request(host=parsed_url.hostname, path=path)
+        if user_agent:
+            request.headers.set("User-Agent", user_agent)
+
+        environment = os.environ.copy()
+        proxy_options = None
+        proxy_url = environment.get("HTTP_PROXY") or environment.get("HTTPS_PROXY")
+        no_proxy = environment.get("NO_PROXY")
+        if proxy_url and parsed_url.hostname not in no_proxy:
+            parsed_proxy_url = urlparse(proxy_url)
+            logger.debug(f"Using the following proxy: {parsed_proxy_url.hostname}")
+            proxy_options = HttpProxyOptions(
+                host_name=parsed_proxy_url.hostname,
+                port=parsed_proxy_url.port,
+                auth_type=HttpProxyAuthenticationType.Basic if proxy_url else HttpProxyAuthenticationType.Nothing,
+                auth_username=parsed_proxy_url.username or None,
+                auth_password=parsed_proxy_url.password or None,
+            )
+
+        self._tls_connection_options.set_server_name(parsed_url.hostname)
+        websocket.connect(
+            host=parsed_url.hostname,
+            handshake_request=request,
+            port=443,
+            tls_connection_options=self._tls_connection_options,
+            proxy_options=proxy_options,
+            on_connection_setup=self._on_connection,
+            on_connection_shutdown=self._on_connection_shutdown,
+            on_incoming_frame_payload=self._on_incoming_frame_payload_data,
+            on_incoming_frame_complete=self._on_incoming_frame_complete
+        )
+
+        # Wait for the on_connection callback to be called.
+        self._on_connection_event.wait()
+
+        if not self._websocket:
+            self.close()
+            raise self._exception
+
+    def write_data_from_input(self):
+        try:
+            # Start writing data to the websocket connection and block current thread.
+            self._write_data_from_input()
+        finally:
+            self.close()
+
+        if self._exception:
+            raise self._exception
+
+    def close(self):
+        if self._websocket:
+            self._websocket.close()
+        self.websocketio.close()
+        self._shutdown_event.set()
+
+    def _write_data_from_input(self):
+        while not self._shutdown_event.is_set():
+            # Wait until there's some data to read
+            if not self.websocketio.has_data_to_read():
+                time.sleep(self._WAIT_INTERVAL_FOR_INPUT)
+                continue
+
+            try:
+                data = self.websocketio.read(self._MAX_BYTES_PER_FRAME)
+            except InputClosedError as e:
+                logger.debug('Input closed. Shutting down websocket.')
+                self.close()
+
+            try:
+                self._websocket.send_frame(
+                    opcode=Opcode.BINARY,
+                    payload=data,
+                    on_complete=self._on_send_frame_complete_data,
+                )
+                # Block until send_frame on_complete
+                self._send_frame_results_queue.get()
+            except RuntimeError as e:
+                crt_exceptions = [
+                    "AWS_ERROR_HTTP_WEBSOCKET_CLOSE_FRAME_SENT",
+                    "AWS_ERROR_HTTP_CONNECTION_CLOSED",
+                ]
+                # Expected exception if server or user closes conn. Catch it and gracefully exit this method.
+                if any(exc_code in str(e.args) for exc_code in crt_exceptions):
+                    logger.debug(f"Received exception when sending websocket frame: {e.args}")
+                    self.close()
+                else:
+                    raise e
+
+    def _on_connection(self, data: OnConnectionSetupData) -> None:
+        request_id_header = [
+            header
+            for header in data.handshake_response_headers
+            if any("x-amzn-requestid" == key.lower() for key in header)
+        ]
+        if request_id_header:
+            logger.debug(f"OpenTunnel RequestId: {request_id_header[0][1]}")
+        if data.exception:
+            if data.handshake_response_status:
+                logger.debug(f"Status code: {data.handshake_response_status}")
+            if data.handshake_response_body:
+                decoded_response = data.handshake_response_body.decode("utf-8")
+                logger.error(decoded_response)
+            self._exception = data.exception
+        self._websocket = data.websocket
+        self._on_connection_event.set()
+
+    def _on_incoming_frame_payload_data(self, incoming_frame_data: OnIncomingFramePayloadData) -> None:
+        opcode = incoming_frame_data.frame.opcode
+        if not opcode.is_data_frame():
+            if opcode == Opcode.CLOSE and incoming_frame_data.data:
+                self._close_frame_bytes += incoming_frame_data.data
+            return
+        if opcode == Opcode.TEXT:
+            self._exception = WebsocketException("Received invalid data from server, closing websocket connection.")
+            self.close()
+            return
+        self.websocketio.write(incoming_frame_data.data)
+
+    def _on_incoming_frame_complete(self, incoming_frame_data: OnIncomingFrameCompleteData):
+        if incoming_frame_data.frame.opcode == Opcode.CLOSE and incoming_frame_data.exception is None:
+            if len(self._close_frame_bytes) > 0:
+                shutdown_code_as_bytes = self._close_frame_bytes[0:2]
+                # The shutdown code is a packed 2 byte unsigned int.
+                shutdown_code = struct.unpack(">H", shutdown_code_as_bytes)[0]
+                shutdown_reason_in_bytes = self._close_frame_bytes[2:]
+                if shutdown_code != 1000:
+                    logger.debug("Shutdown code: %s", str(shutdown_code))
+                    decoded_shutdown_reason = shutdown_reason_in_bytes.decode("utf-8")
+                    self._exception = WebsocketException(f"Websocket Closure Reason: {decoded_shutdown_reason}")
+            self.close()
+
+    def _on_send_frame_complete_data(self, send_frame_data: OnSendFrameCompleteData) -> None:
+        self._send_frame_results_queue.put(send_frame_data)
+
+    def _on_connection_shutdown(self, data: OnConnectionShutdownData) -> None:
+        if data.exception:
+            self._exception = data.exception
+        self.close()
+
+
+class WebsocketManager:
+    def __init__(self, port, max_websocket_connections, eice_request_signer, user_agent=None):
+        self._port = port
+        self._executor = ThreadPoolExecutor(
+            max_workers=max_websocket_connections
+        )
+        self._connection_id_counter = 1
+        self._max_websocket_connections = max_websocket_connections
+        self._socket = None
+        self._inflight_futures_and_websockets = []
+        self._eice_request_signer = eice_request_signer
+        self._user_agent = user_agent
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for _, web_socket in self._inflight_futures_and_websockets:
+            # Close the websocket handlers.
+            web_socket.close()
+        if self._socket:
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+                self._socket.close()
+            # On Windows, if the socket is already closed, we will get an OSError.
+            except OSError:
+                pass
+        self._executor.shutdown()
+
+    # Used to break out of while loop in tests.
+    RUNNING = threading.Event()
+
+    def run(self):
+        # If no port is specified, open a singular websocket connection.
+        if not self._port:
+            websocketio = WindowsStdinStdoutIO() if is_windows else StdinStdoutIO()
+            future = self._open_websocket_connection(Websocket(websocketio, websocket_id=None))
+            # Block until the future completes.
+            future.result()
+        else:
+            self._listen_on_port()
+
+    def _listen_on_port(self):
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.bind(("localhost", self._port))
+        self._socket.listen()
+        print(f"Listening for connections on port {self._port}.")
+        while not self.RUNNING.is_set():
+            socket_list = [self._socket]
+            read_sockets, _, _ = select.select(socket_list, [], [], 0.1)
+            if read_sockets:
+                conn, addr = self._socket.accept()
+                # Check if we have reached max connections
+                self._remove_done_futures()
+                if len(self._inflight_futures_and_websockets) >= self._max_websocket_connections:
+                    print(f"Max websocket connections {self._max_websocket_connections} have been reached, closing "
+                          f"incoming connection.")
+                    conn.close()
+                    continue
+
+                websocket_id = self._connection_id_counter
+                self._connection_id_counter += 1
+                print(f"[{websocket_id}] Accepted new tcp connection, opening websocket tunnel.")
+                try:
+                    web_socket = Websocket(TCPSocketIO(conn), websocket_id)
+                    future = self._open_websocket_connection(web_socket)
+                    future.add_done_callback(self._print_tcp_conn_closed(web_socket))
+                except WebsocketException as e:
+                    logger.error(f"[{websocket_id}] Encountered error opening websocket: {e.args}")
+
+    def _open_websocket_connection(self, web_socket):
+        presigned_url = self._eice_request_signer.get_presigned_url()
+        web_socket.connect(presigned_url, self._user_agent)
+
+        future = self._executor.submit(web_socket.write_data_from_input)
+
+        self._inflight_futures_and_websockets.append((future, web_socket))
+        return future
+
+    def _print_tcp_conn_closed(self, web_socket):
+        def _on_done_callback(future):
+            if future.exception():
+                logger.error(
+                    f"[{web_socket.websocket_id}] Encountered error with websocket: {future.exception().args}"
+                )
+            print(f"[{web_socket.websocket_id}] Closing tcp connection.")
+
+        return _on_done_callback
+
+    def _remove_done_futures(self):
+        self._inflight_futures_and_websockets = [
+            (future, web_socket)
+            for future, web_socket in self._inflight_futures_and_websockets
+            if not future.done()
+        ]

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -17,6 +17,7 @@ registered with the event system.
 
 """
 from awscli.argprocess import ParamShorthandParser
+from awscli.customizations.ec2instanceconnect import register_ec2_instance_connect_commands
 from awscli.paramfile import register_uri_param_handler
 from awscli.clidriver import no_pager_handler
 from awscli.customizations import datapipeline
@@ -200,3 +201,4 @@ def awscli_initialize(event_handlers):
     register_alias_commands(event_handlers)
     register_kinesis_list_streams_pagination_backcompat(event_handlers)
     register_quicksight_asset_bundle_customizations(event_handlers)
+    register_ec2_instance_connect_commands(event_handlers)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "ruamel.yaml.clib>=0.2.0,<=0.2.7",
     "prompt-toolkit>=3.0.24,<3.0.39",
     "distro>=1.5.0,<1.9.0",
-    "awscrt>=0.12.4,<=0.16.16",
+    "awscrt>=0.16.4,<=0.16.16",
     "python-dateutil>=2.1,<3.0.0",
     "jmespath>=0.7.1,<1.1.0",
     "urllib3>=1.25.4,<1.27",

--- a/tests/functional/ec2instanceconnect/__init__.py
+++ b/tests/functional/ec2instanceconnect/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/ec2instanceconnect/test_opentunnel.py
+++ b/tests/functional/ec2instanceconnect/test_opentunnel.py
@@ -1,0 +1,653 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import concurrent.futures
+import contextlib
+import ctypes
+import os
+import queue
+import socket
+import struct
+import sys
+import threading
+import time
+import urllib.parse
+import traceback
+from typing import Optional, Callable, Union
+from unittest import mock
+import datetime
+
+from dateutil.tz import tzutc
+import awscrt
+import pytest
+from awscrt.http import HttpRequest, HttpProxyOptions
+from awscrt.io import ClientBootstrap, SocketOptions, TlsConnectionOptions
+from awscrt.websocket import OnConnectionSetupData, OnConnectionShutdownData, OnIncomingFramePayloadData, \
+    OnIncomingFrameCompleteData, IncomingFrame, Opcode, OnSendFrameCompleteData, OnIncomingFrameBeginData
+from awscli.customizations.ec2instanceconnect.websocket import WebsocketManager
+
+from awscli.compat import is_windows
+from awscli.customizations.ec2instanceconnect.websocket import BaseWebsocketIO
+from tests import SessionStubber, AWSRequest, CLIRunner, HTTPResponse
+
+STDIN_QUEUE = queue.Queue()
+STDOUT_QUEUE = queue.Queue()
+SHUTDOWN_SENTINEL = object()
+
+
+class StubStdinStdoutIO(BaseWebsocketIO):
+
+    def has_data_to_read(self):
+        return not STDIN_QUEUE.empty()
+
+    def read(self, amt) -> bytes:
+        return STDIN_QUEUE.get()
+
+    def write(self, data):
+        STDOUT_QUEUE.put(data)
+
+    def close(self):
+        pass
+
+
+def pop_stdout_content():
+    return STDOUT_QUEUE.get(block=False)
+
+
+def assert_stdout_empty():
+    assert STDOUT_QUEUE.empty()
+
+
+class MockCRTWebsocket(threading.Thread):
+
+    def __init__(self):
+        super().__init__()
+        self.url = None
+        self.client_input_queue = queue.Queue()
+        self._server_input_queue = queue.Queue()
+        self._shutdown_event = threading.Event()
+
+        # Callbacks that get set when connect is called
+        self._on_connection_setup = None
+        self._on_connection_shutdown = None
+        self._on_incoming_frame_begin = None
+        self._on_incoming_frame_payload = None
+        self._on_incoming_frame_complete = None
+
+        self._shutdown_reason = None
+        self._shutdown_exception = None
+
+    def connect(
+            self,
+            *,
+            host: str,
+            port: Optional[int] = None,
+            handshake_request: HttpRequest,
+            bootstrap: Optional[ClientBootstrap] = None,
+            socket_options: Optional[SocketOptions] = None,
+            tls_connection_options: Optional[TlsConnectionOptions] = None,
+            proxy_options: Optional[HttpProxyOptions] = None,
+            manage_read_window: bool = False,
+            initial_read_window: Optional[int] = None,
+            on_connection_setup: Callable[[OnConnectionSetupData], None],
+            on_connection_shutdown: Optional[Callable[[OnConnectionShutdownData], None]] = None,
+            on_incoming_frame_begin: Optional[Callable[[OnIncomingFrameBeginData], None]] = None,
+            on_incoming_frame_payload: Optional[Callable[[OnIncomingFramePayloadData], None]] = None,
+            on_incoming_frame_complete: Optional[Callable[[OnIncomingFrameCompleteData], None]] = None,
+    ):
+        self.url = host + handshake_request.path
+
+        self._on_connection_setup = on_connection_setup
+        self._on_connection_shutdown = on_connection_shutdown
+        self._on_incoming_frame_begin = on_incoming_frame_begin
+        self._on_incoming_frame_payload = on_incoming_frame_payload
+        self._on_incoming_frame_complete = on_incoming_frame_complete
+
+        crt_websocket = mock.Mock(awscrt.websocket.WebSocket)
+        crt_websocket.send_frame = self.send_frame_from_client
+        data = OnConnectionSetupData()
+        data.handshake_response_headers = []
+        data.websocket = crt_websocket
+        self._on_connection_setup(data)
+
+        # Kick off thread that mocks reading and writing to the client.
+        self.start()
+
+    # Appends data to the server_input_queue, which will represent the server sending data to the websocket
+    def add_output_from_server(self, data_in_bytes):
+        self._server_input_queue.put(data_in_bytes)
+
+    # Appends data to the client_input_queue, which will represent the client sending data to the websocket
+    def send_frame_from_client(
+            self,
+            opcode: Opcode,
+            payload: Optional[Union[str, bytes, bytearray, memoryview]] = None,
+            *,
+            fin: bool = True,
+            on_complete: Optional[Callable[[OnSendFrameCompleteData], None]] = None,
+    ):
+        if opcode == Opcode.BINARY:
+            data = OnSendFrameCompleteData()
+            on_complete(data)
+            if len(payload) > 0:
+                self.client_input_queue.put(payload)
+
+    def add_shutdown_from_server(self, shutdown_reason=None, shutdown_exception=None):
+        self._server_input_queue.put(SHUTDOWN_SENTINEL)
+        self._shutdown_reason = shutdown_reason
+        self._shutdown_exception = shutdown_exception
+
+    def run(self):
+        while not self._shutdown_event.is_set():
+
+            if not self._server_input_queue.empty():
+                data_in_bytes = self._server_input_queue.get()
+                if data_in_bytes == SHUTDOWN_SENTINEL:
+                    self._shutdown_event.set()
+                else:
+                    incoming_frame = IncomingFrame(opcode=Opcode.BINARY, payload_length=len(data_in_bytes), fin=True)
+                    payload_data = OnIncomingFramePayloadData(frame=incoming_frame, data=data_in_bytes)
+                    self._on_incoming_frame_payload(payload_data)
+
+                    complete_data = OnIncomingFrameCompleteData(frame=incoming_frame)
+                    self._on_incoming_frame_complete(complete_data)
+
+        if self._shutdown_reason:
+            shutdown_code = 1
+            packed_shutdown_code = struct.pack(">H", shutdown_code)
+            encoded_shutdown_reason = self._shutdown_reason.encode()
+            data_in_bytes = packed_shutdown_code + encoded_shutdown_reason
+            incoming_frame = IncomingFrame(opcode=Opcode.CLOSE, payload_length=len(data_in_bytes), fin=True)
+            payload_data = OnIncomingFramePayloadData(frame=incoming_frame, data=data_in_bytes)
+            self._on_incoming_frame_payload(payload_data)
+
+            complete_data = OnIncomingFrameCompleteData(frame=incoming_frame)
+            self._on_incoming_frame_complete(complete_data)
+
+        self._on_connection_shutdown(OnConnectionShutdownData(exception=self._shutdown_exception))
+
+
+@pytest.fixture
+def session_stubber():
+    return SessionStubber()
+
+
+@pytest.fixture
+def region():
+    return "us-west-2"
+
+
+@pytest.fixture
+def cli_runner(session_stubber, region):
+    cli_runner = CLIRunner(session_stubber=session_stubber)
+    cli_runner.env["AWS_DEFAULT_REGION"] = region
+    return cli_runner
+
+
+@pytest.fixture(autouse=True)
+def clean_io_queues():
+    while not STDIN_QUEUE.empty():
+        STDIN_QUEUE.get()
+    while not STDOUT_QUEUE.empty():
+        STDOUT_QUEUE.get()
+
+
+@pytest.fixture
+def io_patch():
+    io_to_patch = "WindowsStdinStdoutIO" if is_windows else "StdinStdoutIO"
+    new_websocket_io = StubStdinStdoutIO
+    return mock.patch(
+        f"awscli.customizations.ec2instanceconnect.websocket.{io_to_patch}",
+        new=new_websocket_io
+    )
+
+
+@pytest.fixture
+def mock_crt_websocket():
+    return MockCRTWebsocket()
+
+
+@pytest.fixture
+def connect_patch(mock_crt_websocket):
+    return mock.patch("awscrt.websocket.connect", new=mock_crt_websocket.connect)
+
+
+@pytest.fixture
+def describe_instance_response():
+    return """
+    <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+        <reservationSet>
+            <item>
+                <instancesSet>
+                    <item>
+                        <instanceId>i-123</instanceId>
+                        <subnetId>subnet-123</subnetId>
+                        <vpcId>vpc-123</vpcId>
+                        <privateIpAddress>10.0.0.0</privateIpAddress>
+                    </item>
+                </instancesSet>
+            </item>
+        </reservationSet>
+    </DescribeInstancesResponse>
+    """
+
+
+@pytest.fixture
+def request_params_for_describe_instance():
+    return {'InstanceIds': ['i-123']}
+
+
+@pytest.fixture
+def dns_name():
+    return "eice-123.ec2-instance-connect-endpoint.us-west-2.amazonaws.com"
+
+@pytest.fixture
+def fips_dns_name():
+    return "eice-123.fips.ec2-instance-connect-endpoint.us-west-2.amazonaws.com"
+
+@pytest.fixture
+def describe_eice_response(dns_name, fips_dns_name):
+    return f"""
+    <DescribeInstanceConnectEndpointsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+        <instanceConnectEndpointSet>
+            <item>
+                <dnsName>{dns_name}</dnsName>
+                <fipsDnsName>{fips_dns_name}</fipsDnsName>
+                <instanceConnectEndpointId>eice-123</instanceConnectEndpointId>
+                <state>create-complete</state>
+                <subnetId>subnet-123</subnetId>
+                <vpcId>vpc-123</vpcId>
+            </item>
+        </instanceConnectEndpointSet>
+    </DescribeInstanceConnectEndpointsResponse>
+    """
+
+@pytest.fixture
+def describe_eice_response_without_fips_dns(dns_name, fips_dns_name):
+    return f"""
+    <DescribeInstanceConnectEndpointsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+        <instanceConnectEndpointSet>
+            <item>
+                <dnsName>{dns_name}</dnsName>
+                <instanceConnectEndpointId>eice-123</instanceConnectEndpointId>
+                <state>create-complete</state>
+                <subnetId>subnet-123</subnetId>
+                <vpcId>vpc-123</vpcId>
+            </item>
+        </instanceConnectEndpointSet>
+    </DescribeInstanceConnectEndpointsResponse>
+    """
+
+@pytest.fixture
+def describe_eice_response_empty_fips_dns(dns_name, fips_dns_name):
+    return f"""
+    <DescribeInstanceConnectEndpointsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+        <instanceConnectEndpointSet>
+            <item>
+                <dnsName>{dns_name}</dnsName>
+                <fipsDnsName></fipsDnsName>
+                <instanceConnectEndpointId>eice-123</instanceConnectEndpointId>
+                <state>create-complete</state>
+                <subnetId>subnet-123</subnetId>
+                <vpcId>vpc-123</vpcId>
+            </item>
+        </instanceConnectEndpointSet>
+    </DescribeInstanceConnectEndpointsResponse>
+    """
+
+@pytest.fixture
+def request_params_for_describe_eice():
+    return {'Filters': [{'Name': 'state', 'Values': ['create-complete']}, {'Name': 'vpc-id', 'Values': ['vpc-123']}]}
+
+
+@pytest.fixture
+def datetime_utcnow_patch():
+    clock = datetime.datetime(2020, 1, 1, 1, 1, 1, tzinfo=tzutc())
+    with mock.patch('datetime.datetime') as dt:
+        dt.utcnow.return_value = clock
+        yield dt
+
+
+@pytest.fixture
+def run_listener_cmd_in_thread_executor(
+        cli_runner, mock_crt_websocket, connect_patch, io_patch
+    ):
+    stop_event = threading.Event()
+    with mock.patch.object(WebsocketManager, 'RUNNING', new_callable=mock.PropertyMock) as websocket_join:
+        websocket_join.return_value = stop_event
+        with connect_patch, io_patch:
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                def submit_run_command(cmdline):
+                    return executor.submit(cli_runner.run, cmdline)
+                yield submit_run_command
+                stop_event.set()
+
+
+def connect_to_listener(listener_future):
+    retry_connection = True
+    attempts = 0
+    max_attempts = 5
+    tracebacks = ''
+    while retry_connection:
+        attempts += 1
+        time.sleep(0.2)
+        try:
+            return socket.create_connection(("localhost", 3333), timeout=5)
+        except (ConnectionError, OSError) as e:
+            tracebacks += f'Traceback from attempt {attempts}:\n{traceback.format_exc()}\n'
+            if attempts == max_attempts:
+                retry_connection = False
+        except Exception as e:
+            tracebacks += f'Traceback from attempt {attempts}:\n{traceback.format_exc()}\n'
+            retry_connection = False
+    msg = (
+        f'Failed to connect to open-tunnel command after {attempts} attempts.\n'
+        f'{tracebacks}'
+    )
+    if listener_future.done():
+        cli_runner_result = listener_future.result()
+        msg += (
+            f'RC from open-tunnel cmd: {cli_runner_result.rc}\n'
+            f'Stdout from open-tunnel cmd: {cli_runner_result.stdout}\n'
+            f'Stderr from open-tunnel cmd: {cli_runner_result.stderr}'
+        )
+    assert False, msg
+
+
+def assert_url(dns_name, url):
+    _, _, path, _, qs, _ = urllib.parse.urlparse(url)
+    parsed_qs = urllib.parse.parse_qs(qs)
+
+    assert path == f"{dns_name}/openTunnel"
+    assert parsed_qs["instanceConnectEndpointId"]
+    assert parsed_qs["remotePort"]
+    assert parsed_qs["privateIpAddress"]
+    assert parsed_qs["maxTunnelDuration"]
+    assert parsed_qs["X-Amz-Algorithm"]
+    assert parsed_qs["X-Amz-Credential"]
+    assert parsed_qs["X-Amz-Date"]
+    assert parsed_qs["X-Amz-SignedHeaders"]
+    assert parsed_qs["X-Amz-Signature"]
+    assert parsed_qs["X-Amz-Expires"] == ["60"]
+
+
+class TestOpenTunnel:
+
+    def test_single_connection_mode(
+            self,
+            cli_runner,
+            mock_crt_websocket,
+            connect_patch,
+            io_patch,
+            describe_instance_response,
+            dns_name,
+            describe_eice_response,
+            request_params_for_describe_instance,
+            request_params_for_describe_eice,
+            datetime_utcnow_patch,
+    ):
+        cli_runner.env["AWS_USE_FIPS_ENDPOINT"] = "false"
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--max-tunnel-duration", "1"
+        ]
+        cli_runner.add_response(HTTPResponse(body=describe_instance_response))
+        cli_runner.add_response(HTTPResponse(body=describe_eice_response))
+
+        test_server_input = b"Test Server Output"
+        mock_crt_websocket.add_output_from_server(test_server_input)
+        mock_crt_websocket.add_shutdown_from_server()
+
+        with connect_patch, io_patch:
+            result = cli_runner.run(cmdline)
+
+        assert 0 == result.rc
+        assert pop_stdout_content() == test_server_input
+        assert_stdout_empty()
+        # Order of the query params on the url mater because of sigv4
+        assert "eice-123.ec2-instance-connect-endpoint.us-west-2.amazonaws.com/openTunnel?" \
+               "instanceConnectEndpointId=eice-123&remotePort=22&privateIpAddress=10.0.0.0&" \
+               "maxTunnelDuration=1&X-Amz-Algorithm=AWS4-HMAC-SHA256&" \
+               "X-Amz-Credential=access_key%2F20200101%2Fus-west-2%2Fec2-instance-connect%2Faws4_request&" \
+               "X-Amz-Date=20200101T010101Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&" \
+               "X-Amz-Signature=3a56740422a5b9aebd22d860b7a30c729e459a6f71a83bc0de3a2b44b7353f28" == \
+               mock_crt_websocket.url
+        assert_url(dns_name, mock_crt_websocket.url)
+        assert result.aws_requests == [
+            AWSRequest(
+                service_name='ec2',
+                operation_name='DescribeInstances',
+                params=request_params_for_describe_instance,
+            ),
+            AWSRequest(
+                service_name='ec2',
+                operation_name='DescribeInstanceConnectEndpoints',
+                params=request_params_for_describe_eice,
+            )
+        ]
+
+    def test_single_connection_mode_with_no_describe_calls(
+            self,
+            cli_runner,
+            mock_crt_websocket,
+            connect_patch,
+            io_patch,
+            dns_name,
+    ):
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--private-ip-address", "10.0.0.0",
+            "--instance-connect-endpoint-id", "eice-123",
+            "--instance-connect-endpoint-dns-name", dns_name,
+            "--max-tunnel-duration", "1"
+        ]
+
+        test_server_input = b"Test Server Output"
+        mock_crt_websocket.add_output_from_server(test_server_input)
+        mock_crt_websocket.add_shutdown_from_server()
+
+        with connect_patch, io_patch:
+            result = cli_runner.run(cmdline)
+
+        assert 0 == result.rc
+        assert pop_stdout_content() == test_server_input
+        assert_stdout_empty()
+        assert_url(dns_name, mock_crt_websocket.url)
+        assert result.aws_requests == []
+
+
+    def test_multiple_connection_mode(
+            self,
+            run_listener_cmd_in_thread_executor,
+            mock_crt_websocket,
+    ):
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--private-ip-address", "10.0.0.0",
+            "--instance-connect-endpoint-id", "eice-123",
+            "--instance-connect-endpoint-dns-name", "test",
+            "--local-port", "3333"
+        ]
+        future = run_listener_cmd_in_thread_executor(cmdline)
+        # Retry several times since it can take few ms to set up everything
+        with contextlib.closing(connect_to_listener(future)) as s:
+            test_server_input = b"Test Server Output"
+            mock_crt_websocket.add_output_from_server(test_server_input)
+
+            # Reading from the TCP Conn should return test server input
+            data = s.recv(1024)
+            assert test_server_input == data
+
+            test_client_input = b"Test Client Input"
+            # Writing to the TCP Conn should ensure a frame is sent with that data
+            s.sendall(test_client_input)
+            client_input_sent_to_websocket = mock_crt_websocket.client_input_queue.get(timeout=5)
+            assert test_client_input == client_input_sent_to_websocket
+
+            mock_crt_websocket.add_shutdown_from_server()
+
+    def test_command_uses_fips_endpoint_to_connect(
+            self, cli_runner, mock_crt_websocket, connect_patch, io_patch, describe_instance_response,
+            fips_dns_name, describe_eice_response,
+    ):
+        cli_runner.env["AWS_USE_FIPS_ENDPOINT"] = "true"
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--max-tunnel-duration", "1"
+        ]
+        cli_runner.add_response(HTTPResponse(body=describe_instance_response))
+        cli_runner.add_response(HTTPResponse(body=describe_eice_response))
+
+
+        test_server_input = b"Test Server Output"
+        mock_crt_websocket.add_output_from_server(test_server_input)
+        mock_crt_websocket.add_shutdown_from_server()
+
+        with connect_patch, io_patch:
+            result = cli_runner.run(cmdline)
+
+        assert 0 == result.rc
+        assert_url(fips_dns_name, mock_crt_websocket.url)
+
+    def test_command_returns_shutdown_reason(
+            self, cli_runner, mock_crt_websocket, connect_patch, io_patch
+    ):
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--private-ip-address", "10.0.0.0",
+            "--instance-connect-endpoint-id", "eice-123",
+            "--instance-connect-endpoint-dns-name", "test"
+        ]
+
+        shutdown_reason = "Test Shutdown"
+        mock_crt_websocket.add_shutdown_from_server(shutdown_reason=shutdown_reason)
+
+        with connect_patch, io_patch:
+            result = cli_runner.run(cmdline)
+
+        assert 255 == result.rc
+        assert shutdown_reason in result.stderr
+
+    def test_command_returns_shutdown_exception(
+            self, cli_runner, mock_crt_websocket, connect_patch, io_patch
+    ):
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--private-ip-address", "10.0.0.0",
+            "--instance-connect-endpoint-id", "eice-123",
+            "--instance-connect-endpoint-dns-name", "test"
+        ]
+
+        shutdown_exception_message = "Test Shutdown Error"
+        mock_crt_websocket.add_shutdown_from_server(shutdown_exception=RuntimeError(shutdown_exception_message))
+
+        with connect_patch, io_patch:
+            result = cli_runner.run(cmdline)
+
+        assert 255 == result.rc
+        assert shutdown_exception_message in result.stderr
+
+    @pytest.mark.parametrize("cli_input,expected", [
+        # Customer must provide instance id or private ip
+        (
+                [
+                    "ec2-instance-connect", "open-tunnel",
+                    "--instance-connect-endpoint-id", "eice-123",
+                    "--instance-connect-endpoint-dns-name", "test"
+                ],
+                "Specify an instance id or private ip"
+        ),
+        # Customer must define eice id when dns name is provided
+        (
+                [
+                    "ec2-instance-connect", "open-tunnel",
+                    "--instance-id", "i-123",
+                    "--instance-connect-endpoint-dns-name", "test"
+                ],
+                "Specify an instance connect endpoint id"
+        ),
+        # Customer must define eice id when private ip is provided
+        (
+                [
+                    "ec2-instance-connect", "open-tunnel",
+                    "--instance-id", "i-123",
+                    "--private-ip-address", "0.0.0.0"
+                ],
+                "Specify an instance connect endpoint id"
+        ),
+        # Customer must use provide local port when using command in isatty mode
+        (
+                [
+                    "ec2-instance-connect", "open-tunnel",
+                    "--instance-id", "i-123"
+                ],
+                "This command does not support interactive mode"
+        )
+    ])
+    @mock.patch("sys.stdin")
+    def test_command_fails_when_invalid_input(self, mock_stdin, cli_runner, cli_input, expected):
+        mock_stdin.isatty.return_value = True
+        result = cli_runner.run(cli_input)
+
+        assert 252 == result.rc
+        assert expected in result.stderr
+
+    @pytest.mark.parametrize("duration", ["-1", "0", "3601"])
+    def test_command_fails_when_using_invalid_max_tunnel_duration(self, cli_runner, duration):
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--max-tunnel-duration", duration
+        ]
+        result = cli_runner.run(cmdline)
+
+        assert 252 == result.rc
+        assert "Invalid max connection timeout specified" in result.stderr
+
+    def test_command_fails_when_no_fips_endpoint_available_to_connect(
+            self, cli_runner, describe_instance_response, describe_eice_response_without_fips_dns,
+    ):
+        cli_runner.env["AWS_USE_FIPS_ENDPOINT"] = "true"
+        cmdline = [
+            "ec2-instance-connect", "open-tunnel",
+            "--instance-id", "i-123",
+            "--max-tunnel-duration", "1"
+        ]
+        cli_runner.add_response(HTTPResponse(body=describe_instance_response))
+        cli_runner.add_response(HTTPResponse(body=describe_eice_response_without_fips_dns))
+
+        result = cli_runner.run(cmdline)
+
+        assert 253 == result.rc
+        assert "Unable to find FIPS Endpoint" in result.stderr
+
+    def test_command_fails_when_empty_fips_endpoint_available_to_connect(
+                self, cli_runner, describe_instance_response, describe_eice_response_empty_fips_dns,
+        ):
+            cli_runner.env["AWS_USE_FIPS_ENDPOINT"] = "true"
+            cmdline = [
+                "ec2-instance-connect", "open-tunnel",
+                "--instance-id", "i-123",
+                "--max-tunnel-duration", "1"
+            ]
+            cli_runner.add_response(HTTPResponse(body=describe_instance_response))
+            cli_runner.add_response(HTTPResponse(body=describe_eice_response_empty_fips_dns))
+
+            result = cli_runner.run(cmdline)
+
+            assert 253 == result.rc
+            assert "Unable to find FIPS Endpoint" in result.stderr

--- a/tests/functional/ec2instanceconnect/test_ssh.py
+++ b/tests/functional/ec2instanceconnect/test_ssh.py
@@ -1,0 +1,863 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from unittest import mock
+
+import os
+import pytest
+import sys
+
+from tests import SessionStubber, AWSRequest, CLIRunner, HTTPResponse
+
+
+@pytest.fixture
+def session_stubber():
+    return SessionStubber()
+
+
+@pytest.fixture
+def region():
+    return "us-west-2"
+
+
+@pytest.fixture
+def aws_config_file(tmp_path):
+    config_file = os.path.join(tmp_path, 'aws-config-file-for-ssh-command')
+    with open(config_file, 'wb') as fd:
+        fd.write(
+            b'[profile test-profile]\n'
+            b'aws_access_key_id=access_key\n'
+            b'aws_secret_access_key=secret_key\n'
+            b'[profile test-fips]\n'
+            b'use_fips_endpoint=true\n'
+            b'aws_access_key_id=access_key\n'
+            b'aws_secret_access_key=secret_key\n')
+        return config_file
+
+
+@pytest.fixture
+def cli_runner(session_stubber, region, aws_config_file):
+    cli_runner = CLIRunner(session_stubber=session_stubber)
+    cli_runner.env["AWS_DEFAULT_REGION"] = region
+    cli_runner.env["AWS_CONFIG_FILE"] = aws_config_file
+    return cli_runner
+
+
+def get_describe_private_instance_response():
+    return """
+     <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+         <reservationSet>
+             <item>
+                 <instancesSet>
+                     <item>
+                         <instanceId>i-123</instanceId>
+                         <subnetId>subnet-123</subnetId>
+                         <vpcId>vpc-123</vpcId>
+                         <privateIpAddress>10.0.0.0</privateIpAddress>
+                     </item>
+                 </instancesSet>
+             </item>
+         </reservationSet>
+     </DescribeInstancesResponse>
+     """
+
+
+@pytest.fixture
+def describe_private_instance_response():
+    return get_describe_private_instance_response()
+
+
+def get_describe_public_instance_response():
+    return """
+     <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+         <reservationSet>
+             <item>
+                 <instancesSet>
+                     <item>
+                         <instanceId>i-123</instanceId>
+                         <subnetId>subnet-123</subnetId>
+                         <vpcId>vpc-123</vpcId>
+                         <ipAddress>11.11.11.11</ipAddress>
+                         <privateIpAddress>10.0.0.0</privateIpAddress>
+                         <ipv6Addresses>2600:1f10:4f8e:db01:73f5:6b9d:c0da:1c27</ipv6Addresses>
+                     </item>
+                 </instancesSet>
+             </item>
+         </reservationSet>
+     </DescribeInstancesResponse>
+     """
+
+
+@pytest.fixture
+def describe_public_instance_response():
+    return get_describe_public_instance_response()
+
+
+def get_describe_ipv6_instance_response():
+    return """
+     <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+         <reservationSet>
+             <item>
+                 <instancesSet>
+                     <item>
+                         <instanceId>i-123</instanceId>
+                         <subnetId>subnet-123</subnetId>
+                         <vpcId>vpc-123</vpcId>
+                         <privateIpAddress>10.0.0.0</privateIpAddress>
+                         <ipv6Address>2600:1f10:4f8e:db01:73f5:6b9d:c0da:1c27</ipv6Address>
+                     </item>
+                 </instancesSet>
+             </item>
+         </reservationSet>
+     </DescribeInstancesResponse>
+     """
+
+
+@pytest.fixture
+def describe_ipv6_instance_response():
+    return get_describe_ipv6_instance_response()
+
+
+@pytest.fixture
+def describe_no_ip_instance_response():
+    return """
+     <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+         <reservationSet>
+             <item>
+                 <instancesSet>
+                     <item>
+                         <instanceId>i-123</instanceId>
+                         <subnetId>subnet-123</subnetId>
+                         <vpcId>vpc-123</vpcId>
+                     </item>
+                 </instancesSet>
+             </item>
+         </reservationSet>
+     </DescribeInstancesResponse>
+     """
+
+
+@pytest.fixture
+def send_ssh_public_key_response():
+    return b'{"RequestId":"01adeb55-3f80-4736-b789-d57feb69691d","Success":true}'
+
+
+@pytest.fixture
+def request_params_for_describe_instance():
+    return {'InstanceIds': ['i-123']}
+
+
+def get_describe_eice_response():
+    return f"""
+    <DescribeInstanceConnectEndpointsResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+        <instanceConnectEndpointSet>
+            <item>
+                <dnsName>dns.com</dnsName>
+                <fipsDnsName>fips.dns.com</fipsDnsName>
+                <instanceConnectEndpointId>eice-123</instanceConnectEndpointId>
+                <state>create-complete</state>
+                <subnetId>subnet-123</subnetId>
+                <vpcId>vpc-123</vpcId>
+            </item>
+        </instanceConnectEndpointSet>
+    </DescribeInstanceConnectEndpointsResponse>
+    """
+
+
+@pytest.fixture
+def describe_eice_response():
+    return get_describe_eice_response()
+
+
+def get_request_params_for_describe_eice():
+    return {'Filters': [{'Name': 'state', 'Values': ['create-complete']}, {'Name': 'vpc-id', 'Values': ['vpc-123']}]}
+
+
+def get_request_params_for_describe_eice_with_eice_id():
+    return {'Filters': [{'Name': 'state', 'Values': ['create-complete']}], 'InstanceConnectEndpointIds': ['eice-12345']}
+
+
+class TestSSHCommand:
+    @pytest.mark.parametrize(
+        "describe_instance_response,describe_eice_response,request_params_for_describe_eice,cli_input,expected_ssh_command",
+        [
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o', 'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                          '--private-ip-address 10.0.0.0 --remote-port 22 '
+                          '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: connect by instance id + key'
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice_with_eice_id(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-id", "i-123",
+                    "--eice-options", "endpointId=eice-12345",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: connect to specific EICE'
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                None,
+                None,
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-id", "i-123",
+                    "--eice-options", "endpointId=eice-12345,dnsName=dns.domain.com",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 '
+                    '--instance-connect-endpoint-id eice-12345 --instance-connect-endpoint-dns-name dns.domain.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id="Open-Tunnel: connect by eice id + domain"
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-id", "i-123",
+                    "--eice-options", "maxTunnelDuration=61",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com '
+                    '--max-tunnel-duration 61',
+                    'ec2-user@10.0.0.0'
+                ],
+                id="Open-Tunnel: allow customer to define maxTunnelDuration"
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-id", "i-123",
+                    "--ssh-port", "24",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '24', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 24 '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id="Open-Tunnel: allow customer to define ssh port"
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-id", "i-123",
+                    "--os-user", "new-user",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'new-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: allow customer to define ssh user'
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-id", "i-123",
+                    "--local-forwarding", "8080:localhost:9090",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-L', '8080:localhost:9090',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: allow customer to local-forwarding'
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--region", "us-east-2",
+                    "--profile", "test-profile"
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 --region us-east-2 --profile test-profile '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: pass global parameters to sub-command'
+            ),
+
+            pytest.param(
+                get_describe_public_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--connection-type", "eice"
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o',
+                    'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                    '--private-ip-address 10.0.0.0 --remote-port 22 '
+                    '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: select private IP when connection type eice'
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--profile", "test-fips",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o', 'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                          '--private-ip-address 10.0.0.0 --remote-port 22 --profile test-fips '
+                          '--instance-connect-endpoint-id eice-123 '
+                          '--instance-connect-endpoint-dns-name fips.dns.com',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: connect by instance id + key to fips endpoint'
+            ),
+
+            pytest.param(
+                get_describe_public_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--eice-options", "maxTunnelDuration=61",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o', 'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                          '--private-ip-address 10.0.0.0 --remote-port 22 '
+                          '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com '
+                          '--max-tunnel-duration 61',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Open-Tunnel: use private ip and eice when eice options defined without connection-type'
+            ),
+
+            pytest.param(
+                get_describe_public_instance_response(),
+                get_describe_eice_response(),
+                get_request_params_for_describe_eice(),
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--connection-type", "eice",
+                    "--instance-ip", "1.10.10.10",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    '-o', 'ProxyCommand=aws ec2-instance-connect open-tunnel --instance-id i-123 '
+                          '--private-ip-address 1.10.10.10 --remote-port 22 '
+                          '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+                    'ec2-user@1.10.10.10'
+                ],
+                id='Open-Tunnel: use provided ip'
+            ),
+
+            pytest.param(
+                get_describe_public_instance_response(),
+                None,
+                None,
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--ssh-port", "24",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '24', '-i', '/tmp/ssh-file',
+                    'ec2-user@11.11.11.11'
+                ],
+                id='Public: connect to public IP'
+            ),
+
+            pytest.param(
+                get_describe_public_instance_response(),
+                None,
+                None,
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--instance-ip", "10.0.0.1",
+                    "--connection-type", "direct",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    'ec2-user@10.0.0.1'
+                ],
+                id='Public: connect to provided ip address'
+            ),
+
+            pytest.param(
+                get_describe_public_instance_response(),
+                None,
+                None,
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--connection-type", "direct",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    'ec2-user@11.11.11.11'
+                ],
+                id='Public: use public when connection-type direct'
+            ),
+
+            pytest.param(
+                get_describe_private_instance_response(),
+                None,
+                None,
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--connection-type", "direct",
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    'ec2-user@10.0.0.0'
+                ],
+                id='Public: use private ip since no public ip when connection-type direct'
+            ),
+
+            pytest.param(
+                get_describe_ipv6_instance_response(),
+                None,
+                None,
+                [
+                    "ec2-instance-connect", "ssh",
+                    "--instance-id", "i-123",
+                    "--private-key-file", "/tmp/ssh-file",
+                    "--connection-type", "direct"
+                ],
+                [
+                    'ssh', '-o', 'ServerAliveInterval=5',
+                    '-p', '22', '-i', '/tmp/ssh-file',
+                    'ec2-user@2600:1f10:4f8e:db01:73f5:6b9d:c0da:1c27'
+                ],
+                id='Public: IPv6: use ipv6 when connection-type direct and no IPv4 address'
+            ),
+        ])
+    @mock.patch("shutil.which")
+    @mock.patch("subprocess.call")
+    @mock.patch.object(sys, 'argv', ['aws'])
+    def test_successful_ssh_for_instance(self, mock_subproc_call, mock_which, cli_runner,
+                                         request_params_for_describe_instance,
+                                         describe_instance_response, describe_eice_response,
+                                         request_params_for_describe_eice, cli_input, expected_ssh_command):
+        mock_which.return_value = "ssh"
+        mock_subproc_call.return_value = 0
+        cli_runner.add_response(HTTPResponse(body=describe_instance_response))
+        if describe_eice_response:
+            cli_runner.add_response(HTTPResponse(body=describe_eice_response))
+
+        result = cli_runner.run(cli_input)
+
+        assert 0 == result.rc
+        assert mock_subproc_call.called
+        requests = [
+            AWSRequest(
+                service_name='ec2',
+                operation_name='DescribeInstances',
+                params=request_params_for_describe_instance,
+            ),
+        ]
+        if describe_eice_response:
+            requests += [
+                AWSRequest(
+                    service_name='ec2',
+                    operation_name='DescribeInstanceConnectEndpoints',
+                    params=request_params_for_describe_eice,
+                ),
+            ]
+        assert result.aws_requests == requests
+        mock_which.assert_called_once_with('ssh')
+        mock_subproc_call.assert_called_once_with(expected_ssh_command)
+
+    @mock.patch("shutil.which")
+    @mock.patch("subprocess.call")
+    @mock.patch.object(sys, 'argv', ['aws.cmd'])
+    def test_valid_input_without_ssh_key(self, mock_subproc_call, mock_which, cli_runner, describe_eice_response,
+                                         describe_private_instance_response, send_ssh_public_key_response):
+        mock_which.return_value = '/some/path/to/ssh'
+        mock_subproc_call.return_value = 0
+        cli_runner.add_response(HTTPResponse(body=describe_private_instance_response))
+        cli_runner.add_response(HTTPResponse(body=describe_eice_response))
+        cli_runner.add_response(HTTPResponse(body=send_ssh_public_key_response))
+
+        result = cli_runner.run([
+            "ec2-instance-connect", "ssh",
+            "--instance-id", "i-04997c129f59becde",
+        ])
+
+        assert 0 == result.rc
+        assert mock_subproc_call.called
+        assert result.aws_requests == [
+            AWSRequest(
+                service_name='ec2',
+                operation_name='DescribeInstances',
+                params={'InstanceIds': ['i-04997c129f59becde']},
+            ),
+            AWSRequest(
+                service_name='ec2',
+                operation_name='DescribeInstanceConnectEndpoints',
+                params=mock.ANY,
+            ),
+            AWSRequest(
+                service_name='ec2-instance-connect',
+                operation_name='SendSSHPublicKey',
+                params=mock.ANY,
+            ),
+        ]
+        mock_which.assert_called_once_with('ssh')
+        mock_subproc_call.assert_called_once_with([
+            '/some/path/to/ssh', '-o', 'ServerAliveInterval=5',
+            '-p', '22', '-i', mock.ANY,
+            '-o',
+            'ProxyCommand=aws.cmd ec2-instance-connect open-tunnel --instance-id i-04997c129f59becde '
+            '--private-ip-address 10.0.0.0 --remote-port 22 '
+            '--instance-connect-endpoint-id eice-123 --instance-connect-endpoint-dns-name dns.com',
+            'ec2-user@10.0.0.0'
+        ])
+
+    def test_no_ip_on_instance(self, cli_runner, describe_no_ip_instance_response):
+        cli_runner.add_response(HTTPResponse(body=describe_no_ip_instance_response))
+
+        result = cli_runner.run([
+            "ec2-instance-connect", "ssh",
+            "--instance-id", "i-04997c129f59becde",
+            "--private-key-file", "/tmp/ssh-file",
+        ])
+
+        assert 252 == result.rc
+        assert 'Unable to find any IP address on the instance to connect to.' in result.stderr
+
+    def test_command_fails_when_eice_connection_type_and_no_private_ip(
+            self, cli_runner, describe_no_ip_instance_response):
+        cli_runner.add_response(HTTPResponse(body=describe_no_ip_instance_response))
+
+        result = cli_runner.run([
+            "ec2-instance-connect", "ssh",
+            "--instance-id", "i-04997c129f59becde",
+            "--private-key-file", "/tmp/ssh-file",
+            "--connection-type", "eice"
+        ])
+
+        assert 252 == result.rc
+        assert 'Unable to find any IP address on the instance to connect to.' in result.stderr
+
+    @pytest.mark.parametrize("cli_input,expected_error_code,expected", [
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+            ],
+            252,
+            "the following arguments are required: --instance-id",
+            id="Failure: Customer must provide instance-id"
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--connection-type", "test",
+            ],
+            252,
+            "argument --connection-type: Invalid choice, valid choices are:",
+            id='Failure: Customer must provide connection-type when IP defined'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--connection-type", "direct",
+                "--eice-options", "endpointId=eice-12345"
+            ],
+            252,
+            "eice-options can't be specified when connection type is direct.",
+            id='Failure: Customer can not use connection-type direct with eice-id'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--connection-type", "direct",
+                "--eice-options", "dnsName=test.com"
+            ],
+            252,
+            "eice-options can't be specified when connection type is direct.",
+            id='Failure: Customer can not use connection-type direct with eice-dns-name'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--connection-type", "direct",
+                "--eice-options", "maxTunnelDuration=12"
+            ],
+            252,
+            "eice-options can't be specified when connection type is direct.",
+            id='Failure: Customer can not use connection-type direct with maxTunnelDuration'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--eice-options", "dnsName=test"
+            ],
+            252,
+            "When specifying dnsName, you must specify endpointId.",
+            id='Failure: Customer must define eice-id when eice-dns provided'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--ssh-port", "ab"
+            ],
+            255,
+            "invalid literal for int() with base 10",
+            id='Failure: port must be int'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--eice-options", "maxTunnelDuration=ab"
+            ],
+            255,
+            'invalid literal for int() with base 10',
+            id='Failure: maxTunnelDuration must be int'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--instance-ip", "10.0.0.1"
+            ],
+            252,
+            'When specifying instance-ip, you must specify connection-type.',
+            id='Failure: Customer must define connection-type when ip define instead of Instance ID'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "a-12345"
+            ],
+            252,
+            'The specified instance ID is invalid.',
+            id='Failure: Customer provide valid Instance ID'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12+3:4;5"
+            ],
+            252,
+            'The specified instance ID is invalid.',
+            id='Failure: Customer provide valid Instance ID without special characters'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--eice-options", "endpointId=aeice-12345"
+            ],
+            252,
+            'The specified endpointId is invalid.',
+            id='Failure: Customer must define valid EICE ID'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--eice-options", "endpointId=eice-12;3:4+5-"
+            ],
+            252,
+            'The specified endpointId is invalid.',
+            id='Failure: Customer must define valid EICE ID without special characters'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--eice-options", "endpointId=eice-12345,dnsName=dns.domain.+com",
+            ],
+            252,
+            'The specified dnsName is invalid.',
+            id='Failure: Customer must define valid EICE dnsName without special characters'
+        ),
+
+        pytest.param(
+            [
+                "ec2-instance-connect", "ssh",
+                "--instance-id", "i-12345",
+                "--eice-options", "test=123"
+            ],
+            252,
+            'Unknown parameter in input',
+            id="Failure: Customer must define allowed eice options"
+        ),
+    ])
+    def test_command_fails_when_invalid_input(self, cli_runner, cli_input, expected_error_code, expected):
+        result = cli_runner.run(cli_input)
+
+        assert expected_error_code == result.rc
+        assert expected in result.stderr
+
+    @pytest.mark.parametrize("duration", ["-1", "0", "3601"])
+    def test_command_fails_when_using_invalid_max_tunnel_duration(self, cli_runner, duration):
+        cmdline = [
+            "ec2-instance-connect", "ssh",
+            "--instance-id", "i-123",
+            "--eice-options", f"maxTunnelDuration={duration}"
+        ]
+        result = cli_runner.run(cmdline)
+
+        assert 252 == result.rc
+        assert "Invalid value specified for maxTunnelDuration. Value must be greater than 1 and less than 3600." \
+               in result.stderr
+
+    @mock.patch("shutil.which")
+    @mock.patch.object(sys, 'argv', ['aws'])
+    def test_command_error_when_ssh_not_available(self, mock_which, cli_runner,
+                                                  describe_public_instance_response,
+                                                  request_params_for_describe_instance):
+        mock_which.return_value = None
+        cli_runner.add_response(HTTPResponse(body=describe_public_instance_response))
+
+        result = cli_runner.run([
+            "ec2-instance-connect", "ssh",
+            "--instance-id", "i-123",
+            "--private-key-file", "/tmp/ssh-file",
+        ])
+
+        assert 253 == result.rc
+        assert 'SSH not available.' in result.stderr
+        assert result.aws_requests == [
+            AWSRequest(
+                service_name='ec2',
+                operation_name='DescribeInstances',
+                params=request_params_for_describe_instance,
+            ),
+        ]

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -26,4 +26,3 @@ class TestWriteException(unittest.TestCase):
                 "\n%s\n" % error_message
             )
             self.assertEqual(outfile.read(), expected_output)
-

--- a/tests/unit/customizations/ec2instanceconnect/__init__.py
+++ b/tests/unit/customizations/ec2instanceconnect/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/unit/customizations/ec2instanceconnect/test_eicesigner.py
+++ b/tests/unit/customizations/ec2instanceconnect/test_eicesigner.py
@@ -1,0 +1,156 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from urllib.parse import urlencode
+
+import mock
+import pytest
+
+from botocore.session import Session
+from botocore.signers import RequestSigner
+from awscli.customizations.ec2instanceconnect.eicesigner import (
+    InstanceConnectEndpointRequestSigner,
+)
+
+
+@pytest.fixture
+def service_model_mock():
+    return mock.Mock()
+
+
+@pytest.fixture
+def session_mock(service_model_mock):
+    session_mock = mock.Mock(spec=Session)
+    session_mock.get_service_model.return_value = service_model_mock
+    return session_mock
+
+
+@pytest.fixture
+def request_signer_mock():
+    return mock.Mock(spec=RequestSigner)
+
+
+@pytest.fixture
+def eice_id():
+    return "instanceConnectEndpointId"
+
+
+@pytest.fixture
+def remote_port():
+    return "1"
+
+
+@pytest.fixture
+def private_ip():
+    return "127.0.0.1"
+
+
+@pytest.fixture
+def dns_name():
+    return "amazon.com"
+
+
+@pytest.fixture
+def max_tunnel_duration():
+    return "1"
+
+
+class TestInstanceConnectEndpointRequestSigner:
+
+    def test_get_presigned_url_without_max_tunnel_duration(
+            self, session_mock, request_signer_mock, eice_id, remote_port, private_ip, dns_name
+    ):
+        eice_request_signer = InstanceConnectEndpointRequestSigner(
+            session_mock,
+            instance_connect_endpoint_dns_name=dns_name,
+            instance_connect_endpoint_id=eice_id,
+            remote_port=remote_port,
+            instance_private_ip=private_ip,
+            max_tunnel_duration=None,
+            request_singer=request_signer_mock,
+        )
+
+        expected_url = "wss://" + dns_name + "/openTunnel?params"
+        request_signer_mock.generate_presigned_url.return_value = expected_url
+
+        returned_url = eice_request_signer.get_presigned_url()
+
+        assert returned_url == expected_url
+
+        qs_components = {
+            "instanceConnectEndpointId": eice_id,
+            "remotePort": remote_port,
+            "privateIpAddress": private_ip,
+        }
+        expected_query_string = urlencode(qs_components)
+        expected_request_dict = {
+            "url": "wss://"
+                   + dns_name
+                   + "/openTunnel?"
+                   + expected_query_string,
+            "body": {},
+            "headers": {"host": dns_name},
+            "method": "GET",
+            "query_string": "",
+            "url_path": "/",
+            "context": {},
+        }
+        request_signer_mock.generate_presigned_url.assert_called_with(
+            request_dict=expected_request_dict,
+            operation_name="openTunnel",
+            expires_in=60,
+        )
+
+    def test_get_presigned_url_with_max_connection_timeout(
+            self, session_mock, request_signer_mock, eice_id, remote_port, private_ip, dns_name, max_tunnel_duration
+    ):
+        eice_request_signer = InstanceConnectEndpointRequestSigner(
+            session_mock,
+            instance_connect_endpoint_dns_name=dns_name,
+            instance_connect_endpoint_id=eice_id,
+            remote_port=remote_port,
+            instance_private_ip=private_ip,
+            max_tunnel_duration=max_tunnel_duration,
+            request_singer=request_signer_mock,
+        )
+
+        expected_url = "wss://" + dns_name + "/openTunnel?params"
+        request_signer_mock.generate_presigned_url.return_value = expected_url
+
+        returned_url = eice_request_signer.get_presigned_url()
+
+        assert returned_url == expected_url
+
+        qs_components = {
+            "instanceConnectEndpointId": eice_id,
+            "remotePort": remote_port,
+            "privateIpAddress": private_ip,
+            "maxTunnelDuration": max_tunnel_duration,
+        }
+        expected_query_string = urlencode(qs_components)
+        expected_request_dict = {
+            "url": "wss://"
+                   + dns_name
+                   + "/openTunnel?"
+                   + expected_query_string,
+            "body": {},
+            "headers": {"host": dns_name},
+            "method": "GET",
+            "query_string": "",
+            "url_path": "/",
+            "context": {},
+        }
+        eice_request_signer._request_signer.generate_presigned_url.assert_called_with(
+            request_dict=expected_request_dict,
+            operation_name="openTunnel",
+            expires_in=60,
+        )

--- a/tests/unit/customizations/ec2instanceconnect/test_websocket.py
+++ b/tests/unit/customizations/ec2instanceconnect/test_websocket.py
@@ -1,0 +1,506 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+import platform
+import socket
+import struct
+import sys
+from io import TextIOWrapper, BytesIO
+from threading import Event
+from queue import Queue
+from unittest import mock
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import pytest
+from awscrt import websocket
+from awscrt.http import HttpProxyAuthenticationType, HttpProxyOptions, HttpRequest, HttpHeaders
+from awscrt.io import ClientTlsContext, TlsContextOptions, TlsConnectionOptions
+from awscrt.websocket import (
+    Opcode,
+    OnConnectionSetupData,
+    OnIncomingFramePayloadData,
+    IncomingFrame,
+    OnSendFrameCompleteData,
+    OnConnectionShutdownData,
+    OnIncomingFrameCompleteData,
+    WebSocket,
+)
+
+from awscli.customizations.ec2instanceconnect.websocket import (
+    BaseWebsocketIO, Websocket, StdinStdoutIO, WindowsStdinStdoutIO,
+    TCPSocketIO, WebsocketException, WebsocketManager, InputClosedError,
+)
+
+
+skip_if_windows = pytest.mark.skipif(
+    platform.system() not in ['Darwin', 'Linux'],
+    reason="This test does not run on windows.")
+if_windows = pytest.mark.skipif(
+    platform.system() in ['Darwin', 'Linux'],
+    reason="This test only runs on windows.")
+
+
+class TestWebsocketIO:
+
+    def test_stdin_stdout_io_read(self, monkeypatch):
+        io = StdinStdoutIO()
+
+        expected_data = b"Test"
+        monkeypatch.setattr('sys.stdin', TextIOWrapper(BytesIO(expected_data)))
+
+        returned_data = io.read(100)
+
+        assert returned_data == expected_data
+
+    def test_stdin_stdout_io_write(self, monkeypatch):
+        io = StdinStdoutIO()
+
+        mock_text_io_wrapper = mock.Mock(spec=TextIOWrapper)
+        monkeypatch.setattr('sys.stdout', mock_text_io_wrapper)
+
+        expected_data = b"Test"
+        io.write(expected_data)
+
+        mock_text_io_wrapper.buffer.write.assert_called_with(expected_data)
+        assert mock_text_io_wrapper.flush.called
+
+    @skip_if_windows
+    @mock.patch("select.select")
+    def test_stdin_stdout_io_has_data_to_read_returns_false_non_windows(self, mock_select):
+        io = StdinStdoutIO()
+
+        expected_socket_list = [sys.stdin]
+
+        mock_select.return_value = None, None, None
+
+        return_val = io.has_data_to_read()
+
+        mock_select.assert_called_with(expected_socket_list, [], [], 0.05)
+        assert not return_val
+
+    @skip_if_windows
+    @mock.patch("select.select")
+    def test_stdin_stdout_io_has_data_to_read_returns_true_non_windows(self, mock_select):
+        io = StdinStdoutIO()
+
+        expected_socket_list = [sys.stdin]
+
+        mock_select.return_value = True, None, None
+
+        return_val = io.has_data_to_read()
+
+        mock_select.assert_called_with(expected_socket_list, [], [], 0.05)
+        assert return_val
+
+    @if_windows
+    def test_windows_stdin_stdout_io_has_data_to_read_always_returns_true(self):
+        io = WindowsStdinStdoutIO()
+        assert io.has_data_to_read()
+
+    def test_tcp_socket_io_read(self):
+        mock_conn = mock.Mock(spec=socket.SocketType)
+        io = TCPSocketIO(mock_conn)
+
+        expected_data = b"Test"
+        mock_conn.recv.return_value = expected_data
+
+        bytes_to_read = 100
+        returned_data = io.read(bytes_to_read)
+
+        assert returned_data == expected_data
+        mock_conn.recv.assert_called_with(bytes_to_read)
+
+    def test_tcp_socket_io_write(self):
+        mock_conn = mock.Mock(spec=socket.SocketType)
+        io = TCPSocketIO(mock_conn)
+
+        expected_data = b"Test"
+
+        io.write(expected_data)
+
+        mock_conn.sendall.assert_called_with(expected_data)
+
+
+    def test_tcp_socket_io_read_raise_error_when_empty_data(self):
+        mock_conn = mock.Mock(spec=socket.SocketType)
+        io = TCPSocketIO(mock_conn)
+
+        expected_data = b""
+        mock_conn.recv.return_value = expected_data
+
+        bytes_to_read = 100
+        with pytest.raises(InputClosedError):
+            io.read(bytes_to_read)
+
+        mock_conn.recv.assert_called_with(bytes_to_read)
+
+@pytest.fixture
+def mock_websocketio():
+    return mock.Mock(spec=BaseWebsocketIO)
+
+
+@pytest.fixture
+def mock_crt_websocket():
+    return mock.Mock(spec=WebSocket)
+
+
+@pytest.fixture
+def mock_on_connection_event():
+    return mock.Mock(spec=Event)
+
+
+@pytest.fixture
+def mock_send_frame_results_queue():
+    return mock.Mock(spec=Queue)
+
+
+@pytest.fixture
+def mock_shutdown_event():
+    return mock.Mock(spec=Event)
+
+
+@pytest.fixture
+def mock_tls_connection_options():
+    return mock.Mock(spec=TlsConnectionOptions)
+
+
+@pytest.fixture
+def mock_handshake_request():
+    return mock.Mock(spec=HttpRequest)
+
+
+@pytest.fixture
+def web_socket(mock_websocketio, mock_crt_websocket, mock_on_connection_event, mock_send_frame_results_queue,
+               mock_shutdown_event, mock_tls_connection_options):
+    web_socket = Websocket(mock_websocketio, "websocket-id", mock_tls_connection_options, mock_on_connection_event,
+                           mock_shutdown_event, mock_send_frame_results_queue)
+    web_socket._websocket = mock_crt_websocket
+    return web_socket
+
+
+def assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio):
+    assert mock_shutdown_event.set.called
+    assert mock_crt_websocket.close.called
+    assert mock_websocketio.close.called
+
+
+class CaptureCRTWebsocket:
+    def __init__(self):
+        self.on_connection_setup_handler = None
+        self.on_connection_shutdown_handler = None
+        self.on_incoming_frame_payload_handler = None
+        self.on_incoming_frame_complete_handler = None
+
+    def connect(self, **kwargs):
+        self.on_connection_setup_handler = kwargs['on_connection_setup']
+        self.on_connection_shutdown_handler = kwargs['on_connection_shutdown']
+        self.on_incoming_frame_payload_handler = kwargs['on_incoming_frame_payload']
+        self.on_incoming_frame_complete_handler = kwargs['on_incoming_frame_complete']
+
+
+@pytest.fixture
+def capture_crt_websocket():
+    return CaptureCRTWebsocket()
+
+
+@pytest.fixture
+def websocket_url():
+    return 'wss://amazon.com/openTunnel?params'
+
+
+class TestWebsocket:
+    @pytest.fixture(autouse=True)
+    def patch_crt_websocket(self, monkeypatch, capture_crt_websocket):
+        monkeypatch.setattr("awscrt.websocket.connect", capture_crt_websocket.connect)
+
+    @patch.object(websocket, "connect")
+    @patch.object(websocket, "create_handshake_request")
+    def test_connect(
+            self, mock_handshake, mock_connect, mock_handshake_request,
+            mock_on_connection_event, mock_tls_connection_options, web_socket, websocket_url
+    ):
+        parsed_url = urlparse(websocket_url)
+        host = parsed_url.hostname
+        path = parsed_url.path + "?" + parsed_url.query
+        mock_handshake.return_value = mock_handshake_request
+
+        http_headers = HttpHeaders()
+        mock_handshake_request.headers = http_headers
+
+        web_socket.connect(websocket_url, 'defined-user-agent')
+
+        mock_handshake.assert_called_with(host=host, path=path)
+        mock_tls_connection_options.set_server_name.assert_called_with(host)
+        assert 'defined-user-agent' == http_headers.get('User-Agent')
+        mock_connect.assert_called_with(
+            host=host,
+            handshake_request=mock_handshake_request,
+            port=443,
+            tls_connection_options=mock_tls_connection_options,
+            proxy_options=None,
+            on_connection_setup=mock.ANY,
+            on_connection_shutdown=mock.ANY,
+            on_incoming_frame_payload=mock.ANY,
+            on_incoming_frame_complete=mock.ANY
+        )
+
+        assert mock_on_connection_event.wait.called
+
+    @patch.object(websocket, "connect")
+    @patch.object(websocket, "create_handshake_request")
+    @mock.patch.dict(os.environ, {"HTTPS_PROXY": "http://user1:pass1@localhost:8989", "NO_PROXY": "different-domain"})
+    def test_connect_with_proxy(
+            self, mock_handshake, mock_connect, mock_on_connection_event,
+            mock_tls_connection_options, web_socket, websocket_url
+    ):
+        parsed_url = urlparse(websocket_url)
+        host = parsed_url.hostname
+        path = parsed_url.path + "?" + parsed_url.query
+        mock_handshake.return_value = mock_handshake_request
+
+        web_socket.connect(websocket_url)
+
+        mock_handshake.assert_called_with(host=host, path=path)
+        mock_tls_connection_options.set_server_name.assert_called_with(host)
+        mock_connect.assert_called_with(
+            host=host,
+            handshake_request=mock_handshake_request,
+            port=443,
+            tls_connection_options=mock_tls_connection_options,
+            proxy_options=mock.ANY,
+            on_connection_setup=mock.ANY,
+            on_connection_shutdown=mock.ANY,
+            on_incoming_frame_payload=mock.ANY,
+            on_incoming_frame_complete=mock.ANY
+        )
+        assert "localhost" == mock_connect.call_args.kwargs['proxy_options'].host_name
+        assert 8989 == mock_connect.call_args.kwargs['proxy_options'].port
+        assert HttpProxyAuthenticationType.Basic == mock_connect.call_args.kwargs['proxy_options'].auth_type
+        assert "user1" == mock_connect.call_args.kwargs['proxy_options'].auth_username
+        assert "pass1" == mock_connect.call_args.kwargs['proxy_options'].auth_password
+
+        assert mock_on_connection_event.wait.called
+
+    @patch.object(websocket, "connect")
+    @patch.object(websocket, "create_handshake_request")
+    @mock.patch.dict(os.environ,
+                     {"HTTPS_PROXY": "http://user1:pass1@localhost:8989", "NO_PROXY": "1eice-123.eice.amazon.com"})
+    def test_connect_with_proxy_define_and_no_proxy_defined(
+            self, mock_handshake, mock_connect, mock_handshake_request,
+            mock_on_connection_event, mock_tls_connection_options, web_socket
+    ):
+        url = "wss://eice-123.eice.amazon.com/openTunnel?params"
+        parsed_url = urlparse(url)
+        host = parsed_url.hostname
+        path = parsed_url.path + "?" + parsed_url.query
+        mock_handshake.return_value = mock_handshake_request
+
+        web_socket.connect(url)
+
+        mock_handshake.assert_called_with(host=host, path=path)
+        mock_tls_connection_options.set_server_name.assert_called_with(host)
+        mock_connect.assert_called_with(
+            host=host,
+            handshake_request=mock_handshake_request,
+            port=443,
+            tls_connection_options=mock_tls_connection_options,
+            proxy_options=None,
+            on_connection_setup=mock.ANY,
+            on_connection_shutdown=mock.ANY,
+            on_incoming_frame_payload=mock.ANY,
+            on_incoming_frame_complete=mock.ANY
+        )
+
+        assert mock_on_connection_event.wait.called
+
+    def test_write_data_from_input_when_there_is_data_to_read(
+            self, mock_websocketio, mock_crt_websocket, mock_send_frame_results_queue, mock_shutdown_event,
+            web_socket, capture_crt_websocket
+    ):
+        data_as_bytes = b"Test"
+        mock_websocketio.read.return_value = data_as_bytes
+        mock_websocketio.has_data_to_read.return_value = True
+
+        mock_shutdown_event.is_set.side_effect = [False, True]
+
+        web_socket.write_data_from_input()
+
+        mock_websocketio.read.assert_called_with(65_000)
+        mock_crt_websocket.send_frame.assert_called_with(
+            opcode=Opcode.BINARY,
+            payload=data_as_bytes,
+            on_complete=mock.ANY,
+        )
+        assert mock_send_frame_results_queue.get.called
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    @mock.patch("time.sleep")
+    def test_write_data_from_input_when_there_is_no_data_to_read(
+            self, mock_sleep, mock_websocketio, mock_crt_websocket, mock_shutdown_event, web_socket
+    ):
+        mock_websocketio.has_data_to_read.return_value = False
+
+        mock_shutdown_event.is_set.side_effect = [False, True]
+
+        web_socket.write_data_from_input()
+
+        mock_sleep.assert_called_with(0.05)
+
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    def test_write_data_from_input_shuts_down_when_sends_frame_throws_close_frame_sent(
+            self, mock_websocketio, mock_crt_websocket, mock_shutdown_event, web_socket
+    ):
+        mock_crt_websocket.send_frame.side_effect = RuntimeError(
+            "AWS_ERROR_HTTP_WEBSOCKET_CLOSE_FRAME_SENT"
+        )
+
+        data_as_bytes = b"Test"
+        mock_websocketio.read.return_value = data_as_bytes
+        mock_websocketio.has_data_to_read.return_value = True
+        mock_shutdown_event.is_set.side_effect = [False, True]
+
+        web_socket.write_data_from_input()
+
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    def test_write_data_northbound_shuts_down_when_sends_frame_throws_http_connection_closed(
+            self, mock_websocketio, mock_crt_websocket, mock_shutdown_event, web_socket
+    ):
+        mock_crt_websocket.send_frame.side_effect = RuntimeError(
+            "AWS_ERROR_HTTP_CONNECTION_CLOSED"
+        )
+
+        data_as_bytes = b"Test"
+        mock_websocketio.read.return_value = data_as_bytes
+        mock_websocketio.has_data_to_read.return_value = True
+        mock_shutdown_event.is_set.side_effect = [False, True]
+
+        web_socket.write_data_from_input()
+
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    def test_on_connection_sets_websocket(self, capture_crt_websocket, websocket_url,
+                                          mock_on_connection_event, web_socket):
+        data = OnConnectionSetupData()
+        data.websocket = mock.Mock(spec=Websocket)
+        request_id = "request_id"
+        data.handshake_response_headers = [("X-Amzn-RequestId", request_id)]
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_connection_setup_handler(data)
+
+        assert data.websocket == web_socket._websocket
+        assert mock_on_connection_event.set.called
+
+    def test_on_connection_with_exception(self, mock_on_connection_event, web_socket, websocket_url,
+                                          capture_crt_websocket):
+        data = OnConnectionSetupData()
+        request_id = "request_id"
+        data.handshake_response_headers = [("X-Amzn-RequestId", request_id)]
+        data.exception = Exception()
+        data.handshake_response_status = 401
+        data.handshake_response_body = b"Failed to connect"
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_connection_setup_handler(data)
+
+        assert mock_on_connection_event.set.called
+
+    def test_on_incoming_frame_payload_data_with_binary_frame(
+            self, mock_websocketio, web_socket, websocket_url, capture_crt_websocket
+    ):
+        data_in_bytes = b"Test"
+        frame = IncomingFrame(opcode=Opcode.BINARY, payload_length=len(data_in_bytes), fin=True)
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_incoming_frame_payload_handler(
+            OnIncomingFramePayloadData(data=data_in_bytes, frame=frame)
+        )
+
+        mock_websocketio.write.assert_called_with(data_in_bytes)
+
+    def test_on_incoming_frame_payload_data_with_close_frame(
+            self, web_socket, websocket_url, capture_crt_websocket
+    ):
+        data_in_bytes = b"Test"
+        frame = IncomingFrame(opcode=Opcode.CLOSE, payload_length=len(data_in_bytes), fin=True)
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_incoming_frame_payload_handler(
+            OnIncomingFramePayloadData(data=data_in_bytes, frame=frame)
+        )
+
+        assert bytearray(data_in_bytes) == web_socket._close_frame_bytes
+
+    def test_on_incoming_frame_payload_data_with_text_frame_sets_shutdown_event(
+            self, mock_websocketio, mock_crt_websocket, mock_shutdown_event, web_socket,
+            websocket_url, capture_crt_websocket
+    ):
+        data_in_bytes = b"Test"
+        frame = IncomingFrame(opcode=Opcode.TEXT, payload_length=len(data_in_bytes), fin=True)
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_incoming_frame_payload_handler(
+            OnIncomingFramePayloadData(data=data_in_bytes, frame=frame)
+        )
+
+        assert isinstance(web_socket.exception, WebsocketException)
+
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    def test_on_incoming_frame_complete_with_close_frame(
+            self, mock_websocketio, mock_crt_websocket, mock_shutdown_event, web_socket,
+            websocket_url, capture_crt_websocket
+    ):
+
+        shutdown_reason = b"Test"
+        data_in_bytes = struct.pack(">H", 1) + shutdown_reason
+        frame = IncomingFrame(opcode=Opcode.CLOSE, payload_length=len(shutdown_reason), fin=True)
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_incoming_frame_payload_handler(
+            OnIncomingFramePayloadData(frame=frame, data=data_in_bytes,)
+        )
+        capture_crt_websocket.on_incoming_frame_complete_handler(
+            OnIncomingFrameCompleteData(frame=frame, exception=None)
+        )
+
+        expected_exc = WebsocketException(f"Websocket Closure Reason: {shutdown_reason.decode()}")
+        assert isinstance(web_socket.exception, WebsocketException)
+        # Ensure shutdown reason is decoded properly. (validate properties on WebsocketException)
+        assert web_socket.exception.args == expected_exc.args
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    def test_on_incoming_frame_complete_with_close_frame_ignores_shutdown_code_1000(
+            self, mock_websocketio, mock_crt_websocket, mock_shutdown_event, web_socket,
+            websocket_url, capture_crt_websocket
+    ):
+        frame = IncomingFrame(opcode=Opcode.CLOSE, payload_length=0, fin=True)
+        incoming_frame_data = OnIncomingFrameCompleteData(frame=frame)
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_incoming_frame_complete_handler(incoming_frame_data)
+
+        assert not web_socket.exception
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)
+
+    def test_on_connection_shutdown(self, mock_websocketio, mock_crt_websocket, mock_shutdown_event,
+                                    web_socket, websocket_url, capture_crt_websocket):
+        data = OnConnectionShutdownData()
+
+        web_socket.connect(websocket_url)
+        capture_crt_websocket.on_connection_shutdown_handler(data)
+
+        assert_websocket_closed(mock_shutdown_event, mock_crt_websocket, mock_websocketio)


### PR DESCRIPTION
The ssh command allows you to connect to an EC2 instance using an OpenSSH client.

The open-tunnel command allows you to connect to an EC2 instance using a web socket tunnel. Using the web socket tunnel, you can then send SSH traffic through an EC2 Instance Connect Endpoint in the case your instance does not have a public IP.

This change also required bumping the lower bound dependency range on CRT. The open-tunnel command uses websockets under the hood and websockets were added as part of CRT 0.16.1. Version 0.16.4 is the lowest version that passed all of the ec2-instance-connect tests and had no more bug fixes related to the web socket development.