### PR TITLE
S3 high level checksums

### DIFF
--- a/.changes/next-release/feature-s3-95496.json
+++ b/.changes/next-release/feature-s3-95496.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "s3",
+  "description": "Adds ``--checksum-mode`` and ``--checksum-algorithm`` parameters to high-level ``s3`` commands."
+}

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -474,12 +474,14 @@ class RequestParamsMapper(object):
         cls._set_sse_request_params(request_params, cli_params)
         cls._set_sse_c_request_params(request_params, cli_params)
         cls._set_request_payer_param(request_params, cli_params)
+        cls._set_checksum_algorithm_param(request_params, cli_params)
 
     @classmethod
     def map_get_object_params(cls, request_params, cli_params):
         """Map CLI params to GetObject request params"""
         cls._set_sse_c_request_params(request_params, cli_params)
         cls._set_request_payer_param(request_params, cli_params)
+        cls._set_checksum_mode_param(request_params, cli_params)
 
     @classmethod
     def map_copy_object_params(cls, request_params, cli_params):
@@ -492,6 +494,7 @@ class RequestParamsMapper(object):
         cls._set_sse_c_and_copy_source_request_params(
             request_params, cli_params)
         cls._set_request_payer_param(request_params, cli_params)
+        cls._set_checksum_algorithm_param(request_params, cli_params)
 
     @classmethod
     def map_head_object_params(cls, request_params, cli_params):
@@ -533,6 +536,16 @@ class RequestParamsMapper(object):
     def _set_request_payer_param(cls, request_params, cli_params):
         if cli_params.get('request_payer'):
             request_params['RequestPayer'] = cli_params['request_payer']
+
+    @classmethod
+    def _set_checksum_mode_param(cls, request_params, cli_params):
+        if cli_params.get('checksum_mode'):
+            request_params['ChecksumMode'] = cli_params['checksum_mode']
+
+    @classmethod
+    def _set_checksum_algorithm_param(cls, request_params, cli_params):
+        if cli_params.get('checksum_algorithm'):
+            request_params['ChecksumAlgorithm'] = cli_params['checksum_algorithm']
 
     @classmethod
     def _set_general_object_params(cls, request_params, cli_params):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -700,6 +700,7 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertEqual(self.operations_called[0][1]['ChecksumAlgorithm'], 'CRC32')
 
+    @requires_crt
     def test_upload_with_checksum_algorithm_crc32c(self):
         full_path = self.files.create_file('foo.txt', 'contents')
         cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --checksum-algorithm CRC32C'

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -725,8 +725,8 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[1][0].name, 'UploadPart')
         self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'CRC32')
         self.assertEqual(self.operations_called[3][0].name, 'CompleteMultipartUpload')
-        self.assertEqual(self.operations_called[3][1]['MultipartUpload']['Parts'][0]['ChecksumCRC32'], 'foo-1')
-        self.assertEqual(self.operations_called[3][1]['MultipartUpload']['Parts'][1]['ChecksumCRC32'], 'foo-2')
+        self.assertIn({'ETag': 'foo-e1', 'ChecksumCRC32': 'foo-1', 'PartNumber': 1}, self.operations_called[3][1]['MultipartUpload']['Parts'])
+        self.assertIn({'ETag': 'foo-e2', 'ChecksumCRC32': 'foo-2', 'PartNumber': 2}, self.operations_called[3][1]['MultipartUpload']['Parts'])
 
     def test_copy_with_checksum_algorithm_crc32(self):
         self.parsed_responses = [

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -725,8 +725,10 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[1][0].name, 'UploadPart')
         self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'CRC32')
         self.assertEqual(self.operations_called[3][0].name, 'CompleteMultipartUpload')
