### PR TITLE
Make BUILDDIR optional to honor env variable for sphinx-build

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,7 +5,7 @@
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
-BUILDDIR      = build
+BUILDDIR      ?= build
 MANBUILDDIR   = $(BUILDDIR)/man1
 SOURCEDIR     = source
 


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Allow overriding of the BUILDDIR from an environment variable when running `sphinx-build`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
