### PR TITLE
Fix malformed JSON in Athena Query Results example

### DIFF
--- a/awscli/examples/athena/get-query-results.rst
+++ b/awscli/examples/athena/get-query-results.rst
@@ -242,8 +242,6 @@ Output::
                         "Label": "location",
                         "Type": "varchar",
                         "Precision": 2147483647,
-                    "Data": [
-    
                         "Scale": 0,
                         "Nullable": "UNKNOWN",
                         "CaseSensitive": true


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
The goal of this PR is to fix an issue in the example output of the [Athena Get Query Results API](https://docs.aws.amazon.com/cli/latest/reference/athena/get-query-results.html#examples).  Currently, there appears to be a malformed piece of JSON in the body, resulting in failure to parse the example response.

