### PR TITLE
[v2] Raise version floor of CRT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "ruamel.yaml.clib>=0.2.0,<=0.2.7",
     "prompt-toolkit>=3.0.24,<3.0.39",
     "distro>=1.5.0,<1.9.0",
-    "awscrt>=0.16.4,<=0.19.16",
+    "awscrt>=0.19.12,<=0.19.16",
     "python-dateutil>=2.1,<3.0.0",
     "jmespath>=0.7.1,<1.1.0",
     "urllib3>=1.25.4,<1.27",


### PR DESCRIPTION
The minimum version to use the new CRT interfaces is  0.19.12. Versions after 0.19.12 have solely been bug fixes and performance improvements and are not required for usage.