-        self.assertIn({'ETag': 'foo-e1', 'ChecksumCRC32': 'foo-1', 'PartNumber': 1}, self.operations_called[3][1]['MultipartUpload']['Parts'])
-        self.assertIn({'ETag': 'foo-e2', 'ChecksumCRC32': 'foo-2', 'PartNumber': 2}, self.operations_called[3][1]['MultipartUpload']['Parts'])
+        self.assertIn({'ETag': 'foo-e1', 'ChecksumCRC32': 'foo-1', 'PartNumber': 1},
+                      self.operations_called[3][1]['MultipartUpload']['Parts'])
+        self.assertIn({'ETag': 'foo-e2', 'ChecksumCRC32': 'foo-2', 'PartNumber': 2},
+                      self.operations_called[3][1]['MultipartUpload']['Parts'])
 
     def test_copy_with_checksum_algorithm_crc32(self):
         self.parsed_responses = [

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -693,6 +693,84 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertIn('upload failed', stderr)
         self.assertIn('warning: File has an invalid timestamp.', stderr)
 
+    def test_upload_with_checksum_algorithm_crc32(self):
+        full_path = self.files.create_file('foo.txt', 'contents')
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --checksum-algorithm CRC32'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        self.assertEqual(self.operations_called[0][1]['ChecksumAlgorithm'], 'CRC32')
+
+    def test_upload_with_checksum_algorithm_crc32c(self):
+        full_path = self.files.create_file('foo.txt', 'contents')
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --checksum-algorithm CRC32C'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[0][0].name, 'PutObject')
+        self.assertEqual(self.operations_called[0][1]['ChecksumAlgorithm'], 'CRC32C')
+
+    def test_multipart_upload_with_checksum_algorithm_crc32(self):
+        full_path = self.files.create_file('foo.txt', 'a' * 10 * (1024 ** 2))
+        self.parsed_responses = [
+            {'UploadId': 'foo'},
+            {'ETag': 'foo-e1', 'ChecksumCRC32': 'foo-1'},
+            {'ETag': 'foo-e2', 'ChecksumCRC32': 'foo-2'},
+            {}
+        ]
+        cmdline = ('%s %s s3://bucket/key2.txt'
+                   ' --checksum-algorithm CRC32' % (self.prefix, full_path))
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 4, self.operations_called)
+        self.assertEqual(self.operations_called[0][0].name, 'CreateMultipartUpload')
+        self.assertEqual(self.operations_called[0][1]['ChecksumAlgorithm'], 'CRC32')
+        self.assertEqual(self.operations_called[1][0].name, 'UploadPart')
+        self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'CRC32')
+        self.assertEqual(self.operations_called[3][0].name, 'CompleteMultipartUpload')
+        self.assertEqual(self.operations_called[3][1]['MultipartUpload']['Parts'][0]['ChecksumCRC32'], 'foo-1')
+        self.assertEqual(self.operations_called[3][1]['MultipartUpload']['Parts'][1]['ChecksumCRC32'], 'foo-2')
+
+    def test_copy_with_checksum_algorithm_crc32(self):
+        self.parsed_responses = [
+            self.head_object_response(),
+            # Mocked CopyObject response with a CRC32 checksum specified
+            {
+                'ETag': 'foo-1',
+                'ChecksumCRC32': 'Tq0H4g=='
+            }
+        ]
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket2/key.txt --checksum-algorithm CRC32'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[1][0].name, 'CopyObject')
+        self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'CRC32')
+
+    def test_download_with_checksum_mode_crc32(self):
+        self.parsed_responses = [
+            self.head_object_response(),
+            # Mocked GetObject response with a checksum algorithm specified
+            {
+                'ETag': 'foo-1',
+                'ChecksumCRC32': 'Tq0H4g==',
+                'Body': BytesIO(b'foo')
+            }
+        ]
+        cmdline = f'{self.prefix} s3://bucket/foo {self.files.rootdir} --checksum-mode ENABLED'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[1][0].name, 'GetObject')
+        self.assertEqual(self.operations_called[1][1]['ChecksumMode'], 'ENABLED')
+
+    def test_download_with_checksum_mode_crc32c(self):
+        self.parsed_responses = [
+            self.head_object_response(),
+            # Mocked GetObject response with a checksum algorithm specified
+            {
+                'ETag': 'foo-1',
+                'ChecksumCRC32C': 'checksum',
+                'Body': BytesIO(b'foo')
+            }
+        ]
+        cmdline = f'{self.prefix} s3://bucket/foo {self.files.rootdir} --checksum-mode ENABLED'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[1][0].name, 'GetObject')
+        self.assertEqual(self.operations_called[1][1]['ChecksumMode'], 'ENABLED')
+
 
 class TestStreamingCPCommand(BaseAWSCommandParamsTest):
     def test_streaming_upload(self):

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -297,8 +297,6 @@ class TestSyncCommand(BaseS3TransferCommandTest):
 
     def test_copy_with_checksum_algorithm_update_sha1(self):
         cmdline = f'{self.prefix} s3://src-bucket/ s3://dest-bucket/ --checksum-algorithm SHA1'
-        list_objects_src_with_checksum_algorithm = self.list_objects_response(['mykey'])
-        list_objects_src_with_checksum_algorithm['Contents'][0]['ChecksumAlgorithm'] = 'SHA1'
         self.parsed_responses = [
             # Response for ListObjects on source bucket
             {

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -288,6 +288,99 @@ class TestSyncCommand(BaseS3TransferCommandTest):
             ]
         )
 
