### PR TITLE
Add CLI Examples for CloudWatch InternetMonitor

### DIFF
--- a/awscli/examples/application-insights/add-workload.rst
+++ b/awscli/examples/application-insights/add-workload.rst
@@ -1,0 +1,27 @@
+**To add a workload to a component**
+
+This example uses the ``add-workload`` command to add a workload to a component. ::
+
+    aws application-insights add-workload \
+        --resource-group-name "sqlserver" \
+        --component-name "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56" \
+        --workload-configuration file://workload.json
+
+Contents of ``workload.json``::
+
+    {
+        "WorkloadName": "SQL",
+        "Tier": "SQL_SERVER",
+        "Configuration": "{\"logs\":[{\"logGroupName\":\"SQL_SERVER-sqlserver\",\"logPath\":\"/var/log/mysql\",\"logType\":\"MYSQL\",\"monitor\":true,\"encoding\":\"utf-16\"}]}"
+    }
+
+Output::
+
+    {
+        "WorkloadId": "w-0123fb74-fb3b-4dc8-b6cc-aab404a1234",
+        "WorkloadConfiguration": {
+            "WorkloadName": "SQL",
+            "Tier": "SQL_SERVER",
+            "Configuration": "{\"logs\":[{\"logGroupName\":\"SQL_SERVER-sqlserver\",\"logPath\":\"/var/log/mysql\",\"logType\":\"MYSQL\",\"monitor\":true,\"encoding\":\"utf-16\"}]}"
+        }
+    }

--- a/awscli/examples/application-insights/create-application.rst
+++ b/awscli/examples/application-insights/create-application.rst
@@ -1,0 +1,22 @@
+**To create an application from a resource group**
+
+This example uses the ``create-application command`` to create an application from a resource group. ::
+
+    aws application-insights create-application \
+        --resource-group-name myapp
+
+Output::
+
+    {
+        "ApplicationInfo": {
+            "AccountId": "123456789012",
+            "ResourceGroupName": "myapp",
+            "LifeCycle": "CREATING",
+            "OpsCenterEnabled": false,
+            "CWEMonitorEnabled": false,
+            "Remarks": "",
+            "AutoConfigEnabled": false,
+            "DiscoveryType": "RESOURCE_GROUP_BASED",
+            "AttachMissingPermission": false
+        }
+    }

--- a/awscli/examples/application-insights/create-component.rst
+++ b/awscli/examples/application-insights/create-component.rst
@@ -1,0 +1,10 @@
+**To create a component for an application**
+
+This example uses the ``create-component command`` to create a component by grouping similar standalone instances to monitor.
+
+    aws application-insights create-component \
+        --resource-group-name MYEC2 \
+        --component-name mycustomcomp \
+        --resource-list arn:aws:ec2:eu-west-1:123456789012:instance/i-0f6bcd63ce2f03f
+
+This command returns to the prompt if successful

--- a/awscli/examples/application-insights/create-log-pattern.rst
+++ b/awscli/examples/application-insights/create-log-pattern.rst
@@ -1,0 +1,22 @@
+**To create a log pattern and add it to a log pattern set**
+
+This example uses the ``create-log-pattern`` command to add an log pattern to a log pattern set. ::
+
+    aws application-insights create-log-pattern \
+        --resource-group-name MYEC2 \
+        --pattern-set-name SAMPLE \
+        --pattern-name new 
+        --pattern error 
+        --rank 750000
+
+Output::
+
+    {
+        "LogPattern": {
+            "PatternSetName": "SAMPLE",
+            "PatternName": "new",
+            "Pattern": "error",
+            "Rank": 750000
+        },
+        "ResourceGroupName": "MYEC2"
+    }

--- a/awscli/examples/application-insights/delete-application.rst
+++ b/awscli/examples/application-insights/delete-application.rst
@@ -1,0 +1,8 @@
+**To delete an application**
+
+This example uses the ``delete-application`` command to remove the specified application from monitoring. ::
+
+    aws application-insights delete-application \
+        --resource-group-name sqlnew
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/delete-component.rst
+++ b/awscli/examples/application-insights/delete-component.rst
@@ -1,0 +1,9 @@
+**To delete a component from an application**
+
+This example uses the ``delete-component`` command to ungroup a component from an application. ::
+
+    aws application-insights delete-component \
+        --resource-group-name MYEC2 \
+        --component-name custom_new
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/delete-log-pattern.rst
+++ b/awscli/examples/application-insights/delete-log-pattern.rst
@@ -1,0 +1,10 @@
+**To delete a log pattern from a log pattern set**
+
+This example uses the ``delete-log-pattern`` command to remove a log pattern from a log pattern set. ::
+
+    aws application-insights delete-log-pattern \
+        --resource-group-name MYEC2 \
+        --pattern-set-name MYTEST \
+        --pattern-name MYPATTERN
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/describe-application.rst
+++ b/awscli/examples/application-insights/describe-application.rst
@@ -1,0 +1,22 @@
+**To describe an application**
+
+This example uses the ``describe-application`` command to describe an application. ::
+
+    aws application-insights describe-application \
+        --resource-group-name MYEC2
+
+Output::
+
+    {
+        "ApplicationInfo": {
+            "AccountId": "123456789012",
+            "ResourceGroupName": "MYEC2",
+            "LifeCycle": "ACTIVE",
+            "OpsCenterEnabled": false,
+            "CWEMonitorEnabled": true,
+            "Remarks": "Monitoring application, detected 1 unconfigured component",
+            "AutoConfigEnabled": true,
+            "DiscoveryType": "RESOURCE_GROUP_BASED",
+            "AttachMissingPermission": true
+        }
+    }

