### PR TITLE
Fix IPv6 support

### DIFF
--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -25,7 +25,11 @@ from botocore.hooks import first_non_none_response
 from botocore.httpchecksum import handle_checksum_body
 from botocore.httpsession import URLLib3Session
 from botocore.response import StreamingBody
-from botocore.utils import get_environ_proxies, is_valid_endpoint_url
+from botocore.utils import (
+    get_environ_proxies,
+    is_valid_endpoint_url,
+    is_valid_ipv6_endpoint_url,
+)
 
 logger = logging.getLogger(__name__)
 history_recorder = get_global_history_recorder()
@@ -283,9 +287,12 @@ class EndpointCreator(object):
                         socket_options=None,
                         client_cert=None,
                         proxies_config=None):
-        if not is_valid_endpoint_url(endpoint_url):
-
+        if (
+            not is_valid_endpoint_url(endpoint_url)
+            and not is_valid_ipv6_endpoint_url(endpoint_url)
+        ):
             raise ValueError("Invalid endpoint: %s" % endpoint_url)
+
         if proxies is None:
             proxies = self._get_proxies(endpoint_url)
         endpoint_prefix = service_model.endpoint_prefix

--- a/tests/unit/botocore/test_endpoint.py
+++ b/tests/unit/botocore/test_endpoint.py
@@ -12,8 +12,10 @@
 # language governing permissions and limitations under the License.
 import io
 import socket
-from tests import mock, unittest
 
+import pytest
+
+from tests import mock, unittest
 from botocore.awsrequest import AWSRequest
 from botocore.endpoint import Endpoint, DEFAULT_TIMEOUT
 from botocore.endpoint import EndpointCreator
@@ -293,6 +295,25 @@ class TestEndpointCreator(unittest.TestCase):
             self.service_model, region_name='us-east-1',
             endpoint_url='https://endpoint.url')
         self.assertEqual(endpoint.host, 'https://endpoint.url')
+
+    def test_creates_endpoint_with_ipv4_url(self):
+        endpoint = self.creator.create_endpoint(
+            self.service_model, region_name='us-east-1',
+            endpoint_url='https://192.168.0.0')
+        self.assertEqual(endpoint.host, 'https://192.168.0.0')
+
+    def test_creates_endpoint_with_ipv6_url(self):
+        endpoint = self.creator.create_endpoint(
+            self.service_model, region_name='us-east-1',
+            endpoint_url='https://[100:0:2::61]:7480')
+        self.assertEqual(endpoint.host, 'https://[100:0:2::61]:7480')
+
+    def test_raises_error_with_invalid_url(self):
+        with pytest.raises(ValueError):
+            self.creator.create_endpoint(
+                self.service_model, region_name='us-east-1',
+                endpoint_url='https://*.aws.amazon.com/'
+            )
 
     def test_create_endpoint_with_default_timeout(self):
         endpoint = self.creator.create_endpoint(


### PR DESCRIPTION
This PR ports https://github.com/boto/botocore/pull/2574 forward into the CLIv2 as it appears to have been missed. This will avoid incorrect validation failures within botocore and defer validation/routing decisions down the stack to urllib3.