### PR TITLE
Add ability to specify a yaml file as parameters

### DIFF
--- a/tests/functional/cloudformation/create-stack-example-parameters.yml
+++ b/tests/functional/cloudformation/create-stack-example-parameters.yml
@@ -1,0 +1,7 @@
+---
+- ParameterKey: SecurityGroupDescription
+  ParameterValue: "Security group providing SSH access"
+- ParameterKey: FromPort
+  ParameterValue: "22"
+- ParameterKey: CidrIp
+  ParameterValue: "0.0.0.0/0"

--- a/tests/functional/cloudformation/test_create_stack.py
+++ b/tests/functional/cloudformation/test_create_stack.py
@@ -11,6 +11,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import os
+
 from awscli.testutils import BaseAWSCommandParamsTest
 
 
@@ -62,4 +64,20 @@ class TestCreateStack(BaseAWSCommandParamsTest):
         cmdline += ' --stack-name test --parameters --template-url http://foo'
         result = {'StackName': 'test', 'TemplateURL': 'http://foo',
                   'Parameters': []}
+        self.assert_params_for_cmd(cmdline, result)
+
+    def test_can_handle_yaml_parameter_file(self):
+        param_path = os.path.join(os.path.dirname(__file__), 'create-stack-example-parameters.yml')
+        cmdline = self.prefix
+        cmdline += ' --stack-name test --template-url http://foo'
+        cmdline += ' --parameters file://%s' % param_path
+        result = {'StackName': 'test', 'TemplateURL': 'http://foo',
+                  'Parameters': [
+                      {'ParameterKey': 'SecurityGroupDescription',
+                       'ParameterValue': 'Security group providing SSH access'},
+                      {'ParameterKey': 'FromPort',
+                       'ParameterValue': '22'},
+                      {'ParameterKey': 'CidrIp',
+                       'ParameterValue': '0.0.0.0/0'},
+                  ]}
         self.assert_params_for_cmd(cmdline, result)

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -432,6 +432,10 @@ class TestParamShorthand(BaseArgProcessTest):
         with self.assertRaisesRegex(ParamError, error_msg):
             self.parse_shorthand(p, ['ParameterKey=key,ParameterValue="foo,bar\''])
 
+    def test_should_not_parse_list_based_yaml(self):
+        p = self.get_param_model('cloudformation.CreateStack.Parameters')
+        returned = self.parse_shorthand(p, ['---\n- ParameterKey: key\n  ParameterValue: foo'])
+        self.assertIsNone(returned)
 
 class TestParamShorthandCustomArguments(BaseArgProcessTest):
 
@@ -782,6 +786,17 @@ class TestDocGen(BaseArgProcessTest):
         generated_example = self.get_generated_example_for(argument)
         self.assertEqual(generated_example, '')
 
+class TestUnpackYAMLParams(BaseArgProcessTest):
+    def setUp(self):
+        super(TestUnpackYAMLParams, self).setUp()
+        self.simplify = ParamShorthandParser()
+
+    def test_yaml_list(self):
+        p = self.get_param_model('cloudformation.CreateStack.Parameters')
+        value = '---\n- ParameterKey: key\n  ParameterValue: foo'
+        returned = unpack_cli_arg(p, value)
+        self.assertEqual(returned, [{'ParameterKey': 'key',
+                                      'ParameterValue': 'foo'}])
 
 class TestUnpackJSONParams(BaseArgProcessTest):
     def setUp(self):


### PR DESCRIPTION
*Issue #2275 

- Adds ability to specify a yaml file as parameters
- Will work for any list yaml files (but not for dictionary yaml files)

[Screencast from 25-08-23 18:45:15.webm](https://github.com/aws/aws-cli/assets/43259657/cc8e320a-13f5-4949-a3a4-d98bec8f843d)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
