### PR TITLE
[v2] End of support for macOS 10.14 and prior

### DIFF
--- a/.changes/next-release/feature-macOS-4122.json
+++ b/.changes/next-release/feature-macOS-4122.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "macOS",
+  "description": "End of support for macOS 10.14 and prior"
+}

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ The aws-cli package works on Python versions:
 -------
 Notices
 -------
-On 2024-06-20, support for macOS versions 10.14 and prior will be dropped.
+On 2024-06-20, support for macOS versions 10.14 and prior was dropped.
 To avoid disruption, customers using macOS 10.14 or prior
 should upgrade to macOS 10.15 or later. For more information, please see
 this `blog post <https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/>`__.

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The aws-cli package works on Python versions:
 Notices
 -------
 On 2024-06-20, support for macOS versions 10.14 and prior was dropped.
-To avoid disruption, customers using macOS 10.14 or prior
+To use up-to-date versions of AWS CLI v2, customers using macOS 10.14 or prior
 should upgrade to macOS 10.15 or later. For more information, please see
 this `blog post <https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/>`__.
 

--- a/configure
+++ b/configure
@@ -2122,8 +2122,8 @@ printf "%s\n" "unknown" >&6; }
             "$sys_version_minor" -lt "$min_version_minor"; then
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: pending-end-of-support" >&5
 printf "%s\n" "pending-end-of-support" >&6; }
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: On $end_support_date, the AWS CLI v2 will drop support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&5
-printf "%s\n" "$as_me: WARNING: On $end_support_date, the AWS CLI v2 will drop support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&2;}
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: On $end_support_date, the AWS CLI v2 dropped support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&5
+printf "%s\n" "$as_me: WARNING: On $end_support_date, the AWS CLI v2 dropped support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&2;}
         else
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: supported" >&5
 printf "%s\n" "supported" >&6; }

--- a/configure
+++ b/configure
@@ -2122,8 +2122,8 @@ printf "%s\n" "unknown" >&6; }
             "$sys_version_minor" -lt "$min_version_minor"; then
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: pending-end-of-support" >&5
 printf "%s\n" "pending-end-of-support" >&6; }
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: On $end_support_date, the AWS CLI v2 dropped support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&5
-printf "%s\n" "$as_me: WARNING: On $end_support_date, the AWS CLI v2 dropped support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&2;}
+            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: On $end_support_date, the AWS CLI v2 dropped support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&5
+printf "%s\n" "$as_me: WARNING: On $end_support_date, the AWS CLI v2 dropped support for macOS versions below $min_version. macOS $ac_macos_version was detected for this system. Please upgrade to macOS version $min_version or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/" >&2;}
         else
             { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: supported" >&5
 printf "%s\n" "supported" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_SUBST(DOWNLOAD_DEPS_FLAG)
 
 ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
 if test "$ac_operating_system" = Darwin; then
-    AC_CHECK_PENDING_MACOS_END_OF_SUPPORT([10.15.0], [June 20, 2024])
+    AC_CHECK_MACOS_END_OF_SUPPORT([10.15.0], [June 20, 2024])
 fi
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/m4/macos_support.m4
+++ b/m4/macos_support.m4
@@ -1,4 +1,4 @@
-AC_DEFUN([AC_CHECK_PENDING_MACOS_END_OF_SUPPORT], [
+AC_DEFUN([AC_CHECK_MACOS_END_OF_SUPPORT], [
     min_version='$1'
     end_support_date='$2'
 
@@ -23,7 +23,7 @@ AC_DEFUN([AC_CHECK_PENDING_MACOS_END_OF_SUPPORT], [
             "$sys_version_minor" -lt "$min_version_minor"; then
             AC_MSG_RESULT([pending-end-of-support])
             AC_MSG_WARN(m4_normalize([
-                On $end_support_date, the AWS CLI v2 will drop support
+                On $end_support_date, the AWS CLI v2 dropped support
                 for macOS versions below $min_version. macOS $ac_macos_version
                 was detected for this system. Please upgrade to macOS version
                 $min_version or later to ensure compatibility with future versions

--- a/m4/macos_support.m4
+++ b/m4/macos_support.m4
@@ -26,7 +26,7 @@ AC_DEFUN([AC_CHECK_MACOS_END_OF_SUPPORT], [
                 On $end_support_date, the AWS CLI v2 dropped support
                 for macOS versions below $min_version. macOS $ac_macos_version
                 was detected for this system. Please upgrade to macOS version
-                $min_version or later to ensure compatibility with future versions
+                $min_version or later to use up-to-date versions
                 of AWS CLI v2. For more information, please visit:
                 https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/
             ]))

--- a/macpkg/distribution.xml
+++ b/macpkg/distribution.xml
@@ -10,7 +10,7 @@
     function checkOsVersion() {
       if(system.compareVersions(system.version.ProductVersion, '10.15.0') < 0) {
         my.result.type = 'Warning';
-        my.result.message = 'On June 20, 2024, the AWS CLI v2 dropped support for macOS versions below 10.15.0. Please upgrade to macOS version 10.15.0 or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
+        my.result.message = 'On June 20, 2024, the AWS CLI v2 dropped support for macOS versions below 10.15.0. Please upgrade to macOS version 10.15.0 or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
         return false;
       }
       return true;

--- a/macpkg/distribution.xml
+++ b/macpkg/distribution.xml
@@ -10,7 +10,7 @@
     function checkOsVersion() {
       if(system.compareVersions(system.version.ProductVersion, '10.15.0') < 0) {
         my.result.type = 'Warning';
-        my.result.message = 'On June 20, 2024, the AWS CLI v2 will drop support for macOS versions below 10.15.0. Please upgrade to macOS version 10.15.0 or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
+        my.result.message = 'On June 20, 2024, the AWS CLI v2 dropped support for macOS versions below 10.15.0. Please upgrade to macOS version 10.15.0 or later to ensure compatibility with future versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
         return false;
       }
       return true;


### PR DESCRIPTION
Update macOS source distribution and PKG installer warnings following the end of support for macOS versions 10.14 and prior. For more, see the announcement blog post:

https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/

In the future, we should set some flag to determine whether the wording should be `will drop` or `dropped`.