### PR TITLE
Update ioerror

### DIFF
--- a/awscli/customizations/ecs/deploy.py
+++ b/awscli/customizations/ecs/deploy.py
@@ -161,7 +161,7 @@ class ECSDeploy(BasicCommand):
         try:
             with compat_open(full_path) as f:
                 return f.read()
-        except (OSError, IOError, UnicodeDecodeError) as e:
+        except (OSError, UnicodeDecodeError) as e:
             raise exceptions.FileLoadError(
                 file_path=file_path, error=e)
 

--- a/awscli/customizations/eks/kubeconfig.py
+++ b/awscli/customizations/eks/kubeconfig.py
@@ -156,7 +156,7 @@ class KubeconfigLoader(object):
         try:
             with open(path, "r") as stream:
                 loaded_content=ordered_yaml_load(stream)
-        except IOError as e:
+        except OSError as e:
             if e.errno == errno.ENOENT:
                 loaded_content=None
             else:
@@ -200,7 +200,7 @@ class KubeconfigWriter(object):
                         0o600),
                     "w+") as stream:
                 ordered_yaml_dump(config.content, stream)
-        except (IOError, OSError) as e:
+        except OSError as e:
             raise KubeconfigInaccessableError(
                 f"Can't open kubeconfig for writing: {e}")
 

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -58,13 +58,13 @@ def is_readable(path):
     if os.path.isdir(path):
         try:
             os.listdir(path)
-        except (OSError, IOError):
+        except OSError:
             return False
     else:
         try:
             with _open(path, 'r') as fd:
                 pass
-        except (OSError, IOError):
+        except OSError:
             return False
     return True
 

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -255,7 +255,7 @@ def get_file_stat(path):
     """
     try:
         stats = os.stat(path)
-    except IOError as e:
+    except OSError as e:
         raise ValueError('Could not retrieve file stat of "%s": %s' % (
             path, e))
 

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -47,7 +47,7 @@ class Formatter(object):
     def _flush_stream(self, stream):
         try:
             stream.flush()
-        except IOError:
+        except OSError:
             pass
 
 
@@ -69,7 +69,7 @@ class FullyBufferedFormatter(Formatter):
             response_data = self._args.query.search(response_data)
         try:
             self._format_response(command_name, response_data, stream)
-        except IOError as e:
+        except OSError as e:
             # If the reading end of our stdout stream has closed the file
             # we can just exit.
             pass
@@ -120,7 +120,7 @@ class TableFormatter(FullyBufferedFormatter):
         if self._build_table(command_name, response):
             try:
                 self.table.render(stream)
-            except IOError:
+            except OSError:
                 # If they're piping stdout to another process which exits before
                 # we're done writing all of our output, we'll get an error about a
                 # closed pipe which we can safely ignore.

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -242,7 +242,7 @@ def get_file(prefix, path, mode):
             'Unable to load paramfile (%s), text contents could '
             'not be decoded.  If this is a binary file, please use the '
             'fileb:// prefix instead of the file:// prefix.' % file_path)
-    except (OSError, IOError) as e:
+    except OSError as e:
         raise ResourceLoadingError('Unable to load paramfile %s: %s' % (
             path, e))
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -217,8 +217,8 @@ class OutputStreamFactory(object):
         try:
             process = self._popen(**popen_kwargs)
             yield process.stdin
-        except IOError:
-            # Ignore IOError since this can commonly be raised when a pager
+        except OSError:
+            # Ignore OSError since this can commonly be raised when a pager
             # is closed abruptly and causes a broken pipe.
             pass
         finally:


### PR DESCRIPTION
IOError has been deprecated since Python version 3.3, and has been merged (with various other exceptions) into OSError


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
