### PR TITLE
Add explicit --include-sdist parameter to update lockfiles workflow command

### DIFF
--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -54,12 +54,12 @@ jobs:
       - name: Regenerate windows files
         if: runner.os == 'Windows'
         run: |
-          python scripts/regenerate-lock-files --show-files
+          python scripts/regenerate-lock-files --show-files --include-sdist
           echo "CHANGES=$(git status --porcelain=v1)" >> $env:GITHUB_ENV
       - name: Regenerate lock files
         if: runner.os != 'Windows'
         run: |
-          python scripts/regenerate-lock-files --show-files
+          python scripts/regenerate-lock-files --show-files --include-sdist
           echo "CHANGES<<EOF" >> $GITHUB_ENV
           echo "CHANGES=$(git status --porcelain=v1)" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV


### PR DESCRIPTION
*Issue #, if available:*

#8901 (related PR that updated these files recently)

*Description of changes:*

The `include_sdist` parameter has a default of `True`, but this is not clear in the workflow.

https://github.com/aws/aws-cli/blob/2aaa023ce6720e1e90ba4f8eb6a77c3e833af356/scripts/regenerate-lock-files#L211

Adding an explicit parameter helps clarify the intention of running this workflow to regenerate lockfiles for the source distribution:

- `requirements/download-deps/bootstrap-lock.txt`
- `requirements/download-deps/bootstrap-win-lock.txt`
- `requirements/download-deps/portable-exe-lock.txt`
- `requirements/download-deps/portable-exe-win-lock.txt`
- `requirements/download-deps/system-sandbox-lock.txt`
- `requirements/download-deps/system-sandbox-win-lock.txt`

It does not update these "base" lockfiles:

- `requirements-dev-lock.txt`
- `requirements-test-lock.txt`
- `requirements-base-lock.txt`
- `requirements-build-lock.txt`
- `requirements-docs-lock.txt`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
