### PR TITLE
[v2] Update CRT throughput target defaults

### DIFF
--- a/.changes/next-release/bugfix-s3-83640.json
+++ b/.changes/next-release/bugfix-s3-83640.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Support integers (e.g. 1024) and values that do not have a magnitude prefix (e.g. 1024B/s) for s3 rate configurations."
+}

--- a/.changes/next-release/enchancement-s3-12369.json
+++ b/.changes/next-release/enchancement-s3-12369.json
@@ -1,0 +1,5 @@
+{
+  "type": "enchancement",
+  "category": "``s3``",
+  "description": "Update ``target_bandwidth`` defaults. If not configured, the AWS CLI will use the AWS CRT to attempt to determine a recommended target throughput to use based on the system. If there is no recommended throughput, the AWS CLI now falls back to ten gigabits per second."
+}

--- a/awscli/customizations/s3/transferconfig.py
+++ b/awscli/customizations/s3/transferconfig.py
@@ -30,7 +30,7 @@ DEFAULTS = {
     'max_queue_size': 1000,
     'max_bandwidth': None,
     'preferred_transfer_client': constants.AUTO_RESOLVE_TRANSFER_CLIENT,
-    'target_bandwidth': int(5 * (1024 ** 3) / 8),  # which is 5 Gb/s
+    'target_bandwidth': None,
 }
 
 

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -25,13 +25,18 @@ from awscrt.io import (
     EventLoopGroup,
     TlsContextOptions,
 )
-from awscrt.s3 import S3Client, S3RequestTlsMode, S3RequestType
+from awscrt.s3 import (
+    S3Client,
+    S3RequestTlsMode,
+    S3RequestType,
+    get_recommended_throughput_target_gbps,
+)
 from botocore import UNSIGNED
 from botocore.compat import urlsplit
 from botocore.config import Config
 from botocore.exceptions import NoCredentialsError
 
-from s3transfer.constants import GB, MB
+from s3transfer.constants import MB
 from s3transfer.exceptions import TransferNotDoneError
 from s3transfer.futures import BaseTransferFuture, BaseTransferMeta
 from s3transfer.utils import CallArgs, OSUtils, get_callbacks
