### PR TITLE
Add base ruff config + lint top level files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+exclude: "\
+    ^(\
+    .github|\
+    .changes|\
+    docs/|\
+    awscli/examples|\
+    CHANGELOG.rst\
+    )"
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: 'https://github.com/PyCQA/isort'
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.8
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst
 include LICENSE.txt
 include requirements.txt
 include UPGRADE_PY3.md
+include .pre-commit-config.yaml
 recursive-include awscli/examples *.rst *.txt
 recursive-include awscli/data *.json
 recursive-include awscli/topics *.rst *.json

--- a/awscli/__init__.py
+++ b/awscli/__init__.py
@@ -15,6 +15,7 @@ AWSCLI
 ----
 A Universal Command Line Environment for Amazon Web Services.
 """
+
 import os
 
 __version__ = '1.34.1'
@@ -40,8 +41,16 @@ EnvironmentVariables = {
 }
 
 
-SCALAR_TYPES = set([
-    'string', 'float', 'integer', 'long', 'boolean', 'double',
-    'blob', 'timestamp'
-])
+SCALAR_TYPES = set(
+    [
+        'string',
+        'float',
+        'integer',
+        'long',
+        'boolean',
+        'double',
+        'blob',
+        'timestamp',
+    ]
+)
 COMPLEX_TYPES = set(['structure', 'map', 'list'])

--- a/awscli/__main__.py
+++ b/awscli/__main__.py
@@ -16,6 +16,5 @@ import sys
 
 from awscli.clidriver import main
 
-
 if __name__ == "__main__":
     sys.exit(main())

--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -14,7 +14,6 @@ import argparse
 import sys
 from difflib import get_close_matches
 
-
 AWS_CLI_V2_MESSAGE = (
     'Note: AWS CLI version 2, the latest major version '
     'of the AWS CLI, is now stable and recommended for general '
@@ -45,9 +44,10 @@ class CommandAction(argparse.Action):
     are dynamically retrieved from the keys of the referenced command
     table
     """
+
     def __init__(self, option_strings, dest, command_table, **kwargs):
         self.command_table = command_table
-        super(CommandAction, self).__init__(
+        super().__init__(
             option_strings, dest, choices=self.choices, **kwargs
         )
 
@@ -83,9 +83,9 @@ class CLIArgParser(argparse.ArgumentParser):
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:
             msg = ['Invalid choice, valid choices are:\n']
-            for i in range(len(action.choices))[::self.ChoicesPerLine]:
+            for i in range(len(action.choices))[:: self.ChoicesPerLine]:
                 current = []
-                for choice in action.choices[i:i+self.ChoicesPerLine]:
+                for choice in action.choices[i : i + self.ChoicesPerLine]:
                     current.append('%-40s' % choice)
                 msg.append(' | '.join(current))
             possible = get_close_matches(value, action.choices, cutoff=0.8)
@@ -97,7 +97,9 @@ class CLIArgParser(argparse.ArgumentParser):
             raise argparse.ArgumentError(action, '\n'.join(msg))
 
     def parse_known_args(self, args, namespace=None):
-        parsed, remaining = super(CLIArgParser, self).parse_known_args(args, namespace)
+        parsed, remaining = super().parse_known_args(
+            args, namespace
+        )
         terminal_encoding = getattr(sys.stdin, 'encoding', 'utf-8')
         if terminal_encoding is None:
             # In some cases, sys.stdin won't have an encoding set,
@@ -121,15 +123,22 @@ class CLIArgParser(argparse.ArgumentParser):
 class MainArgParser(CLIArgParser):
     Formatter = argparse.RawTextHelpFormatter
 
-    def __init__(self, command_table, version_string,
-                 description, argument_table, prog=None):
-        super(MainArgParser, self).__init__(
+    def __init__(
+        self,
+        command_table,
+        version_string,
+        description,
+        argument_table,
+        prog=None,
+    ):
+        super().__init__(
             formatter_class=self.Formatter,
             add_help=False,
             conflict_handler='resolve',
             description=description,
             usage=USAGE,
-            prog=prog)
+            prog=prog,
+        )
         self._build(command_table, version_string, argument_table)
 
     def _create_choice_help(self, choices):
@@ -142,27 +151,32 @@ class MainArgParser(CLIArgParser):
         for argument_name in argument_table:
             argument = argument_table[argument_name]
             argument.add_to_parser(self)
-        self.add_argument('--version', action="version",
-                          version=version_string,
-                          help='Display the version of this tool')
-        self.add_argument('command', action=CommandAction,
-                          command_table=command_table)
+        self.add_argument(
+            '--version',
+            action="version",
+            version=version_string,
+            help='Display the version of this tool',
+        )
+        self.add_argument(
+            'command', action=CommandAction, command_table=command_table
+        )
 
 
 class ServiceArgParser(CLIArgParser):
-
     def __init__(self, operations_table, service_name):
-        super(ServiceArgParser, self).__init__(
+        super().__init__(
             formatter_class=argparse.RawTextHelpFormatter,
             add_help=False,
             conflict_handler='resolve',
-            usage=USAGE)
+            usage=USAGE,
+        )
         self._build(operations_table)
         self._service_name = service_name
 
     def _build(self, operations_table):
-        self.add_argument('operation', action=CommandAction,
-                          command_table=operations_table)
+        self.add_argument(
+            'operation', action=CommandAction, command_table=operations_table
+        )
 
 
 class ArgTableArgParser(CLIArgParser):
@@ -172,11 +186,12 @@ class ArgTableArgParser(CLIArgParser):
         # command_table is an optional subcommand_table.  If it's passed
         # in, then we'll update the argparse to parse a 'subcommand' argument
         # and populate the choices field with the command table keys.
-        super(ArgTableArgParser, self).__init__(
+        super().__init__(
             formatter_class=self.Formatter,
             add_help=False,
             usage=USAGE,
-            conflict_handler='resolve')
+            conflict_handler='resolve',
+        )
         if command_table is None:
             command_table = {}
         self._build(argument_table, command_table)
@@ -186,8 +201,12 @@ class ArgTableArgParser(CLIArgParser):
             argument = argument_table[arg_name]
             argument.add_to_parser(self)
         if command_table:
-            self.add_argument('subcommand', action=CommandAction,
-                              command_table=command_table, nargs='?')
+            self.add_argument(
+                'subcommand',
+                action=CommandAction,
+                command_table=command_table,
+                nargs='?',
+            )
 
     def parse_known_args(self, args, namespace=None):
         if len(args) == 1 and args[0] == 'help':
@@ -195,5 +214,6 @@ class ArgTableArgParser(CLIArgParser):
             namespace.help = 'help'
             return namespace, []
         else:
-            return super(ArgTableArgParser, self).parse_known_args(
-                args, namespace)
+            return super().parse_known_args(
+                args, namespace
+            )

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -11,18 +11,19 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 """Module for processing CLI args."""
-import os
+
 import logging
+import os
 
 from botocore.compat import OrderedDict, json
-
-from awscli import SCALAR_TYPES, COMPLEX_TYPES
-from awscli import shorthand
-from awscli.utils import (
-    find_service_and_method_in_event_name, is_document_type,
-    is_document_type_container
-)
 from botocore.utils import is_json_value_header
+
+from awscli import COMPLEX_TYPES, SCALAR_TYPES, shorthand
+from awscli.utils import (
+    find_service_and_method_in_event_name,
+    is_document_type,
+    is_document_type_container,
+)
 
 LOG = logging.getLogger('awscli.argprocess')
 
@@ -40,9 +41,8 @@ class ParamError(Exception):
         :param message: The error message to display to the user.
 
         """
-        full_message = ("Error parsing parameter '%s': %s" %
-                        (cli_name, message))
-        super(ParamError, self).__init__(full_message)
+        full_message = "Error parsing parameter '%s': %s" % (cli_name, message)
+        super().__init__(full_message)
         self.cli_name = cli_name
         self.message = message
 
@@ -55,16 +55,18 @@ class ParamUnknownKeyError(Exception):
     def __init__(self, key, valid_keys):
         valid_keys = ', '.join(valid_keys)
         full_message = (
-            "Unknown key '%s', valid choices "
-            "are: %s" % (key, valid_keys))
-        super(ParamUnknownKeyError, self).__init__(full_message)
+            f"Unknown key '{key}', valid choices are: {valid_key}"
+        )
+        super().__init__(full_message)
 
 
 class TooComplexError(Exception):
     pass
 
 
-def unpack_argument(session, service_name, operation_name, cli_argument, value):
+def unpack_argument(
+    session, service_name, operation_name, cli_argument, value
+):
     """
     Unpack an argument's value from the commandline. This is part one of a two
     step process in handling commandline arguments. Emits the load-cli-arg
@@ -76,11 +78,12 @@ def unpack_argument(session, service_name, operation_name, cli_argument, value):
     param_name = getattr(cli_argument, 'name', 'anonymous')
 
     value_override = session.emit_first_non_none_response(
-        'load-cli-arg.%s.%s.%s' % (service_name,
-                                   operation_name,
-                                   param_name),
-        param=cli_argument, value=value, service_name=service_name,
-        operation_name=operation_name)
+        f'load-cli-arg.{service_name}.{operation_name}.{param_name}',
+        param=cli_argument,
+        value=value,
+        service_name=service_name,
+        operation_name=operation_name,
+    )
 
     if value_override is not None:
         value = value_override
@@ -102,8 +105,10 @@ def _detect_shape_structure(param, stack):
         if param.type_name in SCALAR_TYPES:
             return 'scalar'
         elif param.type_name == 'structure':
-            sub_types = [_detect_shape_structure(p, stack)
-                        for p in param.members.values()]
+            sub_types = [
+                _detect_shape_structure(p, stack)
+                for p in param.members.values()
+            ]
             # We're distinguishing between structure(scalar)
             # and structure(scalars), because for the case of
             # a single scalar in a structure we can simplify
@@ -141,29 +146,31 @@ def unpack_cli_arg(cli_argument, value):
     :return: The "unpacked" argument than can be sent to the `Operation`
         object in python.
     """
-    return _unpack_cli_arg(cli_argument.argument_model, value,
-                           cli_argument.cli_name)
+    return _unpack_cli_arg(
+        cli_argument.argument_model, value, cli_argument.cli_name
+    )
 
 
 def _special_type(model):
     # check if model is jsonvalue header and that value is serializable
-    if model.serialization.get('jsonvalue') and \
-       model.serialization.get('location') == 'header' and \
-       model.type_name == 'string':
+    if (
+        model.serialization.get('jsonvalue')
+        and model.serialization.get('location') == 'header'
+        and model.type_name == 'string'
+    ):
         return True
     return False
 
 
 def _unpack_cli_arg(argument_model, value, cli_name):
-    if is_json_value_header(argument_model) or \
-            is_document_type(argument_model):
+    if is_json_value_header(argument_model) or is_document_type(
+        argument_model
+    ):
         return _unpack_json_cli_arg(argument_model, value, cli_name)
     elif argument_model.type_name in SCALAR_TYPES:
-        return unpack_scalar_cli_arg(
-            argument_model, value, cli_name)
+        return unpack_scalar_cli_arg(argument_model, value, cli_name)
     elif argument_model.type_name in COMPLEX_TYPES:
-        return _unpack_complex_cli_arg(
-            argument_model, value, cli_name)
+        return _unpack_complex_cli_arg(argument_model, value, cli_name)
     else:
         return str(value)
 
@@ -173,8 +180,8 @@ def _unpack_json_cli_arg(argument_model, value, cli_name):
         return json.loads(value, object_pairs_hook=OrderedDict)
     except ValueError as e:
         raise ParamError(
-            cli_name, "Invalid JSON: %s\nJSON received: %s"
-            % (e, value))
+            cli_name, f"Invalid JSON: {e}\nJSON received: {value}"
+        )
 
 
 def _unpack_complex_cli_arg(argument_model, value, cli_name):
@@ -182,7 +189,7 @@ def _unpack_complex_cli_arg(argument_model, value, cli_name):
     if type_name == 'structure' or type_name == 'map':
         if value.lstrip()[0] == '{':
             return _unpack_json_cli_arg(argument_model, value, cli_name)
-        raise ParamError(cli_name, "Invalid JSON:\n%s" % value)
+        raise ParamError(cli_name, f"Invalid JSON:\n{value}")
     elif type_name == 'list':
         if isinstance(value, str):
             if value.lstrip()[0] == '[':
@@ -198,9 +205,10 @@ def _unpack_complex_cli_arg(argument_model, value, cli_name):
             # 2. It's possible this is a list of json objects:
             # --filters '{"Name": ..}' '{"Name": ...}'
             member_shape_model = argument_model.member
-            return [_unpack_cli_arg(member_shape_model, v, cli_name)
-                    for v in value]
-        except (ValueError, TypeError) as e:
+            return [
+                _unpack_cli_arg(member_shape_model, v, cli_name) for v in value
+            ]
+        except (ValueError, TypeError):
             # The list params don't have a name/cli_name attached to them
             # so they will have bad error messages.  We're going to
             # attach the parent parameter to this error message to provide
@@ -211,13 +219,21 @@ def _unpack_complex_cli_arg(argument_model, value, cli_name):
 def unpack_scalar_cli_arg(argument_model, value, cli_name=''):
     # Note the cli_name is used strictly for error reporting.  It's
     # not required to use unpack_scalar_cli_arg
-    if argument_model.type_name == 'integer' or argument_model.type_name == 'long':
+    if (
+        argument_model.type_name == 'integer'
+        or argument_model.type_name == 'long'
+    ):
         return int(value)
-    elif argument_model.type_name == 'float' or argument_model.type_name == 'double':
+    elif (
+        argument_model.type_name == 'float'
+        or argument_model.type_name == 'double'
+    ):
         # TODO: losing precision on double types
         return float(value)
-    elif argument_model.type_name == 'blob' and \
-            argument_model.serialization.get('streaming'):
+    elif (
+        argument_model.type_name == 'blob'
+        and argument_model.serialization.get('streaming')
+    ):
         file_path = os.path.expandvars(value)
         file_path = os.path.expanduser(file_path)
         if not os.path.isfile(file_path):
@@ -256,8 +272,7 @@ def _is_complex_shape(model):
     return True
 
 
-class ParamShorthand(object):
-
+class ParamShorthand:
     def _uses_old_list_case(self, service_id, operation_name, argument_name):
         """
         Determines whether a given operation for a service needs to use the
