### PR TITLE
add --version-id option to s3 presign

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -690,7 +690,13 @@ class PresignCommand(S3Command):
                   'cli_type_name': 'integer',
                   'help_text': (
                       'Number of seconds until the pre-signed '
-                      'URL expires.  Default is 3600 seconds.')}]
+                      'URL expires.  Default is 3600 seconds.')},
+                 {'name': 'version-id', 'default': None,
+                  'cli_type_name': 'string',
+                  'help_text': (
+                      'Version id for the object that the pre-signed '
+                      'URL will reference. If not set, the URL will '
+                      'reference the latest version of the object.')}]
 
     def _run_main(self, parsed_args, parsed_globals):
         super(PresignCommand, self)._run_main(parsed_args, parsed_globals)
@@ -698,9 +704,16 @@ class PresignCommand(S3Command):
         if path.startswith('s3://'):
             path = path[5:]
         bucket, key = find_bucket_key(path)
+
+        params = {'Bucket': bucket, 'Key': key}
+
+        version_id = parsed_args.version_id
+        if version_id is not None:
+            params['VersionId'] = version_id
+
         url = self.client.generate_presigned_url(
             'get_object',
-            {'Bucket': bucket, 'Key': key},
+            Params=params,
             ExpiresIn=parsed_args.expires_in
         )
         uni_print(url)

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -152,6 +152,24 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
         }
         self.assert_presigned_url_matches(stdout, expected)
 
+    def test_handles_version_id(self):
+        version_id = 'some_version'
+        stdout = self.get_presigned_url_for_cmd(
+            self.prefix + 's3://bucket/key --version-id %s' % version_id)
+
+        self.assert_presigned_url_matches(
+            stdout, {
+                'hostname': 'bucket.s3.amazonaws.com',
+                'path': '/key',
+                'query_params': {
+                    'AWSAccessKeyId': 'access_key',
+                    'Expires': str(FROZEN_TIMESTAMP + DEFAULT_EXPIRES),
+                    'Signature': 'G8%2BT1QlGztwA6Un8AavaXRaYBsE%3D',
+                    'versionId': version_id
+                }
+            }
+        )
+
     def test_s3_prefix_not_needed(self):
         # Consistent with the 'ls' command.
         stdout = self.get_presigned_url_for_cmd(


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Adds a `--version-id` option to `s3 presign` in order to generate a presigned url for a particular object version.

The parameter name aligns with `s3api get-object`:

```
          [--version-id <value>]

       --version-id (string)
          VersionId used to reference a specific version of the object.
```

.NET SDK Example: [GetPreSignedUrlRequest.VersionId](https://docs.aws.amazon.com/sdkfornet1/latest/apidocs/html/P_Amazon_S3_Model_GetPreSignedUrlRequest_VersionId.htm)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
