### PR TITLE
Remove `utcnow` calls for python 3.12 deprecation warning

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -20,7 +20,7 @@ import collections
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.artifact_exporter import mktempfile, parse_s3_url
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 LOG = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class Deployer(object):
         :return:
         """
 
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         description = "Created by AWS CLI at {0} UTC".format(now)
 
         # Each changeset will get a unique name based on time

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -19,7 +19,7 @@ import re
 import sys
 import zlib
 from zlib import error as ZLibError
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dateutil import tz, parser
 
 from pyasn1.error import PyAsn1Error
@@ -417,7 +417,7 @@ class DigestTraverser(object):
         :param end_date: Date to stop validating at (inclusive).
         """
         if end_date is None:
-            end_date = datetime.utcnow()
+            end_date = datetime.now(timezone.utc)
         end_date = normalize_date(end_date)
         start_date = normalize_date(start_date)
         bucket = self.starting_bucket
@@ -720,7 +720,7 @@ class CloudTrailValidateLogs(BasicCommand):
         if args.end_time:
             self.end_time = normalize_date(parse_date(args.end_time))
         else:
-            self.end_time = normalize_date(datetime.utcnow())
+            self.end_time = datetime.now(timezone.utc)
         if self.start_time > self.end_time:
             raise ValueError(('Invalid time range specified: start-time must '
                               'occur before end-time'))

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -150,7 +150,7 @@ class CodeCommitGetCommand(BasicCommand):
         request = AWSRequest()
         request.url = url_to_sign
         request.method = 'GIT'
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         request.context['timestamp'] = now.strftime('%Y%m%dT%H%M%S')
         split = urlsplit(request.url)
         # we don't want to include the port number in the signature

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -16,7 +16,7 @@ import sys
 import zipfile
 import tempfile
 import contextlib
-from datetime import datetime
+from datetime import datetime, timezone
 
 from botocore.exceptions import ClientError
 
@@ -131,7 +131,7 @@ class Push(BasicCommand):
         if not parsed_args.description:
             parsed_args.description = (
                 'Uploaded by AWS CLI {0} UTC'.format(
-                    datetime.utcnow().isoformat()
+                    datetime.now(timezone.utc).isoformat()
                 )
             )
 

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from awscli.formatter import get_formatter
 from awscli.arguments import CustomArgument
