### PR TITLE
update medical-image examples

### DIFF
--- a/awscli/examples/medical-imaging/copy-image-set.rst
+++ b/awscli/examples/medical-imaging/copy-image-set.rst
@@ -13,7 +13,7 @@ Output::
 
     {
         "destinationImageSetProperties": {
-            "latestVersionId": "1",
+            "latestVersionId": "2",
             "imageSetWorkflowStatus": "COPYING",
             "updatedAt": 1680042357.432,
             "imageSetId": "b9a06fef182a5f992842f77f8e0868e5",
@@ -21,9 +21,10 @@ Output::
             "createdAt": 1680042357.432
         },
         "sourceImageSetProperties": {
-            "latestVersionId": "5",
+            "latestVersionId": "1",
             "imageSetWorkflowStatus": "COPYING_WITH_READ_ONLY_ACCESS",
             "updatedAt": 1680042357.432,
+            "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",
             "imageSetState": "LOCKED",
             "createdAt": 1680027126.436
         },
@@ -37,7 +38,7 @@ The following ``copy-image-set`` code example makes a duplicate copy of an image
     aws medical-imaging copy-image-set \
         --datastore-id 12345678901234567890123456789012 \
         --source-image-set-id ea92b0d8838c72a3f25d00d13616f87e \
-        --copy-image-set-information '{"sourceImageSet": {"latestVersionId": "5" }, "destinationImageSet": { "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e", "latestVersionId": "1"} }'
+        --copy-image-set-information '{"sourceImageSet": {"latestVersionId": "1" }, "destinationImageSet": { "imageSetId": "b9a06fef182a5f992842f77f8e0868e5", "latestVersionId": "1"} }'
 
 
 
@@ -54,7 +55,7 @@ Output::
             "createdAt": 1680042357.432
         },
         "sourceImageSetProperties": {
-            "latestVersionId": "5",
+            "latestVersionId": "1",
             "imageSetWorkflowStatus": "COPYING_WITH_READ_ONLY_ACCESS",
             "updatedAt": 1680042505.135,
             "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",

--- a/awscli/examples/medical-imaging/search-image-sets.rst
+++ b/awscli/examples/medical-imaging/search-image-sets.rst
@@ -144,4 +144,62 @@ Output::
         }]
     }
 
+**Example 4: To search image sets with an EQUAL operator on DICOMSeriesInstanceUID and BETWEEN on updatedAt and sort response in ASC order on updatedAt field**
+
+The following ``search-image-sets`` code example searches for image sets with an EQUAL operator on DICOMSeriesInstanceUID and BETWEEN on updatedAt and sort response in ASC order on updatedAt field.
+
+Note:
+Provide updatedAt in example format ("1985-04-12T23:20:50.52Z"). ::
+
+    aws medical-imaging search-image-sets \
+        --datastore-id 12345678901234567890123456789012 \
+        --search-criteria  file://search-criteria.json
+
+
+Contents of ``search-criteria.json`` ::
+
+    {
+        "filters": [{
+            "values": [{
+                "updatedAt": "2024-03-11T15:00:05.074000-07:00"
+            }, {
+                "updatedAt": "2024-03-11T16:00:05.074000-07:00"
+            }],
+            "operator": "BETWEEN"
+        }, {
+            "values": [{
+                "DICOMSeriesInstanceUID": "1.2.840.99999999.84710745.943275268089"
+            }],
+            "operator": "EQUAL"
+        }],
+        "sort": {
+            "sortField": "updatedAt",
+            "sortOrder": "ASC"
+        }
+    }
+
+Output::
+
+    {
+        "imageSetsMetadataSummaries": [{
+            "imageSetId": "09876543210987654321098765432109",
+            "createdAt": "2022-12-06T21:40:59.429000+00:00",
+            "version": 1,
+            "DICOMTags": {
+                "DICOMStudyId": "2011201407",
+                "DICOMStudyDate": "19991122",
+                "DICOMPatientSex": "F",
+                "DICOMStudyInstanceUID": "1.2.840.99999999.84710745.943275268089",
+                "DICOMPatientBirthDate": "19201120",
+                "DICOMStudyDescription": "UNKNOWN",
+                "DICOMPatientId": "SUBJECT08701",
+                "DICOMPatientName": "Melissa844 Huel628",
+                "DICOMNumberOfStudyRelatedInstances": 1,
+                "DICOMStudyTime": "140728",
+                "DICOMNumberOfStudyRelatedSeries": 1
+            },
+            "lastUpdatedAt": "2022-12-06T21:40:59.429000+00:00"
+        }]
+    }
+
 For more information, see `Searching image sets <https://docs.aws.amazon.com/healthimaging/latest/devguide/search-image-sets.html>`__ in the *AWS HealthImaging Developer Guide*.

