### PR TITLE
Add dependabot for v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: "pip"
     directory: "/"
     open-pull-requests-limit: 10
@@ -8,6 +17,7 @@ updates:
     target-branch: "v2"
     labels:
       - "dependencies"
+      - "v2"
     allow:
       - dependency-name: "PyInstaller"
       - dependency-name: "flit_core"
@@ -23,3 +33,20 @@ updates:
       - dependency-name: "jmespath"
       - dependency-name: "urllib3"
       - dependency-name: "wheel"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "v1"
+    allow:
+      - dependency-name: "colorama"
+      - dependency-name: "docutils"
+      - dependency-name: "awscrt"
+      - dependency-name: "pyyaml"
+      - dependency-name: "wheel"
+      - dependency-name: "rsa"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "sunday"
     target-branch: "develop"
     ignore:
       - dependency-name: "*"
@@ -39,6 +40,7 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+      day: "sunday"
     target-branch: "develop"
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,6 @@ updates:
     allow:
       - dependency-name: "colorama"
       - dependency-name: "docutils"
-      - dependency-name: "awscrt"
       - dependency-name: "pyyaml"
       - dependency-name: "wheel"
       - dependency-name: "rsa"


### PR DESCRIPTION
This PR will setup dependabot for the v1 (develop) branch to monitor both third party dependencies on a weekly cadence, as well as keep our github actions up to date. This will be followed by a separate PR to move us to strict pins for GHA packages to meet OpenSSF guidance.
