### PR TITLE
Added bugs to stale issue automation

### DIFF
--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -21,7 +21,7 @@ jobs:
 
         # These labels are required
         stale-issue-label: closing-soon
-        exempt-issue-labels: automation-exempt, help wanted, bug, confusing-error, community
+        exempt-issue-labels: automation-exempt, help wanted, confusing-error, community
         response-requested-label: response-requested
 
         # Don't set closed-for-staleness label to skip closing very old issues


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We're adding bugs to the stale issue workflow. This was disabled at some point because we didn't want ancient bugs to be closed. That workflow no longer exists, so this should be fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