@@ -265,27 +280,24 @@ class ParamShorthand(object):
         a single member.
         """
         cases = {
-            'firehose': {
-                'put-record-batch': ['records']
-            },
+            'firehose': {'put-record-batch': ['records']},
             'workspaces': {
                 'reboot-workspaces': ['reboot-workspace-requests'],
                 'rebuild-workspaces': ['rebuild-workspace-requests'],
-                'terminate-workspaces': ['terminate-workspace-requests']
+                'terminate-workspaces': ['terminate-workspace-requests'],
             },
             'elastic-load-balancing': {
                 'remove-tags': ['tags'],
                 'describe-instance-health': ['instances'],
                 'deregister-instances-from-load-balancer': ['instances'],
-                'register-instances-with-load-balancer': ['instances']
-            }
+                'register-instances-with-load-balancer': ['instances'],
+            },
         }
         cases = cases.get(service_id, {}).get(operation_name, [])
         return argument_name in cases
 
 
 class ParamShorthandParser(ParamShorthand):
-
     def __init__(self):
         self._parser = shorthand.ShorthandParser()
         self._visitor = shorthand.BackCompatVisitor()
@@ -321,18 +333,21 @@ class ParamShorthandParser(ParamShorthand):
         if not self._should_parse_as_shorthand(cli_argument, value):
             return
         else:
-            service_id, operation_name = \
-                find_service_and_method_in_event_name(event_name)
+            service_id, operation_name = find_service_and_method_in_event_name(
+                event_name
+            )
             return self._parse_as_shorthand(
-                cli_argument, value, service_id, operation_name)
+                cli_argument, value, service_id, operation_name
+            )
 
-    def _parse_as_shorthand(self, cli_argument, value, service_id,
-                            operation_name):
+    def _parse_as_shorthand(
+        self, cli_argument, value, service_id, operation_name
+    ):
         try:
-            LOG.debug("Parsing param %s as shorthand",
-                        cli_argument.cli_name)
+            LOG.debug("Parsing param %s as shorthand", cli_argument.cli_name)
             handled_value = self._handle_special_cases(
-                cli_argument, value, service_id, operation_name)
+                cli_argument, value, service_id, operation_name
+            )
             if handled_value is not None:
                 return handled_value
             if isinstance(value, list):
@@ -357,15 +372,20 @@ class ParamShorthandParser(ParamShorthand):
             raise ParamError(cli_argument.cli_name, str(e))
         return parsed
 
-    def _handle_special_cases(self, cli_argument, value, service_id,
-                              operation_name):
+    def _handle_special_cases(
+        self, cli_argument, value, service_id, operation_name
+    ):
         # We need to handle a few special cases that the previous
         # parser handled in order to stay backwards compatible.
         model = cli_argument.argument_model
-        if model.type_name == 'list' and \
-           model.member.type_name == 'structure' and \
-           len(model.member.members) == 1 and \
-           self._uses_old_list_case(service_id, operation_name, cli_argument.name):
+        if (
+            model.type_name == 'list'
+            and model.member.type_name == 'structure'
+            and len(model.member.members) == 1
+            and self._uses_old_list_case(
+                service_id, operation_name, cli_argument.name
+            )
+        ):
             # First special case is handling a list of structures
             # of a single element such as:
             #
@@ -378,11 +398,13 @@ class ParamShorthandParser(ParamShorthand):
             key_name = list(model.member.members.keys())[0]
             new_values = [{key_name: v} for v in value]
             return new_values
-        elif model.type_name == 'structure' and \
-                len(model.members) == 1 and \
-                'Value' in model.members and \
-                model.members['Value'].type_name == 'string' and \
-                '=' not in value:
+        elif (
+            model.type_name == 'structure'
+            and len(model.members) == 1
+            and 'Value' in model.members
+            and model.members['Value'].type_name == 'string'
+            and '=' not in value
+        ):
             # Second special case is where a structure of a single
             # value whose member name is "Value" can be specified
             # as:
@@ -401,9 +423,13 @@ class ParamShorthandParser(ParamShorthand):
         else:
             check_val = value
         if isinstance(check_val, str) and check_val.strip().startswith(
-                ('[', '{')):
-            LOG.debug("Param %s looks like JSON, not considered for "
-                      "param shorthand.", cli_argument.py_name)
+            ('[', '{')
+        ):
+            LOG.debug(
+                "Param %s looks like JSON, not considered for "
+                "param shorthand.",
+                cli_argument.py_name,
+            )
             return False
         model = cli_argument.argument_model
         return _supports_shorthand_syntax(model)
@@ -421,8 +447,9 @@ class ParamShorthandDocGen(ParamShorthand):
             return _supports_shorthand_syntax(argument_model)
         return False
 
-    def generate_shorthand_example(self, cli_argument, service_id,
-                                   operation_name):
+    def generate_shorthand_example(
+        self, cli_argument, service_id, operation_name
+    ):
         """Generate documentation for a CLI argument.
 
         :type cli_argument: awscli.arguments.BaseCLIArgument
@@ -437,7 +464,8 @@ class ParamShorthandDocGen(ParamShorthand):
 
         """
         docstring = self._handle_special_cases(
-            cli_argument, service_id, operation_name)
+            cli_argument, service_id, operation_name
+        )
         if docstring is self._DONT_DOC:
             return None
         elif docstring:
@@ -457,22 +485,27 @@ class ParamShorthandDocGen(ParamShorthand):
 
     def _handle_special_cases(self, cli_argument, service_id, operation_name):
         model = cli_argument.argument_model
-        if model.type_name == 'list' and \
-                model.member.type_name == 'structure' and \
-                len(model.member.members) == 1 and \
-                self._uses_old_list_case(
-                    service_id, operation_name, cli_argument.name):
+        if (
+            model.type_name == 'list'
+            and model.member.type_name == 'structure'
+            and len(model.member.members) == 1
+            and self._uses_old_list_case(
+                service_id, operation_name, cli_argument.name
+            )
+        ):
             member_name = list(model.member.members)[0]
             # Handle special case where the min/max is exactly one.
             metadata = model.metadata
+            cli_name = cli_argument.cli_name
             if metadata.get('min') == 1 and metadata.get('max') == 1:
-                return '%s %s1' % (cli_argument.cli_name, member_name)
-            return '%s %s1 %s2 %s3' % (cli_argument.cli_name, member_name,
-                                       member_name, member_name)
-        elif model.type_name == 'structure' and \
-                len(model.members) == 1 and \
-                'Value' in model.members and \
-                model.members['Value'].type_name == 'string':
+                return f'{cli_name} {member_name}1'
+            return f'{cli_name} {member_name}1 {member_name}2 {member_name}3'
+        elif (
+            model.type_name == 'structure'
+            and len(model.members) == 1
+            and 'Value' in model.members
+            and model.members['Value'].type_name == 'string'
+        ):
             return self._DONT_DOC
         return ''
 

--- a/awscli/bcdoc/docstringparser.py
+++ b/awscli/bcdoc/docstringparser.py
@@ -51,12 +51,13 @@ class DocStringParser(HTMLParser):
         self.tree.add_data(data)
 
 
-class HTMLTree(object):
+class HTMLTree:
     """
     A tree which handles HTML nodes. Designed to work with a python HTML parser,
     meaning that the current_node will be the most recently opened tag. When
     a tag is closed, the current_node moves up to the parent node.
     """
+
     def __init__(self, doc):
         self.doc = doc
         self.head = StemNode()
@@ -93,7 +94,7 @@ class HTMLTree(object):
         self.head.write(self.doc)
 
 
-class Node(object):
+class Node:
     def __init__(self, parent=None):
         self.parent = parent
 
@@ -103,7 +104,7 @@ class Node(object):
 
 class StemNode(Node):
     def __init__(self, parent=None):
-        super(StemNode, self).__init__(parent)
+        super().__init__(parent)
         self.children = []
 
     def add_child(self, child):
@@ -122,8 +123,9 @@ class TagNode(StemNode):
     """
     A generic Tag node. It will verify that handlers exist before writing.
     """
+
     def __init__(self, tag, attrs=None, parent=None):
-        super(TagNode, self).__init__(parent)
+        super().__init__(parent)
         self.attrs = attrs
         self.tag = tag
 
@@ -145,11 +147,11 @@ class TagNode(StemNode):
 
 class LineItemNode(TagNode):
     def __init__(self, attrs=None, parent=None):
-        super(LineItemNode, self).__init__('li', attrs, parent)
+        super().__init__('li', attrs, parent)
 
     def write(self, doc):
         self._lstrip(self)
-        super(LineItemNode, self).write(doc)
+        super().write(doc)
 
     def _lstrip(self, node):
         """
@@ -174,8 +176,9 @@ class DataNode(Node):
     """
     A Node that contains only string data.
     """
+
     def __init__(self, data, parent=None):
-        super(DataNode, self).__init__(parent)
+        super().__init__(parent)
         if not isinstance(data, str):
             raise ValueError("Expecting string type, %s given." % type(data))
         self.data = data

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -10,47 +10,52 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import sys
-import signal
 import logging
+import signal
+import sys
 
 import botocore.session
-from botocore import __version__ as botocore_version
-from botocore.hooks import HierarchicalEmitter
-from botocore import xform_name
-from botocore.compat import copy_kwargs, OrderedDict
-from botocore.exceptions import NoCredentialsError
-from botocore.exceptions import NoRegionError
-from botocore.exceptions import ProfileNotFound
+from botocore.compat import OrderedDict, copy_kwargs
+from botocore.exceptions import (
+    NoCredentialsError,
+    NoRegionError,
+    ProfileNotFound,
+)
 from botocore.history import get_global_history_recorder
 
 from awscli import EnvironmentVariables, __version__
+from awscli.alias import AliasCommandInjector, AliasLoader
+from awscli.argparser import (
+    USAGE,
+    ArgTableArgParser,
+    MainArgParser,
+    ServiceArgParser,
+)
+from awscli.argprocess import unpack_argument
+from awscli.arguments import (
+    BooleanArgument,
+    CLIArgument,
+    CustomArgument,
+    ListArgument,
+    UnknownArgumentError,
+)
+from awscli.commands import CLICommand
 from awscli.compat import get_stderr_text_writer
 from awscli.formatter import get_formatter
+from awscli.help import (
+    OperationHelpCommand,
+    ProviderHelpCommand,
+    ServiceHelpCommand,
+)
 from awscli.plugin import load_plugins
-from awscli.commands import CLICommand
-from awscli.argparser import MainArgParser
-from awscli.argparser import ServiceArgParser
-from awscli.argparser import ArgTableArgParser
-from awscli.argparser import USAGE
-from awscli.help import ProviderHelpCommand
-from awscli.help import ServiceHelpCommand
-from awscli.help import OperationHelpCommand
-from awscli.arguments import CustomArgument
-from awscli.arguments import ListArgument
-from awscli.arguments import BooleanArgument
-from awscli.arguments import CLIArgument
-from awscli.arguments import UnknownArgumentError
-from awscli.argprocess import unpack_argument
-from awscli.alias import AliasLoader
-from awscli.alias import AliasCommandInjector
-from awscli.utils import emit_top_level_args_parsed_event
-from awscli.utils import write_exception
-
+from awscli.utils import emit_top_level_args_parsed_event, write_exception
+from botocore import __version__ as botocore_version
+from botocore import xform_name
 
 LOG = logging.getLogger('awscli.clidriver')
 LOG_FORMAT = (
-    '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
+    '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+)
 HISTORY_RECORDER = get_global_history_recorder()
 # Don't remove this line.  The idna encoding
 # is used by getaddrinfo when dealing with unicode hostnames,
@@ -61,7 +66,7 @@ HISTORY_RECORDER = get_global_history_recorder()
 # the encodings.idna is imported and registered in the codecs registry,
 # which will stop the LookupErrors from happening.
 # See: https://bugs.python.org/issue29288
-u''.encode('idna')
+''.encode('idna')
 
 
 def main():
@@ -74,8 +79,10 @@ def main():
 def create_clidriver():
     session = botocore.session.Session(EnvironmentVariables)
     _set_user_agent_for_session(session)
-    load_plugins(session.full_config.get('plugins', {}),
-                 event_hooks=session.get_component('event_emitter'))
+    load_plugins(
+        session.full_config.get('plugins', {}),
+        event_hooks=session.get_component('event_emitter'),
+    )
     driver = CLIDriver(session=session)
     return driver
 
@@ -86,8 +93,7 @@ def _set_user_agent_for_session(session):
     session.user_agent_extra = 'botocore/%s' % botocore_version
 
 
-class CLIDriver(object):
-
+class CLIDriver:
     def __init__(self, session=None):
         if session is None:
             self.session = botocore.session.get_session(EnvironmentVariables)
@@ -126,24 +132,27 @@ class CLIDriver(object):
 
         """
         command_table = self._build_builtin_commands(self.session)
-        self.session.emit('building-command-table.main',
-                          command_table=command_table,
-                          session=self.session,
-                          command_object=self)
+        self.session.emit(
+            'building-command-table.main',
+            command_table=command_table,
+            session=self.session,
+            command_object=self,
+        )
         return command_table
 
     def _build_builtin_commands(self, session):
         commands = OrderedDict()
         services = session.get_available_services()
         for service_name in services:
-            commands[service_name] = ServiceCommand(cli_name=service_name,
-                                                    session=self.session,
-                                                    service_name=service_name)
+            commands[service_name] = ServiceCommand(
+                cli_name=service_name,
+                session=self.session,
+                service_name=service_name,
+            )
         return commands
 
     def _add_aliases(self, command_table, parser):
-        injector = AliasCommandInjector(
-            self.session, self.alias_loader)
+        injector = AliasCommandInjector(self.session, self.alias_loader)
         injector.inject_aliases(command_table, parser)
 
     def _build_argument_table(self):
@@ -156,37 +165,45 @@ class CLIDriver(object):
             cli_argument.add_to_arg_table(argument_table)
         # Then the final step is to send out an event so handlers
         # can add extra arguments or modify existing arguments.
-        self.session.emit('building-top-level-params',
-                          argument_table=argument_table)
+        self.session.emit(
+            'building-top-level-params', argument_table=argument_table
+        )
         return argument_table
 
     def _create_cli_argument(self, option_name, option_params):
         return CustomArgument(
-            option_name, help_text=option_params.get('help', ''),
+            option_name,
+            help_text=option_params.get('help', ''),
             dest=option_params.get('dest'),
             default=option_params.get('default'),
             action=option_params.get('action'),
             required=option_params.get('required'),
             choices=option_params.get('choices'),
-            cli_type_name=option_params.get('type'))
+            cli_type_name=option_params.get('type'),
+        )
 
     def create_help_command(self):
         cli_data = self._get_cli_data()
-        return ProviderHelpCommand(self.session, self._get_command_table(),
-                                   self._get_argument_table(),
-                                   cli_data.get('description', None),
-                                   cli_data.get('synopsis', None),
-                                   cli_data.get('help_usage', None))
+        return ProviderHelpCommand(
+            self.session,
+            self._get_command_table(),
+            self._get_argument_table(),
+            cli_data.get('description', None),
+            cli_data.get('synopsis', None),
+            cli_data.get('help_usage', None),
+        )
 
     def _create_parser(self, command_table):
         # Also add a 'help' command.
         command_table['help'] = self.create_help_command()
         cli_data = self._get_cli_data()
         parser = MainArgParser(
-            command_table, self.session.user_agent(),
+            command_table,
+            self.session.user_agent(),
             cli_data.get('description', None),
             self._get_argument_table(),
-            prog="aws")
+            prog="aws",
+        )
         return parser
 
     def main(self, args=None):
@@ -211,7 +228,8 @@ class CLIDriver(object):
             self._handle_top_level_args(parsed_args)
             self._emit_session_event(parsed_args)
             HISTORY_RECORDER.record(
-                'CLI_VERSION', self.session.user_agent(), 'CLI')
+                'CLI_VERSION', self.session.user_agent(), 'CLI'
+            )
             HISTORY_RECORDER.record('CLI_ARGUMENTS', args, 'CLI')
             return command_table[parsed_args.command](remaining, parsed_args)
         except UnknownArgumentError as e:
@@ -220,13 +238,16 @@ class CLIDriver(object):
             sys.stderr.write("\n")
             return 255
         except NoRegionError as e:
-            msg = ('%s You can also configure your region by running '
-                   '"aws configure".' % e)
+            msg = (
+                '%s You can also configure your region by running '
+                '"aws configure".' % e
+            )
             self._show_error(msg)
             return 255
         except NoCredentialsError as e:
-            msg = ('%s. You can configure credentials by running '
-                   '"aws configure".' % e)
+            msg = (
+                f'{e}. You can configure credentials by running "aws configure".'
+            )
             self._show_error(msg)
             return 255
         except KeyboardInterrupt:
@@ -248,8 +269,10 @@ class CLIDriver(object):
         # session components to be reset (such as session.profile = foo)
         # then all the prior registered components would be removed.
         self.session.emit(
-            'session-initialized', session=self.session,
-            parsed_args=parsed_args)
+            'session-initialized',
+            session=self.session,
+            parsed_args=parsed_args,
+        )
 
     def _show_error(self, msg):
         LOG.debug(msg, exc_info=True)
@@ -267,24 +290,28 @@ class CLIDriver(object):
             # Unfortunately, by setting debug mode here, we miss out
             # on all of the debug events prior to this such as the
             # loading of plugins, etc.
-            self.session.set_stream_logger('botocore', logging.DEBUG,
-                                           format_string=LOG_FORMAT)
-            self.session.set_stream_logger('awscli', logging.DEBUG,
-                                           format_string=LOG_FORMAT)
-            self.session.set_stream_logger('s3transfer', logging.DEBUG,
-                                           format_string=LOG_FORMAT)
-            self.session.set_stream_logger('urllib3', logging.DEBUG,
-                                           format_string=LOG_FORMAT)
+            self.session.set_stream_logger(
+                'botocore', logging.DEBUG, format_string=LOG_FORMAT
+            )
+            self.session.set_stream_logger(
+                'awscli', logging.DEBUG, format_string=LOG_FORMAT
+            )
+            self.session.set_stream_logger(
+                's3transfer', logging.DEBUG, format_string=LOG_FORMAT
+            )
+            self.session.set_stream_logger(
+                'urllib3', logging.DEBUG, format_string=LOG_FORMAT
+            )
             LOG.debug("CLI version: %s", self.session.user_agent())
             LOG.debug("Arguments entered to CLI: %s", sys.argv[1:])
 
         else:
-            self.session.set_stream_logger(logger_name='awscli',
-                                           log_level=logging.ERROR)
+            self.session.set_stream_logger(
+                logger_name='awscli', log_level=logging.ERROR
+            )
 
 
 class ServiceCommand(CLICommand):
-
     """A service command for the CLI.
 
     For example, ``aws ec2 ...`` we'd create a ServiceCommand
@@ -343,11 +370,13 @@ class ServiceCommand(CLICommand):
         if self._service_model is None:
             try:
                 api_version = self.session.get_config_variable(
-                    'api_versions').get(self._service_name, None)
+                    'api_versions'
+                ).get(self._service_name, None)
             except ProfileNotFound:
                 api_version = None
             self._service_model = self.session.get_service_model(
-                self._service_name, api_version=api_version)
+                self._service_name, api_version=api_version
+            )
         return self._service_model
 
     def __call__(self, args, parsed_globals):
