### PR TITLE
[v2] Update RSA private key size to 2048 in CloudTrail unit test

### DIFF
--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -362,7 +362,7 @@ class TestSha256RSADigestValidator(unittest.TestCase):
         self._digest_data['_signature'] = 'aeff'
 
     def test_validates_digests(self):
-        private_key = rsa.generate_private_key(65537, 512, default_backend())
+        private_key = rsa.generate_private_key(65537, 2048, default_backend())
         sha256_hash = hashlib.sha256(self._inflated_digest)
         string_to_sign = "%s\n%s/%s\n%s\n%s" % (
             self._digest_data['digestEndTime'],


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-cli/pull/8895

*Description of changes:*

This is required to unblock updating our `cryptography` pin as a unit test for a CloudTrail customization is failing:

https://github.com/aws/aws-cli/pull/8895

This test was ported 5 years ago as is using a key size of 512:

https://github.com/aws/aws-cli/pull/4846

As of `cryptography==43.0.0` the minimum key size allowed is 1024:

https://github.com/pyca/cryptography/commit/83dcbc190165ad5c1f86bddaee76e0b288803c43

This change bumps it up to a more modern value of 2048. This has only a couple hundredths of a second time difference to generate as tested on my Mac.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