--- a/awscli/examples/medical-imaging/update-image-set-metadata.rst
+++ b/awscli/examples/medical-imaging/update-image-set-metadata.rst
@@ -1,6 +1,6 @@
-**To update image set metadata**
+**To insert or update an attribute in image set metadata**
 
-The following ``update-image-set-metadata`` code example updates image set metadata. ::
+The following ``update-image-set-metadata`` code example inserts or updates an attribute in image set metadata. ::
 
     aws medical-imaging update-image-set-metadata \
         --datastore-id 12345678901234567890123456789012 \
@@ -23,7 +23,75 @@ Note: ``updatableAttributes`` is a Base64 encoded JSON string. Here is the unenc
 Output::
 
     {
-        "latestVersionId": "5",
+        "latestVersionId": "2",
+        "imageSetWorkflowStatus": "UPDATING",
+        "updatedAt": 1680042257.908,
+        "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",
+        "imageSetState": "LOCKED",
+        "createdAt": 1680027126.436,
+        "datastoreId": "12345678901234567890123456789012"
+    }
+
+**To remove an attribute from image set metadata**
+
+The following ``update-image-set-metadata`` code example removes an attribute from image set metadata. ::
+
+    aws medical-imaging update-image-set-metadata \
+        --datastore-id 12345678901234567890123456789012 \
+        --image-set-id ea92b0d8838c72a3f25d00d13616f87e \
+        --latest-version-id 1 \
+        --update-image-set-metadata-updates file://metadata-updates.json
+
+Contents of ``metadata-updates.json`` ::
+
+    {
+        "DICOMUpdates": {
+            "removableAttributes": "e1NjaGVtYVZlcnNpb246MS4xLFN0dWR5OntESUNPTTp7U3R1ZHlEZXNjcmlwdGlvbjpDSEVTVH19fQo="
+        }
+    }
+
+Note: ``removableAttributes`` is a Base64 encoded JSON string. Here is the unencoded JSON string. The key and value must match the attribute to be removed.
+
+{"SchemaVersion":1.1,"Study":{"DICOM":{"StudyDescription":"CHEST"}}}
+
+Output::
+
+    {
+        "latestVersionId": "2",
+        "imageSetWorkflowStatus": "UPDATING",
+        "updatedAt": 1680042257.908,
+        "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",
+        "imageSetState": "LOCKED",
+        "createdAt": 1680027126.436,
+        "datastoreId": "12345678901234567890123456789012"
+    }
+
+**To remove an instance from image set metadata**
+
+The following ``update-image-set-metadata`` code example removes an instance from image set metadata. ::
+
+    aws medical-imaging update-image-set-metadata \
+        --datastore-id 12345678901234567890123456789012 \
+        --image-set-id ea92b0d8838c72a3f25d00d13616f87e \
+        --latest-version-id 1 \
+        --update-image-set-metadata-updates file://metadata-updates.json
+
+Contents of ``metadata-updates.json`` ::
+
+    {
+        "DICOMUpdates": {
+            "removableAttributes": "eezEuMS4xLjEuMS4xLjEyMzQ1LjEyMzQ1Njc4OTAxMi4xMjMuMTIzNDU2Nzg5MDEyMzQuMTp7SW5zdGFuY2VzOnsxLjEuMS4xLjEuMS4xMjM0NS4xMjM0NTY3ODkwMTIuMTIzLjEyMzQ1Njc4OTAxMjM0LjE6e319fX19fQo="
+        }
+    }
+
+Note: ``removableAttributes`` is a Base64 encoded JSON string. Here is the unencoded JSON string.
+
+{"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1":{"Instances":{"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1":{}}}}}}
+
+Output::
+
+    {
+        "latestVersionId": "2",
         "imageSetWorkflowStatus": "UPDATING",
         "updatedAt": 1680042257.908,
         "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",


### PR DESCRIPTION
Add an example for medical-imaging search-image-sets.

Update the existing example for medical-imaging update-image-set-metadata
Add 2 examples to  medical-imaging update-image-set-metadata

These changes were made at the request of the HealthImaging documentation writer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