--- a/awscli/examples/application-insights/describe-component-configuration-recommendation.rst
+++ b/awscli/examples/application-insights/describe-component-configuration-recommendation.rst
@@ -1,0 +1,14 @@
+**To describe a recommendation for a component configuration**
+
+The following example uses the ``describe-component-configuration-recommendation`` command to describe the recommended configuration for a component. ::
+
+    aws application-insights describe-component-configuration-recommendation \
+        --resource-group-name MYEC2 \
+        --component-name arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56 \
+        --tier DEFAULT
+
+Output::
+
+    {
+        "ComponentConfiguration": "{\n  \"alarmMetrics\" : [ {\n    \"alarmMetricName\" : \"CPUUtilization\",\n    \"monitor\" : true\n  }, {\n    \"alarmMetricName\" : \"StatusCheckFailed\",\n    \"monitor\" : true\n  }, {\n    \"alarmMetricName\" : \"Processor % Processor Time\",\n    \"monitor\" : true\n  }, {\n    \"alarmMetricName\" : \"Memory % Committed Bytes In Use\",\n    \"monitor\" : true\n  }, {\n    \"alarmMetricName\" : \"LogicalDisk % Free Space\",\n    \"monitor\" : true\n  }, {\n    \"alarmMetricName\" : \"Memory Available Mbytes\",\n    \"monitor\" : true\n  } ],\n  \"logs\" : [ {\n    \"logGroupName\" : \"APPLICATION-MYEC2\",\n    \"logPath\" : \"\",\n    \"logType\" : \"APPLICATION\",\n    \"monitor\" : true,\n    \"encoding\" : \"utf-8\"\n  } ],\n  \"windowsEvents\" : [ {\n    \"logGroupName\" : \"WINDOWS_EVENTS-Application-MYEC2\",\n    \"eventName\" : \"Application\",\n    \"eventLevels\" : [ \"WARNING\", \"ERROR\", \"CRITICAL\" ],\n    \"monitor\" : true\n  }, {\n    \"logGroupName\" : \"WINDOWS_EVENTS-System-MYEC2\",\n    \"eventName\" : \"System\",\n    \"eventLevels\" : [ \"WARNING\", \"ERROR\", \"CRITICAL\" ],\n    \"monitor\" : true\n  }, {\n    \"logGroupName\" : \"WINDOWS_EVENTS-Security-MYEC2\",\n    \"eventName\" : \"Security\",\n    \"eventLevels\" : [ \"WARNING\", \"ERROR\", \"CRITICAL\" ],\n    \"monitor\" : true\n  } ],\n  \"subComponents\" : [ {\n    \"subComponentType\" : \"AWS::EC2::Volume\",\n    \"alarmMetrics\" : [ {\n      \"alarmMetricName\" : \"BurstBalance\",\n      \"monitor\" : true\n    } ]\n  } ]\n}"
+    }

--- a/awscli/examples/application-insights/describe-component-configuration.rst
+++ b/awscli/examples/application-insights/describe-component-configuration.rst
@@ -1,0 +1,15 @@
+**To describe the configuration for a component**
+
+This example uses the ``describe-component-configuration`` command to describe the configuration of the component. Note: The component name is the ARN of the component and not the resource's name. ::
+
+    aws application-insights describe-component-configuration \
+        --resource-group-name MYEC2 \
+        --component-name arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56
+
+Output::
+
+    {
+        "Monitor": true,
+        "Tier": "DEFAULT",
+        "ComponentConfiguration": "{\n  \"alarmMetrics\" : [ {\n    \"alarmMetricName\" : \"CPUUtilization\",\n    \"monitor\" : true\n  } ],\n  \"logs\" : [ ]\n}"
+    }

--- a/awscli/examples/application-insights/describe-component.rst
+++ b/awscli/examples/application-insights/describe-component.rst
@@ -1,0 +1,25 @@
+**To describe a component and its resources in an application**
+
+This example uses the ``describe-component`` command to describe a component and lists the resources that are grouped together in a component. Note: The component name is the ARN of the component and not the resource's name. ::
+
+    aws application-insights describe-component \
+        --resource-group-name MYEC2 \
+        --component-name arn:aws:autoscaling:eu-west-1:123456789012:autoScalingGroup:abcd123e-853e-4b67-132a-bcd63ce2f03f:autoScalingGroupName/MyEC2ASG
+
+Output::
+
+    {
+        "ApplicationComponent": {
+            "ComponentName": "arn:aws:autoscaling:eu-west-1:123456789012:autoScalingGroup:abcd123e-853e-4b67-132a-bcd63ce2f03f:autoScalingGroupName/MyEC2ASG",
+            "ResourceType": "AWS::AutoScaling::AutoScalingGroup",
+            "OsType": "LINUX",
+            "Tier": "DEFAULT",
+            "Monitor": true,
+            "DetectedWorkload": {
+                "DEFAULT": {
+                    "Priority": "1"
+                }
+            }
+        },
+        "ResourceList": []
+    }

--- a/awscli/examples/application-insights/describe-log-pattern.rst
+++ b/awscli/examples/application-insights/describe-log-pattern.rst
@@ -1,0 +1,21 @@
+**To describe a log pattern from a log pattern set**
+
+This example uses the ``describe-log-pattern`` command to describe a log pattern from a log pattern set. ::
+
+    aws application-insights describe-log-pattern \
+        --resource-group-name MYEC2 \
+        --pattern-set-name SAMPLE \
+        --pattern-name new2
+
+Output::
+
+    {
+        "ResourceGroupName": "MYEC2",
+        "AccountId": "123456789012",
+        "LogPattern": {
+            "PatternSetName": "SAMPLE",
+            "PatternName": "new2",
+            "Pattern": "error",
+            "Rank": 750000
+        }
+    }

