### PR TITLE
Add more detail to the no-paginate parameter description

### DIFF
--- a/awscli/data/cli.json
+++ b/awscli/data/cli.json
@@ -17,7 +17,7 @@
         },
         "no-paginate": {
             "action": "store_false",
-            "help": "<p>Disable automatic pagination.</p>",
+            "help": "<p>Disable automatic pagination.  If automatic pagination is disabled, the AWS CLI will only make one call, for the first page of results.</p>",
             "dest": "paginate"
         },
         "output": {

--- a/awscli/examples/global_options.rst
+++ b/awscli/examples/global_options.rst
@@ -25,6 +25,10 @@
   
   *   table
   
+  *   yaml
+  
+  *   yaml-stream
+  
   
 ``--query`` (string)
   
@@ -69,4 +73,26 @@
 ``--cli-connect-timeout`` (int)
   
   The maximum socket connect time in seconds. If the value is set to 0, the socket connect will be blocking and not timeout. The default value is 60 seconds.
+  
+``--cli-binary-format`` (string)
+  
+  The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The raw-in-base64-out format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally. When providing contents from a file that map to a binary blob ``fileb://`` will always be treated as binary and use the file contents directly regardless of the ``cli-binary-format`` setting. When using ``file://`` the file contents will need to properly formatted for the configured ``cli-binary-format``.
+  
+  
+  *   base64
+  
+  *   raw-in-base64-out
+  
+  
+``--no-cli-pager`` (boolean)
+  
+  Disable cli pager for output.
+  
+``--cli-auto-prompt`` (boolean)
+  
+  Automatically prompt for CLI input parameters.
+  
+``--no-cli-auto-prompt`` (boolean)
+  
+  Disable automatically prompt for CLI input parameters.
   

--- a/awscli/examples/global_options.rst
+++ b/awscli/examples/global_options.rst
@@ -12,7 +12,7 @@
   
 ``--no-paginate`` (boolean)
   
-  Disable automatic pagination.
+  Disable automatic pagination. If automatic pagination is disabled, the AWS CLI will only make one call, for the first page of results.
   
 ``--output`` (string)
   
@@ -24,10 +24,6 @@
   *   text
   
   *   table
-  
-  *   yaml
-  
-  *   yaml-stream
   
   
 ``--query`` (string)
@@ -73,26 +69,4 @@
 ``--cli-connect-timeout`` (int)
   
   The maximum socket connect time in seconds. If the value is set to 0, the socket connect will be blocking and not timeout. The default value is 60 seconds.
-  
-``--cli-binary-format`` (string)
-  
-  The formatting style to be used for binary blobs. The default format is base64. The base64 format expects binary blobs to be provided as a base64 encoded string. The raw-in-base64-out format preserves compatibility with AWS CLI V1 behavior and binary values must be passed literally. When providing contents from a file that map to a binary blob ``fileb://`` will always be treated as binary and use the file contents directly regardless of the ``cli-binary-format`` setting. When using ``file://`` the file contents will need to properly formatted for the configured ``cli-binary-format``.
-  
-  
-  *   base64
-  
-  *   raw-in-base64-out
-  
-  
-``--no-cli-pager`` (boolean)
-  
-  Disable cli pager for output.
-  
-``--cli-auto-prompt`` (boolean)
-  
-  Automatically prompt for CLI input parameters.
-  
-``--no-cli-auto-prompt`` (boolean)
-  
-  Disable automatically prompt for CLI input parameters.
   


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-cli/issues/8281
*Description of changes:*
Clarified that `no-paginate` makes the CLI only make one call for the first page of results, rather than multiple calls for all results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
