### PR TITLE
fix: "invalid escape sequence" error in some regexp and strings.

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -460,9 +460,9 @@ except ImportError:
                 id = l[1]
         return '', version, id
 
-    _distributor_id_file_re = re.compile("(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
-    _release_file_re = re.compile("(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
-    _codename_file_re = re.compile("(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
+    _distributor_id_file_re = re.compile(r"(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
+    _release_file_re = re.compile(r"(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
+    _codename_file_re = re.compile(r"(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
 
     def linux_distribution(distname='', version='', id='',
                            supported_dists=_supported_dists,

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -73,7 +73,7 @@ def assert_cloudtrail_arn_is_valid(trail_arn):
     """Ensures that the arn looks correct.
 
     ARNs look like: arn:aws:cloudtrail:us-east-1:123456789012:trail/foo"""
-    pattern = re.compile('arn:.+:cloudtrail:.+:\d{12}:trail/.+')
+    pattern = re.compile(r'arn:.+:cloudtrail:.+:\d{12}:trail/.+')
     if not pattern.match(trail_arn):
         raise ValueError('Invalid trail ARN provided: %s' % trail_arn)
 

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -58,11 +58,11 @@ class Push(BasicCommand):
             'synopsis': '--s3-location s3://<bucket>/<key>',
             'required': True,
             'help_text': (
-                'Required. Information about the location of the application '
-                'revision to be uploaded to Amazon S3. You must specify both '
-                'a bucket and a key that represent the Amazon S3 bucket name '
-                'and the object key name. Content will be zipped before '
-                'uploading. Use the format s3://\<bucket\>/\<key\>'
+                r'Required. Information about the location of the application '
+                r'revision to be uploaded to Amazon S3. You must specify both '
+                r'a bucket and a key that represent the Amazon S3 bucket name '
+                r'and the object key name. Content will be zipped before '
+                r'uploading. Use the format s3://\<bucket\>/\<key\>'
             )
         },
         {

--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -196,7 +196,7 @@ class CreateCluster(Command):
 
         if (parsed_args.release_label is None and
                 parsed_args.ami_version is not None):
-            is_valid_ami_version = re.match('\d?\..*', parsed_args.ami_version)
+            is_valid_ami_version = re.match(r'\d?\..*', parsed_args.ami_version)
             if is_valid_ami_version is None:
                 raise exceptions.InvalidAmiVersionError(
                     ami_version=parsed_args.ami_version)

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -129,9 +129,9 @@ class ShorthandParser(object):
 
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
-    _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
-    _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
-    _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
+    _START_WORD = r'\!\#-&\(-\+\--\<\>-Z\\-z' + '\u007c-\uffff'
+    _FIRST_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\\\^-\|~-' + '\uffff'
+    _SECOND_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\<\>-' + '\uffff'
     _ESCAPED_COMMA = '(\\\\,)'
     _FIRST_VALUE = _NamedRegex(
         'first',


### PR DESCRIPTION
Fixed "invalid escape sequence" errors caused by missing 'r' modifiers or incomplete escaping in some strings.

# Problem

Sometimes aws-cli stopped by errors like following

```
aws: error: argument --role-arn: expected one argument
/usr/local/lib/python3.12/site-packages/awscli/compat.py:463: SyntaxWarning: invalid escape sequence '\s'
  _distributor_id_file_re = re.compile("(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/compat.py:464: SyntaxWarning: invalid escape sequence '\s'
  _release_file_re = re.compile("(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/compat.py:465: SyntaxWarning: invalid escape sequence '\s'
  _codename_file_re = re.compile("(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:132: SyntaxWarning: invalid escape sequence '\!'
  _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:133: SyntaxWarning: invalid escape sequence '\s'
  _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:134: SyntaxWarning: invalid escape sequence '\s'
  _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/customizations/cloudtrail/validation.py:76: SyntaxWarning: invalid escape sequence '\d'
  pattern = re.compile('arn:.+:cloudtrail:.+:\d{12}:trail/.+')
/usr/local/lib/python3.12/site-packages/awscli/customizations/codedeploy/push.py:65: SyntaxWarning: invalid escape sequence '\<'
  'uploading. Use the format s3://\<bucket\>/\<key\>'
/usr/local/lib/python3.12/site-packages/awscli/customizations/emr/createcluster.py:199: SyntaxWarning: invalid escape sequence '\d'
  is_valid_ami_version = re.match('\d?\..*', parsed_args.ami_version)
Unable to locate credentials. You can configure credentials by running "aws configure".
```

I saw the errors at aws-cli version 1.30.5 (commit 1a1e73c2cd99edf98a037fb774cadb6e3cd3afc1).

# Cause of Errors

The errors caused by missing 'r' modifiers or incomplete escaping.

# Description of changes

This pull request fixes missing 'r' modifiers and escaping in those strings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Thanks for reviewing :-)