--- a/awscli/examples/application-insights/describe-observation.rst
+++ b/awscli/examples/application-insights/describe-observation.rst
@@ -1,0 +1,21 @@
+**To describe an observation from an application**
+
+This example uses the ``describe-observation`` command to describe an observation such as an anomaly or error in the application. ::
+
+    aws application-insights describe-observation \
+        --observation-id o-1aaaf123-abc4-5678-a12e-d01234e56d7e
+
+Output::
+
+    {
+        "Observation": {
+            "Id": "o-1aaaf123-abc4-5678-a12e-d01234e56d7e",
+            "StartTime": "2024-01-01T02:05:55.432000+00:00",
+            "EndTime": "2024-01-01T02:12:55.435000+00:00",
+            "SourceType": "ALARM",
+            "SourceARN": "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56",
+            "MetricNamespace": "AWS/EC2",
+            "MetricName": "CPUUtilization",
+            "Value": 99.0208333333334
+        }
+    }

--- a/awscli/examples/application-insights/describe-problem-observations.rst
+++ b/awscli/examples/application-insights/describe-problem-observations.rst
@@ -1,0 +1,23 @@
+**To describe obervations reported for a problem in an application**
+
+This example uses the ``describe-problem-observations`` command to describe the observations found such as anomalies or errors associated with a problem within an application. ::
+
+    aws application-insights describe-problem-observations \
+        --problem-id p-1aaaf123-abc4-5678-a12e-d01234e56d7e
+
+Output::
+
+    {
+        "RelatedObservations": {
+            "ObservationList": [{
+                "Id": "o-1aaaf123-abc4-5678-a12e-d01234e56d7e",
+                "StartTime": "2024-01-01T02:05:55.432000+00:00",
+                "EndTime": "2024-01-01T02:12:55.435000+00:00",
+                "SourceType": "ALARM",
+                "SourceARN": "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56",
+                "MetricNamespace": "AWS/EC2",
+                "MetricName": "CPUUtilization",
+                 "Value": 99.0208333333334
+            }]
+        }
+    }

--- a/awscli/examples/application-insights/describe-problem.rst
+++ b/awscli/examples/application-insights/describe-problem.rst
@@ -1,0 +1,29 @@
+**To describe a problem in an application**
+
+This example uses the ``describe-problem`` command to describe a problem reported in an application. ::
+
+    aws application-insights describe-problem \
+        --problem-id p-1aaaf123-abc4-5678-a12e-d01234e56d7e
+
+Output::
+
+    {
+        "Problem": {
+            "Id": "p-1aaaf123-abc4-5678-a12e-d01234e56d7e",
+            "Title": "EC2: High CPU",
+            "Insights": "High CPU on the .NET application layer. This can result in application performance degradation due to high load on web servers, or application errors. If you experience high load conditions for long periods of time, use AWS Auto Scaling to add additional resources to process the load. To troubleshoot, collect a full user dump with task manager on the high CPU process and collect PerfMon logs with the thread counter to identify the thread ID causing high CPU.",
+            "Status": "PENDING",
+            "AffectedResource": "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56",
+            "StartTime": "2024-01-01T02:05:55.432000+00:00",
+            "EndTime": "1970-01-01T00:00:00+00:00",
+            "SeverityLevel": "Medium",
+            "AccountId": "123456789012",
+            "ResourceGroupName": "MYEC2",
+            "Feedback": {
+                "INSIGHTS_FEEDBACK": "NOT_SPECIFIED"
+            },
+            "RecurringCount": 0,
+            "Visibility": "VISIBLE",
+            "ResolutionMethod": "UNRESOLVED"
+        }
+    }

--- a/awscli/examples/application-insights/describe-workload.rst
+++ b/awscli/examples/application-insights/describe-workload.rst
@@ -1,0 +1,19 @@
+**To describe a workload in an application**
+
+This example uses the ``describe-workload`` command to describe a workload and its configuration from an application. ::
+
+    aws application-insights describe-workload \
+        --resource-group-name MYEC2 \
+        --component-name arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56 \
+        --workload-id w-2aaaf123-abc4-5678-a12e-d01234e56d7e
+
+Output::
+
+    {
+        "WorkloadId": "w-2aaaf123-abc4-5678-a12e-d01234e56d7e",
+        "WorkloadConfiguration": {
+            "WorkloadName": "MYSQL",
+            "Tier": "MYSQL",
+            "Configuration": "{\"logs\":[],\"windowsEvents\":[{\"logGroupName\":\"WINDOWS_EVENTS-Application-MYEC2\",\"eventName\":\"Application\",\"eventLevels\":[\"WARNING\",\"ERROR\",\"CRITICAL\"],\"monitor\":true},{\"logGroupName\":\"WINDOWS_EVENTS-System-MYEC2\",\"eventName\":\"System\",\"eventLevels\":[\"WARNING\",\"ERROR\",\"CRITICAL\"],\"monitor\":true},{\"logGroupName\":\"WINDOWS_EVENTS-Security-MYEC2\",\"eventName\":\"Security\",\"eventLevels\":[\"WARNING\",\"ERROR\",\"CRITICAL\"],\"monitor\":true}]}"
+        }
+    }

--- a/awscli/examples/application-insights/list-applications.rst
+++ b/awscli/examples/application-insights/list-applications.rst
@@ -1,0 +1,21 @@
+**To list all applications**
+
+This example uses the ``list-applications`` command to lists the applications that you are monitoring. ::
+
+    aws application-insights list-applications
+
+Output::
+
+    {
+        "ApplicationInfoList": [{
+            "AccountId": "123456789012",
+            "ResourceGroupName": "MYEC2",
+            "LifeCycle": "ACTIVE",
+            "OpsCenterEnabled": false,
+            "CWEMonitorEnabled": true,
+            "Remarks": "",
+            "AutoConfigEnabled": true,
+            "DiscoveryType": "RESOURCE_GROUP_BASED",
+            "AttachMissingPermission": true
+        }]
+    }

