### PR TITLE
Add changelog for Python interpreter version update

### DIFF
--- a/.changes/next-release/enhancement-Python-35655.json
+++ b/.changes/next-release/enhancement-Python-35655.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Python",
+  "description": "Update bundled Python interpreter version to 3.11.9"
+}


### PR DESCRIPTION
This is applicable to the bundled Python interpreter versions in official AWS CLI v2 installers and Docker images.