@@ -372,10 +401,12 @@ class ServiceCommand(CLICommand):
                 operation_model=operation_model,
                 operation_caller=CLIOperationCaller(self.session),
             )
-        self.session.emit('building-command-table.%s' % self._name,
-                          command_table=command_table,
-                          session=self.session,
-                          command_object=self)
+        self.session.emit(
+            f'building-command-table.{self._name}',
+            command_table=command_table,
+            session=self.session,
+            command_object=self,
+        )
         self._add_lineage(command_table)
         return command_table
 
@@ -386,23 +417,25 @@ class ServiceCommand(CLICommand):
 
     def create_help_command(self):
         command_table = self._get_command_table()
-        return ServiceHelpCommand(session=self.session,
-                                  obj=self._get_service_model(),
-                                  command_table=command_table,
-                                  arg_table=None,
-                                  event_class='.'.join(self.lineage_names),
-                                  name=self._name)
+        return ServiceHelpCommand(
+            session=self.session,
+            obj=self._get_service_model(),
+            command_table=command_table,
+            arg_table=None,
+            event_class='.'.join(self.lineage_names),
+            name=self._name,
+        )
 
     def _create_parser(self):
         command_table = self._get_command_table()
         # Also add a 'help' command.
         command_table['help'] = self.create_help_command()
         return ServiceArgParser(
-            operations_table=command_table, service_name=self._name)
+            operations_table=command_table, service_name=self._name
+        )
 
 
-class ServiceOperation(object):
-
+class ServiceOperation:
     """A single operation of a service.
 
     This class represents a single operation for a service, for
@@ -416,8 +449,9 @@ class ServiceOperation(object):
     }
     DEFAULT_ARG_CLASS = CLIArgument
 
-    def __init__(self, name, parent_name, operation_caller,
-                 operation_model, session):
+    def __init__(
+        self, name, parent_name, operation_caller, operation_model, session
+    ):
         """
 
         :type name: str
@@ -480,10 +514,17 @@ class ServiceOperation(object):
     def __call__(self, args, parsed_globals):
         # Once we know we're trying to call a particular operation
         # of a service we can go ahead and load the parameters.
-        event = 'before-building-argument-table-parser.%s.%s' % \
-            (self._parent_name, self._name)
-        self._emit(event, argument_table=self.arg_table, args=args,
-                   session=self._session, parsed_globals=parsed_globals)
+        event = (
+            'before-building-argument-table-parser.'
+            f'{self._parent_name}.{self._name}'
+        )
+        self._emit(
+            event,
+            argument_table=self.arg_table,
+            args=args,
+            session=self._session,
+            parsed_globals=parsed_globals,
+        )
         operation_parser = self._create_operation_parser(self.arg_table)
         self._add_help(operation_parser)
         parsed_args, remaining = operation_parser.parse_known_args(args)
@@ -494,21 +535,22 @@ class ServiceOperation(object):
             remaining.append(parsed_args.help)
         if remaining:
             raise UnknownArgumentError(
-                "Unknown options: %s" % ', '.join(remaining))
-        event = 'operation-args-parsed.%s.%s' % (self._parent_name,
-                                                 self._name)
-        self._emit(event, parsed_args=parsed_args,
-                   parsed_globals=parsed_globals)
+                f"Unknown options: {', '.join(remaining)}"
+            )
+        event = f'operation-args-parsed.{self._parent_name}.{self._name}'
+        self._emit(
+            event, parsed_args=parsed_args, parsed_globals=parsed_globals
+        )
         call_parameters = self._build_call_parameters(
-            parsed_args, self.arg_table)
+            parsed_args, self.arg_table
+        )
 
-        event = 'calling-command.%s.%s' % (self._parent_name,
-                                           self._name)
+        event = f'calling-command.{self._parent_name}.{self._name}'
         override = self._emit_first_non_none_response(
             event,
             call_parameters=call_parameters,
             parsed_args=parsed_args,
-            parsed_globals=parsed_globals
+            parsed_globals=parsed_globals,
         )
         # There are two possible values for override. It can be some type
         # of exception that will be raised if detected or it can represent
@@ -529,14 +571,18 @@ class ServiceOperation(object):
             return self._operation_caller.invoke(
                 self._operation_model.service_model.service_name,
                 self._operation_model.name,
-                call_parameters, parsed_globals)
+                call_parameters,
+                parsed_globals,
+            )
 
     def create_help_command(self):
         return OperationHelpCommand(
             self._session,
             operation_model=self._operation_model,
             arg_table=self.arg_table,
-            name=self._name, event_class='.'.join(self.lineage_names))
+            name=self._name,
+            event_class='.'.join(self.lineage_names),
+        )
 
     def _add_help(self, parser):
         # The 'help' output is processed a little differently from
@@ -566,8 +612,9 @@ class ServiceOperation(object):
         service_name = self._operation_model.service_model.endpoint_prefix
         operation_name = xform_name(self._name, '-')
 
-        return unpack_argument(session, service_name, operation_name,
-                               cli_argument, value)
+        return unpack_argument(
+            session, service_name, operation_name, cli_argument, value
+        )
 
     def _create_argument_table(self):
         argument_table = OrderedDict()
@@ -579,8 +626,9 @@ class ServiceOperation(object):
             arg_dict = input_shape.members
         for arg_name, arg_shape in arg_dict.items():
             cli_arg_name = xform_name(arg_name, '-')
-            arg_class = self.ARG_TYPES.get(arg_shape.type_name,
-                                           self.DEFAULT_ARG_CLASS)
+            arg_class = self.ARG_TYPES.get(
+                arg_shape.type_name, self.DEFAULT_ARG_CLASS
+            )
             is_token = arg_shape.metadata.get('idempotencyToken', False)
             is_required = arg_name in required_arguments and not is_token
             event_emitter = self._session.get_component('event_emitter')
@@ -590,31 +638,31 @@ class ServiceOperation(object):
                 is_required=is_required,
                 operation_model=self._operation_model,
                 serialized_name=arg_name,
-                event_emitter=event_emitter)
+                event_emitter=event_emitter,
+            )
             arg_object.add_to_arg_table(argument_table)
         LOG.debug(argument_table)
-        self._emit('building-argument-table.%s.%s' % (self._parent_name,
-                                                      self._name),
-                   operation_model=self._operation_model,
-                   session=self._session,
-                   command=self,
-                   argument_table=argument_table)
+        self._emit(
+            f'building-argument-table.{self._parent_name}.{self._name}',
+            operation_model=self._operation_model,
+            session=self._session,
+            command=self,
+            argument_table=argument_table,
+        )
         return argument_table
 
     def _emit(self, name, **kwargs):
         return self._session.emit(name, **kwargs)
 
     def _emit_first_non_none_response(self, name, **kwargs):
-        return self._session.emit_first_non_none_response(
-            name, **kwargs)
+        return self._session.emit_first_non_none_response(name, **kwargs)
 
     def _create_operation_parser(self, arg_table):
         parser = ArgTableArgParser(arg_table)
         return parser
 
 
-class CLIOperationCaller(object):
-
+class CLIOperationCaller:
     """Call an AWS operation and format the response."""
 
     def __init__(self, session):
@@ -645,27 +693,31 @@ class CLIOperationCaller(object):
 
         """
         client = self._session.create_client(
-            service_name, region_name=parsed_globals.region,
+            service_name,
+            region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
-            verify=parsed_globals.verify_ssl)
+            verify=parsed_globals.verify_ssl,
+        )
         response = self._make_client_call(
-            client, operation_name, parameters, parsed_globals)
+            client, operation_name, parameters, parsed_globals
+        )
         self._display_response(operation_name, response, parsed_globals)
         return 0
 
-    def _make_client_call(self, client, operation_name, parameters,
-                          parsed_globals):
+    def _make_client_call(
+        self, client, operation_name, parameters, parsed_globals
+    ):
         py_operation_name = xform_name(operation_name)
         if client.can_paginate(py_operation_name) and parsed_globals.paginate:
             paginator = client.get_paginator(py_operation_name)
             response = paginator.paginate(**parameters)
         else:
             response = getattr(client, xform_name(operation_name))(
-                **parameters)
+                **parameters
+            )
         return response
 
-    def _display_response(self, command_name, response,
-                          parsed_globals):
+    def _display_response(self, command_name, response, parsed_globals):
         output = parsed_globals.output
         if output is None:
             output = self._session.get_config_variable('output')

--- a/awscli/commands.py
+++ b/awscli/commands.py
@@ -12,8 +12,7 @@
 # language governing permissions and limitations under the License.
 
 
-class CLICommand(object):
-
+class CLICommand:
     """Interface for a CLI command.
 
     This class represents a top level CLI command

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -1,10 +1,15 @@
 # Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
-
+#
 #     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 
 import collections.abc as collections_abc
 import contextlib
@@ -23,10 +28,6 @@ from urllib.request import urlopen
 
 from botocore.compat import six, OrderedDict
 
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
 import sys
 import zipfile
 from functools import partial

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -6,33 +6,30 @@
 
 #     http://aws.amazon.com/apache2.0/
 
+import collections.abc as collections_abc
+import contextlib
+import io
+import locale
+import os
+import os.path
+import queue
+import re
+import shlex
+import signal
+import urllib.parse as urlparse
+from configparser import RawConfigParser
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from botocore.compat import six, OrderedDict
+
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
-import re
-import shlex
-import os
-import os.path
-import platform
 import zipfile
-import signal
-import contextlib
-import queue
-import io
-import collections.abc as collections_abc
-import locale
-import urllib.parse as urlparse
-from urllib.error import URLError
-from urllib.request import urlopen
-from configparser import RawConfigParser
 from functools import partial
-
-from urllib.error import URLError
-
-from botocore.compat import six
-from botocore.compat import OrderedDict
 
 # Backwards compatible definitions from six
 PY3 = sys.version_info[0] == 3
@@ -49,6 +46,7 @@ raw_input = input
 # package the files in a zip container.
 try:
     import zlib
+
     ZIP_COMPRESSION_MODE = zipfile.ZIP_DEFLATED
 except ImportError:
     ZIP_COMPRESSION_MODE = zipfile.ZIP_STORED
@@ -73,14 +71,12 @@ else:
 
 class StdinMissingError(Exception):
     def __init__(self):
-        message = (
-            'stdin is required for this operation, but is not available.'
-        )
+        message = 'stdin is required for this operation, but is not available.'
         super(StdinMissingError, self).__init__(message)
 
 
-class NonTranslatedStdout(object):
-    """ This context manager sets the line-end translation mode for stdout.
+class NonTranslatedStdout:
+    """This context manager sets the line-end translation mode for stdout.
 
     It is deliberately set to binary mode so that `\r` does not get added to
     the line ending. This can be useful when printing commands where a
@@ -90,13 +86,16 @@ class NonTranslatedStdout(object):
     def __enter__(self):
         if sys.platform == "win32":
             import msvcrt
