### PR TITLE
Add macOS deprecation warning

### DIFF
--- a/.changes/next-release/enhancement-macOS-53495.json
+++ b/.changes/next-release/enhancement-macOS-53495.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "macOS",
+  "description": "Add deprecation warnings for macOS versions 10.14 and prior to the PKG installer and source distribution bundle."
+}

--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,21 @@ The aws-cli package works on Python versions:
 
  Jump to:
 
+-  `Notices <#notices>`__
 -  `Installation <#installation>`__
 -  `Getting Started <#getting-started>`__
 -  `Getting Help <#getting-help>`__
 -  `More Resources <#more-resources>`__
+
+
+-------
+Notices
+-------
+On 2024-06-20, support for macOS versions 10.14 and prior will be dropped.
+To avoid disruption, customers using macOS 10.14 or prior
+should upgrade to macOS 10.15 or later. For more information, please see
+this `blog post <https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/>`__.
+
 
 ------------
 Installation

--- a/configure
+++ b/configure
@@ -2093,6 +2093,44 @@ fi
 printf "%s\n" "$with_download_deps" >&6; }
 
 
+ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
+if test "$ac_operating_system" = Darwin; then
+
+    min_version='10.15.0'
+    end_support_date='June 20, 2024'
+
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for macOS version support" >&5
+printf %s "checking for macOS version support... " >&6; }
+    ac_macos_version=`(sw_vers -productVersion) 2>/dev/null || echo unknown`
+
+    if test "$ac_macos_version" = unknown; then
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unknown" >&5
+printf "%s\n" "unknown" >&6; }
+    else
+        sys_version_major=`echo "$ac_macos_version" | \
+            sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
+        sys_version_minor=`echo "$ac_macos_version" | \
+            sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
+
+        min_version_major=`echo "$min_version" | \
+            sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
+        min_version_minor=`echo "$min_version" | \
+            sed 's/\([0-9]*\)\.\([0-9]*\).*/\2/'`
+
+        if test "$sys_version_major" -lt "$min_version_major" || \
+            test "$sys_version_major" -eq "$min_version_major" -a \
+            "$sys_version_minor" -lt "$min_version_minor"; then
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: pending-end-of-support" >&5
+printf "%s\n" "pending-end-of-support" >&6; }
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: On $end_support_date, the AWS CLI v2 will drop support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&5
+printf "%s\n" "$as_me: WARNING: On $end_support_date, the AWS CLI v2 will drop support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&2;}
+        else
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: supported" >&5
+printf "%s\n" "supported" >&6; }
+        fi
+    fi
+
+fi
 ac_config_files="$ac_config_files Makefile"
 
 cat >confcache <<\_ACEOF

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,10 @@ fi
 AC_MSG_RESULT($with_download_deps)
 AC_SUBST(DOWNLOAD_DEPS_FLAG)
 
+ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
+if test "$ac_operating_system" = Darwin; then
+    AC_CHECK_PENDING_MACOS_END_OF_SUPPORT([10.15.0], [June 20, 2024])
+fi
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
 OVERRIDE_HELP

--- a/m4/macos_support.m4
+++ b/m4/macos_support.m4
@@ -1,0 +1,37 @@
+AC_DEFUN([AC_CHECK_PENDING_MACOS_END_OF_SUPPORT], [
+    min_version='$1'
+    end_support_date='$2'
+
+    AC_MSG_CHECKING([for macOS version support])
+    ac_macos_version=`(sw_vers -productVersion) 2>/dev/null || echo unknown`
+
+    if test "$ac_macos_version" = unknown; then
+        AC_MSG_RESULT([unknown])
+    else
+        sys_version_major=`echo "$ac_macos_version" | \
+            sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+        sys_version_minor=`echo "$ac_macos_version" | \
+            sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+
+        min_version_major=`echo "$min_version" | \
+            sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+        min_version_minor=`echo "$min_version" | \
+            sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+
+        if test "$sys_version_major" -lt "$min_version_major" || \
+            test "$sys_version_major" -eq "$min_version_major" -a \
+            "$sys_version_minor" -lt "$min_version_minor"; then
+            AC_MSG_RESULT([pending-end-of-support])
+            AC_MSG_WARN(m4_normalize([
+                On $end_support_date, the AWS CLI v2 will drop support
+                for macOS versions below $min_version. macOS $ac_macos_version
+                was detected for this system. Please upgrade to macOS version
+                $min_version or later to ensure compatibility with future versions
+                of AWS CLI v2. For more information, please visit:
+                https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/
+            ]))
+        else
+            AC_MSG_RESULT([supported])
+        fi
+    fi
+])

--- a/macpkg/distribution.xml
+++ b/macpkg/distribution.xml
@@ -4,6 +4,19 @@
     <title>AWS Command Line Interface</title>
     <license file="LICENSE.txt" />
     <readme file="README.html" mimetype="text/html" />
+    <installation-check script="checkOsVersion();"/>
+    <script>
+    <![CDATA[
+    function checkOsVersion() {
+      if(system.compareVersions(system.version.ProductVersion, '10.15.0') < 0) {
+        my.result.type = 'Warning';
+        my.result.message = 'On June 20, 2024, the AWS CLI v2 will drop support for macOS versions below 10.15.0. Please upgrade to macOS version 10.15.0 or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
+        return false;
+      }
+      return true;
+    }
+    ]]>
+    </script>
     <domains enable_anywhere="true" enable_currentUserHome="true" enable_localSystem="true" />
     <options customize="always" require-scripts="false" />
     <choices-outline>


### PR DESCRIPTION
As part of a broader effort to define a macOS support policy for the AWS CLI v2, this PR will warn users attempting to install the AWS CLI v2 via the PKG installer or source distribution bundle on a macOS version marked for deprecation. Today, those versions are macOS versions 10.14 and below.

For more information, see this blog post: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/