### PR TITLE
Fix --profile completion for aws s3 ls

### DIFF
--- a/awscli/autocomplete/parser.py
+++ b/awscli/autocomplete/parser.py
@@ -312,7 +312,7 @@ class CLIParser(object):
         return is_command_name and (remaining_parts or not is_part_of_command)
 
     def _handle_positional(self, current, state, remaining_parts, parsed):
-        # This is can either be a subcommand or a positional argument
+        # This can either be a subcommand or a positional argument
         #
         # First we can check if this is a valid subcommand given our lineage.
         # We're one off here, we need to compute a new *potential*
@@ -331,10 +331,10 @@ class CLIParser(object):
             # has a positional argument. This will require an additional
             # select on the argument index.
             positional_argname = self._get_positional_argname(state)
-        if (positional_argname and
+        if (not state.current_param and positional_argname and
             positional_argname not in parsed.parsed_params):
             # Parse the current string to be a positional argument
-            # if the command has the a positional arg and the positional arg
+            # if the command has a positional arg and the positional arg
             # has not already been parsed.
             if not remaining_parts:
                 # We are currently parsing the positional argument
@@ -353,8 +353,9 @@ class CLIParser(object):
             if not remaining_parts:
                 # If this is the last chunk of the command line but
                 # it's not a subcommand then we'll mark it as the last
-                # fragment.  This is likely a partially entered
-                # command, e.g 'aws ec2 run-instan'
+                # fragment. This could either be a partially entered command
+                # (e.g 'aws ec2 run-instan') or a value for an option
+                # (e.g 'aws ec2 describe-instances --profile ')
                 parsed.current_fragment = current
             elif current:
                 outfile_arg = self._index.get_argument_data(

--- a/tests/unit/autocomplete/test_parser.py
+++ b/tests/unit/autocomplete/test_parser.py
@@ -682,6 +682,20 @@ class TestCanParseCLICommand(unittest.TestCase):
         )
         self.assert_parsed_s3api_result_correct(result)
 
+    def test_option_with_command_expecting_positional(self):
+        result = self.cli_parser.parse(
+            'aws logs tail --region '
+        )
+
+        self.assert_parsed_results_equal(
+            result,
+            current_command='tail',
+            current_param='region',
+            global_params={'region': ''},
+            lineage=['aws', 'logs'],
+            unparsed_items=[],
+        )
+
 
 class TestParseState(unittest.TestCase):
     def test_can_set_initial_state(self):


### PR DESCRIPTION
Issue #7739

Bug also affects any option completions following commands that expect positional args

*Description of changes:*
- Adds a check in the parser that ensures state isn't currently at a parameter before assuming current fragment is a positional.
- Also fixes some grammatical errors in comments

[Screencast from 23-08-23 16:58:46.webm](https://github.com/aws/aws-cli/assets/43259657/148cb810-827b-4b9e-b716-0045803c44f0)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
