### PR TITLE
[v2] Add additional note on CRT auto mode

### DIFF
--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -283,7 +283,8 @@ files to and from S3. Valid choices are:
 
   * The host running the AWS CLI is optimized for the ``crt`` transfer client.
     Currently, the ``crt`` transfer client is optimized for Amazon EC2 instances
-    that are of any of these instance types:
+    that are running Linux as the operating system and are of any of these
+    instance types:
 
     * ``p4d.24xlarge``
     * ``p4de.24xlarge``


### PR DESCRIPTION
The CRT `is_optimized_for_system()` utility only returns `True` for environments running Linux. So this update clarifies that the system must be running Linux in addition to being one of the enumerated instance types in order to auto resolve into using the CRT client.

