### PR TITLE
Make AWS_DOCS_BASE global 

### DIFF
--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -312,6 +312,17 @@ AVAILABLE_COMMANDS = 'Available Commands'
 class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_breadcrumbs(self, help_command, event_name, **kwargs):
+        """
+        This method generates breadcrumbs for the documentation of a command.
+
+        Args:
+            help_command (str): The command for which breadcrumbs are generated.
+            event_name (str): The event name associated with the command.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            None
+        """
         pass
 
     def doc_synopsis_start(self, help_command, **kwargs):

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -326,7 +326,6 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
         pass
 
     def doc_synopsis_start(self, help_command, **kwargs):
-        doc = help_command.doc
         doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.codeblock(help_command.synopsis)
         doc.include_doc_string(help_command.help_usage)

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -127,11 +127,11 @@ class ArgumentType(Enum):
 
     def doc_title(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.new_paragraph()
+        doc.style.new_paragraph() 
         reference = help_command.event_class.replace('.', ' ')
         if reference != 'aws':
             reference = 'aws ' + reference
-        doc.writeln('.. _cli:%s:' % reference)
+        doc.writeln(f'.. _cli: {reference}') # f-string formatting.  
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -307,6 +307,8 @@ class ArgumentType(Enum):
 
 # Global constants for document sections
 SYNOPSIS = 'Synopsis'
+AVAILABLE_SERVICES = 'Available Services'
+AVAILABLE_COMMANDS = 'Available Commands'
 class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_breadcrumbs(self, help_command, event_name, **kwargs):
@@ -333,7 +335,7 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_subitems_start(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Available Services')
+        doc.style.h2(AVAILABLE_SERVICES) # Replace magic string with global constant
         doc.style.toctree()
 
     def doc_subitem(self, command_name, help_command, **kwargs):
@@ -381,7 +383,7 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_subitems_start(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Available Commands')
+        doc.style.h2(AVAILABLE_COMMANDS) # Replace magic string with global constant
         doc.style.toctree()
 
     def doc_subitem(self, command_name, help_command, **kwargs):
@@ -611,6 +613,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
 #Global constants for document sections
 DESCRIPTION = 'Description'
+AVAILABLE_TOPICS = 'Available Topics'
 class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     DESCRIPTION = (
         'This is the AWS CLI Topic Guide. It gives access to a set '
@@ -664,7 +667,7 @@ class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_subitems_start(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Available Topics')
+        doc.style.h2(AVAILABLE_TOPICS) # Replace magic string with global constant
 
         categories = self._topic_tag_db.query('category')
         topic_names = self._topic_tag_db.get_all_topic_names()

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -168,33 +168,16 @@ class CLIDocumentEventHandler(object):
         doc.style.h2('Options')
         if not help_command.arg_table:
             doc.write('*None*\n')
-
     def doc_option(self, arg_name, help_command, **kwargs):
         doc = help_command.doc
         argument = help_command.arg_table[arg_name]
-        if argument.group_name in self._arg_groups:
-            if argument.group_name in self._documented_arg_groups:
-                # This arg is already documented so we can move on.
-                return
-            name = ' | '.join(
-                ['``%s``' % a.cli_name for a in
-                 self._arg_groups[argument.group_name]])
-            self._documented_arg_groups.append(argument.group_name)
-        else:
-            name = '``%s``' % argument.cli_name
-        doc.write('%s (%s)\n' % (name, self._get_argument_type_name(
-            argument.argument_model, argument.cli_type_name)))
-        doc.style.indent()
-        doc.include_doc_string(argument.documentation)
-        if is_streaming_blob_type(argument.argument_model):
-            self._add_streaming_blob_note(doc)
-        if is_tagged_union_type(argument.argument_model):
-            self._add_tagged_union_note(argument.argument_model, doc)
-        if hasattr(argument, 'argument_model'):
-            self._document_enums(argument.argument_model, doc)
-            self._document_nested_structure(argument.argument_model, doc)
+        self._document_arg_group(argument, doc)
+        self._document_individual_arg(argument, doc)
+        self._add_notes(argument, doc)
+        self._document_model(argument, doc)
         doc.style.dedent()
-        doc.style.new_paragraph()
+        doc.style.new_paragraph() 
+   
 
     def doc_global_option(self, help_command, **kwargs):
         doc = help_command.doc

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -304,8 +304,7 @@ class ArgumentType(Enum):
                f"following top level keys can be set: {members_str}.")
         doc.writeln(msg)
         doc.style.end_note()
-
-# Global constants for document sections
+ # Global constants for document sections
 SYNOPSIS = 'Synopsis'
 AVAILABLE_SERVICES = 'Available Services'
 AVAILABLE_COMMANDS = 'Available Commands'
@@ -326,6 +325,7 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
         pass
 
     def doc_synopsis_start(self, help_command, **kwargs):
+        doc = help_command.doc 
         doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.codeblock(help_command.synopsis)
         doc.include_doc_string(help_command.help_usage)
@@ -404,11 +404,11 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
         # direct the subitem to the command's index because
         # it has more subcommands to be documented.
         if (len(subcommand_table) > 0):
-            file_name = '%s/index' % command_name
+            file_name = f"{command_name}/index" # f-string formatting.
             doc.style.tocitem(command_name, file_name=file_name)
         else:
             doc.style.tocitem(command_name)
-
+service_uid
 #Global constants for document sections
 DESCRIPTION = 'Description'
 OUTPUT = 'Output'
@@ -434,7 +434,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             # If there's no service_uid in the model, we can't
             # be certain if the generated cross link will work
             # so we don't generate any crosslink info.
-            return
+            raise ValueError("Missing service_uid in service_model metadata") #Add error message for missing service_uid
         doc.style.new_paragraph()
         doc.write("See also: ")
         link = '%s/%s/%s' % (self.AWS_DOC_BASE, service_uid,

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -53,15 +53,22 @@ class CLIDocumentEventHandler(object):
                 arg_groups.setdefault(arg.group_name, []).append(arg)
         return arg_groups 
 
+from enum import Enum
+
+class ArgumentType(Enum):
+    JSON = 'JSON'
+    DOCUMENT = 'document'
+    STREAMING_BLOB = 'streaming blob'
+    TAGGED_UNION = 'tagged union structure'
     def _get_argument_type_name(self, shape, default):
         if is_json_value_header(shape):
-            return 'JSON'
+            return ArgumentType.JSON.value # Replace local constants with global constants
         if is_document_type(shape):
-            return 'document'
+            return ArgumentType.DOCUMENT.value # Replace local constants with global constants
         if is_streaming_blob_type(shape):
-            return 'streaming blob'
+            return ArgumentType.STREAMING_BLOB.value # Replace local constants with global constants
         if is_tagged_union_type(shape):
-            return 'tagged union structure'
+            return ArgumentType.TAGGED_UNION.value  # Replace local constants with global constants
         return default
 
     def _map_handlers(self, session, event_class, mapfn):
@@ -89,6 +96,7 @@ class CLIDocumentEventHandler(object):
         except Exception as e:
               LOG.debug("Error registering event handlers for %s: %s",
                         event_class, e, exc_info=True) 
+              
     def unregister(self):
         """
         The default unregister iterates through all of the

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -71,7 +71,7 @@ class ArgumentType(Enum):
             return ArgumentType.TAGGED_UNION.value  # Replace local constants with global constants
         return default
 
-    def _map_handlers(self, session, event_class, mapfn):
+    def _map_event_handlers(self, session, event_class, mapfn): 
         for event in DOC_EVENTS:
             event_handler_name = event.replace('-', '_')
             if hasattr(self, event_handler_name):

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -350,7 +350,7 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_subitem(self, command_name, help_command, **kwargs):
         doc = help_command.doc
-        file_name = '%s/index' % command_name
+        file_name = f'{command_name}/index' # f-string formatting.
         doc.style.tocitem(command_name, file_name=file_name)
 
 

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -84,8 +84,11 @@ class CLIDocumentEventHandler(object):
         handler method will be registered for the all events of
         that type for the specified ``event_class``.
         """
-        self._map_handlers(session, event_class, session.register)
-
+        try:
+           self._map_handlers(session, event_class, session.register)
+        except Exception as e:
+              LOG.debug("Error registering event handlers for %s: %s",
+                        event_class, e, exc_info=True) 
     def unregister(self):
         """
         The default unregister iterates through all of the

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -46,11 +46,12 @@ class CLIDocumentEventHandler(object):
         self._documented_arg_groups = []
 
     def _build_arg_table_groups(self, help_command):
+        """ Builds a dictionary of argument groups for the given help command."""
         arg_groups = {}
         for arg in help_command.arg_table.values():
             if arg.group_name is not None:
                 arg_groups.setdefault(arg.group_name, []).append(arg)
-        return arg_groups
+        return arg_groups 
 
     def _get_argument_type_name(self, shape, default):
         if is_json_value_header(shape):

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -108,10 +108,11 @@ class ArgumentType(Enum):
         self._map_handlers(self.help_command.session,
                            self.help_command.event_class,
                            self.help_command.session.unregister)
+
     # These are default doc handlers that apply in the general case.
 
     def doc_breadcrumbs(self, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         if doc.target != 'man':
             cmd_names = help_command.event_class.split('.')
             doc.write('[ ')
@@ -125,7 +126,7 @@ class ArgumentType(Enum):
             doc.write(' ]')
 
     def doc_title(self, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         doc.style.new_paragraph() 
         reference = help_command.event_class.replace('.', ' ')
         if reference != 'aws':
@@ -134,20 +135,20 @@ class ArgumentType(Enum):
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         doc.style.h2(DESCRIPTION) # Replace local constants with global constants
         doc.include_doc_string(help_command.description) 
         doc.style.new_paragraph()
 
     def doc_synopsis_start(self, help_command, **kwargs):
         self._documented_arg_groups = []
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.start_codeblock()
         doc.writeln('%s' % help_command.name)
 
     def doc_synopsis_option(self, arg_name, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         argument = help_command.arg_table[arg_name]
         if argument.group_name in self._arg_groups:
             if argument.group_name in self._documented_arg_groups:
@@ -167,7 +168,7 @@ class ArgumentType(Enum):
         doc.writeln('%s' % option_str)
 
     def doc_synopsis_end(self, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         # Append synopsis for global options.
         doc.write_from_file(GLOBAL_OPTIONS_SYNOPSIS_FILE)
         doc.style.end_codeblock()
@@ -177,12 +178,12 @@ class ArgumentType(Enum):
         self._documented_arg_groups = []
 
     def doc_options_start(self, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         doc.style.h2(OPTIONS)  # Replace local constants with global constants
         if not help_command.arg_table:
             doc.write('*None*\n')
     def doc_option(self, arg_name, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         argument = help_command.arg_table[arg_name]
         self._document_arg_group(argument, doc)
         self._document_individual_arg(argument, doc)
@@ -193,17 +194,17 @@ class ArgumentType(Enum):
    
 
     def doc_global_option(self, help_command, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         doc.style.h2('Global Options')
         doc.write_from_file(GLOBAL_OPTIONS_FILE)
 
     def doc_relateditems_start(self, help_command, **kwargs):
         if help_command.related_items:
-            doc = self.get_doc(help_command)
+            doc = help_command.doc
             doc.style.h2('See Also')
 
     def doc_relateditem(self, help_command, related_item, **kwargs):
-        doc = self.get_doc(help_command)
+        doc = help_command.doc
         doc.write('* ')
         doc.style.sphinx_reference_label(
             label='cli:%s' % related_item,

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -408,12 +408,12 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
             doc.style.tocitem(command_name, file_name=file_name)
         else:
             doc.style.tocitem(command_name)
-            
+
 #Global constants for document sections
 DESCRIPTION = 'Description'
 OUTPUT = 'Output'
 
-AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'
+AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI' #Now global 
 class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_description(self, help_command, **kwargs):

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -110,9 +110,10 @@ class ArgumentType(Enum):
                            self.help_command.session.unregister)
 
     # These are default doc handlers that apply in the general case.
-
+    def get_doc(self, help_command):
+        return help_command.doc
     def doc_breadcrumbs(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         if doc.target != 'man':
             cmd_names = help_command.event_class.split('.')
             doc.write('[ ')
@@ -126,7 +127,7 @@ class ArgumentType(Enum):
             doc.write(' ]')
 
     def doc_title(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.new_paragraph() 
         reference = help_command.event_class.replace('.', ' ')
         if reference != 'aws':
@@ -135,20 +136,20 @@ class ArgumentType(Enum):
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2(DESCRIPTION) # Replace local constants with global constants
         doc.include_doc_string(help_command.description) 
         doc.style.new_paragraph()
 
     def doc_synopsis_start(self, help_command, **kwargs):
         self._documented_arg_groups = []
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.start_codeblock()
         doc.writeln('%s' % help_command.name)
 
     def doc_synopsis_option(self, arg_name, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         argument = help_command.arg_table[arg_name]
         if argument.group_name in self._arg_groups:
             if argument.group_name in self._documented_arg_groups:
@@ -168,7 +169,7 @@ class ArgumentType(Enum):
         doc.writeln('%s' % option_str)
 
     def doc_synopsis_end(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         # Append synopsis for global options.
         doc.write_from_file(GLOBAL_OPTIONS_SYNOPSIS_FILE)
         doc.style.end_codeblock()
@@ -178,12 +179,12 @@ class ArgumentType(Enum):
         self._documented_arg_groups = []
 
     def doc_options_start(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2(OPTIONS)  # Replace local constants with global constants
         if not help_command.arg_table:
             doc.write('*None*\n')
     def doc_option(self, arg_name, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         argument = help_command.arg_table[arg_name]
         self._document_arg_group(argument, doc)
         self._document_individual_arg(argument, doc)
@@ -194,17 +195,17 @@ class ArgumentType(Enum):
    
 
     def doc_global_option(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2('Global Options')
         doc.write_from_file(GLOBAL_OPTIONS_FILE)
 
     def doc_relateditems_start(self, help_command, **kwargs):
         if help_command.related_items:
-            doc = help_command.doc
+            doc = self.get_doc(help_command)
             doc.style.h2('See Also')
 
     def doc_relateditem(self, help_command, related_item, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.write('* ')
         doc.style.sphinx_reference_label(
             label='cli:%s' % related_item,

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -108,11 +108,10 @@ class ArgumentType(Enum):
         self._map_handlers(self.help_command.session,
                            self.help_command.event_class,
                            self.help_command.session.unregister)
-
     # These are default doc handlers that apply in the general case.
 
     def doc_breadcrumbs(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         if doc.target != 'man':
             cmd_names = help_command.event_class.split('.')
             doc.write('[ ')
@@ -126,7 +125,7 @@ class ArgumentType(Enum):
             doc.write(' ]')
 
     def doc_title(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.new_paragraph() 
         reference = help_command.event_class.replace('.', ' ')
         if reference != 'aws':
@@ -135,20 +134,20 @@ class ArgumentType(Enum):
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2(DESCRIPTION) # Replace local constants with global constants
         doc.include_doc_string(help_command.description) 
         doc.style.new_paragraph()
 
     def doc_synopsis_start(self, help_command, **kwargs):
         self._documented_arg_groups = []
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.start_codeblock()
         doc.writeln('%s' % help_command.name)
 
     def doc_synopsis_option(self, arg_name, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         argument = help_command.arg_table[arg_name]
         if argument.group_name in self._arg_groups:
             if argument.group_name in self._documented_arg_groups:
@@ -168,7 +167,7 @@ class ArgumentType(Enum):
         doc.writeln('%s' % option_str)
 
     def doc_synopsis_end(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         # Append synopsis for global options.
         doc.write_from_file(GLOBAL_OPTIONS_SYNOPSIS_FILE)
         doc.style.end_codeblock()
@@ -178,12 +177,12 @@ class ArgumentType(Enum):
         self._documented_arg_groups = []
 
     def doc_options_start(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2(OPTIONS)  # Replace local constants with global constants
         if not help_command.arg_table:
             doc.write('*None*\n')
     def doc_option(self, arg_name, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         argument = help_command.arg_table[arg_name]
         self._document_arg_group(argument, doc)
         self._document_individual_arg(argument, doc)
@@ -194,17 +193,17 @@ class ArgumentType(Enum):
    
 
     def doc_global_option(self, help_command, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.style.h2('Global Options')
         doc.write_from_file(GLOBAL_OPTIONS_FILE)
 
     def doc_relateditems_start(self, help_command, **kwargs):
         if help_command.related_items:
-            doc = help_command.doc
+            doc = self.get_doc(help_command)
             doc.style.h2('See Also')
 
     def doc_relateditem(self, help_command, related_item, **kwargs):
-        doc = help_command.doc
+        doc = self.get_doc(help_command)
         doc.write('* ')
         doc.style.sphinx_reference_label(
             label='cli:%s' % related_item,

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -33,8 +33,10 @@ EXAMPLES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 GLOBAL_OPTIONS_FILE = os.path.join(EXAMPLES_DIR, 'global_options.rst')
 GLOBAL_OPTIONS_SYNOPSIS_FILE = os.path.join(EXAMPLES_DIR,
                                             'global_synopsis.rst')
-
-
+# Global constants for document sections
+DESCRIPTION = 'Desription'
+SYNOPSIS = 'Synopsis'
+OPTIONS = 'Options'
 class CLIDocumentEventHandler(object):
 
     def __init__(self, help_command):
@@ -122,14 +124,14 @@ class CLIDocumentEventHandler(object):
 
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Description')
-        doc.include_doc_string(help_command.description)
+        doc.style.h2(DESCRIPTION) # Replace local constants with global constants
+        doc.include_doc_string(help_command.description) 
         doc.style.new_paragraph()
 
     def doc_synopsis_start(self, help_command, **kwargs):
         self._documented_arg_groups = []
         doc = help_command.doc
-        doc.style.h2('Synopsis')
+        doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.start_codeblock()
         doc.writeln('%s' % help_command.name)
 
@@ -165,7 +167,7 @@ class CLIDocumentEventHandler(object):
 
     def doc_options_start(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Options')
+        doc.style.h2(OPTIONS)  # Replace local constants with global constants
         if not help_command.arg_table:
             doc.write('*None*\n')
     def doc_option(self, arg_name, help_command, **kwargs):
@@ -278,7 +280,7 @@ class CLIDocumentEventHandler(object):
                "(e.g. ``path/to/file``) and must **not** "
                "be prefixed with ``file://`` or ``fileb://``")
         doc.writeln(msg)
-        doc.style.end_note()
+        doc.style.end_note() 
 
     def _add_tagged_union_note(self, shape, doc):
         doc.style.start_note()
@@ -290,7 +292,8 @@ class CLIDocumentEventHandler(object):
         doc.writeln(msg)
         doc.style.end_note()
 
-
+# Global constants for document sections
+SYNOPSIS = 'Synopsis'
 class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_breadcrumbs(self, help_command, event_name, **kwargs):
@@ -298,7 +301,7 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_synopsis_start(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Synopsis')
+        doc.style.h2(SYNOPSIS) # Replace local constants with global constants
         doc.style.codeblock(help_command.synopsis)
         doc.include_doc_string(help_command.help_usage)
 
@@ -326,6 +329,8 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
         doc.style.tocitem(command_name, file_name=file_name)
 
 
+#Global constants for document sections
+DESCRIPTION = 'Description'
 class ServiceDocumentEventHandler(CLIDocumentEventHandler):
 
     # A service document has no synopsis.
@@ -357,7 +362,7 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc
         service_model = help_command.obj
-        doc.style.h2('Description')
+        doc.style.h2(DESCRIPTION) # Replace local constants with global constants
         # TODO: need a documentation attribute.
         doc.include_doc_string(service_model.documentation)
 
@@ -379,7 +384,9 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
         else:
             doc.style.tocitem(command_name)
 
-
+#Global constants for document sections
+DESCRIPTION = 'Description'
+OUTPUT = 'Output'
 class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
     AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'
@@ -387,7 +394,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc
         operation_model = help_command.obj
-        doc.style.h2('Description')
+        doc.style.h2(DESCRIPTION) # Replace local constants with global constants
         doc.include_doc_string(operation_model.documentation)
         self._add_webapi_crosslink(help_command)
         self._add_note_for_document_types_if_used(help_command)
@@ -580,7 +587,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_output(self, help_command, event_name, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Output')
+        doc.style.h2(OUTPUT) # Replace local constants with global constants
         operation_model = help_command.obj
         output_shape = operation_model.output_shape
         if output_shape is None or not output_shape.members:
@@ -589,7 +596,8 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             for member_name, member_shape in output_shape.members.items():
                 self._doc_member(doc, member_name, member_shape, stack=[])
 
-
+#Global constants for document sections
+DESCRIPTION = 'Description'
 class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     DESCRIPTION = (
         'This is the AWS CLI Topic Guide. It gives access to a set '
@@ -622,7 +630,7 @@ class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc
-        doc.style.h2('Description')
+        doc.style.h2(DESCRIPTION) # Replace local constants with global constants
         doc.include_doc_string(self.DESCRIPTION)
         doc.style.new_paragraph()
 

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -408,13 +408,13 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
             doc.style.tocitem(command_name, file_name=file_name)
         else:
             doc.style.tocitem(command_name)
-service_uid
+            
 #Global constants for document sections
 DESCRIPTION = 'Description'
 OUTPUT = 'Output'
-class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
-    AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'
+AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'
+class OperationDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_description(self, help_command, **kwargs):
         doc = help_command.doc


### PR DESCRIPTION
Initially, the AWS_DOC_BASE constant was only used in the OperationDocumentEventHandler class. If it's to be used elsewhere in the future, it would be better to make it a global constant. So I made AWS_DOC_BASE accessible throughout the module. 