### PR TITLE
Correct typo in start-live-tail command UI and description

### DIFF
--- a/awscli/customizations/logs/startlivetail.py
+++ b/awscli/customizations/logs/startlivetail.py
@@ -50,7 +50,7 @@ DESCRIPTION = (
     "A session can go on for a maximum of 3 hours.\n\n"
     "By default, this command start a native tailing session "
     "where recent log events appear from the bottom, "
-    "the log events are output as-is in Plain text.  You can run this command with --interactive flag, "
+    "the log events are output as-is in Plain text.  You can run this command with --mode interactive, "
     "which starting an interactive tailing session. Interactive tailing provides the ability to "
     "highlight up to 5 terms in your logs. "
     "The severity codes are highlighted by default. The logs are output in JSON format if possible, "
@@ -753,7 +753,7 @@ class InteractiveUI(BaseLiveTailUI):
 
     def _create_metadata(self):
         self._metadata = FormattedTextControl(
-            text="Higlighted Terms: {}, 0 events/sec, Sampled: No | 00:00:00"
+            text="Highlighted Terms: {}, 0 events/sec, Sampled: No | 00:00:00"
         )
         return Window(
             self._metadata,
@@ -780,7 +780,7 @@ class InteractiveUI(BaseLiveTailUI):
         is_sampled = "Yes" if self._log_events_printer.is_sampled else "No"
 
         self._metadata.text = ANSI(
-            f"Higlighted Terms: {{{keyword_count_map}}}, {events_per_second} events/sec, Sampled: {is_sampled} | {hours}:{minutes}:{seconds}"
+            f"Highlighted Terms: {{{keyword_count_map}}}, {events_per_second} events/sec, Sampled: {is_sampled} | {hours}:{minutes}:{seconds}"
         )
 
     async def highlight_term_in_buffer(self, keyword: Keyword):

--- a/tests/unit/customizations/logs/test_startlivetail.py
+++ b/tests/unit/customizations/logs/test_startlivetail.py
@@ -570,7 +570,7 @@ class LiveTailKeyBindingsTest(unittest.TestCase):
 
         self.ui._application.exit.assert_called_once_with()
 
-        # if in higlight mode, escape gets you out of highlight
+        # if in highlight mode, escape gets you out of highlight
         self.key_bindings._input_state = InputState.HIGHLIGHT
 
         self.key_bindings.bindings[10].handler(escape_event)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Corrects a typo in the UI where there was a missing h. 
Updates description to correctly reflect use of interactive mode for command. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
