### PR TITLE
Remove six from awscli codebase

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import argparse
 import sys
-from awscli.compat import six
 from difflib import get_close_matches
 
 
@@ -106,12 +105,12 @@ class CLIArgParser(argparse.ArgumentParser):
             # default to utf-8.
             terminal_encoding = 'utf-8'
         for arg, value in vars(parsed).items():
-            if isinstance(value, six.binary_type):
+            if isinstance(value, bytes):
                 setattr(parsed, arg, value.decode(terminal_encoding))
             elif isinstance(value, list):
                 encoded = []
                 for v in value:
-                    if isinstance(v, six.binary_type):
+                    if isinstance(v, bytes):
                         encoded.append(v.decode(terminal_encoding))
                     else:
                         encoded.append(v)

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -13,7 +13,6 @@
 """Module for processing CLI args."""
 import os
 import logging
-from awscli.compat import six
 
 from botocore.compat import OrderedDict, json
 
@@ -166,7 +165,7 @@ def _unpack_cli_arg(argument_model, value, cli_name):
         return _unpack_complex_cli_arg(
             argument_model, value, cli_name)
     else:
-        return six.text_type(value)
+        return str(value)
 
 
 def _unpack_json_cli_arg(argument_model, value, cli_name):
@@ -185,7 +184,7 @@ def _unpack_complex_cli_arg(argument_model, value, cli_name):
             return _unpack_json_cli_arg(argument_model, value, cli_name)
         raise ParamError(cli_name, "Invalid JSON:\n%s" % value)
     elif type_name == 'list':
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             if value.lstrip()[0] == '[':
                 return _unpack_json_cli_arg(argument_model, value, cli_name)
         elif isinstance(value, list) and len(value) == 1:
@@ -226,7 +225,7 @@ def unpack_scalar_cli_arg(argument_model, value, cli_name=''):
             raise ParamError(cli_name, msg)
         return open(file_path, 'rb')
     elif argument_model.type_name == 'boolean':
-        if isinstance(value, six.string_types) and value.lower() == 'false':
+        if isinstance(value, str) and value.lower() == 'false':
             return False
         return bool(value)
     else:
@@ -401,7 +400,7 @@ class ParamShorthandParser(ParamShorthand):
             check_val = value[0]
         else:
             check_val = value
