### PR TITLE
Add custom marker for checking validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [tool.pytest.ini_options]
 markers = [
     "slow: marks tests as slow",
+    "validates_models: marks tests as one which validates service models",
 ]

--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
 from botocore.model import OperationModel
 
 from awscli.clidriver import create_clidriver

--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -21,6 +21,7 @@ _ALLOWED_COMMANDS = [
 ]
 
 
+@pytest.mark.validates_models
 def test_no_event_stream_unless_allowed():
     driver = create_clidriver()
     help_command = driver.create_help_command()


### PR DESCRIPTION
Adds a marker to tests which allows us to run only tests that validate models