### PR TITLE
 [v2] Implement configured endpoint URL resolution

### DIFF
--- a/.changes/next-release/feature-configuration-92113.json
+++ b/.changes/next-release/feature-configuration-92113.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "configuration",
+  "description": "Configure the endpoint URL in the shared configuration file or via an environment variable for a specific AWS service or all AWS services."
+}

--- a/awscli/botocore/args.py
+++ b/awscli/botocore/args.py
@@ -70,7 +70,7 @@ class ClientArgsCreator(object):
         s3_config = final_args['s3_config']
         partition = endpoint_config['metadata'].get('partition', None)
         socket_options = final_args['socket_options']
-
+        configured_endpoint_url = final_args['configured_endpoint_url']
         signing_region = endpoint_config['signing_region']
         endpoint_region_name = endpoint_config['region_name']
 
@@ -108,7 +108,7 @@ class ClientArgsCreator(object):
             service_model,
             endpoint_region_name,
             region_name,
-            endpoint_url,
+            configured_endpoint_url,
             endpoint,
             is_secure,
             endpoint_bridge,
@@ -151,10 +151,16 @@ class ClientArgsCreator(object):
                 user_agent += ' %s' % client_config.user_agent_extra
 
         s3_config = self.compute_s3_config(client_config)
+
+        configured_endpoint_url = self._compute_configured_endpoint_url(
+            client_config=client_config,
+            endpoint_url=endpoint_url,
+        )
+
         endpoint_config = self._compute_endpoint_config(
             service_name=service_name,
             region_name=region_name,
-            endpoint_url=endpoint_url,
+            endpoint_url=configured_endpoint_url,
             is_secure=is_secure,
             endpoint_bridge=endpoint_bridge,
             s3_config=s3_config,
@@ -196,12 +202,34 @@ class ClientArgsCreator(object):
             'service_name': service_name,
             'parameter_validation': parameter_validation,
             'user_agent': user_agent,
+            'configured_endpoint_url': configured_endpoint_url,
             'endpoint_config': endpoint_config,
             'protocol': protocol,
             'config_kwargs': config_kwargs,
             's3_config': s3_config,
             'socket_options': self._compute_socket_options(scoped_config)
         }
+
+    def _compute_configured_endpoint_url(self, client_config, endpoint_url):
+        if endpoint_url is not None:
+            return endpoint_url
+
+        if self._ignore_configured_endpoint_urls(client_config):
+            logger.debug("Ignoring configured endpoint URLs.")
+            return endpoint_url
+
+        return self._config_store.get_config_variable('endpoint_url')
+
+    def _ignore_configured_endpoint_urls(self, client_config):
+        if (
+            client_config
+            and client_config.ignore_configured_endpoint_urls is not None
+        ):
+            return client_config.ignore_configured_endpoint_urls
+
+        return self._config_store.get_config_variable(
+            'ignore_configured_endpoint_urls'
+        )
 
     def compute_s3_config(self, client_config):
         s3_configuration = self._config_store.get_config_variable('s3')

--- a/awscli/botocore/config.py
+++ b/awscli/botocore/config.py
@@ -162,6 +162,13 @@ class Config(object):
         endpoint resolution.
 
         Defaults to None.
+
+    :type ignore_configured_endpoint_urls: bool
+    :param ignore_configured_endpoint_urls: Setting to True disables use
+        of endpoint URLs provided via environment variables and
+        the shared configuration file.
+
+        Defaults to None.
     """
     OPTION_DEFAULTS = OrderedDict([
         ('region_name', None),
@@ -181,6 +188,7 @@ class Config(object):
         ('endpoint_discovery_enabled', None),
         ('use_dualstack_endpoint', None),
         ('use_fips_endpoint', None),
+        ('ignore_configured_endpoint_urls', None),
     ])
 
     def __init__(self, *args, **kwargs):

--- a/awscli/botocore/configloader.py
+++ b/awscli/botocore/configloader.py
@@ -198,6 +198,17 @@ def _parse_nested(config_value):
     return parsed
 
 
+def _parse_section(key, values):
+    result = {}
+    try:
+        parts = shlex.split(key)
+    except ValueError:
+        return result
+    if len(parts) == 2:
+        result[parts[1]] = values
+    return result
+
+
 def build_profile_map(parsed_ini_config):
     """Convert the parsed INI config into a profile map.
 
@@ -252,22 +263,15 @@ def build_profile_map(parsed_ini_config):
     parsed_config = copy.deepcopy(parsed_ini_config)
     profiles = {}
     sso_sessions = {}
+    services = {}
     final_config = {}
     for key, values in parsed_config.items():
         if key.startswith("profile"):
-            try:
-                parts = shlex.split(key)
-            except ValueError:
-                continue
-            if len(parts) == 2:
-                profiles[parts[1]] = values
+            profiles.update(_parse_section(key, values))
         elif key.startswith("sso-session"):