-            self.previous_mode = msvcrt.setmode(sys.stdout.fileno(),
-                                                os.O_BINARY)
+
+            self.previous_mode = msvcrt.setmode(
+                sys.stdout.fileno(), os.O_BINARY
+            )
         return sys.stdout
 
     def __exit__(self, type, value, traceback):
         if sys.platform == "win32":
             import msvcrt
+
             msvcrt.setmode(sys.stdout.fileno(), self.previous_mode)
 
 
@@ -312,12 +311,12 @@ try:
     from platform import linux_distribution
 except ImportError:
     _UNIXCONFDIR = '/etc'
-    def _dist_try_harder(distname, version, id):
 
-        """ Tries some special tricks to get the distribution
-            information in case the default method fails.
-            Currently supports older SuSE Linux, Caldera OpenLinux and
-            Slackware Linux distributions.
+    def _dist_try_harder(distname, version, id):
+        """Tries some special tricks to get the distribution
+        information in case the default method fails.
+        Currently supports older SuSE Linux, Caldera OpenLinux and
+        Slackware Linux distributions.
         """
         if os.path.exists('/var/adm/inst-log/info'):
             # SuSE Linux stores distribution information in that file
@@ -349,7 +348,7 @@ except ImportError:
         if os.path.isdir('/usr/lib/setup'):
             # Check for slackware version tag file (thanks to Greg Andruk)
             verfiles = os.listdir('/usr/lib/setup')
-            for n in range(len(verfiles)-1, -1, -1):
+            for n in range(len(verfiles) - 1, -1, -1):
                 if verfiles[n][:14] != 'slack-version-':
                     del verfiles[n]
             if verfiles:
@@ -361,14 +360,13 @@ except ImportError:
         return distname, version, id
 
     _release_filename = re.compile(r'(\w+)[-_](release|version)', re.ASCII)
-    _lsb_release_version = re.compile(r'(.+)'
-                                      r' release '
-                                      r'([\d.]+)'
-                                      r'[^(]*(?:\((.+)\))?', re.ASCII)
-    _release_version = re.compile(r'([^0-9]+)'
-                                  r'(?: release )?'
-                                  r'([\d.]+)'
-                                  r'[^(]*(?:\((.+)\))?', re.ASCII)
+    _lsb_release_version = re.compile(
+        r'(.+) release ([\d.]+)[^(]*(?:\((.+)\))?', re.ASCII
+    )
+    _release_version = re.compile(
+        r'([^0-9]+)(?: release )?([\d.]+)[^(]*(?:\((.+)\))?',
+        re.ASCII,
+    )
 
     # See also http://www.novell.com/coolsolutions/feature/11251.html
     # and http://linuxmafia.com/faq/Admin/release-files.html
@@ -376,12 +374,24 @@ except ImportError:
     # and http://www.die.net/doc/linux/man/man1/lsb_release.1.html
 
     _supported_dists = (
-        'SuSE', 'debian', 'fedora', 'redhat', 'centos',
-        'mandrake', 'mandriva', 'rocks', 'slackware', 'yellowdog', 'gentoo',
-        'UnitedLinux', 'turbolinux', 'arch', 'mageia')
+        'SuSE',
+        'debian',
+        'fedora',
+        'redhat',
+        'centos',
+        'mandrake',
+        'mandriva',
+        'rocks',
+        'slackware',
+        'yellowdog',
+        'gentoo',
+        'UnitedLinux',
+        'turbolinux',
+        'arch',
+        'mageia',
+    )
 
     def _parse_release_file(firstline):
-
         # Default to empty 'version' and 'id' strings.  Both defaults are used
         # when 'firstline' is empty.  'id' defaults to empty when an id can not
         # be deduced.
@@ -411,34 +421,39 @@ except ImportError:
     _release_file_re = re.compile("(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
     _codename_file_re = re.compile("(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
 
-    def linux_distribution(distname='', version='', id='',
-                           supported_dists=_supported_dists,
-                           full_distribution_name=1):
-        return _linux_distribution(distname, version, id, supported_dists,
-                                   full_distribution_name)
+    def linux_distribution(
+        distname='',
+        version='',
+        id='',
+        supported_dists=_supported_dists,
+        full_distribution_name=1,
+    ):
+        return _linux_distribution(
+            distname, version, id, supported_dists, full_distribution_name
+        )
 
-    def _linux_distribution(distname, version, id, supported_dists,
-                            full_distribution_name):
-
-        """ Tries to determine the name of the Linux OS distribution name.
-            The function first looks for a distribution release file in
-            /etc and then reverts to _dist_try_harder() in case no
-            suitable files are found.
-            supported_dists may be given to define the set of Linux
-            distributions to look for. It defaults to a list of currently
-            supported Linux distributions identified by their release file
-            name.
-            If full_distribution_name is true (default), the full
-            distribution read from the OS is returned. Otherwise the short
-            name taken from supported_dists is used.
-            Returns a tuple (distname, version, id) which default to the
-            args given as parameters.
+    def _linux_distribution(
+        distname, version, id, supported_dists, full_distribution_name
+    ):
+        """Tries to determine the name of the Linux OS distribution name.
+        The function first looks for a distribution release file in
+        /etc and then reverts to _dist_try_harder() in case no
+        suitable files are found.
+        supported_dists may be given to define the set of Linux
+        distributions to look for. It defaults to a list of currently
+        supported Linux distributions identified by their release file
+        name.
+        If full_distribution_name is true (default), the full
+        distribution read from the OS is returned. Otherwise the short
+        name taken from supported_dists is used.
+        Returns a tuple (distname, version, id) which default to the
+        args given as parameters.
         """
         # check for the Debian/Ubuntu /etc/lsb-release file first, needed so
         # that the distribution doesn't get identified as Debian.
         # https://bugs.python.org/issue9514
         try:
-            with open("/etc/lsb-release", "r") as etclsbrel:
+            with open("/etc/lsb-release") as etclsbrel:
                 for line in etclsbrel:
                     m = _distributor_id_file_re.search(line)
                     if m:
@@ -451,8 +466,8 @@ except ImportError:
                         _u_id = m.group(1).strip()
                 if _u_distname and _u_version:
                     return (_u_distname, _u_version, _u_id)
-        except (EnvironmentError, UnboundLocalError):
-                pass
+        except (OSError, UnboundLocalError):
+            pass
 
         try:
             etc = os.listdir(_UNIXCONFDIR)
@@ -471,8 +486,11 @@ except ImportError:
             return _dist_try_harder(distname, version, id)
 
         # Read the first line
-        with open(os.path.join(_UNIXCONFDIR, file), 'r',
-                  encoding='utf-8', errors='surrogateescape') as f:
+        with open(
+            os.path.join(_UNIXCONFDIR, file),
+            encoding='utf-8',
+            errors='surrogateescape',
+        ) as f:
             firstline = f.readline()
         _distname, _version, _id = _parse_release_file(firstline)
 

--- a/awscli/completer.py
+++ b/awscli/completer.py
@@ -1,18 +1,20 @@
 # Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
-
+#
 #     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
 
 import copy
 import logging
 import sys
 
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
 import awscli.clidriver
 
 LOG = logging.getLogger(__name__)

--- a/awscli/completer.py
+++ b/awscli/completer.py
@@ -5,20 +5,20 @@
 
 #     http://aws.amazon.com/apache2.0/
 
+import copy
+import logging
+import sys
+
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import awscli.clidriver
-import sys
-import logging
-import copy
 
 LOG = logging.getLogger(__name__)
 
 
-class Completer(object):
-
+class Completer:
     def __init__(self, driver=None):
         if driver is not None:
             self.driver = driver
@@ -26,7 +26,8 @@ class Completer(object):
             self.driver = awscli.clidriver.create_clidriver()
         self.main_help = self.driver.create_help_command()
         self.main_options = self._get_documented_completions(
-            self.main_help.arg_table)
+            self.main_help.arg_table
+        )
 
     def complete(self, cmdline, point=None):
         if point is None:
@@ -46,22 +47,28 @@ class Completer(object):
             return self._complete_provider(current_arg, opts)
         elif subcmd_name is None:
             return self._complete_command(cmd_name, cmd, current_arg, opts)
-        return self._complete_subcommand(subcmd_name, subcmd, current_arg, opts)
+        return self._complete_subcommand(
+            subcmd_name, subcmd, current_arg, opts
+        )
 
     def _complete_command(self, command_name, command_help, current_arg, opts):
         if current_arg == command_name:
             if command_help:
                 return self._get_documented_completions(
-                    command_help.command_table)
+                    command_help.command_table
+                )
         elif current_arg.startswith('-'):
             return self._find_possible_options(current_arg, opts)
         elif command_help is not None:
             # See if they have entered a partial command name
             return self._get_documented_completions(
-                command_help.command_table, current_arg)
+                command_help.command_table, current_arg
+            )
         return []
 
-    def _complete_subcommand(self, subcmd_name, subcmd_help, current_arg, opts):
+    def _complete_subcommand(
+        self, subcmd_name, subcmd_help, current_arg, opts
+    ):
         if current_arg != subcmd_name and current_arg.startswith('-'):
             return self._find_possible_options(current_arg, opts, subcmd_help)
         return []
@@ -81,11 +88,13 @@ class Completer(object):
             return self._find_possible_options(current_arg, opts)
         elif current_arg == 'aws':
             return self._get_documented_completions(
-                self.main_help.command_table)
+                self.main_help.command_table
+            )
         else:
             # Otherwise, see if they have entered a partial command name
             return self._get_documented_completions(
-                self.main_help.command_table, current_arg)
+                self.main_help.command_table, current_arg
+            )
 
     def _get_command(self, command_help, command_args):
         if command_help is not None and command_help.command_table is not None:
@@ -112,7 +121,8 @@ class Completer(object):
         all_options = copy.copy(self.main_options)
         if subcmd_help is not None:
             all_options += self._get_documented_completions(
-                subcmd_help.arg_table)
+                subcmd_help.arg_table
+            )
 
         for option in opts:
             # Look through list of options on cmdline. If there are

--- a/awscli/errorhandler.py
+++ b/awscli/errorhandler.py
@@ -16,16 +16,27 @@ LOG = logging.getLogger(__name__)
 
 
 class BaseOperationError(Exception):
-    MSG_TEMPLATE = ("A {error_type} error ({error_code}) occurred "
-                    "when calling the {operation_name} operation: "
-                    "{error_message}")
+    MSG_TEMPLATE = (
+        "A {error_type} error ({error_code}) occurred "
+        "when calling the {operation_name} operation: "
+        "{error_message}"
+    )
 
-    def __init__(self, error_code, error_message, error_type, operation_name,
-                 http_status_code):
+    def __init__(
+        self,
+        error_code,
+        error_message,
+        error_type,
+        operation_name,
+        http_status_code,
+    ):
         msg = self.MSG_TEMPLATE.format(
-            error_code=error_code, error_message=error_message,
-            error_type=error_type, operation_name=operation_name)
-        super(BaseOperationError, self).__init__(msg)
+            error_code=error_code,
+            error_message=error_message,
+            error_type=error_type,
+            operation_name=operation_name,
+        )
+        super().__init__(msg)
         self.error_code = error_code
         self.error_message = error_message
         self.error_type = error_type
@@ -41,7 +52,7 @@ class ServerError(BaseOperationError):
     pass
 
 
-class ErrorHandler(object):
+class ErrorHandler:
     """
     This class is responsible for handling any HTTP errors that occur
     when a service operation is called.  It is registered for the
@@ -59,15 +70,21 @@ class ErrorHandler(object):
         if http_response.status_code >= 500:
             error_type = 'server'
             error_class = ServerError
-        elif http_response.status_code >= 400 or http_response.status_code == 301:
+        elif (
+            http_response.status_code >= 400
+            or http_response.status_code == 301
+        ):
             error_type = 'client'
             error_class = ClientError
         if error_class is not None:
             code, message = self._get_error_code_and_message(parsed)
             raise error_class(
-                error_code=code, error_message=message,
-                error_type=error_type, operation_name=model.name,
-                http_status_code=http_response.status_code)
+                error_code=code,
+                error_message=message,
+                error_type=error_type,
+                operation_name=model.name,
+                http_status_code=http_response.status_code,
+            )
 
     def _get_error_code_and_message(self, response):
         code = 'Unknown'

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -16,87 +16,113 @@ This is a collection of built in CLI extensions that can be automatically
 registered with the event system.
 
 """
+
 from awscli.argprocess import ParamShorthandParser
-from awscli.paramfile import register_uri_param_handler
 from awscli.customizations import datapipeline
 from awscli.customizations.addexamples import add_examples
 from awscli.customizations.argrename import register_arg_renames
 from awscli.customizations.assumerole import register_assume_role_provider
 from awscli.customizations.awslambda import register_lambda_create_function
 from awscli.customizations.cliinputjson import register_cli_input_json
-from awscli.customizations.cloudformation import initialize as cloudformation_init
+from awscli.customizations.cloudformation import (
+    initialize as cloudformation_init,
+)
 from awscli.customizations.cloudfront import register as register_cloudfront
 from awscli.customizations.cloudsearch import initialize as cloudsearch_init
 from awscli.customizations.cloudsearchdomain import register_cloudsearchdomain
 from awscli.customizations.cloudtrail import initialize as cloudtrail_init
 from awscli.customizations.codeartifact import register_codeartifact_commands
 from awscli.customizations.codecommit import initialize as codecommit_init
-from awscli.customizations.codedeploy.codedeploy import initialize as \
-    codedeploy_init
+from awscli.customizations.codedeploy.codedeploy import (
+    initialize as codedeploy_init,
+)
 from awscli.customizations.configservice.getstatus import register_get_status
-from awscli.customizations.configservice.putconfigurationrecorder import \
-    register_modify_put_configuration_recorder
-from awscli.customizations.configservice.rename_cmd import \
-    register_rename_config
+from awscli.customizations.configservice.putconfigurationrecorder import (
+    register_modify_put_configuration_recorder,
+)
+from awscli.customizations.configservice.rename_cmd import (
+    register_rename_config,
+)
 from awscli.customizations.configservice.subscribe import register_subscribe
 from awscli.customizations.configure.configure import register_configure_cmd
-from awscli.customizations.history import register_history_mode
-from awscli.customizations.history import register_history_commands
+from awscli.customizations.dlm.dlm import dlm_initialize
+from awscli.customizations.dynamodb import register_dynamodb_paginator_fix
 from awscli.customizations.ec2.addcount import register_count_events
 from awscli.customizations.ec2.bundleinstance import register_bundleinstance
 from awscli.customizations.ec2.decryptpassword import ec2_add_priv_launch_key
+from awscli.customizations.ec2.paginate import register_ec2_page_size_injector
 from awscli.customizations.ec2.protocolarg import register_protocol_args
 from awscli.customizations.ec2.runinstances import register_runinstances
 from awscli.customizations.ec2.secgroupsimplify import register_secgroup
