### PR TITLE
allow building documentation out of source tree

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,6 +17,7 @@ import sys, os
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../..'))
 
 import bootstrapdocs
 

--- a/doc/source/htmlgen
+++ b/doc/source/htmlgen
@@ -3,6 +3,9 @@ import os
 import sys
 import json
 import argparse
+
+sys.path.insert(0, os.path.abspath('../..'))
+
 import awscli.clidriver
 from awscli.help import PagingHelpRenderer
 


### PR DESCRIPTION
*Description of changes:*
This fix alters `sys.path` pointing to project source root sirectory to allow build documenation without have `awscli` module installed. Documentation can be generated right after clone by execute `sphinx-build -T -b <format> doc/source` which guarantees that rendered documentation will be generated against correct version of the module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
