### PR TITLE
Start testing on 3.13 beta build

### DIFF
--- a/.github/workflows/run-dep-tests.yml
+++ b/.github/workflows/run-dep-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13-dev"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
         # Python 3.8 and 3.9 do not run on m1 hardware which is now standard for
         # macOS-latest.


### PR DESCRIPTION
This PR will start provisional testing on the recently released beta for Python 3.13. This will be used to catch any issues early before the official release in October.