-        if isinstance(check_val, six.string_types) and check_val.strip().startswith(
+        if isinstance(check_val, str) and check_val.strip().startswith(
                 ('[', '{')):
             LOG.debug("Param %s looks like JSON, not considered for "
                       "param shorthand.", cli_argument.py_name)

--- a/awscli/bcdoc/docstringparser.py
+++ b/awscli/bcdoc/docstringparser.py
@@ -10,10 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.compat import six
+from html.parser import HTMLParser
 
 
-class DocStringParser(six.moves.html_parser.HTMLParser):
+class DocStringParser(HTMLParser):
     """
     A simple HTML parser.  Focused on converting the subset of HTML
     that appears in the documentation strings of the JSON models into
@@ -23,20 +23,20 @@ class DocStringParser(six.moves.html_parser.HTMLParser):
     def __init__(self, doc):
         self.tree = None
         self.doc = doc
-        six.moves.html_parser.HTMLParser.__init__(self)
+        HTMLParser.__init__(self)
 
     def reset(self):
-        six.moves.html_parser.HTMLParser.reset(self)
+        HTMLParser.reset(self)
         self.tree = HTMLTree(self.doc)
 
     def feed(self, data):
         # HTMLParser is an old style class, so the super() method will not work.
-        six.moves.html_parser.HTMLParser.feed(self, data)
+        HTMLParser.feed(self, data)
         self.tree.write()
         self.tree = HTMLTree(self.doc)
 
     def close(self):
-        six.moves.html_parser.HTMLParser.close(self)
+        HTMLParser.close(self)
         # Write if there is anything remaining.
         self.tree.write()
         self.tree = HTMLTree(self.doc)
@@ -176,7 +176,7 @@ class DataNode(Node):
     """
     def __init__(self, data, parent=None):
         super(DataNode, self).__init__(parent)
-        if not isinstance(data, six.string_types):
+        if not isinstance(data, str):
             raise ValueError("Expecting string type, %s given." % type(data))
         self.data = data
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -29,7 +29,6 @@ from awscli.compat import get_stderr_text_writer
 from awscli.formatter import get_formatter
 from awscli.plugin import load_plugins
 from awscli.commands import CLICommand
-from awscli.compat import six
 from awscli.argparser import MainArgParser
 from awscli.argparser import ServiceArgParser
 from awscli.argparser import ArgTableArgParser

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -19,25 +19,29 @@ import platform
 import zipfile
 import signal
 import contextlib
+import queue
+import io
+import collections.abc as collections_abc
+import locale
+import urllib.parse as urlparse
+from urllib.error import URLError
+from urllib.request import urlopen
 from configparser import RawConfigParser
 from functools import partial
 
-from botocore.compat import six
-#import botocore.compat
+from urllib.error import URLError
 
+from botocore.compat import six
 from botocore.compat import OrderedDict
 
-# If you ever want to import from the vendored six. Add it here and then
-# import from awscli.compat. Also try to keep it in alphabetical order.
-# This may get large.
-advance_iterator = six.advance_iterator
-PY3 = six.PY3
-queue = six.moves.queue
-shlex_quote = six.moves.shlex_quote
-StringIO = six.StringIO
-BytesIO = six.BytesIO
-urlopen = six.moves.urllib.request.urlopen
-binary_type = six.binary_type
+# Backwards compatible definitions from six
+PY3 = sys.version_info[0] == 3
+advance_iterator = next
+shlex_quote = shlex.quote
+StringIO = io.StringIO
+BytesIO = io.BytesIO
+binary_type = bytes
+raw_input = input
 
 
 # Most, but not all, python installations will have zlib. This is required to
@@ -104,89 +108,33 @@ def ensure_text_type(s):
     raise ValueError("Expected str, unicode or bytes, received %s." % type(s))
 
 
-if six.PY3:
-    import collections.abc as collections_abc
-    import locale
-    import urllib.parse as urlparse
+def get_binary_stdin():
+    if sys.stdin is None:
+        raise StdinMissingError()
+    return sys.stdin.buffer
 
-    from urllib.error import URLError
 
-    raw_input = input
+def get_binary_stdout():
+    return sys.stdout.buffer
 
-    def get_binary_stdin():
-        if sys.stdin is None:
-            raise StdinMissingError()
-        return sys.stdin.buffer
 
-    def get_binary_stdout():
-        return sys.stdout.buffer
+def _get_text_writer(stream, errors):
+    return stream
 
-    def _get_text_writer(stream, errors):
-        return stream
 
-    def bytes_print(statement, stdout=None):
-        """
-        This function is used to write raw bytes to stdout.
-        """
-        if stdout is None:
-            stdout = sys.stdout
+def bytes_print(statement, stdout=None):
+    """
+    This function is used to write raw bytes to stdout.
+    """
+    if stdout is None:
+        stdout = sys.stdout
 
-        if getattr(stdout, 'buffer', None):
-            stdout.buffer.write(statement)
-        else:
-            # If it is not possible to write to the standard out buffer.
-            # The next best option is to decode and write to standard out.
-            stdout.write(statement.decode('utf-8'))
-
-else:
-    import codecs
-    import collections as collections_abc
-    import locale
-    import io
-    import urlparse
-
-    from urllib2 import URLError
-
-    raw_input = raw_input
-
-    def get_binary_stdin():
-        if sys.stdin is None:
-            raise StdinMissingError()
-        return sys.stdin
-
-    def get_binary_stdout():
-        return sys.stdout
-
-    def _get_text_writer(stream, errors):
-        # In python3, all the sys.stdout/sys.stderr streams are in text
-        # mode.  This means they expect unicode, and will encode the
-        # unicode automatically before actually writing to stdout/stderr.
-        # In python2, that's not the case.  In order to provide a consistent
-        # interface, we can create a wrapper around sys.stdout that will take
-        # unicode, and automatically encode it to the preferred encoding.
-        # That way consumers can just call get_text_writer(stream) and write
-        # unicode to the returned stream.  Note that get_text_writer
-        # just returns the stream in the PY3 section above because python3
-        # handles this.
-
-        # We're going to use the preferred encoding, but in cases that there is
-        # no preferred encoding we're going to fall back to assuming ASCII is
-        # what we should use. This will currently break the use of
-        # PYTHONIOENCODING, which would require checking stream.encoding first,
-        # however, the existing behavior is to only use
-        # locale.getpreferredencoding() and so in the hope of not breaking what
-        # is currently working, we will continue to only use that.
-        encoding = locale.getpreferredencoding()
-        if encoding is None:
-            encoding = "ascii"
-
-        return codecs.getwriter(encoding)(stream, errors)
-
-    def bytes_print(statement, stdout=None):
-        if stdout is None:
-            stdout = sys.stdout
-
-        stdout.write(statement)
+    if getattr(stdout, 'buffer', None):
+        stdout.buffer.write(statement)
+    else:
+        # If it is not possible to write to the standard out buffer.
+        # The next best option is to decode and write to standard out.
+        stdout.write(statement.decode('utf-8'))
 
 
 def compat_open(filename, mode='r', encoding=None, access_permissions=None):
@@ -252,7 +200,7 @@ def compat_shell_quote(s, platform=None):
     if platform == "win32":
         return _windows_shell_quote(s)
     else:
-        return shlex_quote(s)
+        return shlex.quote(s)
 
 
 def _windows_shell_quote(s):

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -101,9 +101,9 @@ class NonTranslatedStdout(object):
 
 
 def ensure_text_type(s):
-    if isinstance(s, six.text_type):
+    if isinstance(s, str):
         return s
-    if isinstance(s, six.binary_type):
+    if isinstance(s, bytes):
         return s.decode('utf-8')
     raise ValueError("Expected str, unicode or bytes, received %s." % type(s))
 

--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -14,9 +14,8 @@ import zipfile
 import copy
 from contextlib import closing
 
-from botocore.vendored import six
-
 from awscli.arguments import CustomArgument, CLIArgument
+from awscli.compat import BytesIO
 
 
 ERROR_MSG = (
@@ -90,7 +89,7 @@ def _should_contain_zip_content(value):
         # still try to load the contents as a zip file
         # to be absolutely sure.
         value = value.encode('utf-8')
-    fileobj = six.BytesIO(value)
+    fileobj = BytesIO(value)
     try:
         with closing(zipfile.ZipFile(fileobj)) as f:
             f.infolist()

--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -18,7 +18,6 @@ import zipfile
 import contextlib
 import uuid
 import shutil
-from awscli.compat import six
 from botocore.utils import set_value_from_jmespath
 
 from awscli.compat import urlparse
@@ -33,7 +32,7 @@ LOG = logging.getLogger(__name__)
 
 
 def is_path_value_valid(path):
-    return isinstance(path, six.string_types)
+    return isinstance(path, str)
 
 
 def make_abs_path(directory, path):
@@ -70,7 +69,7 @@ def parse_s3_url(url,
                  object_key_property="Key",
                  version_property=None):
 
-    if isinstance(url, six.string_types) \
+    if isinstance(url, str) \
             and url.startswith("s3://"):
 
         # Python < 2.7.10 don't parse query parameters from URI with custom

--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -16,8 +16,6 @@ from botocore.compat import OrderedDict
 import yaml
 from yaml.resolver import ScalarNode, SequenceNode
 
-from awscli.compat import six
-
 
 def intrinsics_multi_constructor(loader, tag_prefix, node):
     """
@@ -35,7 +33,7 @@ def intrinsics_multi_constructor(loader, tag_prefix, node):
 
     cfntag = prefix + tag
 
-    if tag == "GetAtt" and isinstance(node.value, six.string_types):
+    if tag == "GetAtt" and isinstance(node.value, str):
         # ShortHand notation for !GetAtt accepts Resource.Attribute format
         # while the standard notation is to use an array
         # [Resource, Attribute]. Convert shorthand to standard format

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -20,10 +20,9 @@ from datetime import datetime
 
 from botocore.exceptions import ClientError
 
-from awscli.compat import six
 from awscli.customizations.codedeploy.utils import validate_s3_location
 from awscli.customizations.commands import BasicCommand
-from awscli.compat import ZIP_COMPRESSION_MODE
+from awscli.compat import BytesIO, ZIP_COMPRESSION_MODE
 
 
 ONE_MB = 1 << 20
@@ -246,7 +245,7 @@ class Push(BasicCommand):
                     Key=params.key,
                     UploadId=upload_id,
                     PartNumber=part_num,
-                    Body=six.BytesIO(data)
+                    Body=BytesIO(data)
                 )
                 multipart_list.append({
                     'PartNumber': part_num,

--- a/awscli/customizations/configure/__init__.py
+++ b/awscli/customizations/configure/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import string
-from botocore.vendored.six.moves import shlex_quote
+from awscli.compat import shlex
 
 NOT_SET = '<not set>'
 PREDEFINED_SECTION_NAMES = ('preview', 'plugins')
@@ -45,5 +45,5 @@ def mask_value(current_value):
 def profile_to_section(profile_name):
     """Converts a profile name to a section header to be used in the config."""
     if any(c in _WHITESPACE for c in profile_name):
-        profile_name = shlex_quote(profile_name)
+        profile_name = shlex.quote(profile_name)
     return 'profile %s' % profile_name

--- a/awscli/customizations/configure/get.py
+++ b/awscli/customizations/configure/get.py
@@ -14,7 +14,6 @@ import sys
 import logging
 
 from awscli.customizations.commands import BasicCommand
-from awscli.compat import six
 
 from . import PREDEFINED_SECTION_NAMES
 
@@ -56,7 +55,7 @@ class ConfigureGetCommand(BasicCommand):
 
         LOG.debug(u'Config value retrieved: %s' % value)
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             self._stream.write(value)
             self._stream.write('\n')
             return 0

--- a/awscli/customizations/dynamodb.py
+++ b/awscli/customizations/dynamodb.py
@@ -14,8 +14,6 @@ import base64
 import binascii
 import logging
 
-from awscli.compat import six
-
 logger = logging.getLogger(__name__)
 
 

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -17,8 +17,6 @@ import hmac
 import base64
 import datetime
 
-from awscli.compat import six
-
 from awscli.arguments import CustomArgument
 
 logger = logging.getLogger('ec2bundleinstance')
@@ -132,9 +130,9 @@ def _generate_signature(params):
     policy = params.get('UploadPolicy')
     sak = params.get('_SAK')
     if policy and sak:
-        policy = base64.b64encode(six.b(policy)).decode('utf-8')
+        policy = base64.b64encode(policy.encode('latin-1')).decode('utf-8')
         new_hmac = hmac.new(sak.encode('utf-8'), digestmod=sha1)
-        new_hmac.update(six.b(policy))
+        new_hmac.update(policy.encode('latin-1'))
         ps = base64.encodebytes(new_hmac.digest()).strip().decode('utf-8')
         params['UploadPolicySignature'] = ps
         del params['_SAK']

--- a/awscli/customizations/ec2/decryptpassword.py
+++ b/awscli/customizations/ec2/decryptpassword.py
@@ -14,7 +14,6 @@ import logging
 import os
 import base64
 import rsa
-from awscli.compat import six
 
 from botocore import model
 
@@ -109,7 +108,7 @@ class LaunchKeyArgument(BaseCLIArgument):
             try:
                 with open(self._key_path) as pk_file:
                     pk_contents = pk_file.read()
-                    private_key = rsa.PrivateKey.load_pkcs1(six.b(pk_contents))
+                    private_key = rsa.PrivateKey.load_pkcs1(pk_contents.encode("latin-1"))
                     value = base64.b64decode(value)
                     value = rsa.decrypt(value, private_key)
                     logger.debug(parsed)

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -19,7 +19,6 @@ import xml.dom.minidom
 import colorama
 
 from awscli.table import COLORAMA_KWARGS
-from awscli.compat import six
 from awscli.customizations.history.commands import HistorySubcommand
 from awscli.customizations.history.filters import RegexFilter
 
@@ -213,7 +212,7 @@ class DetailedFormatter(Formatter):
         self._write_output(formatted_value)
 
     def _write_output(self, content):
-        if isinstance(content, six.text_type):
+        if isinstance(content, str):
             content = content.encode('utf-8')
         self._output.write(content)
 

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -24,7 +24,7 @@ import textwrap
 
 from botocore.exceptions import ClientError
 
-from awscli.compat import shlex_quote, urlopen, ensure_text_type
+from awscli.compat import urlopen, ensure_text_type
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import create_client_from_parsed_globals
 
@@ -475,7 +475,7 @@ class OpsWorksRegister(BasicCommand):
                 call.append(self._use_address)
 
             remote_call = ["/bin/sh", "-c", remote_script]
-            call.append(" ".join(shlex_quote(word) for word in remote_call))
+            call.append(" ".join(shlex.quote(word) for word in remote_call))
             subprocess.check_call(call)
 
     def _pre_config_document(self, args):

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -21,7 +21,6 @@ from botocore.exceptions import ClientError
 from awscli.customizations.s3.utils import find_bucket_key, get_file_stat
 from awscli.customizations.s3.utils import BucketLister, create_warning, \
     find_dest_path_comp_key, EPOCH_TIME
-from awscli.compat import six
 from awscli.compat import queue
 
 _open = open
@@ -250,7 +249,7 @@ class FileGenerator(object):
         happens we warn using a FileDecodingError that provides more
         information into what's going on.
         """
-        if not isinstance(filename, six.text_type):
+        if not isinstance(filename, str):
             decoding_error = FileDecodingError(dirname, filename)
             warning = create_warning(repr(filename),
                                      decoding_error.error_message)

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -19,7 +19,6 @@ from botocore.utils import is_s3express_bucket, ensure_boolean
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
 
-from awscli.compat import six
 from awscli.compat import queue
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.s3.comparator import Comparator
@@ -739,7 +738,7 @@ class S3TransferCommand(S3Command):
             parsed_args.paths = [parsed_args.paths]
         for i in range(len(parsed_args.paths)):
             path = parsed_args.paths[i]
-            if isinstance(path, six.binary_type):
+            if isinstance(path, bytes):
                 dec_path = path.decode(sys.getfilesystemencoding())
                 enc_path = dec_path.encode('utf-8')
                 new_path = enc_path.decode('utf-8')

--- a/awscli/customizations/s3/transferconfig.py
+++ b/awscli/customizations/s3/transferconfig.py
@@ -13,7 +13,6 @@
 from s3transfer.manager import TransferConfig
 
 from awscli.customizations.s3.utils import human_readable_to_bytes
-from awscli.compat import six
 # If the user does not specify any overrides,
 # these are the default values we use for the s3 transfer
 # commands.
@@ -64,13 +63,13 @@ class RuntimeConfig(object):
     def _convert_human_readable_sizes(self, runtime_config):
         for attr in self.HUMAN_READABLE_SIZES:
             value = runtime_config.get(attr)
-            if value is not None and not isinstance(value, six.integer_types):
+            if value is not None and not isinstance(value, int):
                 runtime_config[attr] = human_readable_to_bytes(value)
 
     def _convert_human_readable_rates(self, runtime_config):
         for attr in self.HUMAN_READABLE_RATES:
             value = runtime_config.get(attr)
-            if value is not None and not isinstance(value, six.integer_types):
+            if value is not None and not isinstance(value, int):
                 if not value.endswith('B/s'):
                     raise InvalidConfigError(
                         'Invalid rate: %s. The value must be expressed '

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -17,7 +17,6 @@ import copy
 from botocore.awsrequest import AWSRequest
 from botocore.httpsession import URLLib3Session
 from botocore.exceptions import ProfileNotFound
-from awscli.compat import six
 
 from awscli.compat import compat_open
 from awscli.argprocess import ParamError
@@ -197,7 +196,7 @@ class URIArgumentHandler(object):
         try:
             return get_paramfile(value, self._prefixes)
         except ResourceLoadingError as e:
-            raise ParamError(param.cli_name, six.text_type(e))
+            raise ParamError(param.cli_name, str(e))
 
 
 def get_paramfile(path, cases):
@@ -224,7 +223,7 @@ def get_paramfile(path, cases):
 
     """
     data = None
-    if isinstance(path, six.string_types):
+    if isinstance(path, str):
         for prefix, function_spec in cases.items():
             if path.startswith(prefix):
                 function, kwargs = function_spec

--- a/awscli/table.py
+++ b/awscli/table.py
@@ -17,7 +17,6 @@ import unicodedata
 import colorama
 
 from awscli.utils import is_a_tty
-from awscli.compat import six
 
 
 # `autoreset` allows us to not have to sent reset sequences for every
@@ -35,7 +34,7 @@ def get_text_length(text):
     # * A(Ambiguous)
     # * F(Fullwidth)
     # * W(Wide)
-    text = six.text_type(text)
+    text = str(text)
     return sum(2 if unicodedata.east_asian_width(char) in 'WFA' else 1
                for char in text)
 
@@ -412,7 +411,7 @@ class Section(object):
         self._update_max_widths(row)
 
     def _format_row(self, row):
-        return [six.text_type(r) for r in row]
+        return [str(r) for r in row]
 
     def _update_max_widths(self, row):
         if not self._max_widths:

--- a/awscli/text.py
+++ b/awscli/text.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
 
 
 def format_text(data, stream):
@@ -25,7 +24,7 @@ def _format_text(item, stream, identifier=None, scalar_keys=None):
     else:
         # If it's not a list or a dict, we just write the scalar
         # value out directly.
-        stream.write(six.text_type(item))
+        stream.write(str(item))
         stream.write('\n')
 
 
@@ -66,7 +65,7 @@ def _format_scalar_list(elements, identifier, stream):
                                        item))
     else:
         # For a bare list, just print the contents.
-        stream.write('\t'.join([six.text_type(item) for item in elements]))
+        stream.write('\t'.join([str(item) for item in elements]))
         stream.write('\n')
 
 
@@ -107,10 +106,10 @@ def _partition_dict(item_dict, scalar_keys):
             if isinstance(value, (dict, list)):
                 non_scalar.append((key, value))
             else:
-                scalar.append(six.text_type(value))
+                scalar.append(str(value))
     else:
         for key in scalar_keys:
-            scalar.append(six.text_type(item_dict.get(key, '')))
+            scalar.append(str(item_dict.get(key, '')))
         remaining_keys = sorted(set(item_dict.keys()) - set(scalar_keys))
         for remaining_key in remaining_keys:
             non_scalar.append((remaining_key, item_dict[remaining_key]))

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -18,9 +18,9 @@ import os
 import sys
 import subprocess
 
-from awscli.compat import six
-from awscli.compat import get_binary_stdout
-from awscli.compat import get_popen_kwargs_for_pager_cmd
+from awscli.compat import (
+    BytesIO, StringIO, get_binary_stdout, get_popen_kwargs_for_pager_cmd
+)
 
 
 def split_on_commas(value):
@@ -29,7 +29,7 @@ def split_on_commas(value):
         return value.split(',')
     elif not any(char in value for char in ['"', "'", '[', ']']):
         # Simple escaping, let the csv module handle it.
-        return list(csv.reader(six.StringIO(value), escapechar='\\'))[0]
+        return list(csv.reader(StringIO(value), escapechar='\\'))[0]
     else:
         # If there's quotes for the values, we have to handle this
         # ourselves.
@@ -38,7 +38,7 @@ def split_on_commas(value):
 
 def _split_with_quotes(value):
     try:
-        parts = list(csv.reader(six.StringIO(value), escapechar='\\'))[0]
+        parts = list(csv.reader(StringIO(value), escapechar='\\'))[0]
     except csv.Error:
         raise ValueError("Bad csv value: %s" % value)
     iter_parts = iter(parts)
@@ -88,7 +88,7 @@ def _eat_items(value, iter_parts, part, end_char, replace_char=''):
     chunks = [current.replace(replace_char, '')]
     while True:
         try:
-            current = six.advance_iterator(iter_parts)
+            current = next(iter_parts)
         except StopIteration:
             raise ValueError(value)
         chunks.append(current.replace(replace_char, ''))
@@ -236,7 +236,7 @@ class OutputStreamFactory(object):
 
 def write_exception(ex, outfile):
     outfile.write("\n")
-    outfile.write(six.text_type(ex))
+    outfile.write(str(ex))
     outfile.write("\n")
 
 

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import gzip
 
-from awscli.compat import six
 from botocore.exceptions import ClientError
 from tests.unit.customizations.cloudtrail.test_validation import \
     create_scenario, TEST_TRAIL_ARN, START_DATE, END_DATE, VALID_TEST_KEY, \
@@ -20,6 +19,7 @@ from tests.unit.customizations.cloudtrail.test_validation import \
 from awscli.testutils import mock, BaseAWSCommandParamsTest
 from awscli.customizations.cloudtrail.validation import DigestTraverser, \
     DATE_FORMAT, format_display_date, S3ClientProvider
+from awscli.compat import BytesIO
 from botocore.handlers import parse_get_bucket_location
 
 RETRIEVER_FUNCTION = 'awscli.customizations.cloudtrail.validation.create_digest_traverser'
@@ -28,7 +28,7 @@ END_TIME_ARG = END_DATE.strftime(DATE_FORMAT)
 
 
 def _gz_compress(data):
-    out = six.BytesIO()
+    out = BytesIO()
     f = gzip.GzipFile(fileobj=out, mode="wb")
     f.write(data.encode())
     f.close()
@@ -96,7 +96,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
     def test_verbose_output_shows_happy_case(self):
         self.parsed_responses = [
             {'LocationConstraint': 'us-east-1'},
-            {'Body': six.BytesIO(_gz_compress(self._logs[0]['_raw_value']))}
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))}
         ]
         key_provider, digest_provider, validator = create_scenario(
             ['gap', 'link'], [[], [self._logs[0]]])
@@ -226,7 +226,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             ['gap'], [[self._logs[0]]])
         self.parsed_responses = [
             {'LocationConstraint': ''},
-            {'Body': six.BytesIO(_gz_compress('does not match'))}
+            {'Body': BytesIO(_gz_compress('does not match'))}
         ]
         _setup_mock_traverser(self._mock_traverser, key_provider,
                               digest_provider, validator)
@@ -242,9 +242,9 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             [[self._logs[2]], [], [self._logs[0], self._logs[1]]])
         self.parsed_responses = [
             {'LocationConstraint': ''},
-            {'Body': six.BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
-            {'Body': six.BytesIO(_gz_compress(self._logs[1]['_raw_value']))},
-            {'Body': six.BytesIO(_gz_compress(self._logs[2]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[1]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[2]['_raw_value']))},
         ]
         _setup_mock_traverser(self._mock_traverser, key_provider,
                               digest_provider, validator)
@@ -301,7 +301,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         self.parsed_responses = [
             {'LocationConstraint': ''},
             {'Contents': [{'Key': key}]},
-            {'Body': six.BytesIO(_gz_compress(self._logs[0]['_raw_value'])),
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value'])),
              'Metadata': {}},
         ]
         s3_client_provider = S3ClientProvider(self.driver.session, 'us-east-1')
@@ -323,7 +323,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
     def test_follows_trails_when_bucket_changes(self):
         self.parsed_responses = [
             {'LocationConstraint': 'us-east-1'},
-            {'Body': six.BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
             {'LocationConstraint': 'us-west-2'},
             {'LocationConstraint': 'eu-west-1'}
         ]

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -25,8 +25,8 @@ from awscli.testutils import BaseAWSHelpOutputTest
 from awscli.testutils import FileCreator
 from awscli.testutils import mock
 from awscli.testutils import aws
+from awscli.compat import StringIO
 
-from awscli.compat import six
 from awscli.alias import AliasLoader
 
 
@@ -204,7 +204,7 @@ class TestRemoveDeprecatedCommands(BaseAWSHelpOutputTest):
         # command verify that we get a SystemExit exception
         # and that we get something in stderr that says that
         # we made an invalid choice (because the operation is removed).
-        stderr = six.StringIO()
+        stderr = StringIO()
         with mock.patch('sys.stderr', stderr):
             with self.assertRaises(SystemExit):
                 self.driver.main([service, command, 'help'])

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -14,11 +14,9 @@
 import base64
 import datetime
 
-from six.moves import cStringIO
-
 import awscli.customizations.ec2.bundleinstance
-from awscli.compat import six
 from awscli.testutils import mock, BaseAWSCommandParamsTest
+from awscli.compat import StringIO
 
 
 class TestBundleInstance(BaseAWSCommandParamsTest):
@@ -69,7 +67,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def test_policy_provided(self):
         policy = '{"notarealpolicy":true}'
-        base64policy = base64.encodebytes(six.b(policy)).strip().decode('utf-8')
+        base64policy = base64.encodebytes(policy.encode('latin-1')).strip().decode('utf-8')
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
@@ -88,7 +86,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(args_list, result)
 
     def test_both(self):
-        captured = cStringIO()
+        captured = StringIO()
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
         args = ' --instance-id i-12345678 --owner-aki blah --owner-sak blah --storage %s' % json
         args_list = (self.prefix + args).split()

--- a/tests/functional/ec2/test_create_tags.py
+++ b/tests/functional/ec2/test_create_tags.py
@@ -13,7 +13,6 @@
 # language governing permissions and limitations under the License.
 import sys
 
-from awscli.compat import six
 from awscli.testutils import unittest
 from awscli.testutils import BaseAWSCommandParamsTest
 
@@ -28,18 +27,4 @@ class TestCreateTags(BaseAWSCommandParamsTest):
         result = {
             'Resources': ['i-12345678'],
             'Tags': [{'Key': 'Name', 'Value': 'bar'}]}
-        self.assert_params_for_cmd(cmdline, result)
-
-    @unittest.skipIf(
-        six.PY3, 'Unicode cmd line test only is relevant to python2.')
-    def test_create_tag_unicode(self):
-        cmdline = self.prefix
-        cmdline += u' --resources i-12345678 --tags Key=Name,Value=\u6211'
-        encoding = getattr(sys.stdin, 'encoding', 'utf-8')
-        if encoding is None:
-            encoding = 'utf-8'
-        cmdline = cmdline.encode(encoding)
-        result = {
-            'Resources': ['i-12345678'],
-            'Tags': [{'Key': 'Name', 'Value': u'\u6211'}]}
         self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/elasticbeanstalk/test_create_application.py
+++ b/tests/functional/elasticbeanstalk/test_create_application.py
@@ -13,7 +13,6 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest, unittest
 import sys
-from awscli.compat import six
 
 
 class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
@@ -24,22 +23,4 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --application-name FooBar'
         result = {'ApplicationName': 'FooBar',}
-        self.assert_params_for_cmd(cmdline, result)
-
-    @unittest.skipIf(
-        six.PY3, 'Unicode cmd line test only is relevant to python2.')
-    def test_py2_bytestring_unicode(self):
-        # In Python2, sys.argv is a list of bytestrings that are encoded
-        # in whatever encoding the terminal uses.  We have an extra step
-        # where we need to decode the bytestring into unicode.  In
-        # python3, sys.argv is a list of unicode objects so this test
-        # doesn't make sense for python3.
-        cmdline = self.prefix
-        app_name = u'\u2713'
-        cmdline += u' --application-name %s' % app_name
-        encoding = getattr(sys.stdin, 'encoding')
-        if encoding is None:
-            encoding = 'utf-8'
-        cmdline = cmdline.encode(encoding)
-        result = {'ApplicationName': u'\u2713',}
         self.assert_params_for_cmd(cmdline, result)

--- a/tests/functional/gamelift/test_get_game_session_log.py
+++ b/tests/functional/gamelift/test_get_game_session_log.py
@@ -13,7 +13,7 @@
 import os
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, mock
-from awscli.compat import six
+from awscli.compat import BytesIO
 
 
 class TestGetGameSessionLog(BaseAWSCommandParamsTest):
@@ -28,7 +28,7 @@ class TestGetGameSessionLog(BaseAWSCommandParamsTest):
             'awscli.customizations.gamelift.getlog.urlopen')
         self.contents = b'My Contents'
         self.urlopen_mock = self.urlopen_patch.start()
-        self.urlopen_mock.return_value = six.BytesIO(self.contents)
+        self.urlopen_mock.return_value = BytesIO(self.contents)
 
     def tearDown(self):
         super(TestGetGameSessionLog, self).tearDown()

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -15,7 +15,6 @@ import datetime
 from dateutil.tz import tzutc
 from botocore.compat import urlparse, parse_qs
 
-from awscli.compat import six
 from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
@@ -24,7 +23,7 @@ class TestGenerateDBAuthToken(BaseAWSCommandParamsTest):
     prefix = 'rds generate-db-auth-token'
 
     def _urlparse(self, url):
-        if isinstance(url, six.binary_type):
+        if isinstance(url, bytes):
             # Not really necessary, but it helps to reduce noise on Python 2.x
             url = url.decode('utf8')
         return urlparse(url)

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import mock, BaseAWSCommandParamsTest, FileCreator
-from awscli.compat import six
+from awscli.compat import BytesIO
 
 class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
     def setUp(self):
@@ -57,7 +57,7 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
     def get_object_response(self):
         return {
             'ETag': '"foo-1"',
-            'Body': six.BytesIO(b'foo')
+            'Body': BytesIO(b'foo')
         }
 
     def copy_object_response(self):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -16,12 +16,12 @@ import os
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import capture_input
 from awscli.testutils import mock 
-from awscli.compat import six
+from awscli.compat import BytesIO
 from tests.functional.s3 import BaseS3TransferCommandTest
 from tests import requires_crt
 
 
-class BufferedBytesIO(six.BytesIO):
+class BufferedBytesIO(BytesIO):
     @property
     def buffer(self):
         return self
@@ -178,7 +178,7 @@ class TestCPCommand(BaseCPCommandTest):
     def test_operations_used_in_download_file(self):
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},
-            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+            {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix,
                                                  self.files.rootdir)
@@ -306,7 +306,7 @@ class TestCPCommand(BaseCPCommandTest):
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},
-            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')}
+            {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')}
         ]
         with mock.patch('os.utime') as mock_utime:
             mock_utime.side_effect = OSError(1, '')
@@ -324,7 +324,7 @@ class TestCPCommand(BaseCPCommandTest):
                 ],
                 'CommonPrefixes': []
             },
-            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+            {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
         cmdline = '%s s3://bucket/foo %s --recursive --force-glacier-transfer'\
                   % (self.prefix, self.files.rootdir)
@@ -512,7 +512,7 @@ class TestCPCommand(BaseCPCommandTest):
                 "ContentLength": 4,
                 "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
                 "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
-                "Body": six.BytesIO(b'foo\n')
+                "Body": BytesIO(b'foo\n')
             },
             {}
         ]
@@ -790,7 +790,7 @@ class TestStreamingCPCommand(BaseAWSCommandParamsTest):
                 "ContentLength": 4,
                 "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
                 "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
-                "Body": six.BytesIO(b'foo\n')
+                "Body": BytesIO(b'foo\n')
             }
         ]
 

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -11,8 +11,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
 from awscli.customizations.s3.utils import S3PathResolver
+from awscli.compat import BytesIO
 from tests.functional.s3 import BaseS3TransferCommandTest
 from tests import requires_crt
 
@@ -83,7 +83,7 @@ class TestMvCommand(BaseS3TransferCommandTest):
             # Response for HeadObject
             {"ContentLength": 100, "LastModified": "00:00:00Z"},
             # Response for GetObject
-            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+            {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
             # Response for DeleteObject
             {}
         ]

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -12,8 +12,8 @@
 # language governing permissions and limitations under the License.
 import os
 
-from awscli.compat import six
 from awscli.testutils import mock, cd
+from awscli.compat import BytesIO
 from tests.functional.s3 import BaseS3TransferCommandTest
 
 
@@ -65,7 +65,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
                 {"Key": key, "Size": 3,
                  "LastModified": "2014-01-09T20:45:49.000Z"}]},
             {'ETag': '"c8afdb36c52cf4727836669019e69222-"',
-             'Body': six.BytesIO(b'foo')}
+             'Body': BytesIO(b'foo')}
         ]
         self.run_cmd(cmdline, expected_rc=0)
         # Make sure the file now exists.
@@ -83,7 +83,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
                 ],
                 'CommonPrefixes': []
             },
-            {'ETag': '"foo-1"', 'Body': six.BytesIO(b'foo')},
+            {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
         cmdline = '%s s3://bucket/foo %s --force-glacier-transfer' % (
             self.prefix, self.files.rootdir)

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -12,10 +12,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.compat import StringIO
 import os
 import re
-
-from awscli.compat import six
 
 import awscli.clidriver
 
@@ -26,7 +25,7 @@ class TestGetObject(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestGetObject, self).setUp()
-        self.parsed_response = {'Body': six.StringIO()}
+        self.parsed_response = {'Body': StringIO()}
 
     def remove_file_if_exists(self, filename):
         if os.path.isfile(filename):

--- a/tests/functional/s3api/test_put_bucket_tagging.py
+++ b/tests/functional/s3api/test_put_bucket_tagging.py
@@ -15,7 +15,6 @@ import re
 import copy
 
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.compat import six
 
 
 # file is gone in python3, so instead IOBase must be used.

--- a/tests/functional/s3api/test_put_object.py
+++ b/tests/functional/s3api/test_put_object.py
@@ -16,7 +16,6 @@ import re
 import copy
 
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
-from awscli.compat import six
 
 import awscli.clidriver
 

--- a/tests/functional/ses/test_send_email.py
+++ b/tests/functional/ses/test_send_email.py
@@ -13,9 +13,6 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
 
-from awscli.compat import six
-from six.moves import cStringIO
-
 
 class TestSendEmail(BaseAWSCommandParamsTest):
 

--- a/tests/functional/test_preview.py
+++ b/tests/functional/test_preview.py
@@ -10,9 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
-
 from awscli.customizations import preview
+from awscli.compat import StringIO
 from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
@@ -20,7 +19,7 @@ class TestPreviewMode(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestPreviewMode, self).setUp()
-        self.stderr = six.StringIO()
+        self.stderr = StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
         self.full_config = {'profiles': {}}

--- a/tests/functional/test_streaming_output.py
+++ b/tests/functional/test_streaming_output.py
@@ -11,7 +11,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
+from awscli.compat import BytesIO
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import FileCreator
 
@@ -33,7 +33,7 @@ class TestStreamingOutput(BaseAWSCommandParamsTest):
         )
         self.parsed_response = {
             'ContentType': 'video/webm',
-            'Payload': six.BytesIO(b'testbody')
+            'Payload': BytesIO(b'testbody')
         }
         outpath = self.files.full_path('outfile')
         params = {

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -30,7 +30,7 @@ import logging
 
 import pytest
 
-from awscli.compat import six, urlopen
+from awscli.compat import BytesIO, urlopen
 import botocore.session
 
 from awscli.testutils import unittest, get_stdout_encoding
@@ -188,7 +188,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
     def test_mv_s3_to_s3_multipart(self):
         from_bucket = _SHARED_BUCKET
         to_bucket = self.create_bucket()
-        file_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 10))
+        file_contents = BytesIO(b'abcd' * (1024 * 1024 * 10))
         self.put_object(from_bucket, 'foo.txt', file_contents)
 
         p = aws('s3 mv s3://%s/foo.txt s3://%s/foo.txt' % (from_bucket,
@@ -202,7 +202,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
         from_bucket = _SHARED_BUCKET
         to_bucket = self.create_bucket()
 
-        large_file_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 10))
+        large_file_contents = BytesIO(b'abcd' * (1024 * 1024 * 10))
         small_file_contents = 'small file contents'
         self.put_object(from_bucket, 'largefile', large_file_contents)
         self.put_object(from_bucket, 'smallfile', small_file_contents)
@@ -250,7 +250,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
     def test_mv_with_large_file(self):
         bucket_name = _SHARED_BUCKET
         # 40MB will force a multipart upload.
-        file_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 10))
+        file_contents = BytesIO(b'abcd' * (1024 * 1024 * 10))
         foo_txt = self.files.create_file(
             'foo.txt', file_contents.getvalue().decode('utf-8'))
         p = aws('s3 mv %s s3://%s/foo.txt' % (foo_txt, bucket_name))
@@ -287,7 +287,7 @@ class TestMoveCommand(BaseS3IntegrationTest):
         # but a mv command doesn't make sense because a mv is just a
         # cp + an rm of the src file.  We should be consistent and
         # not allow large files to be mv'd onto themselves.
-        file_contents = six.BytesIO(b'a' * (1024 * 1024 * 10))
+        file_contents = BytesIO(b'a' * (1024 * 1024 * 10))
         bucket_name = _SHARED_BUCKET
         self.put_object(bucket_name, key_name='key.txt',
                         contents=file_contents)
@@ -382,7 +382,7 @@ class TestCp(BaseS3IntegrationTest):
     def test_cp_s3_s3_multipart(self):
         from_bucket = _SHARED_BUCKET
         to_bucket = self.create_bucket()
-        file_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 10))
+        file_contents = BytesIO(b'abcd' * (1024 * 1024 * 10))
         self.put_object(from_bucket, 'foo.txt', file_contents)
 
         p = aws('s3 cp s3://%s/foo.txt s3://%s/foo.txt' %
@@ -407,7 +407,7 @@ class TestCp(BaseS3IntegrationTest):
     def test_download_large_file(self):
         # This will force a multipart download.
         bucket_name = _SHARED_BUCKET
-        foo_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 10))
+        foo_contents = BytesIO(b'abcd' * (1024 * 1024 * 10))
         self.put_object(bucket_name, key_name='foo.txt',
                         contents=foo_contents)
         local_foo_txt = self.files.full_path('foo.txt')
@@ -420,7 +420,7 @@ class TestCp(BaseS3IntegrationTest):
     @skip_if_windows('SIGINT not supported on Windows.')
     def test_download_ctrl_c_does_not_hang(self):
         bucket_name = _SHARED_BUCKET
-        foo_contents = six.BytesIO(b'abcd' * (1024 * 1024 * 40))
+        foo_contents = BytesIO(b'abcd' * (1024 * 1024 * 40))
         self.put_object(bucket_name, key_name='foo.txt',
                         contents=foo_contents)
         local_foo_txt = self.files.full_path('foo.txt')
@@ -993,7 +993,7 @@ class TestUnableToWriteToFile(BaseS3IntegrationTest):
         # which effectively disables the expect 100 continue logic.
         # This will result in a test error because we won't follow
         # the temporary redirect for the newly created bucket.
-        contents = six.BytesIO(b'a' * 10 * 1024 * 1024)
+        contents = BytesIO(b'a' * 10 * 1024 * 1024)
         self.put_object(bucket_name, 'foo.txt',
                         contents=contents)
         os.chmod(self.files.rootdir, 0o444)

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -16,7 +16,7 @@ import os
 
 from datetime import datetime
 
-from six import StringIO
+from awscli.compat import StringIO
 from botocore.session import Session
 from botocore.credentials import Credentials
 from awscli.customizations.codecommit import CodeCommitGetCommand

--- a/tests/unit/customizations/cloudformation/__init__.py
+++ b/tests/unit/customizations/cloudformation/__init__.py
@@ -11,7 +11,5 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import six, unittest
-
-if six.PY3:
-    unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual
+import unittest
+unittest.TestCase.assertItemsEqual = unittest.TestCase.assertCountEqual

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import tempfile
-import six
 import collections
 
 from awscli.testutils import mock, unittest

--- a/tests/unit/customizations/cloudtrail/test_subscribe.py
+++ b/tests/unit/customizations/cloudtrail/test_subscribe.py
@@ -16,8 +16,8 @@ from botocore.client import ClientError
 from botocore.session import Session
 
 from tests.unit.test_clidriver import FakeSession
-from awscli.compat import six
 from awscli.customizations.cloudtrail.subscribe import CloudTrailError, CloudTrailSubscribe
+from awscli.compat import BytesIO
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import mock, unittest, temporary_file
 
@@ -70,7 +70,7 @@ class TestCloudTrailCommand(unittest.TestCase):
 
         self.subscribe.s3 = mock.Mock()
         self.subscribe.s3.meta.region_name = 'us-east-1'
-        policy_template = six.BytesIO(six.b(u'{"Statement": []}'))
+        policy_template = BytesIO(u'{"Statement": []}'.encode('latin-1'))
         self.subscribe.s3.get_object = mock.Mock(
             return_value={'Body': policy_template})
         self.subscribe.s3.head_bucket.return_value = {}

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -14,12 +14,11 @@
 import awscli
 
 from argparse import Namespace
-from six import StringIO
 from botocore.exceptions import ClientError
 
 from awscli.customizations.codedeploy.push import Push
 from awscli.testutils import mock, unittest
-from awscli.compat import ZIP_COMPRESSION_MODE
+from awscli.compat import StringIO, ZIP_COMPRESSION_MODE
 
 
 class TestPush(unittest.TestCase):

--- a/tests/unit/customizations/configservice/test_getstatus.py
+++ b/tests/unit/customizations/configservice/test_getstatus.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
-
+from awscli.compat import StringIO
 from awscli.testutils import mock, unittest
 from awscli.customizations.configservice.getstatus import GetStatusCommand
 
@@ -78,7 +77,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'Delivery Channels:\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -98,7 +97,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'Delivery Channels:\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -113,7 +112,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'Delivery Channels:\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -144,7 +143,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'recorder: OFF\n\n'
             'Delivery Channels:\n\n'
         )
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -170,7 +169,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last stream delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -198,7 +197,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -227,7 +226,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'message: This is the error\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -259,7 +258,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -298,7 +297,7 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())
 
@@ -361,6 +360,6 @@ class TestGetStatusCommand(unittest.TestCase):
             'last snapshot delivery status: SUCCESS\n\n'
         )
 
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.cmd._run_main(self.parsed_args, self.parsed_globals)
             self.assertEqual(expected_output, mock_stdout.getvalue())

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -15,7 +15,7 @@ import os
 from awscli.customizations.configure import configure, ConfigValue, NOT_SET
 from awscli.customizations.configure import profile_to_section
 from awscli.testutils import mock, unittest
-from awscli.compat import six
+from awscli.compat import StringIO
 
 from . import FakeSession
 
@@ -135,7 +135,7 @@ class TestInteractivePrompter(unittest.TestCase):
     def setUp(self):
         self.input_patch = mock.patch('awscli.compat.raw_input')
         self.mock_raw_input = self.input_patch.start()
-        self.stdout = six.StringIO()
+        self.stdout = StringIO()
         self.stdout_patch = mock.patch('sys.stdout', self.stdout)
         self.stdout_patch.start()
 

--- a/tests/unit/customizations/configure/test_get.py
+++ b/tests/unit/customizations/configure/test_get.py
@@ -11,9 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
+from awscli.compat import StringIO
 
 from awscli.customizations.configure.get import ConfigureGetCommand
-from awscli.compat import six
 
 from . import FakeSession
 
@@ -21,8 +21,8 @@ from . import FakeSession
 class TestConfigureGetCommand(unittest.TestCase):
 
     def create_command(self, session):
-        stdout = six.StringIO()
-        stderr = six.StringIO()
+        stdout = StringIO()
+        stderr = StringIO()
         command = ConfigureGetCommand(session, stdout, stderr)
         return stdout, stderr, command
 

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -13,8 +13,8 @@
 from argparse import Namespace
 
 from awscli.testutils import mock, unittest
-from awscli.compat import six
 from awscli.customizations.configure.list import ConfigureListCommand
+from awscli.compat import StringIO
 
 from . import FakeSession
 
@@ -27,7 +27,7 @@ class TestConfigureListCommand(unittest.TestCase):
             all_variables={'config_file': '/config/location'})
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -46,7 +46,7 @@ class TestConfigureListCommand(unittest.TestCase):
         session.session_var_map = {'profile': (None, "PROFILE_ENV_VAR")}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -63,7 +63,7 @@ class TestConfigureListCommand(unittest.TestCase):
         session.session_var_map = {'region': ('region', "AWS_DEFAULT_REGION")}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -94,7 +94,7 @@ class TestConfigureListCommand(unittest.TestCase):
             'profile': ('profile', 'AWS_DEFAULT_PROFILE')}
         session.full_config = {
             'profiles': {'default': {'region': 'AWS_DEFAULT_REGION'}}}
-        stream = six.StringIO()
+        stream = StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=None)
         rendered = stream.getvalue()
@@ -123,7 +123,7 @@ class TestConfigureListCommand(unittest.TestCase):
         session.session_var_map = {'profile': (None, ['AWS_PROFILE'])}
         session.full_config = {
             'profiles': {'foo': {'region': 'AWS_REGION'}}}
-        stream = six.StringIO()
+        stream = StringIO()
         self.configure_list = ConfigureListCommand(session, stream)
         self.configure_list(args=[], parsed_globals=parsed_globals)
         rendered = stream.getvalue()

--- a/tests/unit/customizations/datapipeline/test_listrunsformatter.py
+++ b/tests/unit/customizations/datapipeline/test_listrunsformatter.py
@@ -14,15 +14,15 @@
 import difflib
 
 from awscli.testutils import mock, unittest
-from awscli.compat import six
 from awscli.customizations.datapipeline.listrunsformatter \
     import ListRunsFormatter
+from awscli.compat import StringIO
 
 
 class TestListRunsFormatter(unittest.TestCase):
     def setUp(self):
         self.formatter = ListRunsFormatter(mock.Mock(query=None))
-        self.stream = six.StringIO()
+        self.stream = StringIO()
 
     def assert_data_renders_to(self, data, table):
         self.formatter('list-runs', data, stream=self.stream)

--- a/tests/unit/customizations/gamelift/test_getlog.py
+++ b/tests/unit/customizations/gamelift/test_getlog.py
@@ -15,9 +15,9 @@ import os
 
 from botocore.session import get_session
 
-from awscli.compat import six
 from awscli.testutils import unittest, mock, FileCreator
 from awscli.customizations.gamelift.getlog import GetGameSessionLogCommand
+from awscli.compat import BytesIO
 
 
 class TestGetGameSessionLogCommand(unittest.TestCase):
@@ -37,7 +37,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
         self.urlopen_patch = mock.patch(
             'awscli.customizations.gamelift.getlog.urlopen')
         self.urlopen_mock = self.urlopen_patch.start()
-        self.urlopen_mock.return_value = six.BytesIO(self.contents)
+        self.urlopen_mock.return_value = BytesIO(self.contents)
 
     def tearDown(self):
         self.create_client_patch.stop()

--- a/tests/unit/customizations/gamelift/test_uploadbuild.py
+++ b/tests/unit/customizations/gamelift/test_uploadbuild.py
@@ -18,11 +18,11 @@ import zipfile
 from botocore.session import get_session
 from botocore.exceptions import ClientError
 
-from awscli.compat import six
 from awscli.testutils import unittest, mock, FileCreator
 from awscli.customizations.gamelift.uploadbuild import UploadBuildCommand
 from awscli.customizations.gamelift.uploadbuild import zip_directory
 from awscli.customizations.gamelift.uploadbuild import validate_directory
+from awscli.compat import StringIO
 
 
 class TestGetGameSessionLogCommand(unittest.TestCase):
@@ -142,7 +142,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             OperatingSystem=operating_system)
 
     def test_error_message_when_directory_is_empty(self):
-        with mock.patch('sys.stderr', six.StringIO()) as mock_stderr:
+        with mock.patch('sys.stderr', StringIO()) as mock_stderr:
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
@@ -158,7 +158,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             '--build-root', ''
         ]
 
-        with mock.patch('sys.stderr', six.StringIO()) as mock_stderr:
+        with mock.patch('sys.stderr', StringIO()) as mock_stderr:
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
@@ -175,7 +175,7 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             '--build-root', dir_not_exist
         ]
 
-        with mock.patch('sys.stderr', six.StringIO()) as mock_stderr:
+        with mock.patch('sys.stderr', StringIO()) as mock_stderr:
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),

--- a/tests/unit/customizations/s3/__init__.py
+++ b/tests/unit/customizations/s3/__init__.py
@@ -12,8 +12,6 @@
 # language governing permissions and limitations under the License.
 import os
 
-from awscli.compat import six
-
 
 class FakeTransferFuture(object):
     def __init__(self, result=None, exception=None, meta=None):
@@ -56,8 +54,8 @@ def make_loc_files(file_creator, size=None):
 
     filename2 = file_creator.create_file(
         os.path.join('some_directory', 'another_directory', 'text2.txt'), body)
-    filename1 = six.text_type(filename1)
-    filename2 = six.text_type(filename2)
+    filename1 = str(filename1)
+    filename2 = str(filename2)
     return [filename1, filename2, os.path.dirname(filename2),
             os.path.dirname(filename1)]
 

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -20,7 +20,6 @@ import shutil
 import socket
 
 from botocore.exceptions import ClientError
-from awscli.compat import six
 
 from awscli.customizations.s3.filegenerator import FileGenerator, \
     FileDecodingError, FileStat, is_special_file, is_readable
@@ -311,7 +310,7 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
         self.files.remove_all()
 
     def test_no_follow_symlink(self):
-        abs_root = six.text_type(os.path.abspath(self.root) + os.sep)
+        abs_root = str(os.path.abspath(self.root) + os.sep)
         input_local_dir = {'src': {'path': abs_root,
                                    'type': 'local'},
                            'dest': {'path': self.bucket,
@@ -325,14 +324,14 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
         self.assertEqual(len(result_list), len(self.filenames))
         # Just check to make sure the right local files are generated.
         for i in range(len(result_list)):
-            filename = six.text_type(os.path.abspath(self.filenames[i]))
+            filename = str(os.path.abspath(self.filenames[i]))
             self.assertEqual(result_list[i], filename)
 
     def test_warn_bad_symlink(self):
         """
         This tests to make sure it fails when following bad symlinks.
         """
-        abs_root = six.text_type(os.path.abspath(self.root) + os.sep)
+        abs_root = str(os.path.abspath(self.root) + os.sep)
         input_local_dir = {'src': {'path': abs_root,
                                    'type': 'local'},
                            'dest': {'path': self.bucket,
@@ -349,14 +348,14 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
         self.assertEqual(len(result_list), len(all_filenames))
         # Just check to make sure the right local files are generated.
         for i in range(len(result_list)):
-            filename = six.text_type(os.path.abspath(all_filenames[i]))
+            filename = str(os.path.abspath(all_filenames[i]))
             self.assertEqual(result_list[i], filename)
         self.assertFalse(file_gen.result_queue.empty())
 
     def test_follow_symlink(self):
         # First remove the bad symlink.
         os.remove(os.path.join(self.root, 'symlink_2'))
-        abs_root = six.text_type(os.path.abspath(self.root) + os.sep)
+        abs_root = str(os.path.abspath(self.root) + os.sep)
         input_local_dir = {'src': {'path': abs_root,
                                    'type': 'local'},
                            'dest': {'path': self.bucket,
@@ -371,7 +370,7 @@ class TestSymlinksIgnoreFiles(unittest.TestCase):
         self.assertEqual(len(result_list), len(all_filenames))
         # Just check to make sure the right local files are generated.
         for i in range(len(result_list)):
-            filename = six.text_type(os.path.abspath(all_filenames[i]))
+            filename = str(os.path.abspath(all_filenames[i]))
             self.assertEqual(result_list[i], filename)
 
 
@@ -379,7 +378,7 @@ class TestListFilesLocally(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):
-        self.directory = six.text_type(tempfile.mkdtemp())
+        self.directory = str(tempfile.mkdtemp())
 
     def tearDown(self):
         shutil.rmtree(self.directory)

--- a/tests/unit/customizations/s3/test_transferconfig.py
+++ b/tests/unit/customizations/s3/test_transferconfig.py
@@ -10,10 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import sys
+
 from awscli.testutils import unittest
 
 from awscli.customizations.s3 import transferconfig
-from awscli.compat import six
 
 
 class TestTransferConfig(unittest.TestCase):
@@ -65,7 +66,7 @@ class TestTransferConfig(unittest.TestCase):
         # MAXSIZE is the max size of an int on python 2 and the maximum size
         # of Py_ssize_t on python 3, but notably not the maximum size of an
         # int since they are effectively unbounded.
-        long_value = six.MAXSIZE + 1
+        long_value = sys.maxsize + 1
         runtime_config = self.build_config_with(
             multipart_threshold=long_value)
         self.assertEqual(runtime_config['multipart_threshold'], long_value)

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -14,12 +14,12 @@
 import awscli
 
 from argparse import Namespace
-from six import StringIO
 from botocore.session import Session
 from botocore.credentials import Credentials
 from awscli.customizations.codecommit import CodeCommitGetCommand
 from awscli.customizations.codecommit import CodeCommitCommand
 from awscli.testutils import mock, unittest, StringIOWithFileNo
+from awscli.compat import StringIO
 
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -10,13 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
-
 from botocore.model import DenormalizedStructureBuilder
 
 from awscli.testutils import mock, unittest
 from awscli.customizations.generatecliskeleton import \
     GenerateCliSkeletonArgument
+from awscli.compat import StringIO
 
 
 class TestGenerateCliSkeleton(unittest.TestCase):
@@ -80,7 +79,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
     def test_generate_json_skeleton(self):
         parsed_args = mock.Mock()
         parsed_args.generate_cli_skeleton = 'input'
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
                 parsed_args=parsed_args, parsed_globals=None
@@ -93,7 +92,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
     def test_no_generate_json_skeleton(self):
         parsed_args = mock.Mock()
         parsed_args.generate_cli_skeleton = None
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
                 parsed_args=parsed_args, parsed_globals=None
@@ -110,7 +109,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         # Set the input shape to ``None``.
         self.argument = GenerateCliSkeletonArgument(
             self.session, mock.Mock(input_shape=None))
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             rc = self.argument.generate_json_skeleton(
                 service_operation=self.service_operation, call_parameters=None,
                 parsed_args=parsed_args, parsed_globals=None
@@ -137,7 +136,7 @@ class TestGenerateCliSkeleton(unittest.TestCase):
         operation_model = mock.Mock(input_shape=shape)
         argument = GenerateCliSkeletonArgument(
             self.session, operation_model)
-        with mock.patch('sys.stdout', six.StringIO()) as mock_stdout:
+        with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             rc = argument.generate_json_skeleton(
                 call_parameters=None, parsed_args=parsed_args,
                 parsed_globals=None

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -15,7 +15,6 @@ from botocore.handlers import disable_signing
 import os
 
 from awscli.testutils import mock, unittest
-from awscli.compat import six
 from awscli.customizations import globalargs
 
 
@@ -57,7 +56,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         parsed_args = FakeParsedArgs(query='foo.bar')
         globalargs.resolve_types(parsed_args)
         # Assert that it looks like a jmespath parsed expression.
-        self.assertFalse(isinstance(parsed_args.query, six.string_types))
+        self.assertFalse(isinstance(parsed_args.query, str))
         self.assertTrue(hasattr(parsed_args.query, 'search'))
 
     def test_parse_query_error_message(self):

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -13,12 +13,11 @@
 # language governing permissions and limitations under the License.
 from botocore.compat import json
 import platform
-from awscli.compat import six
 from awscli.formatter import JSONFormatter
 
 from awscli.testutils import BaseAWSCommandParamsTest, unittest
 from awscli.testutils import mock, skip_if_windows
-from awscli.compat import get_stdout_text_writer
+from awscli.compat import StringIO, get_stdout_text_writer
 
 
 class TestGetPasswordData(BaseAWSCommandParamsTest):
@@ -105,7 +104,7 @@ class TestListUsers(BaseAWSCommandParamsTest):
     def test_json_prints_unicode_chars(self):
         self.parsed_response['Users'][1]['UserId'] = u'\u2713'
         output = self.run_cmd('iam list-users', expected_rc=0)[0]
-        with mock.patch('sys.stdout', six.StringIO()) as f:
+        with mock.patch('sys.stdout', StringIO()) as f:
             out = get_stdout_text_writer()
             out.write(u'\u2713')
             expected = f.getvalue()
@@ -120,7 +119,7 @@ class TestFormattersHandleClosedPipes(unittest.TestCase):
         args = mock.Mock(query=None)
         operation = mock.Mock(can_paginate=False)
         response = '{"Foo": "Bar"}'
-        fake_closed_stream = mock.Mock(spec=six.StringIO)
+        fake_closed_stream = mock.Mock(spec=StringIO)
         fake_closed_stream.flush.side_effect = IOError
         formatter = JSONFormatter(args)
         formatter('command_name', response, stream=fake_closed_stream)

--- a/tests/unit/output/test_table_formatter.py
+++ b/tests/unit/output/test_table_formatter.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import unittest
-from awscli.compat import six
 
 from awscli.formatter import TableFormatter
 from awscli.table import MultiTable, Styler
+from awscli.compat import StringIO
 
 SIMPLE_LIST = {
     "QueueUrls": [
@@ -378,7 +378,7 @@ class TestTableFormatter(unittest.TestCase):
                                 auto_reformat=False)
         self.formatter = TableFormatter(Object(color='off'))
         self.formatter.table = self.table
-        self.stream = six.StringIO()
+        self.stream = StringIO()
 
     def assert_data_renders_to(self, data, table):
         self.formatter('OperationName', data, stream=self.stream)

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -13,14 +13,12 @@
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.testutils import mock, unittest
+from awscli.compat import StringIO
 import json
 import os
 import sys
 import re
 import locale
-
-from awscli.compat import six
-from six.moves import cStringIO
 
 from awscli.formatter import Formatter
 
@@ -153,22 +151,3 @@ class TestDescribeChangesets(BaseAWSCommandParamsTest):
                     key, actual_count, count
                 )
             )
-
-
-class CustomFormatter(Formatter):
-    def __call__(self, operation, response, stream=None):
-        self.stream = self._get_default_stream()
-
-
-class TestDefaultStream(BaseAWSCommandParamsTest):
-    @unittest.skipIf(six.PY3, "Text writer only vaild on py3.")
-    def test_default_stream_with_table_output(self):
-        formatter = CustomFormatter(None)
-        stream = cStringIO()
-        with mock.patch('sys.stdout', stream):
-            formatter(None, None)
-            formatter.stream.write(u'\u00e9')
-        # Ensure the unicode data is written as UTF-8 by default.
-        self.assertEqual(
-            formatter.stream.getvalue(),
-            u'\u00e9'.encode(locale.getpreferredencoding()))

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -17,8 +17,8 @@ from awscli.testutils import BaseAWSCommandParamsTest
 import logging
 import io
 import sys
+import importlib
 
-from awscli.compat import six
 from botocore.awsrequest import AWSResponse
 from botocore.exceptions import NoCredentialsError
 from botocore.compat import OrderedDict
@@ -35,6 +35,7 @@ from awscli.paramfile import URIArgumentHandler
 from awscli.customizations.commands import BasicCommand
 from awscli import formatter
 from awscli.argparser import HELP_BLURB
+from awscli.compat import StringIO
 from botocore.hooks import HierarchicalEmitter
 
 
@@ -314,14 +315,8 @@ class TestCliDriver(unittest.TestCase):
         self.assertEqual(rc, 130)
 
     def test_error_unicode(self):
-        # We need a different type for Py3 and Py2 because on Py3 six.StringIO
-        # doesn't let us set the encoding and returns a string.
-        if six.PY3:
-            stderr_b = io.BytesIO()
-            stderr = io.TextIOWrapper(stderr_b, encoding="UTF-8")
-        else:
-            stderr = stderr_b = six.StringIO()
-            stderr.encoding = "UTF-8"
+        stderr_b = io.BytesIO()
+        stderr = io.TextIOWrapper(stderr_b, encoding="UTF-8")
         driver = CLIDriver(session=self.session)
         fake_client = mock.Mock()
         fake_client.list_objects.side_effect = Exception(u"☃")
@@ -341,8 +336,8 @@ class TestCliDriverHooks(unittest.TestCase):
         self.session = FakeSession()
         self.emitter = mock.Mock()
         self.emitter.emit.return_value = []
-        self.stdout = six.StringIO()
-        self.stderr = six.StringIO()
+        self.stdout = StringIO()
+        self.stderr = StringIO()
         self.stdout_patch = mock.patch('sys.stdout', self.stdout)
         #self.stdout_patch.start()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
@@ -419,7 +414,7 @@ class TestCliDriverHooks(unittest.TestCase):
 
 class TestSearchPath(unittest.TestCase):
     def tearDown(self):
-        six.moves.reload_module(awscli)
+        importlib.reload(awscli)
 
     @mock.patch('os.pathsep', ';')
     @mock.patch('os.environ', {'AWS_DATA_PATH': 'c:\\foo;c:\\bar'})
@@ -427,7 +422,7 @@ class TestSearchPath(unittest.TestCase):
         driver = CLIDriver()
         # Because the os.environ patching happens at import time,
         # we have to force a reimport of the module to test our changes.
-        six.moves.reload_module(awscli)
+        importlib.reload(awscli)
         # Our two overrides should be the last two elements in the search path.
         search_paths = driver.session.get_component(
             'data_loader').search_paths
@@ -440,7 +435,7 @@ class TestAWSCommand(BaseAWSCommandParamsTest):
     # but with the http part mocked out.
     def setUp(self):
         super(TestAWSCommand, self).setUp()
-        self.stderr = six.StringIO()
+        self.stderr = StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
 
@@ -807,7 +802,7 @@ class TestHTTPParamFileDoesNotExist(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestHTTPParamFileDoesNotExist, self).setUp()
-        self.stderr = six.StringIO()
+        self.stderr = StringIO()
         self.stderr_patch = mock.patch('sys.stderr', self.stderr)
         self.stderr_patch.start()
 

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -15,8 +15,6 @@ import signal
 
 import pytest
 
-from botocore.compat import six
-
 from awscli.compat import ensure_text_type
 from awscli.compat import compat_shell_quote
 from awscli.compat import compat_open
@@ -29,25 +27,25 @@ class TestEnsureText(unittest.TestCase):
     def test_string(self):
         value = 'foo'
         response = ensure_text_type(value)
-        self.assertIsInstance(response, six.text_type)
+        self.assertIsInstance(response, str)
         self.assertEqual(response, 'foo')
 
     def test_binary(self):
         value = b'bar'
         response = ensure_text_type(value)
-        self.assertIsInstance(response, six.text_type)
+        self.assertIsInstance(response, str)
         self.assertEqual(response, 'bar')
 
     def test_unicode(self):
         value = u'baz'
         response = ensure_text_type(value)
-        self.assertIsInstance(response, six.text_type)
+        self.assertIsInstance(response, str)
         self.assertEqual(response, 'baz')
 
     def test_non_ascii(self):
         value = b'\xe2\x9c\x93'
         response = ensure_text_type(value)
-        self.assertIsInstance(response, six.text_type)
+        self.assertIsInstance(response, str)
         self.assertEqual(response, u'\u2713')
 
     def test_non_string_or_bytes_raises_error(self):

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -17,11 +17,11 @@ import json
 import sys
 import os
 
-from awscli.compat import six
 from awscli.help import PosixHelpRenderer, ExecutableNotFoundError
 from awscli.help import WindowsHelpRenderer, ProviderHelpCommand, HelpCommand
 from awscli.help import TopicListerCommand, TopicHelpCommand
 from awscli.argparser import HELP_BLURB
+from awscli.compat import StringIO
 
 
 class HelpSpyMixin(object):
@@ -106,7 +106,7 @@ class TestHelpPager(unittest.TestCase):
 
     @skip_if_windows('Requires POSIX system.')
     def test_renderer_falls_back_to_mandoc(self):
-        stdout = six.StringIO()
+        stdout = StringIO()
         renderer = FakePosixHelpRenderer(output_stream=stdout)
 
         renderer.exists_on_path['groff'] = False
@@ -119,7 +119,7 @@ class TestHelpPager(unittest.TestCase):
     def test_no_pager_exists(self):
         fake_pager = 'foobar'
         os.environ['MANPAGER'] = fake_pager
-        stdout = six.StringIO()
+        stdout = StringIO()
         renderer = FakePosixHelpRenderer(output_stream=stdout)
         renderer.exists_on_path[fake_pager] = False
 

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.compat import six
 from awscli.testutils import mock, unittest, FileCreator
 from awscli.testutils import skip_if_windows
 
@@ -37,7 +36,7 @@ class TestParamFile(unittest.TestCase):
         prefixed_filename = 'file://' + filename
         data = self.get_paramfile(prefixed_filename)
         self.assertEqual(data, contents)
-        self.assertIsInstance(data, six.string_types)
+        self.assertIsInstance(data, str)
 
     def test_binary_file(self):
         contents = 'This is a test'
@@ -45,7 +44,7 @@ class TestParamFile(unittest.TestCase):
         prefixed_filename = 'fileb://' + filename
         data = self.get_paramfile(prefixed_filename)
         self.assertEqual(data, b'This is a test')
-        self.assertIsInstance(data, six.binary_type)
+        self.assertIsInstance(data, bytes)
 
     @skip_if_windows('Binary content error only occurs '
                      'on non-Windows platforms.')

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -21,8 +21,8 @@
 #
 import sys
 
-from awscli.compat import six
 from awscli.testutils import mock, unittest
+from awscli.compat import StringIO
 
 from awscli import text
 
@@ -30,7 +30,7 @@ from awscli import text
 class TestSection(unittest.TestCase):
     def format_text(self, data, stream=None):
         if stream is None:
-            stream = six.StringIO()
+            stream = StringIO()
         text.format_text(data, stream=stream)
         return stream.getvalue()
 


### PR DESCRIPTION
This PR removes usage of six in the CLI v1 codebase and minimizes its presence to one import from Botocore. This is left in place for backwards compatibility but is considered deprecated and may be removed in a future version. Downstream distributors may choose to patch out this single import to remove the requirement on keeping `six` in their ecosystem.

The primary changes here are in three classes:

1. `six.*_type(s)`, six maintains references to things like `bytes`, `str`, `basestr`, `unicode` depending on the Python version being used. We're removing this for the direct call to either `str` for `six.text_type` or `bytes` for `six.binary_type`. This also applies to `six.integer_types` and `six.string_types` which are used for type checking.

  ```python
  >>> import six
  >>> six.text_type
  <class 'str'>
  >>> six.binary_type
  <class 'bytes'>
  >>> six.string_types
  (<class 'str'>,)
  >>> six.integer_types
 (<class 'int'>,)
  ```
  
2. `six.moves.*`, these changes are placeholders that map between changed references to the same class. This was to account for modules that got renamed in Python 3. These are no longer needed so they've been moved to their Python 3 equivalent, you can find the full mapping table [here](https://six.readthedocs.io/#module-six.moves).

3. `six.b() six.u(), six.BytesIO(), six.StringIO()`, these are used for bringing StringIO/BytesIO back to Python 2 and dealing with the differences of bytes/unicode between the two major versions. StringIO and BytesIO are already present in the standard library `io` module, so we no longer need `six` for these. For `six.b` and `six.u`, these are just syntax sugar around `value.encode('latin-1')` and a literal no-op for `six.u` in Python 3. There's some discussion to be had on whether this should really be `value.encode('utf-8')` where we're using `six.b` but I've left it exactly as it was with `six` to make sure we're not breaking anything.

If you have more questions, you can read the full six docs [here](https://six.readthedocs.io).