### PR TITLE
[v2] Add s3 integration tests using directory buckets

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -181,16 +181,15 @@ def create_bucket(session, name=None, region=None):
     return bucket_name
 
 
-def create_dir_bucket(session, name=None, region=None, az=None):
+def create_dir_bucket(session, name=None, location=None):
     """
     Creates a S3 directory bucket
     :returns: the name of the bucket created
     """
-    if not region:
-        region = 'us-west-2'
+    if not location:
+        location = ('us-west-2', 'usw2-az1')
+    region, az = location
     client = session.create_client('s3', region_name=region)
-    if not az:
-        az = 'usw2-az1'
     if name:
         bucket_name = name
     else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -531,10 +531,12 @@ class S3Utils:
         self.wait_bucket_exists(bucket_name)
         return bucket_name
 
-    def create_dir_bucket(self, name=None, region=None, az=None):
-        if not region:
+    def create_dir_bucket(self, name=None, location=None):
+        if location:
+            region, _ = location
+        else:
             region = self._region
-        bucket_name = create_dir_bucket(self._session, name, region, az)
+        bucket_name = create_dir_bucket(self._session, name, location)
         self._bucket_to_region[bucket_name] = region
         # Wait for the bucket to exist before letting it be used.
         self.wait_bucket_exists(bucket_name)

--- a/tests/integration/customizations/s3/conftest.py
+++ b/tests/integration/customizations/s3/conftest.py
@@ -47,6 +47,20 @@ def shared_copy_bucket(s3_utils):
     s3_utils.delete_bucket(bucket_name)
 
 
+@pytest.fixture(scope='package')
+def shared_dir_bucket(s3_utils):
+    bucket_name = s3_utils.create_dir_bucket()
+    yield bucket_name
+    s3_utils.delete_bucket(bucket_name)
+
+
+@pytest.fixture(scope='package')
+def shared_copy_dir_bucket(s3_utils):
+    bucket_name = s3_utils.create_dir_bucket()
+    yield bucket_name
+    s3_utils.delete_bucket(bucket_name)
+
+
 # Bucket for cross-region, cross-S3 copies
 @pytest.fixture(scope='package')
 def shared_cross_region_bucket(s3_utils):
@@ -75,12 +89,15 @@ def shared_non_dns_compatible_us_east_1_bucket(s3_utils):
 def clean_shared_buckets(s3_utils, shared_bucket, shared_copy_bucket,
                          shared_cross_region_bucket,
                          shared_non_dns_compatible_bucket,
-                         shared_non_dns_compatible_us_east_1_bucket):
+                         shared_non_dns_compatible_us_east_1_bucket,
+                         shared_dir_bucket, shared_copy_dir_bucket,):
     s3_utils.remove_all_objects(shared_bucket)
     s3_utils.remove_all_objects(shared_copy_bucket)
     s3_utils.remove_all_objects(shared_cross_region_bucket)
     s3_utils.remove_all_objects(shared_non_dns_compatible_bucket)
     s3_utils.remove_all_objects(shared_non_dns_compatible_us_east_1_bucket)
+    s3_utils.remove_all_objects(shared_dir_bucket)
+    s3_utils.remove_all_objects(shared_copy_dir_bucket)
 
 
 @pytest.fixture


### PR DESCRIPTION
Set up S3 directory bucket creation/teardown for integration tests with high-level `s3` commands. For the existing teardown logic to be compatible with directory buckets, we switch from `ListObjects` to `ListObjectsV2` when clearing out test buckets.