### PR TITLE
S3transfer update

### DIFF
--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -768,6 +768,14 @@ class S3ClientArgsCreator:
             ),
             'on_progress': self.get_crt_callback(future, 'progress'),
         }
+
+        # For DEFAULT requests, CRT requires the official S3 operation name.
+        # So transform string like "delete_object" -> "DeleteObject".
+        if make_request_args['type'] == S3RequestType.DEFAULT:
+            make_request_args['operation_name'] = ''.join(
+                x.title() for x in request_type.split('_')
+            )
+
         if is_s3express_bucket(call_args.bucket):
             make_request_args['signing_config'] = AwsSigningConfig(
                 algorithm=AwsSigningAlgorithm.V4_S3EXPRESS

--- a/tests/functional/s3transfer/test_crt.py
+++ b/tests/functional/s3transfer/test_crt.py
@@ -513,6 +513,7 @@ class TestCRTTransferManager(unittest.TestCase):
             {
                 'request': mock.ANY,
                 'type': awscrt.s3.S3RequestType.DEFAULT,
+                'operation_name': "DeleteObject",
                 'on_progress': mock.ANY,
                 'on_done': mock.ANY,
             },

--- a/tests/integration/s3transfer/test_crt.py
+++ b/tests/integration/s3transfer/test_crt.py
@@ -13,6 +13,9 @@
 import glob
 import io
 import os
+from uuid import uuid4
+
+from botocore.exceptions import ClientError
 
 from s3transfer.subscribers import BaseSubscriber
 from s3transfer.utils import OSUtils
@@ -403,6 +406,17 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
             future = transfer.delete(self.bucket_name, 'foo.txt')
             future.result()
         self.assertTrue(self.object_not_exists('foo.txt'))
+
+    def test_delete_exception_no_such_bucket(self):
+        # delete() uses awscrt.s3.S3RequestType.DEFAULT under the hood.
+        # Test that CRT exceptions translate properly into the botocore exceptions.
+        transfer = self._create_s3_transfer()
+        with self.assertRaises(ClientError) as ctx:
+            future = transfer.delete(
+                f"{self.bucket_name}-NONEXISTENT-{uuid4()}", "foo.txt"
+            )
+            future.result()
+        self.assertEqual(ctx.exception.__class__.__name__, 'NoSuchBucket')
 
     def test_many_files_download(self):
         transfer = self._create_s3_transfer()


### PR DESCRIPTION
This PR ports https://github.com/boto/s3transfer/commit/81a0c702da85512a1ee23a0a18883e9b09fa199b to the CLI v2 to support current releases of the AWS CRT.
