### PR TITLE
Add CLI examples for CloudWatch OAM

### DIFF
--- a/awscli/examples/oam/create-link.rst
+++ b/awscli/examples/oam/create-link.rst
@@ -1,0 +1,24 @@
+**To Create a link**
+
+The following ``create-link`` example creates a link between a source account and a sink that you have created in a monitoring account. ::
+
+    aws oam create-link \
+        --label-template sourceAccount \
+        --resource-types AWS::CloudWatch::Metric \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+        "Label": "sourceAccount",
+        "LabelTemplate": "sourceAccount",
+        "ResourceTypes": [
+            "AWS::CloudWatch::Metric"
+        ],
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/create-sink.rst
+++ b/awscli/examples/oam/create-sink.rst
@@ -1,0 +1,17 @@
+**To Create a sink**
+
+The following ``create-sink`` example creates a sink in the current account, so that it can be used as a monitoring account in CloudWatch cross-account observability. ::
+
+    aws oam create-sink \
+        --name DemoSink
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Name": "DemoSink",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-link.rst
+++ b/awscli/examples/oam/delete-link.rst
@@ -1,0 +1,8 @@
+**To Delete a link**
+
+The following ``delete-link`` example deletes a link between a monitoring account sink and a source account. ::
+
+    aws oam delete-link \
+        --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-link.rst
+++ b/awscli/examples/oam/delete-link.rst
@@ -1,8 +1,10 @@
 **To Delete a link**
 
-The following ``delete-link`` example deletes a link between a monitoring account sink and a source account. If the command succeeds, no output is returned. ::
+The following ``delete-link`` example deletes a link between a monitoring account sink and a source account.
 
     aws oam delete-link \
         --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111
+
+This command produces no output.
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-link.rst
+++ b/awscli/examples/oam/delete-link.rst
@@ -1,6 +1,6 @@
 **To Delete a link**
 
-The following ``delete-link`` example deletes a link between a monitoring account sink and a source account. ::
+The following ``delete-link`` example deletes a link between a monitoring account sink and a source account. If the command succeeds, no output is returned. ::
 
     aws oam delete-link \
         --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111

--- a/awscli/examples/oam/delete-link.rst
+++ b/awscli/examples/oam/delete-link.rst
@@ -1,6 +1,6 @@
 **To Delete a link**
 
-The following ``delete-link`` example deletes a link between a monitoring account sink and a source account.
+The following ``delete-link`` example deletes a link between a monitoring account sink and a source account. ::
 
     aws oam delete-link \
         --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111

--- a/awscli/examples/oam/delete-sink.rst
+++ b/awscli/examples/oam/delete-sink.rst
@@ -1,0 +1,8 @@
+**To Delete a sink**
+
+The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink. ::
+
+    aws oam delete-sink \
+        --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-sink.rst
+++ b/awscli/examples/oam/delete-sink.rst
@@ -1,8 +1,10 @@
 **To Delete a sink**
 
-The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink. If the command succeeds, no output is returned. ::
+The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink.
 
     aws oam delete-sink \
         --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+This command produces no output.
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-sink.rst
+++ b/awscli/examples/oam/delete-sink.rst
@@ -1,6 +1,6 @@
 **To Delete a sink**
 
-The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink. ::
+The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink. If the command succeeds, no output is returned. ::
 
     aws oam delete-sink \
         --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345

--- a/awscli/examples/oam/delete-sink.rst
+++ b/awscli/examples/oam/delete-sink.rst
@@ -1,6 +1,6 @@
 **To Delete a sink**
 
-The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink.
+The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink. ::
 
     aws oam delete-sink \
         --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345

--- a/awscli/examples/oam/get-link.rst
+++ b/awscli/examples/oam/get-link.rst
@@ -17,6 +17,6 @@ Output::
         ],
         "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
         "Tags": {}
