### PR TITLE
Remove AWS Mobile Hub customization

### DIFF
--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -91,7 +91,6 @@ ARGUMENT_RENAMES = {
     'license-manager.get-grant.version': 'grant-version',
     'license-manager.delete-grant.version': 'grant-version',
     'license-manager.get-license.version': 'license-version',
-    'mobile.create-project.region': 'project-region',
     'rekognition.create-stream-processor.output': 'stream-processor-output',
     'eks.create-cluster.version': 'kubernetes-version',
     'eks.update-cluster-version.version': 'kubernetes-version',


### PR DESCRIPTION
This PR will remove the, now deprecated, AWS Mobile Hub service from the AWS CLI. This service will no longer be accessible in all new AWS SDKs starting today, July 22nd, 2024.