### PR TITLE
[v2] Add changelogs for Python and OpenSSL version updates

### DIFF
--- a/.changes/next-release/enhancement-Python-87171.json
+++ b/.changes/next-release/enhancement-Python-87171.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Update bundled Python interpreter to 3.11.4"
+}

--- a/.changes/next-release/enhancement-openssl-13154.json
+++ b/.changes/next-release/enhancement-openssl-13154.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "openssl",
+  "description": "Update bundled openssl version to 1.1.1u"
+}


### PR DESCRIPTION
These version updates are only applicable to the officially vended AWS CLI v2 executables.