### PR TITLE
Sanitize __type metadata out of response parsing for tagged unions

### DIFF
--- a/awscli/botocore/parsers.py
+++ b/awscli/botocore/parsers.py
@@ -343,13 +343,15 @@ class ResponseParser(object):
 
     def _has_unknown_tagged_union_member(self, shape, value):
         if shape.is_tagged_union:
-            if len(value) != 1:
+            cleaned_value = value.copy()
+            cleaned_value.pop("__type", None)
+            if len(cleaned_value) != 1:
                 error_msg = (
                     "Invalid service response: %s must have one and only "
                     "one member set."
                 )
                 raise ResponseParserError(error_msg % shape.name)
-            tag = self._get_first_key(value)
+            tag = self._get_first_key(cleaned_value)
             if tag not in shape.members:
                 msg = (
                     "Received a tagged union response with member "

--- a/tests/unit/botocore/test_parsers.py
+++ b/tests/unit/botocore/test_parsers.py
@@ -519,6 +519,35 @@ class TestTaggedUnions(unittest.TestCase):
         with self.assertRaises(parsers.ResponseParserError):
             parser.parse(response, output_shape)
 
+    def test_parser_accepts_type_metadata_with_union(self):
+        parser = parsers.JSONParser()
+        response = b'{"Foo": "mystring", "__type": "mytype"}'
+        headers = {'x-amzn-requestid': 'request-id'}
+        output_shape = model.StructureShape(
+            'OutputShape',
+            {
+                'type': 'structure',
+                'union': True,
+                'members': {
+                    'Foo': {
+                        'shape': 'StringType',
+                    },
+                    'Bar': {
+                        'shape': 'StringType',
+                    },
+                },
+            },
+            model.ShapeResolver({'StringType': {'type': 'string'}}),
+        )
+
+        response = {
+            'body': response,
+            'headers': headers,
+            'status_code': 200,
+        }
+        parsed = parser.parse(response, output_shape)
+        self.assertEqual(parsed['Foo'], 'mystring')
+
 
 class TestHeaderResponseInclusion(unittest.TestCase):
     def create_parser(self):


### PR DESCRIPTION
This PR ports forward a bug fix from Botocore to properly parse tagged unions that contain a `__type` attribute in JSON RPC services.