### PR TITLE
[v2] Introduce ``auto`` mode for ``preferred_transfer_client``

### DIFF
--- a/.changes/next-release/feature-s3-589.json
+++ b/.changes/next-release/feature-s3-589.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "``s3``",
+  "description": "Add ``auto`` as new default option for ``preferred_transfer_client`` S3 configuration. This option auto resolves the S3 transfer client to use based on the system running the ``s3`` transfer commands. In addition, the ``default`` value for the ``preferred_transfer_client`` configuration is now named ``classic``."
+}

--- a/awscli/customizations/s3/constants.py
+++ b/awscli/customizations/s3/constants.py
@@ -12,5 +12,6 @@
 # language governing permissions and limitations under the License.
 
 # Constants for preferred_transfer_client configuration
-DEFAULT_TRANSFER_CLIENT = 'default'
+AUTO_RESOLVE_TRANSFER_CLIENT = 'auto'
+CLASSIC_TRANSFER_CLIENT = 'classic'
 CRT_TRANSFER_CLIENT = 'crt'

--- a/awscli/customizations/s3/factory.py
+++ b/awscli/customizations/s3/factory.py
@@ -54,7 +54,7 @@ class ClientFactory:
 
 class TransferManagerFactory:
     _MAX_IN_MEMORY_CHUNKS = 6
-    _CRT_PROCCESS_LOCK_NAME = 'aws-cli'
+    _CRT_PROCESS_LOCK_NAME = 'aws-cli'
 
     def __init__(self, session):
         self._session = session
@@ -107,7 +107,7 @@ class TransferManagerFactory:
         return self._acquire_crt_s3_process_lock() is None
 
     def _acquire_crt_s3_process_lock(self):
-        return acquire_crt_s3_process_lock(self._CRT_PROCCESS_LOCK_NAME)
+        return acquire_crt_s3_process_lock(self._CRT_PROCESS_LOCK_NAME)
 
     def _create_crt_transfer_manager(self, params, runtime_config):
         self._acquire_crt_s3_process_lock()

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -38,7 +38,7 @@ from s3transfer.utils import CallArgs, OSUtils, get_callbacks
 
 logger = logging.getLogger(__name__)
 
-CRT_S3_PROCCESS_LOCK = None
+CRT_S3_PROCESS_LOCK = None
 
 
 def acquire_crt_s3_process_lock(name):
@@ -52,8 +52,8 @@ def acquire_crt_s3_process_lock(name):
     # released when the lock object is garbage collected. So, the CRT process
     # lock is set as a global so that it is not unintentionally garbage
     # collected/released if reference of the lock is lost.
-    global CRT_S3_PROCCESS_LOCK
-    if CRT_S3_PROCCESS_LOCK is None:
+    global CRT_S3_PROCESS_LOCK
+    if CRT_S3_PROCESS_LOCK is None:
         crt_lock = awscrt.s3.CrossProcessLock(name)
         try:
             crt_lock.acquire()
@@ -62,8 +62,8 @@ def acquire_crt_s3_process_lock(name):
             # returns a RuntimeError. We return None here to signal that our
             # current process was not able to acquire the lock.
             return None
-        CRT_S3_PROCCESS_LOCK = crt_lock
-    return CRT_S3_PROCCESS_LOCK
+        CRT_S3_PROCESS_LOCK = crt_lock
+    return CRT_S3_PROCESS_LOCK
 
 
 class CRTCredentialProviderAdapter:

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -38,6 +38,33 @@ from s3transfer.utils import CallArgs, OSUtils, get_callbacks
 
 logger = logging.getLogger(__name__)
 
+CRT_S3_PROCCESS_LOCK = None
+
+
+def acquire_crt_s3_process_lock(name):
+    # Currently, the CRT S3 client performs best when there is only one
+    # instance of it running on a host. This lock allows an application to
+    # signal across processes whether there is another process of the same
+    # application using the CRT S3 client and prevent spawning more than one
+    # CRT S3 clients running on the system for that application.
+    #
+    # NOTE: When acquiring the CRT process lock, the lock automatically is
+    # released when the lock object is garbage collected. So, the CRT process
+    # lock is set as a global so that it is not unintentionally garbage
+    # collected/released if reference of the lock is lost.
+    global CRT_S3_PROCCESS_LOCK
+    if CRT_S3_PROCCESS_LOCK is None:
+        crt_lock = awscrt.s3.CrossProcessLock(name)
+        try:
+            crt_lock.acquire()
+        except RuntimeError:
+            # If there is another process that is holding the lock, the CRT
+            # returns a RuntimeError. We return None here to signal that our
+            # current process was not able to acquire the lock.
+            return None
+        CRT_S3_PROCCESS_LOCK = crt_lock
+    return CRT_S3_PROCCESS_LOCK
+
 
 class CRTCredentialProviderAdapter:
     def __init__(self, botocore_credential_provider):

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -279,23 +279,50 @@ Experimental Configuration Values
 preferred_transfer_client
 -------------------------
 
