### PR TITLE
Fix tests so they do not create local directories

### DIFF
--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -294,12 +294,12 @@ class TestSyncCommandWithS3Express(BaseS3TransferCommandTest):
     prefix = 's3 sync '
 
     def test_incompatible_with_sync_upload(self):
-        cmdline = '%s localdirectory/ s3://testdirectorybucket--usw2-az1--x-s3/' % self.prefix
+        cmdline = '%s %s s3://testdirectorybucket--usw2-az1--x-s3/' % (self.prefix, self.files.rootdir)
         stderr = self.run_cmd(cmdline, expected_rc=255)[1]
         self.assertIn('Cannot use sync command with a directory bucket.', stderr)
 
     def test_incompatible_with_sync_download(self):
-        cmdline = '%s s3://testdirectorybucket--usw2-az1--x-s3/ localdirectory/' % self.prefix
+        cmdline = '%s s3://testdirectorybucket--usw2-az1--x-s3/ %s' % (self.prefix, self.files.rootdir)
         stderr = self.run_cmd(cmdline, expected_rc=255)[1]
         self.assertIn('Cannot use sync command with a directory bucket.', stderr)
 


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Fix the test so that the `localdirectory/` is not created in the tests' working directory when running the test suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
