### PR TITLE
s3errormsg: handle none error message

### DIFF
--- a/awscli/customizations/s3errormsg.py
+++ b/awscli/customizations/s3errormsg.py
@@ -54,8 +54,8 @@ def enhance_error_msg(parsed, **kwargs):
 
 
 def _is_sigv4_error_message(parsed):
-    return ('Please use AWS4-HMAC-SHA256' in
-            parsed.get('Error', {}).get('Message', ''))
+    message = parsed.get('Error', {}).get('Message', '') or ''
+    return ('Please use AWS4-HMAC-SHA256' in message)
 
 
 def _is_permanent_redirect_message(parsed):
@@ -63,5 +63,5 @@ def _is_permanent_redirect_message(parsed):
 
 
 def _is_kms_sigv4_error_message(parsed):
-    return ('AWS KMS managed keys require AWS Signature Version 4' in
-            parsed.get('Error', {}).get('Message', ''))
+    message = parsed.get('Error', {}).get('Message', '') or ''
+    return ('AWS KMS managed keys require AWS Signature Version 4' in message)

--- a/tests/unit/customizations/test_s3errormsg.py
+++ b/tests/unit/customizations/test_s3errormsg.py
@@ -75,6 +75,18 @@ class TestGetRegionFromEndpoint(unittest.TestCase):
         # Nothing should have changed
         self.assertEqual(parsed, expected)
 
+    def test_error_message_none(self):
+        parsed = {
+            'Error': {
+                'Message': None,
+                'Code': 'Other Message'
+            }
+        }
+        expected = copy.deepcopy(parsed)
+        s3errormsg.enhance_error_msg(parsed)
+        # Nothing should have changed
+        self.assertEqual(parsed, expected)
+
     def test_not_an_error_message(self):
         parsed = {
             'Success': 'response',


### PR DESCRIPTION
*Description of changes:*
If the returned xml contains an empty message `<Message></Message>` this will be translated to None type in the parsed var from botocore therefore in the enhance_error_msg checks it will fail to iterate on by the _is_sigv4_error_message and _is_kms_sigv4_error_message functions.