@@ -184,7 +184,7 @@ class QueryArgBuilder(object):
     """
     def __init__(self, current_time=None):
         if current_time is None:
-            current_time = datetime.utcnow()
+            current_time = datetime.now(timezone.utc)
         self.current_time = current_time
 
     def build_query(self, parsed_args):

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -119,7 +119,7 @@ def _generate_policy(params):
     # Called if there is no policy supplied by the user.
     # Creates a policy that provides access for 24 hours.
     delta = datetime.timedelta(hours=24)
-    expires = datetime.datetime.utcnow() + delta
+    expires = datetime.datetime.now(datetime.timezone.utc) + delta
     expires_iso = expires.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     policy = POLICY.format(expires=expires_iso,
                            bucket=params['Bucket'],

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -16,7 +16,7 @@ import json
 import os
 import sys
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from botocore.signers import RequestSigner
 from botocore.model import ServiceId
 
@@ -106,7 +106,7 @@ class GetTokenCommand(BasicCommand):
     ]
 
     def get_expiration_time(self):
-        token_expiration = datetime.utcnow() + timedelta(
+        token_expiration = datetime.now(timezone.utc) + timedelta(
             minutes=TOKEN_EXPIRATION_MINS
         )
         return token_expiration.strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -505,7 +505,7 @@ class OpsWorksRegister(BasicCommand):
             "Resource": arn,
         }
         if timeout is not None:
-            valid_until = datetime.datetime.utcnow() + timeout
+            valid_until = datetime.datetime.now(datetime.timezone.utc) + timeout
             statement["Condition"] = {
                 "DateLessThan": {
                     "aws:CurrentTime":

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -33,7 +33,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestBundleInstance, self).setUp()
-        # This mocks out datetime.datetime.utcnow() so that it always
+        # This mocks out datetime.datetime.now() so that it always
         # returns the same datetime object.  This is because this value
         # is embedded into the policy file that is generated and we
         # don't what the policy or its signature to change each time
@@ -43,7 +43,9 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
             mock.Mock(wraps=datetime.datetime)
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(2013, 8, 9)
+        mocked_datetime.now.return_value = datetime.datetime(
+            2013, 8, 9, tzinfo=datetime.timezone.utc
+        )
 
     def tearDown(self):
         super(TestBundleInstance, self).tearDown()

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import base64
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import os
 
@@ -79,7 +79,9 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_get_token(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(
+            2019, 10, 23, 23, 0, 0, 0, tzinfo=timezone.utc
+        )
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         response = self.run_get_token(cmd)
         self.assertEqual(
@@ -97,7 +99,9 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_query_nested_object(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(
+            2019, 10, 23, 23, 0, 0, 0, tzinfo=timezone.utc
+        )
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --query status'
         response = self.run_get_token(cmd)
@@ -119,7 +123,9 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_output_text(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(
+            2019, 10, 23, 23, 0, 0, 0, tzinfo=timezone.utc
+        )
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --output text'
         stdout, _, _ = self.run_cmd(cmd)
@@ -129,7 +135,9 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_output_table(self, mock_datetime):
-        mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
+        mock_datetime.now.return_value = datetime(
+            2019, 10, 23, 23, 0, 0, 0, tzinfo=timezone.utc
+        )
         cmd = 'eks get-token --cluster-name %s' % self.cluster_name
         cmd += ' --output table'
         stdout, _, _ = self.run_cmd(cmd)

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -52,7 +52,7 @@ class TestGenerateDBAuthToken(BaseAWSCommandParamsTest):
         clock = datetime.datetime(2016, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             stdout, _, _ = self.run_cmd(command, expected_rc=0)
 
         expected = (

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -17,13 +17,16 @@ from awscli.testutils import BaseAWSCommandParamsTest, mock, temporary_file
 from awscli.testutils import create_clidriver
 
 
-# Values used to fix time.time() and datetime.datetime.utcnow()
+# Values used to fix time.time() and datetime.datetime.now()
 # so we know the exact values of the signatures generated.
 FROZEN_TIMESTAMP = 1471305652
 DEFAULT_EXPIRES = 3600
 FROZEN_TIME = mock.Mock(return_value=FROZEN_TIMESTAMP)
 FROZEN_DATETIME = mock.Mock(
-    return_value=datetime.datetime(2016, 8, 18, 14, 33, 3, 0))
+    return_value=datetime.datetime(
+        2016, 8, 18, 14, 33, 3, 0, tzinfo=datetime.timezone.utc
+    )
+)
 
 
 class TestPresignCommand(BaseAWSCommandParamsTest):
@@ -75,7 +78,7 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
     def get_presigned_url_for_cmd(self, cmdline):
         with mock.patch('time.time', FROZEN_TIME):
             with mock.patch('datetime.datetime') as d:
-                d.utcnow = FROZEN_DATETIME
+                d.now = FROZEN_DATETIME
                 stdout = self.assert_params_for_cmd(cmdline, None)[0].strip()
                 return stdout
 

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -14,7 +14,7 @@
 import awscli
 import os
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from six import StringIO
 from botocore.session import Session
@@ -59,7 +59,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8, tzinfo=timezone.utc)
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
@@ -74,7 +74,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_fips_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8, tzinfo=timezone.utc)
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
@@ -89,7 +89,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_vpc_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8, tzinfo=timezone.utc)
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -32,8 +32,8 @@ class TestOpsWorksBase(unittest.TestCase):
             mock.Mock(wraps=datetime.datetime)
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
-            2013, 8, 9, 23, 42)
+        mocked_datetime.now.return_value = datetime.datetime(
+            2013, 8, 9, 23, 42, tzinfo=datetime.timezone.utc)
 
     def tearDown(self):
         self.datetime_patcher.stop()


### PR DESCRIPTION
*Description of changes:*
Replace `utcnow()` with `now(datetime.timezone.utc)`. CI is expected to fail until https://github.com/boto/botocore/pull/3093 is merged. Ran all tests successfully on my local using the branch from that PR as the installed version of botocore in the virtual environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
