### PR TITLE
Use builtin mock

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -40,7 +40,7 @@ from awscli.compat import StringIO
 from ruamel.yaml import YAML
 
 try:
-    import mock
+    from unittest import mock
 except ImportError as e:
     # In the off chance something imports this module
     # that's not suppose to, we should not stop the CLI

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 jsonschema==4.7.2
-mock==1.3.0
 pytest==7.2.0
 coverage==7.0.1
 pytest-cov==4.0.0

--- a/tests/functional/autoprompt/test_autoprompt.py
+++ b/tests/functional/autoprompt/test_autoprompt.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 
 import pytest

--- a/tests/functional/botocore/csm/test_monitoring.py
+++ b/tests/functional/botocore/csm/test_monitoring.py
@@ -18,7 +18,7 @@ import os
 import socket
 import threading
 
-import mock
+from unittest import mock
 import pytest
 
 from tests import temporary_file

--- a/tests/functional/botocore/test_apigateway.py
+++ b/tests/functional/botocore/test_apigateway.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from tests import BaseSessionTest, ClientHTTPStubber
 

--- a/tests/functional/botocore/test_cloudsearchdomain.py
+++ b/tests/functional/botocore/test_cloudsearchdomain.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from tests import BaseSessionTest, ClientHTTPStubber
 

--- a/tests/functional/botocore/test_cognito_idp.py
+++ b/tests/functional/botocore/test_cognito_idp.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import pytest
 
 from tests import create_session, ClientHTTPStubber

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -16,7 +16,7 @@ import threading
 import os
 import math
 import time
-import mock
+from unittest import mock
 import tempfile
 import shutil
 from datetime import datetime, timedelta

--- a/tests/functional/botocore/test_docdb.py
+++ b/tests/functional/botocore/test_docdb.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from contextlib import contextmanager
 
 import botocore.session

--- a/tests/functional/botocore/test_ec2.py
+++ b/tests/functional/botocore/test_ec2.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import datetime
-import mock
+from unittest import mock
 
 from tests import unittest, ClientHTTPStubber, BaseSessionTest
 from botocore.compat import parse_qs, urlparse

--- a/tests/functional/botocore/test_history.py
+++ b/tests/functional/botocore/test_history.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 
-import mock
+from unittest import mock
 
 from tests import BaseSessionTest, ClientHTTPStubber
 from botocore.history import BaseHistoryHandler

--- a/tests/functional/botocore/test_lex.py
+++ b/tests/functional/botocore/test_lex.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from datetime import datetime
 
 from tests import BaseSessionTest, ClientHTTPStubber

--- a/tests/functional/botocore/test_machinelearning.py
+++ b/tests/functional/botocore/test_machinelearning.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from tests import BaseSessionTest, ClientHTTPStubber
 

--- a/tests/functional/botocore/test_neptune.py
+++ b/tests/functional/botocore/test_neptune.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from contextlib import contextmanager
 
 import botocore.session

--- a/tests/functional/botocore/test_public_apis.py
+++ b/tests/functional/botocore/test_public_apis.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from collections import defaultdict
 
-import mock
+from unittest import mock
 import pytest
 
 from tests import ClientHTTPStubber

--- a/tests/functional/botocore/test_regions.py
+++ b/tests/functional/botocore/test_regions.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import pytest
 
 from botocore.client import ClientEndpointBridge

--- a/tests/functional/botocore/test_session.py
+++ b/tests/functional/botocore/test_session.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest, temporary_file
 
-import mock
+from unittest import mock
 
 import botocore.session
 from botocore.exceptions import ProfileNotFound

--- a/tests/functional/botocore/test_six_threading.py
+++ b/tests/functional/botocore/test_six_threading.py
@@ -1,7 +1,7 @@
 """
 Regression test for six issue #98 (https://github.com/benjaminp/six/issues/98)
 """
-from mock import patch
+from unittest.mock import patch
 import sys
 import threading
 import time

--- a/tests/functional/botocore/test_sts.py
+++ b/tests/functional/botocore/test_sts.py
@@ -13,7 +13,7 @@
 from datetime import datetime
 import re
 
-import mock
+from unittest import mock
 
 from tests import BaseSessionTest
 from tests import temporary_file

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import BaseAWSCommandParamsTest
 

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import BaseAWSCommandParamsTest
 

--- a/tests/functional/cloudfront/test_sign.py
+++ b/tests/functional/cloudfront/test_sign.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from botocore.compat import urlparse, parse_qs
 
 from awscli.testutils import FileCreator

--- a/tests/functional/cloudfront/test_update_distribution.py
+++ b/tests/functional/cloudfront/test_update_distribution.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import BaseAWSCommandParamsTest
 

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import gzip
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from awscli.compat import six
 from botocore.exceptions import ClientError

--- a/tests/functional/configservice/test_subscribe.py
+++ b/tests/functional/configservice/test_subscribe.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.customizations.configservice.subscribe import S3BucketHelper

--- a/tests/functional/dependencies/test_colorama.py
+++ b/tests/functional/dependencies/test_colorama.py
@@ -2,7 +2,7 @@ import os
 import sys
 from contextlib import contextmanager
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from awscli.testutils import unittest, skip_if_windows
 from awscli.testutils import capture_output

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -28,7 +28,7 @@ from awscli.testutils import FileCreator
 
 from awscli.compat import six
 from awscli.alias import AliasLoader
