### PR TITLE
[v2] Emit handlers before endpoint resolution

### DIFF
--- a/.changes/next-release/bugfix-endpoints-90314.json
+++ b/.changes/next-release/bugfix-endpoints-90314.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "endpoints",
+  "description": "Include params set in provide-client-param event handlers in dynamic context params for endpoint resolution."
+}

--- a/awscli/botocore/client.py
+++ b/awscli/botocore/client.py
@@ -602,7 +602,6 @@ class ClientEndpointBridge(object):
 
 
 class BaseClient(object):
-
     # This is actually reassigned with the py->op_name mapping
     # when the client creator creates the subclass.  This value is used
     # because calls such as client.get_paginator('list_objects') use the
@@ -682,6 +681,12 @@ class BaseClient(object):
             'auth_type': operation_model.auth_type,
         }
 
+        api_params = self._emit_api_params(
+            api_params=api_params,
+            operation_model=operation_model,
+            context=request_context,
+        )
+
         (
             endpoint_url,
             additional_headers,
@@ -756,8 +761,6 @@ class BaseClient(object):
             headers=None,
             set_user_agent_header=True,
     ):
-        api_params = self._emit_api_params(
-            api_params, operation_model, context)
         request_dict = self._serializer.serialize_to_request(
             api_params, operation_model)
         if not self._client_config.inject_host_prefix:

--- a/awscli/botocore/signers.py
+++ b/awscli/botocore/signers.py
@@ -614,6 +614,11 @@ def generate_presigned_url(self, ClientMethod, Params=None, ExpiresIn=3600,
 
     operation_model = self.meta.service_model.operation_model(
         operation_name)
+    params = self._emit_api_params(
+        api_params=params,
+        operation_model=operation_model,
+        context=context,
+    )
     bucket_is_arn = ArnParser.is_arn(params.get('Bucket', ''))
     (
         endpoint_url,
@@ -738,7 +743,11 @@ def generate_presigned_post(self, Bucket, Key, Fields=None, Conditions=None,
     # serialized to what a presign post requires.
     operation_model = self.meta.service_model.operation_model(
         'CreateBucket')
-    params = {'Bucket': bucket}
+    params = self._emit_api_params(
+        api_params={'Bucket': bucket},
+        operation_model=operation_model,
+        context=context,
+    )
     bucket_is_arn = ArnParser.is_arn(params.get('Bucket', ''))
     (
         endpoint_url,


### PR DESCRIPTION
*Issue #, if available:*

This ports the following botocore pull request:

https://github.com/boto/botocore/pull/2920

*Description of changes:*

Emit `provide-client-params.*` and `before-parameter-build.*` before endpoint resolution.

One update to the endpoint name in the `test_signers.py` unit test was applied to use the region name (`us-east-1`) in the s3 endpoint, consistent with existing CLI v2 tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
