### PR TITLE
Since aws eks get-token has been accepting profile arguments for sometime now, we will use the profile argument instead of the AWS_PROFILE environment variable.

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -333,9 +333,9 @@ class EKSClient(object):
             ])
 
         if self._session.profile:
-            generated_user["user"]["exec"]["env"] = [OrderedDict([
-                ("name", "AWS_PROFILE"),
-                ("value", self._session.profile)
-            ])]
+            generated_user["user"]["exec"]["args"].extend([
+                "--profile",
+                self._session.profile
+            ])
 
         return generated_user


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
