### PR TITLE
[v2] Only pass profile parameter in command to session manager plugin

### DIFF
--- a/.changes/next-release/bugfix-ssmstartsession-37817.json
+++ b/.changes/next-release/bugfix-ssmstartsession-37817.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``ssm start-session``",
+  "description": "Only provide profile name to session-manager-plugin if provided using --profile flag"
+}

--- a/awscli/customizations/sessionmanager.py
+++ b/awscli/customizations/sessionmanager.py
@@ -104,11 +104,12 @@ class StartSessionCaller(CLIOperationCaller):
         response = client.start_session(**parameters)
         session_id = response['SessionId']
         region_name = client.meta.region_name
-        # profile_name is used to passed on to session manager plugin
+        # Profile_name is used to passed on to session manager plugin
         # to fetch same profile credentials to make an api call in the plugin.
-        # If no profile is passed then pass on empty string
-        profile_name = self._session.profile \
-            if self._session.profile is not None else ''
+        # If --profile flag is configured, pass it to Session Manager plugin.
+        # If not, set empty string.
+        profile_name = parsed_globals.profile \
+            if parsed_globals.profile is not None else ''
         endpoint_url = client.meta.endpoint_url
         ssm_env_name = self.DEFAULT_SSM_ENV_NAME
 

--- a/tests/functional/ssm/test_start_session.py
+++ b/tests/functional/ssm/test_start_session.py
@@ -15,7 +15,8 @@ import json
 
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import BaseAWSHelpOutputTest
-from awscli.testutils import mock
+from awscli.testutils import create_clidriver, mock, temporary_file
+from botocore.exceptions import ProfileNotFound
 
 
 class TestSessionManager(BaseAWSCommandParamsTest):
@@ -41,7 +42,7 @@ class TestSessionManager(BaseAWSCommandParamsTest):
                 json.dumps(expected_response),
                 mock.ANY,
                 "StartSession",
-                mock.ANY,
+                "",
                 json.dumps(start_session_params),
                 mock.ANY,
             ],
@@ -80,12 +81,223 @@ class TestSessionManager(BaseAWSCommandParamsTest):
                 ssm_env_name,
                 mock.ANY,
                 "StartSession",
-                mock.ANY,
+                "",
                 json.dumps(start_session_params),
                 mock.ANY,
             ],
             env=expected_env,
         )