-            try:
-                parts = shlex.split(key)
-            except ValueError:
-                continue
-            if len(parts) == 2:
-                sso_sessions[parts[1]] = values
+            sso_sessions.update(_parse_section(key, values))
+        elif key.startswith("services"):
+            services.update(_parse_section(key, values))
         elif key == 'default':
             # default section is special and is considered a profile
             # name but we don't require you use 'profile "default"'
@@ -277,4 +281,5 @@ def build_profile_map(parsed_ini_config):
             final_config[key] = values
     final_config['profiles'] = profiles
     final_config['sso_sessions'] = sso_sessions
+    final_config['services'] = services
     return final_config

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -13,6 +13,7 @@
 """This module contains the inteface for controlling how configuration
 is loaded.
 """
+import copy
 import logging
 import os
 
@@ -301,6 +302,13 @@ class ConfigValueStore(object):
             for logical_name, provider in mapping.items():
                 self.set_config_provider(logical_name, provider)
 
+    def __copy__(self):
+        config_store = ConfigValueStore(copy.copy(self._mapping))
+        for logical_name, override_value in self._overrides.items():
+            config_store.set_config_variable(logical_name, override_value)
+
+        return config_store
+
     def get_config_variable(self, logical_name):
         """
         Retrieve the value associeated with the specified logical_name
@@ -321,6 +329,27 @@ class ConfigValueStore(object):
             return None
         provider = self._mapping[logical_name]
         return provider.provide()
+
+    def get_config_provider(self, logical_name):
+        """
+        Retrieve the provider associated with the specified logical_name.
+        If no provider is found None will be returned.
+
+        :type logical_name: str
+        :param logical_name: The logical name of the session variable
+            you want to retrieve.  This name will be mapped to the
+            appropriate environment variable name for this session as
+            well as the appropriate config file entry.
+
+        :returns: configuration provider or None if not defined.
+        """
+        if (
+            logical_name in self._overrides
+            or logical_name not in self._mapping
+        ):
+            return None
+        provider = self._mapping[logical_name]
+        return provider
 
     def set_config_variable(self, logical_name, value):
         """Set a configuration variable to a specific value.

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -17,6 +17,7 @@ import logging
 import os
 
 from botocore import utils
+from botocore.exceptions import InvalidConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         'use_fips_endpoint',
         'AWS_USE_FIPS_ENDPOINT',
         None, utils.ensure_boolean),
+    'ignore_configured_endpoint_urls': (
+        'ignore_configured_endpoint_urls',
+        'AWS_IGNORE_CONFIGURED_ENDPOINT_URLS',
+        None,
+        utils.ensure_boolean,
+    ),
     'parameter_validation': ('parameter_validation', None, True, None),
     # Client side monitoring configurations.
     # Note: These configurations are considered internal to botocore.
@@ -561,3 +568,142 @@ class ConstantProvider(BaseProvider):
 
     def __repr__(self):
         return 'ConstantProvider(value=%s)' % self._value
+
+
+class ConfiguredEndpointProvider(BaseProvider):
+    """Lookup an endpoint URL from environment variable or shared config file.
+
+    NOTE: This class is considered private and is subject to abrupt breaking
+    changes or removal without prior announcement. Please do not use it
+    directly.
+    """
+
+    _ENDPOINT_URL_LOOKUP_ORDER = [
+        'environment_service',
+        'environment_global',
+        'config_service',
+        'config_global',
+    ]
+
+    def __init__(
+        self,
+        full_config,
+        scoped_config,
+        client_name,
+        environ=None,
+    ):
+        """Initialize a ConfiguredEndpointProviderChain.
+
+        :type full_config: dict
+        :param full_config: This is the dict representing the full
+            configuration file.
+
+        :type scoped_config: dict
+        :param scoped_config: This is the dict representing the configuration
+            for the current profile for the session.
+
+        :type client_name: str
+        :param client_name: The name used to instantiate a client using
+            botocore.session.Session.create_client.
+
+        :type environ: dict
+        :param environ: A mapping to use for environment variables. If this
+            is not provided it will default to use os.environ.
+        """
+        self._full_config = full_config
+        self._scoped_config = scoped_config
+        self._client_name = client_name
+        self._transformed_service_id = self._get_snake_case_service_id(
+            self._client_name
+        )
+        if environ is None:
+            environ = os.environ
+        self._environ = environ
+
+    def provide(self):
+        """Lookup the configured endpoint URL.
+
+        The order is:
+
+        1. The value provided by a service-specific environment variable.
+        2. The value provided by the global endpoint environment variable
+           (AWS_ENDPOINT_URL).
+        3. The value provided by a service-specific parameter from a services
+           definition section in the shared configuration file.
+        4. The value provided by the global parameter from a services
+           definition section in the shared configuration file.
+        """
+        for location in self._ENDPOINT_URL_LOOKUP_ORDER:
+            logger.debug(
+                'Looking for endpoint for %s via: %s',
+                self._client_name,
+                location,
+            )
+
+            endpoint_url = getattr(self, f'_get_endpoint_url_{location}')()
+
+            if endpoint_url:
+                logger.info(
+                    'Found endpoint for %s via: %s.',
+                    self._client_name,
+                    location,
+                )
+                return endpoint_url
+
+        logger.debug('No configured endpoint found.')
+        return None
+
+    def _get_snake_case_service_id(self, client_name):
+        # Get the service ID without loading the service data file, accounting
+        # for any aliases and standardizing the names with hyphens.
+        client_name = utils.SERVICE_NAME_ALIASES.get(client_name, client_name)
+        hyphenized_service_id = (
+            utils.CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES.get(
+                client_name, client_name
+            )
+        )
+        return hyphenized_service_id.replace('-', '_')
+
+    def _get_service_env_var_name(self):
+        transformed_service_id_env = self._transformed_service_id.upper()
+        return f'AWS_ENDPOINT_URL_{transformed_service_id_env}'
+
+    def _get_services_config(self):
+        if 'services' not in self._scoped_config:
+            return {}
+
+        section_name = self._scoped_config['services']
+        services_section = self._full_config.get('services', {}).get(
+            section_name
+        )
+
+        if not services_section:
+            error_msg = (
+                f'The profile is configured to use the services '
+                f'section but the "{section_name}" services '
+                f'configuration does not exist.'
+            )
+            raise InvalidConfigError(error_msg=error_msg)
+
+        return services_section
+
+    def _get_endpoint_url_config_service(self):
+        snakecase_service_id = self._transformed_service_id.lower()
+        return (
+            self._get_services_config()
+            .get(snakecase_service_id, {})
+            .get('endpoint_url')
+        )
+
+    def _get_endpoint_url_config_global(self):
+        return self._scoped_config.get('endpoint_url')
+
+    def _get_endpoint_url_environment_service(self):
+        return EnvironmentProvider(
+            name=self._get_service_env_var_name(), env=self._environ
+        ).provide()
+
+    def _get_endpoint_url_environment_global(self):
+        return EnvironmentProvider(
+            name='AWS_ENDPOINT_URL', env=self._environ
+        ).provide()

