### PR TITLE
Correct JSON sample output of sts assume-role-with-web-identity command

### DIFF
--- a/awscli/examples/sts/assume-role-with-web-identity.rst
+++ b/awscli/examples/sts/assume-role-with-web-identity.rst
@@ -13,12 +13,12 @@ The following ``assume-role-with-web-identity`` command retrieves a set of short
 Output::
 
     {
-        "SubjectFromWebIdentityToken": "amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A"
+        "SubjectFromWebIdentityToken": "amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A",
         "Audience": "client.5498841531868486423.1548@apps.example.com",
         "AssumedRoleUser": {
             "Arn": "arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1",
             "AssumedRoleId": "AROACLKWSDQRAOEXAMPLE:app1"
-        }
+        },
         "Credentials": {
             "AccessKeyId": "AKIAIOSFODNN7EXAMPLE",
             "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY",


### PR DESCRIPTION
In the example output of the sts assume-role-with-web-identity command, two commas are missing to be valid JSON.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.