+    def test_upload_with_checksum_algorithm_sha1(self):
+        self.files.create_file('foo.txt', 'contents')
+        cmdline = f'{self.prefix} {self.files.rootdir} s3://bucket/ --checksum-algorithm SHA1'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[1][0].name, 'PutObject')
+        self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'SHA1')
+
+    def test_copy_with_checksum_algorithm_update_sha1(self):
+        cmdline = f'{self.prefix} s3://src-bucket/ s3://dest-bucket/ --checksum-algorithm SHA1'
+        list_objects_src_with_checksum_algorithm = self.list_objects_response(['mykey'])
+        list_objects_src_with_checksum_algorithm['Contents'][0]['ChecksumAlgorithm'] = 'SHA1'
+        self.parsed_responses = [
+            # Response for ListObjects on source bucket
+            {
+                'Contents': [
+                    {
+                        'Key': 'mykey',
+                        'LastModified': '00:00:00Z',
+                        'Size': 100,
+                        'ChecksumAlgorithm': 'SHA1'
+                    }
+                ],
+                'CommonPrefixes': []
+            },
+            # Response for ListObjects on destination bucket
+            self.list_objects_response([]),
+            # Response for CopyObject
+            {
+                'ChecksumSHA1': 'sha1-checksum'
+            }
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assert_operations_called(
+            [
+                self.list_objects_request('src-bucket'),
+                self.list_objects_request('dest-bucket'),
+                (
+                    'CopyObject', {
+                        'CopySource': {
+                            'Bucket': 'src-bucket',
+                            'Key': 'mykey'
+                        },
+                        'Bucket': 'dest-bucket',
+                        'Key': 'mykey',
+                        'ChecksumAlgorithm': 'SHA1'
+                    }
+                )
+            ]
+        )
+
+    def test_upload_with_checksum_algorithm_sha256(self):
+        self.files.create_file('foo.txt', 'contents')
+        cmdline = f'{self.prefix} {self.files.rootdir} s3://bucket/ --checksum-algorithm SHA256'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[1][0].name, 'PutObject')
+        self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'SHA256')
+
+    def test_download_with_checksum_mode_sha1(self):
+        self.parsed_responses = [
+            self.list_objects_response(['bucket']),
+            # Mocked GetObject response with a checksum algorithm specified
+            {
+                'ContentLength': '100',
+                'LastModified': '00:00:00Z',
+                'ETag': 'foo-1',
+                'ChecksumSHA1': 'checksum',
+                'Body': BytesIO(b'foo')
+            }
+        ]
+        cmdline = f'{self.prefix} s3://bucket/foo {self.files.rootdir} --checksum-mode ENABLED'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjectsV2')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObject')
+        self.assertIn(('ChecksumMode', 'ENABLED'), self.operations_called[1][1].items())
+
+    def test_download_with_checksum_mode_sha256(self):
+        self.parsed_responses = [
+            self.list_objects_response(['bucket']),
+            # Mocked GetObject response with a checksum algorithm specified
+            {
+                'ContentLength': '100',
+                'LastModified': '00:00:00Z',
+                'ETag': 'foo-1',
+                'ChecksumSHA256': 'checksum',
+                'Body': BytesIO(b'foo')
+            }
+        ]
+        cmdline = f'{self.prefix} s3://bucket/foo {self.files.rootdir} --checksum-mode ENABLED'
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(self.operations_called[0][0].name, 'ListObjectsV2')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObject')
+        self.assertIn(('ChecksumMode', 'ENABLED'), self.operations_called[1][1].items())
+
 
 class TestSyncCommandWithS3Express(BaseS3TransferCommandTest):
 

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -348,8 +348,6 @@ class TestSyncCommand(BaseS3TransferCommandTest):
             self.list_objects_response(['bucket']),
             # Mocked GetObject response with a checksum algorithm specified
             {
-                'ContentLength': '100',
-                'LastModified': '00:00:00Z',
                 'ETag': 'foo-1',
                 'ChecksumSHA1': 'checksum',
                 'Body': BytesIO(b'foo')
@@ -366,8 +364,6 @@ class TestSyncCommand(BaseS3TransferCommandTest):
             self.list_objects_response(['bucket']),
             # Mocked GetObject response with a checksum algorithm specified
             {
-                'ContentLength': '100',
-                'LastModified': '00:00:00Z',
                 'ETag': 'foo-1',
                 'ChecksumSHA256': 'checksum',
                 'Body': BytesIO(b'foo')

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -649,6 +649,46 @@ class CommandParametersTest(unittest.TestCase):
         cmd_params.add_paths(paths)
         self.assertFalse(cmd_params.parameters['is_stream'])
 
+    def test_validate_checksum_algorithm_download_error(self):
+        paths = ['s3://bucket/key', self.file_creator.rootdir]
+        parameters = {'checksum_algorithm': 'CRC32'}
+        cmd_params = CommandParameters('cp', parameters, '')
+        with self.assertRaises(ValueError) as cm:
+            cmd_params.add_paths(paths)
+            self.assertIn('Expected checksum-algorithm parameter to be used with one of following path formats', cm.msg)
+
+    def test_validate_checksum_algorithm_sync_download_error(self):
+        paths = ['s3://bucket/key', self.file_creator.rootdir]
+        parameters = {'checksum_algorithm': 'CRC32C'}
+        cmd_params = CommandParameters('sync', parameters, '')
+        with self.assertRaises(ValueError) as cm:
+            cmd_params.add_paths(paths)
+            self.assertIn('Expected checksum-algorithm parameter to be used with one of following path formats', cm.msg)
+
+    def test_validate_checksum_mode_upload_error(self):
+        paths = [self.file_creator.rootdir, 's3://bucket/key']
+        parameters = {'checksum_mode': 'ENABLED'}
+        cmd_params = CommandParameters('cp', parameters, '')
+        with self.assertRaises(ValueError) as cm:
+            cmd_params.add_paths(paths)
+            self.assertIn('Expected checksum-mode parameter to be used with one of following path formats', cm.msg)
+
+    def test_validate_checksum_mode_sync_upload_error(self):
+        paths = [self.file_creator.rootdir, 's3://bucket/key']
+        parameters = {'checksum_mode': 'ENABLED'}
+        cmd_params = CommandParameters('sync', parameters, '')
+        with self.assertRaises(ValueError) as cm:
+            cmd_params.add_paths(paths)
+            self.assertIn('Expected checksum-mode parameter to be used with one of following path formats', cm.msg)
+
+    def test_validate_checksum_mode_move_error(self):
+        paths = ['s3://bucket/key', 's3://bucket2/key']
+        parameters = {'checksum_mode': 'ENABLED'}
+        cmd_params = CommandParameters('mv', parameters, '')
+        with self.assertRaises(ValueError) as cm:
+            cmd_params.add_paths(paths)
+            self.assertIn('Expected checksum-mode parameter to be used with one of following path formats', cm.msg)
+
     def test_validate_streaming_paths_error(self):
         parameters = {'src': '-', 'dest': 's3://bucket'}
         cmd_params = CommandParameters('sync', parameters, '')

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -665,6 +665,56 @@ class TestRequestParamsMapperSSE(unittest.TestCase):
              'SSECustomerKey': 'my-sse-c-key'})
 
 