--- a/awscli/botocore/handlers.py
+++ b/awscli/botocore/handlers.py
@@ -65,6 +65,7 @@ from botocore.utils import (
     is_global_accesspoint,
     percent_encode,
     switch_host_with_param,
+    SERVICE_NAME_ALIASES,
 )
 
 logger = logging.getLogger(__name__)
@@ -90,10 +91,6 @@ VALID_S3_ARN = re.compile('|'.join([_ACCESSPOINT_ARN, _OUTPOST_ARN]))
 # botocore/data/s3/2006-03-01/endpoints-rule-set-1.json
 S3_SIGNING_NAMES = ('s3', 's3-outposts', 's3-object-lambda')
 VERSION_ID_SUFFIX = re.compile(r'\?versionId=[^\s]+$')
-
-SERVICE_NAME_ALIASES = {
-    'runtime.sagemaker': 'sagemaker-runtime'
-}
 
 
 def handle_service_name_alias(service_name, **kwargs):

--- a/awscli/botocore/session.py
+++ b/awscli/botocore/session.py
@@ -840,8 +840,7 @@ class Session(object):
         auth_token = self.get_auth_token()
         endpoint_resolver = self._get_internal_component('endpoint_resolver')
         exceptions_factory = self._get_internal_component('exceptions_factory')
