### PR TITLE
Disable S3 Express support for s3 sync command

### DIFF
--- a/.changes/next-release/bugfix-s3sync-90191.json
+++ b/.changes/next-release/bugfix-s3sync-90191.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3 sync``",
+  "description": "Disable S3 Express support for s3 sync command"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -15,6 +15,7 @@ import logging
 import sys
 
 from botocore.client import Config
+from botocore.utils import is_s3express_bucket
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
 
@@ -1166,6 +1167,21 @@ class CommandParameters(object):
         self._validate_streaming_paths()
         self._validate_path_args()
         self._validate_sse_c_args()
+        self._validate_not_s3_express_bucket_for_sync()
+
+    def _validate_not_s3_express_bucket_for_sync(self):
+        if self.cmd == 'sync' and \
+            (self._is_s3express_path(self.parameters['src']) or
+             self._is_s3express_path(self.parameters['dest'])):
+            raise ValueError(
+                "Cannot use sync command with a directory bucket."
+            )
+
+    def _is_s3express_path(self, path):
+        if path.startswith("s3://"):
+            bucket = split_s3_bucket_key(path)[0]
+            return is_s3express_bucket(bucket)
+        return False
 
     def _validate_streaming_paths(self):
         self.parameters['is_stream'] = False

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -997,3 +997,13 @@ class ConsistencyWaiter(object):
     def _fail_message(self, attempts, successes):
         format_args = (attempts, successes)
         return 'Failed after %s attempts, only had %s successes' % format_args
+
+
+@contextlib.contextmanager
+def cd(path):
+    try:
+        original_dir = os.getcwd()
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original_dir)


### PR DESCRIPTION
*Issue #, if available:*

#8470 

*Description of changes:*

Disable S3 Express support for s3 sync command

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
