### PR TITLE
Fix open tunnel bug when NO_PROXY is unset

### DIFF
--- a/.changes/next-release/bugfix-ec2instanceconnectssh-67721.json
+++ b/.changes/next-release/bugfix-ec2instanceconnectssh-67721.json
@@ -1,0 +1,6 @@
+{
+    "type": "bugfix",
+    "category": "``ec2-instance-connect ssh``",
+    "description": "Fix runtime error when HTTP_PROXY environment variable is set and NO_PROXY is not set for eice connection type `#8023 <https://github.com/aws/aws-cli/issues/8023>`__"
+  }
+  

--- a/awscli/customizations/ec2instanceconnect/websocket.py
+++ b/awscli/customizations/ec2instanceconnect/websocket.py
@@ -154,7 +154,7 @@ class Websocket:
         environment = os.environ.copy()
         proxy_options = None
         proxy_url = environment.get("HTTP_PROXY") or environment.get("HTTPS_PROXY")
-        no_proxy = environment.get("NO_PROXY")
+        no_proxy = environment.get("NO_PROXY", "")
         if proxy_url and parsed_url.hostname not in no_proxy:
             parsed_proxy_url = urlparse(proxy_url)
             logger.debug(f"Using the following proxy: {parsed_proxy_url.hostname}")


### PR DESCRIPTION
https://github.com/aws/aws-cli/issues/8023

*Description of changes:*
Allow NO_PROXY to be `None`. If it is not defined or is empty or `None` then we don't check.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
