### PR TITLE
[v2] Fix execution env resolution in version string

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -451,8 +451,8 @@ class CLIDriver(object):
             f' {platform.system()}/{platform.release()}'
         )
 
-        if execution_env := os.environ.get('AWS_EXECUTION_ENV') is not None:
-            version_string += f' exec-env/{execution_env}'
+        if 'AWS_EXECUTION_ENV' in os.environ:
+            version_string += f' exec-env/{os.environ.get("AWS_EXECUTION_ENV")}'
         
         version_string += f' {_get_distribution_source()}/{platform.machine()}'
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -288,6 +288,13 @@ class TestBasicCommandFunctionality(unittest.TestCase):
             re.fullmatch(user_agent_regex, version_output)
         )
 
+    def test_version_with_exec_env(self):
+        base_env_vars = os.environ.copy()
+        base_env_vars['AWS_EXECUTION_ENV'] = 'an_execution_env'
+        p = aws('--version', env_vars=base_env_vars)
+        version_output = p.stdout
+        self.assertTrue(f' exec-env/an_execution_env' in version_output)
+
     def test_traceback_printed_when_debug_on(self):
         p = aws('ec2 describe-instances --filters BADKEY=foo --debug')
         self.assertIn('Traceback (most recent call last):', p.stderr, p.stderr)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The `is not None` always resolved to True or False.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