-from awscli.customizations.ec2.paginate import register_ec2_page_size_injector
 from awscli.customizations.ecr import register_ecr_commands
 from awscli.customizations.ecr_public import register_ecr_public_commands
-from awscli.customizations.emr.emr import emr_initialize
-from awscli.customizations.emrcontainers import \
-    initialize as emrcontainers_initialize
-from awscli.customizations.eks import initialize as eks_initialize
 from awscli.customizations.ecs import initialize as ecs_initialize
+from awscli.customizations.eks import initialize as eks_initialize
+from awscli.customizations.emr.emr import emr_initialize
+from awscli.customizations.emrcontainers import (
+    initialize as emrcontainers_initialize,
+)
 from awscli.customizations.gamelift import register_gamelift_commands
-from awscli.customizations.generatecliskeleton import \
-    register_generate_cli_skeleton
+from awscli.customizations.generatecliskeleton import (
+    register_generate_cli_skeleton,
+)
 from awscli.customizations.globalargs import register_parse_global_args
+from awscli.customizations.history import (
+    register_history_commands,
+    register_history_mode,
+)
 from awscli.customizations.iamvirtmfa import IAMVMFAWrapper
-from awscli.customizations.iot import register_create_keys_and_cert_arguments
-from awscli.customizations.iot import register_create_keys_from_csr_arguments
+from awscli.customizations.iot import (
+    register_create_keys_and_cert_arguments,
+    register_create_keys_from_csr_arguments,
+)
 from awscli.customizations.iot_data import register_custom_endpoint_note
+from awscli.customizations.kinesis import (
+    register_kinesis_list_streams_pagination_backcompat,
+)
 from awscli.customizations.kms import register_fix_kms_create_grant_docs
-from awscli.customizations.dlm.dlm import dlm_initialize
+from awscli.customizations.logs import register_logs_commands
+from awscli.customizations.mturk import register_alias_mturk_command
 from awscli.customizations.opsworks import initialize as opsworks_init
+from awscli.customizations.opsworkscm import register_alias_opsworks_cm
+from awscli.customizations.overridesslcommonname import (
+    register_override_ssl_common_name,
+)
 from awscli.customizations.paginate import register_pagination
 from awscli.customizations.preview import register_preview_commands
 from awscli.customizations.putmetricdata import register_put_metric_data
-from awscli.customizations.rds import register_rds_modify_split
-from awscli.customizations.rds import register_add_generate_db_auth_token
-from awscli.customizations.rekognition import register_rekognition_detect_labels
+from awscli.customizations.quicksight import (
+    register_quicksight_asset_bundle_customizations,
+)
+from awscli.customizations.rds import (
+    register_add_generate_db_auth_token,
+    register_rds_modify_split,
+)
+from awscli.customizations.rekognition import (
+    register_rekognition_detect_labels,
+)
 from awscli.customizations.removals import register_removals
 from awscli.customizations.route53 import register_create_hosted_zone_doc_fix
 from awscli.customizations.s3.s3 import s3_plugin_initialize
 from awscli.customizations.s3errormsg import register_s3_error_msg
-from awscli.customizations.scalarparse import register_scalar_parser
-from awscli.customizations.sessendemail import register_ses_send_email
-from awscli.customizations.streamingoutputarg import add_streaming_output_arg
-from awscli.customizations.translate import register_translate_import_terminology
-from awscli.customizations.toplevelbool import register_bool_params
-from awscli.customizations.waiters import register_add_waiters
-from awscli.customizations.opsworkscm import register_alias_opsworks_cm
-from awscli.customizations.mturk import register_alias_mturk_command
-from awscli.customizations.sagemaker import register_alias_sagemaker_runtime_command
-from awscli.customizations.servicecatalog import register_servicecatalog_commands
 from awscli.customizations.s3events import register_event_stream_arg
+from awscli.customizations.sagemaker import (
+    register_alias_sagemaker_runtime_command,
+)
+from awscli.customizations.scalarparse import register_scalar_parser
+from awscli.customizations.servicecatalog import (
+    register_servicecatalog_commands,
+)
+from awscli.customizations.sessendemail import register_ses_send_email
 from awscli.customizations.sessionmanager import register_ssm_session
 from awscli.customizations.sms_voice import register_sms_voice_hide
-from awscli.customizations.dynamodb import register_dynamodb_paginator_fix
-from awscli.customizations.overridesslcommonname import register_override_ssl_common_name
-from awscli.customizations.kinesis import \
-    register_kinesis_list_streams_pagination_backcompat
-from awscli.customizations.quicksight import \
-    register_quicksight_asset_bundle_customizations
-from awscli.customizations.logs import register_logs_commands
+from awscli.customizations.streamingoutputarg import add_streaming_output_arg
+from awscli.customizations.toplevelbool import register_bool_params
+from awscli.customizations.translate import (
+    register_translate_import_terminology,
+)
+from awscli.customizations.waiters import register_add_waiters
+from awscli.paramfile import register_uri_param_handler
 
 
 def awscli_initialize(event_handlers):
@@ -106,23 +132,25 @@ def awscli_initialize(event_handlers):
     # The s3 error message needs to registered before the
     # generic error handler.
     register_s3_error_msg(event_handlers)
-#    # The following will get fired for every option we are
-#    # documenting.  It will attempt to add an example_fn on to
-#    # the parameter object if the parameter supports shorthand
-#    # syntax.  The documentation event handlers will then use
-#    # the examplefn to generate the sample shorthand syntax
-#    # in the docs.  Registering here should ensure that this
-#    # handler gets called first but it still feels a bit brittle.
-#    event_handlers.register('doc-option-example.*.*.*',
-#                            param_shorthand.add_example_fn)
-    event_handlers.register('doc-examples.*.*',
-                            add_examples)
+    #    # The following will get fired for every option we are
+    #    # documenting.  It will attempt to add an example_fn on to
+    #    # the parameter object if the parameter supports shorthand
+    #    # syntax.  The documentation event handlers will then use
+    #    # the examplefn to generate the sample shorthand syntax
+    #    # in the docs.  Registering here should ensure that this
+    #    # handler gets called first but it still feels a bit brittle.
+    #    event_handlers.register('doc-option-example.*.*.*',
+    #                            param_shorthand.add_example_fn)
+    event_handlers.register('doc-examples.*.*', add_examples)
     register_cli_input_json(event_handlers)
-    event_handlers.register('building-argument-table.*',
-                            add_streaming_output_arg)
+    event_handlers.register(
+        'building-argument-table.*', add_streaming_output_arg
+    )
     register_count_events(event_handlers)
-    event_handlers.register('building-argument-table.ec2.get-password-data',
-                            ec2_add_priv_launch_key)
+    event_handlers.register(
+        'building-argument-table.ec2.get-password-data',
+        ec2_add_priv_launch_key,
+    )
     register_parse_global_args(event_handlers)
     register_pagination(event_handlers)
     register_secgroup(event_handlers)
@@ -169,10 +197,12 @@ def awscli_initialize(event_handlers):
     register_custom_endpoint_note(event_handlers)
     event_handlers.register(
         'building-argument-table.iot.create-keys-and-certificate',
-        register_create_keys_and_cert_arguments)
+        register_create_keys_and_cert_arguments,
+    )
     event_handlers.register(
         'building-argument-table.iot.create-certificate-from-csr',
-        register_create_keys_from_csr_arguments)
+        register_create_keys_from_csr_arguments,
+    )
     register_cloudfront(event_handlers)
     register_gamelift_commands(event_handlers)
     register_ec2_page_size_injector(event_handlers)

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -12,35 +12,37 @@
 # language governing permissions and limitations under the License.
 import logging
 import os
-import sys
 import platform
 import shlex
-from subprocess import Popen, PIPE
+import sys
+from subprocess import PIPE, Popen
 
 from docutils.core import publish_string
 from docutils.writers import manpage
 
-from awscli.clidocs import ProviderDocumentEventHandler
-from awscli.clidocs import ServiceDocumentEventHandler
-from awscli.clidocs import OperationDocumentEventHandler
-from awscli.clidocs import TopicListerDocumentEventHandler
-from awscli.clidocs import TopicDocumentEventHandler
+from awscli.argparser import ArgTableArgParser
+from awscli.argprocess import ParamShorthandParser
 from awscli.bcdoc import docevents
 from awscli.bcdoc.restdoc import ReSTDocument
 from awscli.bcdoc.textwriter import TextWriter
-from awscli.argprocess import ParamShorthandParser
-from awscli.argparser import ArgTableArgParser
+from awscli.clidocs import (
+    OperationDocumentEventHandler,
+    ProviderDocumentEventHandler,
+    ServiceDocumentEventHandler,
+    TopicDocumentEventHandler,
+    TopicListerDocumentEventHandler,
+)
 from awscli.topictags import TopicTagDB
 from awscli.utils import ignore_ctrl_c
-
 
 LOG = logging.getLogger('awscli.help')
 
 
 class ExecutableNotFoundError(Exception):
     def __init__(self, executable_name):
-        super(ExecutableNotFoundError, self).__init__(
-            'Could not find executable named "%s"' % executable_name)
+        super().__init__(
+            f'Could not find executable named "{executable_name}"'
+        )
 
 
 def get_renderer():
@@ -54,7 +56,7 @@ def get_renderer():
         return PosixHelpRenderer()
 
 
-class PagingHelpRenderer(object):
+class PagingHelpRenderer:
     """
     Interface for a help renderer.
 
@@ -62,6 +64,7 @@ class PagingHelpRenderer(object):
     a particular platform.
 
     """
+
     def __init__(self, output_stream=sys.stdout):
         self.output_stream = output_stream
 
@@ -116,7 +119,8 @@ class PosixHelpRenderer(PagingHelpRenderer):
 
     def _convert_doc_content(self, contents):
         man_contents = publish_string(
-            contents, writer=manpage.Writer(),
+            contents,
+            writer=manpage.Writer(),
             settings_overrides=self._DEFAULT_DOCUTILS_SETTINGS_OVERRIDES,
         )
         if self._exists_on_path('groff'):
@@ -133,8 +137,9 @@ class PosixHelpRenderer(PagingHelpRenderer):
     def _send_output_to_pager(self, output):
         cmdline = self.get_pager_cmdline()
         if not self._exists_on_path(cmdline[0]):
-            LOG.debug("Pager '%s' not found in PATH, printing raw help." %
-                      cmdline[0])
+            LOG.debug(
+                "Pager '%s' not found in PATH, printing raw help.", cmdline[0]
+            )
             self.output_stream.write(output.decode('utf-8') + "\n")
             self.output_stream.flush()
             return
@@ -157,8 +162,12 @@ class PosixHelpRenderer(PagingHelpRenderer):
     def _exists_on_path(self, name):
         # Since we're only dealing with POSIX systems, we can
         # ignore things like PATHEXT.
-        return any([os.path.exists(os.path.join(p, name))
-                    for p in os.environ.get('PATH', '').split(os.pathsep)])
+        return any(
+            [
+                os.path.exists(os.path.join(p, name))
+                for p in os.environ.get('PATH', '').split(os.pathsep)
+            ]
+        )
 
 
 class WindowsHelpRenderer(PagingHelpRenderer):
@@ -168,7 +177,8 @@ class WindowsHelpRenderer(PagingHelpRenderer):
 
     def _convert_doc_content(self, contents):
         text_output = publish_string(
-            contents, writer=TextWriter(),
+            contents,
+            writer=TextWriter(),
             settings_overrides=self._DEFAULT_DOCUTILS_SETTINGS_OVERRIDES,
         )
         return text_output
@@ -180,7 +190,7 @@ class WindowsHelpRenderer(PagingHelpRenderer):
         return Popen(*args, **kwargs)
 
 
-class HelpCommand(object):
+class HelpCommand:
     """
     HelpCommand Interface
     ---------------------
@@ -278,8 +288,9 @@ class HelpCommand(object):
             subcommand_parser = ArgTableArgParser({}, self.subcommand_table)
             parsed, remaining = subcommand_parser.parse_known_args(args)
             if getattr(parsed, 'subcommand', None) is not None:
-                return self.subcommand_table[parsed.subcommand](remaining,
-                                                                parsed_globals)
+                return self.subcommand_table[parsed.subcommand](
+                    remaining, parsed_globals
+                )
 
         # Create an event handler for a Provider Document
         instance = self.EventHandlerClass(self)
@@ -297,12 +308,13 @@ class ProviderHelpCommand(HelpCommand):
     This is what is called when ``aws help`` is run.
 
     """
+
     EventHandlerClass = ProviderDocumentEventHandler
 
-    def __init__(self, session, command_table, arg_table,
-                 description, synopsis, usage):
-        HelpCommand.__init__(self, session, None,
-                             command_table, arg_table)
+    def __init__(
+        self, session, command_table, arg_table, description, synopsis, usage
+    ):
+        HelpCommand.__init__(self, session, None, command_table, arg_table)
         self.description = description
         self.synopsis = synopsis
         self.help_usage = usage
@@ -351,10 +363,12 @@ class ServiceHelpCommand(HelpCommand):
 
     EventHandlerClass = ServiceDocumentEventHandler
 
-    def __init__(self, session, obj, command_table, arg_table, name,
-                 event_class):
-        super(ServiceHelpCommand, self).__init__(session, obj, command_table,
-                                                 arg_table)
+    def __init__(
+        self, session, obj, command_table, arg_table, name, event_class
+    ):
+        super().__init__(
+            session, obj, command_table, arg_table
+        )
         self._name = name
         self._event_class = event_class
 
