### PR TITLE
Handle missing DEFAULT_CIPHERS from urllib3 2.x

### DIFF
--- a/awscli/botocore/httpsession.py
+++ b/awscli/botocore/httpsession.py
@@ -19,7 +19,6 @@ from urllib3.exceptions import ReadTimeoutError as URLLib3ReadTimeoutError
 from urllib3.exceptions import SSLError as URLLib3SSLError
 from urllib3.util.retry import Retry
 from urllib3.util.ssl_ import (
-    DEFAULT_CIPHERS,
     OP_NO_COMPRESSION,
     PROTOCOL_TLS,
     OP_NO_SSLv2,
@@ -41,6 +40,14 @@ try:
     from urllib3.contrib.pyopenssl import orig_util_SSLContext as SSLContext
 except ImportError:
     from urllib3.util.ssl_ import SSLContext
+
+try:
+    from urllib3.util.ssl_ import DEFAULT_CIPHERS
+except ImportError:
+    # Defer to system configuration starting with
+    # urllib3 2.0. This will choose the ciphers provided by
+    # Openssl 1.1.1+ or secure system defaults.
+    DEFAULT_CIPHERS = None
 
 import botocore.awsrequest
 from botocore.compat import (
@@ -99,7 +106,10 @@ def create_urllib3_context(
 
     context = SSLContext(ssl_version)
 
-    context.set_ciphers(ciphers or DEFAULT_CIPHERS)
+    if ciphers:
+        context.set_ciphers(ciphers)
+    elif DEFAULT_CIPHERS:
+        context.set_ciphers(DEFAULT_CIPHERS)
 
     # Setting the default here, as we may have no ssl module on import
     cert_reqs = ssl.CERT_REQUIRED if cert_reqs is None else cert_reqs


### PR DESCRIPTION
This PR ports https://github.com/boto/botocore/pull/2922 and https://github.com/boto/botocore/pull/2924 from Botocore to the AWS CLI v2 to maintain consistency. Note that the AWS CLI v2 still _does not_ support urllib3 2.x at this time. Change in support can be tracked in the [`pyproject.toml`](https://github.com/aws/aws-cli/blob/ac98e5e7526627c069dd34c10a77324dc86a4169/pyproject.toml#L47) for the project.  