### PR TITLE
Add missing CHANGELOG entry for `securitylake`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,7 @@ CHANGELOG
 * api-change:``iotwireless``: Add Multicast Group support in Network Analyzer Configuration.
 * api-change:``sagemaker``: Added ml.p4d and ml.inf1 as supported instance type families for SageMaker Notebook Instances.
 * api-change:``chime-sdk-voice``: Added optional CallLeg field to StartSpeakerSearchTask API request
+* api-change:``securitylake``: Log sources are now versioned. AWS log sources and custom sources will now come with a version identifier that enables producers to vend multiple schema versions to subscribers. Security Lake API have been refactored to more closely align with AWS API conventions.
 
 
 2.11.23
@@ -5638,6 +5639,7 @@ CHANGELOG
 * api-change:``polly``: Amazon Polly adds 2 new voices - Sofie (da-DK) and Niamh (en-IE)
 * api-change:``securityhub``: Added new resource detail objects to ASFF, including resources for AwsGuardDutyDetector, AwsAmazonMqBroker, AwsEventSchemasRegistry, AwsAppSyncGraphQlApi and AwsStepFunctionStateMachine.
 * api-change:``wafv2``: This SDK release provides customers the ability to use Header Order as a field to match.
+* api-change:``securitylake``: Log sources are now versioned. AWS log sources and custom sources will now come with a version identifier that enables producers to vend multiple schema versions to subscribers. Security Lake API have been refactored to more closely align with AWS API conventions.
 
 
 1.27.142


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/7938

*Description of changes:* 
>...a patch was added [here](https://github.com/boto/botocore/pull/2961/files) a few days ago which included changes to the service API model. There were issues with the preview release and those changes were required for the [GA release](https://aws.amazon.com/blogs/security/amazon-security-lake-is-now-generally-available/) that you referenced. Unfortunately a CHANGELOG entry did not get added due to this.

[Here](https://github.com/aws/aws-sdk-js-v3/blob/cb4a0e30c3dda0a7911c96b0a57e9db0c64a5066/CHANGELOG.md?plain=1#L220) are release notes in JS v3 SDK.

I can also create PRs for AWS CLI v1, boto3, and botocore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
