### PR TITLE
Add CLI examples for Amazon CloudWatch

### DIFF
--- a/awscli/examples/cloudwatch/delete-anomaly-detector.rst
+++ b/awscli/examples/cloudwatch/delete-anomaly-detector.rst
@@ -1,0 +1,10 @@
+**To delete a specified anomaly detection model**
+
+The following ``delete-anomaly-detector`` example deletes an anomaly detector model in the specified account. If the command succeeds, no output is returned. ::
+
+    aws cloudwatch delete-anomaly-detector \
+        --namespace AWS/Logs \
+        --metric-name IncomingBytes \
+        --stat SampleCount 
+
+For more information, see `Deleting an anomaly detection model <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Anomaly_Detection_Alarm.html#Delete_Anomaly_Detection_Model>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/delete-dashboards.rst
+++ b/awscli/examples/cloudwatch/delete-dashboards.rst
@@ -1,0 +1,8 @@
+**To delete specified dashboards**
+
+The following ``delete-dashboards`` example deletes two dashboards named ``Dashboard-A`` and ``Dashboard-B`` in the specified account. If the command succeeds, no output is returned. ::
+
+    aws cloudwatch delete-dashboards \
+        --dashboard-names Dashboard-A Dashboard-B
+
+For more information, see `Amazon CloudWatch dashboards <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/delete-insight-rules.rst
+++ b/awscli/examples/cloudwatch/delete-insight-rules.rst
@@ -1,0 +1,14 @@
+**To delete specified contributor insights rules**
+
+The following ``delete-insight-rules`` example deletes two contributor insights rules named ``Rule-A`` and ``Rule-B`` in the specified account. ::
+
+    aws cloudwatch delete-insight-rules \
+        --rule-names Rule-A Rule-B 
+
+Output::
+
+    {
+        "Failures": []
+    }
+
+For more information, see `Use Contributor Insights to analyze high-cardinality data <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContributorInsights.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/delete-metric-stream.rst
+++ b/awscli/examples/cloudwatch/delete-metric-stream.rst
@@ -1,0 +1,8 @@
+**To delete a specified metric stream**
+
+The following ``delete-metric-stream`` example deletes the metric stream named ``QuickPartial-gSCKvO`` in the specified account. If the command succeeds, no output is returned. ::
+
+    aws cloudwatch delete-metric-stream \
+        --name QuickPartial-gSCKvO 
+
+For more information, see `Use metric streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/describe-anomaly-detectors.rst
+++ b/awscli/examples/cloudwatch/describe-anomaly-detectors.rst
@@ -1,0 +1,59 @@
+**To retrieve a list of anomaly detection models**
+
+The following ``describe-anomaly-detectors`` example displays information about anomaly detector models that are associated with ``AWS/Logs`` namespace in the specified account. ::
+
+    aws cloudwatch describe-anomaly-detectors \
+        --namespace AWS/Logs
+
+Output::
+
+    {
+        "AnomalyDetectors": [
+            {
+                "Namespace": "AWS/Logs",
+                "MetricName": "IncomingBytes",
+                "Dimensions": [],
+                "Stat": "SampleCount",
+                "Configuration": {
+                    "ExcludedTimeRanges": []
+                },
+                "StateValue": "TRAINED",
+                "SingleMetricAnomalyDetector": {
+                    "AccountId": "123456789012",
+                    "Namespace": "AWS/Logs",
+                    "MetricName": "IncomingBytes",
+                    "Dimensions": [],
+                    "Stat": "SampleCount"
+                }
+            },
+            {
+                "Namespace": "AWS/Logs",
+                "MetricName": "IncomingBytes",
+                "Dimensions": [
+                    {
+                        "Name": "LogGroupName",
+                        "Value": "demo"
+                    }
+                ],
+                "Stat": "Average",
+                "Configuration": {
+                    "ExcludedTimeRanges": []
+                },
+                "StateValue": "PENDING_TRAINING",
+                "SingleMetricAnomalyDetector": {
+                    "AccountId": "123456789012",
+                    "Namespace": "AWS/Logs",
+                    "MetricName": "IncomingBytes",
+                    "Dimensions": [
+                        {
+                            "Name": "LogGroupName",
+                            "Value": "demo"
+                        }
+                    ],
+                    "Stat": "Average"
+                }
+            }
+        ]
+    }
+
+For more information, see `Using CloudWatch anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/describe-insight-rules.rst
+++ b/awscli/examples/cloudwatch/describe-insight-rules.rst
@@ -1,0 +1,28 @@
+**To retrieve a list of Contributor Insights rules**
+
+The following ``describe-insight-rules`` example shows all the Contributor Insight rules in the specified account. ::
+
+    aws cloudwatch describe-insight-rules 
+
+Output::
+
+    {
+        "InsightRules": [
+            {
+                "Name": "Rule-A",
+                "State": "ENABLED",
+                "Schema": "CloudWatchLogRule/1",
+                "Definition": "{\n\t\"AggregateOn\": \"Count\",\n\t\"Contribution\": {\n\t\t\"Filters\": [],\n\t\t\"Keys\": [\n\t\t\t\"$.requestId\"\n\t\t]\n\t},\n\t\"LogFormat\": \"JSON\",\n\t\"Schema\": {\n\t\t\"Name\": \"CloudWatchLogRule\",\n\t\t\"Version\": 1\n\t},\n\t\"LogGroupARNs\": [\n\t\t\"arn:aws:logs:us-east-1:123456789012:log-group:demo\"\n\t]\n}",
+                "ManagedRule": false
+            },
+            {
+                "Name": "Rule-B",
+                "State": "ENABLED",
+                "Schema": "CloudWatchLogRule/1",
+                "Definition": "{\n\t\"AggregateOn\": \"Count\",\n\t\"Contribution\": {\n\t\t\"Filters\": [],\n\t\t\"Keys\": [\n\t\t\t\"$.requestId\"\n\t\t]\n\t},\n\t\"LogFormat\": \"JSON\",\n\t\"Schema\": {\n\t\t\"Name\": \"CloudWatchLogRule\",\n\t\t\"Version\": 1\n\t},\n\t\"LogGroupARNs\": [\n\t\t\"arn:aws:logs:us-east-1:123456789012:log-group:demo-1\"\n\t]\n}",
+                "ManagedRule": false
+            }
+        ]
+    }
+
+For more information, see `Use Contributor Insights to analyze high-cardinality data <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContributorInsights.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/disable-insight-rules.rst
+++ b/awscli/examples/cloudwatch/disable-insight-rules.rst
@@ -1,0 +1,14 @@
+**To disable specified contributor insight rules**
+
+The following ``disable-insight-rules`` example disables two contributor insights rules named ``Rule-A`` and ``Rule-B`` in the specified account. ::
+
+    aws cloudwatch disable-insight-rules \
+        --rule-names Rule-A Rule-B
+
+Output::
+
+    {
+        "Failures": []
+    }
+
+For more information, see `Use Contributor Insights to analyze high-cardinality data <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContributorInsights.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/enable-insight-rules.rst
+++ b/awscli/examples/cloudwatch/enable-insight-rules.rst
@@ -1,0 +1,14 @@
+**To enable specified contributor insight rules**
+
+The following ``enable-insight-rules`` example enables two contributor insights rules named ``Rule-A`` and ``Rule-B`` in the specified account. ::
+
+    aws cloudwatch enable-insight-rules \
+        --rule-names Rule-A Rule-B
+
+Output::
+
+    {
+        "Failures": []
+    }
+
+For more information, see `Use Contributor Insights to analyze high-cardinality data <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContributorInsights.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/get-dashboard.rst
+++ b/awscli/examples/cloudwatch/get-dashboard.rst
@@ -1,0 +1,16 @@
+**To retrieve information about a Dashboard**
+
+The following ``get-dashboard`` example displays information about the dashboard named ``Dashboard-A`` in the specified account. ::
+
+    aws cloudwatch get-dashboard \
+        --dashboard-name Dashboard-A 
+
+Output::
+
+    {
+        "DashboardArn": "arn:aws:cloudwatch::123456789012:dashboard/Dashboard-A",
+        "DashboardBody": "{\"widgets\":[{\"type\":\"metric\",\"x\":0,\"y\":0,\"width\":6,\"height\":6,\"properties\":{\"view\":\"timeSeries\",\"stacked\":false,\"metrics\":[[\"AWS/EC2\",\"NetworkIn\",\"InstanceId\",\"i-0131f062232ade043\"],[\".\",\"NetworkOut\",\".\",\".\"]],\"region\":\"us-east-1\"}}]}",
+        "DashboardName": "Dashboard-A"
+    }
+
+For more information, see `Amazon CloudWatch dashboards <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/get-metric-stream.rst
+++ b/awscli/examples/cloudwatch/get-metric-stream.rst
@@ -1,0 +1,22 @@
+**To retrieve information about a metric stream**
+
+The following ``get-metric-stream`` example displays information about the metric stream named ``QuickFull-GuaFbs`` in the specified account. ::
+
+    aws cloudwatch get-metric-stream \
+        --name QuickFull-GuaFbs
+
+Output::
+
+    {
+        "Arn": "arn:aws:cloudwatch:us-east-1:123456789012:metric-stream/QuickFull-GuaFbs",
+        "Name": "QuickFull-GuaFbs",
+        "FirehoseArn": "arn:aws:firehose:us-east-1:123456789012:deliverystream/MetricStreams-QuickFull-GuaFbs-WnySbECG",
+        "RoleArn": "arn:aws:iam::123456789012:role/service-role/MetricStreams-FirehosePutRecords-JN10W9B3",
+        "State": "running",
+        "CreationDate": "2024-10-11T18:48:59.187000+00:00",
+        "LastUpdateDate": "2024-10-11T18:48:59.187000+00:00",
+        "OutputFormat": "json",
+        "IncludeLinkedAccountsMetrics": false
+    }
+
+For more information, see `Use metric streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/list-dashboards.rst
+++ b/awscli/examples/cloudwatch/list-dashboards.rst
@@ -1,6 +1,6 @@
 **To retrieve a list of Dashboards**
 
