### PR TITLE
[v2] Remove mock imports

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -33,21 +33,13 @@ import binascii
 import math
 from pprint import pformat
 from subprocess import Popen, PIPE
+from unittest import mock
 import unittest
 
 from awscli.compat import StringIO
 
 from ruamel.yaml import YAML
 
-try:
-    import mock
-except ImportError as e:
-    # In the off chance something imports this module
-    # that's not suppose to, we should not stop the CLI
-    # by raising an ImportError.  Now if anything actually
-    # *uses* this module that isn't suppose to, that's a
-    # different story.
-    mock = None
 from awscli.compat import six
 from botocore.session import Session
 from botocore.exceptions import ClientError

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,4 @@
 jsonschema==4.7.2
-mock==1.3.0
 pytest==7.2.0
 coverage==7.0.1
 pytest-cov==4.0.0

--- a/tests/functional/autoprompt/test_autoprompt.py
+++ b/tests/functional/autoprompt/test_autoprompt.py
@@ -1,10 +1,8 @@
-import mock
 import os
-
 import pytest
 
 from awscli.clidriver import create_clidriver
-from awscli.testutils import FileCreator
+from awscli.testutils import mock, FileCreator
 
 
 def set_up(config, env_var):

--- a/tests/functional/botocore/csm/test_monitoring.py
+++ b/tests/functional/botocore/csm/test_monitoring.py
@@ -18,10 +18,9 @@ import os
 import socket
 import threading
 
-import mock
 import pytest
 
-from tests import temporary_file
+from tests import mock, temporary_file
 from tests import ClientHTTPStubber
 from botocore import xform_name
 import botocore.session

--- a/tests/functional/botocore/test_apigateway.py
+++ b/tests/functional/botocore/test_apigateway.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from tests import BaseSessionTest, ClientHTTPStubber
 
 

--- a/tests/functional/botocore/test_cloudsearchdomain.py
+++ b/tests/functional/botocore/test_cloudsearchdomain.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from tests import BaseSessionTest, ClientHTTPStubber
 
 

--- a/tests/functional/botocore/test_cognito_idp.py
+++ b/tests/functional/botocore/test_cognito_idp.py
@@ -10,10 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import pytest
 