-}
+    }
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-link.rst
+++ b/awscli/examples/oam/get-link.rst
@@ -1,0 +1,22 @@
+**To return complete information about one link**
+
+The following ``get-link`` example returns complete information about one link. ::
+
+    aws oam get-link \
+        --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+        "Label": "sourceAccount",
+        "LabelTemplate": "sourceAccount",
+        "ResourceTypes": [
+            "AWS::CloudWatch::Metric"
+        ],
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Tags": {}
+}
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-sink-policy.rst
+++ b/awscli/examples/oam/get-sink-policy.rst
@@ -10,7 +10,7 @@ Output::
     {
         "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
         "SinkId": "a1b2c3d4-5678-90ab-cdef-example12345",
-        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
-}
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
+    }
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-sink-policy.rst
+++ b/awscli/examples/oam/get-sink-policy.rst
@@ -1,0 +1,16 @@
+**To return the current sink policy attached to the sink**
+
+The following ``get-sink-policy`` example returns the current sink policy attached to the sink. ::
+
+    aws oam get-sink-policy \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "SinkId": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
+}
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-sink-policy.rst
+++ b/awscli/examples/oam/get-sink-policy.rst
@@ -10,7 +10,7 @@ Output::
     {
         "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
         "SinkId": "a1b2c3d4-5678-90ab-cdef-example12345",
-        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
     }
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-sink.rst
+++ b/awscli/examples/oam/get-sink.rst
@@ -1,0 +1,17 @@
+**To return complete information about one monitoring account sink**
+
+The following ``get-sink`` example returns complete information about one monitoring account sink. ::
+
+    aws oam get-sink \
+        --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Name": "DemoSink",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-attached-links.rst
+++ b/awscli/examples/oam/list-attached-links.rst
@@ -1,0 +1,23 @@
+**To return a list of source account links that are linked to this monitoring account sink**
+
+The following ``list-attached-links`` example returns a list of source account links that are linked to this monitoring account sink. ::
+
+    aws oam list-attached-links \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Items": [{
+            "Label": "Monitoring account",
+            "LinkArn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+            "ResourceTypes": [
+                "AWS::ApplicationInsights::Application",
+                "AWS::Logs::LogGroup",
+                "AWS::CloudWatch::Metric",
+                "AWS::XRay::Trace"
+            ]
+        }]
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-links.rst
+++ b/awscli/examples/oam/list-links.rst
@@ -1,0 +1,21 @@
+**To return a list of links for one monitoring account sink**
+
+The following ``list-links`` example return a list of links for one monitoring account sink. Run this operation in a source account to return a list of links to monitoring account sinks that this source account has. ::
+
+    aws oam list-links
+
+Output::
+
+    {
+        "Items": [{
+            "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+            "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+            "Label": "sourceAccount",
+            "ResourceTypes": [
+                "AWS::CloudWatch::Metric"
+            ],
+            "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345"
+        }]
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-sinks.rst
+++ b/awscli/examples/oam/list-sinks.rst
@@ -1,0 +1,19 @@
+**To return the list of sinks created in the monitoring account**
+
+The following ``list-sinks`` example returns list of sinks created in the monitoring account. Run this operation in a monitoring account. ::
+
+    aws oam list-sinks
+
+Output::
+
+    {
+        "Items": [
+            {
+                "Arn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+                "Id": "a1b2c3d4-5678-90ab-cdef-example12345",
+                "Name": "DemoSink"
+            }
+        ]
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-tags-for-resource.rst
+++ b/awscli/examples/oam/list-tags-for-resource.rst
@@ -1,0 +1,16 @@
+**To Displays the tags associated with a resource**
+
+The following ``list-tags-for-resource`` example displays the tags associated with a sink. ::
+
+    aws oam list-tags-for-resource \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Tags": {
+            "Team": "Devops"
+        }
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/put-sink-policy.rst
+++ b/awscli/examples/oam/put-sink-policy.rst
@@ -1,0 +1,17 @@
+**To Creates or updates the resource policy**
+
+The following ``put-sink-policy`` example creates or updates the resource policy that grants permissions to source accounts to link to the monitoring account sink. ::
+
+    aws oam put-sink-policy \
+        --policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}" \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "SinkId": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/put-sink-policy.rst
+++ b/awscli/examples/oam/put-sink-policy.rst
@@ -3,7 +3,7 @@
 The following ``put-sink-policy`` example creates or updates the resource policy that grants permissions to source accounts to link to the monitoring account sink. ::
 
     aws oam put-sink-policy \
-        --policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}" \
+        --policy '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789111:root"},"Action":["oam:CreateLink","oam:UpdateLink"],"Resource":"*","Condition":{"ForAllValues:StringEquals":{"oam:ResourceTypes":["AWS::Logs::LogGroup","AWS::CloudWatch::Metric","AWS::XRay::Trace","AWS::ApplicationInsights::Application"]}}}]}' \
         --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
 
 Output::

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -3,7 +3,7 @@
 The following ``tag-resource`` example assign a tag to the log group ``demo-log-group``.
 
     aws oam tag-resource \
-        --resource-arn arn:aws:logs:us-east-1:123456789:log-group:demo-log-group \
+        --resource-arn arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group \
         --tags team=Devops
 
 This command produces no output.

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -1,9 +1,11 @@
 **To Assign one or more tags to the specified resource**
 
-The following ``tag-resource`` example assign a tag to the log group ``demo-log-group``. If the command succeeds, no output is returned. ::
+The following ``tag-resource`` example assign a tag to the log group ``demo-log-group``.
 
     aws oam tag-resource \
         --resource-arn arn:aws:logs:us-east-1:123456789:log-group:demo-log-group \
         --tags team=Devops
