### PR TITLE
Adding functionality in aws logs tail  to log message as a single json without additional formatting

### DIFF
--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -106,11 +106,17 @@ class PrettyJSONLogEventsFormatter(BaseLogEventsFormatter):
 
 class BasicEventsFormatter(BaseLogEventsFormatter):
     def display_log_event(self, log_event):
-        self._write_log_event(json.dumps(log_event))
+        self._write_log_event(json.dumps({
+            "timestamp": log_event["timestamp"].strftime("%Y-%m-%dT%H:%M:%S"),
+            "message": self._format_json(log_event["message"])
+        }))
 
-    def _format_timestamp(self, timestamp):
-        return self._color_if_configured(
-            timestamp.strftime("%Y-%m-%dT%H:%M:%S"), self._TIMESTAMP_COLOR)
+    def _format_json(self, log_message):
+        try:
+            return json.loads(log_message)
+        except json.decoder.JSONDecodeError:
+            pass
+        return log_message
 
 class TailCommand(BasicCommand):
     NAME = 'tail'

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -104,6 +104,13 @@ class PrettyJSONLogEventsFormatter(BaseLogEventsFormatter):
         return self._color_if_configured(
             timestamp.isoformat(), self._TIMESTAMP_COLOR)
 
+class BasicEventsFormatter(BaseLogEventsFormatter):
+    def display_log_event(self, log_event):
+        self._write_log_event(json.dumps(log_event))
+
+    def _format_timestamp(self, timestamp):
+        return self._color_if_configured(
+            timestamp.strftime("%Y-%m-%dT%H:%M:%S"), self._TIMESTAMP_COLOR)
 
 class TailCommand(BasicCommand):
     NAME = 'tail'
@@ -154,7 +161,7 @@ class TailCommand(BasicCommand):
         {
             'name': 'format',
             'default': 'detailed',
-            'choices': ['detailed', 'short', 'json'],
+            'choices': ['detailed', 'short', 'json', 'none'],
             'help_text': (
                 'The format to display the logs. The following formats are '
                 'supported:\n\n'
@@ -167,6 +174,8 @@ class TailCommand(BasicCommand):
                 'a shortened timestamp and the log message.'
                 '</li>'
                 '<li> json - Pretty print any messages that are entirely JSON.'
+                '</li>'
+                 '<li> none - Events are printed as single line json message'
                 '</li>'
                 '</ul>'
             )
@@ -205,6 +214,7 @@ class TailCommand(BasicCommand):
     _FORMAT_TO_FORMATTER_CLS = {
         'detailed': DetailedLogEventsFormatter,
         'short': ShortLogEventsFormatter,
+        'none': BasicEventsFormatter,
         'json': PrettyJSONLogEventsFormatter,
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes https://github.com/aws/aws-cli/issues/6630

*Description of changes:*
Added a new formatter that logs entire log in a single line. So that it can be used with other formatters like https://github.com/pinojs/pino-pretty.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