-**Default** - ``default``
+**Default** - ``auto``
 
 Determines the underlying Amazon S3 transfer client to use for transferring
 files to and from S3. Valid choices are:
 
-* ``default`` -  Use the builtin, Python-based transfer client that supports
-  all ``s3`` commands, parameters, and non-experimental configuration values.
+* ``auto`` - Auto resolve the Amazon S3 transfer client to use. Currently,
+  it resolves to ``crt`` when all of the following criteria is met:
+
+  * The ``s3`` command used is not an S3 to S3 copy transfer. The ``crt``
+    transfer client currently only supports uploads to S3, downloads from
+    S3, and deletion of S3 objects.
+
+  * The host running the AWS CLI is optimized for the ``crt`` transfer client.
+    Currently, the ``crt`` transfer client is optimized for Amazon EC2 instances
+    that are of any of these instance types:
+
+    * ``p4d.24xlarge``
+    * ``p4de.24xlarge``
+    * ``p5.48xlarge``
+    * ``trn1n.32xlarge``
+    * ``trn1.32xlarge``
+
+  * There are no other running processes of the AWS CLI using the CRT S3 transfer
+    client. To force multiple concurrently running processes of the AWS CLI to use
+    the CRT S3 transfer client, set the ``preferred_transfer_client`` configuration
+    variable to ``crt``.
+
+  Otherwise, it resolves to ``classic``. Between versions of the AWS CLI, auto
+  resolution criteria may change. To guarantee use of a specific transfer client,
+  set the ``preferred_transfer_client`` configuration variable to the
+  appropriate transfer client listed below.
+
+* ``classic`` -  Use the builtin, Python-based transfer client that supports
+  all ``s3`` commands, parameters, and most configuration values.
 
 * ``crt`` - Use the AWS Common Runtime (CRT) transfer client when
   possible. It is a C-based S3 transfer client that can improve transfer
   throughput. Currently, the CRT transfer client does not support all of the
-  functionality available in the ``default`` transfer client. The list below
-  details what functionality is not supported by the ``crt`` transfer client
-  option and the corresponding behavior of the AWS CLI if it is configured to
-  prefer the ``crt`` transfer client:
+  functionality available in the ``classic`` transfer client. The list below
+  details what functionality is currently not supported by the ``crt``
+  transfer client option and the corresponding behavior of the AWS CLI if it
+  is configured to prefer the ``crt`` transfer client:
 
-  * S3 to S3 copies - Falls back to using the ``default`` transfer client
+  * S3 to S3 copies - Falls back to using the ``classic`` transfer client
 
   * Region redirects - Transfers fail for requests sent to a region that does
     not match the region of the targeted S3 bucket.

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -302,6 +302,7 @@ class BaseS3CLIRunnerTest(unittest.TestCase):
         return (
             '[default]\n'
             's3 =\n'
+            '  preferred_transfer_client = classic\n'
             '  max_concurrent_requests = 1\n'
         )
 

--- a/tests/unit/customizations/s3/test_factory.py
+++ b/tests/unit/customizations/s3/test_factory.py
@@ -42,7 +42,7 @@ def mock_crt_process_lock(monkeypatch):
     # test cases will start off with no previously cached process lock and
     # if a cross process is instantiated/acquired it will be the mock that
     # can be used for controlling lock behavior.
-    monkeypatch.setattr('s3transfer.crt.CRT_S3_PROCCESS_LOCK', None)
+    monkeypatch.setattr('s3transfer.crt.CRT_S3_PROCESS_LOCK', None)
     with mock.patch('awscrt.s3.CrossProcessLock', spec=True) as mock_lock:
         yield mock_lock
 
