### PR TITLE
Fix broken link in execute-command.rst

### DIFF
--- a/awscli/examples/ecs/execute-command.rst
+++ b/awscli/examples/ecs/execute-command.rst
@@ -11,4 +11,4 @@ The following ``execute-command`` example runs an interactive /bin/sh command ag
 
 This command produces no output.
 
-For more information, see `Using Amazon ECS Exec for debugging <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.htm>`__ in the *Amazon ECS Developer Guide*.
+For more information, see `Using Amazon ECS Exec for debugging <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html>`__ in the *Amazon ECS Developer Guide*.


### PR DESCRIPTION
*Issue #, if available:* aws/aws-cli#8066

*Description of changes:* invalid link url was redirecting to the ECS docs homepage (Welcome.html)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
