### PR TITLE
Pin alabaster version

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,6 @@
 Jinja2<3.1.0
 Sphinx==3.0.2
 sphinx-notfound-page==0.4
+# alabaster 0.7.14 dropped support for Sphinx<3.4
+# and Sphinx 3.0.2 bounds alabaster>=0.7,<0.8.
+alabaster==0.7.13


### PR DESCRIPTION
`alabaster` is a transitive dependency we take via `Sphinx`. This commit pins the version of `alabaster` we use to ensure compatibility with our version of `Sphinx`.