### PR TITLE
Pin attrs

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,9 @@
 jsonschema==4.7.2
+# Pin attrs, a dependency of jsonschema.
+# Needed until we move to proper lockfiles.
+# Deprecation warning is currently breaking
+# CLIv2 testing.
+attrs==23.2.0
 pytest==7.2.0
 coverage==7.0.1
 pytest-cov==4.0.0


### PR DESCRIPTION
The recent release of `attrs` 24.1.0 on Saturday appears to have broken some of our testing. This is a transitive dependency of `jsonschema` which is currently pinned. The CLIv2 is missing lockfiles like we use in our other repositories which should help avoid this in the future. For the time being, we'll pin this manually until the lock file fix is finished.