### PR TITLE
Allow to specify polling delay and max attempts in cloudformation deploy

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -258,6 +258,30 @@ class DeployCommand(BasicCommand):
                 ' to resources in the stack if the resource supports it.'
                 ' Syntax: TagKey1=TagValue1 TagKey2=TagValue2 ...'
             )
+        },
+        {
+            'name': 'wait-delay',
+            'required': False,
+            'default': 30,
+            'help_text': (
+                'Delay in seconds to between each call to check wether '
+                'the stack has been created/updated or not'
+            ),
+            'schema': {
+                'type': 'integer'
+            }
+        },
+        {
+            'name': 'wait-max-attempts',
+            'required': False,
+            'default': 120,
+            'help_text': (
+                'Max attempts to check wether the stack has been created/'
+                'updated or not'
+            ),
+            'schema': {
+                'type': 'integer'
+            }
         }
     ]
 
@@ -310,7 +334,10 @@ class DeployCommand(BasicCommand):
         else:
             s3_uploader = None
 
-        deployer = Deployer(cloudformation_client)
+        wait_delay = parsed_args.wait_delay
+        wait_max_attempts = parsed_args.wait_max_attempts
+
+        deployer = Deployer(cloudformation_client, wait_delay, wait_max_attempts)
         return self.deploy(deployer, stack_name, template_str,
                            parameters, parsed_args.capabilities,
                            parsed_args.execute_changeset, parsed_args.role_arn,

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -30,10 +30,12 @@ ChangeSetResult = collections.namedtuple(
 
 class Deployer(object):
 
-    def __init__(self, cloudformation_client,
+    def __init__(self, cloudformation_client, wait_delay, wait_max_attempts,
                  changeset_prefix="awscli-cloudformation-package-deploy-"):
         self._client = cloudformation_client
         self.changeset_prefix = changeset_prefix
+        self.wait_delay = wait_delay
+        self.wait_max_attempts = wait_max_attempts
 
     def has_stack(self, stack_name):
         """
@@ -206,11 +208,11 @@ class Deployer(object):
             raise RuntimeError("Invalid changeset type {0}"
                                .format(changeset_type))
 
-        # Poll every 30 seconds. Polling too frequently risks hitting rate limits
-        # on CloudFormation's DescribeStacks API
+        # Default delay to 30 seconds. Polling too frequently risks hitting rate
+        # limits on CloudFormation's DescribeStacks API
         waiter_config = {
-            'Delay': 30,
-            'MaxAttempts': 120,
+            'Delay': self.wait_delay,
+            'MaxAttempts': self.wait_max_attempts,
         }
 
         try:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding two parameters for the `cloudformation deploy` command.
- `--wait-delay` allowing user to customize the polling delay for awscli to check whether the stack has been created/updated yet
- `--wait-max-attempts` allowing user to customize the max number of attempts for awscli to check whether the stack has been created/updated yet


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
