### PR TITLE
S3 Expires Timestamp Deprecation

### DIFF
--- a/.changes/next-release/enhancement-s3-92930.json
+++ b/.changes/next-release/enhancement-s3-92930.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
-  "category": "s3",
+  "category": "``s3``",
   "description": "Adds logic to gracefully handle invalid timestamps returned in the Expires header."
 }

--- a/.changes/next-release/enhancement-s3-92930.json
+++ b/.changes/next-release/enhancement-s3-92930.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "s3",
+  "description": "Adds logic to gracefully handle invalid timestamps returned in the Expires header."
+}

--- a/awscli/bcdoc/restdoc.py
+++ b/awscli/bcdoc/restdoc.py
@@ -70,10 +70,10 @@ class ReSTDocument(object):
     def find_last_write(self, content):
         """
         Returns the index of the last occurrence of the content argument
-        in the stack, or raises a ValueError if content is not on the stack.
+        in the stack, or returns None if content is not on the stack.
         """
         try:
-            return len(self._writes) - self._writes[::-1].index(content)
+            return len(self._writes) - self._writes[::-1].index(content) - 1
         except ValueError:
             return None
 

--- a/awscli/bcdoc/restdoc.py
+++ b/awscli/bcdoc/restdoc.py
@@ -67,6 +67,23 @@ class ReSTDocument(object):
         """
         self._writes.append(s)
 
+    def find_last_write(self, content):
+        """
+        Returns the index of the last occurrence of the content argument
+        in the stack, or raises a ValueError if content is not on the stack.
+        """
+        try:
+            return len(self._writes) - self._writes[::-1].index(content)
+        except ValueError:
+            return None
+
+    def insert_write(self, index, content):
+        """
+        Inserts the content argument to the stack directly before the
+        supplied index.
+        """
+        self._writes.insert(index, content)
+
     def getvalue(self):
         """
         Returns the current content of the document as a string.

--- a/awscli/customizations/s3events.py
+++ b/awscli/customizations/s3events.py
@@ -37,7 +37,6 @@ def register_document_expires_string(event_handlers):
         document_expires_string
     )
 
