### PR TITLE
Add another example for cognito-idp update-user-pool

### DIFF
--- a/awscli/examples/cognito-idp/update-user-pool.rst
+++ b/awscli/examples/cognito-idp/update-user-pool.rst
@@ -5,3 +5,11 @@ This example adds tags to a user pool.
 Command::
 
   aws cognito-idp update-user-pool --user-pool-id us-west-2_aaaaaaaaa --user-pool-tags Team=Blue,Area=West
+
+As mentioned earlier, this example does not specify values for other attributes, such as Lambda triggers and email settings, so Amazon Cognito sets them to their default settings.
+
+For example, if you want to avoid this behavior for the pre sign-up Lambda trigger, execute the following command. ::
+
+ aws cognito-idp update-user-pool --user-pool-id us-west-2_aaaaaaaaa \
+   --user-pool-tags Team=Blue,Area=West \
+   --cli-input-json '{ "LambdaConfig": { "PreSignUp": "arn:aws:lambda:us-west-2:123456789012:function:my-function" } }'


### PR DESCRIPTION

*Description of changes:*

The aws cognito-idp update-user-pool command can reset certain attributes of a user pool, so I've added an example of how to avoid that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
