### PR TITLE
[v2] Add changelog for OpenSSL version update

### DIFF
--- a/.changes/next-release/enhancement-openssl-59096.json
+++ b/.changes/next-release/enhancement-openssl-59096.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "openssl",
+  "description": "Update bundled OpenSSL version to 1.1.1y for Linux installers"
+}


### PR DESCRIPTION
This version update is only applicable to official Linux executables for the AWS CLI v2.