### PR TITLE
[v2] Expose Dockerfile path param to regenerate-configure script

### DIFF
--- a/scripts/regenerate-configure/regenerate-configure
+++ b/scripts/regenerate-configure/regenerate-configure
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import argparse
 import re
-import time
 from pathlib import Path
 from subprocess import run
 
@@ -11,18 +10,18 @@ DOCKERFILE_PATH = ROOT / "scripts" / "regenerate-configure" / "Dockerfile"
 IMAGE_RE = re.compile(r"sha256:(?P<image>.*?)\s")
 
 
-def main(cleanup):
-    image = _build_image()
+def main(dockerfile_path, cleanup):
+    image = _build_image(dockerfile_path)
     container_id = _start_image(image)
     _extract_configure_file(container_id)
     if cleanup:
         _cleanup_image_and_container(image, container_id)
 
 
-def _build_image():
-    print(f"Building docker image from: {DOCKERFILE_PATH}")
+def _build_image(dockerfile_path):
+    print(f"Building docker image from: {dockerfile_path}")
     result = _docker(
-        ["build", "-f", str(DOCKERFILE_PATH), ".", "--quiet"],
+        ["build", "-f", dockerfile_path, ".", "--quiet"],
         cwd=ROOT,
     )
     _assert_success(result)
@@ -74,10 +73,18 @@ def _assert_success(result):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "--dockerfile-path",
+        default=str(DOCKERFILE_PATH),
+        help="Path to Dockerfile to build.",
+    )
+    parser.add_argument(
         "--no-cleanup",
         action="store_true",
         default=False,
         help="Do not clean up docker image and container. Useful for debugging.",
     )
     args = parser.parse_args()
-    main(not args.no_cleanup)
+    main(
+        args.dockerfile_path,
+        not args.no_cleanup
+    )

--- a/scripts/regenerate-configure/regenerate-configure
+++ b/scripts/regenerate-configure/regenerate-configure
@@ -10,7 +10,7 @@ DOCKERFILE_PATH = ROOT / "scripts" / "regenerate-configure" / "Dockerfile"
 IMAGE_RE = re.compile(r"sha256:(?P<image>.*?)\s")
 
 
-def main(dockerfile_path, cleanup):
+def main(cleanup, dockerfile_path):
     image = _build_image(dockerfile_path)
     container_id = _start_image(image)
     _extract_configure_file(container_id)
@@ -85,6 +85,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     main(
-        args.dockerfile_path,
-        not args.no_cleanup
+        not args.no_cleanup,
+        args.dockerfile_path
     )


### PR DESCRIPTION
Expose `--dockerfile-path` parameter to the `regenerate-configure-script` to allow building an arbitrary Dockerfile for running autoreconf.