### PR TITLE
[v2] S3Transfer handle checksums on copy

### DIFF
--- a/.changes/next-release/bugfix-copy-71252.json
+++ b/.changes/next-release/bugfix-copy-71252.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "copy",
+  "description": "Added support for ``ChecksumAlgorithm`` when uploading copy data in parts."
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Ported over https://github.com/boto/s3transfer/pull/242/files to handle checksums on copy to our vendored S3Transfer.

*Descriptions of tests:*
- Tested changes using the new unit/functional tests.
- Tested the changes manually using aws s3 cp command via the `s3-high-level-checksums` branch (as of writing).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
