### PR TITLE
[V1] Improve performance when parsing invalid shorthand syntax

### DIFF
--- a/.changes/next-release/bugfix-shorthand-99230.json
+++ b/.changes/next-release/bugfix-shorthand-99230.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "shorthand",
+  "description": "Improve performance when parsing invalid shorthand syntax."
+}

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -124,8 +124,8 @@ class ShorthandParser:
 
     """
 
-    _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\\|\\\'|[^\'])*\'')
-    _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\\\|\\"|[^"])*"')
+    _SINGLE_QUOTED = _NamedRegex('singled quoted', r'\'(?:\\\'|[^\'])*\'')
+    _DOUBLE_QUOTED = _NamedRegex('double quoted', r'"(?:\\"|[^"])*"')
     _START_WORD = r'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
     _FIRST_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
     _SECOND_FOLLOW_CHARS = r'\s\!\#-&\(-\+\--\<\>-\uffff'


### PR DESCRIPTION
*Issue #, if available:* V1 port of #8992

*Description of changes:* This avoids exponential backtracking when parsing shorthand syntax that:
1. Starts with either `'` or `"`, but is not closed
2. Contains a lot of `\`

Now, these will finish quickly and throw the expected `ShorthandParseError`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
