### PR TITLE
Fix regex strings in Python 3.12

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -418,9 +418,9 @@ except ImportError:
                 id = l[1]
         return '', version, id
 
-    _distributor_id_file_re = re.compile("(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
-    _release_file_re = re.compile("(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
-    _codename_file_re = re.compile("(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
+    _distributor_id_file_re = re.compile(r"(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
+    _release_file_re = re.compile(r"(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
+    _codename_file_re = re.compile(r"(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
 
     def linux_distribution(
         distname='',

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -73,16 +73,24 @@ def assert_cloudtrail_arn_is_valid(trail_arn):
     """Ensures that the arn looks correct.
 
     ARNs look like: arn:aws:cloudtrail:us-east-1:123456789012:trail/foo"""
-    pattern = re.compile('arn:.+:cloudtrail:.+:\d{12}:trail/.+')
+    pattern = re.compile(r'arn:.+:cloudtrail:.+:\d{12}:trail/.+')
     if not pattern.match(trail_arn):
         raise ValueError('Invalid trail ARN provided: %s' % trail_arn)
 
 
-def create_digest_traverser(cloudtrail_client, organization_client,
-                            s3_client_provider, trail_arn,
-                            trail_source_region=None, on_invalid=None,
-                            on_gap=None, on_missing=None, bucket=None,
-                            prefix=None, account_id=None):
+def create_digest_traverser(
+    cloudtrail_client,
+    organization_client,
+    s3_client_provider,
+    trail_arn,
+    trail_source_region=None,
+    on_invalid=None,
+    on_gap=None,
+    on_missing=None,
+    bucket=None,
+    prefix=None,
+    account_id=None,
+):
     """Creates a CloudTrail DigestTraverser and its object graph.
 
     :type cloudtrail_client: botocore.client.CloudTrail
@@ -244,9 +252,16 @@ class DigestProvider(object):
     dict. This class is not responsible for validation or iterating from
     one digest to the next.
     """
-    def __init__(self, s3_client_provider, account_id, trail_name,
-                 trail_home_region, trail_source_region=None,
-                 organization_id=None):
+
+    def __init__(
+        self,
+        s3_client_provider,
+        account_id,
+        trail_name,
+        trail_home_region,
+        trail_source_region=None,
+        organization_id=None,
+    ):
         self._client_provider = s3_client_provider
         self.trail_name = trail_name
         self.account_id = account_id

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -61,8 +61,8 @@ class Push(BasicCommand):
                 'revision to be uploaded to Amazon S3. You must specify both '
                 'a bucket and a key that represent the Amazon S3 bucket name '
                 'and the object key name. Content will be zipped before '
-                'uploading. Use the format s3://\<bucket\>/\<key\>'
-            )
+                'uploading. Use the format s3://<bucket>/<key>'
+            ),
         },
         {
             'name': 'ignore-hidden-files',

--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -199,9 +199,11 @@ class CreateCluster(Command):
                     raise ValueError('aws: error: invalid json argument for '
                                      'option --configurations')
 
-        if (parsed_args.release_label is None and
-                parsed_args.ami_version is not None):
-            is_valid_ami_version = re.match('\d?\..*', parsed_args.ami_version)
+        if (
+            parsed_args.release_label is None
+            and parsed_args.ami_version is not None
+        ):
+            is_valid_ami_version = re.match(r'\d?\..*', parsed_args.ami_version)
             if is_valid_ami_version is None:
                 raise exceptions.InvalidAmiVersionError(
                     ami_version=parsed_args.ami_version)

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -126,9 +126,9 @@ class ShorthandParser:
 
     _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
     _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
-    _START_WORD = '\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
-    _FIRST_FOLLOW_CHARS = '\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
-    _SECOND_FOLLOW_CHARS = '\s\!\#-&\(-\+\--\<\>-\uffff'
+    _START_WORD = r'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
+    _FIRST_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
+    _SECOND_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\<\>-\uffff'
     _ESCAPED_COMMA = '(\\\\,)'
     _FIRST_VALUE = _NamedRegex(
         'first',


### PR DESCRIPTION
This PR fixes misformatted regex strings in the CLI v1. These became DeprecationWarnings in Python 3.6 but were missed until they were converted to SyntaxWarnings in 3.12. This PR should prevent those warnings from being raised when the CLI v1 is run on Python 3.12.