--- a/awscli/examples/application-insights/list-components.rst
+++ b/awscli/examples/application-insights/list-components.rst
@@ -1,0 +1,24 @@
+**To list all components in an application**
+
+This example uses the ``list-components`` command to list all the components in an application. ::
+
+    aws application-insights list-components \
+        --resource-group-name MYEC2
+
+Output::
+
+    {
+        "ApplicationComponentList": [{
+            "ComponentName": "arn:aws:ec2:us-east-1:123456789012:autoScalingGroup:bosy123f-853e-2b43-876c-bad63ce2f03f:autoScalingGroupName/MyEC2ASG",
+            "ResourceType": "AWS::AutoScaling::AutoScalingGroup",
+            "OsType": "LINUX",
+            "Tier": "DEFAULT",
+            "Monitor": true
+        }, {
+            "ComponentName": "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56",
+            "ResourceType": "AWS::EC2::Instance",
+            "OsType": "WINDOWS",
+            "Tier": "DEFAULT",
+            "Monitor": true
+        }]
+    }

--- a/awscli/examples/application-insights/list-configuration-history.rst
+++ b/awscli/examples/application-insights/list-configuration-history.rst
@@ -1,0 +1,30 @@
+**To describe the configuration history of a component**
+
+This example uses the ``list-configuration-history`` command to list the INFO, WARN, and ERROR events for periodic configuration updates performed by Application Insights. ::
+
+    aws application-insights list-configuration-history \
+        --resource-group-name MYEC2
+
+Output::
+
+    {
+        "EventList": [{
+            "ResourceGroupName": "MYEC2",
+            "AccountId": "123456789012",
+            "MonitoredResourceARN": "customizedcomponent-1235a90-b1c2-12c3-be32-12d630f12d55",
+            "EventStatus": "INFO",
+            "EventResourceType": "CLOUDWATCH_METRIC",
+            "EventTime": "2024-05-01T07:00:32.346000+00:00",
+            "EventDetail": "Metric Memory Available Mbytes does not exist for component customizedcomponent-1235a90-b1c2-12c3-be32-12d630f12d55, alarm cannot be created. Possible reason might be metric misses data points for two weeks, or required workload to emit this metric not installed.",
+            "EventResourceName": "Memory Available Mbytes"
+        }, {
+            "ResourceGroupName": "MYEC2",
+            "AccountId": "123456789012",
+            "MonitoredResourceARN": "customizedcomponent-1235a90-b1c2-12c3-be32-12d630f12d55",
+            "EventStatus": "INFO",
+            "EventResourceType": "CLOUDWATCH_METRIC",
+            "EventTime": "2024-05-01T07:00:32.284000+00:00",
+            "EventDetail": "Metric Memory % Committed Bytes In Use does not exist for component customizedcomponent-1235a90-b1c2-12c3-be32-12d630f12d55, alarm cannot be created. Possible reason might be metric misses data points for two weeks, or required workload to emit this metric not installed.",
+            "EventResourceName": "Memory % Committed Bytes In Use"
+        }]
+    }

--- a/awscli/examples/application-insights/list-log-pattern-sets.rst
+++ b/awscli/examples/application-insights/list-log-pattern-sets.rst
@@ -1,0 +1,14 @@
+**To list all log pattern sets**
+
+This example uses the ``list-log-pattern-sets`` command to list all log pattern sets in an application. ::
+
+    aws application-insights list-log-pattern-sets \
+        --resource-group-name MYEC2
+
+Output::
+
+    {
+        "ResourceGroupName": "MYEC2",
+        "AccountId": "123456789012",
+        "LogPatternSets": ["SAMPLE"]
+    }

--- a/awscli/examples/application-insights/list-log-patterns.rst
+++ b/awscli/examples/application-insights/list-log-patterns.rst
@@ -1,0 +1,24 @@
+**To list all log patterns in a log pattern set**
+
+This example uses the ``list-log-patterns`` command to lists all the log patterns in a log pattern set. ::
+
+    aws application-insights list-log-patterns \
+        --resource-group-name MYEC2
+
+Output::
+
+    {
+        "ResourceGroupName": "MYEC2",
+        "AccountId": "123456789012",
+        "LogPatterns": [{
+            "PatternSetName": "SAMPLE",
+            "PatternName": "new",
+            "Pattern": "error",
+            "Rank": 1
+        }, {
+            "PatternSetName": "SAMPLE",
+            "PatternName": "new2",
+            "Pattern": "error",
+            "Rank": 750000
+        }]
+    }

--- a/awscli/examples/application-insights/list-problems.rst
+++ b/awscli/examples/application-insights/list-problems.rst
@@ -1,0 +1,31 @@
+**To list all problems identified in an application**
+
+This example uses the ``list-problems`` command to list all the identified problems in an applicaiton. ::
+
+    aws application-insights list-problems \
+        --resource-group-name MYEC2
+
+Output::
+
+    {
+        "ProblemList": [{
+            "Id": "p-1aaaf123-abc4-5678-a12e-d01234e56d7e",
+            "Title": "EC2: High CPU",
+            "Insights": "High CPU on the .NET application layer. This can result in application performance degradation due to high load on web servers, or application errors. If you experience high load conditions for long periods of time, use AWS Auto Scaling to add additional resources to process the load. To troubleshoot, collect a full user dump with task manager on the high CPU process and collect PerfMon logs with the thread counter to identify the thread ID causing high CPU.",
+            "Status": "PENDING",
+            "AffectedResource": "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56",
+            "StartTime": "2024-05-01T08:05:55.432000+00:00",
+            "EndTime": "1970-01-01T00:00:00+00:00",
+            "SeverityLevel": "Medium",
+            "AccountId": "123456789012",
+            "ResourceGroupName": "MYEC2",
+            "Feedback": {
+                "INSIGHTS_FEEDBACK": "NOT_SPECIFIED"
+            },
+            "RecurringCount": 0,
+            "Visibility": "VISIBLE",
+            "ResolutionMethod": "UNRESOLVED"
+        }],
+        "ResourceGroupName": "MYEC2",
+        "AccountId": "123456789012"
+    }