@@ -374,10 +388,10 @@ class OperationHelpCommand(HelpCommand):
     e.g. ``aws ec2 describe-instances help``.
 
     """
+
     EventHandlerClass = OperationDocumentEventHandler
 
-    def __init__(self, session, operation_model, arg_table, name,
-                 event_class):
+    def __init__(self, session, operation_model, arg_table, name, event_class):
         HelpCommand.__init__(self, session, operation_model, None, arg_table)
         self.param_shorthand = ParamShorthandParser()
         self._name = name
@@ -396,7 +410,7 @@ class TopicListerCommand(HelpCommand):
     EventHandlerClass = TopicListerDocumentEventHandler
 
     def __init__(self, session):
-        super(TopicListerCommand, self).__init__(session, None, {}, {})
+        super().__init__(session, None, {}, {})
 
     @property
     def event_class(self):
@@ -411,7 +425,7 @@ class TopicHelpCommand(HelpCommand):
     EventHandlerClass = TopicDocumentEventHandler
 
     def __init__(self, session, topic_name):
-        super(TopicHelpCommand, self).__init__(session, None, {}, {})
+        super().__init__(session, None, {}, {})
         self._topic_name = topic_name
 
     @property

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -10,17 +10,16 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import copy
 import logging
 import os
-import copy
 
 from botocore.awsrequest import AWSRequest
-from botocore.httpsession import URLLib3Session
 from botocore.exceptions import ProfileNotFound
+from botocore.httpsession import URLLib3Session
 
-from awscli.compat import compat_open
 from awscli.argprocess import ParamError
-
+from awscli.compat import compat_open
 
 logger = logging.getLogger(__name__)
 
@@ -28,123 +27,108 @@ logger = logging.getLogger(__name__)
 # special param file processing.  This is typically because it
 # refers to an actual URI of some sort and we don't want to actually
 # download the content (i.e TemplateURL in cloudformation).
-PARAMFILE_DISABLED = set([
-    'api-gateway.put-integration.uri',
-    'api-gateway.create-integration.integration-uri',
-    'api-gateway.update-integration.integration-uri',
-    'api-gateway.create-api.target',
-    'api-gateway.update-api.target',
-    'appstream.create-stack.redirect-url',
-    'appstream.create-stack.feedback-url',
-    'appstream.update-stack.redirect-url',
-    'appstream.update-stack.feedback-url',
-    'cloudformation.create-stack.template-url',
-    'cloudformation.update-stack.template-url',
-    'cloudformation.create-stack-set.template-url',
-    'cloudformation.update-stack-set.template-url',
-    'cloudformation.create-change-set.template-url',
-    'cloudformation.validate-template.template-url',
-    'cloudformation.estimate-template-cost.template-url',
-    'cloudformation.get-template-summary.template-url',
-
-    'cloudformation.create-stack.stack-policy-url',
-    'cloudformation.update-stack.stack-policy-url',
-    'cloudformation.set-stack-policy.stack-policy-url',
-    # aws cloudformation package --template-file
-    'custom.package.template-file',
-    # aws cloudformation deploy --template-file
-    'custom.deploy.template-file',
-
-    'cloudformation.update-stack.stack-policy-during-update-url',
-    'cloudformation.register-type.schema-handler-package',
-    # We will want to change the event name to ``s3`` as opposed to
-    # custom in the near future along with ``s3`` to ``s3api``.
-    'custom.cp.website-redirect',
-    'custom.mv.website-redirect',
-    'custom.sync.website-redirect',
-
-    'guardduty.create-ip-set.location',
-    'guardduty.update-ip-set.location',
-    'guardduty.create-threat-intel-set.location',
-    'guardduty.update-threat-intel-set.location',
-    'comprehend.detect-dominant-language.text',
-    'comprehend.batch-detect-dominant-language.text-list',
-    'comprehend.detect-entities.text',
-    'comprehend.batch-detect-entities.text-list',
-    'comprehend.detect-key-phrases.text',
-    'comprehend.batch-detect-key-phrases.text-list',
-    'comprehend.detect-sentiment.text',
-    'comprehend.batch-detect-sentiment.text-list',
-
-    'emr.create-studio.idp-auth-url',
-
-    'iam.create-open-id-connect-provider.url',
-
-    'machine-learning.predict.predict-endpoint',
-
-    'mediatailor.put-playback-configuration.ad-decision-server-url',
-    'mediatailor.put-playback-configuration.slate-ad-url',
-    'mediatailor.put-playback-configuration.video-content-source-url',
-
-    'rds.copy-db-cluster-snapshot.pre-signed-url',
-    'rds.create-db-cluster.pre-signed-url',
-    'rds.copy-db-snapshot.pre-signed-url',
-    'rds.create-db-instance-read-replica.pre-signed-url',
-
-    'sagemaker.create-notebook-instance.default-code-repository',
-    'sagemaker.create-notebook-instance.additional-code-repositories',
-    'sagemaker.update-notebook-instance.default-code-repository',
-    'sagemaker.update-notebook-instance.additional-code-repositories',
-
-    'serverlessapplicationrepository.create-application.home-page-url',
-    'serverlessapplicationrepository.create-application.license-url',
-    'serverlessapplicationrepository.create-application.readme-url',
-    'serverlessapplicationrepository.create-application.source-code-url',
-    'serverlessapplicationrepository.create-application.template-url',
-    'serverlessapplicationrepository.create-application-version.source-code-url',
-    'serverlessapplicationrepository.create-application-version.template-url',
-    'serverlessapplicationrepository.update-application.home-page-url',
-    'serverlessapplicationrepository.update-application.readme-url',
-
-    'service-catalog.create-product.support-url',
-    'service-catalog.update-product.support-url',
-
-    'ses.create-custom-verification-email-template.failure-redirection-url',
-    'ses.create-custom-verification-email-template.success-redirection-url',
-    'ses.put-account-details.website-url',
-    'ses.update-custom-verification-email-template.failure-redirection-url',
-    'ses.update-custom-verification-email-template.success-redirection-url',
-
-    'sqs.add-permission.queue-url',
-    'sqs.change-message-visibility.queue-url',
-    'sqs.change-message-visibility-batch.queue-url',
-    'sqs.delete-message.queue-url',
-    'sqs.delete-message-batch.queue-url',
-    'sqs.delete-queue.queue-url',
-    'sqs.get-queue-attributes.queue-url',
-    'sqs.list-dead-letter-source-queues.queue-url',
-    'sqs.receive-message.queue-url',
-    'sqs.remove-permission.queue-url',
-    'sqs.send-message.queue-url',
-    'sqs.send-message-batch.queue-url',
-    'sqs.set-queue-attributes.queue-url',
-    'sqs.purge-queue.queue-url',
-    'sqs.list-queue-tags.queue-url',
-    'sqs.tag-queue.queue-url',
-    'sqs.untag-queue.queue-url',
-
-    's3.copy-object.website-redirect-location',
-    's3.create-multipart-upload.website-redirect-location',
-    's3.put-object.website-redirect-location',
-
-    # Double check that this has been renamed!
-    'sns.subscribe.notification-endpoint',
-
-    'iot.create-job.document-source',
-    'translate.translate-text.text',
-
-    'workdocs.create-notification-subscription.notification-endpoint'
-])
+PARAMFILE_DISABLED = set(
+    [
+        'api-gateway.put-integration.uri',
+        'api-gateway.create-integration.integration-uri',
+        'api-gateway.update-integration.integration-uri',
+        'api-gateway.create-api.target',
+        'api-gateway.update-api.target',
+        'appstream.create-stack.redirect-url',
+        'appstream.create-stack.feedback-url',
+        'appstream.update-stack.redirect-url',
+        'appstream.update-stack.feedback-url',
+        'cloudformation.create-stack.template-url',
+        'cloudformation.update-stack.template-url',
+        'cloudformation.create-stack-set.template-url',
+        'cloudformation.update-stack-set.template-url',
+        'cloudformation.create-change-set.template-url',
+        'cloudformation.validate-template.template-url',
+        'cloudformation.estimate-template-cost.template-url',
+        'cloudformation.get-template-summary.template-url',
+        'cloudformation.create-stack.stack-policy-url',
+        'cloudformation.update-stack.stack-policy-url',
+        'cloudformation.set-stack-policy.stack-policy-url',
+        # aws cloudformation package --template-file
+        'custom.package.template-file',
+        # aws cloudformation deploy --template-file
+        'custom.deploy.template-file',
+        'cloudformation.update-stack.stack-policy-during-update-url',
+        'cloudformation.register-type.schema-handler-package',
+        # We will want to change the event name to ``s3`` as opposed to
+        # custom in the near future along with ``s3`` to ``s3api``.
+        'custom.cp.website-redirect',
+        'custom.mv.website-redirect',
+        'custom.sync.website-redirect',
+        'guardduty.create-ip-set.location',
+        'guardduty.update-ip-set.location',
+        'guardduty.create-threat-intel-set.location',
+        'guardduty.update-threat-intel-set.location',
+        'comprehend.detect-dominant-language.text',
+        'comprehend.batch-detect-dominant-language.text-list',
+        'comprehend.detect-entities.text',
+        'comprehend.batch-detect-entities.text-list',
+        'comprehend.detect-key-phrases.text',
+        'comprehend.batch-detect-key-phrases.text-list',
+        'comprehend.detect-sentiment.text',
+        'comprehend.batch-detect-sentiment.text-list',
+        'emr.create-studio.idp-auth-url',
+        'iam.create-open-id-connect-provider.url',
+        'machine-learning.predict.predict-endpoint',
+        'mediatailor.put-playback-configuration.ad-decision-server-url',
+        'mediatailor.put-playback-configuration.slate-ad-url',
+        'mediatailor.put-playback-configuration.video-content-source-url',
+        'rds.copy-db-cluster-snapshot.pre-signed-url',
+        'rds.create-db-cluster.pre-signed-url',
+        'rds.copy-db-snapshot.pre-signed-url',
+        'rds.create-db-instance-read-replica.pre-signed-url',
+        'sagemaker.create-notebook-instance.default-code-repository',
+        'sagemaker.create-notebook-instance.additional-code-repositories',
+        'sagemaker.update-notebook-instance.default-code-repository',
+        'sagemaker.update-notebook-instance.additional-code-repositories',
+        'serverlessapplicationrepository.create-application.home-page-url',
+        'serverlessapplicationrepository.create-application.license-url',
+        'serverlessapplicationrepository.create-application.readme-url',
+        'serverlessapplicationrepository.create-application.source-code-url',
+        'serverlessapplicationrepository.create-application.template-url',
+        'serverlessapplicationrepository.create-application-version.source-code-url',
+        'serverlessapplicationrepository.create-application-version.template-url',
+        'serverlessapplicationrepository.update-application.home-page-url',
+        'serverlessapplicationrepository.update-application.readme-url',
+        'service-catalog.create-product.support-url',
+        'service-catalog.update-product.support-url',
+        'ses.create-custom-verification-email-template.failure-redirection-url',
+        'ses.create-custom-verification-email-template.success-redirection-url',
+        'ses.put-account-details.website-url',
+        'ses.update-custom-verification-email-template.failure-redirection-url',
+        'ses.update-custom-verification-email-template.success-redirection-url',
+        'sqs.add-permission.queue-url',
+        'sqs.change-message-visibility.queue-url',
+        'sqs.change-message-visibility-batch.queue-url',
+        'sqs.delete-message.queue-url',
+        'sqs.delete-message-batch.queue-url',
+        'sqs.delete-queue.queue-url',
+        'sqs.get-queue-attributes.queue-url',
+        'sqs.list-dead-letter-source-queues.queue-url',
+        'sqs.receive-message.queue-url',
+        'sqs.remove-permission.queue-url',
+        'sqs.send-message.queue-url',
+        'sqs.send-message-batch.queue-url',
+        'sqs.set-queue-attributes.queue-url',
+        'sqs.purge-queue.queue-url',
+        'sqs.list-queue-tags.queue-url',
+        'sqs.tag-queue.queue-url',
+        'sqs.untag-queue.queue-url',
+        's3.copy-object.website-redirect-location',
+        's3.create-multipart-upload.website-redirect-location',
+        's3.put-object.website-redirect-location',
+        # Double check that this has been renamed!
+        'sns.subscribe.notification-endpoint',
+        'iot.create-job.document-source',
+        'translate.translate-text.text',
+        'workdocs.create-notification-subscription.notification-endpoint',
+    ]
+)
 
 
 class ResourceLoadingError(Exception):
@@ -154,8 +138,10 @@ class ResourceLoadingError(Exception):
 def register_uri_param_handler(session, **kwargs):
     prefix_map = copy.deepcopy(LOCAL_PREFIX_MAP)
     try:
-        fetch_url = session.get_scoped_config().get(
-            'cli_follow_urlparam', 'true') == 'true'
+        fetch_url = (
+            session.get_scoped_config().get('cli_follow_urlparam', 'true')
+            == 'true'
+        )
     except ProfileNotFound:
         # If a --profile is provided that does not exist, loading
         # a value from get_scoped_config will crash the CLI.
@@ -173,7 +159,7 @@ def register_uri_param_handler(session, **kwargs):
     session.register('load-cli-arg', handler)
 
 
-class URIArgumentHandler(object):
+class URIArgumentHandler:
     def __init__(self, prefixes=None):
         if prefixes is None:
             prefixes = copy.deepcopy(LOCAL_PREFIX_MAP)
@@ -184,8 +170,9 @@ class URIArgumentHandler(object):
         """Handler that supports param values from URIs."""
         cli_argument = param
         qualified_param_name = '.'.join(event_name.split('.')[1:])
-        if qualified_param_name in PARAMFILE_DISABLED or \
-                getattr(cli_argument, 'no_paramfile', None):
+        if qualified_param_name in PARAMFILE_DISABLED or getattr(
+            cli_argument, 'no_paramfile', None
+        ):
             return
         else:
             return self._check_for_uri_param(cli_argument, value)
@@ -232,7 +219,7 @@ def get_paramfile(path, cases):
 
 
 def get_file(prefix, path, mode):
-    file_path = os.path.expandvars(os.path.expanduser(path[len(prefix):]))
+    file_path = os.path.expandvars(os.path.expanduser(path[len(prefix) :]))
     try:
         with compat_open(file_path, mode) as f:
             return f.read()
@@ -240,10 +227,12 @@ def get_file(prefix, path, mode):
         raise ResourceLoadingError(
             'Unable to load paramfile (%s), text contents could '
             'not be decoded.  If this is a binary file, please use the '
-            'fileb:// prefix instead of the file:// prefix.' % file_path)
-    except (OSError, IOError) as e:
-        raise ResourceLoadingError('Unable to load paramfile %s: %s' % (
-            path, e))
+            'fileb:// prefix instead of the file:// prefix.' % file_path
+        )
+    except OSError as e:
+        raise ResourceLoadingError(
+            f'Unable to load paramfile {path}: {e}'
+        )
 
 
 def get_uri(prefix, uri):
@@ -254,8 +243,8 @@ def get_uri(prefix, uri):
             return r.text
         else:
             raise ResourceLoadingError(
-                "received non 200 status code of %s" % (
-                    r.status_code))
+                f"received non 200 status code of {r.status_code}"
+            )
     except Exception as e:
         raise ResourceLoadingError('Unable to retrieve %s: %s' % (uri, e))
 

--- a/awscli/schema.py
+++ b/awscli/schema.py
@@ -17,7 +17,7 @@ class ParameterRequiredError(ValueError):
     pass
 
 
-class SchemaTransformer(object):
+class SchemaTransformer:
     """
     Transforms a custom argument parameter schema into an internal
     model representation so that it can be treated like a normal