@@ -94,7 +99,7 @@ def create_s3_crt_client(
     region,
     botocore_credential_provider=None,
     num_threads=None,
-    target_throughput=5 * GB / 8,
+    target_throughput=None,
     part_size=8 * MB,
     use_ssl=True,
     verify=None,
@@ -114,7 +119,12 @@ def create_s3_crt_client(
 
     :type target_throughput: Optional[int]
     :param target_throughput: Throughput target in Bytes.
-        Default is 0.625 GB/s (which translates to 5 Gb/s).
+        By default, CRT will automatically attempt to choose a target
+        throughput that matches the system's maximum network throughput.
+        Currently, if CRT is unable to determine the maximum network
+        throughput, a fallback target throughput of 1.25 GB/s
+        (which translates to 10Gb/s) is used. To guarantee a specific target
+        throughput, set a value for this parameter.
 
     :type part_size: Optional[int]
     :param part_size: Size, in Bytes, of parts that files will be downloaded
@@ -163,8 +173,9 @@ def create_s3_crt_client(
         provider = AwsCredentialsProvider.new_delegate(
             credentails_provider_adapter
         )
-
-    target_gbps = target_throughput * 8 / GB
+    target_gbps = _get_crt_throughput_target_gbps(
+        provided_throughput_target_bytes=target_throughput
+    )
     return S3Client(
         bootstrap=bootstrap,
         region=region,
@@ -174,6 +185,23 @@ def create_s3_crt_client(
         tls_connection_options=tls_connection_options,
         throughput_target_gbps=target_gbps,
     )
+
+
+def _get_crt_throughput_target_gbps(provided_throughput_target_bytes=None):
+    if provided_throughput_target_bytes is None:
+        target_gbps = get_recommended_throughput_target_gbps()
+        logger.debug(
+            'Recommended CRT throughput target in gbps: %s', target_gbps
+        )
+        if target_gbps is None:
+            target_gbps = 10.0
+    else:
+        # NOTE: The GB constant in s3transfer is technically a gibibyte. The
+        # GB constant is not used here because the CRT interprets a gigabyte
+        # as a base power of 10 (i.e. 1000 ** 3 instead of 1024 ** 3).
+        target_gbps = provided_throughput_target_bytes * 8 / 1_000_000_000
+    logger.debug('Using CRT throughput target in gbps: %s', target_gbps)
+    return target_gbps
 
 
 class CRTTransferManager:

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -335,21 +335,30 @@ files to and from S3. Valid choices are:
 target_bandwidth
 ----------------
 .. note::
-   This experimental configuration option is only supported when
-   ``preferred_transfer_client`` is set to ``crt``. The ``default`` transfer
-   client does not support it.
+   This configuration option is only supported when the ``preferred_transfer_client``
+   configuration value is set to or resolves to ``crt``. The ``classic`` transfer
+   client does not support this configuration option.
 
-**Default** - ``5Gb/s``
+**Default** - Automatically derived based on system
 
 Controls the target bandwidth that the transfer client will try to reach
-for S3 uploads and downloads. The value can be specified as:
+for S3 uploads and downloads. By default, the AWS CLI will automatically
+attempt to choose a target bandwidth that matches the system's maximum
+network bandwidth. Currently, if the AWS CLI is unable to determine the
+maximum network bandwith, the AWS CLI falls back to a target bandwidth of
+ten gigabits per second (i.e. equivalent to setting the ``target_bandwidth``
+configuration option to ``10000000000b/s``). To guarantee a specific target bandwith,
+explicitly configure the ``target_bandwidth`` configuration option. Its
+value can be specified as:
 
 * An integer in terms of **bytes** per second. For example,
-  ``1073741824`` would set the target bandwidth to 1 GB per second.
+  ``1073741824`` would set the target bandwidth to 1 gibibyte per second.
 * A rate suffix. This can be expressed in terms of either bytes per second
   (``B/s``) or bits per second (``b/s``). You can specify rate suffixes
   using: ``KB/s``, ``MB/s``, ``GB/s``, ``Kb/s``, ``Mb/s``, ``Gb/s`` etc.
-  For example: ``200MB/s``, ``10GB/s``, ``200Mb/s``, ``10Gb/s``.
+  For example: ``200MB/s``, ``10GB/s``, ``200Mb/s``, ``10Gb/s``. When specifying
+  rate suffixes, values are expanded using powers of 2 instead of 10. For example,
+  specifying ``1KB/s`` is equivalent to specifying ``1024B/s`` instead of ``1000B/s``.
 
 This difference between ``target_bandwidth`` and the ``max_bandwidth`` is that
 ``max_bandwidth`` is purely for rate limiting and makes no adjustments to


### PR DESCRIPTION
Instead of defaulting to five gigabits per second when no target througput is configured, the AWS CLI will use the CRT to determine if there is a recommended target throughput to use. If it is unable, to determine a recommended target throughput, it will default to ten gigabits per second, which is the current throughput default for the CRT S3 client.

This behavior was updated to help minimize the amount of configuration required to get the fastest throughputs from the CRT transfer client. The fallback throughput was updated from five to ten gigabits so that the CRT S3 integration is consistent with the underlying CRT S3 client's defaults.

This also fixes an issue where it was documented that a user could provide integers (e.g. `1024`) and human readable rates that lack a magnitude prefix (e.g. `1024B/s`) for S3 rate-related configurations. However, providing these sorts of values resulted in value errors. This adds support for these formats so the behavior matches the documentation and also makes it easier to specify exact rates especially when you are expecting powers of 10 (and not 2) when using magnitude suffixes (`MB`, `GB`, etc.) 