+class TestRequestParamsMapperChecksumAlgorithm:
+    @pytest.fixture
+    def cli_params(self):
+        return {'checksum_algorithm': 'CRC32'}
+
+    @pytest.fixture
+    def cli_params_no_algorithm(self):
+        return {}
+
+    def test_put_object(self, cli_params):
+        request_params = {}
+        RequestParamsMapper.map_put_object_params(request_params, cli_params)
+        assert request_params == {'ChecksumAlgorithm': 'CRC32'}
+
+    def test_put_object_no_checksum(self, cli_params_no_algorithm):
+        request_params = {}
+        RequestParamsMapper.map_put_object_params(request_params, cli_params_no_algorithm)
+        assert 'ChecksumAlgorithm' not in request_params
+
+    def test_copy_object(self, cli_params):
+        request_params = {}
+        RequestParamsMapper.map_copy_object_params(request_params, cli_params)
+        assert request_params == {'ChecksumAlgorithm': 'CRC32'}
+
+    def test_copy_object_no_checksum(self, cli_params_no_algorithm):
+        request_params = {}
+        RequestParamsMapper.map_put_object_params(request_params, cli_params_no_algorithm)
+        assert 'ChecksumAlgorithm' not in request_params
+
+
+class TestRequestParamsMapperChecksumMode:
+    @pytest.fixture
+    def cli_params(self):
+        return {'checksum_mode': 'ENABLED'}
+
+    @pytest.fixture
+    def cli_params_no_checksum(self):
+        return {}
+
+    def test_get_object(self, cli_params):
+        request_params = {}
+        RequestParamsMapper.map_get_object_params(request_params, cli_params)
+        assert request_params == {'ChecksumMode': 'ENABLED'}
+
+    def test_get_object_no_checksums(self, cli_params_no_checksum):
+        request_params = {}
+        RequestParamsMapper.map_get_object_params(request_params, cli_params_no_checksum)
+        assert 'ChecksumMode' not in request_params
+
+
 class TestRequestParamsMapperRequestPayer(unittest.TestCase):
     def setUp(self):
         self.cli_params = {'request_payer': 'requester'}


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/aws/aws-cli/issues/6750

Low-level `aws s3api` commands support checksums other than MD5 for verifying end-to-end data integrity. This pull request ports over similar functionality to high-level `aws s3` commands. 

*Description of changes:*
- Added `--checksum-algorithm` flag for file uploads using `aws s3 cp`, `aws s3 sync`, and `aws s3 mv`.
  - Supported algorithms are CRC32, SHA256, SHA1, CRC32C.
- Added `--checksum-mode` flag for file downloads using `aws s3 cp`, `aws s3 sync`, and `aws s3 mv`.
- Added unit and functional tests to assert the correctness of these changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
