### PR TITLE
Add ability for s3 cp to match by partial prefix

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -283,7 +283,7 @@ def find_dest_path_comp_key(files, src_path=None):
 
     sep_table = {'s3': '/', 'local': os.sep}
 
-    if files['dir_op']:
+    if files['dir_op'] or files['partial_prefix']:
         rel_path = src_path[len(src['path']):]
     else:
         rel_path = src_path.split(sep_table[src_type])[-1]

--- a/tests/unit/customizations/s3/test_fileformat.py
+++ b/tests/unit/customizations/s3/test_fileformat.py
@@ -27,13 +27,13 @@ class FileFormatTest(unittest.TestCase):
         """
         src = '.' + os.sep
         dest = 's3://kyknapp/golfVid/'
-        parameters = {'dir_op': True}
+        parameters = {'dir_op': True, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': os.path.abspath(src) + os.sep,
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/', 'type': 's3'},
-                     'dir_op': True, 'use_src_name': True}
+                     'dir_op': True, 'use_src_name': True, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
 
     def test_op_dir_noslash(self):
@@ -43,13 +43,13 @@ class FileFormatTest(unittest.TestCase):
         """
         src = '.'
         dest = 's3://kyknapp/golfVid'
-        parameters = {'dir_op': True}
+        parameters = {'dir_op': True, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': os.path.abspath(src) + os.sep,
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/', 'type': 's3'},
-                     'dir_op': True, 'use_src_name': True}
+                     'dir_op': True, 'use_src_name': True, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
 
     def test_local_use_src_name(self):
@@ -59,14 +59,14 @@ class FileFormatTest(unittest.TestCase):
         """
         src = 's3://kyknapp/golfVid/hello.txt'
         dest = '.'
-        parameters = {'dir_op': False}
+        parameters = {'dir_op': False, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': 'kyknapp/golfVid/hello.txt',
                              'type': 's3'},
                      'dest': {'path': os.path.abspath(dest) + os.sep,
                               'type': 'local'},
-                     'dir_op': False, 'use_src_name': True}
+                     'dir_op': False, 'use_src_name': True, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
 
     def test_local_noexist_file(self):
@@ -76,14 +76,14 @@ class FileFormatTest(unittest.TestCase):
         """
         src = 's3://kyknapp/golfVid/hello.txt'
         dest = 'someFile' + os.sep
-        parameters = {'dir_op': False}
+        parameters = {'dir_op': False, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': 'kyknapp/golfVid/hello.txt',
                              'type': 's3'},
                      'dest': {'path': os.path.abspath(dest) + os.sep,
                               'type': 'local'},
-                     'dir_op': False, 'use_src_name': True}
+                     'dir_op': False, 'use_src_name': True, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
 
     def test_local_keep_dest_name(self):
@@ -93,14 +93,14 @@ class FileFormatTest(unittest.TestCase):
         """
         src = 's3://kyknapp/golfVid/hello.txt'
         dest = 'hello.txt'
-        parameters = {'dir_op': False}
+        parameters = {'dir_op': False, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': 'kyknapp/golfVid/hello.txt',
                              'type': 's3'},
                      'dest': {'path': os.path.abspath(dest),
                               'type': 'local'},
-                     'dir_op': False, 'use_src_name': False}
+                     'dir_op': False, 'use_src_name': False, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
 
     def test_s3_use_src_name(self):
@@ -110,13 +110,13 @@ class FileFormatTest(unittest.TestCase):
         """
         src = 'fileformat_test.py'
         dest = 's3://kyknapp/golfVid/'
-        parameters = {'dir_op': False}
+        parameters = {'dir_op': False, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': os.path.abspath(src),
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/', 'type': 's3'},
-                     'dir_op': False, 'use_src_name': True}
+                     'dir_op': False, 'use_src_name': True, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
 
     def test_s3_keep_dest_name(self):
@@ -126,14 +126,38 @@ class FileFormatTest(unittest.TestCase):
         """
         src = 'fileformat_test.py'
         dest = 's3://kyknapp/golfVid/file.py'
-        parameters = {'dir_op': False}
+        parameters = {'dir_op': False, 'partial_prefix': False}
         files = self.file_format.format(src, dest, parameters)
 
         ref_files = {'src': {'path': os.path.abspath(src),
                              'type': 'local'},
                      'dest': {'path': 'kyknapp/golfVid/file.py', 'type': 's3'},
-                     'dir_op': False, 'use_src_name': False}
+                     'dir_op': False, 'use_src_name': False, 'partial_prefix': False}
         self.assertEqual(files, ref_files)
+    def test_s3_partial_prefix_match_to_local(self):
+        src = 's3://kyknapp/golf'
+        dest = os.path.join('somedirectory', 'hello')
+        parameters = {'dir_op': False, 'partial_prefix': True}
+        files = self.file_format.format(src, dest, parameters)
+
+        ref_files = {'src': {'path': 'kyknapp/golf',
+                             'type': 's3'},
+                     'dest': {'path': os.path.abspath(dest) + os.path.sep, 'type': 'local'},
+                     'dir_op': False, 'use_src_name': False, 'partial_prefix': True}
+        self.assertEqual(files, ref_files)
+
+    def test_s3_partial_prefix_match_to_s3(self):
+        src = 's3://kyknapp/golf'
+        dest = 's3://aidand/hello-world'
+        parameters = {'dir_op': False, 'partial_prefix': True}
+        files = self.file_format.format(src, dest, parameters)
+
+        ref_files = {'src': {'path': 'kyknapp/golf',
+                             'type': 's3'},
+                     'dest': {'path': 'aidand/hello-world/', 'type': 's3'},
+                     'dir_op': False, 'use_src_name': True, 'partial_prefix': True}
+        self.assertEqual(files, ref_files)
+
 
 
 if __name__ == "__main__":

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -458,6 +458,20 @@ class CommandParametersTest(unittest.TestCase):
         CommandParameters('cp', params, '')
         self.assertFalse(params.get('is_move'))
 
+    def test_validate_recursive_and_partial_prefix(self):
+        params = {'dir_op': True, 'partial_prefix': True}
+        error_msg = 'Cannot specify --recursive and --partial-prefix together.'
+        with self.assertRaisesRegex(ParamValidationError, error_msg):
+            CommandParameters('cp', params, '')
+
+    def test_validate_partial_prefix_with_local_src(self):
+        params = {'dir_op': False, 'partial_prefix': True}
+        error_msg = 'Cannot specify --partial-prefix with a local source.'
+        cmd = CommandParameters('cp', params, '')
+        paths = [self.file_creator.rootdir, 's3://bucket/foo']
+        with self.assertRaisesRegex(ParamValidationError, error_msg):
+            cmd.add_paths(paths)
+
 
 class HelpDocTest(BaseAWSHelpOutputTest):
     def setUp(self):


### PR DESCRIPTION
*Issue #1454 

- Adds a `--partial-prefix` option to `aws s3 cp`  so users can match partially by prefix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
