### PR TITLE
CLI examples HealthImaging, update to CopyImageSet and UpdateImageSetMetadata

### DIFF
--- a/awscli/examples/medical-imaging/copy-image-set.rst
+++ b/awscli/examples/medical-imaging/copy-image-set.rst
@@ -1,13 +1,11 @@
 **Example 1: To copy an image set without a destination.**
 
-The following ``copy-image-set`` code example makes a duplicate copy of an image set without a destination. ::
+The following ``copy-image-set`` example makes a duplicate copy of an image set without a destination. ::
 
     aws medical-imaging copy-image-set \
         --datastore-id 12345678901234567890123456789012 \
         --source-image-set-id ea92b0d8838c72a3f25d00d13616f87e \
         --copy-image-set-information '{"sourceImageSet": {"latestVersionId": "1" } }'
-
-
 
 Output::
 
@@ -33,15 +31,12 @@ Output::
 
 **Example 2: To copy an image set with a destination.**
 
-The following ``copy-image-set`` code example makes a duplicate copy of an image set with a destination. ::
+The following ``copy-image-set`` example makes a duplicate copy of an image set with a destination. ::
 
     aws medical-imaging copy-image-set \
         --datastore-id 12345678901234567890123456789012 \
         --source-image-set-id ea92b0d8838c72a3f25d00d13616f87e \
         --copy-image-set-information '{"sourceImageSet": {"latestVersionId": "1" }, "destinationImageSet": { "imageSetId": "b9a06fef182a5f992842f77f8e0868e5", "latestVersionId": "1"} }'
-
-
-
 
 Output::
 
@@ -51,6 +46,39 @@ Output::
             "imageSetWorkflowStatus": "COPYING",
             "updatedAt": 1680042505.135,
             "imageSetId": "b9a06fef182a5f992842f77f8e0868e5",
+            "imageSetState": "LOCKED",
+            "createdAt": 1680042357.432
+        },
+        "sourceImageSetProperties": {
+            "latestVersionId": "1",
+            "imageSetWorkflowStatus": "COPYING_WITH_READ_ONLY_ACCESS",
+            "updatedAt": 1680042505.135,
+            "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",
+            "imageSetState": "LOCKED",
+            "createdAt": 1680027126.436
+        },
+        "datastoreId": "12345678901234567890123456789012"
+    }
+
+**Example 3: To copy a subset of instances from a source image set to a destination image set.**
+
+The following ``copy-image-set`` example copies one DICOM instance from the source image set to the destination image set.
+The force parameter is provided to override inconsistencies in the Patient, Study, and Series level attributes. ::
+
+    aws medical-imaging copy-image-set \
+        --datastore-id 12345678901234567890123456789012 \
+        --source-image-set-id ea92b0d8838c72a3f25d00d13616f87e \
+        --copy-image-set-information '{"sourceImageSet": {"latestVersionId": "1","DICOMCopies": {"copiableAttributes": "{\"SchemaVersion\":\"1.1\",\"Study\":{\"Series\":{\"1.3.6.1.4.1.5962.99.1.3673257865.2104868982.1369432891697.3666.0\":{\"Instances\":{\"1.3.6.1.4.1.5962.99.1.3673257865.2104868982.1369432891697.3669.0\":{}}}}}}"}},"destinationImageSet": {"imageSetId": "b9eb50d8ee682eb9fcf4acbf92f62bb7","latestVersionId": "1"}}' \
+        --force
+
+Output::
+
+    {
+        "destinationImageSetProperties": {
+            "latestVersionId": "2",
+            "imageSetWorkflowStatus": "COPYING",
+            "updatedAt": 1680042505.135,
+            "imageSetId": "b9eb50d8ee682eb9fcf4acbf92f62bb7",
             "imageSetState": "LOCKED",
             "createdAt": 1680042357.432
         },

--- a/awscli/examples/medical-imaging/update-image-set-metadata.rst
+++ b/awscli/examples/medical-imaging/update-image-set-metadata.rst
@@ -1,24 +1,21 @@
-**To insert or update an attribute in image set metadata**
+**Example 1: To insert or update an attribute in image set metadata**
 
-The following ``update-image-set-metadata`` code example inserts or updates an attribute in image set metadata. ::
+The following ``update-image-set-metadata`` example inserts or updates an attribute in image set metadata. ::
 
     aws medical-imaging update-image-set-metadata \
         --datastore-id 12345678901234567890123456789012 \
         --image-set-id ea92b0d8838c72a3f25d00d13616f87e \
         --latest-version-id 1 \
+        --cli-binary-format raw-in-base64-out \
         --update-image-set-metadata-updates file://metadata-updates.json
 
 Contents of ``metadata-updates.json`` ::
 
     {
         "DICOMUpdates": {
-            "updatableAttributes": "eyJTY2hlbWFWZXJzaW9uIjoxLjEsIlBhdGllbnQiOnsiRElDT00iOnsiUGF0aWVudE5hbWUiOiJNWF5NWCJ9fX0="
+            "updatableAttributes": "{\"SchemaVersion\":1.1,\"Patient\":{\"DICOM\":{\"PatientName\":\"MX^MX\"}}}"
         }
     }
-
-Note: ``updatableAttributes`` is a Base64 encoded JSON string. Here is the unencoded JSON string.
-
-{"SchemaVersion":1.1,"Patient":{"DICOM":{"PatientName":"MX^MX"}}}
 
 Output::
 
@@ -32,27 +29,24 @@ Output::
         "datastoreId": "12345678901234567890123456789012"
     }
 
