### PR TITLE
Add --exclude-profile option to eks update-kubeconfig

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -103,7 +103,14 @@ class UpdateKubeconfigCommand(BasicCommand):
             'help_text': ("Alias for the generated user name. "
                           "Defaults to match cluster ARN."),
             'required': False
-        }
+        },
+        {
+            'name': 'exclude-profile',
+            'action': 'store_true',
+            'default': False,
+            'help_text': ("Exclude the AWS_PROFILE environment variable "
+                          "from the generated user's exec config.")
+        },
     ]
 
     def _display_entries(self, entries):
@@ -332,7 +339,7 @@ class EKSClient(object):
                 self._parsed_args.role_arn
             ])
 
-        if self._session.profile:
+        if self._session.profile and not self._parsed_args.exclude_profile:
             generated_user["user"]["exec"]["env"] = [OrderedDict([
                 ("name", "AWS_PROFILE"),
                 ("value", self._session.profile)

--- a/tests/functional/eks/test_update_kubeconfig.py
+++ b/tests/functional/eks/test_update_kubeconfig.py
@@ -186,7 +186,8 @@ class TestUpdateKubeconfig(unittest.TestCase):
     def assert_cmd(self, configs, passed_config,
                    env_variable_configs,
                    default_config=os.path.join(".kube", "config"),
-                   verbose=False):
+                   verbose=False,
+                   exclude_profile=False,):
         """
         Run update-kubeconfig in a temp directory,
         This directory will have copies of all testdata files whose names
@@ -216,6 +217,8 @@ class TestUpdateKubeconfig(unittest.TestCase):
             args += ["--kubeconfig", self._get_temp_config(passed_config)]
         if verbose:
             args += ["--verbose"]
+        if exclude_profile:
+            args += ["--exclude-profile"]
 
         with mock.patch.dict(os.environ, {'KUBECONFIG': env_variable}):
             with mock.patch(
@@ -422,3 +425,12 @@ class TestUpdateKubeconfig(unittest.TestCase):
 
         self.assert_cmd(configs, passed, environment)
         self.assert_config_state("valid_old_api_version", "valid_old_api_version_updated")
+
+    @mock.patch.dict(os.environ, {'AWS_PROFILE': 'test'})
+    def test_exclude_profile(self):
+        configs = []
+        passed = "new_config"
+        environment = []
+
+        self.assert_cmd(configs, passed, environment, exclude_profile=True)
+        self.assert_config_state("new_config", "output_single")

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -217,7 +217,7 @@ class TestEKSClient(unittest.TestCase):
         self._session.create_client.return_value = self._mock_client
         self._session.profile = None
 
-        self._client = EKSClient(self._session, parsed_args=Namespace(cluster_name="ExampleCluster", role_arn=None))
+        self._client = EKSClient(self._session, parsed_args=Namespace(cluster_name="ExampleCluster", role_arn=None, exclude_profile=False))
 
     def test_get_cluster_description(self):
         self.assertEqual(self._client.cluster_description,


### PR DESCRIPTION
*Issue #, if available:*

This PR resolves https://github.com/aws/aws-cli/issues/7087, and replaces https://github.com/aws/aws-cli/pull/7845

*Description of changes:*

This PR adds a new option to `aws eks update-kubeconfig` called `exclude-profile`. Currently, when using `update-kubeconfig`, if an AWS profile session is detected the generated kubeconfig will include an `env` block with `AWS_PROFILE` in the user's exec config. Example:

```
users:
- name: arn:aws:eks:region:111222333444:cluster/ExampleCluster
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1beta1
      args:
      - --region
      - region
      - eks
      - get-token
      - --cluster-name
      - ExampleCluster
      - --output
      - json
      command: aws
      env:
        - name: AWS_PROFILE
          value: <profile-name>
```
This may be undesirable behavior depending on how you manage your AWS credentials. When specifying the `--exclude-profile` option added in this PR, the `env` block will not be added.

Rather than as described in the issue above, I chose to add `exclude-profile` instead of `include-profile` to keep consistent behavior with previous versions of awscli. 

I added a unit test to ensure the option works properly. The test injects an `AWS_PROFILE` environment variable at runtime to simulate an AWS "session" and passes `--exclude-profile` to the command, and asserts that the resulting kubeconfig does _not_ have an `env` block; if `exclude_profile` is set to `False`, the test fails (as it should). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. I am available to make any changes needed for this PR to be merged.
