### PR TITLE
Add note on chunk size adjustment behavior

### DIFF
--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -171,7 +171,9 @@ file is divided into chunks.  This configuration option specifies what
 the chunk size (also referred to as the part size) should be.  This
 value can specified using the same semantics as ``multipart_threshold``,
 that is either as the number of bytes as an integer, or using a size
-suffix.
+suffix. If the specified chunk size does not fit within the established
+limits for S3 multipart uploads, the chunk size will be automatically 
+adjusted to a valid value
 
 
 max_bandwidth

--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -173,7 +173,7 @@ value can specified using the same semantics as ``multipart_threshold``,
 that is either as the number of bytes as an integer, or using a size
 suffix. If the specified chunk size does not fit within the established
 limits for S3 multipart uploads, the chunk size will be automatically 
-adjusted to a valid value
+adjusted to a valid value.
 
 
 max_bandwidth


### PR DESCRIPTION
Page: https://docs.aws.amazon.com/cli/latest/topic/s3-config.html#multipart-chunksize

*Description of changes:* Add note on chunk size adjustment behavior [here](https://github.com/boto/s3transfer/blob/da68b50bb5a6b0c342ad0d87f9b1f80ab81dffce/s3transfer/utils.py#L778) in s3transfer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
