### PR TITLE
Extend docutils line length limit

### DIFF
--- a/.changes/next-release/bugfix-help-587.json
+++ b/.changes/next-release/bugfix-help-587.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``help``",
+  "description": "Relax line length limit for rendered ``help`` pages"
+}

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -24,6 +24,7 @@ at the man output, we look one step before at the generated rst output
 from awscli.testutils import BaseAWSHelpOutputTest
 from awscli.testutils import FileCreator
 from awscli.testutils import mock
+from awscli.testutils import aws
 
 from awscli.compat import six
 from awscli.alias import AliasLoader
@@ -482,3 +483,11 @@ class TestStreamingOutputHelp(BaseAWSHelpOutputTest):
         self.driver.main(['s3api', 'get-object', 'help'])
         self.assert_not_contains('outfile <value>')
         self.assert_contains('<outfile>')
+
+
+# Use this test class for "help" cases that require the default renderer
+# (i.e. renderer from get_render()) instead of a mocked version.
+class TestHelpOutputDefaultRenderer:
+    def test_line_lengths_do_not_break_create_launch_template_version_cmd(self):
+        result = aws('ec2 create-launch-template-version help')
+        assert 'exceeds the line-length-limit' not in result.stderr


### PR DESCRIPTION
**Note: This PR targets the `develop` branch even though the related issue currently does not affect v1. This is because once v1 does upgrade `docutils`, it will be impacted. In addition, by merging this into `develop` first, it will become merged into v2. I also confirmed that the changes in this PR are compatible (i.e. ``help`` commands still work) with the ranges of `docutils` supported for v1.**

Addresses: https://github.com/aws/aws-cli/issues/8269

This is a temporary fix to handle JSON snippets in the man pages that are longer than the default docutils line limit of 10,000 and cause the man pages for some EC2 examples to not render.

Long term, we should consider breaking up the enums to multiple lines or potentially not enumerate all enums in the JSON snippets.

The value 50,000 was chosen based on the line length for ``InstanceType`` enums for the ``ec2 create-launch-template-version`` command. Currently, the line length for the ``InstanceType`` enums is just over 10,000. Assuming each enum is 10 characters long, a line length of 50,000 would give us the runway for roughly 4000 more instance types. The line length was not made magnitudes higher (i.e. to avoid hitting this issue ever again) because lines of this length are already not ideal and we should make sure to implement a more long term solution.