--- a/awscli/examples/application-insights/list-tags-for-resource.rst
+++ b/awscli/examples/application-insights/list-tags-for-resource.rst
@@ -1,0 +1,15 @@
+**To list the tags associated with an application**
+
+This command uses the ``list-tags-for-resource`` command to retrieve a list of the tags associated with a specified application. ::
+
+    aws application-insights list-tags-for-resource \
+        --resource-arn arn:aws:applicationinsights:eu-west-1:123456789012:application/resource-group/myapp
+
+Output::
+
+    {
+        "Tags": [{
+            "Key": "AWS",
+            "Value": "tagaws"
+        }]
+    }

--- a/awscli/examples/application-insights/list-workloads.rst
+++ b/awscli/examples/application-insights/list-workloads.rst
@@ -1,0 +1,17 @@
+**To list the workloads on a component**
+
+This example uses the ``list-workloads`` command to lists the workloads that are configured on a specific component. ::
+
+    aws application-insights list-workloads \
+        --resource-group-name MYEC2 —component-name mycustomcomp
+
+Output::
+
+    {
+        "WorkloadList": [{
+            "WorkloadId": "w-1234a76f-a1b6-4e12-a2b1-a123d45678ed",
+            "ComponentName": "mycustomcomp",
+            "WorkloadName": "MYSQL",
+            "Tier": "MYSQL"
+        }]
+    }

--- a/awscli/examples/application-insights/remove-workload.rst
+++ b/awscli/examples/application-insights/remove-workload.rst
@@ -1,0 +1,10 @@
+**To remove a workload from a component**
+
+This example uses the ``remove-workload`` command to remove a workload from a component. ::
+
+    aws application-insights remove-workload \
+        --resource-group-name MYEC2 \
+        --component-name arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56 \
+        --workload-id w-1e2d0be3-fa45-6a78-b9d1-b2034d5dd67e
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/tag-resource.rst
+++ b/awscli/examples/application-insights/tag-resource.rst
@@ -1,0 +1,16 @@
+**To add tags to an application**
+
+This example uses the ``tag-resource`` command to add one or more tags to an application. ::
+
+    aws application-insights tag-resource \
+        --resource-arn arn:aws:applicationinsights:eu-west-1:012345678901:application/resource-group/testgroup \
+        --tags file://tags.json                                                                                
+
+Contents of ``tags.json``::
+
+    [{
+        "Key": "sa",
+        "Value": "sample"
+    }]
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/untag-resource.rst
+++ b/awscli/examples/application-insights/untag-resource.rst
@@ -1,0 +1,9 @@
+**To remove tags from an application**
+
+This example uses the ``untag-resource`` command to remove one or more tags from an application. ::
+
+    aws application-insights untag-resource \
+        --resource-arn arn:aws:applicationinsights:eu-west-1:012345678901:application/resource-group/sameplegroup \
+        --tag-keys sample
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/update-application.rst
+++ b/awscli/examples/application-insights/update-application.rst
@@ -1,0 +1,22 @@
+**To update an application and its settings**
+
+This example uses the ``update-application`` command to update an application's settings to enable SSM Ops Center. ::
+
+    aws application-insights update-application \
+        --resource-group-name ec2 —ops-center-enabled
+
+Output::
+
+    {
+        "ApplicationInfo": {
+            "AccountId": "012345678901",
+            "ResourceGroupName": "ec2",
+            "LifeCycle": "ACTIVE",
+            "OpsCenterEnabled": true,
+            "CWEMonitorEnabled": true,
+            "Remarks": "",
+            "AutoConfigEnabled": true,
+            "DiscoveryType": "RESOURCE_GROUP_BASED",
+            "AttachMissingPermission": true
+        }
+    }

--- a/awscli/examples/application-insights/update-component-configuration.rst
+++ b/awscli/examples/application-insights/update-component-configuration.rst
@@ -1,0 +1,20 @@
+**To update a component configuration**
+
+This example uses the ``update-component-configuration`` command to update a component configuration to monitor a Metric. ::
+
+    aws application-insights update-component-configuration \
+        --resource-group-name ASG \
+        --component-name arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56 \
+        --component-configuration file://config.json
+
+Contents of ``config.json``::
+
+    {
+        "logs": [],
+        "alarmMetrics": [{
+            "alarmMetricName": "CPUUtilization",
+            "monitor": true
+        }]
+    }
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/update-component.rst
+++ b/awscli/examples/application-insights/update-component.rst
@@ -1,0 +1,11 @@
+**To update a component in an application**
+
+This example uses the ``update-component`` command to update a component by changing its name and resource list. ::
+
+    aws application-insights update-component \
+        --resource-group-name MYEC2 \
+        --component-name "custom" \
+        --resource-list "arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56" \
+        --new-component-name custom_new
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/update-log-pattern.rst
+++ b/awscli/examples/application-insights/update-log-pattern.rst
@@ -1,0 +1,22 @@
+**To update a log pattern in a log pattern set**
+
+This example uses the ``update-log-pattern`` command to update the log pattern in a log pattern set. ::
+
+    aws application-insights update-log-pattern \
+        --resource-group-name testgroup \
+        --pattern-set-name Test \
+        --pattern-name newpattern \
+        --pattern ERROR \
+        --rank 2
+
+Output::
+
+    {
+        "ResourceGroupName": "testgroup",
+        "LogPattern": {
+            "PatternSetName": "Test",
+            "PatternName": "newpattern",
+            "Pattern": "ERROR",
+            "Rank": 2
+        }
+    }

