### PR TITLE
[V2] Port "Tolerate custom IMDS endpoints without trailing /" from Botocore

### DIFF
--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -371,10 +371,16 @@ class IMDSFetcher(object):
             raise InvalidIMDSEndpointError(endpoint=chosen_base_url)
 
         return chosen_base_url
+        
+    def _construct_url(self, path):
+        sep = ''
+        if self._base_url and not self._base_url.endswith('/'):
+            sep = '/'
+        return f'{self._base_url}{sep}{path}'
 
     def _fetch_metadata_token(self):
         self._assert_enabled()
-        url = self._base_url + self._TOKEN_PATH
+        url = self._construct_url(self._TOKEN_PATH)
         headers = {
             'x-aws-ec2-metadata-token-ttl-seconds': self._TOKEN_TTL,
         }
@@ -424,7 +430,7 @@ class IMDSFetcher(object):
             self._assert_v1_enabled()
         if retry_func is None:
             retry_func = self._default_retry
-        url = self._base_url + url_path
+        url = self._construct_url(url_path)
         headers = {}
         if token is not None:
             headers['x-aws-ec2-metadata-token'] = token

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -545,6 +545,17 @@ class TestIMDSRegionProvider(BaseIMDSRegionTest):
         provider.provide()
         args, _ = self._send.call_args
         self.assertIn('http://myendpoint/', args[0].url)
+    
+    def test_can_set_imds_service_endpoint_custom(self):
+        driver = create_clidriver()
+        driver.session.set_config_variable(
+            'ec2_metadata_service_endpoint', 'http://myendpoint')
+        self.add_imds_token_response()
+        self.add_get_region_imds_response()
+        provider = IMDSRegionProvider(driver.session)
+        provider.provide()
+        args, _ = self._send.call_args
+        self.assertIn('http://myendpoint/', args[0].url)
 
     def test_imds_service_endpoint_overrides_ipv6_endpoint(self):
         driver = create_clidriver()


### PR DESCRIPTION
*Issue #, if available:* N/A 

*Description of changes:*

Ports the following `botocore` PR:
https://github.com/boto/botocore/pull/2600

*Description of tests:*

All ported unit tests are passing

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
