### PR TITLE
adding schemas-cli-examples

### DIFF
--- a/awscli/examples/schemas/create-discoverer.rst
+++ b/awscli/examples/schemas/create-discoverer.rst
@@ -1,0 +1,20 @@
+**To create a discoverer**
+
+The following ``create-discoverer`` creates a discoverer. ::
+
+	aws schemas create-discoverer \
+		--source-arn arn:aws:events:us-east-1:123456789012:event-bus/example-event-bus \
+		--cross-account
+
+Output ::
+
+	{
+		"DiscovererArn": "arn:aws:schemas:us-east-1:123456789012:discoverer/example-discoverer-name",
+		"DiscovererId": "example-discoverer-name",
+		"SourceArn": "arn:aws:events:us-east-1:123456789012:event-bus/example-event-bus",
+		"State": "STARTED",
+		"Cross123456789012": true,
+		"Tags": {}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/create-registry.rst
+++ b/awscli/examples/schemas/create-registry.rst
@@ -1,0 +1,16 @@
+**To create a registry**
+
+The following ``create-registry`` creates a registry. ::
+
+	aws schemas create-registry \
+		--registry-name example-registry
+
+Output ::
+
+	{
+		"RegistryArn": "arn:aws:schemas:us-east-1:123456789012:registry/example-registry",
+		"RegistryName": "example-registry",
+		"Tags": {}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/create-schema.rst
+++ b/awscli/examples/schemas/create-schema.rst
@@ -1,0 +1,49 @@
+**To create a new JSONSchemaDraft4 schema definition**
+
+The following ``create-schema`` creates a new JSONSchemaDraft4 schema definition. ::
+
+	aws schemas create-schema \
+		--registry-name example-registry 
+		--schema-name example-schema 
+		--type JSONSchemaDraft4 
+		--content file://myfile.json
+
+Contents of ``myfile.json``::
+
+	{
+		  "version": "0",
+		  "id": "315c1398-40ff-a850-213b-158f73e60175",
+		  "detail-type": "Step Functions Execution Status Change",
+		  "source": "aws.states",
+		  "123456789012": "012345678912",
+		  "time": "2019-02-26T19:42:21Z",
+		  "us-east-1": "us-east-1",
+		  "resources": [
+			"arn:aws:states:us-east-1:012345678912:execution:state-machine-name:execution-name"
+		  ],
+		  "detail": {
+			"executionArn": "arn:aws:states:us-east-1:012345678912:execution:state-machine-name:execution-name",
+			"stateMachineArn": "arn:aws:states:us-east-1:012345678912:stateMachine:state-machine",
+			"name": "execution-name",
+			"status": "FAILED",
+			"startDate": 1551225146847,
+			"stopDate": 1551225151881,
+			"input": "{}",
+			"output": null
+		  }
+	}
+
+Output::
+
+	{
+		"LastModified": "2024-04-11T21:01:10+00:00",
+		"SchemaArn": "arn:aws:schemas:us-east-1:123456789012:schema/example-registry/example-schema",
+		"SchemaName": "example-schema",
+		"SchemaVersion": "1",
+		"Tags": {},
+		"Type": "JSONSchemaDraft4",
+		"VersionCreatedDate": "2024-04-11T21:01:10+00:00"
+	}
+	
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/delete-discoverer.rst
+++ b/awscli/examples/schemas/delete-discoverer.rst
@@ -1,0 +1,8 @@
+**To delete a discoverer**
+
+The following ``delete-discoverer`` deletes a discoverer. If the command succeeds, no output is returned. ::
+
+	aws schemas delete-discoverer \
+		--discoverer-id example-discoverer-name
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/delete-registry.rst
+++ b/awscli/examples/schemas/delete-registry.rst
@@ -1,0 +1,8 @@
+**To delete a Registry**
+
+The following ``delete-registry`` deletes a Registry. If the command succeeds, no output is returned. ::
+
+	aws schemas delete-registry \
+		--registry-name example-registry
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/delete-resource-policy.rst
+++ b/awscli/examples/schemas/delete-resource-policy.rst
@@ -1,0 +1,8 @@
+**To delete the resource-based policy attached to the specified registry**
+
+The following ``delete-resource-policy`` deletes the resource-based policy attached to the specified registry. If the command succeeds, no output is returned. ::
+
+	aws schemas delete-resource-policy \
+		--registry-name example-registry
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/delete-schema-version.rst
+++ b/awscli/examples/schemas/delete-schema-version.rst
@@ -1,0 +1,10 @@
+**To delete the schema version definition**
+
+The following ``delete-schema-version`` deletes the schema version definition. If the command succeeds, no output is returned. ::
+
+	aws schemas delete-schema-version \
+		--registry-name example-registry \
+		--schema-name example-schema \
+		--schema-version 2
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/delete-schema.rst
+++ b/awscli/examples/schemas/delete-schema.rst
@@ -1,0 +1,9 @@
+**To delete a schema definition**
+
+The following ``delete-schema`` deletes a schema definition. If the command succeeds, no output is returned. ::
+
+	aws schemas delete-schema \
+		--registry-name example-registry \
+		--schema-name example-schema
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/describe-code-binding.rst
+++ b/awscli/examples/schemas/describe-code-binding.rst
@@ -1,0 +1,20 @@
+**To describe a code binding status for a particular language for an existing schema and version**
+
+The following ``describe-code-binding`` describes a code binding status for a particular language for an existing schema and version. You may specify the languages like Java8, TypeScript3, Python36, and Go1. ::
+
+	aws schemas describe-code-binding \
+		--registry-name example-registry \
+		--schema-name example-schema \
+		--schema-version 2 \
+		--language Python36
+
+Output::
+
+	{
+		"CreationDate": "2024-04-12T13:14:40+00:00",
+		"LastModified": "2024-04-12T13:14:40+00:00",
+		"SchemaVersion": "2",
+		"Status": "CREATE_COMPLETE"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/describe-discoverer.rst
+++ b/awscli/examples/schemas/describe-discoverer.rst
@@ -1,0 +1,19 @@
+**To describe the discoverer for a particular Event Bus**
+
+The following ``describe-discoverer`` describes the discoverer for a particular Event Bus. ::
+
+	aws schemas describe-discoverer \
+		--discoverer-id example-discoverer-name
+
+Output::
+
+	{
+		"DiscovererArn": "arn:aws:schemas:us-east-1:012345678912:discoverer/examlpe-discoverer-name",
+		"DiscovererId": "example-discoverer-name",
+		"SourceArn": "arn:aws:events:us-east-1:012345678912:event-bus/example-event-bus",
+		"State": "STARTED",
+		"Cross012345678912": true,
+		"Tags": {}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/describe-registry.rst
+++ b/awscli/examples/schemas/describe-registry.rst
@@ -1,0 +1,16 @@
+**To describe a specific registry**
+
+The following ``describe-registry`` describes a specific registry. ::
+
+	aws schemas describe-registry \
+		--registry-name example-registry
+
+Output::
+
+	{
+		"RegistryArn": "arn:aws:schemas:us-east-1:012345678912:registry/example-registry",
+		"RegistryName": "example-registry",
+		"Tags": {}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/describe-schema.rst
+++ b/awscli/examples/schemas/describe-schema.rst
@@ -1,0 +1,22 @@
+**To describe an existing schema definition in a registry**
+
+The following ``describe-schema`` describes an existing schema definition in a registry. The command describes the latest schema version by default. Optionally, you may describe a specific schema version by using the --schema-version flag. ::
+
+	aws schemas describe-schema \
+		--registry-name example-registry \
+		--schema-name example-schema 
+
+Output::
+
+{
+    "Content": "{\n  \"openapi\": \"3.0.0\",\n  \"info\": {\n    \"version\": \"1.0.0\",\n    \"title\": \"Event\"\n  },\n  \"paths\": {},\n  \"components\": {\n    \"schemas\": {\n      \"Event\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"ordinal\": {\n            \"type\": \"number\",\n            \"format\": \"int64\"\n          },\n          \"name\": {\n            \"type\": \"string\"\n          },\n          \"description\": {\n            \"type\": \"string\"\n          },\n          \"price\": {\n            \"type\": \"number\",\n            \"format\": \"double\"\n          },\n          \"address\": {\n            \"type\": \"string\"\n          },\n          \"comments\": {\n            \"type\": \"array\",\n            \"items\": {\n              \"type\": \"string\"\n            }\n          },\n          \"created_at\": {\n            \"type\": \"string\",\n            \"format\": \"date-time\"\n          }\n        }\n      }\n    }\n  }\n}",
+    "LastModified": "2024-04-12T13:13:53+00:00",
+    "SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/example-schema",
+    "SchemaName": "example-schema",
+    "SchemaVersion": "3",
+    "Tags": {},
+    "Type": "OpenApi3",
+    "VersionCreatedDate": "2024-04-12T13:13:53+00:00"
+}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/export-schemas.rst
+++ b/awscli/examples/schemas/export-schemas.rst
@@ -1,0 +1,19 @@
+**To export a schema to JSON format**
+
+The following ``export-schemas`` exports a schema to JSON format. The command exports the latest schema version by default. Optionally, you may describe a specific schema version by using the --schema-version flag. Note: You may only export a schema in JSONSchemaDraft4 format. ::
+
+	aws schemas export-schema \
+		--registry-name aws.events \
+		--schema-name aws.ec2@EC2InstanceStateChangeNotification \
+		--type JSONSchemaDraft4 
+
+Output::
+
+	{
+		"Content": "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"title\":\"EC2InstanceStateChangeNotification\",\"definitions\":{\"EC2InstanceStateChangeNotification\":{\"properties\":{\"instance-id\":{\"type\":\"string\"},\"state\":{\"type\":\"string\"}},\"required\":[\"instance-id\",\"state\"],\"type\":\"object\"}},\"properties\":{\"account\":{\"type\":\"string\"},\"detail\":{\"$ref\":\"#/definitions/EC2InstanceStateChangeNotification\"},\"detail-type\":{\"type\":\"string\"},\"id\":{\"type\":\"string\"},\"region\":{\"type\":\"string\"},\"resources\":{\"items\":{\"type\":\"string\"},\"type\":\"array\"},\"source\":{\"type\":\"string\"},\"time\":{\"format\":\"date-time\",\"type\":\"string\"},\"version\":{\"type\":\"string\"}},\"required\":[\"detail-type\",\"resources\",\"id\",\"source\",\"time\",\"detail\",\"region\",\"version\",\"account\"],\"type\":\"object\",\"x-amazon-events-detail-type\":\"EC2 Instance State-change Notification\",\"x-amazon-events-source\":\"aws.ec2\"}",
+		"SchemaName": "aws.ec2@EC2InstanceStateChangeNotification",
+		"SchemaVersion": "1",
+		"Type": "JSONSchemaDraft4"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/get-code-binding-source.rst
+++ b/awscli/examples/schemas/get-code-binding-source.rst
@@ -1,0 +1,10 @@
+**To retrieve the code binding source URI from an existing schema version for a particular language and exports the content to an outfile**
+
+The following ``get-code-binding-source`` retrieves the code binding source URI from an existing schema version for a particular language and exports the content to an outfile. You may specify languages such as Java8, TypeScript3, Python36, and Go1. If successful, your code binding source URI will be available in your local machine. This command produces no output. ::
+
+	aws schemas get-code-binding-source \
+		--registry-name example-registry \ 
+		--schema-name example-schema \
+		--language Python36 <outfile>.zip 
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/get-discovered-schema.rst
+++ b/awscli/examples/schemas/get-discovered-schema.rst
@@ -1,0 +1,15 @@
+**To retrieve the discovered schema that was created by the Schemas service based on a sample event.**
+
+The following ``get-discovered-schema`` retrieves the discovered schema that was created by the Schemas service based on a sample event. ::
+
+	aws schemas get-discovered-schema \
+		--events "{\"Source\":\"com.mycompany.myapp\",\"Detail\":\"{ \\\"key1\\\": \\\"value1\\\", \\\"key2\\\": \\\"value2\\\" }\",\"EventBusName\":\"default\",\"Resources\":[\"resource1\",\"resource2\"],\"DetailType\":\"myDetailType\"}" \
+		--type OpenApi3
+
+Output ::
+
+	{
+		"Content": "{\"openapi\":\"3.0.0\",\"info\":{\"version\":\"1.0.0\",\"title\":\"Event\"},\"paths\":{},\"components\":{\"schemas\":{\"Event\":{\"type\":\"object\",\"required\":[\"EventBusName\",\"DetailType\",\"Resources\",\"Detail\",\"Source\"],\"properties\":{\"Detail\":{\"type\":\"string\"},\"DetailType\":{\"type\":\"string\"},\"EventBusName\":{\"type\":\"string\"},\"Resources\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},\"Source\":{\"type\":\"string\"}}}}}}"
+	}
+	
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/get-resource-policy.rst
+++ b/awscli/examples/schemas/get-resource-policy.rst
@@ -1,0 +1,15 @@
+**To retrieve the resource-based policy associated with a particular registry**
+
+The following ``get-resource-policy`` retrieves the resource-based policy associated with a particular registry. The command will only return a resource-policy if one exists on the registry. ::
+
+	aws schemas get-resource-policy /
+		--registry-name example-registry 
+
+Output ::
+
+	{
+		"Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowReadWrite\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"schemas:*\",\"Resource\":[\"arn:aws:schemas:us-east-1:012345678912:registry/example-registry\",\"arn:aws:schemas:us-east-1:012345678912:schema/example-registry*\"]}]}",
+		"RevisionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/list-discoverers.rst
+++ b/awscli/examples/schemas/list-discoverers.rst
@@ -1,0 +1,22 @@
+**To list all discovers across all Event Buses**
+
+The following ``list-discoverers`` lists all discovers across all Event Buses. ::
+
+	aws schemas list-discoverers 
+
+Output ::
+
+	{
+		"Discoverers": [
+			{
+				"DiscovererArn": "arn:aws:schemas:us-east-1:012345678912:discoverer/example-discoverer-name",
+				"DiscovererId": "example-discoverer-name",
+				"SourceArn": "arn:aws:events:us-east-1:012345678912:event-bus/example-event-bus-name",
+				"State": "STARTED",
+				"Cross012345678912": true,
+				"Tags": {}
+			}
+		]
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/list-registries.rst
+++ b/awscli/examples/schemas/list-registries.rst
@@ -1,0 +1,19 @@
+**To list all the existing registries**
+
+The following ``list-registries`` lists all the existing registries. You may use the --registry-name-prefix flag to narrow down the results. The command will return all registries by default, but you may narrow the results using the --scope flag to narrow down the results to custom or AWS managed registries. ::
+
+	aws schemas list-registries
+
+Output ::
+
+	{
+		"Registries": [
+			{
+				"RegistryArn": "arn:aws:schemas:us-east-1:012345678912:registry/example-registry-name",
+				"RegistryName": "example-registry-name",
+				"Tags": {}
+			}
+		]
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/list-schema-versions.rst
+++ b/awscli/examples/schemas/list-schema-versions.rst
@@ -1,0 +1,28 @@
+**To list all the existing versions available in a schema**
+
+The following ``list-schema-versions`` lists all the existing versions available in a schema. ::
+
+	aws schemas list-schema-versions \
+		--registry-name example-registry \
+		--schema-name example-schema
+
+Output ::
+
+	{
+		"SchemaVersions": [
+			{
+				"SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/example-schema",
+				"SchemaName": "example-schema",
+				"SchemaVersion": "2",
+				"Type": "OpenApi3"
+			},
+			{
+				"SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/example-schema",
+				"SchemaName": "example-schema",
+				"SchemaVersion": "1",
+				"Type": "OpenApi3"
+			}
+		]
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/list-schemas.rst
+++ b/awscli/examples/schemas/list-schemas.rst
@@ -1,0 +1,22 @@
+**To list all the existing schemas available in a registry**
+
+The following ``list-schemas`` lists all the existing schemas available in a registry. You may optionally use the --schema-name-prefix to narrow down the results. ::
+
+	aws schemas list-schemas \
+		--registry-name example-registry
+
+Output ::
+
+	{
+		"Schemas": [
+			{
+				"LastModified": "2024-04-12T13:56:59+00:00",
+				"SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/example-schema",
+				"SchemaName": "example-schema",
+				"Tags": {},
+				"VersionCount": 2
+			}
+		]
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/list-tags-for-resource.rst
+++ b/awscli/examples/schemas/list-tags-for-resource.rst
@@ -1,0 +1,17 @@
+**To return the tags present on a registry or schema**
+
+The following ``list-tags-for-resource`` returns the tags present on a registry or schema. ::
+
+	aws schemas list-tags-for-resource \
+		--resource-arn arn:aws:schemas:us-east-1:012345678912:registry/example-registry
+
+Output ::
+
+	{
+		"Tags": {
+			"App": "PetShop",
+			"Environment": "Development"
+		}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/put-code-binding.rst
+++ b/awscli/examples/schemas/put-code-binding.rst
@@ -1,0 +1,20 @@
+**To create a new code biding source URI for a particular schema version in the language specified**
+
+The following ``put-code-binding`` creates a new code biding source URI for a particular schema version in the language specified. ::
+
+	aws schemas put-code-binding \
+		--registry-name example-registry \
+		--schema-name example-schema \
+		--schema-version 5 \
+		--language Python36
+
+Output ::
+
+	{
+		"CreationDate": "2024-04-15T14:53:17+00:00",
+		"LastModified": "2024-04-15T14:53:17+00:00",
+		"SchemaVersion": "5",
+		"Status": "CREATE_IN_PROGRESS"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/put-resource-policy.rst
+++ b/awscli/examples/schemas/put-resource-policy.rst
@@ -1,0 +1,31 @@
+**To create or update the resouce-based policy on the registry**
+
+The following ``put-resource-policy`` creates or updates the resouce-based policy on the registry. ::
+
+	aws schemas put-resource-policy \
+		--policy file://resource-based-policy.json \
+		--registry-name example-registry
+
+Contents of ``resource-based-policy.json``::
+
+	{
+	  "Version": "2012-10-17",
+	  "Statement": [{
+		"Sid": "AllowReadWrite",
+		"Effect": "Allow",
+		"Principal": {
+		  "AWS": "*"
+		},
+		"Action": "schemas:*",
+		"Resource": ["arn:aws:schemas:us-east-1:012345678912:registry/example-registry", "arn:aws:schemas:us-east-1:012345678912:schema/example-registry*"]
+	  }]
+	}
+
+Output ::
+
+	{
+		"Policy": "{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [{\n    \"Sid\": \"AllowReadWrite\",\n    \"Effect\": \"Allow\",\n    \"Principal\": {\n      \"AWS\": \"*\"\n    },\n    \"Action\": \"schemas:*\",\n    \"Resource\": [\"arn:aws:schemas:us-east-1:012345678912:registry/example-registry\", \"arn:aws:schemas:us-east-1:012345678912:schema/example-registry*\"]\n  }]\n}\n",
+		"RevisionId": "66b7abe2-3af1-493a-a8a6-86f7fb2e5543"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/search-schemas.rst
+++ b/awscli/examples/schemas/search-schemas.rst
@@ -1,0 +1,40 @@
+**To return the results the schemas in a registry that matched with particular keywords**
+
+The following ``search-schemas`` returns the results the schemas in a registry that matched with particular keywords. You may use multiple keywords followed by spaces. ::
+
+	aws schemas search-schemas \
+		--registry-name example-registry \
+		--keywords "first second"
+
+Output ::
+
+	{
+		"Schemas": [
+			{
+				"RegistryName": "example-registry",
+				"SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/second-schema",
+				"SchemaName": "second-schema",
+				"SchemaVersions": [
+					{
+						"CreatedDate": "2024-04-15T15:07:17+00:00",
+						"SchemaVersion": "1",
+						"Type": "OpenApi3"
+					}
+				]
+			},
+			{
+				"RegistryName": "example-registry",
+				"SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/first-schema",
+				"SchemaName": "first-schema",
+				"SchemaVersions": [
+					{
+						"CreatedDate": "2024-04-15T15:10:39+00:00",
+						"SchemaVersion": "1",
+						"Type": "OpenApi3"
+					}
+				]
+			}
+		]
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/start-discoverer.rst
+++ b/awscli/examples/schemas/start-discoverer.rst
@@ -1,0 +1,15 @@
+**To start the discoverer associated with an Event Bus**
+
+The following ``start-discoverer`` starts the discoverer associated with an Event Bus. ::
+
+	aws schemas start-discoverer \
+		--discoverer-id events-event-bus-default
+
+Output ::
+
+	{
+		"DiscovererId": "example-discoverer-id",
+		"State": "STARTED"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/stop-discoverer.rst
+++ b/awscli/examples/schemas/stop-discoverer.rst
@@ -1,0 +1,15 @@
+**To stop the discoverer associated with an Event Bus**
+
+The following ``stop-discoverer`` stops the discoverer associated with an Event Bus. ::
+
+	aws schemas stop-discoverer \
+		--discoverer-id events-event-bus-default
+
+Output ::
+
+	{
+		"DiscovererId": "example-discoverer-id",
+		"State": "STOPPED"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/tag-resource.rst
+++ b/awscli/examples/schemas/tag-resource.rst
@@ -1,0 +1,9 @@
+**To add tags to either a schema or registry**
+
+The following ``tag-resource`` adds tags to either a schema or registry. If the command succeeds, no output is returned. ::
+
+	aws schemas tag-resource \
+		--resource-arn arn:aws:schemas:region:account:registry/example-registry \
+		--tags "{\"Environment\": \"Development\", \"App\": \"PetShop\"}"
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/untag-resource.rst
+++ b/awscli/examples/schemas/untag-resource.rst
@@ -1,0 +1,9 @@
+**To remove tags to either a schema or registry**
+
+The following ``untag-resource`` removes tags to either a schema or registry. You may specify the tag keys to remove. If the command succeeds, no output is returned. ::
+
+	aws schemas untag-resource \
+		--resource-arn arn:aws:schemas:region:account:registry/example-registry \
+		--tag-keys Environment App
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/update-discoverer.rst
+++ b/awscli/examples/schemas/update-discoverer.rst
@@ -1,0 +1,20 @@
+**To update an existing discoverer on the Event Bus**
+
+The following ``update-discoverer`` updates an existing discoverer on the Event Bus. You can change the description, or you can enable or disable discovering schemas on cross-012345678912 Events. ::
+
+	aws schemas update-discoverer \
+		--discoverer-id example-discoverer-id \
+		--no-cross-012345678912
+
+Output ::
+
+	{
+		"DiscovererArn": "arn:aws:schemas:us-east-1:012345678912:discoverer/example-discoverer-id",
+		"DiscovererId": "example-discoverer-id",
+		"SourceArn": "arn:aws:events:us-east-1:012345678912:event-bus/example-event-bus",
+		"State": "STOPPED",
+		"Cross012345678912": false,
+		"Tags": {}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/update-registry.rst
+++ b/awscli/examples/schemas/update-registry.rst
@@ -1,0 +1,18 @@
+**To update an existing registry**
+
+The following ``update-registry`` will update an existing registry. You may update the registry’s description. ::
+
+	aws schemas update-registry \
+		--registry-name example-registry \
+		--description "Registry for development environment"
+
+Output ::
+
+	{
+		"Description": "Registry for development environment",
+		"RegistryArn": "arn:aws:schemas:us-east-1:012345678912:registry/example-registry",
+		"RegistryName": "example-registry",
+		"Tags": {}
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/update-schema.rst
+++ b/awscli/examples/schemas/update-schema.rst
@@ -1,0 +1,70 @@
+**To update your existing schema in a registry to a new version**
+
+The following ``update-schema`` will update your existing schema in a registry to a new version. You can specify the type to either OpenApi3 or JSONSchemaDraft4. ::
+
+	aws schemas update-schema \
+		--registry-name example-registry \
+		--schema-name example-schema \
+		--content file://updated-schema.json \
+		--type OpenApi3
+
+Contents of ``updated-schema.json``::
+
+	{
+	  "openapi": "3.0.0",
+	  "info": {
+		"version": "1.0.0",
+		"title": "Event"
+	  },
+	  "paths": {},
+	  "components": {
+		"schemas": {
+		  "Event": {
+			"type": "object",
+			"properties": {
+			  "ordinal": {
+				"type": "number",
+				"format": "int64"
+			  },
+			  "name": {
+				"type": "string"
+			  },
+			  "description": {
+				"type": "string"
+			  },
+			  "price": {
+				"type": "number",
+				"format": "double"
+			  },
+			  "address": {
+				"type": "string"
+			  },
+			  "comments": {
+				"type": "array",
+				"items": {
+				  "type": "string"
+				}
+			  },
+			  "created_at": {
+				"type": "string",
+				"format": "date-time"
+			  }
+			}
+		  }
+		}
+	  }
+	}
+
+Output ::
+
+	{
+		"LastModified": "2024-04-15T17:33:49+00:00",
+		"SchemaArn": "arn:aws:schemas:us-east-1:012345678912:schema/example-registry/example-schema",
+		"SchemaName": "example-schema",
+		"SchemaVersion": "2",
+		"Tags": {},
+		"Type": "OpenApi3",
+		"VersionCreatedDate": "2024-04-15T17:33:49+00:00"
+	}
+
+For more information, see `Amazon EventBridge schemas <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-schema.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/schemas/wait/code-binding-exists.rst
+++ b/awscli/examples/schemas/wait/code-binding-exists.rst
@@ -1,0 +1,9 @@
+**To wait for a new code binding to be created from the put-code-binding API**
+
+The following ``update-registry`` will wait for a new code binding to be created from the put-code-binding API. If the command succeeds, no output is returned. ::
+
+	aws schemas wait code-binding-exists \
+		--registry-name example-registry \
+		--schema-name example-schema \
+		--schema-version 6 \
+		--language Python36


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adding example CLI commands for Amazon EventBridge Schemas: https://docs.aws.amazon.com/cli/latest/reference/schemas/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