--- a/awscli/examples/application-insights/update-problem.rst
+++ b/awscli/examples/application-insights/update-problem.rst
@@ -1,0 +1,9 @@
+**To update the visibility or status of a problem in an application**
+
+This example uses the ``update-problem`` command to update the status of a problem to resolved. ::
+
+    aws application-insights update-problem \
+        --problem-id p-11b78b15-6f5b-40ca-9da7-12d12345c68b \
+        --update-status RESOLVED
+
+This command returns to the prompt if successful.

--- a/awscli/examples/application-insights/update-workload.rst
+++ b/awscli/examples/application-insights/update-workload.rst
@@ -1,0 +1,28 @@
+**To update a workload in an component**
+
+This example uses the ``update-workload`` command to update the workload of a component. ::
+
+    aws application-insights update-workload \
+        --resource-group-name sqlserver \
+        --component-name arn:aws:ec2:us-east-1:123456789012:instance/i-012abcd34efghi56 \
+        --workload-configuration file://update.json \
+        --workload-id w-765437d7-51e1-438e-8f47-123456fb
+
+Contents of ``update.json``::
+
+    {
+        "WorkloadName": "MYSQL",
+        "Tier": "MYSQL",
+        "Configuration": "{\"logs\":[{\"logGroupName\":\"MYSQL\",\"logPath\":\"/var/log/**\",\"logType\":\"MYSQL\",\"monitor\":true,\"encoding\":\"utf-8\"}]}"
+    }
+
+Output::
+
+    {
+        "WorkloadId": "w-765437d7-51e1-438e-8f47-123456fb",
+        "WorkloadConfiguration": {
+            "WorkloadName": "MYSQL",
+            "Tier": "MYSQL",
+            "Configuration": "{\"logs\":[{\"logGroupName\":\"MYSQL\",\"logPath\":\"/var/log/**\",\"logType\":\"MYSQL\",\"monitor\":true,\"encoding\":\"utf-8\"}]}"
+        }
+    }

--- a/awscli/examples/internetmonitor/create-monitor.rst
+++ b/awscli/examples/internetmonitor/create-monitor.rst
@@ -1,0 +1,16 @@
+**To create a new internet monitor**
+
+This example uses the ``create-monitor`` command to create a new internet monitor. ::
+
+    aws internetmonitor create-monitor \
+        --monitor-name TestMonitor \
+        --resources arn:aws:ec2:us-east-1:123456789012:vpc/vpc-123456abcdef \
+        --traffic-percentage-to-monitor 100 \
+        --internet-measurements-log-delivery S3Config={LogDeliveryStatus=DISABLED} 
+
+Output::
+
+    {
+        "Arn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+        "Status": "PENDING"
+    }

--- a/awscli/examples/internetmonitor/delete-monitor.rst
+++ b/awscli/examples/internetmonitor/delete-monitor.rst
@@ -1,0 +1,8 @@
+**To delete an existing internet monitor**
+
+This example uses the ``delete-monitor`` command to delete an existing internet monitor. ::
+
+    aws internetmonitor delete-monitor \
+        --monitor-name TestMonitor
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/get-health-event.rst
+++ b/awscli/examples/internetmonitor/get-health-event.rst
@@ -1,0 +1,69 @@
+**To describe a health event in a monitor**
+
+This example uses the ``get-health-event`` to describe an existing health event in a monitor. ::
+
+    aws internetmonitor get-health-event \
+        --monitor-name TestTCP \
+        --event-id 2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e
+
+Output::
+
+    {
+        "EventArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor/health-event/2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+        "EventId": "2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+        "StartedAt": "2024-08-02T00:10:00+00:00",
+        "EndedAt": "2024-08-02T00:15:00+00:00",
+        "CreatedAt": "2024-08-02T00:27:12+00:00",
+        "LastUpdatedAt": "2024-08-02T00:32:05+00:00",
+        "ImpactedLocations": [{
+            "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK",
+            "ASNumber": 8075,
+            "Country": "United States",
+            "Subdivision": "Virginia",
+            "Metro": "Washington, DC (Hagrstwn)",
+            "City": "Washington",
+            "Latitude": 38.7095,
+            "Longitude": -78.1539,
+            "CountryCode": "US",
+            "SubdivisionCode": "VA",
+            "ServiceLocation": "us-east-1",
+            "Status": "ACTIVE",
+            "CausedBy": {
+                "Networks": [{
+                    "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                    "ASNumber": 8075
+                }],
+                "AsPath": [{
+                        "ASName": "Amazon.com",
+                        "ASNumber": 16509
+                    },
+                    {
+                        "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                        "ASNumber": 8075
+                    }
+                ],
+                "NetworkEventType": "Internet"
+            },
+            "InternetHealth": {
+                "Availability": {
+                    "ExperienceScore": 100,
+                    "PercentOfTotalTrafficImpacted": 0,
+                    "PercentOfClientLocationImpacted": 0
+                },
+                "Performance": {
+                    "ExperienceScore": 0,
+                    "PercentOfTotalTrafficImpacted": 0.76,
+                    "PercentOfClientLocationImpacted": 100,
+                    "RoundTripTime": {
+                        "P50": 5,
+                        "P90": 73,
+                        "P95": 114
+                    }
+                }
+            }
+        }],
+        "Status": "RESOLVED",
+        "PercentOfTotalTrafficImpacted": 0.76,
+        "ImpactType": "LOCAL_PERFORMANCE",
+        "HealthScoreThreshold": 60
+    }

