### PR TITLE
update readme to include py 3.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ The aws-cli package works on Python versions:
 -  3.9.x and greater
 -  3.10.x and greater
 -  3.11.x and greater
+-  3.12.x and greater
 
 Notices
 ~~~~~~~


### PR DESCRIPTION
Currently the CI jobs already do builds for Python 3.12 but the README
did not explcitly specify support for 3.12

Signed-off-by: Ismayil Mirzali <ismayilmirzeli@gmail.com>

*Issue #, if available:*

*Description of changes:*
Updates the README to explicitly state Python 3.12 support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
