### PR TITLE
Improve error messages for codeartifact login

### DIFF
--- a/.changes/next-release/enhancement-codeartifactlogin-88335.json
+++ b/.changes/next-release/enhancement-codeartifactlogin-88335.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``codeartifact login``",
+  "description": "Include stderr output from underlying login tool when subprocess fails"
+}

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -215,6 +215,13 @@ def get_stderr_text_writer():
     return _get_text_writer(sys.stderr, errors="replace")
 
 
+def get_stderr_encoding():
+    encoding = getattr(sys.__stderr__, 'encoding', None)
+    if encoding is None:
+        encoding = 'utf-8'
+    return encoding
+
+
 def compat_input(prompt):
     """
     Cygwin's pty's are based on pipes. Therefore, when it interacts with a Win32


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Currently codeartifact login command would show the error message from the subprocess in case of failures, which doesn't help with debugging because the message would only contain the exit code. This commit includes the error message from the package tool CLI that is run by the login.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
