### PR TITLE
[V2] Improve performance when parsing invalid shorthand syntax

### DIFF
--- a/.changes/next-release/bugfix-shorthand-72603.json
+++ b/.changes/next-release/bugfix-shorthand-72603.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "shorthand",
+  "description": "Improve performance when parsing invalid shorthand syntax."
+}

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -127,8 +127,8 @@ class ShorthandParser(object):
 
     """
 
-    _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
-    _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
+    _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\'|[^\'])*\'')
+    _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\"|[^"])*"')
     _START_WORD = r'\!\#-&\(-\+\--\<\>-Z\\-z' + '\u007c-\uffff'
     _FIRST_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\\\^-\|~-' + '\uffff'
     _SECOND_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\<\>-' + '\uffff'

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -11,9 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import pytest
+import signal
 
 from awscli import shorthand
-from awscli.testutils import unittest
+from awscli.testutils import unittest, skip_if_windows
+
 
 from botocore import model
 
@@ -150,6 +152,28 @@ PARSING_TEST_CASES = (
 def test_error_parsing(expr):
     with pytest.raises(shorthand.ShorthandParseError):
         shorthand.ShorthandParser().parse(expr)
+
+
+@pytest.mark.parametrize(
+    "expr", (
+        # starting with " but unclosed, then repeated \
+        f'foo="{'\\' * 100}',
+        # starting with ' but unclosed, then repeated \
+        f'foo=\'{'\\' * 100}',
+    )
+)
+@skip_if_windows("Windows does not support signal.SIGALRM.")
+def test_error_with_backtracking(expr):
+    signal.signal(signal.SIGALRM, handle_timeout)
+    # Ensure we don't spend more than 5 seconds backtracking
+    signal.alarm(5)
+    with pytest.raises(shorthand.ShorthandParseError):
+        shorthand.ShorthandParser().parse(expr)
+    signal.alarm(0)
+
+
+def handle_timeout(signum, frame):
+    raise TimeoutError('Shorthand parsing timed out')
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_shorthand.py
+++ b/tests/unit/test_shorthand.py
@@ -157,9 +157,9 @@ def test_error_parsing(expr):
 @pytest.mark.parametrize(
     "expr", (
         # starting with " but unclosed, then repeated \
-        f'foo="{'\\' * 100}',
+        f'foo="' + '\\' * 100,
         # starting with ' but unclosed, then repeated \
-        f'foo=\'{'\\' * 100}',
+        f'foo=\'' + '\\' * 100,
     )
 )
 @skip_if_windows("Windows does not support signal.SIGALRM.")


### PR DESCRIPTION
*Description of changes:* This avoids exponential backtracking when parsing shorthand syntax that:
1. Starts with either `'` or `"`, but is not closed
2. Contains a lot of `\`

Now, these will finish quickly and throw the expected `ShorthandParseError`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