-        config_store = self.get_component('config_store')
-
+        config_store = copy.copy(self.get_component('config_store'))
         self._add_configured_endpoint_provider(
             client_name=service_name,
             config_store=config_store,

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -3302,3 +3302,78 @@ def is_s3_accelerate_url(url):
 
     # Remaining parts must all be in the whitelist.
     return all(p in S3_ACCELERATE_WHITELIST for p in feature_parts)
+
+
+# This parameter is not part of the public interface and is subject to abrupt
+# breaking changes or removal without prior announcement.
+# Mapping of services that have been renamed for backwards compatibility reasons.
+# Keys are the previous name that should be allowed, values are the documented
+# and preferred client name.
+SERVICE_NAME_ALIASES = {'runtime.sagemaker': 'sagemaker-runtime'}
+
+
+# This parameter is not part of the public interface and is subject to abrupt
+# breaking changes or removal without prior announcement.
+# Mapping to determine the service ID for services that do not use it as the
+# model data directory name. The keys are the data directory name and the
+# values are the transformed service IDs (lower case and hyphenated).
+CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES = {
+    # Actual service name we use -> Allowed computed service name.
+    'alexaforbusiness': 'alexa-for-business',
+    'apigateway': 'api-gateway',
+    'application-autoscaling': 'application-auto-scaling',
+    'appmesh': 'app-mesh',
+    'autoscaling': 'auto-scaling',
+    'autoscaling-plans': 'auto-scaling-plans',
+    'ce': 'cost-explorer',
+    'cloudhsmv2': 'cloudhsm-v2',
+    'cloudsearchdomain': 'cloudsearch-domain',
+    'cognito-idp': 'cognito-identity-provider',
+    'config': 'config-service',
+    'cur': 'cost-and-usage-report-service',
+    'datapipeline': 'data-pipeline',
+    'directconnect': 'direct-connect',
+    'devicefarm': 'device-farm',
+    'discovery': 'application-discovery-service',
+    'dms': 'database-migration-service',
+    'ds': 'directory-service',
+    'dynamodbstreams': 'dynamodb-streams',
+    'elasticbeanstalk': 'elastic-beanstalk',
+    'elastictranscoder': 'elastic-transcoder',
+    'elb': 'elastic-load-balancing',
+    'elbv2': 'elastic-load-balancing-v2',
+    'es': 'elasticsearch-service',
+    'events': 'eventbridge',
+    'globalaccelerator': 'global-accelerator',
+    'iot-data': 'iot-data-plane',
+    'iot-jobs-data': 'iot-jobs-data-plane',
+    'iot1click-devices': 'iot-1click-devices-service',
+    'iot1click-projects': 'iot-1click-projects',
+    'iotevents-data': 'iot-events-data',
+    'iotevents': 'iot-events',
+    'iotwireless': 'iot-wireless',
+    'kinesisanalytics': 'kinesis-analytics',
+    'kinesisanalyticsv2': 'kinesis-analytics-v2',
+    'kinesisvideo': 'kinesis-video',
+    'lex-models': 'lex-model-building-service',
+    'lexv2-models': 'lex-models-v2',
+    'lex-runtime': 'lex-runtime-service',
+    'lexv2-runtime': 'lex-runtime-v2',
+    'logs': 'cloudwatch-logs',
+    'machinelearning': 'machine-learning',
+    'marketplacecommerceanalytics': 'marketplace-commerce-analytics',
+    'marketplace-entitlement': 'marketplace-entitlement-service',
+    'meteringmarketplace': 'marketplace-metering',
+    'mgh': 'migration-hub',
+    'resourcegroupstaggingapi': 'resource-groups-tagging-api',
+    'route53': 'route-53',
+    'route53domains': 'route-53-domains',
+    's3control': 's3-control',
+    'sdb': 'simpledb',
+    'secretsmanager': 'secrets-manager',
+    'serverlessrepo': 'serverlessapplicationrepository',
+    'servicecatalog': 'service-catalog',
+    'servicecatalog-appregistry': 'service-catalog-appregistry',
+    'stepfunctions': 'sfn',
+    'storagegateway': 'storage-gateway',
+}

--- a/tests/functional/botocore/configured_endpoint_urls/__init__.py
+++ b/tests/functional/botocore/configured_endpoint_urls/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.

--- a/tests/functional/botocore/configured_endpoint_urls/profile-tests.json
+++ b/tests/functional/botocore/configured_endpoint_urls/profile-tests.json
@@ -1,0 +1,505 @@
+{
+  "description": [
+    "These are test descriptions that describe how specific data should be loaded from a profile file based on a ",
+    "profile name."
+  ],
+
+  "testSuites": [
+    {
+      "profiles": {
+        "default": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "region": "fake-region-10"
+        },
+        "service_localhost_global_only": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "region": "fake-region-10",
+          "endpoint_url": "http://localhost:1234"
+        },
+        "service_global_only": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "region": "fake-region-10",
+          "endpoint_url": "https://global.endpoint.aws"
+        },
+        "service_specific_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "services": "service_specific_s3",
+          "region": "fake-region-10"
+        },
+        "global_and_service_specific_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "endpoint_url": "https://global.endpoint.aws",
+          "services": "service_specific_s3",
+          "region": "fake-region-10"
+        },
+        "ignore_global_and_service_specific_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "endpoint_url": "https://global.endpoint.aws",
+          "services": "service_specific_s3",
+          "region": "fake-region-10",
+          "ignore_configured_endpoint_urls": "true"
+        },
+        "service_specific_dynamodb_and_s3": {
+          "aws_access_key_id": "123",
+          "aws_secret_access_key": "456",
+          "services": "service_specific_dynamodb_and_s3",
+          "region": "fake-region-10"
+        }
+      },
+
+      "services": {
+        "service_specific_s3": {
+          "s3": {
+            "endpoint_url": "https://s3.endpoint.aws"
+          }
+        },
+        "service_specific_dynamodb_and_s3": {
+          "dynamodb": {
+            "endpoint_url": "https://dynamodb.endpoint.aws"
+          },
+          "s3": {
+            "endpoint_url": "https://s3.endpoint.aws"
+          }
+        }
+      },
+
+      "client_configs": {
+        "default": {},
+        "endpoint_url_provided":{
+          "endpoint_url": "https://client-config.endpoint.aws"
+        },
+        "ignore_configured_endpoint_urls": {
+          "ignore_configured_endpoint_urls": true
+        },
+        "provide_and_ignore_configured_endpoint_urls": {
+          "ignore_configured_endpoint_urls": true,
+          "endpoint_url": "https://client-config.endpoint.aws"
+        }
+      },
+
+      "environments": {
+        "default": {},
+        "global_only": {
+          "AWS_ENDPOINT_URL": "https://global-from-envvar.endpoint.aws"
+        },
+        "service_specific_s3": {
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws"
+        },
+        "global_and_service_specific_s3": {
+          "AWS_ENDPOINT_URL": "https://global-from-envvar.endpoint.aws",
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws"
+
+        },
+        "ignore_global_and_service_specific_s3": {
+          "AWS_ENDPOINT_URL": "https://global-from-envvar.endpoint.aws",
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws",
+          "AWS_IGNORE_CONFIGURED_ENDPOINT_URLS": "true"
+        },
+        "service_specific_dynamodb_and_s3": {
+          "AWS_ENDPOINT_URL_DYNAMODB": "https://dynamodb-from-envvar.endpoint.aws",
+          "AWS_ENDPOINT_URL_S3": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+
+    "endpointUrlTests": [
+      {
+        "name": "Global endpoint url is read from services section and used for an S3 client.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service specific endpoint url is read from services section and used for an S3 client.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.endpoint.aws"
+        }
+      },
+      {
+        "name": "S3 Service-specific endpoint URL from configuration file takes precedence over global endpoint URL from configuration file.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precedence over the value resolved by the SDK.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precendence over global endpoint configuration option.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precendence over service-specific endpoint configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Global endpoint url environment variable takes precendence over global endpoint configuration option and service-specific endpoint configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://global-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the value resolved by the SDK.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the services-specific endpoint url configuration option and the global endpoint url configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable and the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable and the the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Service-specific endpoint url environment variable takes precedence over the global endpoint url environment variable, the service-specific endpoint URL configuration option, and the global endpoint URL configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3-from-envvar.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over value provided by the SDK.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url from services section and used for an S3 client.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service specific endpoint url from services section and used for an S3 client.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over S3 Service-specific endpoint URL from configuration file and global endpoint URL from configuration file.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "default",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable and global endpoint configuration option.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable and service-specific endpoint configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over global endpoint url environment variable, global endpoint configuration option, and service-specific endpoint configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_only",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable and the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable and the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the services-specific endpoint url configuration option, and the global endpoint url configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable and the global endpoint url environment variable.",
+        "profile": "default",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the global endpoint url environment variable, and the global endpoint url configuration option.",
+        "profile": "service_global_only",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the global endpoint url environment variable, and the service-specific endpoint url configuration option.",
+        "profile": "service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Client configuration takes precedence over service-specific endpoint url environment variable, the global endpoint url environment variable, the service-specific endpoint URL configuration option, and the global endpoint URL configuration option.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "All configured endpoints ignored due to environment variable.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "ignore_global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.fake-region-10.amazonaws.com"
+        }
+      },
+      {
+        "name": "All configured endpoints ignored due to shared config variable.",
+        "profile": "ignore_global_and_service_specific_s3",
+        "client_config": "default",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.fake-region-10.amazonaws.com"
+        }
+      },
+      {
+        "name": "All configured endpoints ignored due to ignore client config parameter.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "ignore_configured_endpoint_urls",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://s3.fake-region-10.amazonaws.com"
+        }
+      },
+      {
+        "name": "Environment variable and shared config file configured endpoints ignored due to ignore shared config variable and client configured endpoint is used.",
+        "profile": "ignore_global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Environment variable and shared config file configured endpoints ignored due to ignore environment variable and client configured endpoint is used.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "endpoint_url_provided",
+        "environment": "ignore_global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "Environment variable and shared config file configured endpoints ignored due to ignore client config variable and client configured endpoint is used.",
+        "profile": "global_and_service_specific_s3",
+        "client_config": "provide_and_ignore_configured_endpoint_urls",
+        "environment": "global_and_service_specific_s3",
+        "service": "s3",
+        "output": {
+          "endpointUrl": "https://client-config.endpoint.aws"
+        }
+      },
+      {
+        "name": "DynamoDB service-specific endpoint url shared config variable is used when service-specific S3 shared config variable is also present.",
+        "profile": "service_specific_dynamodb_and_s3",
+        "client_config": "default",
+        "environment": "default",
+        "service": "dynamodb",
+        "output": {
+          "endpointUrl": "https://dynamodb.endpoint.aws"
+        }
+      },
+      {
+        "name": "DynamoDB service-specific endpoint url environment variable is used when service-specific S3 environment variable is also present.",
+        "profile": "default",
+        "client_config": "default",
+        "environment": "service_specific_dynamodb_and_s3",
+        "service": "dynamodb",
+        "output": {
+          "endpointUrl": "https://dynamodb-from-envvar.endpoint.aws"
+        }
+      }
+
+    ]
+  }
+  ]
+}

