### PR TITLE
Relocating cache folders outside of home folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ doc/source/reference
 doc/source/topic
 doc/source/tutorial/services.rst
 
+# Virtualenv
+.venv
+
 # Pyenv
 .python-version
 

--- a/awscli/autocomplete/db.py
+++ b/awscli/autocomplete/db.py
@@ -10,7 +10,7 @@ LOG = logging.getLogger(__name__)
 # We may eventually include a pre-generated version of this index as part
 # of our shipped distributable, but for now we'll add this to our cache
 # dir.
-INDEX_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
+INDEX_DIR = os.getenv('AWS_CLI_CACHE_DIR', os.path.join('~', '.aws', 'cli', 'cache'))
 INDEX_FILE = os.path.join(INDEX_DIR, '%s.index' % cli_version)
 BUILTIN_INDEX_FILE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),

--- a/awscli/autoprompt/factory.py
+++ b/awscli/autoprompt/factory.py
@@ -73,7 +73,8 @@ class PromptToolkitFactory:
     def history_driver(self):
         if self._history_driver is None:
             cache_dir = os.path.expanduser(
-                os.path.join('~', '.aws', 'cli', 'cache'))
+                os.getenv('AWS_CLI_CACHE_DIR',
+                os.path.join('~', '.aws', 'cli', 'cache')))
             history_filename = os.path.join(cache_dir, 'prompt_history.json')
             self._history_driver = HistoryDriver(history_filename)
         return self._history_driver

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -2040,7 +2040,7 @@ class SSOProvider(CredentialProvider):
     METHOD = 'sso'
 
     _SSO_TOKEN_CACHE_DIR = os.path.expanduser(
-        os.path.join('~', '.aws', 'sso', 'cache')
+        os.getenv('AWS_SSO_CACHE_DIR', os.path.join('~', '.aws', 'sso', 'cache'))
     )
     _PROFILE_REQUIRED_CONFIG_VARS = (
         'sso_role_name',

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -3210,7 +3210,9 @@ class JSONFileCache:
     values can be retrieved at a later time.
     """
 
-    CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'boto', 'cache'))
+    CACHE_DIR = os.path.expanduser(
+        os.getenv('AWS_CACHE_DIR', os.path.join('~', '.aws', 'boto', 'cache'))
+    )
 
     def __init__(self, working_dir=CACHE_DIR, dumps_func=None):
         self._working_dir = working_dir

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -3211,7 +3211,7 @@ class JSONFileCache:
     """
 
     CACHE_DIR = os.path.expanduser(
-        os.getenv('AWS_CACHE_DIR', os.path.join('~', '.aws', 'boto', 'cache'))
+        os.getenv('AWS_BOTO_CACHE_DIR', os.path.join('~', '.aws', 'boto', 'cache'))
     )
 
     def __init__(self, working_dir=CACHE_DIR, dumps_func=None):

--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -5,7 +5,9 @@ from botocore.exceptions import ProfileNotFound
 from botocore.credentials import JSONFileCache
 
 LOG = logging.getLogger(__name__)
-CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
+CACHE_DIR = os.path.expanduser(
+    os.getenv('AWS_CACHE_DIR', os.path.join('~', '.aws', 'cli', 'cache'))
+)
 
 
 def register_assume_role_provider(event_handlers):

--- a/awscli/customizations/assumerole.py
+++ b/awscli/customizations/assumerole.py
@@ -6,7 +6,7 @@ from botocore.credentials import JSONFileCache
 
 LOG = logging.getLogger(__name__)
 CACHE_DIR = os.path.expanduser(
-    os.getenv('AWS_CACHE_DIR', os.path.join('~', '.aws', 'cli', 'cache'))
+    os.getenv('AWS_CLI_CACHE_DIR', os.path.join('~', '.aws', 'cli', 'cache'))
 )
 
 

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -28,7 +28,7 @@ from awscli.customizations.exceptions import ConfigurationError
 LOG = logging.getLogger(__name__)
 
 SSO_TOKEN_DIR = os.path.expanduser(
-    os.path.join('~', '.aws', 'sso', 'cache')
+    os.getenv('AWS_SSO_CACHE_DIR', os.path.join('~', '.aws', 'sso', 'cache'))
 )
 
 LOGIN_ARGS = [


### PR DESCRIPTION
*Description of changes:*
I am trying to keep my home directory as clean as possible. There might be a better implementation of this quick proposition using `XDG_CACHE_DIR` instead of `~/.aws/xxx/cache` folder as a fallback, I'll give it a go probably soon.
For the time being, I only implemented a way to relocate the the cache folders in custom locations based on dedicated environment variables : 
- `AWS_BOTO_CACHE_DIR` : for configuring `~/.aws/boto/cache`
- `AWS_CLI_CACHE_DIR` : for configuring `~/.aws/cli/cache`
- `AWS_SSO_CACHE_DIR` : for configuring `~/.aws/sso/cache`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
