### PR TITLE
Adding a check to compat.py for 'less' existing

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -61,11 +61,14 @@ is_windows = sys.platform == 'win32'
 is_macos = sys.platform == 'darwin'
 
 
+less_exists = os.system('command -v less > /dev/null')
+
 if is_windows:
     default_pager = 'more'
+elif less_exists == '0':
+    default_pager = 'less'
 else:
-    default_pager = 'less -R'
-
+    default_pager = ''
 
 class StdinMissingError(Exception):
     def __init__(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I added a check to confirm the command `less` exists. If it does not, there is no default pager. 

I have confirmed this works in AL2023
### Steps:
* Remove paging commands
```
sudo mv /usr/bin/less /usr/bin/noless
sudo mv /usr/bin/cat /usr/bin/nocat
```
* confirm they are removed
```
$ cat;less
-bash: cat: command not found
-bash: less: command not found
```
* Confirm CLI works:
```
$ aws ec2 describe-instances --region us-east-1 --query 'Reservations[*].Instances[*].InstanceId'
[
    [
        "i-REDACTED"
    ]
]
```
```
$ aws ec2 describe-instances --region us-east-1 | wc -l
186
```
```
$ aws ec2 describe-instances --region us-east-1 > /dev/null ; echo $?
0

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