-The following ``list-dashboards`` example example lists all the Dashboards in the specified account. ::
+The following ``list-dashboards`` example lists all the Dashboards in the specified account. ::
 
     aws cloudwatch list-dashboards 
 

--- a/awscli/examples/cloudwatch/list-dashboards.rst
+++ b/awscli/examples/cloudwatch/list-dashboards.rst
@@ -1,0 +1,26 @@
+**To retrieve a list of Dashboards**
+
+The following ``list-dashboards`` example example lists all the Dashboards in the specified account. ::
+
+    aws cloudwatch list-dashboards 
+
+Output::
+
+    {
+        "DashboardEntries": [
+            {
+                "DashboardName": "Dashboard-A",
+                "DashboardArn": "arn:aws:cloudwatch::123456789012:dashboard/Dashboard-A",
+                "LastModified": "2024-10-11T18:40:11+00:00",
+                "Size": 271
+            },
+            {
+                "DashboardName": "Dashboard-B",
+                "DashboardArn": "arn:aws:cloudwatch::123456789012:dashboard/Dashboard-B",
+                "LastModified": "2024-10-11T18:44:41+00:00",
+                "Size": 522
+            }
+        ]
+    }
+    
+For more information, see `Amazon CloudWatch dashboards <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Dashboards.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/list-metric-streams.rst
+++ b/awscli/examples/cloudwatch/list-metric-streams.rst
@@ -1,0 +1,23 @@
+**To retrieve a list of metric streams**
+
+The following ``list-metric-streams`` example example lists all the metric streams in the specified account. ::
+
+    aws cloudwatch list-metric-streams 
+
+Output::
+
+    {
+        "Entries": [
+            {
+                "Arn": "arn:aws:cloudwatch:us-east-1:123456789012:metric-stream/QuickFull-GuaFbs",
+                "CreationDate": "2024-10-11T18:48:59.187000+00:00",
+                "LastUpdateDate": "2024-10-11T18:48:59.187000+00:00",
+                "Name": "QuickFull-GuaFbs",
+                "FirehoseArn": "arn:aws:firehose:us-east-1:123456789012:deliverystream/MetricStreams-QuickFull-GuaFbs-WnySbECG",
+                "State": "running",
+                "OutputFormat": "json"
+            }
+        ]
+    }
+
+For more information, see `Use metric streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/list-metric-streams.rst
+++ b/awscli/examples/cloudwatch/list-metric-streams.rst
@@ -1,6 +1,6 @@
 **To retrieve a list of metric streams**
 