+
+This command produces no output.
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -1,6 +1,6 @@
 **To Assign one or more tags to the specified resource**
 
-The following ``tag-resource`` example tags a sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``.
+The following ``tag-resource`` example tags a sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. ::
 
     aws oam tag-resource \
         --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -1,9 +1,9 @@
 **To Assign one or more tags to the specified resource**
 
-The following ``tag-resource`` example tags a sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. If the command succeeds, no output is returned. ::
+The following ``tag-resource`` example assign a tag to the log group ``demo-log-group``. If the command succeeds, no output is returned. ::
 
-    aws oam tag-resource \
-        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \
+    aws logs tag-resource \
+        --resource-arn arn:aws:logs:us-east-1:123456789:log-group:demo-log-group \
         --tags team=Devops
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -1,9 +1,9 @@
 **To Assign one or more tags to the specified resource**
 
-The following ``tag-resource`` example assign a tag to the log group ``demo-log-group``.
+The following ``tag-resource`` example tags a sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``.
 
     aws oam tag-resource \
-        --resource-arn arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \
         --tags team=Devops
 
 This command produces no output.

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -2,7 +2,7 @@
 
 The following ``tag-resource`` example assign a tag to the log group ``demo-log-group``. If the command succeeds, no output is returned. ::
 
-    aws logs tag-resource \
+    aws oam tag-resource \
         --resource-arn arn:aws:logs:us-east-1:123456789:log-group:demo-log-group \
         --tags team=Devops
 

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -1,0 +1,9 @@
+**To Assign one or more tags to the specified resource**
+
+The following ``tag-resource`` example tags a sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. If the command succeeds, no output is returned. ::
+
+    aws oam tag-resource \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \
+        --tags team=Devops
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/untag-resource.rst
+++ b/awscli/examples/oam/untag-resource.rst
@@ -1,6 +1,6 @@
 **To Remove one or more tags from the specified resource.**
 
-The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``.
+The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. ::
 
     aws oam untag-resource \
         --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \

--- a/awscli/examples/oam/untag-resource.rst
+++ b/awscli/examples/oam/untag-resource.rst
@@ -1,4 +1,4 @@
-**To Removes one or more tags from the specified resource.**
+**To Remove one or more tags from the specified resource.**
 
 The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. If the command succeeds, no output is returned. ::
 

--- a/awscli/examples/oam/untag-resource.rst
+++ b/awscli/examples/oam/untag-resource.rst
@@ -1,9 +1,11 @@
 **To Remove one or more tags from the specified resource.**
 
-The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. If the command succeeds, no output is returned. ::
+The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``.
 
     aws oam untag-resource \
         --resource-arn arn:aws:oam:us-east-2:123456789012:sink/f3f42f60-f0f2-425c-1234-12347bdd821f \
         --tag-keys team
+
+This command produces no output.
 
 For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/untag-resource.rst
+++ b/awscli/examples/oam/untag-resource.rst
@@ -1,0 +1,9 @@
+**To Removes one or more tags from the specified resource.**
+
+The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. If the command succeeds, no output is returned. ::
+
+    aws oam untag-resource \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/f3f42f60-f0f2-425c-1234-12347bdd821f \
+        --tag-keys team
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/untag-resource.rst
+++ b/awscli/examples/oam/untag-resource.rst
@@ -3,7 +3,7 @@
 The following ``untag-resource`` example removes a tag with the key ``team`` from Sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``.
 
     aws oam untag-resource \
-        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/f3f42f60-f0f2-425c-1234-12347bdd821f \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \
         --tag-keys team
 
 This command produces no output.

--- a/awscli/examples/oam/update-link.rst
+++ b/awscli/examples/oam/update-link.rst
@@ -1,0 +1,24 @@
+**To change what types of data are shared from a source account to its linked monitoring account sink**
+
+The following ``update-link`` example updates the link ``arn:aws:oam:us-east-2:123456789111:link/0123e691-e7ef-43fa-1234-c57c837fced0`` with resource types ``AWS::CloudWatch::Metric`` and ``AWS::Logs::LogGroup``. ::
+
+    aws oam update-link \
+        --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111 \
+        --resource-types "AWS::CloudWatch::Metric" "AWS::Logs::LogGroup"
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+        "Label": "sourceAccount",
+        "LabelTemplate": "sourceAccount",
+        "ResourceTypes": [
+            "AWS::CloudWatch::Metric",
+            "AWS::Logs::LogGroup"
+        ],
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding example CLI commands for Amazon CloudWatch Observability Access Manager: https://docs.aws.amazon.com/cli/latest/reference/oam/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