@@ -527,7 +527,7 @@ def test_factory_always_acquires_crt_transfer_lock_for_crt_manager(
         transfer_manager_factory, s3_params, preferred_transfer_client
     )
     assert isinstance(transfer_manager, CRTTransferManager)
-    assert s3transfer.crt.CRT_S3_PROCCESS_LOCK
+    assert s3transfer.crt.CRT_S3_PROCESS_LOCK
     mock_crt_process_lock.assert_called_once_with('aws-cli')
     mock_crt_process_lock.return_value.acquire.assert_called_once_with()
 
@@ -554,7 +554,7 @@ def test_factory_never_acquires_crt_transfer_lock_for_classic_manager(
         transfer_manager_factory, s3_params, preferred_transfer_client
     )
     assert isinstance(transfer_manager, TransferManager)
-    assert s3transfer.crt.CRT_S3_PROCCESS_LOCK is None
+    assert s3transfer.crt.CRT_S3_PROCESS_LOCK is None
     mock_crt_process_lock.assert_not_called()
     mock_crt_process_lock.return_value.acquire.assert_not_called()
 

--- a/tests/unit/customizations/s3/test_factory.py
+++ b/tests/unit/customizations/s3/test_factory.py
@@ -10,9 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import pytest
 from awscli.testutils import unittest, mock, FileCreator
 
+import awscrt.s3
 from awscrt.s3 import S3RequestTlsMode
 from botocore.session import Session
 from botocore.config import Config
@@ -20,6 +20,7 @@ from botocore.httpsession import DEFAULT_CA_BUNDLE
 from s3transfer.manager import TransferManager
 import s3transfer.crt
 from s3transfer.crt import CRTTransferManager
+import pytest
 
 from awscli.customizations.s3.factory import (
     ClientFactory, TransferManagerFactory
@@ -67,6 +68,25 @@ def s3_params():
         'endpoint_url': None,
         'verify_ssl': None,
     }
+
+
+def test_crt_get_optimized_platforms_match_expected_platforms():
+    expected_platforms = {
+        'p4d.24xlarge',
+        'p4de.24xlarge',
+        'p5.48xlarge',
+        'trn1n.32xlarge',
+        'trn1.32xlarge',
+    }
+    actual_platforms = set(awscrt.s3.get_optimized_platforms())
+    assert expected_platforms == actual_platforms, (
+        'Expected set of CRT optimized platforms does not match result from '
+        'CRT. The result from CRT determines which platforms the CLI will '
+        'automatically use the S3 CRT client for. If the change in optimized '
+        'platforms is expected/appropriate, update the expected_platforms '
+        'set in this test and the list of CRT optimized platforms in the '
+        'documentation located at: awscli/topics/s3-config.rst'
+    )
 
 
 class TestClientFactory(unittest.TestCase):

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import io
 
+import pytest
 from botocore.credentials import CredentialResolver, ReadOnlyCredentials
 from botocore.session import Session
 
@@ -25,8 +26,48 @@ if HAS_CRT:
     import s3transfer.crt
 
 
+@pytest.fixture
+def mock_crt_process_lock(monkeypatch):
+    # The process lock is cached at the module layer whenever the
+    # cross process lock is successfully acquired. This patch ensures that
+    # test cases will start off with no previously cached process lock and
+    # if a cross process is instantiated/acquired it will be the mock that
+    # can be used for controlling lock behavior.
+    monkeypatch.setattr('s3transfer.crt.CRT_S3_PROCCESS_LOCK', None)
+    with mock.patch('awscrt.s3.CrossProcessLock', spec=True) as mock_lock:
+        yield mock_lock
+
+
 class CustomFutureException(Exception):
     pass