-import mock
+from unittest import mock
 
 
 class TestHelpOutput(BaseAWSHelpOutputTest):

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -14,7 +14,7 @@
 import base64
 import datetime
 
-import mock
+from unittest import mock
 from six.moves import cStringIO
 
 import awscli.customizations.ec2.bundleinstance

--- a/tests/functional/ecs/test_execute_command.py
+++ b/tests/functional/ecs/test_execute_command.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import errno
 import json
 

--- a/tests/functional/eks/test_kubeconfig.py
+++ b/tests/functional/eks/test_kubeconfig.py
@@ -14,7 +14,7 @@
 import os
 import shutil
 import tempfile
-import mock
+from unittest import mock
 
 from botocore.compat import OrderedDict
 

--- a/tests/functional/eks/test_update_kubeconfig.py
+++ b/tests/functional/eks/test_update_kubeconfig.py
@@ -16,9 +16,9 @@ import shutil
 import sys
 import tempfile
 
-import mock
+from unittest import mock
 from botocore.session import get_session
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from awscli.customizations.eks.exceptions import EKSClusterError
 from awscli.customizations.eks.kubeconfig import (

--- a/tests/functional/lightsail/test_push_container_image.py
+++ b/tests/functional/lightsail/test_push_container_image.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 import errno
 import json
 import awscli

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import datetime
-import mock
+from unittest import mock
 
 from dateutil.tz import tzutc
 from botocore.compat import urlparse, parse_qs

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import os
 
 from awscrt.s3 import S3Request

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -11,7 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import os
 
 from awscrt.s3 import S3RequestType, S3RequestTlsMode

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import patch
+from unittest.mock import patch
 import os
 
 from awscrt.s3 import S3RequestType

--- a/tests/functional/servicecatalog/test_generate_createproduct.py
+++ b/tests/functional/servicecatalog/test_generate_createproduct.py
@@ -13,7 +13,7 @@
 
 
 import os
-from mock import mock
+import unittest.mock as mock
 
 from awscli.customizations.servicecatalog.utils \
     import get_s3_path

--- a/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
+++ b/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
@@ -13,7 +13,7 @@
 
 
 import os
-from mock import mock
+import unittest.mock as mock
 
 from awscli.customizations.servicecatalog.utils \
     import get_s3_path

--- a/tests/functional/ses/test_send_email.py
+++ b/tests/functional/ses/test_send_email.py
@@ -15,7 +15,7 @@ from awscli.testutils import BaseAWSCommandParamsTest
 
 from awscli.compat import six
 from six.moves import cStringIO
-import mock
+from unittest import mock
 
 
 class TestSendEmail(BaseAWSCommandParamsTest):

--- a/tests/functional/ssm/test_start_session.py
+++ b/tests/functional/ssm/test_start_session.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import errno
 import json
 

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import os
 import re
 import shutil

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -13,7 +13,7 @@
 import logging
 import os
 
-from mock import patch, ANY
+from unittest.mock import patch, ANY
 
 from awscli.testutils import FileCreator, BaseAWSCommandParamsTest
 from awscli.clidriver import create_clidriver

--- a/tests/integration/botocore/test_client_http.py
+++ b/tests/integration/botocore/test_client_http.py
@@ -2,7 +2,7 @@ import select
 import socket
 import contextlib
 import threading
-import mock
+from unittest import mock
 from tests import unittest
 from contextlib import contextmanager
 

--- a/tests/integration/botocore/test_credentials.py
+++ b/tests/integration/botocore/test_credentials.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
+from unittest import mock
 import tempfile
 import shutil
 import json

--- a/tests/integration/botocore/test_loaders.py
+++ b/tests/integration/botocore/test_loaders.py
@@ -13,7 +13,7 @@
 import os
 from tests import unittest
 
-import mock
+from unittest import mock
 
 import botocore.session
 

--- a/tests/integration/botocore/test_s3.py
+++ b/tests/integration/botocore/test_s3.py
@@ -22,7 +22,7 @@ import tempfile
 import shutil
 import threading
 import logging
-import mock
+from unittest import mock
 from tarfile import TarFile
 from contextlib import closing
 

--- a/tests/integration/botocore/test_smoke.py
+++ b/tests/integration/botocore/test_smoke.py
@@ -11,7 +11,7 @@ to use and all the services in SMOKE_TESTS/ERROR_TESTS will be tested.
 
 """
 import os
-import mock
+from unittest import mock
 from pprint import pformat
 import warnings
 import logging

--- a/tests/integration/customizations/test_generatecliskeleton.py
+++ b/tests/integration/customizations/test_generatecliskeleton.py
@@ -15,7 +15,7 @@ import os
 import json
 import logging
 
-import mock
+from unittest import mock
 import pytest
 from ruamel.yaml import YAML
 

--- a/tests/unit/autoprompt/test_core.py
+++ b/tests/unit/autoprompt/test_core.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from collections import namedtuple
 
 import pytest

--- a/tests/unit/autoprompt/test_doc.py
+++ b/tests/unit/autoprompt/test_doc.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import textwrap
 
 from awscli.clidriver import create_clidriver

--- a/tests/unit/autoprompt/test_factory.py
+++ b/tests/unit/autoprompt/test_factory.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import DummyCompleter, Completer

--- a/tests/unit/autoprompt/test_filters.py
+++ b/tests/unit/autoprompt/test_filters.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import unittest
 from awscli.autoprompt.filters import (

--- a/tests/unit/autoprompt/test_history.py
+++ b/tests/unit/autoprompt/test_history.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
+from unittest import mock
 import os
 import shutil
 import tempfile

--- a/tests/unit/autoprompt/test_logger.py
+++ b/tests/unit/autoprompt/test_logger.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import contextlib
 import logging
-import mock
+from unittest import mock
 import io
 
 from prompt_toolkit.buffer import Buffer

--- a/tests/unit/autoprompt/test_prompttoolkit.py
+++ b/tests/unit/autoprompt/test_prompttoolkit.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
-import mock
+from unittest import mock
 
 from prompt_toolkit.completion import Completion, CompleteEvent
 from prompt_toolkit.document import Document

--- a/tests/unit/autoprompt/test_widgets.py
+++ b/tests/unit/autoprompt/test_widgets.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.formatted_text import FormattedText

--- a/tests/unit/bcdoc/test_docstringparser.py
+++ b/tests/unit/bcdoc/test_docstringparser.py
@@ -18,7 +18,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import mock
+from unittest import mock
 import unittest
 
 import awscli.bcdoc.docstringparser as parser

--- a/tests/unit/botocore/auth/test_signers.py
+++ b/tests/unit/botocore/auth/test_signers.py
@@ -18,7 +18,7 @@ import time
 import base64
 import json
 
-import mock
+from unittest import mock
 
 import botocore.auth
 import botocore.credentials

--- a/tests/unit/botocore/auth/test_sigv4.py
+++ b/tests/unit/botocore/auth/test_sigv4.py
@@ -29,7 +29,7 @@ import datetime
 import re
 from botocore.compat import six, urlsplit, parse_qsl
 
-import mock
+from unittest import mock
 import pytest
 
 from tests import FreezeTime

--- a/tests/unit/botocore/docs/__init__.py
+++ b/tests/unit/botocore/docs/__init__.py
@@ -16,7 +16,7 @@ import tempfile
 import shutil
 
 from botocore.docs.bcdoc.restdoc import DocumentStructure
-import mock
+from unittest import mock
 
 from tests import unittest
 from botocore.compat import OrderedDict

--- a/tests/unit/botocore/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/botocore/docs/bcdoc/test_docstringparser.py
@@ -18,7 +18,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import mock
+from unittest import mock
 from tests import unittest
 
 import botocore.docs.bcdoc.docstringparser as parser

--- a/tests/unit/botocore/docs/test_docs.py
+++ b/tests/unit/botocore/docs/test_docs.py
@@ -14,7 +14,7 @@ import os
 import shutil
 import tempfile
 
-import mock
+from unittest import mock
 
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.session import get_session

--- a/tests/unit/botocore/docs/test_example.py
+++ b/tests/unit/botocore/docs/test_example.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.hooks import HierarchicalEmitter

--- a/tests/unit/botocore/docs/test_params.py
+++ b/tests/unit/botocore/docs/test_params.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.hooks import HierarchicalEmitter

--- a/tests/unit/botocore/docs/test_service.py
+++ b/tests/unit/botocore/docs/test_service.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 
-import mock
+from unittest import mock
 
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.session import get_session

--- a/tests/unit/botocore/retries/test_adaptive.py
+++ b/tests/unit/botocore/retries/test_adaptive.py
@@ -1,6 +1,6 @@
 from tests import unittest
 
-import mock
+from unittest import mock
 
 from botocore.retries import adaptive
 from botocore.retries import standard

--- a/tests/unit/botocore/retries/test_special.py
+++ b/tests/unit/botocore/retries/test_special.py
@@ -1,6 +1,6 @@
 from tests import unittest
 
-import mock
+from unittest import mock
 
 from botocore.compat import six
 from botocore.awsrequest import AWSResponse

--- a/tests/unit/botocore/retries/test_standard.py
+++ b/tests/unit/botocore/retries/test_standard.py
@@ -1,6 +1,6 @@
 from tests import unittest
 
-import mock
+from unittest import mock
 import pytest
 
 from botocore.retries import standard

--- a/tests/unit/botocore/test_args.py
+++ b/tests/unit/botocore/test_args.py
@@ -15,7 +15,7 @@ import socket
 
 import botocore.config
 from tests import unittest
-import mock
+from unittest import mock
 
 from botocore import args
 from botocore import exceptions

--- a/tests/unit/botocore/test_awsrequest.py
+++ b/tests/unit/botocore/test_awsrequest.py
@@ -20,7 +20,7 @@ import io
 import socket
 import sys
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from botocore.exceptions import UnseekableStreamError

--- a/tests/unit/botocore/test_client.py
+++ b/tests/unit/botocore/test_client.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import botocore.config
 from tests import unittest
-import mock
+from unittest import mock
 
 import botocore
 from botocore import utils

--- a/tests/unit/botocore/test_compat.py
+++ b/tests/unit/botocore/test_compat.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import datetime
-import mock
+from unittest import mock
 
 import pytest
 

--- a/tests/unit/botocore/test_config_provider.py
+++ b/tests/unit/botocore/test_config_provider.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest
 import copy
-import mock
+from unittest import mock
 import pytest
 
 import botocore

--- a/tests/unit/botocore/test_configloader.py
+++ b/tests/unit/botocore/test_configloader.py
@@ -14,7 +14,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest, BaseEnvVar
 import os
-import mock
+from unittest import mock
 import tempfile
 import shutil
 

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 from datetime import datetime, timedelta
 import subprocess
-import mock
+from unittest import mock
 import os
 import tempfile
 import shutil

--- a/tests/unit/botocore/test_discovery.py
+++ b/tests/unit/botocore/test_discovery.py
@@ -1,5 +1,5 @@
 import time
-from mock import Mock, call
+from unittest.mock import Mock, call
 from tests import unittest
 
 from botocore.awsrequest import AWSRequest

--- a/tests/unit/botocore/test_endpoint.py
+++ b/tests/unit/botocore/test_endpoint.py
@@ -13,7 +13,7 @@
 import socket
 from tests import unittest
 
-from mock import Mock, patch, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 from botocore.compat import six
 from botocore.awsrequest import AWSRequest

--- a/tests/unit/botocore/test_eventstream.py
+++ b/tests/unit/botocore/test_eventstream.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 """Unit tests for the binary event stream decoder. """
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from botocore.parsers import EventStreamXMLParser
 from botocore.eventstream import (

--- a/tests/unit/botocore/test_handlers.py
+++ b/tests/unit/botocore/test_handlers.py
@@ -14,7 +14,7 @@
 from tests import unittest, BaseSessionTest
 
 import base64
-import mock
+from unittest import mock
 import copy
 import os
 import json

--- a/tests/unit/botocore/test_history.py
+++ b/tests/unit/botocore/test_history.py
@@ -1,6 +1,6 @@
 from tests import unittest
 
-import mock
+from unittest import mock
 
 from botocore.history import HistoryRecorder
 from botocore.history import BaseHistoryHandler

--- a/tests/unit/botocore/test_idempotency.py
+++ b/tests/unit/botocore/test_idempotency.py
@@ -13,7 +13,7 @@
 
 from tests import unittest
 import re
-import mock
+from unittest import mock
 from botocore.handlers import generate_idempotent_uuid
 
 

--- a/tests/unit/botocore/test_loaders.py
+++ b/tests/unit/botocore/test_loaders.py
@@ -22,7 +22,7 @@
 import os
 import contextlib
 import copy
-import mock
+from unittest import mock
 
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.loaders import JSONFileLoader

--- a/tests/unit/botocore/test_paginate.py
+++ b/tests/unit/botocore/test_paginate.py
@@ -20,7 +20,7 @@ from botocore.paginate import TokenEncoder
 from botocore.exceptions import PaginationError
 from botocore.compat import six
 
-import mock
+from unittest import mock
 
 
 def encode_token(token):

--- a/tests/unit/botocore/test_session.py
+++ b/tests/unit/botocore/test_session.py
@@ -19,7 +19,7 @@ import logging
 import tempfile
 import shutil
 
-import mock
+from unittest import mock
 import pytest
 
 import botocore.session

--- a/tests/unit/botocore/test_session_legacy.py
+++ b/tests/unit/botocore/test_session_legacy.py
@@ -19,7 +19,7 @@ import logging
 import tempfile
 import shutil
 
-import mock
+from unittest import mock
 import pytest
 
 import botocore.session

--- a/tests/unit/botocore/test_signers.py
+++ b/tests/unit/botocore/test_signers.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import datetime
 import json
 

--- a/tests/unit/botocore/test_stub.py
+++ b/tests/unit/botocore/test_stub.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from tests import unittest
-import mock
+from unittest import mock
 
 from botocore.stub import Stubber
 from botocore.exceptions import ParamValidationError, StubResponseError, UnStubbedResponseError

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -21,7 +21,7 @@ from tests import FreezeTime
 from dateutil.tz import tzutc, tzoffset
 import datetime
 import copy
-import mock
+from unittest import mock
 import operator
 
 import botocore

--- a/tests/unit/botocore/test_waiters.py
+++ b/tests/unit/botocore/test_waiters.py
@@ -13,7 +13,7 @@
 import os
 from tests import unittest, BaseEnvVar
 
-import mock
+from unittest import mock
 
 import botocore
 from botocore.compat import six

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import botocore.session
 import tempfile
 import os
@@ -9,7 +9,7 @@ import zipfile
 import pytest
 
 from contextlib import contextmanager, closing
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
 from awscli.testutils import FileCreator
 from awscli.customizations.cloudformation import exceptions

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -12,10 +12,10 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
+from unittest import mock
 import tempfile
 import six
-from mock import patch, Mock, MagicMock, call
+from unittest.mock import patch, Mock, MagicMock, call
 import collections
 
 from awscli.customizations.cloudformation.deploy import DeployCommand

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -1,7 +1,7 @@
-import mock
+from unittest import mock
 import botocore.session
 
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
 from awscli.customizations.cloudformation.deployer import Deployer, ChangeSetResult
 from awscli.customizations.cloudformation import exceptions

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -10,13 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import os
 import sys
 import tempfile
 
 from io import StringIO
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 from awscli.customizations.cloudformation.package import PackageCommand
 from awscli.customizations.cloudformation.artifact_exporter import Template
 from awscli.customizations.cloudformation.yamlhelper import yaml_dump

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -10,9 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import tempfile
-from mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 from botocore.compat import json
 from botocore.compat import OrderedDict

--- a/tests/unit/customizations/cloudtrail/test_commands.py
+++ b/tests/unit/customizations/cloudtrail/test_commands.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 from awscli.testutils import unittest
 from awscli.customizations import cloudtrail
 

--- a/tests/unit/customizations/cloudtrail/test_utils.py
+++ b/tests/unit/customizations/cloudtrail/test_utils.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock, call
+from unittest.mock import Mock, call
 from datetime import datetime, timedelta
 from dateutil import parser, tz
 

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -17,7 +17,7 @@ import json
 import gzip
 from datetime import datetime, timedelta
 from dateutil import parser, tz
-from mock import Mock, call
+from unittest.mock import Mock, call
 from argparse import Namespace
 
 from cryptography.hazmat.backends import default_backend

--- a/tests/unit/customizations/codedeploy/test_deregister.py
+++ b/tests/unit/customizations/codedeploy/test_deregister.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from argparse import Namespace
-from mock import MagicMock, call
+from unittest.mock import MagicMock, call
 from awscli.customizations.codedeploy.deregister import Deregister
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError

--- a/tests/unit/customizations/codedeploy/test_install.py
+++ b/tests/unit/customizations/codedeploy/test_install.py
@@ -19,7 +19,7 @@ from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, Syst
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
-from mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch, mock_open
 from socket import timeout
 
 

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -14,7 +14,7 @@
 import awscli
 
 from argparse import Namespace
-from mock import MagicMock, patch, ANY, call
+from unittest.mock import MagicMock, patch, ANY, call
 from six import StringIO
 from botocore.exceptions import ClientError
 

--- a/tests/unit/customizations/codedeploy/test_register.py
+++ b/tests/unit/customizations/codedeploy/test_register.py
@@ -17,7 +17,7 @@ from awscli.customizations.codedeploy.utils import MAX_TAGS_PER_INSTANCE
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.testutils import unittest
-from mock import MagicMock, patch, call, mock_open
+from unittest.mock import MagicMock, patch, call, mock_open
 
 
 class TestRegister(unittest.TestCase):

--- a/tests/unit/customizations/codedeploy/test_systems.py
+++ b/tests/unit/customizations/codedeploy/test_systems.py
@@ -14,7 +14,7 @@
 import subprocess
 
 from argparse import Namespace
-from mock import MagicMock, patch, call, mock_open
+from unittest.mock import MagicMock, patch, call, mock_open
 from awscli.customizations.codedeploy.systems import Windows, Ubuntu, RHEL
 from awscli.testutils import unittest
 

--- a/tests/unit/customizations/codedeploy/test_uninstall.py
+++ b/tests/unit/customizations/codedeploy/test_uninstall.py
@@ -18,7 +18,7 @@ from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, Syst
 from awscli.customizations.codedeploy.uninstall import Uninstall
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.testutils import unittest
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from socket import timeout
 
 

--- a/tests/unit/customizations/codedeploy/test_utils.py
+++ b/tests/unit/customizations/codedeploy/test_utils.py
@@ -15,7 +15,7 @@ import sys
 
 from socket import timeout
 from argparse import Namespace
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
 from awscli.customizations.codedeploy.utils import \
     validate_region, validate_instance_name, validate_tags, \

--- a/tests/unit/customizations/configservice/test_getstatus.py
+++ b/tests/unit/customizations/configservice/test_getstatus.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from awscli.compat import six
 
 from awscli.testutils import unittest

--- a/tests/unit/customizations/configservice/test_subscribe.py
+++ b/tests/unit/customizations/configservice/test_subscribe.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import botocore.session
 from botocore.exceptions import ClientError
 

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
+from unittest import mock
 
 from awscli.customizations.configure import configure, ConfigValue, NOT_SET
 from awscli.customizations.configure import profile_to_section

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
-import mock
+from unittest import mock
 import io
 from datetime import datetime, timedelta
 

--- a/tests/unit/customizations/configure/test_importer.py
+++ b/tests/unit/customizations/configure/test_importer.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import os
-import mock
+from unittest import mock
 
 from . import FakeSession
 from awscli.testutils import unittest

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from argparse import Namespace
 
 from awscli.testutils import unittest

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import os
 
 from awscli.customizations.configure.set import ConfigureSetCommand

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -15,7 +15,7 @@ import dataclasses
 import json
 import typing
 
-import mock
+from unittest import mock
 from datetime import datetime, timedelta
 
 import prompt_toolkit

--- a/tests/unit/customizations/datapipeline/test_commands.py
+++ b/tests/unit/customizations/datapipeline/test_commands.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 
 import copy
-import mock
+from unittest import mock
 import unittest
 
 from awscli.testutils import BaseAWSHelpOutputTest, BaseAWSCommandParamsTest

--- a/tests/unit/customizations/datapipeline/test_create_default_role.py
+++ b/tests/unit/customizations/datapipeline/test_create_default_role.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 import awscli.customizations.datapipeline.createdefaultroles \

--- a/tests/unit/customizations/datapipeline/test_listrunsformatter.py
+++ b/tests/unit/customizations/datapipeline/test_listrunsformatter.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import difflib
-import mock
+from unittest import mock
 import unittest
 
 from awscli.compat import six

--- a/tests/unit/customizations/dlm/test_create_default_role.py
+++ b/tests/unit/customizations/dlm/test_create_default_role.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 
 from awscli.testutils import BaseAWSCommandParamsTest, unittest
 from botocore.compat import json

--- a/tests/unit/customizations/ec2/test_paginate.py
+++ b/tests/unit/customizations/ec2/test_paginate.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from argparse import Namespace
 
 from awscli.testutils import unittest

--- a/tests/unit/customizations/ec2instanceconnect/test_eicesigner.py
+++ b/tests/unit/customizations/ec2instanceconnect/test_eicesigner.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from urllib.parse import urlencode
 
-import mock
+from unittest import mock
 import pytest
 
 from botocore.session import Session

--- a/tests/unit/customizations/ecs/test_codedeployer.py
+++ b/tests/unit/customizations/ecs/test_codedeployer.py
@@ -13,7 +13,7 @@
 
 import hashlib
 import json
-import mock
+from unittest import mock
 
 from botocore import compat
 from awscli.testutils import capture_output, unittest

--- a/tests/unit/customizations/ecs/test_ecsclient.py
+++ b/tests/unit/customizations/ecs/test_ecsclient.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 
 from argparse import Namespace
 from botocore import config

--- a/tests/unit/customizations/ecs/test_executecommand_startsession.py
+++ b/tests/unit/customizations/ecs/test_executecommand_startsession.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import botocore.session
 import json
 import errno

--- a/tests/unit/customizations/eks/test_get_token.py
+++ b/tests/unit/customizations/eks/test_get_token.py
@@ -11,8 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
-from mock import patch, call
+from unittest import mock
+from unittest.mock import patch, call
 import base64
 import botocore
 import json

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -13,7 +13,7 @@
 
 import glob
 import os
-import mock
+from unittest import mock
 import tempfile
 import shutil
 from botocore.compat import OrderedDict

--- a/tests/unit/customizations/emr/__init__.py
+++ b/tests/unit/customizations/emr/__init__.py
@@ -14,7 +14,7 @@
 from awscli.customizations.emr import exceptions
 from awscli.customizations.emr.configutils import ConfigWriter
 from awscli.testutils import BaseAWSCommandParamsTest
-import mock
+from unittest import mock
 
 
 class EMRBaseAWSCommandParamsTest(BaseAWSCommandParamsTest):

--- a/tests/unit/customizations/emr/test_add_instance_groups.py
+++ b/tests/unit/customizations/emr/test_add_instance_groups.py
@@ -16,7 +16,7 @@ from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
 from tests.unit.customizations.emr import test_constants as \
     CONSTANTS
 import json
-from mock import patch
+from unittest.mock import patch
 
 INSTANCE_GROUPS_WITH_AUTOSCALING_POLICY = (
     ' InstanceGroupType=TASK,InstanceType=d2.xlarge,InstanceCount=2,'

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -13,7 +13,7 @@
 
 import os
 import copy
-import mock
+from unittest import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_command.py
+++ b/tests/unit/customizations/emr/test_command.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \

--- a/tests/unit/customizations/emr/test_config.py
+++ b/tests/unit/customizations/emr/test_config.py
@@ -6,7 +6,7 @@ from awscli.customizations.emr.ssh import Put
 from awscli.customizations.emr.ssh import SSH
 from awscli.customizations.emr.ssh import Socks
 from awscli.testutils import BaseAWSHelpOutputTest
-import mock
+from unittest import mock
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
 

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -20,7 +20,7 @@ from tests.unit.customizations.emr import test_constants_instance_fleets as \
 import copy
 import os
 import json
-from mock import patch
+from unittest.mock import patch
 
 
 DEFAULT_CLUSTER_NAME = "Development Cluster"

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -23,7 +23,7 @@ from tests.unit.customizations.emr import test_constants_instance_fleets as \
     CONSTANTS_FLEET
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
-from mock import patch
+from unittest.mock import patch
 
 
 DEFAULT_CLUSTER_NAME = "Development Cluster"

--- a/tests/unit/customizations/emr/test_create_default_role.py
+++ b/tests/unit/customizations/emr/test_create_default_role.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from botocore.compat import json
 from botocore.awsrequest import AWSResponse

--- a/tests/unit/customizations/emr/test_create_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_create_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_describe_cluster.py
+++ b/tests/unit/customizations/emr/test_describe_cluster.py
@@ -15,7 +15,7 @@ import json
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
-from mock import patch
+from unittest.mock import patch
 
 describe_cluster_result_mock_ig = {
     "Cluster": {

--- a/tests/unit/customizations/emr/test_disable_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_disable_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_install_applications.py
+++ b/tests/unit/customizations/emr/test_install_applications.py
@@ -13,7 +13,7 @@
 
 
 import json
-import mock
+from unittest import mock
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
 

--- a/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_schedule_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_schedule_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from unittest import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_sshutils.py
+++ b/tests/unit/customizations/emr/test_sshutils.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.customizations.emr import sshutils
 from awscli.customizations.emr import exceptions

--- a/tests/unit/customizations/emrcontainers/test_update_assume_role_policy.py
+++ b/tests/unit/customizations/emrcontainers/test_update_assume_role_policy.py
@@ -13,7 +13,7 @@
 
 import copy
 import json
-import mock
+from unittest import mock
 
 from awscli.testutils import BaseAWSCommandParamsTest, unittest
 from awscli.customizations.emrcontainers.base36 import Base36

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -17,7 +17,7 @@ import threading
 import datetime
 import numbers
 
-import mock
+from unittest import mock
 
 from awscli.compat import queue
 from awscli.customizations.history.db import DatabaseConnection

--- a/tests/unit/customizations/s3/syncstrategy/test_base.py
+++ b/tests/unit/customizations/s3/syncstrategy/test_base.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import datetime
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from awscli.customizations.s3.filegenerator import FileStat
 from awscli.customizations.s3.syncstrategy.base import BaseSync, \

--- a/tests/unit/customizations/s3/syncstrategy/test_register.py
+++ b/tests/unit/customizations/s3/syncstrategy/test_register.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from awscli.customizations.s3.syncstrategy.register import \
     register_sync_strategy

--- a/tests/unit/customizations/s3/test_comparator.py
+++ b/tests/unit/customizations/s3/test_comparator.py
@@ -13,7 +13,7 @@
 import datetime
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from awscli.customizations.s3.comparator import Comparator
 from awscli.customizations.s3.filegenerator import FileStat

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -21,7 +21,7 @@ import socket
 
 from botocore.exceptions import ClientError
 from awscli.compat import six
-import mock
+from unittest import mock
 
 from awscli.customizations.s3.filegenerator import FileGenerator, \
     FileDecodingError, FileStat, is_special_file, is_readable

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import unittest
 from awscli.customizations.s3.filegenerator import FileStat

--- a/tests/unit/customizations/s3/test_s3.py
+++ b/tests/unit/customizations/s3/test_s3.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock
+from unittest.mock import Mock
 
 from awscli.testutils import unittest, BaseAWSCommandParamsTest
 from awscli.customizations.s3.s3 import awscli_initialize, add_s3

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 
-import mock
+from unittest import mock
 from s3transfer.manager import TransferManager
 
 from awscli.testutils import unittest

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -14,8 +14,8 @@ import argparse
 import os
 import sys
 
-import mock
-from mock import patch, Mock, MagicMock
+from unittest import mock
+from unittest.mock import patch, Mock, MagicMock
 
 import botocore.session
 from awscli.customizations.s3.s3 import S3

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -18,7 +18,7 @@ import ntpath
 import time
 import datetime
 
-import mock
+from unittest import mock
 from dateutil.tz import tzlocal
 import pytest
 from s3transfer.compat import seekable

--- a/tests/unit/customizations/servicecatalog/__init__.py
+++ b/tests/unit/customizations/servicecatalog/__init__.py
@@ -16,7 +16,7 @@ from awscli.testutils import mock
 from awscli.customizations.servicecatalog import \
     register_servicecatalog_commands, GenerateCommand
 from awscli.customizations.servicecatalog import inject_commands
-from mock import call
+from unittest.mock import call
 
 
 class TestRegisterServiceCatalogCommands(unittest.TestCase):

--- a/tests/unit/customizations/servicecatalog/test_generateproduct.py
+++ b/tests/unit/customizations/servicecatalog/test_generateproduct.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from argparse import Namespace
-from mock import patch
+from unittest.mock import patch
 
 from awscli.customizations.servicecatalog import exceptions
 from awscli.customizations.servicecatalog.generateproduct \

--- a/tests/unit/customizations/servicecatalog/test_generateprovisioningartifact.py
+++ b/tests/unit/customizations/servicecatalog/test_generateprovisioningartifact.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 from argparse import Namespace
-from mock import patch
+from unittest.mock import patch
 
 from awscli.customizations.servicecatalog import exceptions
 from awscli.customizations.servicecatalog.generateprovisioningartifact \

--- a/tests/unit/customizations/test_arguments.py
+++ b/tests/unit/customizations/test_arguments.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
+from unittest import mock
 
 from awscli.testutils import unittest, FileCreator, skip_if_windows
 from awscli.customizations.arguments import NestedBlobArgumentHoister

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from botocore.hooks import HierarchicalEmitter
 from botocore.exceptions import ProfileNotFound

--- a/tests/unit/customizations/test_cliinput.py
+++ b/tests/unit/customizations/test_cliinput.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import os
 import shutil
 import tempfile

--- a/tests/unit/customizations/test_cloudsearchdomain.py
+++ b/tests/unit/customizations/test_cloudsearchdomain.py
@@ -16,7 +16,7 @@ from awscli.help import PagingHelpRenderer
 from awscli.customizations.cloudsearchdomain import validate_endpoint_url
 from awscli.customizations.exceptions import ParamValidationError
 
-import mock
+from unittest import mock
 
 
 class TestSearchCommand(BaseAWSCommandParamsTest):

--- a/tests/unit/customizations/test_cloudwatch.py
+++ b/tests/unit/customizations/test_cloudwatch.py
@@ -14,7 +14,7 @@ import decimal
 
 from awscli.testutils import unittest
 
-import mock
+from unittest import mock
 
 from awscli.customizations import putmetricdata
 

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -14,7 +14,7 @@
 import awscli
 
 from argparse import Namespace
-from mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch, call
 from six import StringIO
 from botocore.session import Session
 from botocore.credentials import Credentials

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
-import mock
+from unittest import mock
 
 from awscli.clidriver import CLIDriver
 from awscli.customizations.commands import BasicHelp, BasicCommand

--- a/tests/unit/customizations/test_flatten.py
+++ b/tests/unit/customizations/test_flatten.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
 
-import mock
+from unittest import mock
 
 from awscli.arguments import CLIArgument
 from awscli.customizations import utils

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from botocore.model import DenormalizedStructureBuilder
 

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -16,7 +16,7 @@ import os
 
 from awscli.testutils import unittest
 from awscli.compat import six
-import mock
+from unittest import mock
 
 from awscli.customizations import globalargs
 from awscli.customizations.exceptions import ParamValidationError

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -14,7 +14,7 @@
 import argparse
 import datetime
 import json
-import mock
+from unittest import mock
 
 from botocore.exceptions import ClientError
 

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -16,8 +16,8 @@ from botocore.exceptions import DataNotFoundError
 from botocore.model import OperationModel
 from awscli.help import OperationHelpCommand, OperationDocumentEventHandler
 
-import mock
-from mock import Mock, patch
+from unittest import mock
+from unittest.mock import Mock, patch
 
 from awscli.customizations import paginate
 from awscli.customizations.exceptions import ParamValidationError

--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -11,13 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
+from unittest import mock
 import random
 import string
 import tempfile
 import hashlib
 import shutil
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 import botocore
 import botocore.session

--- a/tests/unit/customizations/test_sessionmanager.py
+++ b/tests/unit/customizations/test_sessionmanager.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 import errno
 import json
 import botocore.session

--- a/tests/unit/customizations/test_timestampformat.py
+++ b/tests/unit/customizations/test_timestampformat.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from botocore.exceptions import ProfileNotFound
 from botocore.session import Session
-from mock import Mock, call
+from unittest.mock import Mock, call
 
 from awscli.customizations import timestampformat
 from awscli.customizations.exceptions import ConfigurationError

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import io
 import argparse
-import mock
+from unittest import mock
 
 from botocore.exceptions import ClientError
 from botocore.model import Shape

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from botocore.waiter import WaiterModel
 from botocore.exceptions import DataNotFoundError

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -13,7 +13,7 @@
 # language governing permissions and limitations under the License.
 from botocore.compat import json
 import platform
-import mock
+from unittest import mock
 from awscli.compat import six
 from awscli.formatter import JSONFormatter
 

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -21,7 +21,7 @@ import locale
 
 from awscli.compat import six
 from six.moves import cStringIO
-import mock
+from unittest import mock
 
 from awscli.formatter import Formatter
 

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
+from unittest import mock
 from botocore import xform_name
 from botocore import model
 from botocore.compat import OrderedDict

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import unittest
 from awscli import arguments

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
+from unittest import mock
 from botocore.model import ShapeResolver, StructureShape, StringShape, \
     ListShape, MapShape, Shape, DenormalizedStructureBuilder
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -20,7 +20,7 @@ from awscli.testutils import BaseAWSCommandParamsTest
 import logging
 import io
 
-import mock
+from unittest import mock
 import awscrt.io
 from awscli.compat import six
 from botocore import xform_name

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -16,7 +16,7 @@ import json
 import sys
 import os
 
-import mock
+from unittest import mock
 
 from awscli.compat import six
 from awscli.help import PosixHelpRenderer, ExecutableNotFoundError

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 from awscli.compat import six
 from awscli.testutils import unittest, FileCreator
 from awscli.testutils import skip_if_windows

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -13,7 +13,7 @@
 import sys
 from awscli.testutils import unittest
 
-import mock
+from unittest import mock
 
 from awscli import plugin
 from botocore import hooks

--- a/tests/unit/test_testutils.py
+++ b/tests/unit/test_testutils.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from unittest import mock
 
 from awscli.testutils import create_bucket
 from awscli.testutils import BaseCLIDriverTest

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -23,7 +23,7 @@ import unittest
 import sys
 
 from awscli.compat import six
-import mock
+from unittest import mock
 
 from awscli import text
 

--- a/tests/unit/test_topictags.py
+++ b/tests/unit/test_topictags.py
@@ -21,7 +21,7 @@
 #
 import json
 
-import mock
+from unittest import mock
 
 from awscli.testutils import unittest, FileCreator
 from awscli.topictags import TopicTagDB

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -20,7 +20,7 @@
 # distribution when running the tests.
 import os
 import sys
-import mock
+from unittest import mock
 import time
 import random
 import shutil


### PR DESCRIPTION
This removes the dependency on the mock package since it's built in to the python versions we support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
