### PR TITLE
Fix pytest-8.0.0 test failures due to incorrect `pytest.warns()`

### DIFF
--- a/tests/unit/botocore/test_session.py
+++ b/tests/unit/botocore/test_session.py
@@ -640,9 +640,7 @@ class TestSessionComponent(BaseSessionTest):
         self.assertIs(
             self.session._get_internal_component('internal'), component)
         with self.assertRaises(ValueError):
-            # get_component has been deprecated to the public
-            with pytest.warns(DeprecationWarning):
-                self.session.get_component('internal')
+            self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(

--- a/tests/unit/botocore/test_session_legacy.py
+++ b/tests/unit/botocore/test_session_legacy.py
@@ -631,9 +631,7 @@ class TestSessionComponent(BaseSessionTest):
         self.assertIs(
             self.session._get_internal_component('internal'), component)
         with self.assertRaises(ValueError):
-            # get_component has been deprecated to the public
-            with pytest.warns(DeprecationWarning):
-                self.session.get_component('internal')
+            self.session.get_component('internal')
 
     def test_internal_endpoint_resolver_is_same_as_deprecated_public(self):
         endpoint_resolver = self.session._get_internal_component(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a port of https://github.com/boto/botocore/pull/3109

Remove two incorrect `pytest.warns()` invocations
for `.get_component('internal')`, in order to fix test failures with pytest 8.0.0.  This version of pytest fixes `pytest.warns()` to work inside `pytest.raises()`, and therefore causes the tests to fail because the warning is not emitted when `get_component()` raises `ValueError`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
