### PR TITLE
Allow configuring local IP for ec2-instance-connect open-tunnel.

### DIFF
--- a/awscli/customizations/ec2instanceconnect/opentunnel.py
+++ b/awscli/customizations/ec2instanceconnect/opentunnel.py
@@ -73,6 +73,12 @@ class OpenTunnelCommand(BasicCommand):
             "required": False,
         },
         {
+            "name": "local-ip",
+            "help_text": "Specify the local IP address to listen on. This defaults to localhost.",
+            "default": "localhost",
+            "required": False,
+        },
+        {
             "name": "max-tunnel-duration",
             "help_text": (
                 "Specify the maximum time, in seconds, to keep a websocket tunnel alive for. This "
@@ -140,7 +146,7 @@ class OpenTunnelCommand(BasicCommand):
         )
 
         with WebsocketManager(
-                parsed_args.local_port, parsed_args.max_websocket_connections, eice_request_signer, self._session.user_agent(),
+                parsed_args.local_port, parsed_args.local_ip, parsed_args.max_websocket_connections, eice_request_signer, self._session.user_agent(),
         ) as websocket_manager:
             websocket_manager.run()
         return 0

--- a/awscli/customizations/ec2instanceconnect/websocket.py
+++ b/awscli/customizations/ec2instanceconnect/websocket.py
@@ -288,8 +288,9 @@ class Websocket:
 
 
 class WebsocketManager:
-    def __init__(self, port, max_websocket_connections, eice_request_signer, user_agent=None):
+    def __init__(self, port, local_ip, max_websocket_connections, eice_request_signer, user_agent=None):
         self._port = port
+        self._local_ip = local_ip
         self._executor = ThreadPoolExecutor(
             max_workers=max_websocket_connections
         )
@@ -332,7 +333,7 @@ class WebsocketManager:
     def _listen_on_port(self):
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        self._socket.bind(("localhost", self._port))
+        self._socket.bind((self._local_ip, self._port))
         self._socket.listen()
         print(f"Listening for connections on port {self._port}.")
         while not self.RUNNING.is_set():


### PR DESCRIPTION
The IP used for ec2-instance-connect open-tunnel was hard-coded to localhost. This means that it does not work for users of the AWS CLI Docker image, because Docker can only expose services that listen on 0.0.0.0.

This PR adds an option --local-ip, consistent with --local-port, which allows the user to override the IP that the tunnel is bound to.

*Issue #, if available:* N/A

*Description of changes:*

- Adds `--local-ip` CLI flag to `open-tunnel` command
- Passes this value through to `WebsocketManager`
- Uses it to bind to

I could not find instructions for running tests, so I did not add a test. I did do a manual sanity check to ensure that it worked as I thought it would.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