@@ -63,6 +63,7 @@ class SchemaTransformer(object):
         $ aws foo bar --baz arg1=Value1,arg2=5 arg1=Value2
 
     """
+
     JSON_SCHEMA_TO_AWS_TYPES = {
         'object': 'structure',
         'array': 'list',
@@ -116,7 +117,8 @@ class SchemaTransformer(object):
         for key, value in schema['properties'].items():
             current_type_name = self._json_schema_to_aws_type(value)
             current_shape_name = self._shape_namer.new_shape_name(
-                current_type_name)
+                current_type_name
+            )
             members[key] = {'shape': current_shape_name}
             if value.get('required', False):
                 required_members.append(key)
@@ -161,7 +163,7 @@ class SchemaTransformer(object):
         return self.JSON_SCHEMA_TO_AWS_TYPES.get(type_name, type_name)
 
 
-class ShapeNameGenerator(object):
+class ShapeNameGenerator:
     def __init__(self):
         self._name_cache = defaultdict(int)
 

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -38,16 +38,16 @@ necessary to maintain backwards compatibility.  This is done in the
 ``BackCompatVisitor`` class.
 
 """
+
 import re
 import string
 
 from awscli.utils import is_document_type
 
-
 _EOF = object()
 
 
-class _NamedRegex(object):
+class _NamedRegex:
     def __init__(self, name, regex_str):
         self.name = name
         self.regex = re.compile(regex_str, re.UNICODE)
@@ -57,25 +57,24 @@ class _NamedRegex(object):
 
 
 class ShorthandParseError(Exception):
-
     def _error_location(self):
         consumed, remaining, num_spaces = self.value, '', self.index
-        if '\n' in self.value[:self.index]:
+        if '\n' in self.value[: self.index]:
             # If there's newlines in the consumed expression, we want
             # to make sure we're only counting the spaces
             # from the last newline:
             # foo=bar,\n
             # bar==baz
             #     ^
-            last_newline = self.value[:self.index].rindex('\n')
+            last_newline = self.value[: self.index].rindex('\n')
             num_spaces = self.index - last_newline - 1
-        if '\n' in self.value[self.index:]:
+        if '\n' in self.value[self.index :]:
             # If there's newline in the remaining, divide value
             # into consumed and remaining
             # foo==bar,\n
             #     ^
             # bar=baz
-            next_newline = self.index + self.value[self.index:].index('\n')
+            next_newline = self.index + self.value[self.index :].index('\n')
             consumed = self.value[:next_newline]
             remaining = self.value[next_newline:]
         return '%s\n%s%s' % (consumed, (' ' * num_spaces) + '^', remaining)
@@ -88,14 +87,13 @@ class ShorthandParseSyntaxError(ShorthandParseError):
         self.actual = actual
         self.index = index
         msg = self._construct_msg()
-        super(ShorthandParseSyntaxError, self).__init__(msg)
+        super().__init__(msg)
 
     def _construct_msg(self):
-        msg = (
-            "Expected: '%s', received: '%s' for input:\n"
-            "%s"
-        ) % (self.expected, self.actual, self._error_location())
-        return msg
+        return (
+            f"Expected: '{self.expected}', received: '{self.actual}' "
+            f"for input:\n" "{self._error_location()}"
+        )
 
 
 class DuplicateKeyInObjectError(ShorthandParseError):
@@ -104,22 +102,21 @@ class DuplicateKeyInObjectError(ShorthandParseError):
         self.value = value
         self.index = index
         msg = self._construct_msg()
-        super(DuplicateKeyInObjectError, self).__init__(msg)
+        super().__init__(msg)
 
     def _construct_msg(self):
-        msg = (
-            "Second instance of key \"%s\" encountered for input:\n%s\n"
-            "This is often because there is a preceding \",\" instead of a "
-            "space."
-        ) % (self.key, self._error_location())
-        return msg
+        return (
+            f"Second instance of key \"{self.key}\" encountered for input:\n"
+            f"{self._error_location()}\nThis is often because there is a "
+            "preceding \",\" instead of a space."
+        )
 
 
 class DocumentTypesNotSupportedError(Exception):
     pass
 
 
-class ShorthandParser(object):
+class ShorthandParser:
     """Parses shorthand syntax in the CLI.
 
     Note that this parser does not rely on any JSON models to control
@@ -129,26 +126,20 @@ class ShorthandParser(object):
 
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
-    _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
-    _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
-    _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
+    _START_WORD = '\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
+    _FIRST_FOLLOW_CHARS = '\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
+    _SECOND_FOLLOW_CHARS = '\s\!\#-&\(-\+\--\<\>-\uffff'
     _ESCAPED_COMMA = '(\\\\,)'
     _FIRST_VALUE = _NamedRegex(
         'first',
-        u'({escaped_comma}|[{start_word}])'
-        u'({escaped_comma}|[{follow_chars}])*'.format(
-            escaped_comma=_ESCAPED_COMMA,
-            start_word=_START_WORD,
-            follow_chars=_FIRST_FOLLOW_CHARS,
-        ))
+        f'({_ESCAPED_COMMA}|[{_START_WORD}])'
+        f'({_ESCAPED_COMMA}|[{_FIRST_FOLLOW_CHARS}])*',
+    )
     _SECOND_VALUE = _NamedRegex(
         'second',
-        u'({escaped_comma}|[{start_word}])'
-        u'({escaped_comma}|[{follow_chars}])*'.format(
-            escaped_comma=_ESCAPED_COMMA,
-            start_word=_START_WORD,
-            follow_chars=_SECOND_FOLLOW_CHARS,
-        ))
+        f'({_ESCAPED_COMMA}|[{_START_WORD}])'
+        f'({_ESCAPED_COMMA}|[{_SECOND_FOLLOW_CHARS}])*',
+    )
 
     def __init__(self):
         self._tokens = []
@@ -205,7 +196,7 @@ class ShorthandParser(object):
             if self._current() not in valid_chars:
                 break
             self._index += 1
-        return self._input_value[start:self._index]
+        return self._input_value[start : self._index]
 
     def _values(self):
         # values = csv-list / explicit-list / hash-literal
@@ -267,7 +258,7 @@ class ShorthandParser(object):
         return csv_list
 
     def _value(self):
-        result = self._FIRST_VALUE.match(self._input_value[self._index:])
+        result = self._FIRST_VALUE.match(self._input_value[self._index :])
         if result is not None:
             consumed = self._consume_matched_regex(result)
             return consumed.replace('\\,', ',').rstrip()
@@ -348,27 +339,30 @@ class ShorthandParser(object):
         if consume_whitespace:
             self._consume_whitespace()
         if self._index >= len(self._input_value):
-            raise ShorthandParseSyntaxError(self._input_value, char,
-                                            'EOF', self._index)
+            raise ShorthandParseSyntaxError(
+                self._input_value, char, 'EOF', self._index
+            )
         actual = self._input_value[self._index]
         if actual != char:
-            raise ShorthandParseSyntaxError(self._input_value, char,
-                                            actual, self._index)
+            raise ShorthandParseSyntaxError(
+                self._input_value, char, actual, self._index
+            )
         self._index += 1
         if consume_whitespace:
             self._consume_whitespace()
 
     def _must_consume_regex(self, regex):
-        result = regex.match(self._input_value[self._index:])
+        result = regex.match(self._input_value[self._index :])
         if result is not None:
             return self._consume_matched_regex(result)
-        raise ShorthandParseSyntaxError(self._input_value, '<%s>' % regex.name,
-                                        '<none>', self._index)
+        raise ShorthandParseSyntaxError(
+            self._input_value, f'<regex.name>', '<none>', self._index
+        )
 
     def _consume_matched_regex(self, result):
         start, end = result.span()
-        v = self._input_value[self._index+start:self._index+end]
-        self._index += (end - start)
+        v = self._input_value[self._index + start : self._index + end]
+        self._index += end - start
         return v
 
     def _current(self):
@@ -390,21 +384,23 @@ class ShorthandParser(object):
             self._index += 1
 
 
-class ModelVisitor(object):
+class ModelVisitor:
     def visit(self, params, model):
         self._visit({}, model, '', params)
 
     def _visit(self, parent, shape, name, value):
-        method = getattr(self, '_visit_%s' % shape.type_name,
-                         self._visit_scalar)
+        method = getattr(
+            self, f'_visit_{shape.type_name}', self._visit_scalar
+        )
         method(parent, shape, name, value)
 
     def _visit_structure(self, parent, shape, name, value):
         if not isinstance(value, dict):
             return
         for member_name, member_shape in shape.members.items():
-            self._visit(value, member_shape, member_name,
-                        value.get(member_name))
+            self._visit(
+                value, member_shape, member_name, value.get(member_name)
+            )
 
     def _visit_list(self, parent, shape, name, value):
         if not isinstance(value, list):
@@ -430,8 +426,9 @@ class BackCompatVisitor(ModelVisitor):
             return
         for member_name, member_shape in shape.members.items():
             try:
-                self._visit(value, member_shape, member_name,
-                            value.get(member_name))
+                self._visit(
+                    value, member_shape, member_name, value.get(member_name)
+                )
             except DocumentTypesNotSupportedError:
                 # Catch and propagate the document type error to a better
                 # error message as when the original error is thrown there is
@@ -440,7 +437,7 @@ class BackCompatVisitor(ModelVisitor):
                 raise ShorthandParseError(
                     'Shorthand syntax does not support document types. Use '
                     'JSON input for top-level argument to specify nested '
-                    'parameter: %s' % member_name
+                    f'parameter: {member_name}'
                 )
 
     def _visit_list(self, parent, shape, name, value):
@@ -450,8 +447,9 @@ class BackCompatVisitor(ModelVisitor):
             if value is not None:
                 parent[name] = [value]
         else:
-            return super(BackCompatVisitor, self)._visit_list(
-                parent, shape, name, value)
+            return super()._visit_list(
+                parent, shape, name, value
+            )
 
     def _visit_scalar(self, parent, shape, name, value):
         if value is None:

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -356,7 +356,7 @@ class ShorthandParser:
         if result is not None:
             return self._consume_matched_regex(result)
         raise ShorthandParseSyntaxError(
-            self._input_value, f'<regex.name>', '<none>', self._index
+            self._input_value, f'<{regex.name}>', '<none>', self._index
         )
 
     def _consume_matched_regex(self, result):

--- a/awscli/table.py
+++ b/awscli/table.py
@@ -6,18 +6,18 @@
 
 #     http://aws.amazon.com/apache2.0/
 
+import struct
+
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
-import struct
 import unicodedata
 
 import colorama
 
 from awscli.utils import is_a_tty
-
 
 # `autoreset` allows us to not have to sent reset sequences for every
 # string. `strip` lets us preserve color when redirecting.
@@ -35,28 +35,32 @@ def get_text_length(text):
     # * F(Fullwidth)
     # * W(Wide)
     text = str(text)
-    return sum(2 if unicodedata.east_asian_width(char) in 'WFA' else 1
-               for char in text)
+    return sum(
+        2 if unicodedata.east_asian_width(char) in 'WFA' else 1
+        for char in text
+    )
 
 
 def determine_terminal_width(default_width=80):
     # If we can't detect the terminal width, the default_width is returned.
     try:
-        from termios import TIOCGWINSZ
         from fcntl import ioctl
+        from termios import TIOCGWINSZ
     except ImportError:
         return default_width
     try:
-        height, width = struct.unpack('hhhh', ioctl(sys.stdout,
-                                                    TIOCGWINSZ, '\000' * 8))[0:2]
+        height, width = struct.unpack(
+            'hhhh', ioctl(sys.stdout, TIOCGWINSZ, '\000' * 8)
+        )[0:2]
     except Exception:
         return default_width
     else:
         return width
 
 
-def center_text(text, length=80, left_edge='|', right_edge='|',
-                text_length=None):
+def center_text(
+    text, length=80, left_edge='|', right_edge='|', text_length=None
+):
     """Center text with specified edge chars.
 
     You can pass in the length of the text as an arg, otherwise it is computed
@@ -77,15 +81,24 @@ def center_text(text, length=80, left_edge='|', right_edge='|',
     return final
 
 
-def align_left(text, length, left_edge='|', right_edge='|', text_length=None,
-               left_padding=2):
+def align_left(
+    text,
+    length,
+    left_edge='|',
+    right_edge='|',
+    text_length=None,
+    left_padding=2,
+):
     """Left align text."""
     # postcondition: get_text_length(returned_text) == length
     if text_length is None:
         text_length = get_text_length(text)
     computed_length = (
-        text_length + left_padding + \
-        get_text_length(left_edge) + get_text_length(right_edge))
+        text_length
+        + left_padding
+        + get_text_length(left_edge)
+        + get_text_length(right_edge)
+    )
     if length - computed_length >= 0:
         padding = left_padding
     else:
@@ -125,9 +138,10 @@ def convert_to_vertical_table(sections):
             sections[i] = new_section
 
 
-class IndentedStream(object):
-    def __init__(self, stream, indent_level, left_indent_char='|',
-                 right_indent_char='|'):
+class IndentedStream:
+    def __init__(
+        self, stream, indent_level, left_indent_char='|', right_indent_char='|'
+    ):
         self._stream = stream
         self._indent_level = indent_level
         self._left_indent_char = left_indent_char
@@ -146,7 +160,7 @@ class IndentedStream(object):
         return getattr(self._stream, attr)
 
 
-class Styler(object):
+class Styler:
     def style_title(self, text):
         return text
 
@@ -167,25 +181,39 @@ class ColorizedStyler(Styler):
     def style_title(self, text):
         # Originally bold + underline
         return text
-        #return colorama.Style.BOLD + text + colorama.Style.RESET_ALL
+        # return colorama.Style.BOLD + text + colorama.Style.RESET_ALL
 
     def style_header_column(self, text):
         # Originally underline
         return text
 
     def style_row_element(self, text):
-        return (colorama.Style.BRIGHT + colorama.Fore.BLUE +
-                text + colorama.Style.RESET_ALL)
+        return (
+            colorama.Style.BRIGHT
+            + colorama.Fore.BLUE
+            + text
+            + colorama.Style.RESET_ALL
+        )
 
     def style_indentation_char(self, text):
-        return (colorama.Style.DIM + colorama.Fore.YELLOW +
-                text + colorama.Style.RESET_ALL)
+        return (
+            colorama.Style.DIM
+            + colorama.Fore.YELLOW
+            + text
+            + colorama.Style.RESET_ALL
+        )
 
 
-class MultiTable(object):
-    def __init__(self, terminal_width=None, initial_section=True,
-                 column_separator='|', terminal=None,
-                 styler=None, auto_reformat=True):
+class MultiTable:
+    def __init__(
+        self,
+        terminal_width=None,
+        initial_section=True,
+        column_separator='|',
+        terminal=None,
+        styler=None,
+        auto_reformat=True,
+    ):
         self._auto_reformat = auto_reformat
         if initial_section:
             self._current_section = Section()
@@ -238,16 +266,22 @@ class MultiTable(object):
             return self._auto_reformat
 
     def _calculate_max_width(self):
-        max_width = max(s.total_width(padding=4, with_border=True,
-                                      outer_padding=s.indent_level)
-                        for s in self._sections)
+        max_width = max(
+            s.total_width(
+                padding=4, with_border=True, outer_padding=s.indent_level
+            )
+            for s in self._sections
+        )
         return max_width
 
     def _render_section(self, section, max_width, stream):