+
+    @mock.patch("awscli.customizations.sessionmanager.check_call")
+    @mock.patch("awscli.customizations.sessionmanager.check_output")
+    def test_profile_parameter_passed_to_sessionmanager_plugin(
+        self, mock_check_output, mock_check_call
+    ):
+        cmdline = (
+            "ssm start-session --target instance-id "
+            "--profile user_profile"
+        )
+        mock_check_call.return_value = 0
+        mock_check_output.return_value = "1.2.500.0\n"
+        expected_response = {
+            "SessionId": "session-id",
+            "TokenValue": "token-value",
+            "StreamUrl": "stream-url",
+        }
+        self.parsed_responses = [expected_response]
+        ssm_env_name = "AWS_SSM_START_SESSION_RESPONSE"
+        start_session_params = {
+            "Target": "instance-id",
+        }
+
+        # We test this by creating 4 credentials
+        # env vars, default profile (default),
+        # env aws profile (local_profile)
+        # and StartSession command profile (user_profile)
+        # We want to make sure only profile name in command
+        # be set to session manager plugin as parameter
+        self.environ['AWS_ACCESS_KEY_ID'] = 'env_var_akid'
+        self.environ['AWS_SECRET_ACCESS_KEY'] = 'env_var_sak'
+
+        with temporary_file('w') as f:
+            f.write(
+                '[default]\n'
+                'aws_access_key_id = shared_default_akid\n'
+                'aws_secret_access_key = shared_default_sak\n'
+                '[local_profile]\n'
+                'aws_access_key_id = shared_local_akid\n'
+                'aws_secret_access_key = shared_local_sak\n'
+                '[user_profile]\n'
+                'aws_access_key_id = shared_user_akid\n'
+                'aws_secret_access_key = shared_user_sak\n'
+            )
+            f.flush()
+
+            self.environ['AWS_SHARED_CREDENTIALS_FILE'] = f.name
+            self.environ["AWS_PROFILE"] = "local_profile"
+
+            expected_env = self.environ.copy()
+            expected_env.update({ssm_env_name: json.dumps(expected_response)})
+
+            self.driver = create_clidriver()
+            self.run_cmd(cmdline, expected_rc=0)
+
+        self.assertEqual(self.operations_called[0][0].name,
+                         'StartSession')
+        self.assertEqual(self.operations_called[0][1],
+                         {'Target': 'instance-id'})
+        mock_check_call.assert_called_once_with(
+            [
+                "session-manager-plugin",
+                ssm_env_name,
+                mock.ANY,
+                "StartSession",
+                "user_profile",
+                json.dumps(start_session_params),
+                mock.ANY,
+            ],
+            env=expected_env,
+        )
+
+    @mock.patch("awscli.customizations.sessionmanager.check_call")
+    @mock.patch("awscli.customizations.sessionmanager.check_output")
+    def test_profile_environment_not_passed_to_sessionmanager_plugin(
+        self, mock_check_output, mock_check_call
+    ):
+        cmdline = "ssm start-session --target instance-id"
+        mock_check_call.return_value = 0
+        mock_check_output.return_value = "1.2.500.0\n"
+        expected_response = {
+            "SessionId": "session-id",
+            "TokenValue": "token-value",
+            "StreamUrl": "stream-url",
+        }
+        self.parsed_responses = [expected_response]
+        ssm_env_name = "AWS_SSM_START_SESSION_RESPONSE"
+        start_session_params = {
+            "Target": "instance-id",
+        }
+
+        with temporary_file('w') as f:
+            f.write(
+                '[default]\n'
+                'aws_access_key_id = shared_default_akid\n'
+                'aws_secret_access_key = shared_default_sak\n'
+                '[local_profile]\n'
+                'aws_access_key_id = shared_local_akid\n'
+                'aws_secret_access_key = shared_local_sak\n'
+            )
+            f.flush()
+
+            self.environ.pop("AWS_ACCESS_KEY_ID", None)
+            self.environ.pop("AWS_SECRET_ACCESS_KEY", None)
+            self.environ['AWS_SHARED_CREDENTIALS_FILE'] = f.name
+            self.environ["AWS_PROFILE"] = "local_profile"
+
+            expected_env = self.environ.copy()
+            expected_env.update({ssm_env_name: json.dumps(expected_response)})
+
+            self.driver = create_clidriver()
+            self.run_cmd(cmdline, expected_rc=0)
+
+        self.assertEqual(self.operations_called[0][0].name,
+                         'StartSession')
+        self.assertEqual(self.operations_called[0][1],
+                         {'Target': 'instance-id'})
+        mock_check_call.assert_called_once_with(
+            [
+                "session-manager-plugin",
+                ssm_env_name,
+                mock.ANY,
+                "StartSession",
+                "",
+                json.dumps(start_session_params),
+                mock.ANY,
+            ],
+            env=expected_env,
+        )
+
+    @mock.patch("awscli.customizations.sessionmanager.check_call")
+    @mock.patch("awscli.customizations.sessionmanager.check_output")
+    def test_default_profile_used_and_not_passed_to_sessionmanager_plugin(
+        self, mock_check_output, mock_check_call
+    ):
+        cmdline = "ssm start-session --target instance-id"
+        mock_check_call.return_value = 0
+        mock_check_output.return_value = "1.2.500.0\n"
+        expected_response = {
+            "SessionId": "session-id",
+            "TokenValue": "token-value",
+            "StreamUrl": "stream-url",
+        }
+        self.parsed_responses = [expected_response]
+        ssm_env_name = "AWS_SSM_START_SESSION_RESPONSE"
+        start_session_params = {
+            "Target": "instance-id",
+        }
+
+        with temporary_file('w') as f:
+            f.write(
+                '[default]\n'
+                'aws_access_key_id = shared_default_akid\n'
+                'aws_secret_access_key = shared_default_sak\n'
+            )
+            f.flush()
+
+            self.environ.pop("AWS_ACCESS_KEY_ID", None)
+            self.environ.pop("AWS_SECRET_ACCESS_KEY", None)
+            self.environ.pop("AWS_SHARED_CREDENTIALS_FILE", None)
+            self.environ.pop("AWS_PROFILE", None)
+
+            expected_env = self.environ.copy()
+            expected_env.update({ssm_env_name: json.dumps(expected_response)})
+
+            self.driver = create_clidriver()
+            self.run_cmd(cmdline, expected_rc=0)
+
+        self.assertEqual(self.operations_called[0][0].name,
+                         'StartSession')
+        self.assertEqual(self.operations_called[0][1],
+                         {'Target': 'instance-id'})
+        mock_check_call.assert_called_once_with(
+            [
+                "session-manager-plugin",
+                ssm_env_name,
+                mock.ANY,
+                "StartSession",
+                "",
+                json.dumps(start_session_params),
+                mock.ANY,
+            ],
+            env=expected_env,
+        )
+
+    def test_start_session_with_user_profile_not_exist(self):
+        cmdline = (
+            "ssm start-session --target instance-id "
+            "--profile user_profile"
+        )
+        with temporary_file('w') as f:
+            f.write(
+                '[default]\n'
+                'aws_access_key_id = shared_default_akid\n'
+                'aws_secret_access_key = shared_default_sak\n'
+            )
+            f.flush()
+
+            self.environ.pop("AWS_ACCESS_KEY_ID", None)
+            self.environ.pop("AWS_SECRET_ACCESS_KEY", None)
+            self.environ.pop("AWS_PROFILE", None)
+            self.environ['AWS_SHARED_CREDENTIALS_FILE'] = f.name
+
+            try:
+                self.driver = create_clidriver()
+                self.run_cmd(cmdline, expected_rc=255)
+            except ProfileNotFound as e:
+                self.assertIn(
+                    'The config profile (user_profile) could not be found',
+                    str(e)
+                )
 
     @mock.patch('awscli.customizations.sessionmanager.check_call')
     @mock.patch("awscli.customizations.sessionmanager.check_output")

