### PR TITLE
Add test to check if example files are executable

### DIFF
--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -319,12 +319,17 @@ class CollectCLICommands(docutils.nodes.GenericNodeVisitor):
 def test_example_file_name(example_file):
     filename = example_file.split(os.sep)[-1]
     _assert_file_is_rst_or_txt(example_file)
+    _assert_file_not_executable(example_file)
     _assert_name_contains_only_allowed_characters(filename)
 
+def has_executable_bit(filename):
+    return os.stat(filename).st_mode & (os.X_OK | os.X_OK >> 3 | os.X_OK >> 6)
 
 def _assert_file_is_rst_or_txt(filepath):
     assert filepath.endswith('.rst') or filepath.endswith('.txt')
 
+def _assert_file_not_executable(filepath):
+    assert not has_executable_bit(filepath)
 
 def _assert_name_contains_only_allowed_characters(filename):
     assert ALLOWED_FILENAME_CHAR_REGEX.match(filename)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/pull/5490

*Description of changes:* Added functional test to check if executable bit exists on example file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
