### PR TITLE
Updated to AWS IAM Identity Center

### DIFF
--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -56,8 +56,8 @@ _CMD_PROMPT_USAGE = (
 _CONFIG_EXTRA_INFO = (
     'Note: The configuration is saved in the shared configuration file. '
     'By default, ``~/.aws/config``. For more information, see the '
-    '"Configuring the AWS CLI to use AWS Single Sign-On" section in the AWS '
-    'CLI User Guide:'
+    '"Configuring the AWS CLI to use AWS IAM Identity Center" section in the '
+    'AWS CLI User Guide:'
     '\n\nhttps://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html'
 )
 
@@ -358,7 +358,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
     DESCRIPTION = (
         'The ``aws configure sso`` command interactively prompts for the '
         'configuration values required to create a profile that sources '
-        'temporary AWS credentials from AWS Single Sign-On.\n\n'
+        'temporary AWS credentials from AWS IAM Identity Center.\n\n'
         f'{_CMD_PROMPT_USAGE}'
         'When providing the ``--profile`` parameter the named profile '
         'will be created or updated. When a profile is not explicitly set '

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -19,13 +19,13 @@ from awscli.customizations.utils import uni_print
 class LoginCommand(BaseSSOCommand):
     NAME = 'login'
     DESCRIPTION = (
-        'Retrieves and caches an AWS SSO access token to exchange for AWS '
-        'credentials. To login, the requested profile must have first been '
-        'setup using ``aws configure sso``. Each time the ``login`` command '
-        'is called, a new SSO access token will be retrieved. Please note '
-        'that only one login session can be active for a given SSO Session '
-        'and creating multiple profiles does not allow for multiple users to '
-        'be authenticated against the same SSO Session.'
+        'Retrieves and caches an AWS IAM Identity Center access token to '
+        'exchange for AWS credentials. To login, the requested profile must '
+        'have first been setup using ``aws configure sso``. Each time the '
+        '``login`` command is called, a new SSO access token will be '
+        'retrieved. Please note that only one login session can be active for '
+        'a given SSO Session and creating multiple profiles does not allow for'
+        ' multiple users to be authenticated against the same SSO Session.'
     )
     ARG_TABLE = LOGIN_ARGS + [
         {

--- a/awscli/customizations/sso/logout.py
+++ b/awscli/customizations/sso/logout.py
@@ -27,9 +27,10 @@ LOG = logging.getLogger(__name__)
 class LogoutCommand(BasicCommand):
     NAME = 'logout'
     DESCRIPTION = (
-        'Removes all cached AWS SSO access tokens and any cached temporary '
-        'AWS credentials retrieved with SSO access tokens across all '
-        'profiles. To use these profiles again, run: ``aws sso login``'
+        'Removes all cached AWS IAM Identity Center access tokens and any '
+        'cached temporary AWS credentials retrieved with SSO access tokens '
+        'across all profiles. To use these profiles again, run: '
+        '``aws sso login``'
     )
     ARG_TABLE = []
 


### PR DESCRIPTION
Updated product naming references of "AWS SSO" to "AWS IAM Identity Center."


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