--- a/awscli/examples/internetmonitor/get-internet-event.rst
+++ b/awscli/examples/internetmonitor/get-internet-event.rst
@@ -1,0 +1,27 @@
+**To describe an event reported by an internet monitor**
+
+This example uses the ``get-internet-event`` command to describe the details reported by a specific event in an internet monitor. ::
+
+    aws internetmonitor get-internet-event \
+    --event-id ba755fe8-b4de-4e24-8b3b-19267bec227e
+
+Output::
+
+    {
+        "EventId": "ba755fe8-b4de-4e24-8b3b-19267bec227e",
+        "EventArn": "arn:aws:internetmonitor::123456789012:internet-event/ba755fe8-b4de-4e24-8b3b-19267bec227e",
+        "StartedAt": "2024-08-27T21:04:00+00:00",
+        "EndedAt": "2024-08-28T03:30:00+00:00",
+        "ClientLocation": {
+            "ASName": "CHARTER-20115",
+            "ASNumber": 20115,
+            "Country": "United States",
+            "Subdivision": "Michigan",
+            "Metro": "505",
+            "City": "Fenton",
+            "Latitude": 42.7893,
+            "Longitude": -83.7135
+        },
+        "EventType": "AVAILABILITY",
+        "EventStatus": "RESOLVED"
+    }

--- a/awscli/examples/internetmonitor/get-monitor.rst
+++ b/awscli/examples/internetmonitor/get-monitor.rst
@@ -1,0 +1,22 @@
+**To describe an existing internet monitor**
+
+This example uses the ``get-monitor`` command to describe the configuration of an existing internet monitor. ::
+
+    aws internetmonitor get-monitor \
+        --monitor-name TestMonitor
+
+Output::
+
+    {
+        "MonitorName": "TestMonitor",
+        "MonitorArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+        "Resources": ["arn:aws:ec2:us-east-1:123456789012:vpc/vpc-123456abcdef"],
+        "Status": "ACTIVE",
+        "CreatedAt": "2024-08-28T20:10:18+00:00",
+        "ModifiedAt": "2024-08-28T20:10:18+00:00",
+        "ProcessingStatus": "COLLECTING_DATA",
+        "ProcessingStatusInfo": "The monitor is OK and is collecting data-points to produce insights",
+        "Tags": {},
+        "InternetMeasurementsLogDelivery": {},
+        "TrafficPercentageToMonitor": 100
+    }

--- a/awscli/examples/internetmonitor/get-query-results.rst
+++ b/awscli/examples/internetmonitor/get-query-results.rst
@@ -1,0 +1,41 @@
+**To fetch the results of a query**
+
+This example uses the ``get-query-results`` command to fetch the results of a query performed in a monitor. ::
+
+    aws internetmonitor get-query-results \
+        --monitor-name TestMonitor \
+        --query-id AQICAHjE50ADcWtUTXGTlgtIHH4U_u4xxxxxx
+
+Output::
+
+    {
+        "Fields": [{
+            "Name": "timestamp",
+            "Type": "integer"
+        }, {
+            "Name": "availability",
+            "Type": "float"
+        }, {
+            "Name": "performance",
+            "Type": "float"
+        }, {
+            "Name": "rtt_p50",
+            "Type": "bigint"
+        }, {
+            "Name": "rtt_p90",
+            "Type": "bigint"
+        }, {
+            "Name": "rtt_p95",
+            "Type": "bigint"
+        }, {
+            "Name": "bytes_in",
+            "Type": "bigint"
+        }, {
+            "Name": "bytes_out",
+            "Type": "bigint"
+        }],
+        "Data": [
+            ["1724833200", "100.0", "100.0", "26", "68", "72", "1258", "120"],
+            ...
+        ]
+    }

--- a/awscli/examples/internetmonitor/get-query-status.rst
+++ b/awscli/examples/internetmonitor/get-query-status.rst
@@ -1,0 +1,13 @@
+**To describe the status of an existing query**
+
+This example uses the ``get-query-status`` command to get a query's current status in an internet monitor. ::
+
+    aws internetmonitor get-query-status \
+        --monitor-name TestTCP \
+        --query-id AQICAHjE50ADcWtUTXGTlgtIHH4U_u4xxxxxx
+
+Output::
+
+    {
+        "Status": "SUCCEEDED"
+    }

--- a/awscli/examples/internetmonitor/list-health-events.rst
+++ b/awscli/examples/internetmonitor/list-health-events.rst
@@ -1,0 +1,72 @@
+**To list all the health events reported by an internet monitor**
+
+This example uses the ``list-health-events`` command to list all the health events reported by an internet monitor. ::
+
+    aws internetmonitor list-health-events \
+        --monitor-name TestMonitor
+
+Output::
+
+    {
+        "HealthEvents": [{
+            "EventArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor/health-event/2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+            "EventId": "2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+            "StartedAt": "2024-08-02T00:10:00+00:00",
+            "EndedAt": "2024-08-02T00:15:00+00:00",
+            "CreatedAt": "2024-08-02T00:27:12+00:00",
+            "LastUpdatedAt": "2024-08-02T00:32:05+00:00",
+            "ImpactedLocations": [{
+                "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK",
+                "ASNumber": 8075,
+                "Country": "United States",
+                "Subdivision": "Virginia",
+                "Metro": "Washington, DC (Hagrstwn)",
+                "City": "Washington",
+                "Latitude": 38.7095,
+                "Longitude": -78.1539,
+                "CountryCode": "US",
+                "SubdivisionCode": "VA",
+                "ServiceLocation": "us-east-1",
+                "Status": "ACTIVE",
+                "CausedBy": {
+                    "Networks": [{
+                        "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                        "ASNumber": 8075
+                    }],
+                    "AsPath": [{
+                            "ASName": "Amazon.com",
+                            "ASNumber": 16509
+                        },
+                        {
+                            "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                            "ASNumber": 8075
+                        }
+                    ],
+                    "NetworkEventType": "Internet"
+                },
+                "InternetHealth": {
+                    "Availability": {
+                        "ExperienceScore": 100,
+                        "PercentOfTotalTrafficImpacted": 0,
+                        "PercentOfClientLocationImpacted": 0
+                    },
+                    "Performance": {
+                        "ExperienceScore": 0,
+                        "PercentOfTotalTrafficImpacted": 0.76,
+                        "PercentOfClientLocationImpacted": 100,
+                        "RoundTripTime": {
+                            "P50": 5,
+                            "P90": 73,
+                            "P95": 114
+                        }
+                    }
+                }
+            }],
+            "Status": "RESOLVED",
+            "PercentOfTotalTrafficImpacted": 0.76,
+            "ImpactType": "LOCAL_PERFORMANCE",
+            "HealthScoreThreshold": 60
+        },
+        ...
+        ]
+    }

