### PR TITLE
Examples: medical-imaging, updates

### DIFF
--- a/awscli/examples/medical-imaging/copy-image-set.rst
+++ b/awscli/examples/medical-imaging/copy-image-set.rst
@@ -64,6 +64,4 @@ Output::
         "datastoreId": "12345678901234567890123456789012"
     }
 
-For more information, see `Copying an image set`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Copying an image set`: https://docs.aws.amazon.com/healthimaging/latest/devguide/copy-image-set.html
+For more information, see `Copying an image set <https://docs.aws.amazon.com/healthimaging/latest/devguide/copy-image-set.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/create-datastore.rst
+++ b/awscli/examples/medical-imaging/create-datastore.rst
@@ -12,6 +12,4 @@ Output::
         "datastoreStatus": "CREATING"
     }
 
-For more information, see `Creating a data store`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Creating a data store`: https://docs.aws.amazon.com/healthimaging/latest/devguide/create-data-store.html
+For more information, see `Creating a data store <https://docs.aws.amazon.com/healthimaging/latest/devguide/create-data-store.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/delete-datastore.rst
+++ b/awscli/examples/medical-imaging/delete-datastore.rst
@@ -12,6 +12,4 @@ Output::
         "datastoreStatus": "DELETING"
     }
 
-For more information, see `Deleting a data store`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Deleting a data store`: https://docs.aws.amazon.com/healthimaging/latest/devguide/delete-data-store.html
+For more information, see `Deleting a data store <https://docs.aws.amazon.com/healthimaging/latest/devguide/delete-data-store.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/delete-image-set.rst
+++ b/awscli/examples/medical-imaging/delete-image-set.rst
@@ -15,6 +15,4 @@ Output::
         "datastoreId": "12345678901234567890123456789012"
     }
 
-For more information, see `Deleting an image set`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Deleting an image set`: https://docs.aws.amazon.com/healthimaging/latest/devguide/delete-image-set.html
+For more information, see `Deleting an image set <https://docs.aws.amazon.com/healthimaging/latest/devguide/delete-image-set.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/get-datastore.rst
+++ b/awscli/examples/medical-imaging/get-datastore.rst
@@ -19,6 +19,4 @@ Output::
         }
     }
 
-For more information, see `Getting data store properties`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Getting data store properties`: https://docs.aws.amazon.com/healthimaging/latest/devguide/get-data-store.html
+For more information, see `Getting data store properties <https://docs.aws.amazon.com/healthimaging/latest/devguide/get-data-store.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/get-dicom-import-job.rst
+++ b/awscli/examples/medical-imaging/get-dicom-import-job.rst
@@ -23,6 +23,4 @@ Output::
         }
     }
 
-For more information, see `Getting import job properties`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Getting import job properties`: https://docs.aws.amazon.com/healthimaging/latest/devguide/get-dicom-import-job.html
+For more information, see `Getting import job properties <https://docs.aws.amazon.com/healthimaging/latest/devguide/get-dicom-import-job.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/get-image-frame.rst
+++ b/awscli/examples/medical-imaging/get-image-frame.rst
@@ -13,6 +13,4 @@ Note:
 This code example does not include output because the GetImageFrame action returns a stream of pixel data to the imageframe.jph file. For information about decoding and viewing image frames, see HTJ2K decoding libraries.
 
 
-For more information, see `Getting image set pixel data`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Getting image set pixel data`: https://docs.aws.amazon.com/healthimaging/latest/devguide/get-image-frame.html
+For more information, see `Getting image set pixel data <https://docs.aws.amazon.com/healthimaging/latest/devguide/get-image-frame.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/get-image-set-metadata.rst
+++ b/awscli/examples/medical-imaging/get-image-set-metadata.rst
@@ -39,6 +39,4 @@ Output::
         "contentEncoding": "gzip"
     }
 
-For more information, see `Getting image set metadata`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Getting image set metadata`: https://docs.aws.amazon.com/healthimaging/latest/devguide/get-image-set-metadata.html
+For more information, see `Getting image set metadata <https://docs.aws.amazon.com/healthimaging/latest/devguide/get-image-set-metadata.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/get-image-set.rst
+++ b/awscli/examples/medical-imaging/get-image-set.rst
@@ -20,6 +20,4 @@ Output::
     }
 
 
-For more information, see `Getting image set properties`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Getting image set properties`: https://docs.aws.amazon.com/healthimaging/latest/devguide/get-image-set-properties.html
+For more information, see `Getting image set properties <https://docs.aws.amazon.com/healthimaging/latest/devguide/get-image-set-properties.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/list-datastores.rst
+++ b/awscli/examples/medical-imaging/list-datastores.rst
@@ -20,6 +20,4 @@ Output::
     }
 
 
-For more information, see `Listing data stores`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Listing data stores`: https://docs.aws.amazon.com/healthimaging/latest/devguide/list-data-stores.html
+For more information, see `Listing data stores <https://docs.aws.amazon.com/healthimaging/latest/devguide/list-data-stores.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/list-dicom-import-jobs.rst
+++ b/awscli/examples/medical-imaging/list-dicom-import-jobs.rst
@@ -21,6 +21,4 @@ Output::
         ]
     }
 