-**To remove an attribute from image set metadata**
+**Example 2: To remove an attribute from image set metadata**
 
-The following ``update-image-set-metadata`` code example removes an attribute from image set metadata. ::
+The following ``update-image-set-metadata`` example removes an attribute from image set metadata. ::
 
     aws medical-imaging update-image-set-metadata \
         --datastore-id 12345678901234567890123456789012 \
         --image-set-id ea92b0d8838c72a3f25d00d13616f87e \
         --latest-version-id 1 \
+        --cli-binary-format raw-in-base64-out \
         --update-image-set-metadata-updates file://metadata-updates.json
 
 Contents of ``metadata-updates.json`` ::
 
     {
         "DICOMUpdates": {
-            "removableAttributes": "e1NjaGVtYVZlcnNpb246MS4xLFN0dWR5OntESUNPTTp7U3R1ZHlEZXNjcmlwdGlvbjpDSEVTVH19fQo="
+            "removableAttributes": "{\"SchemaVersion\":1.1,\"Study\":{\"DICOM\":{\"StudyDescription\":\"CHEST\"}}}"
         }
     }
-
-Note: ``removableAttributes`` is a Base64 encoded JSON string. Here is the unencoded JSON string. The key and value must match the attribute to be removed.
-
-{"SchemaVersion":1.1,"Study":{"DICOM":{"StudyDescription":"CHEST"}}}
 
 Output::
 
@@ -66,27 +60,24 @@ Output::
         "datastoreId": "12345678901234567890123456789012"
     }
 
-**To remove an instance from image set metadata**
+**Example 3: To remove an instance from image set metadata**
 
-The following ``update-image-set-metadata`` code example removes an instance from image set metadata. ::
+The following ``update-image-set-metadata`` example removes an instance from image set metadata. ::
 
     aws medical-imaging update-image-set-metadata \
         --datastore-id 12345678901234567890123456789012 \
         --image-set-id ea92b0d8838c72a3f25d00d13616f87e \
         --latest-version-id 1 \
+        --cli-binary-format raw-in-base64-out \
         --update-image-set-metadata-updates file://metadata-updates.json
 
 Contents of ``metadata-updates.json`` ::
 
     {
         "DICOMUpdates": {
-            "removableAttributes": "eezEuMS4xLjEuMS4xLjEyMzQ1LjEyMzQ1Njc4OTAxMi4xMjMuMTIzNDU2Nzg5MDEyMzQuMTp7SW5zdGFuY2VzOnsxLjEuMS4xLjEuMS4xMjM0NS4xMjM0NTY3ODkwMTIuMTIzLjEyMzQ1Njc4OTAxMjM0LjE6e319fX19fQo="
+            "removableAttributes": "{\"SchemaVersion\": 1.1,\"Study\": {\"Series\": {\"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1\": {\"Instances\": {\"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1\": {}}}}}}"
         }
     }
-
-Note: ``removableAttributes`` is a Base64 encoded JSON string. Here is the unencoded JSON string.
-
-{"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1":{"Instances":{"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1":{}}}}}}
 
 Output::
 
@@ -95,6 +86,127 @@ Output::
         "imageSetWorkflowStatus": "UPDATING",
         "updatedAt": 1680042257.908,
         "imageSetId": "ea92b0d8838c72a3f25d00d13616f87e",
