### PR TITLE
add CI testing against python 3.12 to v2 branch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Seems the updates to run-tests.yml from #8106 and #8258 didn't get auto-merged from develop into v2. We're seeing an error in packaging v2 for conda-forge against python 3.12 (https://github.com/conda-forge/awscli2-feedstock/pull/39), that this will hopefully reproduce in CI here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