--- a/tests/functional/botocore/configured_endpoint_urls/test_configured_endpoint_url.py
+++ b/tests/functional/botocore/configured_endpoint_urls/test_configured_endpoint_url.py
@@ -1,0 +1,249 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import botocore.configprovider
+import botocore.utils
+from botocore.compat import urlsplit
+from botocore.config import Config
+from tests import ClientHTTPStubber
+
+ENDPOINT_TESTDATA_FILE = Path(__file__).parent / "profile-tests.json"
+
+
+def dict_to_ini_section(ini_dict, section_header):
+    section_str = f'[{section_header}]\n'
+    for key, value in ini_dict.items():
+        if isinstance(value, dict):
+            section_str += f"{key} =\n"
+            for new_key, new_value in value.items():
+                section_str += f"  {new_key}={new_value}\n"
+        else:
+            section_str += f"{key}={value}\n"
+    return section_str + "\n"
+
+
+def create_cases():
+    with open(ENDPOINT_TESTDATA_FILE) as f:
+        test_suite = json.load(f)['testSuites'][0]
+
+    for test_case_data in test_suite['endpointUrlTests']:
+        yield pytest.param(
+            {
+                'service': test_case_data['service'],
+                'profile': test_case_data['profile'],
+                'expected_endpoint_url': test_case_data['output'][
+                    'endpointUrl'
+                ],
+                'client_args': get_create_client_args(
+                    test_suite['client_configs'].get(
+                        test_case_data['client_config'], {}
+                    )
+                ),
+                'config_file_contents': get_config_file_contents(
+                    test_case_data['profile'], test_suite
+                ),
+                'environment': test_suite['environments'].get(
+                    test_case_data['environment'], {}
+                ),
+            },
+            id=test_case_data['name'],
+        )
+
+
+def get_create_client_args(test_case_client_config):
+    create_client_args = {}
+
+    if 'endpoint_url' in test_case_client_config:
+        create_client_args['endpoint_url'] = test_case_client_config[
+            'endpoint_url'
+        ]
+
+    if 'ignore_configured_endpoint_urls' in test_case_client_config:
+        create_client_args['config'] = Config(
+            ignore_configured_endpoint_urls=test_case_client_config[
+                'ignore_configured_endpoint_urls'
+            ]
+        )
+
+    return create_client_args
+
+
+def get_config_file_contents(profile_name, test_suite):
+    profile = test_suite['profiles'][profile_name]
+
+    profile_str = dict_to_ini_section(
+        profile,
+        section_header=f"profile {profile_name}",
+    )
+
+    services_section_name = profile.get('services', None)
+
+    if services_section_name is None:
+        return profile_str
+
+    services_section = test_suite['services'][services_section_name]
+
+    service_section_str = dict_to_ini_section(
+        services_section,
+        section_header=f'services {services_section_name}',
+    )
+
+    return profile_str + service_section_str
+
+
+@pytest.fixture
+def client_creator(tmp_path):
+    tmp_config_file_path = tmp_path / 'config'
+    environ = {'AWS_CONFIG_FILE': str(tmp_config_file_path)}
+
+    def _do_create_client(
+        service,
+        profile,
+        client_args=None,
+        config_file_contents=None,
+        environment=None,
+    ):
+        environ.update(environment)
+        with open(tmp_config_file_path, 'w') as f:
+            f.write(config_file_contents)
+            f.flush()
+
+        return botocore.session.Session(profile=profile).create_client(
+            service, **client_args
+        )
+
+    with mock.patch('os.environ', environ):
+        yield _do_create_client
+
+
+def _normalize_endpoint(url):
+    split_endpoint = urlsplit(url)
+    actual_endpoint = f"{split_endpoint.scheme}://{split_endpoint.netloc}"
+    return actual_endpoint
+
+
+def assert_client_endpoint_url(client, expected_endpoint_url):
+    assert client.meta.endpoint_url == expected_endpoint_url
+
+
+def assert_endpoint_url_used_for_operation(
+    client, expected_endpoint_url, operation, params
+):
+    http_stubber = ClientHTTPStubber(client)
+    http_stubber.start()
+    http_stubber.add_response()
+
+    # Call an operation on the client
+    getattr(client, operation)(**params)
+
+    assert (
+        _normalize_endpoint(http_stubber.requests[0].url)
+        == expected_endpoint_url
+    )
+
+
+def _known_service_names_and_models():
+    my_session = botocore.session.get_session()
+    loader = my_session.get_component('data_loader')
+    available_services = loader.list_available_services('service-2')
+
+    result = []
+    for service_name in available_services:
+        model = my_session.get_service_model(service_name)
+        result.append((model.service_name, model))
+    return sorted(result)
+
+
+SERVICE_TO_OPERATION = {'s3': 'list_buckets', 'dynamodb': 'list_tables'}
+
+
+@pytest.mark.parametrize("test_case", create_cases())
+def test_resolve_configured_endpoint_url(test_case, client_creator):
+    client = client_creator(
+        service=test_case['service'],
+        profile=test_case['profile'],
+        client_args=test_case['client_args'],
+        config_file_contents=test_case['config_file_contents'],
+        environment=test_case['environment'],
+    )
+
+    assert_endpoint_url_used_for_operation(
+        client=client,
+        expected_endpoint_url=test_case['expected_endpoint_url'],
+        operation=SERVICE_TO_OPERATION[test_case['service']],
+        params={},
+    )
+
+
+@pytest.mark.parametrize(
+    'service_name,service_model', _known_service_names_and_models()
+)
+def test_expected_service_env_var_name_is_respected(
+    service_name, service_model, client_creator
+):
+    transformed_service_id = service_model.service_id.replace(' ', '_').upper()
+
+    client = client_creator(
+        service=service_name,
+        profile='default',
+        client_args={},
+        config_file_contents=(
+            '[profile default]\n'
+            'aws_access_key_id=123\n'
+            'aws_secret_access_key=456\n'
+            'region=fake-region-10\n'
+        ),
+        environment={
+            f'AWS_ENDPOINT_URL_{transformed_service_id}': 'https://endpoint-override'
+        },
+    )
+
+    assert_client_endpoint_url(
+        client=client, expected_endpoint_url='https://endpoint-override'
+    )
+
+
+@pytest.mark.parametrize(
+    'service_name,service_model', _known_service_names_and_models()
+)
+def test_expected_service_config_section_name_is_respected(
+    service_name, service_model, client_creator
+):
+    transformed_service_id = service_model.service_id.replace(' ', '_').lower()
+
+    client = client_creator(
+        service=service_name,
+        profile='default',
+        client_args={},
+        config_file_contents=(
+            f'[profile default]\n'
+            f'services=my-services\n'
+            f'aws_access_key_id=123\n'
+            f'aws_secret_access_key=456\n'
+            f'region=fake-region-10\n\n'
+            f'[services my-services]\n'
+            f'{transformed_service_id} = \n'
+            f'  endpoint_url = https://endpoint-override\n\n'
+        ),
+        environment={},
+    )
+
+    assert_client_endpoint_url(
+        client=client, expected_endpoint_url='https://endpoint-override'
+    )

