### PR TITLE
replace six.StringIO() by io.StringIO() in remaining places

### DIFF
--- a/awscli/customizations/dynamodb.py
+++ b/awscli/customizations/dynamodb.py
@@ -14,8 +14,6 @@ import base64
 import binascii
 import logging
 
-from awscli.compat import six
-
 logger = logging.getLogger(__name__)
 
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import csv
+import io
 import signal
 import datetime
 import contextlib
@@ -29,7 +30,7 @@ def split_on_commas(value):
         return value.split(',')
     elif not any(char in value for char in ['"', "'", '[', ']']):
         # Simple escaping, let the csv module handle it.
-        return list(csv.reader(six.StringIO(value), escapechar='\\'))[0]
+        return list(csv.reader(io.StringIO(value), escapechar='\\'))[0]
     else:
         # If there's quotes for the values, we have to handle this
         # ourselves.
@@ -38,7 +39,7 @@ def split_on_commas(value):
 
 def _split_with_quotes(value):
     try:
-        parts = list(csv.reader(six.StringIO(value), escapechar='\\'))[0]
+        parts = list(csv.reader(io.StringIO(value), escapechar='\\'))[0]
     except csv.Error:
         raise ValueError("Bad csv value: %s" % value)
     iter_parts = iter(parts)

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -21,12 +21,13 @@ at the man output, we look one step before at the generated rst output
 (it's easier to verify).
 
 """
+import io
+
 from awscli.testutils import BaseAWSHelpOutputTest
 from awscli.testutils import FileCreator
 from awscli.testutils import mock
 from awscli.testutils import aws
 
-from awscli.compat import six
 from awscli.alias import AliasLoader
 
 
@@ -204,7 +205,7 @@ class TestRemoveDeprecatedCommands(BaseAWSHelpOutputTest):
         # command verify that we get a SystemExit exception
         # and that we get something in stderr that says that
         # we made an invalid choice (because the operation is removed).
-        stderr = six.StringIO()
+        stderr = io.StringIO()
         with mock.patch('sys.stderr', stderr):
             with self.assertRaises(SystemExit):
                 self.driver.main([service, command, 'help'])

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -13,8 +13,7 @@
 # language governing permissions and limitations under the License.
 import base64
 import datetime
-
-from six.moves import cStringIO
+import io
 
 import awscli.customizations.ec2.bundleinstance
 from awscli.compat import six
@@ -88,7 +87,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(args_list, result)
 
     def test_both(self):
-        captured = cStringIO()
+        captured = io.StringIO()
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
         args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -12,10 +12,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
+import io
 import os
 import re
-
-from awscli.compat import six
 
 import awscli.clidriver
 
@@ -26,7 +25,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestGetObject, self).setUp()
-        self.parsed_response = {'Body': six.StringIO()}
+        self.parsed_response = {'Body': io.StringIO()}
 
     def remove_file_if_exists(self, filename):
         if os.path.isfile(filename):

--- a/tests/functional/s3api/test_put_bucket_tagging.py
+++ b/tests/functional/s3api/test_put_bucket_tagging.py
@@ -15,7 +15,6 @@ import re
 import copy
 
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.compat import six
 
 
 # file is gone in python3, so instead IOBase must be used.

--- a/tests/functional/s3api/test_put_object.py
+++ b/tests/functional/s3api/test_put_object.py
@@ -16,7 +16,6 @@ import re
 import copy
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
-from awscli.compat import six
 
 import awscli.clidriver
 

--- a/tests/functional/ses/test_send_email.py
+++ b/tests/functional/ses/test_send_email.py
@@ -13,8 +13,6 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
 
-from awscli.compat import six
-from six.moves import cStringIO
 
 
 class TestSendEmail(BaseAWSCommandParamsTest):

--- a/tests/functional/test_preview.py
+++ b/tests/functional/test_preview.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
+import io
 
 from awscli.customizations import preview
 from awscli.testutils import mock, BaseAWSCommandParamsTest
@@ -20,7 +20,7 @@ class TestPreviewMode(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestPreviewMode, self).setUp()
-        self.stderr = six.StringIO()
+        self.stderr = io.StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
         self.full_config = {'profiles': {}}

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import tempfile
-import six
 import collections
 
 from awscli.testutils import mock, unittest

--- a/tests/unit/customizations/configservice/test_getstatus.py
+++ b/tests/unit/customizations/configservice/test_getstatus.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
+import io
 
 from awscli.testutils import mock, unittest
 from awscli.customizations.configservice.getstatus import GetStatusCommand
@@ -78,7 +78,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'Delivery Channels:\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -98,7 +98,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'Delivery Channels:\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -113,7 +113,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'Delivery Channels:\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -144,7 +144,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'recorder: OFF\n\n'
             'Delivery Channels:\n\n'
         )
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -170,7 +170,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last stream delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -198,7 +198,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -227,7 +227,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'message: This is the error\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -259,7 +259,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -298,7 +298,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -361,6 +361,6 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -10,12 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 import os
 
 from awscli.customizations.configure import configure, ConfigValue, NOT_SET
 from awscli.customizations.configure import profile_to_section
 from awscli.testutils import mock, unittest
-from awscli.compat import six
 
 from . import FakeSession
 
@@ -135,7 +135,7 @@ class TestInteractivePrompter(unittest.TestCase):
     def setUp(self):
         self.input_patch = mock.patch('awscli.compat.raw_input')
         self.mock_raw_input = self.input_patch.start()
-        self.stdout = six.StringIO()
+        self.stdout = io.StringIO()
         self.stdout_patch = mock.patch('sys.stdout', self.stdout)
         self.stdout_patch.start()
 

--- a/tests/unit/customizations/configure/test_get.py
+++ b/tests/unit/customizations/configure/test_get.py
@@ -10,10 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 from awscli.testutils import unittest
 
 from awscli.customizations.configure.get import ConfigureGetCommand
-from awscli.compat import six
 
 from . import FakeSession
 
@@ -21,8 +21,8 @@ from . import FakeSession
 class TestConfigureGetCommand(unittest.TestCase):
 
     def create_command(self, session):
-        stdout = six.StringIO()
-        stderr = six.StringIO()
+        stdout = io.StringIO()
+        stderr = io.StringIO()
         command = ConfigureGetCommand(session, stdout, stderr)
         return stdout, stderr, command
 

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -10,10 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 from argparse import Namespace
 
 from awscli.testutils import mock, unittest
-from awscli.compat import six
 from awscli.customizations.configure.list import ConfigureListCommand
 
 from . import FakeSession
@@ -27,7 +27,7 @@ class TestConfigureListCommand(unittest.TestCase):
             all_variables={'config_file': '/config/location'})
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = io.StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -46,7 +46,7 @@ class TestConfigureListCommand(unittest.TestCase):
         session.session_var_map = {'profile': (None, "PROFILE_ENV_VAR")}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = io.StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -63,7 +63,7 @@ class TestConfigureListCommand(unittest.TestCase):
         session.session_var_map = {'region': ('region', "AWS_DEFAULT_REGION")}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = io.StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -94,7 +94,7 @@ class TestConfigureListCommand(unittest.TestCase):
             'profile': ('profile', 'AWS_DEFAULT_PROFILE')}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = io.StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -123,7 +123,7 @@ class TestConfigureListCommand(unittest.TestCase):
         session.session_var_map = {'profile': (None, ['AWS_PROFILE'])}
         session.full_config = {
             'profiles': {'foo': {'region': 'AWS_REGION'}}}
-        stream = six.StringIO()
+        stream = io.StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=parsed_globals)
         rendered = stream.getvalue()

--- a/tests/unit/customizations/datapipeline/test_listrunsformatter.py
+++ b/tests/unit/customizations/datapipeline/test_listrunsformatter.py
@@ -10,11 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 
 import difflib
 
 from awscli.testutils import mock, unittest
-from awscli.compat import six
 from awscli.customizations.datapipeline.listrunsformatter \
     import ListRunsFormatter
 
@@ -22,7 +22,7 @@ from awscli.customizations.datapipeline.listrunsformatter \
 class TestListRunsFormatter(unittest.TestCase):
     def setUp(self):
         self.formatter = ListRunsFormatter(mock.Mock(query=None))
-        self.stream = six.StringIO()
+        self.stream = io.StringIO()
 
     def assert_data_renders_to(self, data, table):
         self.formatter('list-runs', data, stream=self.stream)

--- a/tests/unit/customizations/gamelift/test_uploadbuild.py
+++ b/tests/unit/customizations/gamelift/test_uploadbuild.py
@@ -12,13 +12,13 @@
 # language governing permissions and limitations under the License.
 from argparse import Namespace
 import contextlib
+import io
 import os
 import zipfile
 
 from botocore.session import get_session
 from botocore.exceptions import ClientError
 
-from awscli.compat import six
 from awscli.testutils import unittest, mock, FileCreator
 from awscli.customizations.gamelift.uploadbuild import UploadBuildCommand
 from awscli.customizations.gamelift.uploadbuild import zip_directory
@@ -142,7 +142,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             OperatingSystem=operating_system)
 
     def test_error_message_when_directory_is_empty(self):
-        with mock.patch('sys.stderr', six.StringIO()) as mock_stderr:
+        with mock.patch('sys.stderr', io.StringIO()) as mock_stderr:
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
@@ -158,7 +158,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             '--build-root', ''
         ]
 
-        with mock.patch('sys.stderr', six.StringIO()) as mock_stderr:
+        with mock.patch('sys.stderr', io.StringIO()) as mock_stderr:
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
@@ -175,7 +175,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             '--build-root', dir_not_exist
         ]
 
-        with mock.patch('sys.stderr', six.StringIO()) as mock_stderr:
+        with mock.patch('sys.stderr', io.StringIO()) as mock_stderr:
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
+import io
 
 from botocore.model import DenormalizedStructureBuilder
 
@@ -80,7 +80,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
     def test_generate_json_skeleton(self):
         parsed_args = mock.Mock()
         parsed_args.generate_cli_skeleton = 'input'
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
                 parsed_args=parsed_args, parsed_globals=None
@@ -93,7 +93,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
     def test_no_generate_json_skeleton(self):
         parsed_args = mock.Mock()
         parsed_args.generate_cli_skeleton = None
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
                 parsed_args=parsed_args, parsed_globals=None
@@ -110,7 +110,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         # Set the input shape to ``None``.
         self.argument = GenerateCliSkeletonArgument(
             self.session, mock.Mock(input_shape=None))
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
                 parsed_args=parsed_args, parsed_globals=None
@@ -137,7 +137,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         operation_model = mock.Mock(input_shape=shape)
         argument = GenerateCliSkeletonArgument(
             self.session, operation_model)
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', io.StringIO()) as mock_stdout:
             rc = argument.generate_json_skeleton(
                 call_parameters=None, parsed_args=parsed_args,
                 parsed_globals=None

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -12,8 +12,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore.compat import json
+import io
 import platform
-from awscli.compat import six
 from awscli.formatter import JSONFormatter
 
 from awscli.testutils import BaseAWSCommandParamsTest, unittest
@@ -105,7 +105,7 @@ class TestListUsers(BaseAWSCommandParamsTest):
     def test_json_prints_unicode_chars(self):
         self.parsed_response['Users'][1]['UserId'] = u'\u2713'
         output = self.run_cmd('iam list-users', expected_rc=0)[0]
-        with mock.patch('sys.stdout', six.StringIO()) as f:
+        with mock.patch('sys.stdout', io.StringIO()) as f:
             out = get_stdout_text_writer()
             out.write(u'\u2713')
             expected = f.getvalue()
@@ -120,7 +120,7 @@ class TestFormattersHandleClosedPipes(unittest.TestCase):
         args = mock.Mock(query=None)
         operation = mock.Mock(can_paginate=False)
         response = '{"Foo": "Bar"}'
-        fake_closed_stream = mock.Mock(spec=six.StringIO)
+        fake_closed_stream = mock.Mock(spec=io.StringIO)
         fake_closed_stream.flush.side_effect = IOError
         formatter = JSONFormatter(args)
         formatter('command_name', response, stream=fake_closed_stream)

--- a/tests/unit/output/test_table_formatter.py
+++ b/tests/unit/output/test_table_formatter.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 import unittest
-from awscli.compat import six
 
 from awscli.formatter import TableFormatter
 from awscli.table import MultiTable, Styler
@@ -378,7 +378,7 @@ class TestTableFormatter(unittest.TestCase):
                                 auto_reformat=False)
         self.formatter = TableFormatter(Object(color='off'))
         self.formatter.table = self.table
-        self.stream = six.StringIO()
+        self.stream = io.StringIO()
 
     def assert_data_renders_to(self, data, table):
         self.formatter('OperationName', data, stream=self.stream)

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -13,6 +13,7 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import mock, unittest
+import io
 import json
 import os
 import sys
@@ -20,7 +21,6 @@ import re
 import locale
 
 from awscli.compat import six
-from six.moves import cStringIO
 
 from awscli.formatter import Formatter
 
@@ -164,7 +164,7 @@ class TestDefaultStream(BaseAWSCommandParamsTest):
     @unittest.skipIf(six.PY3, "Text writer only vaild on py3.")
     def test_default_stream_with_table_output(self):
         formatter = CustomFormatter(None)
-        stream = cStringIO()
+        stream = io.StringIO()
         with mock.patch('sys.stdout', stream):
             formatter(None, None)
             formatter.stream.write(u'\u00e9')

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -314,13 +314,13 @@ class TestCliDriver(unittest.TestCase):
         self.assertEqual(rc, 130)
 
     def test_error_unicode(self):
-        # We need a different type for Py3 and Py2 because on Py3 six.StringIO
+        # We need a different type for Py3 and Py2 because on Py3 io.StringIO
         # doesn't let us set the encoding and returns a string.
         if six.PY3:
             stderr_b = io.BytesIO()
             stderr = io.TextIOWrapper(stderr_b, encoding="UTF-8")
         else:
-            stderr = stderr_b = six.StringIO()
+            stderr = stderr_b = io.StringIO()
             stderr.encoding = "UTF-8"
         driver = CLIDriver(session=self.session)
         fake_client = mock.Mock()
@@ -341,8 +341,8 @@ class TestCliDriverHooks(unittest.TestCase):
         self.session = FakeSession()
         self.emitter = mock.Mock()
         self.emitter.emit.return_value = []
-        self.stdout = six.StringIO()
-        self.stderr = six.StringIO()
+        self.stdout = io.StringIO()
+        self.stderr = io.StringIO()
         self.stdout_patch = mock.patch('sys.stdout', self.stdout)
         #self.stdout_patch.start()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
@@ -440,7 +440,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
     # but with the http part mocked out.
     def setUp(self):
         super(TestAWSCommand, self).setUp()
-        self.stderr = six.StringIO()
+        self.stderr = io.StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
 
@@ -807,7 +807,7 @@ class TestHTTPParamFileDoesNotExist(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestHTTPParamFileDoesNotExist, self).setUp()
-        self.stderr = six.StringIO()
+        self.stderr = io.StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
 

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -11,13 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import mock, unittest, skip_if_windows, FileCreator
+import io
 import signal
 import platform
 import json
 import sys
 import os
 
-from awscli.compat import six
 from awscli.help import PosixHelpRenderer, ExecutableNotFoundError
 from awscli.help import WindowsHelpRenderer, ProviderHelpCommand, HelpCommand
 from awscli.help import TopicListerCommand, TopicHelpCommand
@@ -106,7 +106,7 @@ class TestHelpPager(unittest.TestCase):
 
     @skip_if_windows('Requires POSIX system.')
     def test_renderer_falls_back_to_mandoc(self):
-        stdout = six.StringIO()
+        stdout = io.StringIO()
         renderer = FakePosixHelpRenderer(output_stream=stdout)
 
         renderer.exists_on_path['groff'] = False
@@ -119,7 +119,7 @@ class TestHelpPager(unittest.TestCase):
     def test_no_pager_exists(self):
         fake_pager = 'foobar'
         os.environ['MANPAGER'] = fake_pager
-        stdout = six.StringIO()
+        stdout = io.StringIO()
         renderer = FakePosixHelpRenderer(output_stream=stdout)
         renderer.exists_on_path[fake_pager] = False
 

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -19,9 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
+import io
 import sys
 
-from awscli.compat import six
 from awscli.testutils import mock, unittest
 
 from awscli import text
@@ -30,7 +30,7 @@ from awscli import text
 class TestSection(unittest.TestCase):
     def format_text(self, data, stream=None):
         if stream is None:
-            stream = six.StringIO()
+            stream = io.StringIO()
         text.format_text(data, stream=stream)
         return stream.getvalue()
 


### PR DESCRIPTION
Description: trim `six` usage in a controlled way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
