### PR TITLE
Update base image from v2 to v2023

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as installer
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as installer
 ARG EXE_FILENAME=awscli-exe-linux-x86_64.zip
 COPY $EXE_FILENAME .
 RUN yum update -y \
@@ -11,7 +11,7 @@ RUN yum update -y \
   # may be present in /usr/local/bin of the installer stage.
   && ./aws/install --bin-dir /aws-cli-bin/
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN yum update -y \
   && yum install -y less groff \
   && yum clean all


### PR DESCRIPTION
Ref: https://github.com/amazonlinux/amazon-linux-2023

Justification:
amazonlinux:2 failed scans due to "python version 2.7.18 has 12 vulnerabilities" The new base image has Python 3.9.16.

Please keep your images up to date and scan them regularly for vulnerabilities.

*Issue #, if available:*
N/A

*Description of changes:*
Update the base image for the Dockerfile to `amazonlinux:2023`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



```
Scan results for: image public.ecr.aws/amazonlinux/amazonlinux:2 sha256:d701cfab89f359f46710fe3f51f07a8b1e4c5aa462c0de89350ce024f94a058c
Vulnerabilities
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
|      CVE       | SEVERITY | CVSS | PACKAGE | VERSION |                STATUS                |  PUBLISHED  | DISCOVERED | GRACE DAYS |                    DESCRIPTION                     | TRIGGERED FAILURE |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2022-48565 | critical | 9.80 | python  | 2.7.18  | fixed in 3.9.1, 3.8.7, 3.7.10,...    | 72 days     | < 1 hour   | -56        | An XML External Entity (XXE) issue was discovered  | Yes               |
|                |          |      |         |         | 62 days ago                          |             |            |            | in Python through 3.9.1. The plistlib module no    |                   |
|                |          |      |         |         |                                      |             |            |            | longer accepts entity declarations in XML plist    |                   |
|                |          |      |         |         |                                      |             |            |            | file...                                            |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2023-24329 | high     | 7.50 | python  | 2.7.18  | fixed in 3.11.4                      | > 8 months  | < 1 hour   | -234       | An issue in the urllib.parse component of          | Yes               |
|                |          |      |         |         | > 8 months ago                       |             |            |            | Python before 3.11.4 allows attackers to bypass    |                   |
|                |          |      |         |         |                                      |             |            |            | blocklisting methods by supplying a URL that       |                   |
|                |          |      |         |         |                                      |             |            |            | starts with bla...                                 |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2022-48560 | high     | 7.50 | python  | 2.7.18  | fixed in 3.8.2, 3.7.7, 3.6.11        | 72 days     | < 1 hour   | -55        | A use-after-free exists in Python through 3.9 via  | Yes               |
|                |          |      |         |         | 69 days ago                          |             |            |            | heappushpop in heapq.                              |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2022-45061 | high     | 7.50 | python  | 2.7.18  | fixed in 3.11.1, 3.10.9, 3.9.16      | > 11 months | < 1 hour   | -320       | An issue was discovered in Python before 3.11.1.   | Yes               |
|                |          |      |         |         | > 11 months ago                      |             |            |            | An unnecessary quadratic algorithm exists in one   |                   |
|                |          |      |         |         |                                      |             |            |            | path when processing some inputs to the IDNA (RFC  |                   |
|                |          |      |         |         |                                      |             |            |            | 34...                                              |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2022-0391  | high     | 7.50 | python  | 2.7.18  | fixed in 3.9.5, 3.8.11, 3.7.11,...   | > 1 years   | < 1 hour   | -618       | A flaw was found in Python, specifically within    | Yes               |
|                |          |      |         |         | > 1 years ago                        |             |            |            | the urllib.parse module. This module helps break   |                   |
|                |          |      |         |         |                                      |             |            |            | Uniform Resource Locator (URL) strings into        |                   |
|                |          |      |         |         |                                      |             |            |            | component...                                       |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2019-9674  | high     | 7.50 | python  | 2.7.18  | fixed in 3.7.3                       | > 3 years   | < 1 hour   | -320       | Lib/zipfile.py in Python through 3.7.2 allows      | Yes               |
|                |          |      |         |         | > 11 months ago                      |             |            |            | remote attackers to cause a denial of service      |                   |
|                |          |      |         |         |                                      |             |            |            | (resource consumption) via a ZIP bomb.             |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2022-48564 | medium   | 6.50 | python  | 2.7.18  | fixed in 3.9.1, 3.8.2, 3.7.7         | 72 days     | < 1 hour   | -39        | read_ints in plistlib.py in Python through 3.9.1   | Yes               |
|                |          |      |         |         | 69 days ago                          |             |            |            | is vulnerable to a potential DoS attack via CPU    |                   |
|                |          |      |         |         |                                      |             |            |            | and RAM exhaustion when processing malformed Apple |                   |
|                |          |      |         |         |                                      |             |            |            | Pr...                                              |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-3733  | medium   | 6.50 | python  | 2.7.18  | fixed in 3.10.1, 3.9.5, 3.8.10,...   | > 1 years   | < 1 hour   | -573       | There\'s a flaw in urllib\'s                       | Yes               |
|                |          |      |         |         | > 1 years ago                        |             |            |            | AbstractBasicAuthHandler class. An attacker who    |                   |
|                |          |      |         |         |                                      |             |            |            | controls a malicious HTTP server that an HTTP      |                   |
|                |          |      |         |         |                                      |             |            |            | client (such as web browser...                     |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2022-48566 | medium   | 5.90 | python  | 2.7.18  | fixed in 3.9.1, 3.8.7, 3.7.10,...    | 72 days     | < 1 hour   | -33        | An issue was discovered in compare_digest          | Yes               |
|                |          |      |         |         | 62 days ago                          |             |            |            | in Lib/hmac.py in Python through 3.9.1.            |                   |
|                |          |      |         |         |                                      |             |            |            | Constant-time-defeating optimisations were         |                   |
|                |          |      |         |         |                                      |             |            |            | possible in the accumulat...                       |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-23336 | medium   | 5.90 | python  | 2.7.18  | fixed in 3.9.2, 3.8.8, 3.7.10,...    | > 2 years   | < 1 hour   | -961       | The package python/cpython from 0 and before       | Yes               |
|                |          |      |         |         | > 2 years ago                        |             |            |            | 3.6.13, from 3.7.0 and before 3.7.10, from 3.8.0   |                   |
|                |          |      |         |         |                                      |             |            |            | and before 3.8.8, from 3.9.0 and before 3.9.2 are  |                   |
|                |          |      |         |         |                                      |             |            |            | vulner...                                          |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2023-40217 | medium   | 5.30 | python  | 2.7.18  | fixed in 3.11.5, 3.10.13, 3.9.18,... | 70 days     | < 1 hour   | -34        | An issue was discovered in Python before 3.8.18,   | Yes               |
|                |          |      |         |         | 63 days ago                          |             |            |            | 3.9.x before 3.9.18, 3.10.x before 3.10.13, and    |                   |
|                |          |      |         |         |                                      |             |            |            | 3.11.x before 3.11.5. It primarily affects servers |                   |
|                |          |      |         |         |                                      |             |            |            | (s...                                              |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+
| CVE-2023-27043 | medium   | 5.30 | python  | 2.7.18  | fixed in 3.11.1, 2.7.1150            | > 6 months  | < 1 hour   | -160       | The email module of Python through 3.11.3          | Yes               |
|                |          |      |         |         | > 6 months ago                       |             |            |            | incorrectly parses e-mail addresses that contain a |                   |
|                |          |      |         |         |                                      |             |            |            | special character. The wrong portion of an RFC2822 |                   |
|                |          |      |         |         |                                      |             |            |            | header...                                          |                   |
+----------------+----------+------+---------+---------+--------------------------------------+-------------+------------+------------+----------------------------------------------------+-------------------+

Vulnerabilities found for image public.ecr.aws/amazonlinux/amazonlinux:2: total - 12, critical - 1, high - 5, medium - 6, low - 0
Vulnerability threshold check results: FAIL
Scan failed due to vulnerability policy violations: Default - alert all components, 12 vulnerabilities. Blocking vulnerabilities by severity OR by risk factors. Severity distribution : [critical:1 high:5 medium:6]


```