### PR TITLE
[v2] Add support for configuration opt out for IMDS v1 

### DIFF
--- a/.changes/next-release/enhancement-MetadataFetcher-40786.json
+++ b/.changes/next-release/enhancement-MetadataFetcher-40786.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "IMDS",
+  "description": "Adds a config option to opt out of IMDSv1 fallback"
+}

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -79,6 +79,12 @@ BOTOCORE_DEFAUT_SESSION_VARIABLES = {
         'ec2_metadata_service_endpoint_mode',
         'AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE',
         None, None),
+    'ec2_metadata_v1_disabled': (
+        'ec2_metadata_v1_disabled',
+        'AWS_EC2_METADATA_V1_DISABLED',
+        False,
+        utils.ensure_boolean,
+    ),
     'imds_use_ipv6': (
         'imds_use_ipv6',
         'AWS_IMDS_USE_IPV6',

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -80,6 +80,9 @@ def create_credential_resolver(session, cache=None, region_name=None):
         'ec2_metadata_service_endpoint_mode': resolve_imds_endpoint_mode(
             session),
         'ec2_credential_refresh_window': _DEFAULT_ADVISORY_REFRESH_TIMEOUT,
+        'ec2_metadata_v1_disabled': session.get_config_variable(
+            'ec2_metadata_v1_disabled'
+        ),
     }
 
     if cache is None:

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -135,7 +135,10 @@ class IMDSRegionProvider(BaseProvider):
                 'ec2_metadata_service_endpoint'),
             'ec2_metadata_service_endpoint_mode': resolve_imds_endpoint_mode(
                 self._session
-            )
+            ),
+            'ec2_metadata_v1_disabled': self._session.get_config_variable(
+                'ec2_metadata_v1_disabled'
+            ),
         }
         fetcher = InstanceMetadataRegionFetcher(
             timeout=metadata_timeout,

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -2808,6 +2808,13 @@ class TestInstanceMetadataFetcher(unittest.TestCase):
             user_agent=user_agent).retrieve_iam_role_credentials()
         self.assertEqual(result, {})
 
+    def test_v1_disabled_by_config(self):
+        config = {'ec2_metadata_v1_disabled': True}
+        self.add_imds_response(b'', status_code=404)
+        fetcher = InstanceMetadataFetcher(num_attempts=1, config=config)
+        with self.assertRaises(MetadataRetrievalError):
+            fetcher.retrieve_iam_role_credentials()
+
     def _get_datetime(
        self, dt=None, offset=None, offset_func=operator.add
     ):


### PR DESCRIPTION
This is a port of this upstream botocore PR: https://github.com/boto/botocore/pull/3045

The AWS CLI v2 uses a different IMDS region fetcher than botocore. So I added the updates to the IMDS region provider in a separate commit.
