### PR TITLE
[v1] Disable S3 Express support for s3 mb command

### DIFF
--- a/.changes/next-release/bugfix-s3-90647.json
+++ b/.changes/next-release/bugfix-s3-90647.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3",
+  "description": "Disable usage of mb command with S3 Express directory buckets."
+}

--- a/.changes/next-release/bugfix-s3-90647.json
+++ b/.changes/next-release/bugfix-s3-90647.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
-  "category": "s3",
+  "category": "``s3``",
   "description": "Disable usage of mb command with S3 Express directory buckets."
 }

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -802,7 +802,7 @@ class MbCommand(S3Command):
         bucket, _ = split_s3_bucket_key(parsed_args.path)
 
         if is_s3express_bucket(bucket):
-            raise TypeError("Cannot use mb command with a directory bucket.")
+            raise ValueError("Cannot use mb command with a directory bucket.")
 
         bucket_config = {'LocationConstraint': self.client.meta.region_name}
         params = {'Bucket': bucket}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -801,6 +801,9 @@ class MbCommand(S3Command):
             raise TypeError("%s\nError: Invalid argument type" % self.USAGE)
         bucket, _ = split_s3_bucket_key(parsed_args.path)
 
+        if is_s3express_bucket(bucket):
+            raise TypeError("Cannot use mb command with a directory bucket.")
+
         bucket_config = {'LocationConstraint': self.client.meta.region_name}
         params = {'Bucket': bucket}
         if self.client.meta.region_name != 'us-east-1':

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -45,3 +45,8 @@ class TestMBCommand(BaseAWSCommandParamsTest):
     def test_nonzero_exit_if_invalid_path_provided(self):
         command = self.prefix + 'bucket'
         self.run_cmd(command, expected_rc=255)
+
+    def test_incompatible_with_express_directory_bucket(self):
+        command = self.prefix + 's3://bucket--usw2-az1--x-s3/'
+        stderr = self.run_cmd(command, expected_rc=255)[1]
+        self.assertIn('Cannot use mb command with a directory bucket.', stderr)


### PR DESCRIPTION
*Description of changes:*
Disabled the usage of mb command on S3 Express directory buckets.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