-For more information, see `Listing import jobs`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Listing import jobs`: https://docs.aws.amazon.com/healthimaging/latest/devguide/list-dicom-import-jobs.html
+For more information, see `Listing import jobs <https://docs.aws.amazon.com/healthimaging/latest/devguide/list-dicom-import-jobs.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/list-image-set-versions.rst
+++ b/awscli/examples/medical-imaging/list-image-set-versions.rst
@@ -45,6 +45,4 @@ Output::
         ]
     }
 
-For more information, see `Listing image set versions`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Listing image set versions`: https://docs.aws.amazon.com/healthimaging/latest/devguide/list-image-set-versions.html
+For more information, see `Listing image set versions <https://docs.aws.amazon.com/healthimaging/latest/devguide/list-image-set-versions.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/list-tags-for-resource.rst
+++ b/awscli/examples/medical-imaging/list-tags-for-resource.rst
@@ -29,6 +29,4 @@ Output::
         }
     }
 
-For more information, see `Tagging resources with AWS HealthImaging`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Tagging resources with AWS HealthImaging`: https://docs.aws.amazon.com/healthimaging/latest/devguide/tagging.html
+For more information, see `Tagging resources with AWS HealthImaging <https://docs.aws.amazon.com/healthimaging/latest/devguide/tagging.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/search-image-sets.rst
+++ b/awscli/examples/medical-imaging/search-image-sets.rst
@@ -144,6 +144,4 @@ Output::
         }]
     }
 
-For more information, see `Searching image sets`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Searching image sets`: https://docs.aws.amazon.com/healthimaging/latest/devguide/search-image-sets.html
+For more information, see `Searching image sets <https://docs.aws.amazon.com/healthimaging/latest/devguide/search-image-sets.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/start-dicom-import-job.rst
+++ b/awscli/examples/medical-imaging/start-dicom-import-job.rst
@@ -18,6 +18,4 @@ Output::
         "submittedAt": "2022-08-12T11:28:11.152000+00:00"
     }
 
-For more information, see `Starting an import job`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Starting an import job`: https://docs.aws.amazon.com/healthimaging/latest/devguide/start-dicom-import-job.html
+For more information, see `Starting an import job <https://docs.aws.amazon.com/healthimaging/latest/devguide/start-dicom-import-job.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/tag-resource.rst
+++ b/awscli/examples/medical-imaging/tag-resource.rst
@@ -18,6 +18,5 @@ The following ``tag-resource`` code examples tags an image set. ::
 
 This command produces no output.
 
-For more information, see `Tagging resources with AWS HealthImaging`_ in the *AWS HealthImaging Developers Guide*.
+For more information, see `Tagging resources with AWS HealthImaging <https://docs.aws.amazon.com/healthimaging/latest/devguide/tagging.html>`__ in the *AWS HealthImaging Developer Guide*.
 
-.. _`Tagging resources with AWS HealthImaging`: https://docs.aws.amazon.com/healthimaging/latest/devguide/tagging.html

--- a/awscli/examples/medical-imaging/untag-resource.rst
+++ b/awscli/examples/medical-imaging/untag-resource.rst
@@ -20,6 +20,5 @@ The following ``untag-resource`` code example untags an image set. ::
 
 This command produces no output.
 
-For more information, see `Tagging resources with AWS HealthImaging`_ in the *AWS HealthImaging Developers Guide*.
+For more information, see `Tagging resources with AWS HealthImaging <https://docs.aws.amazon.com/healthimaging/latest/devguide/tagging.html>`__ in the *AWS HealthImaging Developer Guide*.
 
-.. _`Tagging resources with AWS HealthImaging`: https://docs.aws.amazon.com/healthimaging/latest/devguide/tagging.html

--- a/awscli/examples/medical-imaging/update-image-set-metadata.rst
+++ b/awscli/examples/medical-imaging/update-image-set-metadata.rst
@@ -32,6 +32,4 @@ Output::
         "datastoreId": "12345678901234567890123456789012"
     }
 
-For more information, see `Updating image set metadata`_ in the *AWS HealthImaging Developers Guide*.
-
-.. _`Updating image set metadata`: https://docs.aws.amazon.com/healthimaging/latest/devguide/update-image-set-metadata.html
+For more information, see `Updating image set metadata <https://docs.aws.amazon.com/healthimaging/latest/devguide/update-image-set-metadata.html>`__ in the *AWS HealthImaging Developer Guide*.


### PR DESCRIPTION
Change
`*AWS HealthImaging Developers Guide*` to `*AWS HealthImaging Developer Guide*` in all medical-imaging examples

Change all "For more information..." to the proper format in all medical-imaging examples, i.e.

```
For more information, see `This is the topic title <https://link.to.the/topic/page>`__ in the *Name of your guide*.
```