-
 def add_event_stream_output_arg(argument_table, operation_model,
                                 session, **kwargs):
     argument_table['outfile'] = S3SelectStreamOutputArgument(

--- a/awscli/customizations/s3events.py
+++ b/awscli/customizations/s3events.py
@@ -64,42 +64,27 @@ def replace_event_stream_docs(help_command, **kwargs):
 
 def document_expires_string(help_command, **kwargs):
     doc = help_command.doc
-    caught_index_error = False
-    popped = []
-    current = ''
-    while current != 'Expires -> (timestamp)':
-        try:
-            current = doc.pop_write()
-            popped.append(current)
-        except IndexError:
-            # Do nothing if Expires is not in the modeled response
-            caught_index_error = True
-            break
+    expires_field_idx = doc.find_last_write('Expires -> (timestamp)')
 
-    # Only inject the deprecation notice if the Expires timestamp arg was found in the document
-    if not caught_index_error:
-        # Put back the expires field and description
-        doc.push_write(popped.pop())
-        doc.push_write(popped.pop())
-        doc.push_write(popped.pop())
-        doc.push_write(popped.pop())
+    if expires_field_idx is None:
+        return
 
-        doc.push_write('\n\n\n' + doc.style.spaces())
-        doc.push_write('.. note::')
-        doc.style.indent()
-        doc.push_write('\n\n\n' + doc.style.spaces())
-        doc.push_write('This member has been deprecated. Please use `ExpiresString` instead.\n')
-        doc.style.dedent()
-        doc.push_write('\n\n' + doc.style.spaces())
+    deprecation_note_and_expires_string = [
+        f'\n\n\n{" " * doc.style.indentation * doc.style.indent_width}',
+        '.. note::',
+        f'\n\n\n{" " * (doc.style.indentation + 1) * doc.style.indent_width}',
+        'This member has been deprecated. Please use `ExpiresString` instead.\n',
+        f'\n\n{" " * doc.style.indentation * doc.style.indent_width}',
+        f'\n\n{" " * doc.style.indentation * doc.style.indent_width}',
+        'ExpiresString -> (string)\n\n',
+        '\tThe raw, unparsed value of the ``Expires`` field.',
+        f'\n\n{" " * doc.style.indentation * doc.style.indent_width}'
+    ]
 
-        doc.push_write('\n\n' + doc.style.spaces())
-        doc.push_write('ExpiresString -> (string)\n\n')
-        doc.push_write('\tThe raw, unparsed value of the ``Expires`` field.')
-        doc.push_write('\n\n' + doc.style.spaces())
-
-    # Write rest of document
-    while len(popped) > 0:
-        doc.push_write(popped.pop())
+    for idx, write in enumerate(deprecation_note_and_expires_string):
+        # We add 4 to the index of the expires field name because each
+        # field in the output section consists of exactly 4 elements.
+        doc.insert_write(expires_field_idx + idx + 4, write)
 
 
 class S3SelectStreamOutputArgument(CustomArgument):

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -105,7 +105,7 @@ from awscli.customizations.removals import register_removals
 from awscli.customizations.route53 import register_create_hosted_zone_doc_fix
 from awscli.customizations.s3.s3 import s3_plugin_initialize
 from awscli.customizations.s3errormsg import register_s3_error_msg
-from awscli.customizations.s3events import register_event_stream_arg
+from awscli.customizations.s3events import register_event_stream_arg, register_document_expires_string
 from awscli.customizations.sagemaker import (
     register_alias_sagemaker_runtime_command,
 )
@@ -215,6 +215,7 @@ def awscli_initialize(event_handlers):
     register_history_mode(event_handlers)
     register_history_commands(event_handlers)
     register_event_stream_arg(event_handlers)
+    register_document_expires_string(event_handlers)
     dlm_initialize(event_handlers)
     register_ssm_session(event_handlers)
     register_sms_voice_hide(event_handlers)

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -85,6 +85,24 @@ class TestGetObject(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
 
+    def test_invalid_expires_timestamp(self):
+        # Checking correct params are generated and that no errors are raised
+        # in the case botocore cannot parse an invalid "Expires" string and surfaces
+        # the raw string value as an "ExpiresString" field.
+        self.parsed_response = {
+            "AcceptRanges": "bytes",
+            "LastModified": "2024-09-20T18:56:59+00:00",
+            "ContentLength": 23230,
+            "ETag": "\"207d91b3fd7953aac7b28b8ddf882953\"",
+            "ContentType": "binary/octet-stream",
+            "ServerSideEncryption": "AES256",
+            "Metadata": {},
+            "ExpiresString": "invalid string"
+        }
+        cmdline = f'{self.prefix} --bucket mybucket --key mykey outfile --debug'
+        self.addCleanup(self.remove_file_if_exists, 'outfile')
+        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/functional/s3api/test_get_object.py
+++ b/tests/functional/s3api/test_get_object.py
@@ -85,24 +85,6 @@ class TestGetObject(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
 
-    def test_invalid_expires_timestamp(self):
-        # Checking correct params are generated and that no errors are raised
-        # in the case botocore cannot parse an invalid "Expires" string and surfaces
-        # the raw string value as an "ExpiresString" field.
-        self.parsed_response = {
-            "AcceptRanges": "bytes",
-            "LastModified": "2024-09-20T18:56:59+00:00",
-            "ContentLength": 23230,
-            "ETag": "\"207d91b3fd7953aac7b28b8ddf882953\"",
-            "ContentType": "binary/octet-stream",
-            "ServerSideEncryption": "AES256",
-            "Metadata": {},
-            "ExpiresString": "invalid string"
-        }
-        cmdline = f'{self.prefix} --bucket mybucket --key mykey outfile --debug'
-        self.addCleanup(self.remove_file_if_exists, 'outfile')
-        self.assert_params_for_cmd(cmdline, {'Bucket': 'mybucket', 'Key': 'mykey'})
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/bcdoc/test_document.py
+++ b/tests/unit/bcdoc/test_document.py
@@ -26,6 +26,10 @@ from awscli.bcdoc.restdoc import ReSTDocument, DocumentStructure
 
 class TestReSTDocument(unittest.TestCase):
 
+    def _write_array(self, doc, arr):
+        for elt in arr:
+            doc.write(elt)
+
     def test_write(self):
         doc = ReSTDocument()
         doc.write('foo')
@@ -35,6 +39,29 @@ class TestReSTDocument(unittest.TestCase):
         doc = ReSTDocument()
         doc.writeln('foo')
         self.assertEqual(doc.getvalue(), b'foo\n')
+
+    def test_find_last_write(self):
+        doc = ReSTDocument()
+        self._write_array(doc, ['a', 'b', 'c', 'd', 'e'])
+        expected_index = 0
+        self.assertEqual(doc.find_last_write('a'), expected_index)
+
+    def test_find_last_write_duplicates(self):
+        doc = ReSTDocument()
+        self._write_array(doc, ['a', 'b', 'c', 'a', 'e'])
+        expected_index = 3
+        self.assertEqual(doc.find_last_write('a'), expected_index)
+
+    def test_find_last_write_not_found(self):
+        doc = ReSTDocument()
+        self._write_array(doc, ['a', 'b', 'c', 'd', 'e'])
+        self.assertIsNone(doc.find_last_write('f'))
+
+    def test_insert_write(self):
+        doc = ReSTDocument()
+        self._write_array(doc, ['foo', 'bar'])
+        doc.insert_write(1, 'baz')
+        self.assertEqual(doc.getvalue(), b'foobazbar')
 
     def test_include_doc_string(self):
         doc = ReSTDocument()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- v1 port of https://github.com/aws/aws-cli/pull/8935, which gracefully handles invalid expires timestamps from S3. 

*Testing:*
- Added a functional test that mocks an invalid Expires value from botocore.
- Manually checked that the output of s3api help commands include the expected documentation changes.
- Rebuilt the html docs and manually checked that some s3api commands include the expected documentation changes.
- I performed manual testing to verify we correctly handle the `ExpiresString` field being included in the response body of the GetObject operation. Below is an example manual test using the command `aws s3api get-object --bucket bucketname --key filename outfile`:

```
}
    "AcceptRanges": "bytes",
    "LastModified": "2024-09-20T18:56:59+00:00",
    "ContentLength": 23230,
    "ETag": "\"207d91b3fd7953aac7b28b8ddf882953\"",
    "ContentType": "binary/octet-stream",
    "Expires": "2025-09-20T07:28:00+00:00",
    "ServerSideEncryption": "AES256",
    "Metadata": {},
    "ExpiresString": "Sat, 20 Sep 2025 07:28:00 GMT"
}
```

*Screenshots:*
#### Example of the injected deprecation notice on the `Expires` output field, and the newly injected synthetic `ExpiresString` field
<img width="779" alt="image" src="https://github.com/user-attachments/assets/0a93a410-a4e8-4c33-bd95-3cfb17ce17a6">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.