### PR TITLE
Bump pyinstaller from 5.12.0 to 5.13.2

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,4 @@
 # Requirements we need to run our build jobs for the installers.
 # We create the separation for cases where we're doing installation
 # from a local dependency directory instead of requirements.txt.
-PyInstaller==5.12.0
+PyInstaller==5.13.2

--- a/requirements/portable-exe-extras.txt
+++ b/requirements/portable-exe-extras.txt
@@ -1,4 +1,4 @@
-pyinstaller==5.12.0
+pyinstaller==5.13.2
 # pyinstaller takes a dependency on importlib_metadata,
 # conditional on the Python version. This generates lockfiles
 # that fail to install on some Python versions supported by v2.


### PR DESCRIPTION
This version supports Python 3.12 and doesn't break anything.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
