### PR TITLE
[v2] Use higher key size for TestSha256RSADigestValidator

### DIFF
--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -362,7 +362,7 @@ class TestSha256RSADigestValidator(unittest.TestCase):
         self._digest_data['_signature'] = 'aeff'
 
     def test_validates_digests(self):
-        private_key = rsa.generate_private_key(65537, 512, default_backend())
+        private_key = rsa.generate_private_key(65537, 1024, default_backend())
         sha256_hash = hashlib.sha256(self._inflated_digest)
         string_to_sign = "%s\n%s/%s\n%s\n%s" % (
             self._digest_data['digestEndTime'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

[cryptography 43.0.0 ](https://github.com/pyca/cryptography/blob/43.0.x/CHANGELOG.rst) requires bumped the minimum key size to 1024.

Since `rsa.generate_private_key()` is only used in this test, this is fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
