### PR TITLE
feat: set None string as None value during aws configure

### DIFF
--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -119,6 +119,8 @@ class ConfigureCommand(BasicCommand):
             current_value = config.get(config_name)
             new_value = self._prompter.get_value(current_value, config_name,
                                                  prompt_text)
+            if new_value == 'None':
+              new_value = None
             if new_value is not None and new_value != current_value:
                 new_values[config_name] = new_value
         config_filename = os.path.expanduser(

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -81,8 +81,25 @@ class TestConfigureCommand(unittest.TestCase):
         # Test the case where the user only wants to change a single_value.
         responses = {
             "AWS Access Key ID": None,
-            "AWS Secert Access Key": None,
+            "AWS Secret Access Key": None,
             "Default region name": None,
+            "Default output format": "NEW OUTPUT FORMAT",
+        }
+        prompter = KeyValuePrompter(responses)
+        self.configure = configure.ConfigureCommand(self.session, prompter=prompter,
+                                                    config_writer=self.writer)
+        self.configure(args=[], parsed_globals=self.global_args)
+
+        # We only need to write out the default output format.
+        self.writer.update_config.assert_called_with(
+            {'output': 'NEW OUTPUT FORMAT'}, 'myconfigfile')
+
+    def test_none_string_set_to_none_value(self):
+        # Test the case where the user will type None instead of typing enter
+        responses = {
+            "AWS Access Key ID": None,
+            "AWS Secret Access Key": None,
+            "Default region name": "None",
             "Default output format": "NEW OUTPUT FORMAT",
         }
         prompter = KeyValuePrompter(responses)


### PR DESCRIPTION
During `aws credentials` command, the CLI ask for the output type
![image](https://github.com/aws/aws-cli/assets/7646137/2840b8f6-d36f-4c54-863f-f160283b7cb1)

Some users of my company, instead of typing enter, type the "None" string that is "advised" by the command
![image](https://github.com/aws/aws-cli/assets/7646137/b3761c9b-659b-4f34-b17c-44b4d9350f49)

Their lack of knowledge about how this kind of advice is handled is the cause, however, I think we could transform the "None" string to None value

I might be missing some edge cases, if my change doesn't make sense, just close the PR

*Description of changes:*

During `aws configure`, we consider 'None' string values to be None values

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.