### PR TITLE
preserves timestamps when copying files to temporary directory

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -212,7 +212,7 @@ def mktempfile():
 def copy_to_temp_dir(filepath):
     tmp_dir = tempfile.mkdtemp()
     dst = os.path.join(tmp_dir, os.path.basename(filepath))
-    shutil.copy(filepath, dst)
+    shutil.copy2(filepath, dst)
     return tmp_dir
 
 


### PR DESCRIPTION
*Issue [#3131](https://github.com/aws/aws-cli/issues/3131)*

*Description of changes:*

Under (some?) circumstances the `cloudformation package` command copies the files to a temporary directory before creating the ZIP file. This updates the timestamps and therefore results in a new s3 resource when upload. This triggers always a redeploy of the affected resource, even when this wasn't required. 

This change at least keeps the original timestamps when copying the file. This limits the cases where the resources are updated unnecessarily.