--- a/tests/functional/botocore/configured_endpoint_urls/test_configured_endpoint_url.py
+++ b/tests/functional/botocore/configured_endpoint_urls/test_configured_endpoint_url.py
@@ -158,7 +158,7 @@ def assert_endpoint_url_used_for_operation(
     )
 
 
-def _known_service_names_and_models():
+def _known_service_names_and_ids():
     my_session = botocore.session.get_session()
     loader = my_session.get_component('data_loader')
     available_services = loader.list_available_services('service-2')
@@ -166,7 +166,7 @@ def _known_service_names_and_models():
     result = []
     for service_name in available_services:
         model = my_session.get_service_model(service_name)
-        result.append((model.service_name, model))
+        result.append((model.service_name, model.service_id))
     return sorted(result)
 
 
@@ -192,12 +192,12 @@ def test_resolve_configured_endpoint_url(test_case, client_creator):
 
 
 @pytest.mark.parametrize(
-    'service_name,service_model', _known_service_names_and_models()
+    'service_name,service_id', _known_service_names_and_ids()
 )
 def test_expected_service_env_var_name_is_respected(
-    service_name, service_model, client_creator
+    service_name, service_id, client_creator
 ):
-    transformed_service_id = service_model.service_id.replace(' ', '_').upper()
+    transformed_service_id = service_id.replace(' ', '_').upper()
 
     client = client_creator(
         service=service_name,
@@ -220,12 +220,12 @@ def test_expected_service_env_var_name_is_respected(
 
 
 @pytest.mark.parametrize(
-    'service_name,service_model', _known_service_names_and_models()
+    'service_name,service_id', _known_service_names_and_ids()
 )
 def test_expected_service_config_section_name_is_respected(
-    service_name, service_model, client_creator
+    service_name, service_id, client_creator
 ):
-    transformed_service_id = service_model.service_id.replace(' ', '_').lower()
+    transformed_service_id = service_id.replace(' ', '_').lower()
 
     client = client_creator(
         service=service_name,

--- a/tests/functional/botocore/test_endpoints.py
+++ b/tests/functional/botocore/test_endpoints.py
@@ -13,68 +13,7 @@
 import pytest
 
 from botocore.session import get_session
-
-
-SERVICE_RENAMES = {
-    # Actual service name we use -> Allowed computed service name.
-    'alexaforbusiness': 'alexa-for-business',
-    'apigateway': 'api-gateway',
-    'application-autoscaling': 'application-auto-scaling',
-    'appmesh': 'app-mesh',
-    'autoscaling': 'auto-scaling',
-    'autoscaling-plans': 'auto-scaling-plans',
-    'ce': 'cost-explorer',
-    'cloudhsmv2': 'cloudhsm-v2',
-    'cloudsearchdomain': 'cloudsearch-domain',
-    'cognito-idp': 'cognito-identity-provider',
-    'config': 'config-service',
-    'cur': 'cost-and-usage-report-service',
-    'datapipeline': 'data-pipeline',
-    'directconnect': 'direct-connect',
-    'devicefarm': 'device-farm',
-    'discovery': 'application-discovery-service',
-    'dms': 'database-migration-service',
-    'ds': 'directory-service',
-    'dynamodbstreams': 'dynamodb-streams',
-    'elasticbeanstalk': 'elastic-beanstalk',
-    'elastictranscoder': 'elastic-transcoder',
-    'elb': 'elastic-load-balancing',
-    'elbv2': 'elastic-load-balancing-v2',
-    'es': 'elasticsearch-service',
-    'events': 'eventbridge',
-    'globalaccelerator': 'global-accelerator',
-    'iot-data': 'iot-data-plane',
-    'iot-jobs-data': 'iot-jobs-data-plane',
-    'iot1click-devices': 'iot-1click-devices-service',
-    'iot1click-projects': 'iot-1click-projects',
-    'iotevents-data': 'iot-events-data',
-    'iotevents': 'iot-events',
-    'iotwireless': 'iot-wireless',
-    'kinesisanalytics': 'kinesis-analytics',
-    'kinesisanalyticsv2': 'kinesis-analytics-v2',
-    'kinesisvideo': 'kinesis-video',
-    'lex-models': 'lex-model-building-service',
-    'lexv2-models': 'lex-models-v2',
-    'lex-runtime': 'lex-runtime-service',
-    'lexv2-runtime': 'lex-runtime-v2',
-    'logs': 'cloudwatch-logs',
-    'machinelearning': 'machine-learning',
-    'marketplacecommerceanalytics': 'marketplace-commerce-analytics',
-    'marketplace-entitlement': 'marketplace-entitlement-service',
-    'meteringmarketplace': 'marketplace-metering',
-    'mgh': 'migration-hub',
-    'resourcegroupstaggingapi': 'resource-groups-tagging-api',
-    'route53': 'route-53',
-    'route53domains': 'route-53-domains',
-    's3control': 's3-control',
-    'sdb': 'simpledb',
-    'secretsmanager': 'secrets-manager',
-    'serverlessrepo': 'serverlessapplicationrepository',
-    'servicecatalog': 'service-catalog',
-    'servicecatalog-appregistry': 'service-catalog-appregistry',
-    'stepfunctions': 'sfn',
-    'storagegateway': 'storage-gateway',
-}
+from botocore.utils import CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES
 
 
 ENDPOINT_PREFIX_OVERRIDE = {
@@ -165,7 +104,7 @@ def _available_services():
 
 
 @pytest.mark.parametrize("service_name", _available_services())
-def test_service_name_matches_endpoint_prefix(service_name):
+def test_client_name_matches_hyphenized_service_id(service_name):
     """Generates tests for each service to verify that the computed service
     named based on the service id matches the service name used to
     create a client (i.e the directory name in botocore/data)
@@ -177,7 +116,9 @@ def test_service_name_matches_endpoint_prefix(service_name):
 
     # Handle known exceptions where we have renamed the service directory
     # for one reason or another.
-    actual_service_name = SERVICE_RENAMES.get(service_name, service_name)
+    actual_service_name = CLIENT_NAME_TO_HYPHENIZED_SERVICE_ID_OVERRIDES.get(
+        service_name, service_name
+    )
 
     err_msg = (
         f"Actual service name `{actual_service_name}` does not match "

--- a/tests/unit/botocore/cfg/aws_services_config
+++ b/tests/unit/botocore/cfg/aws_services_config
@@ -1,0 +1,9 @@
+[default]
+endpoint_url = https://localhost:1234/
+services = my-services
+
+[services my-services]
+s3 =
+  endpoint_url = https://localhost:5678/
+dynamodb =
+  endpoint_url = https://localhost:8888/

--- a/tests/unit/botocore/test_configloader.py
+++ b/tests/unit/botocore/test_configloader.py
@@ -186,6 +186,24 @@ class TestConfigLoader(BaseEnvVar):
         self.assertEqual(sso_config['sso_region'], 'us-east-1')
         self.assertEqual(sso_config['sso_start_url'], 'https://example.com')
 
+    def test_services_config(self):
+        filename = path('aws_services_config')
+        loaded_config = load_config(filename)
+        self.assertIn('profiles', loaded_config)
+        self.assertIn('default', loaded_config['profiles'])
+        self.assertIn('services', loaded_config)
+        self.assertIn('my-services', loaded_config['services'])
+        services_config = loaded_config['services']['my-services']
+        self.assertIn('s3', services_config)
+        self.assertIn('dynamodb', services_config)
+        self.assertEqual(
+            services_config['s3']['endpoint_url'], 'https://localhost:5678/'
+        )
+        self.assertEqual(
+            services_config['dynamodb']['endpoint_url'],
+            'https://localhost:8888/',
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a config provider to resolve the endpoint URL provided in an environment variable or shared configuration file. It resolves the endpoint in the following manner:

1. The value provided through the `endpoint_url` parameter provided to the client constructor.
2. The value provided by a service-specific environment variable.
3. The value provided by the global endpoint environment variable (`AWS_ENDPOINT_URL`).
4. The value provided by a service-specific parameter from a services definition section in the shared configuration file.
5. The value provided by the global parameter from a services definition section in the shared configuration file.
6. The value resolved when no configured endpoint URL is provided.

The endpoint config provider uses the client name (name used to instantiate a client object) for construction and add to the config value store. This uses multiple lookups to handle service name changes for backwards compatibility.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
