### PR TITLE
Ignore urllib3 2.x until we're ready to major version upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,9 @@ updates:
       - dependency-name: "jmespath"
       - dependency-name: "urllib3"
       - dependency-name: "wheel"
+    ignore:
+      - dependency-name: "urllib3"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
This PR instructs dependabot to stop opening PRs for urlllib3 2.x in AWSCLI v2 until we're ready to major version everyone. urllib3 1.x is continuing to receive updates for the immediate future. Once we're at a point we're confident we can move all installers to use urllib3 2.x on all supported systems, we should move the pin.