### PR TITLE
Pin sphinx extension versions

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,3 +4,12 @@ sphinx-notfound-page==0.4
 # alabaster 0.7.14 dropped support for Sphinx<3.4
 # and Sphinx 3.0.2 bounds alabaster>=0.7,<0.8.
 alabaster==0.7.13
+# Latest versions of these packages support only
+# Sphinx>5, which we are not using. Set explicit pins
+# so we can continue to use Sphinx 3.
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5


### PR DESCRIPTION
*Issue #, if available:*

Docs will not build.

*Description of changes:*

Sphinx extensions removed dependency on Sphinx 5 in latest versions, but still require it. Since we are still pinning to Sphinx 3, we need to pin to previous versions of the extensions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