-The following ``list-metric-streams`` example example lists all the metric streams in the specified account. ::
+The following ``list-metric-streams`` example lists all the metric streams in the specified account. ::
 
     aws cloudwatch list-metric-streams 
 

--- a/awscli/examples/cloudwatch/start-metric-streams.rst
+++ b/awscli/examples/cloudwatch/start-metric-streams.rst
@@ -1,0 +1,8 @@
+**To start a specified metric stream**
+
+The following ``start-metric-streams`` example starts the metric stream named ``QuickFull-GuaFbs`` in the specified account. If the command succeeds, no output is returned. ::
+
+    aws cloudwatch start-metric-streams \
+        --names QuickFull-GuaFbs
+
+For more information, see `Use metric streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/cloudwatch/stop-metric-streams.rst
+++ b/awscli/examples/cloudwatch/stop-metric-streams.rst
@@ -1,0 +1,8 @@
+**To stop a specified metric stream**
+
+The following ``stop-metric-streams`` example stops the metric stream named ``QuickFull-GuaFbs`` in the specified account. If the command succeeds, no output is returned. ::
+
+    aws cloudwatch stop-metric-streams \
+        --names QuickFull-GuaFbs
+
+For more information, see `Use metric streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html>`__ in the *Amazon CloudWatch User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding example CLI commands for Amazon CloudWatch: https://docs.aws.amazon.com/cli/latest/reference/cloudwatch/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
