### PR TITLE
Handle expected boolean values for waiter error matcher

### DIFF
--- a/.changes/next-release/bugfix-wait-22691.json
+++ b/.changes/next-release/bugfix-wait-22691.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "wait",
+  "description": "Update waiters to handle expected boolean values when matching errors (`aws/aws-cli#3220 <https://github.com/aws/aws-cli/issues/3220>`__)"
+}

--- a/awscli/botocore/waiter.py
+++ b/awscli/botocore/waiter.py
@@ -280,7 +280,16 @@ class AcceptorConfig(object):
             # response.  So response is still a dictionary, and in the case
             # of an error response will contain the "Error" and
             # "ResponseMetadata" key.
-            return response.get("Error", {}).get("Code", "") == expected
+            # When expected is True, accept any error code.
+            # When expected is False, check if any errors were encountered.
+            # Otherwise, check for a specific AWS error code.
+            if expected is True:
+                return "Error" in response and "Code" in response["Error"]
+            elif expected is False:
+                return "Error" not in response
+            else:
+                return response.get("Error", {}).get("Code", "") == expected
+            
         return acceptor_matches
 
 

--- a/tests/unit/botocore/test_waiters.py
+++ b/tests/unit/botocore/test_waiters.py
@@ -181,6 +181,38 @@ class TestWaiterModel(unittest.TestCase):
         self.assertFalse(
             success_acceptor({'Error': {'Code': 'DoesNotExistErorr'}}))
 
+    def test_single_waiter_supports_no_error(self):
+        single_waiter = {
+            'acceptors': [
+                {
+                    'state': 'success',
+                    'matcher': 'error',
+                    'expected': False,
+                }
+            ],
+        }
+        single_waiter.update(self.boiler_plate_config)
+        config = SingleWaiterConfig(single_waiter)
+        success_acceptor = config.acceptors[0].matcher_func
+        self.assertTrue(success_acceptor({}))
+        self.assertFalse(success_acceptor({'Error': {'Code': 'ExampleError'}}))
+
+    def test_single_waiter_supports_any_error(self):
+        single_waiter = {
+            'acceptors': [
+                {
+                    'state': 'success',
+                    'matcher': 'error',
+                    'expected': True,
+                }
+            ],
+        }
+        single_waiter.update(self.boiler_plate_config)
+        config = SingleWaiterConfig(single_waiter)
+        success_acceptor = config.acceptors[0].matcher_func
+        self.assertTrue(success_acceptor({'Error': {'Code': 'ExampleError1'}}))
+        self.assertTrue(success_acceptor({'Error': {'Code': 'ExampleError2'}}))
+
     def test_unknown_matcher(self):
         unknown_type = 'arbitrary_type'
         single_waiter = {


### PR DESCRIPTION
> AWS CLI v2 version of [boto/botocore#3220](https://github.com/boto/botocore/pull/3220)

## Summary
All services currently define waiter error acceptors that have `expected` string values that represent an AWS Error code like below:
```
{
  "expected":"ResourceNotFoundFault",
  "matcher":"error",
  "state":"success"
}
```
A waiter with this acceptor will continue to wait until an error the the code `ResourceNotFoundFault` is received or the max amount of attempts is reached.

However, it's possible for service teams to define a waiter error acceptor like below which has an `expected` boolean (`true` or `false`) value. The expected behavior is defined below:
* `true` - Match an error code with any value.
* `false` - Match if no errors were encountered

Example:
```
{
  "matcher" : "error",
  "expected" : false,
  "state" : "success"
}
```
A waiter with this acceptor will continue to wait until a response with no error is received or the max amount of attempts is reached.

This CR adds the ability for waiters to handle the acceptors described above. 