-from tests import create_session, ClientHTTPStubber
+from tests import create_session, mock, ClientHTTPStubber
 
 
 OPERATION_PARAMS = {

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -16,7 +16,6 @@ import threading
 import os
 import math
 import time
-import mock
 import tempfile
 import shutil
 from datetime import datetime, timedelta
@@ -27,7 +26,7 @@ from dateutil.tz import tzlocal
 from botocore.exceptions import CredentialRetrievalError
 
 from tests import (
-    unittest, IntegerRefresher, BaseEnvVar, BaseSessionTest, random_chars
+    mock, unittest, IntegerRefresher, BaseEnvVar, BaseSessionTest, random_chars
 )
 from tests import temporary_file, StubbedSession, SessionHTTPStubber
 from botocore import UNSIGNED

--- a/tests/functional/botocore/test_docdb.py
+++ b/tests/functional/botocore/test_docdb.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from contextlib import contextmanager
 
 import botocore.session

--- a/tests/functional/botocore/test_ec2.py
+++ b/tests/functional/botocore/test_ec2.py
@@ -11,9 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import datetime
-import mock
 
-from tests import unittest, ClientHTTPStubber, BaseSessionTest
+from tests import mock, unittest, ClientHTTPStubber, BaseSessionTest
 from botocore.compat import parse_qs, urlparse
 from botocore.stub import Stubber, ANY
 import botocore.session

--- a/tests/functional/botocore/test_history.py
+++ b/tests/functional/botocore/test_history.py
@@ -1,7 +1,5 @@
 from contextlib import contextmanager
 
-import mock
-
 from tests import BaseSessionTest, ClientHTTPStubber
 from botocore.history import BaseHistoryHandler
 from botocore.history import get_global_history_recorder

--- a/tests/functional/botocore/test_lex.py
+++ b/tests/functional/botocore/test_lex.py
@@ -10,10 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from datetime import datetime
 
-from tests import BaseSessionTest, ClientHTTPStubber
+from tests import mock, BaseSessionTest, ClientHTTPStubber
 
 
 class TestLex(BaseSessionTest):

--- a/tests/functional/botocore/test_machinelearning.py
+++ b/tests/functional/botocore/test_machinelearning.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from tests import BaseSessionTest, ClientHTTPStubber
 
 

--- a/tests/functional/botocore/test_neptune.py
+++ b/tests/functional/botocore/test_neptune.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from contextlib import contextmanager
 
 import botocore.session

--- a/tests/functional/botocore/test_public_apis.py
+++ b/tests/functional/botocore/test_public_apis.py
@@ -12,10 +12,9 @@
 # language governing permissions and limitations under the License.
 from collections import defaultdict
 
-import mock
 import pytest
 
-from tests import ClientHTTPStubber
+from tests import mock, ClientHTTPStubber
 from botocore.session import Session
 from botocore.exceptions import NoCredentialsError
 from botocore import xform_name

--- a/tests/functional/botocore/test_regions.py
+++ b/tests/functional/botocore/test_regions.py
@@ -10,14 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import pytest
 
 from botocore.client import ClientEndpointBridge
 from botocore.exceptions import NoRegionError
 from botocore.compat import urlparse
 
-from tests import BaseSessionTest, ClientHTTPStubber
+from tests import mock, BaseSessionTest, ClientHTTPStubber
 
 
 # NOTE: sqs endpoint updated to be the CN in the SSL cert because

--- a/tests/functional/botocore/test_session.py
+++ b/tests/functional/botocore/test_session.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest, temporary_file
-
-import mock
+from tests import mock, unittest, temporary_file
 
 import botocore.session
 from botocore.exceptions import ProfileNotFound

--- a/tests/functional/botocore/test_six_threading.py
+++ b/tests/functional/botocore/test_six_threading.py
@@ -1,12 +1,13 @@
 """
 Regression test for six issue #98 (https://github.com/benjaminp/six/issues/98)
 """
-from mock import patch
 import sys
 import threading
 import time
 
 from botocore.vendored import six
+
+from tests import mock
 
 
 _original_setattr = six.moves.__class__.__setattr__
@@ -48,7 +49,7 @@ class _ExampleThread(threading.Thread):
 
 def test_six_thread_safety():
     _reload_six()
-    with patch('botocore.vendored.six.moves.__class__.__setattr__',
+    with mock.patch('botocore.vendored.six.moves.__class__.__setattr__',
                wraps=_wrapped_setattr):
         threads = []
         for i in range(2):

--- a/tests/functional/botocore/test_sts.py
+++ b/tests/functional/botocore/test_sts.py
@@ -13,10 +13,8 @@
 from datetime import datetime
 import re
 
-import mock
-
 from tests import BaseSessionTest
-from tests import temporary_file
+from tests import mock
 from tests import assert_url_equal
 from tests import ClientHTTPStubber
 from botocore.config import Config

--- a/tests/functional/cloudfront/test_create_distribution.py
+++ b/tests/functional/cloudfront/test_create_distribution.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestCreateDistribution(BaseAWSCommandParamsTest):

--- a/tests/functional/cloudfront/test_create_invalidation.py
+++ b/tests/functional/cloudfront/test_create_invalidation.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestCreateInvalidation(BaseAWSCommandParamsTest):

--- a/tests/functional/cloudfront/test_sign.py
+++ b/tests/functional/cloudfront/test_sign.py
@@ -10,11 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from botocore.compat import urlparse, parse_qs
 
-from awscli.testutils import FileCreator
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest, FileCreator
 
 
 class TestSign(BaseAWSCommandParamsTest):

--- a/tests/functional/cloudfront/test_update_distribution.py
+++ b/tests/functional/cloudfront/test_update_distribution.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestUpdateDistribution(BaseAWSCommandParamsTest):

--- a/tests/functional/configservice/test_subscribe.py
+++ b/tests/functional/configservice/test_subscribe.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 from awscli.customizations.configservice.subscribe import S3BucketHelper
 
 

--- a/tests/functional/dependencies/test_colorama.py
+++ b/tests/functional/dependencies/test_colorama.py
@@ -2,8 +2,6 @@ import os
 import sys
 from contextlib import contextmanager
 
-from mock import Mock, patch
-
 from awscli.testutils import unittest, skip_if_windows
 from awscli.testutils import capture_output
 from awscli.compat import StringIO

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -31,7 +31,6 @@ from tests import CLIRunner
 
 from awscli.compat import six
 from awscli.alias import AliasLoader
-import mock
 
 
 class TestHelpOutput(BaseAWSHelpOutputTest):

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -14,12 +14,11 @@
 import base64
 import datetime
 
-import mock
 from six.moves import cStringIO
 
 import awscli.customizations.ec2.bundleinstance
 from awscli.compat import six
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestBundleInstance(BaseAWSCommandParamsTest):

--- a/tests/functional/ecs/test_execute_command.py
+++ b/tests/functional/ecs/test_execute_command.py
@@ -10,12 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import errno
 import json
 
-from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.testutils import BaseAWSHelpOutputTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest, BaseAWSHelpOutputTest
 
 
 class TestExecuteCommand(BaseAWSCommandParamsTest):

--- a/tests/functional/eks/test_kubeconfig.py
+++ b/tests/functional/eks/test_kubeconfig.py
@@ -14,11 +14,10 @@
 import os
 import shutil
 import tempfile
-import mock
 
 from botocore.compat import OrderedDict
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from tests.functional.eks.test_util import get_testdata
 from awscli.customizations.eks.kubeconfig import (_get_new_kubeconfig_content,
                                                   KubeconfigWriter,

--- a/tests/functional/eks/test_update_kubeconfig.py
+++ b/tests/functional/eks/test_update_kubeconfig.py
@@ -16,9 +16,7 @@ import shutil
 import sys
 import tempfile
 
-import mock
 from botocore.session import get_session
-from mock import patch, Mock
 
 from awscli.customizations.eks.exceptions import EKSClusterError
 from awscli.customizations.eks.kubeconfig import (
@@ -26,7 +24,7 @@ from awscli.customizations.eks.kubeconfig import (
     KubeconfigInaccessableError
 )
 from awscli.customizations.eks.update_kubeconfig import UpdateKubeconfigCommand
-from awscli.testutils import unittest, capture_output
+from awscli.testutils import mock, unittest, capture_output
 from tests.functional.eks.test_util import (
     describe_cluster_response,
     describe_cluster_creating_response,
@@ -54,14 +52,14 @@ def build_environment(entries):
 
 class TestUpdateKubeconfig(unittest.TestCase):
     def setUp(self):
-        self.create_client_patch = patch(
+        self.create_client_patch = mock.patch(
             'botocore.session.Session.create_client'
         )
 
         self.mock_create_client = self.create_client_patch.start()
         self.session = get_session()
 
-        self.client = Mock()
+        self.client = mock.Mock()
         self.client.describe_cluster.return_value = describe_cluster_response()
         self.mock_create_client.return_value = self.client
 
@@ -402,7 +400,7 @@ class TestUpdateKubeconfig(unittest.TestCase):
         passed = "output_combined"
         environment = []
         self.client.describe_cluster =\
-            Mock(return_value=describe_cluster_creating_response())
+            mock.Mock(return_value=describe_cluster_creating_response())
         with self.assertRaises(EKSClusterError):
             self.assert_cmd(configs, passed, environment)
 

--- a/tests/functional/lightsail/test_push_container_image.py
+++ b/tests/functional/lightsail/test_push_container_image.py
@@ -10,14 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import mock
 import errno
 import json
 import awscli
 
-from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.testutils import BaseAWSHelpOutputTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest, BaseAWSHelpOutputTest
 
 
 class TestPushContainerImageTest(BaseAWSCommandParamsTest):

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -12,8 +12,6 @@
 # language governing permissions and limitations under the License.
 import datetime
 
-from tests import mock
-
 from dateutil.tz import tzutc
 from botocore.compat import urlparse, parse_qs
 

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -11,13 +11,14 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import datetime
-import mock
+
+from tests import mock
 
 from dateutil.tz import tzutc
 from botocore.compat import urlparse, parse_qs
 
 from awscli.compat import six
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestGenerateDBAuthToken(BaseAWSCommandParamsTest):

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import os
 
 from awscrt.s3 import S3Request
@@ -18,7 +17,7 @@ from botocore.awsrequest import AWSResponse
 
 from tests import CLIRunner, SessionStubber, HTTPResponse
 from awscli.clidriver import AWSCLIEntryPoint
-from awscli.testutils import unittest, create_clidriver, temporary_file
+from awscli.testutils import unittest, create_clidriver, temporary_file, mock
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
 from awscli.compat import six, urlparse
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -11,14 +11,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import os
 
 from awscrt.s3 import S3RequestType, S3RequestTlsMode
 
 from awscli.customizations.s3.utils import relative_path
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.testutils import capture_input
+from awscli.testutils import capture_input, mock
 from awscli.compat import six, OrderedDict
 from tests.functional.s3 import (
     BaseS3TransferCommandTest, BaseS3CLIRunnerTest, BaseCRTTransferClientTest

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import patch
 import os
 
 from awscrt.s3 import S3RequestType

--- a/tests/functional/servicecatalog/test_generate_createproduct.py
+++ b/tests/functional/servicecatalog/test_generate_createproduct.py
@@ -13,11 +13,10 @@
 
 
 import os
-from mock import mock
 
 from awscli.customizations.servicecatalog.utils \
     import get_s3_path
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestGenerateProduct(BaseAWSCommandParamsTest):

--- a/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
+++ b/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
@@ -13,11 +13,10 @@
 
 
 import os
-from mock import mock
 
 from awscli.customizations.servicecatalog.utils \
     import get_s3_path
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):

--- a/tests/functional/ses/test_send_email.py
+++ b/tests/functional/ses/test_send_email.py
@@ -15,7 +15,6 @@ from awscli.testutils import BaseAWSCommandParamsTest
 
 from awscli.compat import six
 from six.moves import cStringIO
-import mock
 
 
 class TestSendEmail(BaseAWSCommandParamsTest):

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import os
 import re
 import shutil
@@ -19,9 +18,7 @@ from tests import RawResponse
 
 import botocore
 
-import awscli.constants
-from awscli.testutils import FileCreator
-from awscli.testutils import BaseCLIDriverTest
+from awscli.testutils import mock, BaseCLIDriverTest, FileCreator
 from awscli.clidriver import create_clidriver
 
 

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -13,9 +13,7 @@
 import logging
 import os
 
-from mock import patch, ANY
-
-from awscli.testutils import FileCreator, BaseAWSCommandParamsTest
+from awscli.testutils import mock, FileCreator, BaseAWSCommandParamsTest
 from awscli.clidriver import create_clidriver
 
 logger = logging.getLogger(__name__)
@@ -40,7 +38,7 @@ class BaseTestCLIFollowParamFile(BaseAWSCommandParamsTest):
         # can't tell the difference, so we pass ANY here to ignore the rc.
         self.assert_params_for_cmd(cmd,
                                    params={'FunctionName': expected_param},
-                                   expected_rc=ANY)
+                                   expected_rc=mock.ANY)
 
 
 class TestCLIFollowParamFileDefault(BaseTestCLIFollowParamFile):

--- a/tests/integration/botocore/test_client_http.py
+++ b/tests/integration/botocore/test_client_http.py
@@ -2,8 +2,7 @@ import select
 import socket
 import contextlib
 import threading
-import mock
-from tests import unittest
+from tests import mock, unittest
 from contextlib import contextmanager
 
 import botocore.session

--- a/tests/integration/botocore/test_credentials.py
+++ b/tests/integration/botocore/test_credentials.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
 import tempfile
 import shutil
 import json
@@ -20,7 +19,7 @@ from uuid import uuid4
 
 from botocore.session import Session
 from botocore.exceptions import ClientError
-from tests import BaseEnvVar, temporary_file, random_chars
+from tests import BaseEnvVar, temporary_file, random_chars, mock
 
 
 S3_READ_POLICY_ARN = 'arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess'

--- a/tests/integration/botocore/test_loaders.py
+++ b/tests/integration/botocore/test_loaders.py
@@ -11,9 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-from tests import unittest
-
-import mock
+from tests import mock, unittest
 
 import botocore.session
 

--- a/tests/integration/botocore/test_s3.py
+++ b/tests/integration/botocore/test_s3.py
@@ -22,7 +22,6 @@ import tempfile
 import shutil
 import threading
 import logging
-import mock
 from tarfile import TarFile
 from contextlib import closing
 

--- a/tests/integration/botocore/test_smoke.py
+++ b/tests/integration/botocore/test_smoke.py
@@ -11,7 +11,6 @@ to use and all the services in SMOKE_TESTS/ERROR_TESTS will be tested.
 
 """
 import os
-import mock
 from pprint import pformat
 import warnings
 import logging

--- a/tests/integration/customizations/test_generatecliskeleton.py
+++ b/tests/integration/customizations/test_generatecliskeleton.py
@@ -15,11 +15,11 @@ import os
 import json
 import logging
 
-import mock
 import pytest
 from ruamel.yaml import YAML
 
 from awscli.clidriver import create_clidriver
+from awscli.testutils import mock
 
 # NOTE: This should be a standalone pytest fixture.  However, fixtures cannot
 # be used outside of other fixtures or test cases, and it is needed by

--- a/tests/unit/autoprompt/test_core.py
+++ b/tests/unit/autoprompt/test_core.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from collections import namedtuple
 
 import pytest
@@ -18,7 +17,7 @@ import pytest
 from awscli.clidriver import create_clidriver
 from awscli.autoprompt import core
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestCLIAutoPrompt(unittest.TestCase):

--- a/tests/unit/autoprompt/test_doc.py
+++ b/tests/unit/autoprompt/test_doc.py
@@ -10,12 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import textwrap
 
 from awscli.clidriver import create_clidriver
 from awscli.autoprompt.doc import DocsGetter
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestDocsGetter(unittest.TestCase):

--- a/tests/unit/autoprompt/test_factory.py
+++ b/tests/unit/autoprompt/test_factory.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.completion import DummyCompleter, Completer
 from prompt_toolkit.layout import Window
@@ -21,7 +19,7 @@ from awscli.autoprompt.factory import (
     PromptToolkitKeyBindings, PromptToolkitFactory, CLIPromptBuffer
 )
 from awscli.autoprompt.history import HistoryCompleter
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class FakeCLIPromptBuffer(CLIPromptBuffer):

--- a/tests/unit/autoprompt/test_filters.py
+++ b/tests/unit/autoprompt/test_filters.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.autoprompt.filters import (
     search_input_has_focus, help_section_visible, doc_window_has_focus,
     doc_section_visible, is_history_mode, is_multi_column, is_one_column,

--- a/tests/unit/autoprompt/test_history.py
+++ b/tests/unit/autoprompt/test_history.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
 import os
 import shutil
 import tempfile
@@ -26,7 +25,7 @@ from prompt_toolkit.formatted_text import FormattedText
 from awscli.autoprompt.history import (
     HistoryCompleter, HistoryDriver
 )
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestHistoryCompleter(unittest.TestCase):

--- a/tests/unit/autoprompt/test_logger.py
+++ b/tests/unit/autoprompt/test_logger.py
@@ -12,13 +12,12 @@
 # language governing permissions and limitations under the License.
 import contextlib
 import logging
-import mock
 import io
 
 from prompt_toolkit.buffer import Buffer
 from awscli.autoprompt.logger import PromptToolkitHandler
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestPromptToolkitHandler(unittest.TestCase):

--- a/tests/unit/autoprompt/test_prompttoolkit.py
+++ b/tests/unit/autoprompt/test_prompttoolkit.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
-import mock
 
 from prompt_toolkit.completion import Completion, CompleteEvent
 from prompt_toolkit.document import Document
@@ -21,7 +20,7 @@ from awscli.autoprompt.logger import PromptToolkitHandler
 from awscli.autoprompt.prompttoolkit import (
     PromptToolkitCompleter, loggers_handler_switcher
 )
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestPromptToolkitCompleter(unittest.TestCase):

--- a/tests/unit/autoprompt/test_widgets.py
+++ b/tests/unit/autoprompt/test_widgets.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.layout import (
@@ -20,7 +18,7 @@ from prompt_toolkit.layout import (
 from prompt_toolkit.widgets import Dialog
 
 from awscli.autoprompt import widgets
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestHelpPanelWidget(unittest.TestCase):

--- a/tests/unit/bcdoc/test_docstringparser.py
+++ b/tests/unit/bcdoc/test_docstringparser.py
@@ -18,8 +18,9 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import mock
 import unittest
+
+from awscli.testutils import mock
 
 import awscli.bcdoc.docstringparser as parser
 from awscli.bcdoc.restdoc import ReSTDocument

--- a/tests/unit/botocore/auth/test_signers.py
+++ b/tests/unit/botocore/auth/test_signers.py
@@ -12,13 +12,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
+from tests import mock, unittest
 import datetime
 import time
 import base64
 import json
-
-import mock
 
 import botocore.auth
 import botocore.credentials

--- a/tests/unit/botocore/auth/test_sigv4.py
+++ b/tests/unit/botocore/auth/test_sigv4.py
@@ -29,7 +29,6 @@ import datetime
 import re
 from botocore.compat import six, urlsplit, parse_qsl
 
-import mock
 import pytest
 
 from tests import FreezeTime

--- a/tests/unit/botocore/docs/__init__.py
+++ b/tests/unit/botocore/docs/__init__.py
@@ -16,9 +16,8 @@ import tempfile
 import shutil
 
 from botocore.docs.bcdoc.restdoc import DocumentStructure
-import mock
 
-from tests import unittest
+from tests import mock, unittest
 from botocore.compat import OrderedDict
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel, OperationModel

--- a/tests/unit/botocore/docs/bcdoc/test_docstringparser.py
+++ b/tests/unit/botocore/docs/bcdoc/test_docstringparser.py
@@ -18,8 +18,7 @@
 # WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
-import mock
-from tests import unittest
+from tests import mock, unittest
 
 import botocore.docs.bcdoc.docstringparser as parser
 from botocore.docs.bcdoc.restdoc import ReSTDocument

--- a/tests/unit/botocore/docs/test_docs.py
+++ b/tests/unit/botocore/docs/test_docs.py
@@ -14,8 +14,7 @@ import os
 import shutil
 import tempfile
 
-import mock
-
+from tests import mock
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.session import get_session
 from botocore.docs import generate_docs

--- a/tests/unit/botocore/docs/test_example.py
+++ b/tests/unit/botocore/docs/test_example.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
+from tests import mock
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.hooks import HierarchicalEmitter
 from botocore.docs.example import ResponseExampleDocumenter

--- a/tests/unit/botocore/docs/test_params.py
+++ b/tests/unit/botocore/docs/test_params.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
+from tests import mock
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.hooks import HierarchicalEmitter
 from botocore.docs.params import RequestParamsDocumenter

--- a/tests/unit/botocore/docs/test_service.py
+++ b/tests/unit/botocore/docs/test_service.py
@@ -12,8 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 
-import mock
-
+from tests import mock
 from tests.unit.botocore.docs import BaseDocsTest
 from botocore.session import get_session
 from botocore.docs.service import ServiceDocumenter

--- a/tests/unit/botocore/retries/test_adaptive.py
+++ b/tests/unit/botocore/retries/test_adaptive.py
@@ -1,6 +1,4 @@
-from tests import unittest
-
-import mock
+from tests import mock, unittest
 
 from botocore.retries import adaptive
 from botocore.retries import standard

--- a/tests/unit/botocore/retries/test_special.py
+++ b/tests/unit/botocore/retries/test_special.py
@@ -1,6 +1,4 @@
-from tests import unittest
-
-import mock
+from tests import mock, unittest
 
 from botocore.compat import six
 from botocore.awsrequest import AWSResponse

--- a/tests/unit/botocore/retries/test_standard.py
+++ b/tests/unit/botocore/retries/test_standard.py
@@ -1,6 +1,5 @@
-from tests import unittest
+from tests import mock, unittest
 
-import mock
 import pytest
 
 from botocore.retries import standard

--- a/tests/unit/botocore/test_args.py
+++ b/tests/unit/botocore/test_args.py
@@ -14,8 +14,7 @@
 import socket
 
 import botocore.config
-from tests import unittest
-import mock
+from tests import mock, unittest
 
 from botocore import args
 from botocore import exceptions

--- a/tests/unit/botocore/test_awsrequest.py
+++ b/tests/unit/botocore/test_awsrequest.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest
+from tests import mock, unittest
 import os
 import tempfile
 import shutil
@@ -20,7 +20,6 @@ import io
 import socket
 import sys
 
-from mock import Mock, patch
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 
 from botocore.exceptions import UnseekableStreamError
@@ -256,7 +255,7 @@ class TestAWSRequest(unittest.TestCase):
 class TestAWSResponse(unittest.TestCase):
     def setUp(self):
         self.response = AWSResponse('http://url.com', 200, HeadersDict(), None)
-        self.response.raw = Mock()
+        self.response.raw = mock.Mock()
 
     def set_raw_stream(self, blobs):
         def stream(*args, **kwargs):
@@ -291,8 +290,8 @@ class TestAWSHTTPConnection(unittest.TestCase):
         conn._tunnel_headers = {'key': 'value'}
 
         # Create a mock response.
-        self.mock_response = Mock()
-        self.mock_response.fp = Mock()
+        self.mock_response = mock.Mock()
+        self.mock_response.fp = mock.Mock()
 
         # Imitate readline function by creating a list to be sent as
         # a side effect of the mocked readline to be able to track how the
@@ -315,12 +314,12 @@ class TestAWSHTTPConnection(unittest.TestCase):
             response_components[0], int(response_components[1]),
             response_components[2]
         )
-        conn.response_class = Mock()
+        conn.response_class = mock.Mock()
         conn.response_class.return_value = self.mock_response
         return conn
 
     def test_expect_100_continue_returned(self):
-        with patch('urllib3.util.wait_for_read') as wait_mock:
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
             # Shows the server first sending a 100 continue response
             # then a 200 ok response.
             s = FakeSocket(b'HTTP/1.1 100 Continue\r\n\r\nHTTP/1.1 200 OK\r\n')
@@ -336,7 +335,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
             self.assertEqual(response.status, 200)
 
     def test_handles_expect_100_with_different_reason_phrase(self):
-        with patch('urllib3.util.wait_for_read') as wait_mock:
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
             # Shows the server first sending a 100 continue response
             # then a 200 ok response.
             s = FakeSocket(b'HTTP/1.1 100 (Continue)\r\n\r\nHTTP/1.1 200 OK\r\n')
@@ -358,7 +357,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
         # When using squid as an HTTP proxy, it will also send
         # a Connection: keep-alive header back with the 100 continue
         # response.  We need to ensure we handle this case.
-        with patch('urllib3.util.wait_for_read') as wait_mock:
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
             # Shows the server first sending a 100 continue response
             # then a 500 response.  We're picking 500 to confirm we
             # actually parse the response instead of getting the
@@ -381,7 +380,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
     def test_expect_100_continue_sends_307(self):
         # This is the case where we send a 100 continue and the server
         # immediately sends a 307
-        with patch('urllib3.util.wait_for_read') as wait_mock:
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
             # Shows the server first sending a 100 continue response
             # then a 200 ok response.
             s = FakeSocket(
@@ -399,7 +398,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
             self.assertEqual(response.status, 307)
 
     def test_expect_100_continue_no_response_from_server(self):
-        with patch('urllib3.util.wait_for_read') as wait_mock:
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
             # Shows the server first sending a 100 continue response
             # then a 200 ok response.
             s = FakeSocket(
@@ -480,7 +479,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
         conn.sock = s
         # Test that the standard library method was used by patching out
         # the ``_tunnel`` method and seeing if the std lib method was called.
-        with patch('urllib3.connection.HTTPConnection._tunnel') as mock_tunnel:
+        with mock.patch('urllib3.connection.HTTPConnection._tunnel') as mock_tunnel:
             conn._tunnel()
             self.assertTrue(mock_tunnel.called)
 
@@ -498,7 +497,7 @@ class TestAWSHTTPConnection(unittest.TestCase):
     def test_state_reset_on_connection_close(self):
         # This simulates what urllib3 does with connections
         # in its connection pool logic.
-        with patch('urllib3.util.wait_for_read') as wait_mock:
+        with mock.patch('urllib3.util.wait_for_read') as wait_mock:
 
             # First fast fail with a 500 response when we first
             # send the expect header.

--- a/tests/unit/botocore/test_client.py
+++ b/tests/unit/botocore/test_client.py
@@ -11,8 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import botocore.config
-from tests import unittest
-import mock
+from tests import mock, unittest
 
 import botocore
 from botocore import utils

--- a/tests/unit/botocore/test_compat.py
+++ b/tests/unit/botocore/test_compat.py
@@ -11,8 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import datetime
-import mock
-
 import pytest
 
 from botocore.exceptions import MD5UnavailableError
@@ -20,7 +18,7 @@ from botocore.compat import (
     total_seconds, unquote_str, six, ensure_bytes, get_md5,
     compat_shell_split, get_tzinfo_options
 )
-from tests import BaseEnvVar, unittest
+from tests import BaseEnvVar, mock, unittest
 
 
 class TotalSecondsTest(BaseEnvVar):

--- a/tests/unit/botocore/test_config_provider.py
+++ b/tests/unit/botocore/test_config_provider.py
@@ -10,9 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest
+from tests import mock, unittest
 import copy
-import mock
 import pytest
 
 import botocore

--- a/tests/unit/botocore/test_configloader.py
+++ b/tests/unit/botocore/test_configloader.py
@@ -12,9 +12,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from tests import unittest, BaseEnvVar
+from tests import mock, unittest, BaseEnvVar
 import os
-import mock
 import tempfile
 import shutil
 

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -13,7 +13,6 @@
 # language governing permissions and limitations under the License.
 from datetime import datetime, timedelta
 import subprocess
-import mock
 import os
 import tempfile
 import shutil
@@ -41,7 +40,7 @@ from botocore.configprovider import ConfigChainFactory
 from botocore.configprovider import ConfigValueStore
 import botocore.exceptions
 import botocore.session
-from tests import unittest, BaseEnvVar, IntegerRefresher, skip_if_windows
+from tests import mock, unittest, BaseEnvVar, IntegerRefresher, skip_if_windows
 
 
 # Passed to session to keep it from finding default config file

--- a/tests/unit/botocore/test_discovery.py
+++ b/tests/unit/botocore/test_discovery.py
@@ -1,6 +1,5 @@
 import time
-from mock import Mock, call
-from tests import unittest
+from tests import mock, unittest
 
 from botocore.awsrequest import AWSRequest
 from botocore.client import ClientMeta
@@ -148,9 +147,9 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
 
     def construct_manager(self, cache=None, time=None, side_effect=None):
         self.service_model = ServiceModel(self.service_description)
-        self.meta = Mock(spec=ClientMeta)
+        self.meta = mock.Mock(spec=ClientMeta)
         self.meta.service_model = self.service_model
-        self.client = Mock()
+        self.client = mock.Mock()
         if side_effect is None:
             side_effect = [{
                 'Endpoints': [{
@@ -311,7 +310,7 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
         # This second call should be blocked as we just failed
         endpoint = self.manager.describe_endpoint(**kwargs)
         self.assertIsNone(endpoint)
-        self.client.describe_endpoints.call_args_list == [call()]
+        self.client.describe_endpoints.call_args_list == [mock.call()]
 
     def test_describe_endpoint_optional_fails_stale_cache(self):
         key = ()
@@ -326,7 +325,7 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
         # This second call shouldn't go through as we just failed
         endpoint = self.manager.describe_endpoint(**kwargs)
         self.assertEqual(endpoint, 'old.com')
-        self.client.describe_endpoints.call_args_list == [call()]
+        self.client.describe_endpoints.call_args_list == [mock.call()]
 
     def test_describe_endpoint_required_fails_no_cache(self):
         side_effect = [ConnectionError(error=None)] * 2
@@ -353,7 +352,7 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
         # We have a stale endpoint, so this shouldn't fail or force a refresh
         endpoint = self.manager.describe_endpoint(**kwargs)
         self.assertEqual(endpoint, 'old.com')
-        self.client.describe_endpoints.call_args_list == [call()]
+        self.client.describe_endpoints.call_args_list == [mock.call()]
 
     def test_describe_endpoint_required_force_refresh_success(self):
         side_effect = [
@@ -368,13 +367,13 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
         # First call will fail
         with self.assertRaises(EndpointDiscoveryRefreshFailed):
             self.manager.describe_endpoint(**kwargs)
-        self.client.describe_endpoints.call_args_list == [call()]
+        self.client.describe_endpoints.call_args_list == [mock.call()]
         # Force a refresh if the cache is empty but discovery is required
         endpoint = self.manager.describe_endpoint(**kwargs)
         self.assertEqual(endpoint, 'new.com')
 
     def test_describe_endpoint_retries_after_failing(self):
-        fake_time = Mock()
+        fake_time = mock.Mock()
         fake_time.side_effect = [0, 100, 200]
         side_effect = [
             ConnectionError(error=None),
@@ -387,7 +386,7 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
         kwargs = {'Operation': 'TestDiscoveryOptional'}
         endpoint = self.manager.describe_endpoint(**kwargs)
         self.assertIsNone(endpoint)
-        self.client.describe_endpoints.call_args_list == [call()]
+        self.client.describe_endpoints.call_args_list == [mock.call()]
         # Second time should try again as enough time has elapsed
         endpoint = self.manager.describe_endpoint(**kwargs)
         self.assertEqual(endpoint, 'new.com')
@@ -396,12 +395,12 @@ class TestEndpointDiscoveryManager(BaseEndpointDiscoveryTest):
 class TestEndpointDiscoveryHandler(BaseEndpointDiscoveryTest):
     def setUp(self):
         super(TestEndpointDiscoveryHandler, self).setUp()
-        self.manager = Mock(spec=EndpointDiscoveryManager)
+        self.manager = mock.Mock(spec=EndpointDiscoveryManager)
         self.handler = EndpointDiscoveryHandler(self.manager)
         self.service_model = ServiceModel(self.service_description)
 
     def test_register_handler(self):
-        events = Mock(spec=HierarchicalEmitter)
+        events = mock.Mock(spec=HierarchicalEmitter)
         self.handler.register(events, 'foo-bar')
         events.register.assert_any_call(
             'before-parameter-build.foo-bar', self.handler.gather_identifiers

--- a/tests/unit/botocore/test_eventstream.py
+++ b/tests/unit/botocore/test_eventstream.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 """Unit tests for the binary event stream decoder. """
 import pytest
-from mock import Mock
+from tests import mock
 
 from botocore.parsers import EventStreamXMLParser
 from botocore.eventstream import (
@@ -422,7 +422,7 @@ def test_unpack_prelude():
 
 
 def create_mock_raw_stream(*data):
-    raw_stream = Mock()
+    raw_stream = mock.Mock()
     def generator():
         for chunk in data:
             yield chunk
@@ -435,8 +435,8 @@ def test_event_stream_wrapper_iteration():
         b"\x00\x00\x00+\x00\x00\x00\x0e4\x8b\xec{\x08event-id\x04\x00",
         b"\x00\xa0\x0c{'foo':'bar'}\xd3\x89\x02\x85",
     )
-    parser = Mock(spec=EventStreamXMLParser)
-    output_shape = Mock()
+    parser = mock.Mock(spec=EventStreamXMLParser)
+    output_shape = mock.Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
     events = list(event_stream)
     assert len(events) == 1
@@ -451,16 +451,16 @@ def test_event_stream_wrapper_iteration():
 
 def test_eventstream_wrapper_iteration_error():
     raw_stream = create_mock_raw_stream(ERROR_EVENT_MESSAGE[0])
-    parser = Mock(spec=EventStreamXMLParser)
+    parser = mock.Mock(spec=EventStreamXMLParser)
     parser.parse.return_value = {}
-    output_shape = Mock()
+    output_shape = mock.Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
     with pytest.raises(EventStreamError):
         list(event_stream)
 
 
 def test_event_stream_wrapper_close():
-    raw_stream = Mock()
+    raw_stream = mock.Mock()
     event_stream = EventStream(raw_stream, None, None, '')
     event_stream.close()
     raw_stream.close.assert_called_once_with()
@@ -472,8 +472,8 @@ def test_event_stream_initial_response():
         b'\x05event\x0b:event-type\x07\x00\x10initial-response\r:content-type',
         b'\x07\x00\ttext/json{"InitialResponse": "sometext"}\xf6\x98$\x83'
     )
-    parser = Mock(spec=EventStreamXMLParser)
-    output_shape = Mock()
+    parser = mock.Mock(spec=EventStreamXMLParser)
+    output_shape = mock.Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
     event = event_stream.get_initial_response()
     headers = {
@@ -491,8 +491,8 @@ def test_event_stream_initial_response_wrong_type():
         b"\x00\x00\x00+\x00\x00\x00\x0e4\x8b\xec{\x08event-id\x04\x00",
         b"\x00\xa0\x0c{'foo':'bar'}\xd3\x89\x02\x85",
     )
-    parser = Mock(spec=EventStreamXMLParser)
-    output_shape = Mock()
+    parser = mock.Mock(spec=EventStreamXMLParser)
+    output_shape = mock.Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
     with pytest.raises(NoInitialResponseError):
         event_stream.get_initial_response()
@@ -500,8 +500,8 @@ def test_event_stream_initial_response_wrong_type():
 
 def test_event_stream_initial_response_no_event():
     raw_stream = create_mock_raw_stream(b'')
-    parser = Mock(spec=EventStreamXMLParser)
-    output_shape = Mock()
+    parser = mock.Mock(spec=EventStreamXMLParser)
+    output_shape = mock.Mock()
     event_stream = EventStream(raw_stream, output_shape, parser, '')
     with pytest.raises(NoInitialResponseError):
         event_stream.get_initial_response()

--- a/tests/unit/botocore/test_handlers.py
+++ b/tests/unit/botocore/test_handlers.py
@@ -11,10 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest, BaseSessionTest
+from tests import mock, unittest, BaseSessionTest
 
 import base64
-import mock
 import copy
 import os
 import json

--- a/tests/unit/botocore/test_history.py
+++ b/tests/unit/botocore/test_history.py
@@ -1,6 +1,5 @@
-from tests import unittest
+from tests import mock, unittest
 
-import mock
 
 from botocore.history import HistoryRecorder
 from botocore.history import BaseHistoryHandler

--- a/tests/unit/botocore/test_idempotency.py
+++ b/tests/unit/botocore/test_idempotency.py
@@ -11,9 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest
+from tests import mock, unittest
 import re
-import mock
 from botocore.handlers import generate_idempotent_uuid
 
 

--- a/tests/unit/botocore/test_loaders.py
+++ b/tests/unit/botocore/test_loaders.py
@@ -22,14 +22,13 @@
 import os
 import contextlib
 import copy
-import mock
 
 from botocore.exceptions import DataNotFoundError, UnknownServiceError
 from botocore.loaders import JSONFileLoader
 from botocore.loaders import Loader, create_loader
 from botocore.loaders import ExtrasProcessor
 
-from tests import BaseEnvVar
+from tests import mock, BaseEnvVar
 
 
 class TestJSONFileLoader(BaseEnvVar):

--- a/tests/unit/botocore/test_paginate.py
+++ b/tests/unit/botocore/test_paginate.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest
+from tests import mock, unittest
 from botocore import model
 from botocore.paginate import Paginator
 from botocore.paginate import PaginatorModel
@@ -19,8 +19,6 @@ from botocore.paginate import TokenDecoder
 from botocore.paginate import TokenEncoder
 from botocore.exceptions import PaginationError
 from botocore.compat import six
-
-import mock
 
 
 def encode_token(token):

--- a/tests/unit/botocore/test_session.py
+++ b/tests/unit/botocore/test_session.py
@@ -13,13 +13,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import botocore.config
-from tests import unittest, create_session, temporary_file
+from tests import mock, unittest, create_session, temporary_file
 import os
 import logging
 import tempfile
 import shutil
 
-import mock
 import pytest
 
 import botocore.session

--- a/tests/unit/botocore/test_session_legacy.py
+++ b/tests/unit/botocore/test_session_legacy.py
@@ -13,13 +13,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import botocore.config
-from tests import unittest, create_session, temporary_file
+from tests import mock, unittest, create_session, temporary_file
 import os
 import logging
 import tempfile
 import shutil
 
-import mock
 import pytest
 
 import botocore.session

--- a/tests/unit/botocore/test_signers.py
+++ b/tests/unit/botocore/test_signers.py
@@ -10,7 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import datetime
 import json
 
@@ -31,8 +30,7 @@ from botocore.exceptions import UnsupportedSignatureVersionError
 from botocore.signers import RequestSigner, S3PostPresigner, CloudFrontSigner
 from botocore.signers import generate_db_auth_token
 
-from tests import unittest
-from tests import assert_url_equal
+from tests import assert_url_equal, mock, unittest
 
 
 class BaseSignerTest(unittest.TestCase):

--- a/tests/unit/botocore/test_stub.py
+++ b/tests/unit/botocore/test_stub.py
@@ -11,8 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from tests import unittest
-import mock
+from tests import mock, unittest
 
 from botocore.stub import Stubber
 from botocore.exceptions import ParamValidationError, StubResponseError, UnStubbedResponseError

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -15,6 +15,7 @@ import io
 import pytest
 
 from tests import create_session
+from tests import mock
 from tests import unittest
 from tests import RawResponse
 from tests import FreezeTime
@@ -22,7 +23,6 @@ from dateutil.tz import tzutc, tzoffset
 from contextlib import contextmanager
 import datetime
 import copy
-import mock
 import operator
 
 import botocore

--- a/tests/unit/botocore/test_waiters.py
+++ b/tests/unit/botocore/test_waiters.py
@@ -11,9 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-from tests import unittest, BaseEnvVar
-
-import mock
+from tests import mock, unittest, BaseEnvVar
 
 import botocore
 from botocore.compat import six

--- a/tests/unit/customizations/cloudformation/test_artifact_exporter.py
+++ b/tests/unit/customizations/cloudformation/test_artifact_exporter.py
@@ -1,4 +1,3 @@
-import mock
 import botocore.session
 import tempfile
 import os
@@ -9,9 +8,8 @@ import zipfile
 import pytest
 
 from contextlib import contextmanager, closing
-from mock import patch, Mock, MagicMock
 from botocore.stub import Stubber
-from awscli.testutils import FileCreator
+from awscli.testutils import mock, FileCreator
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.artifact_exporter \
     import is_s3_url, parse_s3_url, is_local_file, is_local_folder, \
@@ -191,7 +189,7 @@ def _helper_verify_export_resources(
     test_class, upload_local_artifacts_mock, expected_result
 ):
 
-    s3_uploader_mock = Mock()
+    s3_uploader_mock = mock.Mock()
     upload_local_artifacts_mock.reset_mock()
 
     resource_id = "id"
@@ -234,7 +232,7 @@ class TestArtifactExporter(BaseYAMLTest):
 
     def setUp(self):
         super(TestArtifactExporter, self).setUp()
-        self.s3_uploader_mock = Mock()
+        self.s3_uploader_mock = mock.Mock()
         self.s3_uploader_mock.s3.meta.endpoint_url = "https://s3.some-valid-region.amazonaws.com"
 
     def test_parse_s3_url(self):
@@ -293,7 +291,7 @@ class TestArtifactExporter(BaseYAMLTest):
             self.assertTrue(is_local_folder(filename))
             self.assertFalse(is_local_file(filename))
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_local_file(self, zip_and_upload_mock):
         # Case 1: Artifact path is a relative path
         # Verifies that we package local artifacts appropriately
@@ -323,7 +321,7 @@ class TestArtifactExporter(BaseYAMLTest):
 
             zip_and_upload_mock.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_local_file_abs_path(self, zip_and_upload_mock):
         # Case 2: Artifact path is an absolute path
         # Verifies that we package local artifacts appropriately
@@ -348,7 +346,7 @@ class TestArtifactExporter(BaseYAMLTest):
             self.s3_uploader_mock.upload_with_dedup.assert_called_with(artifact_path)
             zip_and_upload_mock.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_local_folder(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
@@ -366,7 +364,7 @@ class TestArtifactExporter(BaseYAMLTest):
                                             resource_dict,
                                             property_name,
                                             parent_dir,
-                                            Mock())
+                                            mock.Mock())
             self.assertEqual(result, expected_s3_url)
 
             absolute_artifact_path = make_abs_path(parent_dir, artifact_path)
@@ -374,7 +372,7 @@ class TestArtifactExporter(BaseYAMLTest):
             zip_and_upload_mock.assert_called_once_with(absolute_artifact_path,
                                                         mock.ANY)
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_no_path(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
@@ -396,7 +394,7 @@ class TestArtifactExporter(BaseYAMLTest):
         zip_and_upload_mock.assert_called_once_with(parent_dir, mock.ANY)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_s3_url(self,
                                            zip_and_upload_mock):
         property_name = "property"
@@ -417,7 +415,7 @@ class TestArtifactExporter(BaseYAMLTest):
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
     def test_upload_local_artifacts_invalid_value(self, zip_and_upload_mock):
         property_name = "property"
         resource_id = "resource_id"
@@ -444,7 +442,7 @@ class TestArtifactExporter(BaseYAMLTest):
         zip_and_upload_mock.assert_not_called()
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.make_zip")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.make_zip")
     def test_zip_folder(self, make_zip_mock):
         zip_file_name = "name.zip"
         make_zip_mock.return_value = zip_file_name
@@ -455,7 +453,7 @@ class TestArtifactExporter(BaseYAMLTest):
 
         make_zip_mock.assert_called_once_with(mock.ANY, dirname)
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource(self, upload_local_artifacts_mock):
         # Property value is a path to file
 
@@ -482,11 +480,11 @@ class TestArtifactExporter(BaseYAMLTest):
 
         self.assertEqual(resource_dict[resource.PROPERTY_NAME], s3_url)
 
-    @patch("shutil.rmtree")
-    @patch("zipfile.is_zipfile")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("shutil.rmtree")
+    @mock.patch("zipfile.is_zipfile")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_resource_with_force_zip_on_regular_file(self, is_local_file_mock, \
         zip_and_upload_mock, copy_to_temp_dir_mock, is_zipfile_mock, rmtree_mock):
         # Property value is a path to file and FORCE_ZIP is True
@@ -521,11 +519,11 @@ class TestArtifactExporter(BaseYAMLTest):
             is_zipfile_mock.assert_called_once_with(original_path)
             assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
-    @patch("shutil.rmtree")
-    @patch("zipfile.is_zipfile")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("shutil.rmtree")
+    @mock.patch("zipfile.is_zipfile")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_resource_with_force_zip_on_zip_file(self, is_local_file_mock, \
         zip_and_upload_mock, copy_to_temp_dir_mock, is_zipfile_mock, rmtree_mock):
         # Property value is a path to zip file and FORCE_ZIP is True
@@ -558,11 +556,11 @@ class TestArtifactExporter(BaseYAMLTest):
         is_zipfile_mock.assert_called_once_with(original_path)
         assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
-    @patch("shutil.rmtree")
-    @patch("zipfile.is_zipfile")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("shutil.rmtree")
+    @mock.patch("zipfile.is_zipfile")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.copy_to_temp_dir")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.zip_and_upload")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_resource_without_force_zip(self, is_local_file_mock, \
         zip_and_upload_mock, copy_to_temp_dir_mock, is_zipfile_mock, rmtree_mock):
 
@@ -592,7 +590,7 @@ class TestArtifactExporter(BaseYAMLTest):
         is_zipfile_mock.assert_called_once_with(original_path)
         assert resource_dict[resource.PROPERTY_NAME] == s3_url
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_empty_property_value(self, upload_local_artifacts_mock):
         # Property value is empty
 
@@ -616,7 +614,7 @@ class TestArtifactExporter(BaseYAMLTest):
                                                             self.s3_uploader_mock)
         self.assertEqual(resource_dict[resource.PROPERTY_NAME], s3_url)
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_property_value_dict(self, upload_local_artifacts_mock):
         # Property value is a dictionary. Export should not upload anything
 
@@ -637,7 +635,7 @@ class TestArtifactExporter(BaseYAMLTest):
         upload_local_artifacts_mock.assert_not_called()
         self.assertEqual(resource_dict, {"foo": {"a": "b"}})
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_has_package_null_property_to_false(self, upload_local_artifacts_mock):
         # Should not upload anything if PACKAGE_NULL_PROPERTY is set to False
 
@@ -658,7 +656,7 @@ class TestArtifactExporter(BaseYAMLTest):
         upload_local_artifacts_mock.assert_not_called()
         self.assertNotIn(resource.PROPERTY_NAME, resource_dict)
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_export_fails(self, upload_local_artifacts_mock):
 
         class MockResource(Resource):
@@ -677,7 +675,7 @@ class TestArtifactExporter(BaseYAMLTest):
         with self.assertRaises(exceptions.ExportFailedError):
             resource.export(resource_id, resource_dict, parent_dir)
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.upload_local_artifacts")
     def test_resource_with_s3_url_dict(self, upload_local_artifacts_mock):
         """
         Checks if we properly export from the Resource classc
@@ -717,7 +715,7 @@ class TestArtifactExporter(BaseYAMLTest):
             "v": "SomeVersionNumber"
         })
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.Template")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.Template")
     def test_export_cloudformation_stack(self, TemplateMock):
         stack_resource = CloudFormationStackResource(self.s3_uploader_mock)
 
@@ -727,7 +725,7 @@ class TestArtifactExporter(BaseYAMLTest):
         result_s3_url = "s3://hello/world"
         result_path_style_s3_url = "http://s3.amazonws.com/hello/world"
 
-        template_instance_mock = Mock()
+        template_instance_mock = mock.Mock()
         TemplateMock.return_value = template_instance_mock
         template_instance_mock.export.return_value = exported_template_dict
 
@@ -805,7 +803,7 @@ class TestArtifactExporter(BaseYAMLTest):
                 stack_resource.export(resource_id, resource_dict, "dir")
                 self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.Template")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.Template")
     def test_export_serverless_application(self, TemplateMock):
         stack_resource = ServerlessApplicationResource(self.s3_uploader_mock)
 
@@ -815,7 +813,7 @@ class TestArtifactExporter(BaseYAMLTest):
         result_s3_url = "s3://hello/world"
         result_path_style_s3_url = "http://s3.amazonws.com/hello/world"
 
-        template_instance_mock = Mock()
+        template_instance_mock = mock.Mock()
         TemplateMock.return_value = template_instance_mock
         template_instance_mock.export.return_value = exported_template_dict
 
@@ -895,23 +893,23 @@ class TestArtifactExporter(BaseYAMLTest):
         self.assertEqual(resource_dict[property_name], location)
         self.s3_uploader_mock.upload_with_dedup.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
     def test_template_export_metadata(self, yaml_parse_mock):
         parent_dir = os.path.sep
         template_dir = os.path.join(parent_dir, 'foo', 'bar')
         template_path = os.path.join(template_dir, 'path')
         template_str = self.example_yaml_template()
 
-        metadata_type1_class = Mock()
+        metadata_type1_class = mock.Mock()
         metadata_type1_class.RESOURCE_TYPE = "metadata_type1"
         metadata_type1_class.PROPERTY_NAME = "property_1"
-        metadata_type1_instance = Mock()
+        metadata_type1_instance = mock.Mock()
         metadata_type1_class.return_value = metadata_type1_instance
 
-        metadata_type2_class = Mock()
+        metadata_type2_class = mock.Mock()
         metadata_type2_class.RESOURCE_TYPE = "metadata_type2"
         metadata_type2_class.PROPERTY_NAME = "property_2"
-        metadata_type2_instance = Mock()
+        metadata_type2_instance = mock.Mock()
         metadata_type2_class.return_value = metadata_type2_instance
 
         metadata_to_export = [
@@ -933,7 +931,7 @@ class TestArtifactExporter(BaseYAMLTest):
         yaml_parse_mock.return_value = template_dict
 
         # Patch the file open method to return template string
-        with patch(
+        with mock.patch(
                 "awscli.customizations.cloudformation."
                 "artifact_exporter.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
@@ -956,20 +954,20 @@ class TestArtifactExporter(BaseYAMLTest):
             metadata_type2_instance.export.assert_called_once_with(
                 "metadata_type2", mock.ANY, template_dir)
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
     def test_template_export(self, yaml_parse_mock):
         parent_dir = os.path.sep
         template_dir = os.path.join(parent_dir, 'foo', 'bar')
         template_path = os.path.join(template_dir, 'path')
         template_str = self.example_yaml_template()
 
-        resource_type1_class = Mock()
+        resource_type1_class = mock.Mock()
         resource_type1_class.RESOURCE_TYPE = "resource_type1"
-        resource_type1_instance = Mock()
+        resource_type1_instance = mock.Mock()
         resource_type1_class.return_value = resource_type1_instance
-        resource_type2_class = Mock()
+        resource_type2_class = mock.Mock()
         resource_type2_class.RESOURCE_TYPE = "resource_type2"
-        resource_type2_instance = Mock()
+        resource_type2_instance = mock.Mock()
         resource_type2_class.return_value = resource_type2_instance
 
         resources_to_export = [
@@ -999,7 +997,7 @@ class TestArtifactExporter(BaseYAMLTest):
         yaml_parse_mock.return_value = template_dict
 
         # Patch the file open method to return template string
-        with patch(
+        with mock.patch(
                 "awscli.customizations.cloudformation."
                 "artifact_exporter.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
@@ -1179,18 +1177,18 @@ class TestArtifactExporter(BaseYAMLTest):
                 template_exporter.export()
 
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.yaml_parse")
     def test_template_global_export(self, yaml_parse_mock):
         parent_dir = os.path.sep
         template_dir = os.path.join(parent_dir, 'foo', 'bar')
         template_path = os.path.join(template_dir, 'path')
         template_str = self.example_yaml_template()
 
-        resource_type1_class = Mock()
-        resource_type1_instance = Mock()
+        resource_type1_class = mock.Mock()
+        resource_type1_instance = mock.Mock()
         resource_type1_class.return_value = resource_type1_instance
-        resource_type2_class = Mock()
-        resource_type2_instance = Mock()
+        resource_type2_class = mock.Mock()
+        resource_type2_instance = mock.Mock()
         resource_type2_class.return_value = resource_type2_instance
 
         resources_to_export = {
@@ -1214,15 +1212,15 @@ class TestArtifactExporter(BaseYAMLTest):
             "List": ["foo", properties_in_list]
         }
         open_mock = mock.mock_open()
-        include_transform_export_handler_mock = Mock()
+        include_transform_export_handler_mock = mock.Mock()
         include_transform_export_handler_mock.return_value = {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}}
         yaml_parse_mock.return_value = template_dict
 
-        with patch(
+        with mock.patch(
                 "awscli.customizations.cloudformation."
                 "artifact_exporter.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
-            with patch.dict(GLOBAL_EXPORT_DICT, {"Fn::Transform": include_transform_export_handler_mock}):
+            with mock.patch.dict(GLOBAL_EXPORT_DICT, {"Fn::Transform": include_transform_export_handler_mock}):
                 template_exporter = Template(
                     template_path, parent_dir, self.s3_uploader_mock,
                     resources_to_export)
@@ -1244,7 +1242,7 @@ class TestArtifactExporter(BaseYAMLTest):
                 self.assertEqual(exported_template["Resources"]["Resource1"]["Properties"]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
                 self.assertEqual(exported_template["List"][1]["Fn::Transform"], {"Name": "AWS::Include", "Parameters": {"Location": "s3://foo"}})
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_relative_file_path(self, is_local_file_mock):
         #exports transform
         parent_dir = os.path.abspath("someroot")
@@ -1257,7 +1255,7 @@ class TestArtifactExporter(BaseYAMLTest):
         is_local_file_mock.assert_called_with(abs_file_path)
         self.assertEqual(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_absolute_file_path(self, is_local_file_mock):
         #exports transform
         parent_dir = os.path.abspath("someroot")
@@ -1270,7 +1268,7 @@ class TestArtifactExporter(BaseYAMLTest):
         is_local_file_mock.assert_called_with(abs_file_path)
         self.assertEqual(handler_output, {'Name': 'AWS::Include', 'Parameters': {'Location': 's3://foo'}})
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_s3_uri(self, is_local_file_mock):
 
         handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": "s3://bucket/foo.yaml"}}, self.s3_uploader_mock, "parent_dir")
@@ -1280,7 +1278,7 @@ class TestArtifactExporter(BaseYAMLTest):
         is_local_file_mock.assert_not_called()
         self.s3_uploader_mock.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_no_path(self, is_local_file_mock):
 
         handler_output = include_transform_export_handler({"Name": "AWS::Include", "Parameters": {"Location": ""}}, self.s3_uploader_mock, "parent_dir")
@@ -1290,7 +1288,7 @@ class TestArtifactExporter(BaseYAMLTest):
         is_local_file_mock.assert_not_called()
         self.s3_uploader_mock.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_with_dict_value_for_location(self, is_local_file_mock):
 
         handler_output = include_transform_export_handler(
@@ -1304,7 +1302,7 @@ class TestArtifactExporter(BaseYAMLTest):
         self.s3_uploader_mock.assert_not_called()
 
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_non_local_file(self, is_local_file_mock):
         #returns unchanged template dict if transform not a local file, and not a S3 URI
         is_local_file_mock.return_value = False
@@ -1314,7 +1312,7 @@ class TestArtifactExporter(BaseYAMLTest):
             is_local_file_mock.assert_called_with("http://foo.yaml")
             self.s3_uploader_mock.assert_not_called()
 
-    @patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
+    @mock.patch("awscli.customizations.cloudformation.artifact_exporter.is_local_file")
     def test_include_transform_export_handler_non_include_transform(self, is_local_file_mock):
         #ignores transform that is not aws::include
         handler_output = include_transform_export_handler({"Name": "AWS::OtherTransform", "Parameters": {"Location": "foo.yaml"}}, self.s3_uploader_mock, "parent_dir")
@@ -1362,8 +1360,8 @@ class TestArtifactExporter(BaseYAMLTest):
                 os.remove(zipfile_name)
             test_file_creator.remove_all()
 
-    @patch("shutil.copy")
-    @patch("tempfile.mkdtemp")
+    @mock.patch("shutil.copy")
+    @mock.patch("tempfile.mkdtemp")
     def test_copy_to_temp_dir(self, mkdtemp_mock, copyfile_mock):
         temp_dir = "/tmp/foo/"
         filename = "test.js"

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -12,11 +12,11 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
 import tempfile
 import six
-from mock import patch, Mock, MagicMock, call
 import collections
+
+from awscli.testutils import mock
 
 from awscli.customizations.cloudformation.deploy import DeployCommand
 from awscli.customizations.cloudformation.deployer import Deployer
@@ -72,12 +72,12 @@ class TestDeployCommand(BaseYAMLTest):
                                        verify_ssl=None)
         self.deploy_command = DeployCommand(self.session)
 
-        self.deployer = Deployer(Mock())
-        self.deployer.create_and_wait_for_changeset = Mock()
-        self.deployer.execute_changeset = Mock()
-        self.deployer.wait_for_execute = Mock()
+        self.deployer = Deployer(mock.Mock())
+        self.deployer.create_and_wait_for_changeset = mock.Mock()
+        self.deployer.execute_changeset = mock.Mock()
+        self.deployer.wait_for_execute = mock.Mock()
 
-    @patch("awscli.customizations.cloudformation.deploy.yaml_parse")
+    @mock.patch("awscli.customizations.cloudformation.deploy.yaml_parse")
     def test_command_invoked(self, mock_yaml_parse):
         """
         Tests that deploy method is invoked when command is run
@@ -93,19 +93,19 @@ class TestDeployCommand(BaseYAMLTest):
 
             open_mock = mock.mock_open()
             # Patch the file open method to return template string
-            with patch(
+            with mock.patch(
                     "awscli.customizations.cloudformation.deploy.compat_open",
                     open_mock(read_data=template_str)) as open_mock:
 
                 fake_template = get_example_template()
                 mock_yaml_parse.return_value = fake_template
 
-                self.deploy_command.deploy = MagicMock()
+                self.deploy_command.deploy = mock.MagicMock()
                 self.deploy_command.deploy.return_value = 0
-                self.deploy_command.parse_key_value_arg = Mock()
+                self.deploy_command.parse_key_value_arg = mock.Mock()
                 self.deploy_command.parse_key_value_arg.side_effect = [
                     fake_parameter_overrides, fake_tags_dict]
-                self.deploy_command.merge_parameters = MagicMock(
+                self.deploy_command.merge_parameters = mock.MagicMock(
                         return_value=fake_parameters)
 
                 self.parsed_args.template_file = file_path
@@ -130,11 +130,11 @@ class TestDeployCommand(BaseYAMLTest):
                 )
 
                 self.deploy_command.parse_key_value_arg.assert_has_calls([
-                    call(
+                    mock.call(
                         self.parsed_args.parameter_overrides,
                          "parameter-overrides"
                     ),
-                    call(
+                    mock.call(
                         self.parsed_args.tags,
                         "tags"
                     )
@@ -151,7 +151,7 @@ class TestDeployCommand(BaseYAMLTest):
             result = self.deploy_command._run_main(self.parsed_args,
                                                   parsed_globals=self.parsed_globals)
 
-    @patch('awscli.customizations.cloudformation.deploy.os.path.expanduser')
+    @mock.patch('awscli.customizations.cloudformation.deploy.os.path.expanduser')
     def test_expands_user_for_template_file(self, expanduser):
         contents = (
             'Resource:\n'
@@ -172,9 +172,9 @@ class TestDeployCommand(BaseYAMLTest):
         self.assertEqual(parsed, {'Resource': {'Test': {'Type': 'AWS::Foo::Bar'}}})
         self.assertEqual(template_str, contents)
 
-    @patch('awscli.customizations.cloudformation.deploy.os.path.isfile')
-    @patch('awscli.customizations.cloudformation.deploy.yaml_parse')
-    @patch('awscli.customizations.cloudformation.deploy.os.path.getsize')
+    @mock.patch('awscli.customizations.cloudformation.deploy.os.path.isfile')
+    @mock.patch('awscli.customizations.cloudformation.deploy.yaml_parse')
+    @mock.patch('awscli.customizations.cloudformation.deploy.os.path.getsize')
     def test_s3_upload_required_but_missing_bucket(self, mock_getsize, mock_yaml_parse, mock_isfile):
         """
         Tests that large templates are detected prior to deployment
@@ -186,18 +186,18 @@ class TestDeployCommand(BaseYAMLTest):
         mock_yaml_parse.return_value = template_str
         open_mock = mock.mock_open()
 
-        with patch(
+        with mock.patch(
                 "awscli.customizations.cloudformation.deploy.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
             with self.assertRaises(exceptions.DeployBucketRequiredError):
                 result = self.deploy_command._run_main(self.parsed_args,
                                 parsed_globals=self.parsed_globals)
 
-    @patch('awscli.customizations.cloudformation.deploy.os.path.isfile')
-    @patch('awscli.customizations.cloudformation.deploy.yaml_parse')
-    @patch('awscli.customizations.cloudformation.deploy.os.path.getsize')
-    @patch('awscli.customizations.cloudformation.deploy.DeployCommand.deploy')
-    @patch('awscli.customizations.cloudformation.deploy.S3Uploader')
+    @mock.patch('awscli.customizations.cloudformation.deploy.os.path.isfile')
+    @mock.patch('awscli.customizations.cloudformation.deploy.yaml_parse')
+    @mock.patch('awscli.customizations.cloudformation.deploy.os.path.getsize')
+    @mock.patch('awscli.customizations.cloudformation.deploy.DeployCommand.deploy')
+    @mock.patch('awscli.customizations.cloudformation.deploy.S3Uploader')
     def test_s3_uploader_is_configured_properly(self, s3UploaderMock,
         deploy_method_mock, mock_getsize, mock_yaml_parse, mock_isfile):
         """
@@ -211,12 +211,12 @@ class TestDeployCommand(BaseYAMLTest):
         mock_yaml_parse.return_value = template_str
         open_mock = mock.mock_open()
 
-        with patch(
+        with mock.patch(
                 "awscli.customizations.cloudformation.deploy.compat_open",
                 open_mock(read_data=template_str)) as open_mock:
 
             self.parsed_args.s3_bucket = bucket_name
-            s3UploaderObject = Mock()
+            s3UploaderObject = mock.Mock()
             s3UploaderMock.return_value = s3UploaderObject
 
             result = self.deploy_command._run_main(self.parsed_args,

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -1,7 +1,7 @@
-import mock
 import botocore.session
 
-from mock import patch, Mock, MagicMock
+from awscli.testutils import mock
+
 from botocore.stub import Stubber
 from awscli.customizations.cloudformation.deployer import Deployer, ChangeSetResult
 from awscli.customizations.cloudformation import exceptions
@@ -109,7 +109,7 @@ class TestDeployer(BaseYAMLTest):
         tags = [{"Key":"key1", "Value": "val1"}]
 
         # Case 1: Stack DOES NOT exist
-        self.deployer.has_stack = Mock()
+        self.deployer.has_stack = mock.Mock()
         self.deployer.has_stack.return_value = False
 
         expected_params = {
@@ -178,7 +178,7 @@ class TestDeployer(BaseYAMLTest):
         role_arn = "arn:aws:iam::1234567890:role"
         notification_arns = ["arn:aws:sns:region:1234567890:notify"]
 
-        s3_uploader = Mock()
+        s3_uploader = mock.Mock()
         def to_path_style_s3_url(some_string, Version=None):
             return "https://s3.amazonaws.com/bucket/file"
         s3_uploader.to_path_style_s3_url = to_path_style_s3_url
@@ -187,7 +187,7 @@ class TestDeployer(BaseYAMLTest):
         s3_uploader.upload_with_dedup = upload_with_dedup
 
         # Case 1: Stack DOES NOT exist
-        self.deployer.has_stack = Mock()
+        self.deployer.has_stack = mock.Mock()
         self.deployer.has_stack.return_value = False
 
         expected_params = {
@@ -248,7 +248,7 @@ class TestDeployer(BaseYAMLTest):
         s3_uploader = None
         tags = [{"Key":"key1", "Value": "val1"}]
 
-        self.deployer.has_stack = Mock()
+        self.deployer.has_stack = mock.Mock()
         self.deployer.has_stack.return_value = False
 
         self.stub_client.add_client_error(
@@ -311,10 +311,10 @@ class TestDeployer(BaseYAMLTest):
         s3_uploader = None
         tags = [{"Key":"key1", "Value": "val1"}]
 
-        self.deployer.create_changeset = Mock()
+        self.deployer.create_changeset = mock.Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
 
-        self.deployer.wait_for_changeset = Mock()
+        self.deployer.wait_for_changeset = mock.Mock()
 
         result = self.deployer.create_and_wait_for_changeset(
                 stack_name, template, parameters, capabilities, role_arn,
@@ -335,10 +335,10 @@ class TestDeployer(BaseYAMLTest):
         s3_uploader = None
         tags = [{"Key":"key1", "Value": "val1"}]
 
-        self.deployer.create_changeset = Mock()
+        self.deployer.create_changeset = mock.Mock()
         self.deployer.create_changeset.return_value = ChangeSetResult(changeset_id, changeset_type)
 
-        self.deployer.wait_for_changeset = Mock()
+        self.deployer.wait_for_changeset = mock.Mock()
         self.deployer.wait_for_changeset.side_effect = RuntimeError
 
         with self.assertRaises(RuntimeError):
@@ -350,9 +350,9 @@ class TestDeployer(BaseYAMLTest):
         stack_name = "stack_name"
         changeset_id = "changeset-id"
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_deployer = Deployer(mock_client)
-        mock_waiter = Mock()
+        mock_waiter = mock.Mock()
         mock_client.get_waiter.return_value = mock_waiter
 
         response = {
@@ -380,9 +380,9 @@ class TestDeployer(BaseYAMLTest):
         stack_name = "stack_name"
         changeset_id = "changeset-id"
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_deployer = Deployer(mock_client)
-        mock_waiter = Mock()
+        mock_waiter = mock.Mock()
         mock_client.get_waiter.return_value = mock_waiter
 
         response = {
@@ -410,9 +410,9 @@ class TestDeployer(BaseYAMLTest):
         stack_name = "stack_name"
         changeset_id = "changeset-id"
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_deployer = Deployer(mock_client)
-        mock_waiter = Mock()
+        mock_waiter = mock.Mock()
         mock_client.get_waiter.return_value = mock_waiter
 
         response = {
@@ -440,9 +440,9 @@ class TestDeployer(BaseYAMLTest):
         stack_name = "stack_name"
         changeset_type = "CREATE"
 
-        mock_client = Mock()
+        mock_client = mock.Mock()
         mock_deployer = Deployer(mock_client)
-        mock_waiter = Mock()
+        mock_waiter = mock.Mock()
         mock_client.get_waiter.return_value = mock_waiter
 
         waiter_error = botocore.exceptions.WaiterError(name="name",

--- a/tests/unit/customizations/cloudformation/test_package.py
+++ b/tests/unit/customizations/cloudformation/test_package.py
@@ -10,13 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import os
 import sys
 import tempfile
 
+from awscli.testutils import mock
+
 from io import StringIO
-from mock import patch, Mock, MagicMock
 from awscli.customizations.cloudformation.package import PackageCommand
 from awscli.customizations.cloudformation.artifact_exporter import Template
 from awscli.customizations.cloudformation.yamlhelper import yaml_dump
@@ -61,12 +61,12 @@ class TestPackageCommand(BaseYAMLTest):
         self.package_command = PackageCommand(self.session)
 
 
-    @patch("awscli.customizations.cloudformation.package.yaml_dump")
+    @mock.patch("awscli.customizations.cloudformation.package.yaml_dump")
     def test_main(self, mock_yaml_dump):
         exported_template_str = "hello"
 
-        self.package_command.write_output = Mock()
-        self.package_command._export = Mock()
+        self.package_command.write_output = mock.Mock()
+        self.package_command._export = mock.Mock()
         mock_yaml_dump.return_value = exported_template_str
 
         # Create a temporary file and make this my template
@@ -90,7 +90,7 @@ class TestPackageCommand(BaseYAMLTest):
 
     def test_main_error(self):
 
-        self.package_command._export = Mock()
+        self.package_command._export = mock.Mock()
         self.package_command._export.side_effect = RuntimeError()
 
         # Create a temporary file and make this my template
@@ -102,7 +102,7 @@ class TestPackageCommand(BaseYAMLTest):
                 self.package_command._run_main(self.parsed_args, self.parsed_globals)
 
 
-    @patch("awscli.customizations.cloudformation.package.sys.stdout")
+    @mock.patch("awscli.customizations.cloudformation.package.sys.stdout")
     def test_write_output_to_stdout(self, stdoutmock):
         data = u"some data"
         filename = None

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -10,11 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-import tempfile
-from mock import patch, Mock, MagicMock
-
-from botocore.compat import json
 from botocore.compat import OrderedDict
 
 from awscli.customizations.cloudformation.deployer import Deployer

--- a/tests/unit/customizations/cloudtrail/test_commands.py
+++ b/tests/unit/customizations/cloudtrail/test_commands.py
@@ -10,19 +10,18 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations import cloudtrail
 
 class TestCloudTrailPlumbing(unittest.TestCase):
     def test_initialization_registers_injector(self):
-        cli = Mock()
+        cli = mock.Mock()
         cloudtrail.initialize(cli)
         cli.register.assert_called_with('building-command-table.cloudtrail',
                                         cloudtrail.inject_commands)
 
     def test_injection_adds_two_commands_to_cmd_table(self):
         command_table = {}
-        session = Mock()
+        session = mock.Mock()
         cloudtrail.inject_commands(command_table, session)
         self.assertIn('validate-logs', command_table)

--- a/tests/unit/customizations/cloudtrail/test_utils.py
+++ b/tests/unit/customizations/cloudtrail/test_utils.py
@@ -10,12 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock, call
 from datetime import datetime, timedelta
 from dateutil import parser, tz
 
 from awscli.customizations.cloudtrail import utils
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.cloudtrail.utils import (
     normalize_date,
     format_date,
@@ -33,7 +32,7 @@ class TestCloudTrailUtils(unittest.TestCase):
         self.assertEqual("1234", utils.get_account_id_from_arn(arn))
 
     def test_gets_trail_by_arn(self):
-        cloudtrail_client = Mock()
+        cloudtrail_client = mock.Mock()
         cloudtrail_client.describe_trails.return_value = {
             "trailList": [
                 {"TrailARN": "a", "Foo": "Baz"},
@@ -44,7 +43,7 @@ class TestCloudTrailUtils(unittest.TestCase):
         self.assertEqual("Bar", result["Foo"])
 
     def test_throws_when_unable_to_get_trail_by_arn(self):
-        cloudtrail_client = Mock()
+        cloudtrail_client = mock.Mock()
         cloudtrail_client.describe_trails.return_value = {"trailList": []}
         self.assertRaises(ValueError, utils.get_trail_by_arn, cloudtrail_client, "b")
 
@@ -71,7 +70,7 @@ class TestCloudTrailUtils(unittest.TestCase):
 
 class TestPublicKeyProvider(unittest.TestCase):
     def test_returns_public_keys_in_range(self):
-        cloudtrail_client = Mock()
+        cloudtrail_client = mock.Mock()
         cloudtrail_client.list_public_keys.return_value = {
             "PublicKeyList": [
                 {"Fingerprint": "a", "OtherData": "a", "Value": "a"},
@@ -92,11 +91,11 @@ class TestPublicKeyProvider(unittest.TestCase):
             keys,
         )
         cloudtrail_client.list_public_keys.assert_has_calls(
-            [call(EndTime=end_date, StartTime=start_date)]
+            [mock.call(EndTime=end_date, StartTime=start_date)]
         )
 
     def test_returns_public_key_in_range(self):
-        cloudtrail_client = Mock()
+        cloudtrail_client = mock.Mock()
         cloudtrail_client.list_public_keys.return_value = {
             "PublicKeyList": [
                 {"Fingerprint": "a", "OtherData": "a1", "Value": "a2"},
@@ -111,7 +110,7 @@ class TestPublicKeyProvider(unittest.TestCase):
 
     def test_key_not_found(self):
         with self.assertRaises(RuntimeError):
-            cloudtrail_client = Mock()
+            cloudtrail_client = mock.Mock()
             cloudtrail_client.list_public_keys.return_value = {
                 "PublicKeyList": [
                     {"Fingerprint": "123", "OtherData": "456", "Value": "789"},

--- a/tests/unit/customizations/codedeploy/test_deregister.py
+++ b/tests/unit/customizations/codedeploy/test_deregister.py
@@ -12,11 +12,10 @@
 # language governing permissions and limitations under the License.
 
 from argparse import Namespace
-from mock import MagicMock, call
 from awscli.customizations.codedeploy.deregister import Deregister
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestDeregister(unittest.TestCase):
@@ -40,7 +39,7 @@ class TestDeregister(unittest.TestCase):
         self.globals.endpoint_url = self.endpoint_url
         self.globals.verify_ssl = False
 
-        self.codedeploy = MagicMock()
+        self.codedeploy = mock.MagicMock()
         self.codedeploy.get_on_premises_instance.return_value = {
             'instanceInfo': {
                 'iamUserArn': self.iam_user_arn,
@@ -48,12 +47,12 @@ class TestDeregister(unittest.TestCase):
             }
         }
 
-        self.iam = MagicMock()
-        self.list_user_policies = MagicMock()
+        self.iam = mock.MagicMock()
+        self.list_user_policies = mock.MagicMock()
         self.list_user_policies.paginate.return_value = [
             {'PolicyNames': [self.policy_name]}
         ]
-        self.list_access_keys = MagicMock()
+        self.list_access_keys = mock.MagicMock()
         self.list_access_keys.paginate.return_value = [
             {'AccessKeyMetadata': [{'AccessKeyId': self.access_key_id}]}
         ]
@@ -61,7 +60,7 @@ class TestDeregister(unittest.TestCase):
             self.list_user_policies, self.list_access_keys
         ]
 
-        self.session = MagicMock()
+        self.session = mock.MagicMock()
         self.session.create_client.side_effect = [self.codedeploy, self.iam]
         self.deregister = Deregister(self.session)
 
@@ -81,13 +80,13 @@ class TestDeregister(unittest.TestCase):
     def test_deregister_creates_clients(self):
         self.deregister._run_main(self.args, self.globals)
         self.session.create_client.assert_has_calls([
-            call(
+            mock.call(
                 'codedeploy',
                 region_name=self.region,
                 endpoint_url=self.endpoint_url,
                 verify=self.globals.verify_ssl
             ),
-            call('iam', region_name=self.region)
+            mock.call('iam', region_name=self.region)
         ])
 
     def test_deregister_with_tags(self):
@@ -153,8 +152,8 @@ class TestDeregister(unittest.TestCase):
                 instanceName=self.instance_name
             )
         self.iam.get_paginator.assert_has_calls([
-            call('list_user_policies'),
-            call('list_access_keys')
+            mock.call('list_user_policies'),
+            mock.call('list_access_keys')
         ])
         self.list_user_policies.paginate.assert_called_with(
             UserName=self.instance_name

--- a/tests/unit/customizations/codedeploy/test_install.py
+++ b/tests/unit/customizations/codedeploy/test_install.py
@@ -18,8 +18,7 @@ from awscli.customizations.codedeploy.install import Install
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
-from mock import MagicMock, patch, mock_open
+from awscli.testutils import mock, unittest
 from socket import timeout
 
 
@@ -32,37 +31,37 @@ class TestInstall(unittest.TestCase):
         self.key = 'latest/{0}'.format(self.installer)
         self.agent_installer = 's3://{0}/{1}'.format(self.bucket, self.key)
 
-        self.system_patcher = patch('platform.system')
+        self.system_patcher = mock.patch('platform.system')
         self.system = self.system_patcher.start()
         self.system.return_value = 'Linux'
 
-        self.linux_distribution_patcher = patch('awscli.compat.linux_distribution')
+        self.linux_distribution_patcher = mock.patch('awscli.compat.linux_distribution')
         self.linux_distribution = self.linux_distribution_patcher.start()
         self.linux_distribution.return_value = ('Ubuntu', '', '')
 
-        self.urlopen_patcher = patch(
+        self.urlopen_patcher = mock.patch(
             'awscli.customizations.codedeploy.utils.urlopen'
         )
         self.urlopen = self.urlopen_patcher.start()
         self.urlopen.side_effect = timeout('Not EC2 instance')
 
-        self.geteuid_patcher = patch('os.geteuid', create=True)
+        self.geteuid_patcher = mock.patch('os.geteuid', create=True)
         self.geteuid = self.geteuid_patcher.start()
         self.geteuid.return_value = 0
 
-        self.isfile_patcher = patch('os.path.isfile')
+        self.isfile_patcher = mock.patch('os.path.isfile')
         self.isfile = self.isfile_patcher.start()
         self.isfile.return_value = False
 
-        self.makedirs_patcher = patch('os.makedirs')
+        self.makedirs_patcher = mock.patch('os.makedirs')
         self.makedirs = self.makedirs_patcher.start()
 
-        self.copyfile_patcher = patch('shutil.copyfile')
+        self.copyfile_patcher = mock.patch('shutil.copyfile')
         self.copyfile = self.copyfile_patcher.start()
 
-        self.open_patcher = patch(
+        self.open_patcher = mock.patch(
             'awscli.customizations.codedeploy.systems.open',
-            mock_open(), create=True
+            mock.mock_open(), create=True
         )
         self.open = self.open_patcher.start()
 
@@ -75,12 +74,12 @@ class TestInstall(unittest.TestCase):
         self.globals.region = self.region
 
         self.body = 'install-script'
-        self.reader = MagicMock()
+        self.reader = mock.MagicMock()
         self.reader.read.return_value = self.body
-        self.s3 = MagicMock()
+        self.s3 = mock.MagicMock()
         self.s3.get_object.return_value = {'Body': self.reader}
 
-        self.session = MagicMock()
+        self.session = mock.MagicMock()
         self.session.create_client.return_value = self.s3
         self.install = Install(self.session)
 
@@ -139,7 +138,7 @@ class TestInstall(unittest.TestCase):
                 's3://<bucket>/<key>.'):
             self.install._run_main(self.args, self.globals)
 
-    @patch.object(Ubuntu, 'install')
+    @mock.patch.object(Ubuntu, 'install')
     def test_install_with_agent_installer(self, install):
         self.args.agent_installer = self.agent_installer
         self.install._run_main(self.args, self.globals)
@@ -151,7 +150,7 @@ class TestInstall(unittest.TestCase):
         self.assertEqual(self.installer, self.args.installer)
         install.assert_called_with(self.args)
 
-    @patch.object(Ubuntu, 'install')
+    @mock.patch.object(Ubuntu, 'install')
     def test_install_for_ubuntu(self, install):
         self.system.return_value = 'Linux'
         self.linux_distribution.return_value = ('Ubuntu', '', '')
@@ -169,8 +168,8 @@ class TestInstall(unittest.TestCase):
         )
         install.assert_called_with(self.args)
 
-    @patch.object(Windows, 'install')
-    @patch.object(Windows, 'validate_administrator')
+    @mock.patch.object(Windows, 'install')
+    @mock.patch.object(Windows, 'validate_administrator')
     def test_install_for_windows(self, validate_administrator, install):
         self.system.return_value = 'Windows'
         self.install._run_main(self.args, self.globals)

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -8,19 +8,18 @@
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
+# mock.ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
 import awscli
 
 from argparse import Namespace
-from mock import MagicMock, patch, ANY, call
 from six import StringIO
 from botocore.exceptions import ClientError
 
 from awscli.customizations.codedeploy.push import Push
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.compat import ZIP_COMPRESSION_MODE
 
 
@@ -68,22 +67,22 @@ class TestPush(unittest.TestCase):
             }
         }
 
-        self.bundle_mock = MagicMock()
+        self.bundle_mock = mock.MagicMock()
         self.bundle_mock.tell.return_value = (5 << 20)
         self.bundle_mock.read.return_value = b'a' * (5 << 20)
         self.bundle_mock.__enter__.return_value = self.bundle_mock
         self.bundle_mock.__exit__.return_value = None
 
-        self.zipfile_mock = MagicMock()
+        self.zipfile_mock = mock.MagicMock()
         self.zipfile_mock.write.return_value = None
         self.zipfile_mock.close.return_value = None
         self.zipfile_mock.__enter__.return_value = self.zipfile_mock
         self.zipfile_mock.__exit__.return_value = None
 
-        self.session = MagicMock()
+        self.session = mock.MagicMock()
 
         self.push = Push(self.session)
-        self.push.s3 = MagicMock()
+        self.push.s3 = mock.MagicMock()
         self.push.s3.put_object.return_value = self.upload_response
         self.push.s3.create_multipart_upload.return_value = {
             'UploadId': self.upload_id
@@ -93,35 +92,35 @@ class TestPush(unittest.TestCase):
         }
         self.push.s3.complete_multipart_upload\
             .return_value = self.upload_response
-        self.push.codedeploy = MagicMock()
+        self.push.codedeploy = mock.MagicMock()
 
     def test_run_main_throws_on_invalid_args(self):
-        self.push._validate_args = MagicMock()
+        self.push._validate_args = mock.MagicMock()
         self.push._validate_args.side_effect = RuntimeError()
         with self.assertRaises(RuntimeError):
             self.push._run_main(self.args, self.globals)
 
     def test_run_main_creates_clients(self):
-        self.push._validate_args = MagicMock()
-        self.push._push = MagicMock()
+        self.push._validate_args = mock.MagicMock()
+        self.push._push = mock.MagicMock()
         self.push._run_main(self.args, self.globals)
         self.session.create_client.assert_has_calls([
-            call(
+            mock.call(
                 'codedeploy',
                 region_name=self.region,
                 endpoint_url=self.endpoint_url,
                 verify=self.globals.verify_ssl
             ),
-            call('s3', region_name=self.region)
+            mock.call('s3', region_name=self.region)
         ])
 
     def test_run_main_calls_push(self):
-        self.push._validate_args = MagicMock()
-        self.push._push = MagicMock()
+        self.push._validate_args = mock.MagicMock()
+        self.push._push = mock.MagicMock()
         self.push._run_main(self.args, self.globals)
         self.push._push.assert_called_with(self.args)
 
-    @patch.object(
+    @mock.patch.object(
         awscli.customizations.codedeploy.push,
         'validate_s3_location'
     )
@@ -150,8 +149,8 @@ class TestPush(unittest.TestCase):
     def test_push_throws_on_upload_to_s3_error(self):
         self.args.bucket = self.bucket
         self.args.key = self.key
-        self.push._compress = MagicMock(return_value=self.bundle_mock)
-        self.push._upload_to_s3 = MagicMock()
+        self.push._compress = mock.MagicMock(return_value=self.bundle_mock)
+        self.push._upload_to_s3 = mock.MagicMock()
         self.push._upload_to_s3.side_effect = RuntimeError()
         with self.assertRaises(RuntimeError):
             self.push._push(self.args)
@@ -159,20 +158,20 @@ class TestPush(unittest.TestCase):
     def test_push_strips_quotes_from_etag(self):
         self.args.bucket = self.bucket
         self.args.key = self.key
-        self.push._compress = MagicMock(return_value=self.bundle_mock)
-        self.push._upload_to_s3 = MagicMock(return_value=self.upload_response)
-        self.push._register_revision = MagicMock()
+        self.push._compress = mock.MagicMock(return_value=self.bundle_mock)
+        self.push._upload_to_s3 = mock.MagicMock(return_value=self.upload_response)
+        self.push._register_revision = mock.MagicMock()
         self.push._push(self.args)
         self.push._register_revision.assert_called_with(self.args)
         self.assertEqual(str(self.args.eTag), self.upload_response['ETag'].replace('"',""))
 
-    @patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
     def test_push_output_message(self, stdout_mock):
         self.args.bucket = self.bucket
         self.args.key = self.key
-        self.push._compress = MagicMock(return_value=self.bundle_mock)
-        self.push._upload_to_s3 = MagicMock(return_value=self.upload_response)
-        self.push._register_revision = MagicMock()
+        self.push._compress = mock.MagicMock(return_value=self.bundle_mock)
+        self.push._upload_to_s3 = mock.MagicMock(return_value=self.upload_response)
+        self.push._register_revision = mock.MagicMock()
         self.push._push(self.args)
         output = stdout_mock.getvalue().strip()
         expected_revision_output = (
@@ -196,10 +195,10 @@ class TestPush(unittest.TestCase):
         )
         self.assertEqual(expected_output, output)
 
-    @patch('zipfile.ZipFile')
-    @patch('tempfile.TemporaryFile')
-    @patch('os.path')
-    @patch('os.walk')
+    @mock.patch('zipfile.ZipFile')
+    @mock.patch('tempfile.TemporaryFile')
+    @mock.patch('os.path')
+    @mock.patch('os.walk')
     def test_compress_throws_when_no_appspec(self, walk, path, tf, zf):
         walk.return_value = [(self.source, [], ['noappspec.yml'])]
         noappsec_path = self.source + '/noappspec.yml'
@@ -214,10 +213,10 @@ class TestPush(unittest.TestCase):
                     self.args.ignore_hidden_files):
                 pass
 
-    @patch('zipfile.ZipFile')
-    @patch('tempfile.TemporaryFile')
-    @patch('os.path')
-    @patch('os.walk')
+    @mock.patch('zipfile.ZipFile')
+    @mock.patch('tempfile.TemporaryFile')
+    @mock.patch('os.path')
+    @mock.patch('os.walk')
     def test_compress_writes_to_zip_file(self, walk, path, tf, zf):
         walk.return_value = [(self.source, [], [self.appspec])]
         path.join.return_value = self.appspec_path
@@ -228,7 +227,7 @@ class TestPush(unittest.TestCase):
         with self.push._compress(
                 self.args.source,
                 self.args.ignore_hidden_files):
-            zf.assert_called_with(ANY, 'w', allowZip64=True)
+            zf.assert_called_with(mock.ANY, 'w', allowZip64=True)
             zf().write.assert_called_with(
                 '/tmp/appspec.yml',
                 self.appspec,
@@ -267,7 +266,7 @@ class TestPush(unittest.TestCase):
             Key=self.key,
             UploadId=self.upload_id,
             PartNumber=1,
-            Body=ANY
+            Body=mock.ANY
         )
         self.push.s3.complete_multipart_upload.assert_called_with(
             Bucket=self.bucket,

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -8,7 +8,7 @@
 #
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# mock.ANY KIND, either express or implied. See the License for the specific
+# ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
 import awscli

--- a/tests/unit/customizations/codedeploy/test_register.py
+++ b/tests/unit/customizations/codedeploy/test_register.py
@@ -16,8 +16,7 @@ from awscli.customizations.codedeploy.register import Register
 from awscli.customizations.codedeploy.utils import MAX_TAGS_PER_INSTANCE
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
-from mock import MagicMock, patch, call, mock_open
+from awscli.testutils import mock, unittest
 
 
 class TestRegister(unittest.TestCase):
@@ -53,15 +52,15 @@ class TestRegister(unittest.TestCase):
         self.globals.endpoint_url = self.endpoint_url
         self.globals.verify_ssl = False
 
-        self.open_patcher = patch(
+        self.open_patcher = mock.patch(
             'awscli.customizations.codedeploy.register.open',
-            mock_open(), create=True
+            mock.mock_open(), create=True
         )
         self.open = self.open_patcher.start()
 
-        self.codedeploy = MagicMock()
+        self.codedeploy = mock.MagicMock()
 
-        self.iam = MagicMock()
+        self.iam = mock.MagicMock()
         self.iam.create_user.return_value = {
             'User': {'Arn': self.iam_user_arn}
         }
@@ -72,7 +71,7 @@ class TestRegister(unittest.TestCase):
             }
         }
 
-        self.session = MagicMock()
+        self.session = mock.MagicMock()
         self.session.create_client.side_effect = [self.codedeploy, self.iam]
         self.register = Register(self.session)
 
@@ -111,13 +110,13 @@ class TestRegister(unittest.TestCase):
     def test_register_creates_clients(self):
         self.register._run_main(self.args, self.globals)
         self.session.create_client.assert_has_calls([
-            call(
+            mock.call(
                 'codedeploy',
                 region_name=self.region,
                 endpoint_url=self.endpoint_url,
                 verify=self.globals.verify_ssl
             ),
-            call('iam', region_name=self.region)
+            mock.call('iam', region_name=self.region)
         ])
 
     def test_register_with_no_iam_user_arn(self):

--- a/tests/unit/customizations/codedeploy/test_uninstall.py
+++ b/tests/unit/customizations/codedeploy/test_uninstall.py
@@ -17,8 +17,7 @@ from argparse import Namespace
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
 from awscli.customizations.codedeploy.uninstall import Uninstall
 from awscli.customizations.exceptions import ConfigurationError
-from awscli.testutils import unittest
-from mock import MagicMock, patch
+from awscli.testutils import mock, unittest
 from socket import timeout
 
 
@@ -26,31 +25,31 @@ class TestUninstall(unittest.TestCase):
     def setUp(self):
         self.region = 'us-east-1'
 
-        self.system_patcher = patch('platform.system')
+        self.system_patcher = mock.patch('platform.system')
         self.system = self.system_patcher.start()
         self.system.return_value = 'Linux'
 
-        self.linux_distribution_patcher = patch('awscli.compat.linux_distribution')
+        self.linux_distribution_patcher = mock.patch('awscli.compat.linux_distribution')
         self.linux_distribution = self.linux_distribution_patcher.start()
         self.linux_distribution.return_value = ('Ubuntu', '', '')
 
-        self.urlopen_patcher = patch(
+        self.urlopen_patcher = mock.patch(
             'awscli.customizations.codedeploy.utils.urlopen'
         )
         self.urlopen = self.urlopen_patcher.start()
         self.urlopen.side_effect = timeout('Not EC2 instance')
 
-        self.geteuid_patcher = patch('os.geteuid', create=True)
+        self.geteuid_patcher = mock.patch('os.geteuid', create=True)
         self.geteuid = self.geteuid_patcher.start()
         self.geteuid.return_value = 0
 
-        self.remove_patcher = patch('os.remove')
+        self.remove_patcher = mock.patch('os.remove')
         self.remove = self.remove_patcher.start()
 
         self.args = Namespace()
         self.globals = Namespace()
         self.globals.region = self.region
-        self.session = MagicMock()
+        self.session = mock.MagicMock()
         self.uninstall = Uninstall(self.session)
 
     def tearDown(self):
@@ -87,7 +86,7 @@ class TestUninstall(unittest.TestCase):
                 RuntimeError, 'You must run this command as sudo.'):
             self.uninstall._run_main(self.args, self.globals)
 
-    @patch.object(Ubuntu, 'uninstall')
+    @mock.patch.object(Ubuntu, 'uninstall')
     def test_uninstall_for_ubuntu(self, uninstall):
         self.system.return_value = 'Linux'
         self.linux_distribution.return_value = ('Ubuntu', '', '')
@@ -97,7 +96,7 @@ class TestUninstall(unittest.TestCase):
             '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml'
         )
 
-    @patch.object(RHEL, 'uninstall')
+    @mock.patch.object(RHEL, 'uninstall')
     def test_uninstall_for_RHEL(self, uninstall):
         self.system.return_value = 'Linux'
         self.linux_distribution.return_value = ('Red Hat Enterprise Linux Server', '', '')
@@ -107,8 +106,8 @@ class TestUninstall(unittest.TestCase):
             '/etc/codedeploy-agent/conf/codedeploy.onpremises.yml'
         )
 
-    @patch.object(Windows, 'uninstall')
-    @patch.object(Windows, 'validate_administrator')
+    @mock.patch.object(Windows, 'uninstall')
+    @mock.patch.object(Windows, 'validate_administrator')
     def test_uninstall_for_windows(self, validate_administrator, uninstall):
         self.system.return_value = 'Windows'
         self.uninstall._run_main(self.args, self.globals)

--- a/tests/unit/customizations/codedeploy/test_utils.py
+++ b/tests/unit/customizations/codedeploy/test_utils.py
@@ -15,7 +15,6 @@ import sys
 
 from socket import timeout
 from argparse import Namespace
-from mock import MagicMock, patch
 from awscli.customizations.codedeploy.systems import Ubuntu, Windows, RHEL, System
 from awscli.customizations.codedeploy.utils import \
     validate_region, validate_instance_name, validate_tags, \
@@ -24,7 +23,7 @@ from awscli.customizations.codedeploy.utils import \
     MAX_TAG_VALUE_LENGTH
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestUtils(unittest.TestCase):
@@ -35,22 +34,22 @@ class TestUtils(unittest.TestCase):
         self.bucket = 'bucket'
         self.key = 'key'
 
-        self.system_patcher = patch('platform.system')
+        self.system_patcher = mock.patch('platform.system')
         self.system = self.system_patcher.start()
         self.system.return_value = 'Linux'
 
-        self.linux_distribution_patcher = patch('awscli.compat.linux_distribution')
+        self.linux_distribution_patcher = mock.patch('awscli.compat.linux_distribution')
         self.linux_distribution = self.linux_distribution_patcher.start()
         self.linux_distribution.return_value = ('Ubuntu', '', '')
 
-        self.urlopen_patcher = patch(
+        self.urlopen_patcher = mock.patch(
             'awscli.customizations.codedeploy.utils.urlopen'
         )
         self.urlopen = self.urlopen_patcher.start()
         self.urlopen.side_effect = timeout('Not EC2 instance')
 
-        self.globals = MagicMock()
-        self.session = MagicMock()
+        self.globals = mock.MagicMock()
+        self.session = mock.MagicMock()
         self.params = Namespace()
         self.params.session = self.session
 

--- a/tests/unit/customizations/configservice/test_getstatus.py
+++ b/tests/unit/customizations/configservice/test_getstatus.py
@@ -10,10 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from awscli.compat import six
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.configservice.getstatus import GetStatusCommand
 
 

--- a/tests/unit/customizations/configservice/test_subscribe.py
+++ b/tests/unit/customizations/configservice/test_subscribe.py
@@ -10,11 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import botocore.session
 from botocore.exceptions import ClientError
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.compat import StringIO
 from awscli.customizations.configservice.subscribe import SubscribeCommand, \
     S3BucketHelper, SNSTopicHelper

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -11,11 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
 
 from awscli.customizations.configure import configure, ConfigValue, NOT_SET
 from awscli.customizations.configure import profile_to_section
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.compat import six
 
 from . import FakeSession

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
-import mock
 import io
 from datetime import datetime, timedelta
 
@@ -22,7 +21,7 @@ from botocore.credentials import Credentials as StaticCredentials
 from botocore.credentials import ReadOnlyCredentials
 from botocore.session import Session
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.exceptions import ConfigurationError
 from awscli.customizations.configure.exportcreds import (
     Credentials,

--- a/tests/unit/customizations/configure/test_importer.py
+++ b/tests/unit/customizations/configure/test_importer.py
@@ -12,10 +12,9 @@
 # language governing permissions and limitations under the License.
 
 import os
-import mock
 
 from . import FakeSession
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.compat import six
 from awscli.customizations.configure.importer import (
     CredentialImporter,

--- a/tests/unit/customizations/configure/test_list.py
+++ b/tests/unit/customizations/configure/test_list.py
@@ -10,10 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from argparse import Namespace
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.compat import six
 from awscli.customizations.configure.list import ConfigureListCommand
 

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -10,11 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import os
 
 from awscli.customizations.configure.set import ConfigureSetCommand
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from . import FakeSession
 
 

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -15,7 +15,6 @@ import dataclasses
 import json
 import typing
 
-import mock
 from datetime import datetime, timedelta
 
 import prompt_toolkit
@@ -30,7 +29,7 @@ from prompt_toolkit.validation import ValidationError
 
 from botocore.stub import Stubber
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.configure.sso import display_account
 from awscli.customizations.configure.sso import PTKPrompt
 from awscli.customizations.configure.sso import SSOSessionConfigurationPrompter

--- a/tests/unit/customizations/datapipeline/test_commands.py
+++ b/tests/unit/customizations/datapipeline/test_commands.py
@@ -13,10 +13,9 @@
 # language governing permissions and limitations under the License.
 
 import copy
-import mock
 import unittest
 
-from awscli.testutils import BaseAWSHelpOutputTest, BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSHelpOutputTest, BaseAWSCommandParamsTest
 
 from awscli.customizations.datapipeline import convert_described_objects
 from awscli.customizations.datapipeline import ListRunsCommand

--- a/tests/unit/customizations/datapipeline/test_create_default_role.py
+++ b/tests/unit/customizations/datapipeline/test_create_default_role.py
@@ -1,4 +1,3 @@
-import mock
 import pytest
 
 import awscli.customizations.datapipeline.createdefaultroles \
@@ -10,7 +9,7 @@ from awscli.customizations.datapipeline.constants\
     DATAPIPELINE_DEFAULT_RESOURCE_ROLE_ASSUME_POLICY
 
 from awscli.testutils import BaseAWSCommandParamsTest,\
-    unittest
+    mock, unittest
 from awscli.customizations.datapipeline.translator import dict_to_string
 from botocore.compat import json
 

--- a/tests/unit/customizations/datapipeline/test_listrunsformatter.py
+++ b/tests/unit/customizations/datapipeline/test_listrunsformatter.py
@@ -12,12 +12,12 @@
 # language governing permissions and limitations under the License.
 
 import difflib
-import mock
 import unittest
 
 from awscli.compat import six
 from awscli.customizations.datapipeline.listrunsformatter \
     import ListRunsFormatter
+from awscli.testutils import mock
 
 
 class TestListRunsFormatter(unittest.TestCase):

--- a/tests/unit/customizations/dlm/test_create_default_role.py
+++ b/tests/unit/customizations/dlm/test_create_default_role.py
@@ -10,10 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import mock
-
-from awscli.testutils import BaseAWSCommandParamsTest, unittest
+from awscli.testutils import mock, BaseAWSCommandParamsTest, unittest
 from botocore.compat import json
 import botocore.session
 from awscli.customizations.dlm.iam import IAM

--- a/tests/unit/customizations/ec2/test_paginate.py
+++ b/tests/unit/customizations/ec2/test_paginate.py
@@ -10,10 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from argparse import Namespace
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.ec2.paginate import EC2PageSizeInjector
 
 

--- a/tests/unit/customizations/ec2instanceconnect/test_eicesigner.py
+++ b/tests/unit/customizations/ec2instanceconnect/test_eicesigner.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 from urllib.parse import urlencode
 
-import mock
 import pytest
 
 from botocore.session import Session
@@ -20,6 +19,7 @@ from botocore.signers import RequestSigner
 from awscli.customizations.ec2instanceconnect.eicesigner import (
     InstanceConnectEndpointRequestSigner,
 )
+from awscli.testutils import mock
 
 
 @pytest.fixture

--- a/tests/unit/customizations/ecs/test_codedeployer.py
+++ b/tests/unit/customizations/ecs/test_codedeployer.py
@@ -13,10 +13,9 @@
 
 import hashlib
 import json
-import mock
 
 from botocore import compat
-from awscli.testutils import capture_output, unittest
+from awscli.testutils import capture_output, mock, unittest
 from awscli.customizations.ecs.deploy import CodeDeployer, MAX_WAIT_MIN
 from awscli.customizations.ecs.exceptions import MissingPropertyError
 

--- a/tests/unit/customizations/ecs/test_ecsclient.py
+++ b/tests/unit/customizations/ecs/test_ecsclient.py
@@ -11,11 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
-
 from argparse import Namespace
 from botocore import config
-from awscli.testutils import capture_output, unittest
+from awscli.testutils import capture_output, mock, unittest
 from awscli.customizations.ecs.deploy import ECSClient, ECSDeploy
 
 

--- a/tests/unit/customizations/ecs/test_executecommand_startsession.py
+++ b/tests/unit/customizations/ecs/test_executecommand_startsession.py
@@ -10,10 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import botocore.session
 import json
 import errno
+
+from awscli.testutils import mock
 
 import unittest
 from awscli.customizations.ecs import executecommand

--- a/tests/unit/customizations/eks/test_get_token.py
+++ b/tests/unit/customizations/eks/test_get_token.py
@@ -10,15 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import mock
-from mock import patch, call
 import base64
 import botocore
 import json
 from datetime import datetime
 
-from awscli.testutils import unittest, capture_output
+from awscli.testutils import mock, unittest, capture_output
 from awscli.customizations.eks.get_token import (
     GetTokenCommand,
     TokenGenerator
@@ -37,7 +34,7 @@ class BaseTokenTest(unittest.TestCase):
 
 
 class TestTokenGenerator(BaseTokenTest):
-    @patch.object(TokenGenerator, '_get_presigned_url', return_value='aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8=')
+    @mock.patch.object(TokenGenerator, '_get_presigned_url', return_value='aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8=')
     def test_token_no_padding(self, mock_presigned_url):
         generator = TokenGenerator(self._sts_client)
         tok = generator.get_token(self._cluster_name)

--- a/tests/unit/customizations/eks/test_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_kubeconfig.py
@@ -13,7 +13,6 @@
 
 import glob
 import os
-import mock
 import tempfile
 import shutil
 from botocore.compat import OrderedDict

--- a/tests/unit/customizations/emr/__init__.py
+++ b/tests/unit/customizations/emr/__init__.py
@@ -13,8 +13,7 @@
 
 from awscli.customizations.emr import exceptions
 from awscli.customizations.emr.configutils import ConfigWriter
-from awscli.testutils import BaseAWSCommandParamsTest
-import mock
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 
 
 class EMRBaseAWSCommandParamsTest(BaseAWSCommandParamsTest):

--- a/tests/unit/customizations/emr/test_add_instance_groups.py
+++ b/tests/unit/customizations/emr/test_add_instance_groups.py
@@ -10,13 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
 from tests.unit.customizations.emr import test_constants as \
     CONSTANTS
 import json
-from mock import patch
+
 
 INSTANCE_GROUPS_WITH_AUTOSCALING_POLICY = (
     ' InstanceGroupType=TASK,InstanceType=d2.xlarge,InstanceCount=2,'
@@ -358,7 +359,7 @@ class TestAddInstanceGroups(BaseAWSCommandParamsTest):
                   'InstanceGroups': DEFAULT_INSTANCE_GROUPS_WITH_CUSTOM_AMI}
         self.assert_params_for_cmd(cmd, result)
 
-    @patch('awscli.customizations.emr.emrutils.call')
+    @mock.patch('awscli.customizations.emr.emrutils.call')
     def test_constructed_result(self, call_patch):
         call_patch.return_value = ADD_INSTANCE_GROUPS_RESULT
         cmd = self.prefix

--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -13,7 +13,8 @@
 
 import os
 import copy
-import mock
+
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_command.py
+++ b/tests/unit/customizations/emr/test_command.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
+from awscli.testutils import mock
 
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \

--- a/tests/unit/customizations/emr/test_config.py
+++ b/tests/unit/customizations/emr/test_config.py
@@ -5,8 +5,7 @@ from awscli.customizations.emr.ssh import Get
 from awscli.customizations.emr.ssh import Put
 from awscli.customizations.emr.ssh import SSH
 from awscli.customizations.emr.ssh import Socks
-from awscli.testutils import BaseAWSHelpOutputTest
-import mock
+from awscli.testutils import mock, BaseAWSHelpOutputTest
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
 

--- a/tests/unit/customizations/emr/test_create_cluster_ami_version.py
+++ b/tests/unit/customizations/emr/test_create_cluster_ami_version.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
@@ -20,7 +21,6 @@ from tests.unit.customizations.emr import test_constants_instance_fleets as \
 import copy
 import os
 import json
-from mock import patch
 
 
 DEFAULT_CLUSTER_NAME = "Development Cluster"
@@ -1281,7 +1281,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         else:
             self.assertTrue(False)
 
-    @patch('awscli.customizations.emr.emrutils.call')
+    @mock.patch('awscli.customizations.emr.emrutils.call')
     def test_constructed_result(self, call_patch):
         call_patch.return_value = CREATE_CLUSTER_RESULT
         cmd = DEFAULT_CMD

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -17,13 +17,14 @@ import os
 from botocore.compat import json
 from botocore.compat import OrderedDict
 
+from awscli.testutils import mock
+
 from tests.unit.customizations.emr import test_constants as \
     CONSTANTS
 from tests.unit.customizations.emr import test_constants_instance_fleets as \
     CONSTANTS_FLEET
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
-from mock import patch
 
 
 DEFAULT_CLUSTER_NAME = "Development Cluster"
@@ -1016,7 +1017,7 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         result['Steps'] = [PIG_STEP]
         self.assert_params_for_cmd(cmd, result)
 
-    @patch('awscli.customizations.emr.emrutils.call')
+    @mock.patch('awscli.customizations.emr.emrutils.call')
     def test_constructed_result(self, call_patch):
         call_patch.return_value = CREATE_CLUSTER_RESULT
         cmd = DEFAULT_CMD

--- a/tests/unit/customizations/emr/test_create_default_role.py
+++ b/tests/unit/customizations/emr/test_create_default_role.py
@@ -10,15 +10,13 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from botocore.compat import json
 from botocore.awsrequest import AWSResponse
 from botocore.exceptions import ClientError
 
 import awscli.customizations.emr.emrutils as emrutils
 import awscli.customizations.emr.createdefaultroles as createdefaultroles
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
 

--- a/tests/unit/customizations/emr/test_create_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_create_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_describe_cluster.py
+++ b/tests/unit/customizations/emr/test_describe_cluster.py
@@ -13,9 +13,10 @@
 
 import json
 
+from awscli.testutils import mock
+
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
-from mock import patch
 
 describe_cluster_result_mock_ig = {
     "Cluster": {
@@ -371,7 +372,7 @@ EXPECTED_RESULT_IF = {
 class TestDescribeCluster(BaseAWSCommandParamsTest):
     prefix = 'emr describe-cluster'
 
-    @patch('awscli.customizations.emr.emr.DescribeCluster._construct_result')
+    @mock.patch('awscli.customizations.emr.emr.DescribeCluster._construct_result')
     def test_operations_called(self, construct_result_patch):
         construct_result_patch.return_value = dict()
 
@@ -395,7 +396,7 @@ class TestDescribeCluster(BaseAWSCommandParamsTest):
         self.assertEqual(self.operations_called[2][1]['ClusterId'],
                          'j-ABCD')
 
-    @patch('awscli.customizations.emr.emr.DescribeCluster._call')
+    @mock.patch('awscli.customizations.emr.emr.DescribeCluster._call')
     def test_constructed_result_ig(self, call_patch):
         call_patch.side_effect = side_effect_of_call_ig
 
@@ -405,7 +406,7 @@ class TestDescribeCluster(BaseAWSCommandParamsTest):
         result_json = json.loads(result[0])
         self.assertEqual(result_json, EXPECTED_RESULT_IG)
 
-    @patch('awscli.customizations.emr.emr.DescribeCluster._call')
+    @mock.patch('awscli.customizations.emr.emr.DescribeCluster._call')
     def test_constructed_result_if(self, call_patch):
         call_patch.side_effect = side_effect_of_call_if
 

--- a/tests/unit/customizations/emr/test_disable_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_disable_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_install_applications.py
+++ b/tests/unit/customizations/emr/test_install_applications.py
@@ -13,7 +13,7 @@
 
 
 import json
-import mock
+from awscli.testutils import mock
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest
 

--- a/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_restore_from_hbase_backup.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import mock
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_schedule_hbase_backup.py
+++ b/tests/unit/customizations/emr/test_schedule_hbase_backup.py
@@ -10,8 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-
-import mock
+from awscli.testutils import mock
 
 from tests.unit.customizations.emr import EMRBaseAWSCommandParamsTest as \
     BaseAWSCommandParamsTest

--- a/tests/unit/customizations/emr/test_sshutils.py
+++ b/tests/unit/customizations/emr/test_sshutils.py
@@ -10,11 +10,9 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from awscli.customizations.emr import sshutils
 from awscli.customizations.emr import exceptions
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestSSHUtils(unittest.TestCase):

--- a/tests/unit/customizations/emrcontainers/test_update_assume_role_policy.py
+++ b/tests/unit/customizations/emrcontainers/test_update_assume_role_policy.py
@@ -13,9 +13,8 @@
 
 import copy
 import json
-import mock
 
-from awscli.testutils import BaseAWSCommandParamsTest, unittest
+from awscli.testutils import mock, BaseAWSCommandParamsTest, unittest
 from awscli.customizations.emrcontainers.base36 import Base36
 from awscli.customizations.emrcontainers.constants \
     import TRUST_POLICY_STATEMENT_FORMAT, \

--- a/tests/unit/customizations/history/test_db.py
+++ b/tests/unit/customizations/history/test_db.py
@@ -17,8 +17,6 @@ import threading
 import datetime
 import numbers
 
-import mock
-
 from awscli.compat import queue
 from awscli.customizations.history.db import DatabaseConnection
 from awscli.customizations.history.db import DatabaseHistoryHandler
@@ -26,7 +24,7 @@ from awscli.customizations.history.db import DatabaseRecordWriter
 from awscli.customizations.history.db import DatabaseRecordReader
 from awscli.customizations.history.db import PayloadSerializer
 from awscli.customizations.history.db import RecordBuilder
-from awscli.testutils import unittest, FileCreator
+from awscli.testutils import mock, unittest, FileCreator
 from tests import CaseInsensitiveDict
 
 

--- a/tests/unit/customizations/s3/syncstrategy/test_base.py
+++ b/tests/unit/customizations/s3/syncstrategy/test_base.py
@@ -12,12 +12,10 @@
 # language governing permissions and limitations under the License.
 import datetime
 
-from mock import Mock, patch
-
 from awscli.customizations.s3.filegenerator import FileStat
 from awscli.customizations.s3.syncstrategy.base import BaseSync, \
     SizeAndLastModifiedSync, MissingFileSync, NeverSync
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.exceptions import ParamValidationError
 
 
@@ -40,7 +38,7 @@ class TestBaseSync(unittest.TestCase):
         """
         Ensures that the class registers all of the necessary handlers
         """
-        session = Mock()
+        session = mock.Mock()
         self.sync_strategy.register_strategy(session)
         register_args = session.register.call_args_list
         self.assertEqual(register_args[0][0][0],

--- a/tests/unit/customizations/s3/syncstrategy/test_register.py
+++ b/tests/unit/customizations/s3/syncstrategy/test_register.py
@@ -10,18 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock
-
 from awscli.customizations.s3.syncstrategy.register import \
     register_sync_strategy
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestRegisterSyncStrategy(unittest.TestCase):
     def setUp(self):
-        self.session = Mock()
-        self.strategy_cls = Mock()
-        self.strategy_object = Mock()
+        self.session = mock.Mock()
+        self.strategy_cls = mock.Mock()
+        self.strategy_object = mock.Mock()
         self.strategy_cls.return_value = self.strategy_object
 
     def test_register_sync_strategy(self):

--- a/tests/unit/customizations/s3/test_comparator.py
+++ b/tests/unit/customizations/s3/test_comparator.py
@@ -13,17 +13,16 @@
 import datetime
 import unittest
 
-from mock import Mock
-
+from awscli.testutils import mock
 from awscli.customizations.s3.comparator import Comparator
 from awscli.customizations.s3.filegenerator import FileStat
 
 
 class ComparatorTest(unittest.TestCase):
     def setUp(self):
-        self.sync_strategy = Mock()
-        self.not_at_src_sync_strategy = Mock()
-        self.not_at_dest_sync_strategy = Mock()
+        self.sync_strategy = mock.Mock()
+        self.not_at_src_sync_strategy = mock.Mock()
+        self.not_at_dest_sync_strategy = mock.Mock()
         self.comparator = Comparator(self.sync_strategy,
                                      self.not_at_dest_sync_strategy,
                                      self.not_at_src_sync_strategy)

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 import os
 import platform
-from awscli.testutils import unittest, FileCreator, BaseAWSCommandParamsTest
+from awscli.testutils import mock, unittest, FileCreator, BaseAWSCommandParamsTest
 from awscli.testutils import skip_if_windows
 import stat
 import tempfile
@@ -21,7 +21,6 @@ import socket
 
 from botocore.exceptions import ClientError
 from awscli.compat import six
-import mock
 
 from awscli.customizations.s3.filegenerator import FileGenerator, \
     FileDecodingError, FileStat, is_special_file, is_readable

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from awscli.testutils import unittest
 from awscli.customizations.s3.filegenerator import FileStat
 from awscli.customizations.s3.fileinfo import FileInfo

--- a/tests/unit/customizations/s3/test_s3.py
+++ b/tests/unit/customizations/s3/test_s3.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from mock import Mock
-
-from awscli.testutils import unittest, BaseAWSCommandParamsTest
+from awscli.testutils import mock, unittest, BaseAWSCommandParamsTest
 from awscli.customizations.s3.s3 import awscli_initialize, add_s3
 
 
@@ -22,7 +20,7 @@ class AWSInitializeTest(unittest.TestCase):
     all of the commands can be run.
     """
     def setUp(self):
-        self.cli = Mock()
+        self.cli = mock.Mock()
 
     def test_initialize(self):
         awscli_initialize(self.cli)
@@ -39,7 +37,7 @@ class CreateTablesTest(unittest.TestCase):
         Ensures that the table for the service was created properly.
         Also ensures the original s3 service is renamed to ``s3api``.
         """
-        s3_service = Mock()
+        s3_service = mock.Mock()
         s3_service.name = 's3'
         self.services = {'s3': s3_service}
         add_s3(self.services, True)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -12,10 +12,9 @@
 # language governing permissions and limitations under the License.
 import os
 
-import mock
 from s3transfer.manager import TransferManager
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.testutils import FileCreator
 from awscli.compat import queue
 from awscli.customizations.s3.s3handler import S3TransferHandler

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -14,8 +14,6 @@ import argparse
 import os
 import sys
 
-import mock
-from mock import patch, Mock, MagicMock
 
 import botocore.session
 from awscli.customizations.s3.s3 import S3
@@ -25,7 +23,7 @@ from awscli.customizations.s3.transferconfig import RuntimeConfig
 from awscli.customizations.s3.syncstrategy.base import \
     SizeAndLastModifiedSync, NeverSync, MissingFileSync
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest, BaseAWSHelpOutputTest, \
+from awscli.testutils import mock, unittest, BaseAWSHelpOutputTest, \
     BaseAWSCommandParamsTest, FileCreator
 from tests.unit.customizations.s3 import make_loc_files, clean_loc_files
 from awscli.compat import StringIO
@@ -171,9 +169,9 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         super(CommandArchitectureTest, self).setUp()
         self.session = self.driver.session
         self.bucket = 'mybucket'
-        self.transfer_manager = Mock()
-        self.source_client = Mock()
-        self.transfer_client = Mock()
+        self.transfer_manager = mock.Mock()
+        self.source_client = mock.Mock()
+        self.transfer_client = mock.Mock()
         self.file_creator = FileCreator()
         self.loc_files = make_loc_files(self.file_creator)
         self.output = StringIO()
@@ -243,7 +241,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                                                 's3_handler'])
 
     def test_choose_sync_strategy_default(self):
-        self.session = Mock(self.session)
+        self.session = mock.Mock(self.session)
         cmd_arc = self.get_cmd_architecture('sync', self.get_params())
         # Check if no plugins return their sync strategy.  Should
         # result in the default strategies
@@ -263,17 +261,17 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         )
 
     def test_choose_sync_strategy_overwrite(self):
-        self.session = Mock(self.session)
+        self.session = mock.Mock(self.session)
         cmd_arc = self.get_cmd_architecture('sync', self.get_params())
         # Check that the default sync strategy is overwritted if a plugin
         # returns its sync strategy.
-        mock_strategy = Mock()
+        mock_strategy = mock.Mock()
         mock_strategy.sync_type = 'file_at_src_and_dest'
 
-        mock_not_at_dest_sync_strategy = Mock()
+        mock_not_at_dest_sync_strategy = mock.Mock()
         mock_not_at_dest_sync_strategy.sync_type = 'file_not_at_dest'
 
-        mock_not_at_src_sync_strategy = Mock()
+        mock_not_at_src_sync_strategy = mock.Mock()
         mock_not_at_src_sync_strategy.sync_type = 'file_not_at_src'
 
         responses = [(None, mock_strategy),
@@ -299,10 +297,10 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
 class CommandParametersTest(unittest.TestCase):
     def setUp(self):
         self.environ = {}
-        self.environ_patch = patch('os.environ', self.environ)
+        self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
-        self.mock = MagicMock()
-        self.mock.get_config = MagicMock(return_value={'region': None})
+        self.mock = mock.MagicMock()
+        self.mock.get_config = mock.MagicMock(return_value={'region': None})
         self.file_creator = FileCreator()
         self.loc_files = make_loc_files(self.file_creator)
         self.bucket = 's3testbucket'

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest, temporary_file
+from awscli.testutils import mock, unittest, temporary_file
 import argparse
 import os
 
@@ -18,7 +18,6 @@ import ntpath
 import time
 import datetime
 
-import mock
 from dateutil.tz import tzlocal
 import pytest
 from s3transfer.compat import seekable

--- a/tests/unit/customizations/servicecatalog/__init__.py
+++ b/tests/unit/customizations/servicecatalog/__init__.py
@@ -16,7 +16,6 @@ from awscli.testutils import mock
 from awscli.customizations.servicecatalog import \
     register_servicecatalog_commands, GenerateCommand
 from awscli.customizations.servicecatalog import inject_commands
-from mock import call
 
 
 class TestRegisterServiceCatalogCommands(unittest.TestCase):
@@ -24,7 +23,7 @@ class TestRegisterServiceCatalogCommands(unittest.TestCase):
         event_emitter = mock.Mock()
         register_servicecatalog_commands(event_emitter)
         event_emitter.register.assert_has_calls(
-            [call('building-command-table.servicecatalog', inject_commands)])
+            [mock.call('building-command-table.servicecatalog', inject_commands)])
 
 
 class TestInjectCommands(unittest.TestCase):

--- a/tests/unit/customizations/servicecatalog/test_generateproduct.py
+++ b/tests/unit/customizations/servicecatalog/test_generateproduct.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 from argparse import Namespace
-from mock import patch
 
 from awscli.customizations.servicecatalog import exceptions
 from awscli.customizations.servicecatalog.generateproduct \
@@ -59,7 +58,7 @@ class TestCreateProductCommand(unittest.TestCase):
         self.global_args.endpoint_url = None
         self.global_args.verify_ssl = None
 
-    @patch('os.path.getsize', return_value=1)
+    @mock.patch('os.path.getsize', return_value=1)
     def test_happy_path(self, getsize_patch):
         # Arrange
         actual_product_view_detail = self.get_product_view_detail()
@@ -109,7 +108,7 @@ class TestCreateProductCommand(unittest.TestCase):
                          )
         self.assertEqual(0, result)
 
-    @patch('os.path.getsize', return_value=1)
+    @mock.patch('os.path.getsize', return_value=1)
     def test_happy_path_unicode(self, getsize_patch):
         # Arrange
         self.args.product_name = u'\u05d1\u05e8\u05d9\u05e6\u05e7\u05dc\u05d4'
@@ -168,7 +167,7 @@ class TestCreateProductCommand(unittest.TestCase):
                                      "not supported"):
             self.cmd._run_main(self.args, self.global_args)
 
-    @patch('os.path.getsize', return_value=1)
+    @mock.patch('os.path.getsize', return_value=1)
     def test_happy_path_omitting_optional_parameters(self, getsize_patch):
         # Arrange
         self.args.support_description = None

--- a/tests/unit/customizations/servicecatalog/test_generateprovisioningartifact.py
+++ b/tests/unit/customizations/servicecatalog/test_generateprovisioningartifact.py
@@ -12,7 +12,6 @@
 # language governing permissions and limitations under the License.
 
 from argparse import Namespace
-from mock import patch
 
 from awscli.customizations.servicecatalog import exceptions
 from awscli.customizations.servicecatalog.generateprovisioningartifact \
@@ -48,7 +47,7 @@ class TestCreateProvisioningArtifactCommand(unittest.TestCase):
         self.global_args.endpoint_url = None
         self.global_args.verify_ssl = None
 
-    @patch('os.path.getsize', return_value=1)
+    @mock.patch('os.path.getsize', return_value=1)
     def test_happy_path(self, getsize_patch):
         # Arrange
         self.servicecatalog_client.create_provisioning_artifact\
@@ -83,7 +82,7 @@ class TestCreateProvisioningArtifactCommand(unittest.TestCase):
                          captured.stdout.getvalue())
         self.assertEqual(0, result)
 
-    @patch('os.path.getsize', return_value=1)
+    @mock.patch('os.path.getsize', return_value=1)
     def test_happy_path_unicode(self, getsize_patch):
         # Arrange
         self.args.provisioning_artifact_name = u'\u05d1\u05e8\u05d9\u05e6'

--- a/tests/unit/customizations/test_arguments.py
+++ b/tests/unit/customizations/test_arguments.py
@@ -11,9 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
 
-from awscli.testutils import unittest, FileCreator, skip_if_windows
+from awscli.testutils import mock, unittest, FileCreator, skip_if_windows
 from awscli.customizations.arguments import NestedBlobArgumentHoister
 from awscli.customizations.arguments import OverrideRequiredArgsArgument
 from awscli.customizations.arguments import StatefulArgument

--- a/tests/unit/customizations/test_assumerole.py
+++ b/tests/unit/customizations/test_assumerole.py
@@ -10,8 +10,6 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from botocore.hooks import HierarchicalEmitter
 from botocore.exceptions import ProfileNotFound
 from botocore.session import Session
@@ -21,7 +19,7 @@ from botocore.credentials import (
     AssumeRoleWithWebIdentityProvider
 )
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations import assumerole
 
 

--- a/tests/unit/customizations/test_cliinput.py
+++ b/tests/unit/customizations/test_cliinput.py
@@ -10,12 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 import os
 import shutil
 import tempfile
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.argprocess import ParamError
 from awscli.customizations.cliinput import CliInputJSONArgument
 from awscli.customizations.cliinput import CliInputYAMLArgument

--- a/tests/unit/customizations/test_cloudsearchdomain.py
+++ b/tests/unit/customizations/test_cloudsearchdomain.py
@@ -10,13 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.testutils import BaseAWSCommandParamsTest
 from awscli.help import PagingHelpRenderer
 from awscli.customizations.cloudsearchdomain import validate_endpoint_url
 from awscli.customizations.exceptions import ParamValidationError
-
-import mock
 
 
 class TestSearchCommand(BaseAWSCommandParamsTest):

--- a/tests/unit/customizations/test_cloudwatch.py
+++ b/tests/unit/customizations/test_cloudwatch.py
@@ -14,8 +14,6 @@ import decimal
 
 from awscli.testutils import unittest
 
-import mock
-
 from awscli.customizations import putmetricdata
 
 

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -14,13 +14,12 @@
 import awscli
 
 from argparse import Namespace
-from mock import MagicMock, patch, call
 from six import StringIO
 from botocore.session import Session
 from botocore.credentials import Credentials
 from awscli.customizations.codecommit import CodeCommitGetCommand
 from awscli.customizations.codecommit import CodeCommitCommand
-from awscli.testutils import unittest, StringIOWithFileNo
+from awscli.testutils import mock, unittest, StringIOWithFileNo
 from awscli.customizations.exceptions import ParamValidationError
 
 from botocore.auth import SigV4Auth
@@ -78,12 +77,12 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.globals = Namespace()
         self.globals.region = 'us-east-1'
         self.globals.verify_ssl = False
-        self.session = MagicMock()
+        self.session = mock.MagicMock()
         self.session.get_config_variable.return_value = 'us-east-1'
         self.session.get_credentials.return_value = self.credentials
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
     def test_generate_credentials(self, stdout_mock):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
@@ -91,8 +90,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_TRAILING_NEWLINE))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_TRAILING_NEWLINE))
     def test_generate_credentials_trailing_newline(self, stdout_mock):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
@@ -100,8 +99,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_BLANK_LINE))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_BLANK_LINE))
     def test_generate_credentials_blank_line(self, stdout_mock):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
@@ -109,8 +108,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
     def test_generate_credentials_fips_reads_region_from_url(self, stdout_mock):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
@@ -120,8 +119,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(VPC_1_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(VPC_1_PROTOCOL_HOST_PATH))
     def test_generate_credentials_vpc_reads_region_from_url(self, stdout_mock):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
@@ -131,8 +130,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(VPC_2_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(VPC_2_PROTOCOL_HOST_PATH))
     def test_generate_credentials_vpc_2_reads_region_from_url(self, stdout_mock):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
@@ -142,8 +141,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(FIPS_VPC_1_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(FIPS_VPC_1_PROTOCOL_HOST_PATH))
     def test_generate_credentials_fips_vpc_1_reads_region_from_url(self, stdout_mock):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
@@ -153,8 +152,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(FIPS_VPC_2_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(FIPS_VPC_2_PROTOCOL_HOST_PATH))
     def test_generate_credentials_fips_vpc_2_reads_region_from_url(self, stdout_mock):
         self.globals.region = None
         self.session.get_config_variable.return_value = None
@@ -164,8 +163,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(NO_REGION_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(NO_REGION_PROTOCOL_HOST_PATH))
     def test_generate_credentials_reads_region_from_session(self, stdout_mock):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
@@ -173,8 +172,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.assertRegex(
             output, 'username={0}\npassword=.+'.format('access'))
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(NON_AWS_PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(NON_AWS_PROTOCOL_HOST_PATH))
     def test_does_nothing_for_non_amazon_domain(self, stdout_mock):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
@@ -186,8 +185,8 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         with self.assertRaises(ParamValidationError):
             self.get_command._run_main(self.args, self.globals)
 
-    @patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
-    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
+    @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
+    @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
     def test_generate_session_credentials(self, stdout_mock):
         self.credentials = Credentials('access', 'secret', 'token')
         self.session.get_credentials.return_value = self.credentials
@@ -198,10 +197,10 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
             output,
             'username={0}%{1}\npassword=.+'.format('access', 'token'))
 
-    @patch('sys.stdout', MOCK_STDOUT_CLASS())
-    @patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
-    @patch('botocore.auth.SigV4Auth.string_to_sign')
-    @patch('botocore.auth.SigV4Auth.signature')
+    @mock.patch('sys.stdout', MOCK_STDOUT_CLASS())
+    @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
+    @mock.patch('botocore.auth.SigV4Auth.string_to_sign')
+    @mock.patch('botocore.auth.SigV4Auth.signature')
     def test_generate_credentials_creates_a_valid_request(self, signature,
                                                           string_to_sign):
         self.credentials = Credentials('access', 'secret')

--- a/tests/unit/customizations/test_commands.py
+++ b/tests/unit/customizations/test_commands.py
@@ -11,12 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import unittest
-import mock
 
 from awscli.clidriver import CLIDriver
 from awscli.customizations.commands import BasicHelp, BasicCommand
 from awscli.customizations.commands import BasicDocHandler
-from awscli.testutils import BaseAWSCommandParamsTest
+from awscli.testutils import mock, BaseAWSCommandParamsTest
 from botocore.hooks import HierarchicalEmitter
 from tests.unit.test_clidriver import FakeSession, FakeCommand
 

--- a/tests/unit/customizations/test_flatten.py
+++ b/tests/unit/customizations/test_flatten.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest
-
-import mock
+from awscli.testutils import mock, unittest
 
 from awscli.arguments import CLIArgument
 from awscli.customizations import utils

--- a/tests/unit/customizations/test_generatecliskeleton.py
+++ b/tests/unit/customizations/test_generatecliskeleton.py
@@ -10,12 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from botocore.model import DenormalizedStructureBuilder
 
 from awscli.compat import six
-from awscli.testutils import unittest, capture_output
+from awscli.testutils import mock, unittest, capture_output
 from awscli.customizations.generatecliskeleton import \
     GenerateCliSkeletonArgument
 

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -14,9 +14,8 @@ from botocore.session import get_session
 from botocore.handlers import disable_signing
 import os
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.compat import six
-import mock
 
 from awscli.customizations import globalargs
 from awscli.customizations.exceptions import ParamValidationError

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -14,12 +14,11 @@
 import argparse
 import datetime
 import json
-import mock
 
 from botocore.exceptions import ClientError
 
 from awscli.customizations import opsworks
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.customizations.exceptions import ParamValidationError
 
 

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -10,14 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 from botocore.exceptions import DataNotFoundError
 from botocore.model import OperationModel
 from awscli.help import OperationHelpCommand, OperationDocumentEventHandler
-
-import mock
-from mock import Mock, patch
 
 from awscli.customizations import paginate
 from awscli.customizations.exceptions import ParamValidationError
@@ -104,11 +101,11 @@ class TestArgumentTableModifications(TestPaginateBase):
 
 class TestHelpDocumentationModifications(TestPaginateBase):
     def test_injects_pagination_help_text(self):
-        with patch('awscli.customizations.paginate.get_paginator_config',
+        with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value={'result_key': 'abc'}):
             help_command = OperationHelpCommand(
-                Mock(), Mock(), Mock(), 'foo', OperationDocumentEventHandler)
-            help_command.obj = Mock(OperationModel)
+                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+            help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
             self.assertIn('``foo`` is a paginated operation. Multiple API',
@@ -117,22 +114,22 @@ class TestHelpDocumentationModifications(TestPaginateBase):
                           help_command.doc.getvalue().decode())
 
     def test_shows_result_keys_when_array(self):
-        with patch('awscli.customizations.paginate.get_paginator_config',
+        with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value={'result_key': ['abc', '123']}):
             help_command = OperationHelpCommand(
-                Mock(), Mock(), Mock(), 'foo', OperationDocumentEventHandler)
-            help_command.obj = Mock(OperationModel)
+                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+            help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
             self.assertIn('following query expressions: ``abc``, ``123``',
                           help_command.doc.getvalue().decode())
 
     def test_does_not_show_result_key_if_not_present(self):
-        with patch('awscli.customizations.paginate.get_paginator_config',
+        with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value={'limit_key': 'aaa'}):
             help_command = OperationHelpCommand(
-                Mock(), Mock(), Mock(), 'foo', OperationDocumentEventHandler)
-            help_command.obj = Mock(OperationModel)
+                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+            help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
             self.assertIn('``foo`` is a paginated operation. Multiple API',
@@ -141,11 +138,11 @@ class TestHelpDocumentationModifications(TestPaginateBase):
                              help_command.doc.getvalue().decode())
 
     def test_does_not_inject_when_no_pagination(self):
-        with patch('awscli.customizations.paginate.get_paginator_config',
+        with mock.patch('awscli.customizations.paginate.get_paginator_config',
                    return_value=None):
             help_command = OperationHelpCommand(
-                Mock(), Mock(), Mock(), 'foo', OperationDocumentEventHandler)
-            help_command.obj = Mock(OperationModel)
+                mock.Mock(), mock.Mock(), mock.Mock(), 'foo', OperationDocumentEventHandler)
+            help_command.obj = mock.Mock(OperationModel)
             help_command.obj.name = 'foo'
             paginate.add_paging_description(help_command)
             self.assertNotIn('``foo`` is a paginated operation',

--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -11,13 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import os
-import mock
 import random
 import string
 import tempfile
 import hashlib
 import shutil
-from mock import patch, Mock
+
+from awscli.testutils import mock
 
 import botocore
 import botocore.session
@@ -40,8 +40,8 @@ class TestS3Uploader(unittest.TestCase):
         self.s3client = botocore.session.get_session().create_client(
                 's3', region_name=region)
         self.s3client_stub = Stubber(self.s3client)
-        self.transfer_manager_mock = Mock(spec=S3Transfer)
-        self.transfer_manager_mock.upload = Mock()
+        self.transfer_manager_mock = mock.Mock(spec=S3Transfer)
+        self.transfer_manager_mock.upload = mock.Mock()
         self.bucket_name = "bucketname"
         self.prefix = None
 
@@ -49,8 +49,8 @@ class TestS3Uploader(unittest.TestCase):
             self.s3client, self.bucket_name, self.prefix, None, False,
             self.transfer_manager_mock)
 
-    @patch('os.path.getsize', return_value=1)
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch('os.path.getsize', return_value=1)
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_successful(self, progress_percentage_mock, get_size_patch):
         file_name = "filename"
         remote_path = "remotepath"
@@ -63,7 +63,7 @@ class TestS3Uploader(unittest.TestCase):
             self.bucket_name, prefix, remote_path)
 
         # Setup mock to fake that file does not exist
-        s3uploader.file_exists = Mock()
+        s3uploader.file_exists = mock.Mock()
         s3uploader.file_exists.return_value = False
         # set the metadata used by the uploader when uploading
         artifact_metadata = {"key": "val"}
@@ -83,8 +83,8 @@ class TestS3Uploader(unittest.TestCase):
                 expected_extra_args, mock.ANY)
         s3uploader.file_exists.assert_called_once_with(remote_path_with_prefix)
 
-    @patch('os.path.getsize', return_value=1)
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch('os.path.getsize', return_value=1)
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_successful_odict(self, progress_percentage_mock, get_size_patch):
         file_name = "filename"
         remote_path = "remotepath"
@@ -97,7 +97,7 @@ class TestS3Uploader(unittest.TestCase):
             self.bucket_name, prefix, remote_path)
 
         # Setup mock to fake that file does not exist
-        s3uploader.file_exists = Mock()
+        s3uploader.file_exists = mock.Mock()
         s3uploader.file_exists.return_value = False
         # set the metadata used by the uploader when uploading
         artifact_metadata = OrderedDict({"key": "val"})
@@ -117,13 +117,13 @@ class TestS3Uploader(unittest.TestCase):
                 expected_extra_args, mock.ANY)
         s3uploader.file_exists.assert_called_once_with(remote_path_with_prefix)
 
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_idempotency(self, progress_percentage_mock):
         file_name = "filename"
         remote_path = "remotepath"
 
         # Setup mock to fake that file was already uploaded
-        self.s3uploader.file_exists = Mock()
+        self.s3uploader.file_exists = mock.Mock()
         self.s3uploader.file_exists.return_value = True
 
         self.s3uploader.upload(file_name, remote_path)
@@ -131,8 +131,8 @@ class TestS3Uploader(unittest.TestCase):
         self.transfer_manager_mock.upload.assert_not_called()
         self.s3uploader.file_exists.assert_called_once_with(remote_path)
 
-    @patch('os.path.getsize', return_value=1)
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch('os.path.getsize', return_value=1)
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_force_upload(self, progress_percentage_mock, get_size_patch):
         file_name = "filename"
         remote_path = "remotepath"
@@ -145,7 +145,7 @@ class TestS3Uploader(unittest.TestCase):
             None, True, self.transfer_manager_mock)
 
         # Pretend file already exists
-        self.s3uploader.file_exists = Mock()
+        self.s3uploader.file_exists = mock.Mock()
         self.s3uploader.file_exists.return_value = True
 
         # Because we forced an update, this should reupload even if file exists
@@ -162,8 +162,8 @@ class TestS3Uploader(unittest.TestCase):
         # Since ForceUpload=True, we should NEVER do the file-exists check
         self.s3uploader.file_exists.assert_not_called()
 
-    @patch('os.path.getsize', return_value=1)
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch('os.path.getsize', return_value=1)
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_successful_custom_kms_key(self, progress_percentage_mock, get_size_patch):
         file_name = "filename"
         remote_path = "remotepath"
@@ -176,7 +176,7 @@ class TestS3Uploader(unittest.TestCase):
             kms_key_id, False, self.transfer_manager_mock)
 
         # Setup mock to fake that file does not exist
-        self.s3uploader.file_exists = Mock()
+        self.s3uploader.file_exists = mock.Mock()
         self.s3uploader.file_exists.return_value = False
 
         upload_url = self.s3uploader.upload(file_name, remote_path)
@@ -191,14 +191,14 @@ class TestS3Uploader(unittest.TestCase):
                 expected_encryption_args, mock.ANY)
         self.s3uploader.file_exists.assert_called_once_with(remote_path)
 
-    @patch('os.path.getsize', return_value=1)
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch('os.path.getsize', return_value=1)
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_successful_nobucket(self, progress_percentage_mock, get_size_patch):
         file_name = "filename"
         remote_path = "remotepath"
 
         # Setup mock to fake that file does not exist
-        self.s3uploader.file_exists = Mock()
+        self.s3uploader.file_exists = mock.Mock()
         self.s3uploader.file_exists.return_value = False
 
         # Setup uploader to return a NOSuchBucket exception
@@ -209,14 +209,14 @@ class TestS3Uploader(unittest.TestCase):
         with self.assertRaises(NoSuchBucketError):
             self.s3uploader.upload(file_name, remote_path)
 
-    @patch('os.path.getsize', return_value=1)
-    @patch("awscli.customizations.s3uploader.ProgressPercentage")
+    @mock.patch('os.path.getsize', return_value=1)
+    @mock.patch("awscli.customizations.s3uploader.ProgressPercentage")
     def test_upload_successful_exceptions(self, progress_percentage_mock, get_size_patch):
         file_name = "filename"
         remote_path = "remotepath"
 
         # Setup mock to fake that file does not exist
-        self.s3uploader.file_exists = Mock()
+        self.s3uploader.file_exists = mock.Mock()
         self.s3uploader.file_exists.return_value = False
 
         # Raise an unrecognized botocore error
@@ -238,10 +238,10 @@ class TestS3Uploader(unittest.TestCase):
         filename = "filename"
         extension = "extn"
 
-        self.s3uploader.file_checksum = Mock()
+        self.s3uploader.file_checksum = mock.Mock()
         self.s3uploader.file_checksum.return_value = checksum
 
-        self.s3uploader.upload = Mock()
+        self.s3uploader.upload = mock.Mock()
 
         self.s3uploader.upload_with_dedup(filename, extension)
 
@@ -279,9 +279,9 @@ class TestS3Uploader(unittest.TestCase):
             self.assertFalse(self.s3uploader.file_exists(key))
 
         # Let's pretend some other unknown exception happened
-        s3mock = Mock()
+        s3mock = mock.Mock()
         uploader = S3Uploader(s3mock, self.bucket_name)
-        s3mock.head_object = Mock()
+        s3mock.head_object = mock.Mock()
         s3mock.head_object.side_effect = RuntimeError()
 
         with self.assertRaises(RuntimeError):

--- a/tests/unit/customizations/test_timestampformat.py
+++ b/tests/unit/customizations/test_timestampformat.py
@@ -12,16 +12,15 @@
 # language governing permissions and limitations under the License.
 from botocore.exceptions import ProfileNotFound
 from botocore.session import Session
-from mock import Mock, call
 
 from awscli.customizations import timestampformat
 from awscli.customizations.exceptions import ConfigurationError
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 
 
 class TestScalarParse(unittest.TestCase):
     def test_register_timestamp_format(self):
-        event_handers = Mock()
+        event_handers = mock.Mock()
         timestampformat.register_timestamp_format(event_handers)
         event_handers.register_first.assert_called_with(
             'session-initialized', timestampformat.add_timestamp_parser)
@@ -31,17 +30,17 @@ class TestScalarParse(unittest.TestCase):
         self.assertEqual(timestampformat.identity(10), 10)
 
     def test_scalar_parsers_set(self):
-        session = Mock()
+        session = mock.Mock()
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'wire'}
         timestampformat.add_timestamp_parser(session)
         session.get_component.assert_called_with('response_parser_factory')
         factory = session.get_component.return_value
-        expected = [call(timestamp_parser=timestampformat.identity)]
+        expected = [mock.call(timestamp_parser=timestampformat.identity)]
         self.assertEqual(factory.set_parser_defaults.mock_calls, expected)
 
     def test_choose_none_timestamp_formatter(self):
-        session = Mock(spec=Session)
+        session = mock.Mock(spec=Session)
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'wire'}
         factory = session.get_component.return_value
@@ -50,7 +49,7 @@ class TestScalarParse(unittest.TestCase):
             timestamp_parser=timestampformat.identity)
 
     def test_choose_iso_timestamp_formatter(self):
-        session = Mock(spec=Session)
+        session = mock.Mock(spec=Session)
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'iso8601'}
         factory = session.get_component.return_value
@@ -59,7 +58,7 @@ class TestScalarParse(unittest.TestCase):
             timestamp_parser=timestampformat.iso_format)
 
     def test_choose_invalid_timestamp_formatter(self):
-        session = Mock(spec=Session)
+        session = mock.Mock(spec=Session)
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'foobar'}
         session.get_component.return_value
@@ -67,7 +66,7 @@ class TestScalarParse(unittest.TestCase):
             timestampformat.add_timestamp_parser(session)
 
     def test_choose_timestamp_parser_profile_not_found(self):
-        session = Mock(spec=Session)
+        session = mock.Mock(spec=Session)
         session.get_scoped_config.side_effect = ProfileNotFound(profile='foo')
         factory = session.get_component.return_value
         timestampformat.add_timestamp_parser(session)

--- a/tests/unit/customizations/test_utils.py
+++ b/tests/unit/customizations/test_utils.py
@@ -12,14 +12,13 @@
 # language governing permissions and limitations under the License.
 import io
 import argparse
-import mock
 
 from botocore.exceptions import ClientError
 from botocore.model import Shape
 
 from awscli.customizations import utils
 from awscli.customizations.exceptions import ParamValidationError
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.testutils import BaseAWSHelpOutputTest
 
 

--- a/tests/unit/customizations/test_waiters.py
+++ b/tests/unit/customizations/test_waiters.py
@@ -10,12 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
 from botocore.waiter import WaiterModel
 from botocore.exceptions import DataNotFoundError
 
-from awscli.testutils import unittest, BaseAWSHelpOutputTest, \
+from awscli.testutils import mock, unittest, BaseAWSHelpOutputTest, \
     BaseAWSCommandParamsTest
 from awscli.customizations.exceptions import ParamValidationError
 from awscli.customizations.waiters import add_waiters, WaitCommand, \

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -13,11 +13,10 @@
 # language governing permissions and limitations under the License.
 from botocore.compat import json
 import platform
-import mock
 from awscli.compat import six
 from awscli.formatter import JSONFormatter
 
-from awscli.testutils import BaseAWSCommandParamsTest, unittest
+from awscli.testutils import mock, BaseAWSCommandParamsTest, unittest
 from awscli.testutils import skip_if_windows
 from awscli.compat import get_stdout_text_writer
 

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -12,7 +12,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 import json
 import os
 import sys
@@ -21,7 +21,6 @@ import locale
 
 from awscli.compat import six
 from six.moves import cStringIO
-import mock
 
 from awscli.formatter import Formatter
 

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -12,12 +12,11 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
 from botocore import xform_name
 from botocore import model
 from botocore.compat import OrderedDict
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli.testutils import BaseCLIDriverTest
 from awscli.testutils import temporary_file
 from awscli.help import OperationHelpCommand

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -10,9 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 
-from awscli.testutils import unittest
+from awscli.testutils import mock, unittest
 from awscli import arguments
 from botocore.model import StringShape, OperationModel, ServiceModel
 

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -12,11 +12,10 @@
 # language governing permissions and limitations under the License.
 import json
 
-import mock
 from botocore.model import ShapeResolver, StructureShape, StringShape, \
     ListShape, MapShape, Shape, DenormalizedStructureBuilder
 
-from awscli.testutils import unittest, FileCreator
+from awscli.testutils import mock, unittest, FileCreator
 from awscli.clidocs import OperationDocumentEventHandler, \
     CLIDocumentEventHandler, TopicListerDocumentEventHandler, \
     TopicDocumentEventHandler, GlobalOptionsDocumenter

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -20,7 +20,8 @@ from awscli.testutils import BaseAWSCommandParamsTest
 import logging
 import io
 
-import mock
+from awscli.testutils import mock
+
 import awscrt.io
 from awscli.compat import six
 from botocore import xform_name

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -10,13 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import unittest, skip_if_windows, FileCreator
+from awscli.testutils import mock, unittest, skip_if_windows, FileCreator
 import signal
 import json
 import sys
 import os
-
-import mock
 
 from awscli.compat import six
 from awscli.help import PosixHelpRenderer, ExecutableNotFoundError

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -10,9 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
 from awscli.compat import six
-from awscli.testutils import unittest, FileCreator
+from awscli.testutils import mock, unittest, FileCreator
 from awscli.testutils import skip_if_windows
 
 from awscli.paramfile import get_paramfile, ResourceLoadingError

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -11,9 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
-from awscli.testutils import unittest
-
-import mock
+from awscli.testutils import mock, unittest
 
 from awscli import plugin
 from botocore import hooks

--- a/tests/unit/test_testutils.py
+++ b/tests/unit/test_testutils.py
@@ -10,9 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import mock
-
-from awscli.testutils import create_bucket
+from awscli.testutils import create_bucket, mock
 from awscli.testutils import BaseCLIDriverTest
 
 

--- a/tests/unit/test_text.py
+++ b/tests/unit/test_text.py
@@ -23,8 +23,7 @@ import unittest
 import sys
 
 from awscli.compat import six
-import mock
-
+from awscli.testutils import mock
 from awscli import text
 
 

--- a/tests/unit/test_topictags.py
+++ b/tests/unit/test_topictags.py
@@ -21,8 +21,6 @@
 #
 import json
 
-import mock
-
 from awscli.testutils import unittest, FileCreator
 from awscli.topictags import TopicTagDB
 

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -20,7 +20,6 @@
 # distribution when running the tests.
 import os
 import sys
-import mock
 import time
 import random
 import shutil
@@ -35,6 +34,7 @@ from subprocess import Popen, PIPE
 
 from dateutil.tz import tzlocal
 import unittest
+from unittest import mock
 
 import botocore.loaders
 import botocore.session


### PR DESCRIPTION
Remove the `mock` dependency and replace all imports with `unittest.mock`.

This PR is a breakout PR of https://github.com/aws/aws-cli/pull/8757