### PR TITLE
Fix IPv6 SigV4 Signing

### DIFF
--- a/awscli/botocore/auth.py
+++ b/awscli/botocore/auth.py
@@ -33,7 +33,11 @@ from botocore.compat import (
     urlunsplit,
 )
 from botocore.exceptions import NoAuthTokenError, NoCredentialsError
-from botocore.utils import normalize_url_path, percent_encode_sequence
+from botocore.utils import (
+    is_valid_ipv6_endpoint_url,
+    normalize_url_path,
+    percent_encode_sequence,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +66,11 @@ def _host_from_url(url):
     # 3) excludes userinfo
     url_parts = urlsplit(url)
     host = url_parts.hostname  # urlsplit's hostname is always lowercase
+    if is_valid_ipv6_endpoint_url(url):
+        # Enclose IPv6 Literal addresses in
+        # brackets as per RFC 3986 3.2.2.
+        host = f'[{host}]'
+
     default_ports = {
         'http': 80,
         'https': 443

--- a/tests/unit/botocore/test_auth_sigv4.py
+++ b/tests/unit/botocore/test_auth_sigv4.py
@@ -31,3 +31,24 @@ class TestSigV4Auth(unittest.TestCase):
         request = AWSRequest(method='GET', url=endpoint)
         headers_to_sign = self.sigv4.headers_to_sign(request)
         self.assertEqual(expected_host, headers_to_sign.get('host'))
+
+    def test_signed_host_is_ipv6_without_port(self):
+        endpoint = 'http://[::1]'
+        expected_host = '[::1]'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))
+
+    def test_signed_host_is_ipv6_with_default_port(self):
+        endpoint = 'http://[::1]:80'
+        expected_host = '[::1]'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))
+
+    def test_signed_host_is_ipv6_with_explicit_port(self):
+        endpoint = 'http://[::1]:6789'
+        expected_host = '[::1]:6789'
+        request = AWSRequest(method='GET', url=endpoint)
+        headers_to_sign = self.sigv4.headers_to_sign(request)
+        self.assertEqual(expected_host, headers_to_sign.get('host'))


### PR DESCRIPTION
This PR fixes missing brackets from the `Host` header when supplying a hostname that matches an IP-literal as defined in [RFC 3986 3.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2). This will resolve issues between how we're signing requests and how they're being interpreted by AWS services which is currently leading to signature mismatches.