--- a/tests/functional/ssm/test_start_session.py
+++ b/tests/functional/ssm/test_start_session.py
@@ -13,6 +13,7 @@
 import errno
 import json
 
+from awscli.clidriver import AWSCLIEntryPoint
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import BaseAWSHelpOutputTest
 from awscli.testutils import create_clidriver, mock, temporary_file
@@ -140,6 +141,7 @@ class TestSessionManager(BaseAWSCommandParamsTest):
             expected_env.update({ssm_env_name: json.dumps(expected_response)})
 
             self.driver = create_clidriver()
+            self.entry_point = AWSCLIEntryPoint(self.driver)
             self.run_cmd(cmdline, expected_rc=0)
 
         self.assertEqual(self.operations_called[0][0].name,
@@ -198,6 +200,7 @@ class TestSessionManager(BaseAWSCommandParamsTest):
             expected_env.update({ssm_env_name: json.dumps(expected_response)})
 
             self.driver = create_clidriver()
+            self.entry_point = AWSCLIEntryPoint(self.driver)
             self.run_cmd(cmdline, expected_rc=0)
 
         self.assertEqual(self.operations_called[0][0].name,
@@ -253,6 +256,7 @@ class TestSessionManager(BaseAWSCommandParamsTest):
             expected_env.update({ssm_env_name: json.dumps(expected_response)})
 
             self.driver = create_clidriver()
+            self.entry_point = AWSCLIEntryPoint(self.driver)
             self.run_cmd(cmdline, expected_rc=0)
 
         self.assertEqual(self.operations_called[0][0].name,
@@ -292,6 +296,7 @@ class TestSessionManager(BaseAWSCommandParamsTest):
 
             try:
                 self.driver = create_clidriver()
+                self.entry_point = AWSCLIEntryPoint(self.driver)
                 self.run_cmd(cmdline, expected_rc=255)
             except ProfileNotFound as e:
                 self.assertIn(

--- a/tests/unit/customizations/test_sessionmanager.py
+++ b/tests/unit/customizations/test_sessionmanager.py
@@ -10,16 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+import botocore.session
 import errno
 import json
-import botocore.session
+import pytest
 import subprocess
 
-import pytest
-
 from awscli.customizations import sessionmanager
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestSessionManager(unittest.TestCase):
@@ -35,6 +33,9 @@ class TestSessionManager(unittest.TestCase):
         self.session.create_client.return_value = self.client
         self.session.profile = self.profile
         self.caller = sessionmanager.StartSessionCaller(self.session)
+
+        self.parsed_globals = mock.Mock()
+        self.parsed_globals.profile = 'user_profile'
 
     def test_start_session_when_non_custom_start_session_fails(self):
         self.client.start_session.side_effect = Exception('some exception')
@@ -63,7 +64,7 @@ class TestSessionManager(unittest.TestCase):
         self.client.start_session.return_value = start_session_response
 
         rc = self.caller.invoke('ssm', 'StartSession',
-                                start_session_params, mock.Mock())
+                                start_session_params, self.parsed_globals)
         self.assertEqual(rc, 0)
         self.client.start_session.assert_called_with(**start_session_params)
 
@@ -80,7 +81,7 @@ class TestSessionManager(unittest.TestCase):
              start_session_response,
              self.region,
              'StartSession',
-             self.profile,
+             self.parsed_globals.profile,
              json.dumps(start_session_params),
              self.endpoint_url]
         )
@@ -111,7 +112,7 @@ class TestSessionManager(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.caller.invoke('ssm', 'StartSession',
-                               start_session_params, mock.Mock())
+                               start_session_params, self.parsed_globals)
 
             self.client.start_session.assert_called_with(
                 **start_session_params)
@@ -126,7 +127,7 @@ class TestSessionManager(unittest.TestCase):
                  start_session_response,
                  self.region,
                  'StartSession',
-                 self.profile,
+                 self.parsed_globals.profile,
                  json.dumps(start_session_params),
                  self.endpoint_url]
             )
