### PR TITLE
[v2] s3: Handle unlinked current working directory

### DIFF
--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -364,6 +364,11 @@ def relative_path(filename, start=os.path.curdir):
     except ValueError:
         return os.path.abspath(filename)
 
+    except OSError as e:
+        if e.errno != errno.ENOENT:
+            raise e
+        return os.path.abspath(filename)
+
 
 def set_file_utime(filename, desired_time):
     """


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws/aws-cli/issues/7143

*Description of changes:*

The `relative_path` function can also fail on Unix-like systems if the current working directory has been unlinked.

Add this except block next to already existing one for Windows systems where different drives might be in use.

Proof of Concept:
1. Get yourself into an unlinked current working directory
```
MYDIR=$(mktemp -d)
cd $MYDIR
rmdir $MYDIR
```
2. Try to copy a file with absolute path to an s3 bucket
```
aws s3 cp /bin/ls s3://bucket
```

You can see the following output:
```
fatal error: [Errno 2] No such file or directory
```

If you analyze the `aws` call with `strace`, you can see that actually `getcwd` fails and that the error message is not about `/bin/ls` at all:
```
[pid 56266] getcwd(0x558ff0681790, 1024) = -1 ENOENT (No such file or directory)
```

With this patch applied, `aws` continues operation and just prints the absolute path instead of relative one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
