### PR TITLE
Add support for PyYAML 6.0

### DIFF
--- a/.changes/next-release/enhancement-dependency-21293.json
+++ b/.changes/next-release/enhancement-dependency-21293.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "dependency",
+  "description": "Support PyYAML 6.0"
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ requires_dist =
         botocore==1.31.3
         docutils>=0.10,<0.17
         s3transfer>=0.6.0,<0.7.0
-        PyYAML>=3.10,<5.5
+        PyYAML>=3.10,<6.1
         colorama>=0.2.5,<0.4.5
         rsa>=3.1.2,<4.8
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'botocore==1.31.3',
     'docutils>=0.10,<0.17',
     's3transfer>=0.6.0,<0.7.0',
-    'PyYAML>=3.10,<5.5',
+    'PyYAML>=3.10,<6.1',
     'colorama>=0.2.5,<0.4.5',
     'rsa>=3.1.2,<4.8',
 ]


### PR DESCRIPTION
This should partially address this issue: https://github.com/aws/aws-cli/issues/8036. Specifically, PyYAML 6.0 has wheels for Python 3.10 and Python 3.11. However, it won't fix the issue for users that are on platform with no PyYAML wheels (e.g. Alpine). The only way for that to be addressed is through an upstream PyYAML patch (e.g. https://github.com/yaml/pyyaml/pull/702) and release.

Changelog for 6.0: https://github.com/yaml/pyyaml/blob/957ae4d495cf8fcb5475c6c2f1bce801096b68a5/CHANGES#L7-L18

Diff changes between versions: https://github.com/yaml/pyyaml/compare/5.4.1...6.0