-        stream = IndentedStream(stream, section.indent_level,
-                                self._styler.style_indentation_char('|'),
-                                self._styler.style_indentation_char('|'))
-        max_width -= (section.indent_level * 2)
+        stream = IndentedStream(
+            stream,
+            section.indent_level,
+            self._styler.style_indentation_char('|'),
+            self._styler.style_indentation_char('|'),
+        )
+        max_width -= section.indent_level * 2
         self._render_title(section, max_width, stream)
         self._render_column_titles(section, max_width, stream)
         self._render_rows(section, max_width, stream)
@@ -258,8 +292,12 @@ class MultiTable(object):
         # bottom_border:  ----------------------------
         if section.title:
             title = self._styler.style_title(section.title)
-            stream.write(center_text(title, max_width, '|', '|',
-                                     get_text_length(section.title)) + '\n')
+            stream.write(
+                center_text(
+                    title, max_width, '|', '|', get_text_length(section.title)
+                )
+                + '\n'
+            )
             if not section.headers and not section.rows:
                 stream.write('+%s+' % ('-' * (max_width - 2)) + '\n')
 
@@ -268,8 +306,9 @@ class MultiTable(object):
             return
         # In order to render the column titles we need to know
         # the width of each of the columns.
-        widths = section.calculate_column_widths(padding=4,
-                                                 max_width=max_width)
+        widths = section.calculate_column_widths(
+            padding=4, max_width=max_width
+        )
         # TODO: Built a list instead of +=, it's more efficient.
         current = ''
         length_so_far = 0
@@ -283,9 +322,13 @@ class MultiTable(object):
                 first = False
             else:
                 left_edge = ''
-            current += center_text(text=stylized_header, length=width,
-                                   left_edge=left_edge, right_edge='|',
-                                   text_length=get_text_length(header))
+            current += center_text(
+                text=stylized_header,
+                length=width,
+                left_edge=left_edge,
+                right_edge='|',
+                text_length=get_text_length(header),
+            )
             length_so_far += width
         self._write_line_break(stream, widths)
         stream.write(current + '\n')
@@ -307,8 +350,9 @@ class MultiTable(object):
     def _render_rows(self, section, max_width, stream):
         if not section.rows:
             return
-        widths = section.calculate_column_widths(padding=4,
-                                                 max_width=max_width)
+        widths = section.calculate_column_widths(
+            padding=4, max_width=max_width
+        )
         if not widths:
             return
         self._write_line_break(stream, widths)
@@ -325,16 +369,19 @@ class MultiTable(object):
                 else:
                     left_edge = ''
                 stylized = self._styler.style_row_element(element)
-                current += align_left(text=stylized, length=width,
-                                      left_edge=left_edge,
-                                      right_edge=self._column_separator,
-                                      text_length=get_text_length(element))
+                current += align_left(
+                    text=stylized,
+                    length=width,
+                    left_edge=left_edge,
+                    right_edge=self._column_separator,
+                    text_length=get_text_length(element),
+                )
                 length_so_far += width
             stream.write(current + '\n')
         self._write_line_break(stream, widths)
 
 
-class Section(object):
+class Section:
     def __init__(self):
         self.title = ''
         self.headers = []
@@ -344,8 +391,10 @@ class Section(object):
         self._max_widths = []
 
     def __repr__(self):
-        return ("Section(title=%s, headers=%s, indent_level=%s, num_rows=%s)" %
-                (self.title, self.headers, self.indent_level, len(self.rows)))
+        return (
+            f"Section(title={self.title}, headers={self.headers}, "
+            f"indent_level={self.indent_level}, num_rows={len(self.rows)})"
+        )
 
     def calculate_column_widths(self, padding=0, max_width=None):
         # postcondition: sum(widths) == max_width
@@ -385,8 +434,13 @@ class Section(object):
         if with_border:
             total += border_padding
         total += outer_padding + outer_padding
-        return max(get_text_length(self.title) + border_padding + outer_padding +
-                   outer_padding, total)
+        return max(
+            get_text_length(self.title)
+            + border_padding
+            + outer_padding
+            + outer_padding,
+            total,
+        )
 
     def add_title(self, title):
         self.title = title
@@ -404,8 +458,10 @@ class Section(object):
         if self._num_cols is None:
             self._num_cols = len(row)
         if len(row) != self._num_cols:
-            raise ValueError("Row should have %s elements, instead "
-                             "it has %s" % (self._num_cols, len(row)))
+            raise ValueError(
+                f"Row should have {self._num_cols} elements, instead "
+                f"it has {len(row)}"
+            )
         row = self._format_row(row)
         self.rows.append(row)
         self._update_max_widths(row)
@@ -418,4 +474,6 @@ class Section(object):
             self._max_widths = [get_text_length(el) for el in row]
         else:
             for i, el in enumerate(row):
-                self._max_widths[i] = max(get_text_length(el), self._max_widths[i])
+                self._max_widths[i] = max(
+                    get_text_length(el), self._max_widths[i]
+                )

--- a/awscli/table.py
+++ b/awscli/table.py
@@ -1,17 +1,17 @@
 # Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+#
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
 # the License is located at
-
+#
 #     http://aws.amazon.com/apache2.0/
-
-import struct
-
+#
 # or in the "license" file accompanying this file. This file is
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
+import struct
 import sys
 import unicodedata
 
@@ -181,7 +181,6 @@ class ColorizedStyler(Styler):
     def style_title(self, text):
         # Originally bold + underline
         return text
-        # return colorama.Style.BOLD + text + colorama.Style.RESET_ALL
 
     def style_header_column(self, text):
         # Originally underline

--- a/awscli/text.py
+++ b/awscli/text.py
@@ -34,15 +34,18 @@ def _format_list(item, identifier, stream):
     if any(isinstance(el, dict) for el in item):
         all_keys = _all_scalar_keys(item)
         for element in item:
-            _format_text(element, stream=stream, identifier=identifier,
-                         scalar_keys=all_keys)
+            _format_text(
+                element,
+                stream=stream,
+                identifier=identifier,
+                scalar_keys=all_keys,
+            )
     elif any(isinstance(el, list) for el in item):
         scalar_elements, non_scalars = _partition_list(item)
         if scalar_elements:
             _format_scalar_list(scalar_elements, identifier, stream)
         for non_scalar in non_scalars:
-            _format_text(non_scalar, stream=stream,
-                         identifier=identifier)
+            _format_text(non_scalar, stream=stream, identifier=identifier)
     else:
         _format_scalar_list(item, identifier, stream)
 
@@ -61,8 +64,7 @@ def _partition_list(item):
 def _format_scalar_list(elements, identifier, stream):
     if identifier is not None:
         for item in elements:
-            stream.write('%s\t%s\n' % (identifier.upper(),
-                                       item))
+            stream.write(f'{identifier.upper()}\t{item}\n')
     else:
         # For a bare list, just print the contents.
         stream.write('\t'.join([str(item) for item in elements]))
@@ -77,8 +79,7 @@ def _format_dict(scalar_keys, item, identifier, stream):
         stream.write('\t'.join(scalars))
         stream.write('\n')
     for new_identifier, non_scalar in non_scalars:
-        _format_text(item=non_scalar, stream=stream,
-                     identifier=new_identifier)
+        _format_text(item=non_scalar, stream=stream, identifier=new_identifier)
 
 
 def _all_scalar_keys(list_of_dicts):

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -19,12 +19,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import os
 import json
+import os
+
 import docutils.core
 
 
-class TopicTagDB(object):
+class TopicTagDB:
     """This class acts like a database for the tags of all available topics.
 
     A tag is an element in a topic reStructured text file that contains
@@ -67,19 +68,25 @@ class TopicTagDB(object):
     that all tag values for a specific tag of a specific topic are unique.
     """
 
-    VALID_TAGS = ['category', 'description', 'title', 'related topic',
-                  'related command']
+    VALID_TAGS = [
+        'category',
+        'description',
+        'title',
+        'related topic',
+        'related command',
+    ]
 
     # The default directory to look for topics.
     TOPIC_DIR = os.path.join(
-        os.path.dirname(
-            os.path.abspath(__file__)), 'topics')
+        os.path.dirname(os.path.abspath(__file__)), 'topics'
+    )
 
     # The default JSON index to load.
     JSON_INDEX = os.path.join(TOPIC_DIR, 'topic-tags.json')
 
-    def __init__(self, tag_dictionary=None, index_file=JSON_INDEX,
-                 topic_dir=TOPIC_DIR):
+    def __init__(
+        self, tag_dictionary=None, index_file=JSON_INDEX, topic_dir=TOPIC_DIR
+    ):
         """
         :param index_file: The path to a specific JSON index to load.
             If nothing is specified it will default to the default JSON
@@ -121,7 +128,7 @@ class TopicTagDB(object):
 
     def load_json_index(self):
         """Loads a JSON file into the tag dictionary."""
-        with open(self.index_file, 'r') as f:
+        with open(self.index_file) as f:
             self._tag_dictionary = json.load(f)
 
     def save_to_json_index(self):
@@ -156,7 +163,7 @@ class TopicTagDB(object):
         :param topic_files: A list of paths to topics to scan into memory.
         """
         for topic_file in topic_files:
-            with open(topic_file, 'r') as f:
+            with open(topic_file) as f:
                 # Parse out the name of the topic
                 topic_name = self._find_topic_name(topic_file)
                 # Add the topic to the dictionary if it does not exist
@@ -164,7 +171,8 @@ class TopicTagDB(object):
                 topic_content = f.read()
                 # Record the tags and the values
                 self._add_tag_and_values_from_content(
-                    topic_name, topic_content)
+                    topic_name, topic_content
+                )
 
     def _find_topic_name(self, topic_src_file):
         # Get the name of each of these files
@@ -259,9 +267,9 @@ class TopicTagDB(object):
                     # no value constraints are provided or if the tag value
                     # falls in the allowed tag values.
                     if values is None or tag_value in values:
-                        self._add_key_values(query_dict,
-                                             key=tag_value,
-                                             values=[topic_name])
+                        self._add_key_values(
+                            query_dict, key=tag_value, values=[topic_name]
+                        )
         return query_dict
 
     def get_tag_value(self, topic_name, tag, default_value=None):

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -10,16 +10,18 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import csv
-import signal
-import datetime
 import contextlib
+import csv
+import datetime
 import os
-import sys
+import signal
 import subprocess
+import sys
 
 from awscli.compat import (
-    BytesIO, StringIO, get_binary_stdout, get_popen_kwargs_for_pager_cmd
+    StringIO,
+    get_binary_stdout,
+    get_popen_kwargs_for_pager_cmd,
 )
 
 
@@ -50,16 +52,19 @@ def _split_with_quotes(value):
         # Find an opening list bracket
         list_start = part.find('=[')
 
-        if list_start >= 0 and value.find(']') != -1 and \
-           (quote_char is None or part.find(quote_char) > list_start):
+        if (
+            list_start >= 0
+            and value.find(']') != -1
+            and (quote_char is None or part.find(quote_char) > list_start)
+        ):
             # This is a list, eat all the items until the end
             if ']' in part:
                 # Short circuit for only one item
                 new_chunk = part
             else:
                 new_chunk = _eat_items(value, iter_parts, part, ']')
-            list_items = _split_with_quotes(new_chunk[list_start + 2:-1])
-            new_chunk = new_chunk[:list_start + 1] + ','.join(list_items)
+            list_items = _split_with_quotes(new_chunk[list_start + 2 : -1])
+            new_chunk = new_chunk[: list_start + 1] + ','.join(list_items)
             new_parts.append(new_chunk)
             continue
         elif quote_char is None:
@@ -155,8 +160,11 @@ def is_document_type_container(shape):
 
 def is_streaming_blob_type(shape):
     """Check if the shape is a streaming blob type."""
-    return (shape and shape.type_name == 'blob' and
-            shape.serialization.get('streaming', False))
+    return (
+        shape
+        and shape.type_name == 'blob'
+        and shape.serialization.get('streaming', False)
+    )
 
 
 def is_tagged_union_type(shape):
@@ -194,18 +202,17 @@ def ignore_ctrl_c():
 
 
 def emit_top_level_args_parsed_event(session, args):
-    session.emit(
-        'top-level-args-parsed', parsed_args=args, session=session)
+    session.emit('top-level-args-parsed', parsed_args=args, session=session)
 
 
 def is_a_tty():
     try:
         return os.isatty(sys.stdout.fileno())
-    except Exception as e:
+    except Exception:
         return False
 
 
-class OutputStreamFactory(object):
+class OutputStreamFactory:
     def __init__(self, popen=None):
         self._popen = popen
         if popen is None:
@@ -217,7 +224,7 @@ class OutputStreamFactory(object):
         try:
             process = self._popen(**popen_kwargs)
             yield process.stdin
-        except IOError:
+        except OSError:
             # Ignore IOError since this can commonly be raised when a pager
             # is closed abruptly and causes a broken pipe.
             pass
@@ -240,7 +247,7 @@ def write_exception(ex, outfile):
     outfile.write("\n")
 
 
-class ShapeWalker(object):
+class ShapeWalker:
     def walk(self, shape, visitor):
         """Walk through and visit shapes for introspection
 
@@ -285,14 +292,16 @@ class ShapeWalker(object):
         visitor.visit_shape(shape)
 
 
-class BaseShapeVisitor(object):
+class BaseShapeVisitor:
     """Visit shape encountered by ShapeWalker"""
+
     def visit_shape(self, shape):
         pass
 
 
 class ShapeRecordingVisitor(BaseShapeVisitor):
     """Record shapes visited by ShapeWalker"""
+
     def __init__(self):
         self.visited = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,70 @@ markers = [
     "slow: marks tests as slow",
     "validates_models: marks tests as one which validates service models",
 ]
+
+[tool.isort]
+profile = "black"
+line_length = 79
+honor_noqa = true
+src_paths = ["awscli", "tests"]
+
+[tool.ruff]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+# Format same as Black.
+line-length = 79
+indent-width = 4
+
+target-version = "py38"
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F", "UP"]
+ignore = []
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings, spaces for indents
+# and trailing commas.
+quote-style = "preserve"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+docstring-code-format = false
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
This PR is the one in a series of steps to move the AWS CLI codebase onto a standard set of formatting (`ruff`) between all related tools (boto3, botocore, s3transer, awscli and awscli v2). This PR builds on the recent changes to remove six from the codebase and starts by adding our intended ruff configurations and running them over all files matching `awscli/*.py`. This does not include customizations, tests, or our scripts.

The plan currently is to have 3-4 smaller PRs to break up the cognitive overhead for reviewers. We'll tackle the primary files in this PR, then customizations and scripts. Once we're confident the existing test suite is still working with all CLI code changed, we'll migrate the test suite as well. The last piece will be to turn on our linting GHA (boto3 example) and have this standardized across all future PRs.