### PR TITLE
Fix mac builds for v2

### DIFF
--- a/.github/workflows/run-dep-tests.yml
+++ b/.github/workflows/run-dep-tests.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # macOS pinned to 13 due to 14+ defaulting to arm64 hardware
+        os: [ubuntu-latest, macOS-13, windows-latest]
 
     steps:
     - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/source-dist-tests.yml
+++ b/.github/workflows/source-dist-tests.yml
@@ -14,7 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # macOS pinned to 13 due to 14+ defaulting to arm64 hardware
+        os: [ubuntu-latest, macOS-13, windows-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It looks like tests have been broken for Python 3.8 and 3.9 on macOS since the release of macOS 14 which moved the runners to arm64 hardware. This will set both distribution and dependency workflows to use macos-13 which keeps tests on the amd64 hardware for the time being.