### PR TITLE
Add openssh-clients to amazon/aws-cli image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN yum update -y \
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y \
-  && yum install -y less groff \
+  && yum install -y less groff openssh-clients \
   && yum clean all
 COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=installer /aws-cli-bin/ /usr/local/bin/


### PR DESCRIPTION
*Issue #, if available:*

Closes https://github.com/aws/aws-cli/issues/8921

*Description of changes:*

```
aws ec2-connect-instance ssh
```

doesn't work without this package.