@@ -137,7 +138,8 @@ class TestSessionManager(unittest.TestCase):
         self, mock_check_output, mock_check_call
     ):
         mock_check_output.return_value = "1.2.500.0\n"
-        self.session.profile = None
+        self.session.profile = "session_profile"
+        self.parsed_globals.profile = None
         mock_check_call.return_value = 0
 
         start_session_params = {
@@ -149,15 +151,27 @@ class TestSessionManager(unittest.TestCase):
             "TokenValue": "token-value",
             "StreamUrl": "stream-url"
         }
+        ssm_env_name = "AWS_SSM_START_SESSION_RESPONSE"
 
         self.client.start_session.return_value = start_session_response
 
         rc = self.caller.invoke('ssm', 'StartSession',
-                                start_session_params, mock.Mock())
+                                start_session_params, self.parsed_globals)
         self.assertEqual(rc, 0)
         self.client.start_session.assert_called_with(**start_session_params)
         mock_check_call_list = mock_check_call.call_args[0][0]
-        self.assertEqual(mock_check_call_list[4], '')
+        self.assertEqual(
+            mock_check_call_list,
+            [
+                "session-manager-plugin",
+                ssm_env_name,
+                self.region,
+                "StartSession",
+                "",
+                json.dumps(start_session_params),
+                self.endpoint_url,
+            ],
+        )
 
     @mock.patch("awscli.customizations.sessionmanager.check_call")
     @mock.patch("awscli.customizations.sessionmanager.check_output")
@@ -167,7 +181,10 @@ class TestSessionManager(unittest.TestCase):
         mock_check_output.return_value = "1.2.500.0\n"
         mock_check_call.return_value = 0
 
