### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ requires_dist =
         botocore==1.31.3
         docutils>=0.10,<0.17
         s3transfer>=0.6.0,<0.7.0
-        PyYAML>=3.10,<6.1
+        PyYAML>=3.10,<5.4
         colorama>=0.2.5,<0.4.5
         rsa>=3.1.2,<4.8
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     'botocore==1.31.3',
     'docutils>=0.10,<0.17',
     's3transfer>=0.6.0,<0.7.0',
-    'PyYAML>=3.10,<6.1',
+    'PyYAML>=3.10,<5.4',
     'colorama>=0.2.5,<0.4.5',
     'rsa>=3.1.2,<4.8',
 ]


### PR DESCRIPTION
fixed the pyyaml version to less than 5.4 for it to work in python 3.11 with pip 23.*

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
