### PR TITLE
adding more events-cli-examples

### DIFF
--- a/awscli/examples/events/create-api-destination.rst
+++ b/awscli/examples/events/create-api-destination.rst
@@ -1,0 +1,20 @@
+**To create an API destination, which is an HTTP invocation endpoint configured as a target for events**
+
+The following ``create-api-destination`` creates an API destination, which is an HTTP invocation endpoint configured as a target for events. ::
+
+	aws events create-api-destination \
+		--name prodApiDestination \
+		--connection-arn "arn:aws:events:ca-central-1:123456789012:connection/test/e5dd1690-b729-4724-bbd9-390282925efc" \
+		--invocation-endpoint "https://test.com/v1" \
+		--http-method "POST"
+
+Output ::
+
+	{
+		"ApiDestinationArn": "arn:aws:events:ca-central-1:123456789012:api-destination/prodApiDestination/969681cc-82cc-4353-8e77-b74f9764e629",
+		"ApiDestinationState": "ACTIVE",
+		"CreationTime": "2024-10-21T15:25:05+00:00",
+		"LastModifiedTime": "2024-10-21T15:25:05+00:00"
+	}
+
+For more information, see `Create an API destination in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destination-create.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/create-archive.rst
+++ b/awscli/examples/events/create-archive.rst
@@ -1,0 +1,17 @@
+**To create an archive of events with the specified settings**
+
+The following ``create-archive`` creates an archive of events with the specified settings. When you create an archive, incoming events might not immediately start being sent to the archive. Allow a short period of time for changes to take effect. If you do not specify a pattern to filter events sent to the archive, all events are sent to the archive except replayed event. ::
+
+	aws events create-archive \
+		--archive-name ProductionRuleArch \
+		--event-source-arn "arn:aws:events:ca-central-1:123456789012:event-bus/test"
+
+Output ::
+
+	{
+		"ArchiveArn": "arn:aws:events:ca-central-1:123456789012:archive/ProductionRuleArch",
+		"State": "ENABLED",
+		"CreationTime": "2024-10-21T15:10:56+00:00"
+	}
+
+For more information, see `Creating an archive for events in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-archive-event.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/create-connection.rst
+++ b/awscli/examples/events/create-connection.rst
@@ -1,0 +1,19 @@
+**To create a connection**
+
+The following ``create-connection`` creates a connection. A connection defines the authorization type and credentials to use for authorization with an API destination HTTP endpoint. ::
+
+	aws events create-connection \
+		--name ProdConnection \
+		--authorization-type BASIC \
+		--auth-parameters '{"BasicAuthParameters":{"Username":"string","Password":"string"}}'
+ 
+Output ::
+
+	{
+		"ConnectionArn": "arn:aws:events:us-east-1:123456789012:connection/ProdConnection/53eb3384-f1c8-44b6-ba3a-66fe3cc5fd71",
+		"ConnectionState": "AUTHORIZED",
+		"CreationTime": "2024-04-20T07:21:19+00:00",
+		"LastModifiedTime": "2024-04-20T07:21:19+00:00"
+	}
+
+For more information, see `Creating connections for HTTP endpoint targets in EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection-create.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/create-endpoint.rst
+++ b/awscli/examples/events/create-endpoint.rst
@@ -1,0 +1,41 @@
+**To create a global endpoint**
+
+The following ``create-endpoint`` creates a global endpoint. Global endpoints improve your application’s availability by making it regional-fault tolerant. To do this, you define a primary and secondary Region with event buses in each Region. You also create a Amazon Route 53 health check that will tell EventBridge to route events to the secondary Region when an “unhealthy” state is encountered and events will be routed back to the primary Region when the health check reports a “healthy” state. ::
+
+	aws events create-endpoint \
+		--name WestProdConnection \
+		--event-buses '[{"EventBusArn":"arn:aws:events:us-east-1:123456789012:event-bus/default"},{"EventBusArn":"arn:aws:events:us-east-2:123456789012:event-bus/default"}]' \
+		--replication-config '{"State":"ENABLED"}' --routing-config '{"FailoverConfig":{"Primary":{"HealthCheck":"arn:aws:route53:::healthcheck/7f4243fa-ce7e-493b-b3de-4d2058e52ce7"},"Secondary":{"Route":"us-east-2"}}}' \
+		--role-arn arn:aws:iam::123456789012:role/service-role/Amazon_EventBridge_Invoke_Event_Bus_468661116
+ 
+Output ::
+
+	{
+		"Name": "WestProdConnection",
+		"Arn": "arn:aws:events:us-east-1:123456789012:endpoint/WestProdConnection",
+		"RoutingConfig": {
+			"FailoverConfig": {
+				"Primary": {
+					"HealthCheck": "arn:aws:route53:::healthcheck/7f4243fa-ce7e-493b-b3de-4d2058e52ce7"
+				},
+				"Secondary": {
+					"Route": "us-east-2"
+				}
+			}
+		},
+		"ReplicationConfig": {
+			"State": "ENABLED"
+		},
+		"EventBuses": [
+			{
+				"EventBusArn": "arn:aws:events:us-east-1:123456789012:event-bus/default"
+			},
+			{
+				"EventBusArn": "arn:aws:events:us-east-2:123456789012:event-bus/default"
+			}
+		],
+		"RoleArn": "arn:aws:iam::123456789012:role/service-role/Amazon_EventBridge_Invoke_Event_Bus_468661116",
+		"State": "CREATING"
+	}
+
+For more information, see `Creating a global endpoint in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-ge-create-endpoint.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/create-event-bus.rst
+++ b/awscli/examples/events/create-event-bus.rst
@@ -1,0 +1,14 @@
+**To create a new event bus within your account**
+
+The following ``create-event-bus`` creates a new event bus within your account. This can be a custom event bus which you can use to receive events from your custom applications and services, or it can be a partner event bus which can be matched to a partner event source. ::
+
+	aws events create-event-bus \
+		--name prodbus
+
+Output ::
+
+	{
+		"EventBusArn": "arn:aws:events:ca-central-1:123456789012:event-bus/prodbus"
+	}
+
+For more information, see `Creating an event bus in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-event-bus.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/deauthorize-connection.rst
+++ b/awscli/examples/events/deauthorize-connection.rst
@@ -1,0 +1,18 @@
+**To remove all authorization parameters from the connection**
+
+The following ``deauthorize-connection`` removes all authorization parameters from the connection. This lets you remove the secret from the connection so you can reuse it without having to create a new connection. ::
+
+	aws events deauthorize-connection \
+		--name ProdConnection
+ 
+Output ::
+
+	{
+		"ConnectionArn": "arn:aws:events:123456789012:connection/ProdConnection/53eb3384-f1c8-44b6-ba3a-66fe3cc5fd71",
+		"ConnectionState": "DEAUTHORIZING",
+		"CreationTime": "2024-04-20T07:21:19+00:00",
+		"LastModifiedTime": "2024-04-20T07:21:19+00:00",
+		"LastAuthorizedTime": "2024-04-20T07:21:19+00:00"
+	}
+
+For more information, see `De-authorizing connections using the EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection-deauthorize.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/delete-api-destination.rst
+++ b/awscli/examples/events/delete-api-destination.rst
@@ -1,0 +1,8 @@
+**To delete the specified API destination**
+
+The following ``delete-api-destination`` deletes the specified API destination. If the command succeeds, no output is returned. ::
+
+	aws events delete-api-destination \
+		--name ProdDestination
+
+For more information, see `API destinations as targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/delete-archive.rst
+++ b/awscli/examples/events/delete-archive.rst
@@ -1,0 +1,8 @@
+**To delete the specified archive**
+
+The following ``delete-archive`` deletes the specified archive. If the command succeeds, no output is returned. ::
+
+	aws events delete-archive \
+		--archive-name prod-archive
+
+For more information, see `Adding or removing archives on Amazon EventBridge event buses <https://docs.aws.amazon.com/eventbridge/latest/userguide/event-bus-update-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/delete-connection.rst
+++ b/awscli/examples/events/delete-connection.rst
@@ -1,0 +1,18 @@
+**To delete a connection**
+
+The following ``delete-connection`` deletes a connection. ::
+
+	aws events delete-connection \
+		--name ProdConnection
+		
+Output ::
+
+	{
+		"ConnectionArn": "arn:aws:events:us-east-1:123456789012:connection/ProdConnection/53eb3384-f1c8-44b6-ba3a-66fe3cc5fd71",
+		"ConnectionState": "DELETING",
+		"CreationTime": "2024-04-20T07:21:19+00:00",
+		"LastModifiedTime": "2024-04-20T07:55:37+00:00",
+		"LastAuthorizedTime": "2024-04-20T07:21:19+00:00"
+	}
+
+For more information, see `Deleting connections using the EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection-delete.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/delete-endpoint.rst
+++ b/awscli/examples/events/delete-endpoint.rst
@@ -1,0 +1,8 @@
+**To delete the specified Global endpoint**
+
+The following ``delete-endpoint`` deletes the specified Global endpoint. If the command succeeds, no output is returned. ::
+
+	aws events delete-endpoint \
+		--name ProdEndpoint
+
+For more information, see `Global endpoint in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-ge-create-endpoint.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/delete-event-bus.rst
+++ b/awscli/examples/events/delete-event-bus.rst
@@ -1,0 +1,7 @@
+**To delete the specified custom event bus or partner event bus**
+
+The following ``delete-event-bus`` deletes the specified custom event bus or partner event bus. ::
+
+	aws events delete-event-bus --name "MyCustomBus"
+
+For more information, see `Deleting an event bus in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/event-bus-delete.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/describe-api-destination.rst
+++ b/awscli/examples/events/describe-api-destination.rst
@@ -1,0 +1,21 @@
+**To retrieve details about an API destination**
+
+The following ``describe-api-destination`` retrieves details about an API destination. ::
+
+	aws events describe-api-destination --name "pro-api"
+
+Output ::
+
+	{
+		"ApiDestinationArn": "arn:aws:events:us-east-1:123456789012:api-destination/pro-api/ffd6b638-fc1b-4a84-8642-d5d45765b6f5",
+		"Name": "pro-api",
+		"ApiDestinationState": "ACTIVE",
+		"ConnectionArn": "arn:aws:events:us-east-1:123456789012:connection/Api-Connection1/d29e45ad-137c-411f-9b78-221e4203f328",
+		"InvocationEndpoint": "https://google.com",
+		"HttpMethod": "GET",
+		"InvocationRateLimitPerSecond": 300,
+		"CreationTime": "2023-03-29T10:26:12+00:00",
+		"LastModifiedTime": "2023-03-29T10:26:12+00:00"
+	}
+
+For more information, see `API destinations as targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/describe-archive.rst
+++ b/awscli/examples/events/describe-archive.rst
@@ -1,0 +1,22 @@
+**To retrieve details about an archive**
+
+The following ``describe-archive`` retrieves details about an archive. ::
+
+	aws events describe-archive --archive-name "ProArchive"
+
+Output ::
+
+	{
+		"ArchiveArn": "arn:aws:events:us-east-1:123456789012:archive/ProArchive",
+		"ArchiveName": "ProArchive",
+		"EventSourceArn": "arn:aws:events:us-east-1:123456789012:event-bus/default",
+		"EventPattern": "{\"source\":[\"aws.ec2\"],\"detail-type\":[\"AWS API Call via CloudTrail\"],\"detail\":{\"eventSource\":[\"ec2.amazonaws.com\"]}}",
+		"Description": "TestArchive",
+		"State": "ENABLED",
+		"RetentionDays": 0,
+		"SizeBytes": 235439890,
+		"EventCount": 115044,
+		"CreationTime": "2023-04-03T03:38:02+00:00"
+	}
+
+For more information, see `Adding or removing archives on Amazon EventBridge event buses <https://docs.aws.amazon.com/eventbridge/latest/userguide/event-bus-update-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/describe-connection.rst
+++ b/awscli/examples/events/describe-connection.rst
@@ -1,0 +1,27 @@
+**To retrieve details about a connection**
+
+The following ``describe-connection`` retrieves details about a connection. ::
+
+	aws events describe-connection --name "ProdConnection"
+
+Output ::
+
+	{
+		"ConnectionArn": "arn:aws:events:us-east-1:123456789012:connection/ProdConnection/d29e45ad-137c-411f-9b78-221e4203f328",
+		"Name": "ProdConnection1",
+		"Description": "TestConnection",
+		"ConnectionState": "AUTHORIZED",
+		"AuthorizationType": "BASIC",
+		"SecretArn": "arn:aws:secretsmanager:us-east-1:123456789012:secret:events!connection/ProdConnection1/2f54acf8-7d2b-4212-ace4-d73e82a3c005-owp1Jv",
+		"AuthParameters": {
+			"BasicAuthParameters": {
+				"Username": "user"
+			},
+			"InvocationHttpParameters": {}
+		},
+		"CreationTime": "2023-03-29T10:26:11+00:00",
+		"LastModifiedTime": "2023-03-29T10:26:11+00:00",
+		"LastAuthorizedTime": "2023-03-29T10:26:11+00:00"
+	}
+
+For more information, see `Connections for HTTP endpoint targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/describe-endpoint.rst
+++ b/awscli/examples/events/describe-endpoint.rst
@@ -1,0 +1,42 @@
+**To get the information about an existing global endpoint**
+
+The following ``describe-endpoint`` will get the information about an existing global endpoint. ::
+
+	aws events describe-endpoint --name prod
+
+Output ::
+
+	{
+		"Name": "prod",
+		"Description": "sample endpoint",
+		"Arn": "arn:aws:events:us-east-1:123456789101:endpoint/prod",
+		"RoutingConfig": {
+			"FailoverConfig": {
+				"Primary": {
+					"HealthCheck": "arn:aws:route53:::healthcheck/8f7dc0b8-ad9e-1234-846e-3a475c53bb76"
+				},
+				"Secondary": {
+					"Route": "us-east-2"
+				}
+			}
+		},
+		"ReplicationConfig": {
+			"State": "ENABLED"
+		},
+		"EventBuses": [
+			{
+				"EventBusArn": "arn:aws:events:us-east-1:123456789101:event-bus/prod"
+			},
+			{
+				"EventBusArn": "arn:aws:events:us-east-2:123456789101:event-bus/prod"
+			}
+		],
+		"RoleArn": "arn:aws:iam::123456789101:role/service-role/Amazon_EventBridge_Invoke_Event_Bus_prod",
+		"EndpointId": "prod.veo",
+		"EndpointUrl": "https://prod.veo.endpoint.events.amazonaws.com",
+		"State": "ACTIVE",
+		"CreationTime": "2024-05-19T15:22:58.463000+05:30",
+		"LastModifiedTime": "2024-05-19T15:23:00.311000+05:30"
+	}
+
+For more information, see `Global endpoint in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/laprod/userguide/eb-ge-create-endpoint.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/describe-event-bus.rst
+++ b/awscli/examples/events/describe-event-bus.rst
@@ -1,0 +1,15 @@
+**To display details about an event bus in your account**
+
+The following ``describe-event-bus`` displays details about an event bus in your account. ::
+
+	aws events describe-event-bus --name "prodBus"
+
+Output ::
+
+	{
+		"Name": "prodBus",
+		"Arn": "arn:aws:events:us-east-1:123456789012:event-bus/prodBus",
+		"Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"allow_account_to_put_events\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::123456789012:root\",\"arn:aws:iam::016284297628:root\"]},\"Action\":\"events:PutEvents\",\"Resource\":\"arn:aws:events:us-east-1:123456789012:event-bus/prodBus\"}]}"
+	}
+
+For more information, see `Event bus concepts in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is-how-it-works-concepts.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/describe-replay.rst
+++ b/awscli/examples/events/describe-replay.rst
@@ -1,0 +1,29 @@
+**To retrieve details about a replay**
+
+The following ``describe-replay`` retrieves details about a replay. ::
+
+	aws events describe-replay \
+		--replay-name "Replay-1"
+
+Output ::
+
+	{
+			"ReplayName": "Replay-1",
+			"ReplayArn": "arn:aws:events:us-east-2:123456789012:replay/Replay-1",
+			"Description": "ProdReplay",
+			"State": "COMPLETED",
+			"EventSourceArn": "arn:aws:events:us-east-2:123456789012:archive/TestArchive-1",
+			"Destination": {
+				"Arn": "arn:aws:events:us-east-2:123456789012:event-bus/custom",
+				"FilterArns": [
+					"arn:aws:events:us-east-2:123456789012:rule/custom/Test-1"
+				]
+			},
+			"EventStartTime": "2024-02-21T18:30:00+00:00",
+			"EventEndTime": "2024-02-23T09:19:00+00:00",
+			"EventLastReplayedTime": "2024-02-23T09:11:00+00:00",
+			"ReplayStartTime": "2024-02-23T09:18:51+00:00",
+			"ReplayEndTime": "2024-02-23T09:19:53+00:00"
+	}
+
+For more information, see `Archiving and replaying events in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-api-destinations.rst
+++ b/awscli/examples/events/list-api-destinations.rst
@@ -1,0 +1,36 @@
+**To retrieve a list of API destination in the account in the current Region**
+
+The following ``list-api-destinations`` retrieves a list of API destination in the account in the current Region. ::
+
+	aws events list-api-destinations
+
+Output ::
+
+	{
+		"ApiDestinations": [
+			{
+				"ApiDestinationArn": "arn:aws:events:us-east-2:123456789101:api-destination/dest1/3435d8b6-a6ff-4096-8e32-27bc031d44ce",
+				"Name": "dest1",
+				"ApiDestinationState": "ACTIVE",
+				"ConnectionArn": "arn:aws:events:us-east-2:123456789101:connection/con2/6f39f463-2d10-48fc-b5b1-ff25a4bfd049",
+				"InvocationEndpoint": "https://example.com",
+				"HttpMethod": "GET",
+				"InvocationRateLimitPerSecond": 1,
+				"CreationTime": "2022-03-02T06:44:35+00:00",
+				"LastModifiedTime": "2022-03-02T06:44:35+00:00"
+			},
+			{
+				"ApiDestinationArn": "arn:aws:events:us-east-2:123456789101:api-destination/new-api/ffd6b638-fc1b-4a84-8642-d5d45765b6f5",
+				"Name": "new-api",
+				"ApiDestinationState": "ACTIVE",
+				"ConnectionArn": "arn:aws:events:us-east-2:123456789101:connection/Api-Connection1/d29e45ad-137c-411f-9b78-221e4203f328",
+				"InvocationEndpoint": "https://google.com",
+				"HttpMethod": "GET",
+				"InvocationRateLimitPerSecond": 300,
+				"CreationTime": "2023-03-29T10:26:12+00:00",
+				"LastModifiedTime": "2023-03-29T10:26:12+00:00"
+			}
+		]
+	}
+
+For more information, see `API destinations as targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-api-destinations.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-archives.rst
+++ b/awscli/examples/events/list-archives.rst
@@ -1,0 +1,32 @@
+**To list your archives**
+
+The following ``list-archives`` lists your archives. You can either list all the archives or you can provide a prefix to match to the archive names. Filter parameters are exclusive. ::
+
+	aws events list-archives
+
+Output ::
+
+	{
+		"Archives": [
+			{
+				"ArchiveName": "ProdArchive-1",
+				"EventSourceArn": "arn:aws:events:us-east-2:123456789101:event-bus/default",
+				"State": "ENABLED",
+				"RetentionDays": 0,
+				"SizeBytes": 235439890,
+				"EventCount": 115044,
+				"CreationTime": "2023-05-16T04:00:52+00:00"
+			},
+			{
+				"ArchiveName": "ProdArchive-2",
+				"EventSourceArn": "arn:aws:events:us-east-2:123456789101:event-bus/custom",
+				"State": "ENABLED",
+				"RetentionDays": 1,
+				"SizeBytes": 0,
+				"EventCount": 0,
+				"CreationTime": "2023-04-03T03:38:02+00:00"
+			}
+		]
+	}
+
+For more information, see `Archiving and replaying events in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/laProd/userguide/eb-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-connections.rst
+++ b/awscli/examples/events/list-connections.rst
@@ -1,0 +1,41 @@
+**To retrieve a list of connections from the account**
+
+The following ``list-connections`` retrieves a list of connections from the account. ::
+
+	aws events list-connections
+
+Output ::
+
+	{
+		"Connections": [
+			{
+				"ConnectionArn": "arn:aws:events:us-east-2:123456789101:connection/Api-Connection1/d29e45ad-137c-411f-9b78-221e4203f328",
+				"Name": "Api-Connection1",
+				"ConnectionState": "AUTHORIZED",
+				"AuthorizationType": "BASIC",
+				"CreationTime": "2023-03-29T10:26:11+00:00",
+				"LastModifiedTime": "2023-03-29T10:26:11+00:00",
+				"LastAuthorizedTime": "2023-03-29T10:26:11+00:00"
+			},
+			{
+				"ConnectionArn": "arn:aws:events:us-east-2:123456789101:connection/con1/45f3f040-d1be-4d92-a49f-d3f7b30b5122",
+				"Name": "con1",
+				"ConnectionState": "AUTHORIZED",
+				"AuthorizationType": "BASIC",
+				"CreationTime": "2022-03-02T06:44:10+00:00",
+				"LastModifiedTime": "2022-03-02T06:44:10+00:00",
+				"LastAuthorizedTime": "2022-03-02T06:44:10+00:00"
+			},
+			{
+				"ConnectionArn": "arn:aws:events:us-east-2:123456789101:connection/con2/6f39f463-2d10-48fc-b5b1-ff25a4bfd049",
+				"Name": "con2",
+				"ConnectionState": "AUTHORIZED",
+				"AuthorizationType": "BASIC",
+				"CreationTime": "2022-03-02T06:44:35+00:00",
+				"LastModifiedTime": "2022-03-02T06:44:35+00:00",
+				"LastAuthorizedTime": "2022-03-02T06:44:35+00:00"
+			}
+		]
+	}
+
+For more information, see `Connections for HTTP endpoint targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-target-connection.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-endpoints.rst
+++ b/awscli/examples/events/list-endpoints.rst
@@ -1,0 +1,46 @@
+**To list the global endpoints associated with this account**
+
+The following ``list-endpoints`` will list the global endpoints associated with this account. ::
+
+	aws events list-endpoints
+
+Output ::
+
+	{
+		"Endpoints": [
+			{
+				"Name": "Prod",
+				"Description": "",
+				"Arn": "arn:aws:events:us-east-1:123456789101:endpoint/Prod",
+				"RoutingConfig": {
+					"FailoverConfig": {
+						"Primary": {
+							"HealthCheck": "arn:aws:route53:::healthcheck/8f7dc0b8-ad9e-1234-846e-3a475c53bb76"
+						},
+						"Secondary": {
+							"Route": "us-east-2"
+						}
+					}
+				},
+				"ReplicationConfig": {
+					"State": "ENABLED"
+				},
+				"EventBuses": [
+					{
+						"EventBusArn": "arn:aws:events:us-east-1:123456789101:event-bus/Prod"
+					},
+					{
+						"EventBusArn": "arn:aws:events:us-east-2:123456789101:event-bus/Prod"
+					}
+				],
+				"RoleArn": "arn:aws:iam::123456789101:role/service-role/Amazon_EventBridge_Invoke_Event_Bus_Prod",
+				"EndpointId": "Prod.veo",
+				"EndpointUrl": "https://Prod.veo.endpoint.events.amazonaws.com",
+				"State": "ACTIVE",
+				"CreationTime": "2024-05-19T15:22:58.463000+05:30",
+				"LastModifiedTime": "2024-05-19T15:23:00.311000+05:30"
+			}
+		]
+	}
+
+For more information, see `Global endpoint in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/laProd/userguide/eb-ge-create-endpoint.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-event-buses.rst
+++ b/awscli/examples/events/list-event-buses.rst
@@ -1,0 +1,24 @@
+**To list all the event buses in your account**
+
+The following ``list-event-buses`` lists all the event buses in your account, including the default event bus, custom event buses, and partner event buses. ::
+
+	aws events list-event-buses
+
+Output ::
+
+	{
+		"EventBuses": [
+			{
+				"Name": "default",
+				"Arn": "arn:aws:events:us-east-1:123456789012:event-bus/default",
+				"Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"allow_account_to_put_events\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::012345678901:root\"},\"Action\":\"events:PutEvents\",\"Resource\":\"arn:aws:events:us-east-1:123456789012:event-bus/default\"}]}"
+			},
+			{
+				"Name": "custom",
+				"Arn": "arn:aws:events:us-east-1:123456789012:event-bus/custom",
+				"Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"allow_account_to_put_events\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::012345678901:root\"},\"Action\":\"events:PutEvents\",\"Resource\":\"arn:aws:events:us-east-1:123456789012:event-bus/custom\"}]}"
+			}
+		]
+	}
+	
+For more information, see `Event bus concepts in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is-how-it-works-concepts.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-replays.rst
+++ b/awscli/examples/events/list-replays.rst
@@ -1,0 +1,32 @@
+**To list your replays**
+
+The following ``list-replays`` lists your replays. You can either list all the replays or you can provide a prefix to match to the replay names. Filter parameters are exclusive. ::
+
+	aws events list-replays
+
+Output ::
+
+	{
+		"Replays": [
+			{
+				"ReplayName": "Replay-1",
+				"EventSourceArn": "arn:aws:events:us-east-2:123456789012:archive/TestArchive-1",
+				"State": "COMPLETED",
+				"EventStartTime": "2024-02-21T18:30:00+00:00",
+				"EventEndTime": "2024-02-23T09:19:00+00:00",
+				"EventLastReplayedTime": "2024-02-23T09:11:00+00:00",
+				"ReplayStartTime": "2024-02-23T09:18:51+00:00",
+				"ReplayEndTime": "2024-02-23T09:19:53+00:00"
+			},
+			{
+				"ReplayName": "Replay-2",
+				"EventSourceArn": "arn:aws:events:us-east-2:123456789012:archive/TestArchive-2",
+				"State": "STARTING",
+				"EventStartTime": "2024-02-29T18:30:00+00:00",
+				"EventEndTime": "2024-03-31T18:29:59+00:00",
+				"ReplayStartTime": "2024-04-30T08:43:25+00:00"
+			}
+		]
+	}
+
+For more information, see `Archiving and replaying events in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/list-tags-for-resource.rst
+++ b/awscli/examples/events/list-tags-for-resource.rst
@@ -1,0 +1,23 @@
+**To display the tags associated with an EventBridge resource**
+
+The following ``list-tags-for-resource`` displays the tags associated with an EventBridge resource. In EventBridge, rules and event buses can be tagged. ::
+
+	aws events list-tags-for-resource \
+		--resource-arn "arn:aws:events:us-east-1:123456789012:rule/AlarmStateChange"
+
+Output ::
+
+	{
+		"Tags": [
+			{
+				"Key": "Key1",
+				"Value": "Value1"
+			},
+			{
+				"Key": "Env",
+				"Value": "Prod"
+			}
+			]
+	}
+
+For more information, see `Configure tags and review rule <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-create-rule-schedule.html#eb-create-scheduled-rule-review>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/remove-permission.rst
+++ b/awscli/examples/events/remove-permission.rst
@@ -1,0 +1,9 @@
+**To revoke the permission of another Amazon Web Services account to be able to put events to the specified event bus**
+
+The following ``remove-permission`` revokes the permission of another Amazon Web Services account to be able to put events to the specified event bus. Specify the account to revoke by the StatementId value that you associated with the account when you granted it permission with PutPermission. If the command succeeds, no output is returned. ::
+
+	aws events remove-permission \
+		--statement-id allow_account_to_manage_rules_they_created \
+		--event-bus-name CustomBus
+
+For more information, see `Managing event bus permissions in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-bus-permissions-manage.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/start-replay.rst
+++ b/awscli/examples/events/start-replay.rst
@@ -1,0 +1,20 @@
+**To start the specified replay**
+
+The following ``start-replay`` starts the specified replay. Events are not necessarily replayed in the exact same order that they were added to the archive. A replay processes events to replay based on the time in the event, and replays them using 1 minute intervals. If you specify an EventStartTime and an EventEndTime that covers a 20 minute time range, the events are replayed from the first minute of that 20 minute range first. Then the events from the second minute are replayed. You can use DescribeReplay to determine the progress of a replay. The value returned for EventLastReplayedTime indicates the time within the specified time range associated with the last event replayed. ::
+
+		aws events start-replay \
+			--replay-name ProdReplay-1 \
+			--event-source-arn "arn:aws:events:us-east-2:123456789012:archive/ProdArchive-1" \
+			--event-start-time 2024-02-23T00:40:00Z \
+			--event-end-time 2024-02-24T00:40:00Z \
+			--destination '{"Arn":"arn:aws:events:us-east-2:123456789012:event-bus/custom"}'
+			
+Ouput ::
+	
+	{
+		"ReplayArn": "arn:aws:events:us-east-2:123456789012:replay/ProdReplay-1",
+		"State": "STARTING",
+		"ReplayStartTime": "2024-05-19T08:24:40+00:00"
+	}
+
+For more information, see `Archiving and replaying events in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/update-api-destination.rst
+++ b/awscli/examples/events/update-api-destination.rst
@@ -1,0 +1,18 @@
+**To update an API destination**
+
+The following ``update-api-destination`` will update an API destination. ::
+
+	aws events update-api-destination \
+		--name Prod-api-dest \
+		--description "Prod destination"
+
+Output ::
+
+	{
+		"ApiDestinationArn": "arn:aws:events:us-east-1:123456789101:api-destination/Prod-api-dest/6d228937-24b5-a11a72a7f9",
+		"ApiDestinationState": "ACTIVE",
+		"CreationTime": "2022-12-12T13:03:41+05:30",
+		"LastModifiedTime": "2024-05-19T15:31:43+05:30"
+	}
+
+For more information, see `API destinations as targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/laProd/userguide/eb-api-destinations.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/update-archive.rst
+++ b/awscli/examples/events/update-archive.rst
@@ -1,0 +1,16 @@
+**To update the specified archive**
+
+The following ``update-archive`` updates the specified archive. ::
+
+	aws events update-archive \
+		--archive-name hmhdmr --description "Prod archive"
+
+Output ::
+
+	{
+		"ArchiveArn": "arn:aws:events:us-east-1:123456789101:archive/hmhdmr",
+		"State": "ENABLED",
+		"CreationTime": "2023-04-03T09:44:16+05:30"
+	}
+
+For more information, see `Archiving and replaying events in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/laProd/userguide/eb-archive.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/update-connection.rst
+++ b/awscli/examples/events/update-connection.rst
@@ -1,0 +1,19 @@
+**To update settings for a connection**
+
+The following ``update-connection`` updates settings for a connection. ::
+
+	aws events update-connection \
+		--name Prod \
+		--description "prod connection"
+
+Output ::
+
+	{
+		"ConnectionArn": "arn:aws:events:us-east-1:123456789101:connection/Prod/e9820747-32=88cf9",
+		"ConnectionState": "AUTHORIZED",
+		"CreationTime": "2022-12-12T13:03:41+05:30",
+		"LastModifiedTime": "2024-05-19T15:33:24+05:30",
+		"LastAuthorizedTime": "2022-12-12T13:03:41+05:30"
+	}
+
+For more information, see `Connections for HTTP endpoint targets in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/laProd/userguide/eb-target-connection.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/events/update-endpoint.rst
+++ b/awscli/examples/events/update-endpoint.rst
@@ -1,0 +1,41 @@
+ **To update an existing endpoint**
+
+The following ``update-endpoint`` will update an existing endpoint. ::
+
+	aws events update-endpoint \
+		--name test \
+		--description "test endpoint"
+
+Output ::
+
+	{
+		"Name": "test",
+		"Arn": "arn:aws:events:us-east-1:123456789101:endpoint/test",
+		"RoutingConfig": {
+			"FailoverConfig": {
+				"Primary": {
+					"HealthCheck": "arn:aws:route53:::healthcheck/8f7dc0b8-ad9e-1234-846e-3a475c53bb76"
+				},
+				"Secondary": {
+					"Route": "us-east-2"
+				}
+			}
+		},
+		"ReplicationConfig": {
+			"State": "ENABLED"
+		},
+		"EventBuses": [
+			{
+				"EventBusArn": "arn:aws:events:us-east-1:123456789101:event-bus/test"
+			},
+			{
+				"EventBusArn": "arn:aws:events:us-east-2:123456789101:event-bus/test"
+			}
+		],
+		"RoleArn": "arn:aws:iam::123456789101:role/service-role/Amazon_EventBridge_Invoke_Event_Bus_694447205",
+		"EndpointId": "3slpsr0pnp.veo",
+		"EndpointUrl": "https://3slpsr0pnp.veo.endpoint.events.amazonaws.com",
+		"State": "ACTIVE"
+	}
+
+For more information, see `Global endpoint in Amazon EventBridge <https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-ge-create-endpoint.html>`__ in the *Amazon EventBridge User Guide*.


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adding example CLI commands for AWS EventBridge: 
https://docs.aws.amazon.com/cli/latest/reference/events/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