+        "imageSetState": "LOCKED",
+        "createdAt": 1680027126.436,
+        "datastoreId": "12345678901234567890123456789012"
+    }
+
+
+**Example 4: To revert an image set to a previous version**
+
+The following ``update-image-set-metadata`` example shows how to revert an image set to a prior version. CopyImageSet and UpdateImageSetMetadata actions create new versions of image sets. ::
+
+    aws medical-imaging update-image-set-metadata \
+        --datastore-id 12345678901234567890123456789012 \
+        --image-set-id 53d5fdb05ca4d46ac7ca64b06545c66e \
+        --latest-version-id 3 \
+        --cli-binary-format raw-in-base64-out \
+        --update-image-set-metadata-updates '{"revertToVersionId": "1"}'
+
+Output::
+
+    {
+        "datastoreId": "12345678901234567890123456789012",
+        "imageSetId": "53d5fdb05ca4d46ac7ca64b06545c66e",
+        "latestVersionId": "4",
+        "imageSetState": "LOCKED",
+        "imageSetWorkflowStatus": "UPDATING",
+        "createdAt": 1680027126.436,
+        "updatedAt": 1680042257.908
+    }
+
+**Example 5: To add a private DICOM data element to an instance**
+
+The following ``update-image-set-metadata`` example shows how to add a private element to a specified instance within an image set. The DICOM standard permits private data elements for communication of information that cannot be contained in standard data elements. You can create, update, and delete private data elements with the
+UpdateImageSetMetadata action. ::
+
+    aws medical-imaging update-image-set-metadata \
+        --datastore-id 12345678901234567890123456789012 \
+        --image-set-id 53d5fdb05ca4d46ac7ca64b06545c66e \
+        --latest-version-id 1 \
+        --cli-binary-format raw-in-base64-out \
+        --force \
+        --update-image-set-metadata-updates file://metadata-updates.json
+
+Contents of ``metadata-updates.json`` ::
+
+    {
+        "DICOMUpdates": {
+            "updatableAttributes": "{\"SchemaVersion\": 1.1,\"Study\": {\"Series\": {\"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1\": {\"Instances\": {\"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1\": {\"DICOM\": {\"001910F9\": \"97\"},\"DICOMVRs\": {\"001910F9\": \"DS\"}}}}}}}"
+        }
+    }
+
+Output::
+
+    {
+        "latestVersionId": "2",
+        "imageSetWorkflowStatus": "UPDATING",
+        "updatedAt": 1680042257.908,
+        "imageSetId": "53d5fdb05ca4d46ac7ca64b06545c66e",
+        "imageSetState": "LOCKED",
+        "createdAt": 1680027126.436,
+        "datastoreId": "12345678901234567890123456789012"
+    }
+
+**Example 6: To update a private DICOM data element to an instance**
+
+The following ``update-image-set-metadata`` example shows how to update the value of a private data element belonging to an instance within an image set. ::
+
+    aws medical-imaging update-image-set-metadata \
+        --datastore-id 12345678901234567890123456789012 \
+        --image-set-id 53d5fdb05ca4d46ac7ca64b06545c66e \
+        --latest-version-id 1 \
+        --cli-binary-format raw-in-base64-out \
+        --force \
+        --update-image-set-metadata-updates file://metadata-updates.json
+
+Contents of ``metadata-updates.json`` ::
+
+    {
+        "DICOMUpdates": {
+            "updatableAttributes": "{\"SchemaVersion\": 1.1,\"Study\": {\"Series\": {\"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1\": {\"Instances\": {\"1.1.1.1.1.1.12345.123456789012.123.12345678901234.1\": {\"DICOM\": {\"00091001\": \"GE_GENESIS_DD\"}}}}}}}"
+        }
+    }
+
+Output::
+
+    {
+        "latestVersionId": "2",
+        "imageSetWorkflowStatus": "UPDATING",
+        "updatedAt": 1680042257.908,
+        "imageSetId": "53d5fdb05ca4d46ac7ca64b06545c66e",
+        "imageSetState": "LOCKED",
+        "createdAt": 1680027126.436,
+        "datastoreId": "12345678901234567890123456789012"
+    }
+
+**Example 7: To update a SOPInstanceUID with the force parameter**
+
+The following ``update-image-set-metadata`` example shows how to update a SOPInstanceUID, using the force parameter to override the DICOM metadata constraints. ::
+
+    aws medical-imaging update-image-set-metadata \
+            --datastore-id 12345678901234567890123456789012 \
+            --image-set-id 53d5fdb05ca4d46ac7ca64b06545c66e \
+            --latest-version-id 1 \
+            --cli-binary-format raw-in-base64-out \
+            --force \
+            --update-image-set-metadata-updates file://metadata-updates.json
+
+Contents of ``metadata-updates.json`` ::
+
+    {
+        "DICOMUpdates": {
+            "updatableAttributes": "{\"SchemaVersion\":1.1,\"Study\":{\"Series\":{\"1.3.6.1.4.1.5962.99.1.3633258862.2104868982.1369432891697.3656.0\":{\"Instances\":{\"1.3.6.1.4.1.5962.99.1.3633258862.2104868982.1369432891697.3659.0\":{\"DICOM\":{\"SOPInstanceUID\":\"1.3.6.1.4.1.5962.99.1.3633258862.2104868982.1369432891697.3659.9\"}}}}}}}"
+        }
+    }
+
+Output::
+
+    {
+        "latestVersionId": "2",
+        "imageSetWorkflowStatus": "UPDATING",
+        "updatedAt": 1680042257.908,
+        "imageSetId": "53d5fdb05ca4d46ac7ca64b06545c66e",
         "imageSetState": "LOCKED",
         "createdAt": 1680027126.436,
         "datastoreId": "12345678901234567890123456789012"


### PR DESCRIPTION
Added examples documenting new features to HealthImaging.
CopyImageSet - force and instance subset options 
UpdateImageSetMetadata - force, revert and other update options.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
