### PR TITLE
Update EC2 service principal

### DIFF
--- a/.changes/next-release/bugfix-emrcustomization-87155.json
+++ b/.changes/next-release/bugfix-emrcustomization-87155.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "emr customization",
+  "description": "Update the EC2 service principal when creating the trust policy for EMR default roles to always be ec2.amazonaws.com."
+}

--- a/awscli/customizations/emr/constants.py
+++ b/awscli/customizations/emr/constants.py
@@ -22,6 +22,7 @@ EMR_ROLE_POLICY_NAME = "AmazonElasticMapReduceRole"
 EMR_AUTOSCALING_ROLE_POLICY_NAME = "AmazonElasticMapReduceforAutoScalingRole"
 EMR_AUTOSCALING_SERVICE_NAME = "application-autoscaling"
 EMR_AUTOSCALING_SERVICE_PRINCIPAL = "application-autoscaling.amazonaws.com"
+EC2_SERVICE_PRINCIPAL = "ec2.amazonaws.com"
 
 # Action on failure
 CONTINUE = 'CONTINUE'

--- a/awscli/customizations/emr/createdefaultroles.py
+++ b/awscli/customizations/emr/createdefaultroles.py
@@ -24,6 +24,7 @@ from awscli.customizations.emr import exceptions
 from awscli.customizations.emr.command import Command
 from awscli.customizations.emr.constants import EC2
 from awscli.customizations.emr.constants import EC2_ROLE_NAME
+from awscli.customizations.emr.constants import EC2_SERVICE_PRINCIPAL
 from awscli.customizations.emr.constants import ROLE_ARN_PATTERN
 from awscli.customizations.emr.constants import EMR
 from awscli.customizations.emr.constants import EMR_ROLE_NAME
@@ -64,6 +65,9 @@ def get_role_policy_arn(region, policy_name):
 
 
 def get_service_principal(service, endpoint_host, session=None):
+    if service == EC2:
+        return EC2_SERVICE_PRINCIPAL
+
     suffix, region = _get_suffix_and_region_from_endpoint_host(endpoint_host)
     if session is None:
         session = botocore.session.Session()
@@ -277,7 +281,7 @@ class CreateDefaultRoles(Command):
                 service_principal.append(get_service_principal(
                     service, self.emr_endpoint_url, self._session))
 
-        LOG.debug(service_principal)
+        LOG.debug(f'Adding service principal(s) to trust policy: {service_principal}')
 
         parameters = {'RoleName': role_name}
         _assume_role_policy = \

--- a/tests/unit/customizations/emr/test_create_default_role.py
+++ b/tests/unit/customizations/emr/test_create_default_role.py
@@ -110,7 +110,7 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
             {
                 "Sid": "",
                 "Effect": "Allow",
-                "Principal": {"Service": "ec2.amazonaws.com.cn"},
+                "Principal": {"Service": "ec2.amazonaws.com"},
                 "Action": "sts:AssumeRole"
             }
         ]

--- a/tests/unit/customizations/emr/test_get_service_principal.py
+++ b/tests/unit/customizations/emr/test_get_service_principal.py
@@ -19,14 +19,15 @@ from awscli.customizations.emr.exceptions import \
 
 class TestEmrConfig(unittest.TestCase):
     ec2_service = "ec2"
+    ec2_service_principal = "ec2.amazonaws.com"
     emr_service = "elasticmapreduce"
     endpoint1 = "https://ap-southeast-1.elasticmapreduce.abc/"
     endpoint2 = "https://elasticmapreduce.abcd.def.ghi"
-    endpoint3 = "https://grabage.nothing.com"
+    endpoint3 = "https://garbage.nothing.com"
     expected_result1 = "elasticmapreduce.abc"
     expected_result2 = "elasticmapreduce.def.ghi"
 
-    def test_get_service_principal(self):
+    def test_get_emr_service_principal(self):
         msg = "Generated Service Principal does not match the expected" + \
             "Service Principal"
 
@@ -37,8 +38,13 @@ class TestEmrConfig(unittest.TestCase):
         self.assertEqual(result2, self.expected_result2, msg)
 
         self.assertRaises(ResolveServicePrincipalError,
-                          get_service_principal, self.ec2_service,
+                          get_service_principal, self.emr_service,
                           self.endpoint3)
+
+    def test_get_ec2_service_principal(self):
+        self.assertEqual(get_service_principal(self.ec2_service, self.endpoint1), self.ec2_service_principal)
+        self.assertEqual(get_service_principal(self.ec2_service, self.endpoint2), self.ec2_service_principal)
+        self.assertEqual(get_service_principal(self.ec2_service, self.endpoint3), self.ec2_service_principal)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update the EC2 service principal when creating the trust policy for EMR default roles to always be
"ec2.amazonaws.com" instead of using the region to determine it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
