### PR TITLE
Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ When you push to your remote, the output will contain a URL you can use to open 
 
 ## CLI Development Version
 
-If you are interested in using the latest released version of the AWS CLI, please see the [Installation](README.md#installation) section in the README. This section is for anyone who wants to install the development version of the CLI. You might need to do this if:
+If you are interested in using the latest released version of the AWS CLI, please see the [Installation](README.rst#Installation) section in the README. This section is for anyone who wants to install the development version of the CLI. You might need to do this if:
 
 - You are developing a feature for the CLI and plan on submitting a Pull Request.
 - You want to test the latest changes of the CLI before they make it into an official release.


### PR DESCRIPTION
*Issue #8111 

Fixes broken link in contributing guide:

[Screencast from 17-08-23 18:54:25.webm](https://github.com/aws/aws-cli/assets/43259657/c2a26d00-c69d-40dc-ab26-9808a7919ac5)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