+
+
+@pytest.mark.skipif(
+    not HAS_CRT, reason="Test requires awscrt to be installed."
+)
+class TestCRTProcessLock:
+    def test_acquire_crt_s3_process_lock(self, mock_crt_process_lock):
+        lock = s3transfer.crt.acquire_crt_s3_process_lock('app-name')
+        assert lock is s3transfer.crt.CRT_S3_PROCCESS_LOCK
+        assert lock is mock_crt_process_lock.return_value
+        mock_crt_process_lock.assert_called_once_with('app-name')
+        mock_crt_process_lock.return_value.acquire.assert_called_once_with()
+
+    def test_unable_to_acquire_lock_returns_none(self, mock_crt_process_lock):
+        mock_crt_process_lock.return_value.acquire.side_effect = RuntimeError
+        assert s3transfer.crt.acquire_crt_s3_process_lock('app-name') is None
+        assert s3transfer.crt.CRT_S3_PROCCESS_LOCK is None
+        mock_crt_process_lock.assert_called_once_with('app-name')
+        mock_crt_process_lock.return_value.acquire.assert_called_once_with()
+
+    def test_multiple_acquires_return_same_lock(self, mock_crt_process_lock):
+        lock = s3transfer.crt.acquire_crt_s3_process_lock('app-name')
+        assert s3transfer.crt.acquire_crt_s3_process_lock('app-name') is lock
+        assert lock is s3transfer.crt.CRT_S3_PROCCESS_LOCK
+
+        # The process lock should have only been instantiated and acquired once
+        mock_crt_process_lock.assert_called_once_with('app-name')
+        mock_crt_process_lock.return_value.acquire.assert_called_once_with()
 
 
 @requires_crt

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -33,7 +33,7 @@ def mock_crt_process_lock(monkeypatch):
     # test cases will start off with no previously cached process lock and
     # if a cross process is instantiated/acquired it will be the mock that
     # can be used for controlling lock behavior.
-    monkeypatch.setattr('s3transfer.crt.CRT_S3_PROCCESS_LOCK', None)
+    monkeypatch.setattr('s3transfer.crt.CRT_S3_PROCESS_LOCK', None)
     with mock.patch('awscrt.s3.CrossProcessLock', spec=True) as mock_lock:
         yield mock_lock
 
@@ -48,7 +48,7 @@ class CustomFutureException(Exception):
 class TestCRTProcessLock:
     def test_acquire_crt_s3_process_lock(self, mock_crt_process_lock):
         lock = s3transfer.crt.acquire_crt_s3_process_lock('app-name')
-        assert lock is s3transfer.crt.CRT_S3_PROCCESS_LOCK
+        assert lock is s3transfer.crt.CRT_S3_PROCESS_LOCK
         assert lock is mock_crt_process_lock.return_value
         mock_crt_process_lock.assert_called_once_with('app-name')
         mock_crt_process_lock.return_value.acquire.assert_called_once_with()
@@ -56,14 +56,14 @@ class TestCRTProcessLock:
     def test_unable_to_acquire_lock_returns_none(self, mock_crt_process_lock):
         mock_crt_process_lock.return_value.acquire.side_effect = RuntimeError
         assert s3transfer.crt.acquire_crt_s3_process_lock('app-name') is None
-        assert s3transfer.crt.CRT_S3_PROCCESS_LOCK is None
+        assert s3transfer.crt.CRT_S3_PROCESS_LOCK is None
         mock_crt_process_lock.assert_called_once_with('app-name')
         mock_crt_process_lock.return_value.acquire.assert_called_once_with()
 
     def test_multiple_acquires_return_same_lock(self, mock_crt_process_lock):
         lock = s3transfer.crt.acquire_crt_s3_process_lock('app-name')
         assert s3transfer.crt.acquire_crt_s3_process_lock('app-name') is lock
-        assert lock is s3transfer.crt.CRT_S3_PROCCESS_LOCK
+        assert lock is s3transfer.crt.CRT_S3_PROCESS_LOCK
 
         # The process lock should have only been instantiated and acquired once
         mock_crt_process_lock.assert_called_once_with('app-name')


### PR DESCRIPTION
This is the new default value for the s3 ``preferred_transfer_client`` configuration setting. In ``auto`` mode, the AWS CLI will determine whether the current system is optimized for the AWS CRT client (e.g. is an EC2 environment with high network bandwidth). If it is optimized and there are no other AWS CLI processes using the AWS CRT client, the AWS CLI will use the AWS CRT client, and if not, it will use the normal Python transfer client.

In introducing the ``auto`` value, I also renamed the preexisting ``default`` value that mapped to the normal Python transfer client to ``classic``. Specifically, it was confusing that ``default`` was no longer the default value for the ``preferred_transfer_client`` setting. The ``default`` value is now an undocumented alias for ``classic`` that avoids runtime errors for current users that may have explicitly configured the AWS CLI to use the normal Python transfer client.