### PR TITLE
Update `Example 6` title for `aws s3 sync` help doc

### DIFF
--- a/awscli/examples/s3/sync.rst
+++ b/awscli/examples/s3/sync.rst
@@ -80,7 +80,7 @@ Output::
 
     upload: test2.txt to s3://mybucket/test2.txt
 
-**Example 6: Sync all local objects to the specified bucket except ``.jpg`` files**
+**Example 6: Sync all local objects to the specified bucket except specified directory files**
 
 The following ``sync`` command syncs files under a local directory to objects under a specified prefix and bucket by
 downloading S3 objects.  This example uses the ``--exclude`` parameter flag to exclude a specified directory


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

The Example 6 title was not matching the description and example. I assume it was a copy paste issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
