### PR TITLE
Use list building

### DIFF
--- a/awscli/table.py
+++ b/awscli/table.py
@@ -270,8 +270,7 @@ class MultiTable(object):
         # the width of each of the columns.
         widths = section.calculate_column_widths(padding=4,
                                                  max_width=max_width)
-        # TODO: Built a list instead of +=, it's more efficient.
-        current = ''
+        current = []
         length_so_far = 0
         # The first cell needs both left and right edges '|  foo  |'
         # while subsequent cells only need right edges '  foo  |'.
@@ -283,12 +282,12 @@ class MultiTable(object):
                 first = False
             else:
                 left_edge = ''
-            current += center_text(text=stylized_header, length=width,
-                                   left_edge=left_edge, right_edge='|',
-                                   text_length=get_text_length(header))
+            current.append(center_text(text=stylized_header, length=width,
+                                       left_edge=left_edge, right_edge='|',
+                                       text_length=get_text_length(header)))
             length_so_far += width
         self._write_line_break(stream, widths)
-        stream.write(current + '\n')
+        stream.write(''.join(current) + '\n')
 
     def _write_line_break(self, stream, widths):
         # Write out something like:
@@ -313,9 +312,7 @@ class MultiTable(object):
             return
         self._write_line_break(stream, widths)
         for row in section.rows:
-            # TODO: Built the string in a list then join instead of using +=,
-            # it's more efficient.
-            current = ''
+            current = []
             length_so_far = 0
             first = True
             for width, element in zip(widths, row):
@@ -325,12 +322,12 @@ class MultiTable(object):
                 else:
                     left_edge = ''
                 stylized = self._styler.style_row_element(element)
-                current += align_left(text=stylized, length=width,
-                                      left_edge=left_edge,
-                                      right_edge=self._column_separator,
-                                      text_length=get_text_length(element))
+                current.append(align_left(text=stylized, length=width,
+                                          left_edge=left_edge,
+                                          right_edge=self._column_separator,
+                                          text_length=get_text_length(element)))
                 length_so_far += width
-            stream.write(current + '\n')
+            stream.write(''.join(current) + '\n')
         self._write_line_break(stream, widths)
 
 


### PR DESCRIPTION
Remove TODO item in `awscli/table.py` to build a list and then join instead of doing string concatenation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