--- a/awscli/examples/internetmonitor/list-internet-events.rst
+++ b/awscli/examples/internetmonitor/list-internet-events.rst
@@ -1,0 +1,30 @@
+**To list the events reported by an internet monitor**
+
+This example uses the ``list-internet-events`` command to return all the events reported by an internet monitor. ::
+
+    aws internetmonitor list-internet-events
+
+Output::
+
+    {
+        "InternetEvents": [{
+            "EventId": "ba755fe8-b4de-4e24-8b3b-19267bec227e",
+            "EventArn": "arn:aws:internetmonitor::123456789012:internet-event/ba755fe8-b4de-4e24-8b3b-19267bec227e",
+            "StartedAt": "2024-08-27T21:04:00+00:00",
+            "EndedAt": "2024-08-28T03:30:00+00:00",
+            "ClientLocation": {
+                "ASName": "CHARTER-20115",
+                "ASNumber": 20115,
+                "Country": "United States",
+                "Subdivision": "Michigan",
+                "Metro": "505",
+                "City": "Fenton",
+                "Latitude": 42.7893,
+                "Longitude": -83.7135
+            },
+            "EventType": "AVAILABILITY",
+            "EventStatus": "RESOLVED"
+        }, 
+            ...
+        ]
+    }

--- a/awscli/examples/internetmonitor/list-monitors.rst
+++ b/awscli/examples/internetmonitor/list-monitors.rst
@@ -1,0 +1,16 @@
+**To list all existing internet monitors**
+
+This example uses the ``list-monitors`` command to list all internet monitors. ::
+
+    aws internetmonitor list-monitors
+
+Output::
+
+    {
+        "Monitors": [{
+            "MonitorName": "TestMonitor",
+            "MonitorArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+            "Status": "ACTIVE",
+            "ProcessingStatus": "OK"
+        }]
+    }

--- a/awscli/examples/internetmonitor/list-tags-for-resource.rst
+++ b/awscli/examples/internetmonitor/list-tags-for-resource.rst
@@ -1,0 +1,15 @@
+**To list the tags associated with an internet monitor**
+
+This example uses the ``list-tags-for-resource`` command to list the available tags associated with an internet monitor. ::
+
+    aws internetmonitor list-tags-for-resource \
+    --resource-arn arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor
+
+Output::
+
+    {
+        "Tags": {
+            "Environment": "Prod",
+            "Type": "App"
+        }
+    }

--- a/awscli/examples/internetmonitor/start-query.rst
+++ b/awscli/examples/internetmonitor/start-query.rst
@@ -1,0 +1,16 @@
+**To start a new query in an internet monitor**
+
+This example uses the ``start-query`` command to start a new query in an internet monitor. ::
+
+    aws internetmonitor start-query \
+        --monitor-name TestMonitor \
+        --start-time 2024-08-27T00:00:00Z \
+        --end-time 2024-08-28T00:00:00Z \
+        --filter-parameters Field=country,Operator=EQUALS,Values="United States" Field=geo,Values=city \
+        --query-type TOP_LOCATIONS
+
+Output::
+
+    {
+        "QueryId": "AQICAHjE50ADcWtUTXGTlgtIHH4U_uxxxxxxxx"
+    }

--- a/awscli/examples/internetmonitor/stop-query.rst
+++ b/awscli/examples/internetmonitor/stop-query.rst
@@ -1,0 +1,9 @@
+**To stop a running query in an internet monitor**
+
+This example uses the ``stop-query`` command to stop a running query in an internet monitor. ::
+
+    aws internetmonitor stop-query \
+        --monitor-name TestMonitor \
+        --query-id AQICAHjE50ADcWtUTXGTlgtIHH4U_xxxxxxxx
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/tag-resource.rst
+++ b/awscli/examples/internetmonitor/tag-resource.rst
@@ -1,0 +1,11 @@
+**To add tags to an internet monitor**
+
+This example uses the ``tag-resource`` command to add one or more tags to an internet monitor. ::
+
+    aws internetmonitor tag-resource \
+        --resource-arn arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor \
+        --tags Environment=Prod,Type=App
+
+Output::
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/untag-resource.rst
+++ b/awscli/examples/internetmonitor/untag-resource.rst
@@ -1,0 +1,11 @@
+**To remove tags from an internet monitor**
+
+This example uses the ``untag-resource`` command to remove one or more tags from an internet monitor. ::
+
+    aws internetmonitor untag-resource \
+        --resource-arn arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor \
+        --tag-keys Environment Type
+
+Output::
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/update-monitor.rst
+++ b/awscli/examples/internetmonitor/update-monitor.rst
@@ -1,0 +1,14 @@
+**To update an existing internet monitor**
+
+This example uses the ``update-monitor`` command to update an existing internet monitor to monitor an additional resource. ::
+
+    aws internetmonitor update-monitor \
+        --monitor-name TestMonitor \
+        --resources-to-add arn:aws:ec2:us-east-1:123456789012:vpc/vpc-345678defghi
+
+Output::
+
+    {
+        "MonitorArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+        "Status": "PENDING"
+    }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding CLI examples to the CLI documentation for CloudWatch InternetMonitor - https://docs.aws.amazon.com/cli/latest/reference/internetmonitor/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