-        start_session_params = {"Target": "i-123456789"}
+        start_session_params = {
+            "Target": "i-123456789"
+        }
+
         start_session_response = {
             "SessionId": "session-id",
             "TokenValue": "token-value",
@@ -177,7 +194,7 @@ class TestSessionManager(unittest.TestCase):
 
         self.client.start_session.return_value = start_session_response
         rc = self.caller.invoke(
-            "ssm", "StartSession", start_session_params, mock.Mock()
+            "ssm", "StartSession", start_session_params, self.parsed_globals
         )
         self.assertEqual(rc, 0)
         self.client.start_session.assert_called_with(**start_session_params)
@@ -195,7 +212,7 @@ class TestSessionManager(unittest.TestCase):
                 ssm_env_name,
                 self.region,
                 "StartSession",
-                self.profile,
+                self.parsed_globals.profile,
                 json.dumps(start_session_params),
                 self.endpoint_url,
             ],
@@ -215,7 +232,9 @@ class TestSessionManager(unittest.TestCase):
             returncode=1, cmd="session-manager-plugin", output="some error"
         )
 
-        start_session_params = {"Target": "i-123456789"}
+        start_session_params = {
+            "Target": "i-123456789"
+        }
         start_session_response = {
             "SessionId": "session-id",
             "TokenValue": "token-value",
@@ -225,7 +244,10 @@ class TestSessionManager(unittest.TestCase):
         self.client.start_session.return_value = start_session_response
         with self.assertRaises(subprocess.CalledProcessError):
             self.caller.invoke(
-                "ssm", "StartSession", start_session_params, mock.Mock()
+                "ssm",
+                "StartSession",
+                start_session_params,
+                self.parsed_globals
             )
 
         self.client.start_session.assert_called_with(**start_session_params)
@@ -241,7 +263,9 @@ class TestSessionManager(unittest.TestCase):
         self, mock_check_output, mock_check_call
     ):
         mock_check_output.return_value = "1.2.500.0\n"
-        start_session_params = {"Target": "i-123456789"}
+        start_session_params = {
+            "Target": "i-123456789"
+        }
         start_session_response = {
             "SessionId": "session-id",
             "TokenValue": "token-value",
@@ -258,7 +282,7 @@ class TestSessionManager(unittest.TestCase):
 
         self.client.start_session.return_value = start_session_response
         rc = self.caller.invoke(
-            "ssm", "StartSession", start_session_params, mock.Mock()
+            "ssm", "StartSession", start_session_params, self.parsed_globals
         )
         self.assertEqual(rc, 0)
         self.client.start_session.assert_called_with(**start_session_params)
@@ -276,7 +300,7 @@ class TestSessionManager(unittest.TestCase):
                 ssm_env_name,
                 self.region,
                 "StartSession",
-                self.profile,
+                self.parsed_globals.profile,
                 json.dumps(start_session_params),
                 self.endpoint_url,
             ],
@@ -293,7 +317,9 @@ class TestSessionManager(unittest.TestCase):
     ):
         mock_check_output.return_value = "InvalidVersion"
 
-        start_session_params = {"Target": "i-123456789"}
+        start_session_params = {
+            "Target": "i-123456789"
+        }
         start_session_response = {
             "SessionId": "session-id",
             "TokenValue": "token-value",
@@ -302,7 +328,7 @@ class TestSessionManager(unittest.TestCase):
 
         self.client.start_session.return_value = start_session_response
         self.caller.invoke(
-            "ssm", "StartSession", start_session_params, mock.Mock()
+            "ssm", "StartSession", start_session_params, self.parsed_globals
         )
         self.client.start_session.assert_called_with(**start_session_params)
         self.client.terminate_session.assert_not_called()
@@ -318,7 +344,7 @@ class TestSessionManager(unittest.TestCase):
                 json.dumps(start_session_response),
                 self.region,
                 "StartSession",
-                self.profile,
+                self.parsed_globals.profile,
                 json.dumps(start_session_params),
                 self.endpoint_url,
             ],


### PR DESCRIPTION
This is a port of this PR: https://github.com/aws/aws-cli/pull/8705. Some small modifications needed to be made to the tests. The changes to the tests are in a separate commit.
