### PR TITLE
Add CLI Examples for CloudWatch Internet Monitor

### DIFF
--- a/awscli/examples/internetmonitor/create-monitor.rst
+++ b/awscli/examples/internetmonitor/create-monitor.rst
@@ -1,0 +1,16 @@
+**To create a new internet monitor**
+
+This example uses the ``create-monitor`` command to create a new internet monitor. ::
+
+    aws internetmonitor create-monitor \
+        --monitor-name TestMonitor \
+        --resources arn:aws:ec2:us-east-1:123456789012:vpc/vpc-123456abcdef \
+        --traffic-percentage-to-monitor 100 \
+        --internet-measurements-log-delivery S3Config={LogDeliveryStatus=DISABLED} 
+
+Output::
+
+    {
+        "Arn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+        "Status": "PENDING"
+    }

--- a/awscli/examples/internetmonitor/delete-monitor.rst
+++ b/awscli/examples/internetmonitor/delete-monitor.rst
@@ -1,0 +1,8 @@
+**To delete an existing internet monitor**
+
+This example uses the ``delete-monitor`` command to delete an existing internet monitor. ::
+
+    aws internetmonitor delete-monitor \
+        --monitor-name TestMonitor
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/get-health-event.rst
+++ b/awscli/examples/internetmonitor/get-health-event.rst
@@ -1,0 +1,69 @@
+**To describe a health event in a monitor**
+
+This example uses the ``get-health-event`` to describe an existing health event in a monitor. ::
+
+    aws internetmonitor get-health-event \
+        --monitor-name TestTCP \
+        --event-id 2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e
+
+Output::
+
+    {
+        "EventArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor/health-event/2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+        "EventId": "2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+        "StartedAt": "2024-08-02T00:10:00+00:00",
+        "EndedAt": "2024-08-02T00:15:00+00:00",
+        "CreatedAt": "2024-08-02T00:27:12+00:00",
+        "LastUpdatedAt": "2024-08-02T00:32:05+00:00",
+        "ImpactedLocations": [{
+            "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK",
+            "ASNumber": 8075,
+            "Country": "United States",
+            "Subdivision": "Virginia",
+            "Metro": "Washington, DC (Hagrstwn)",
+            "City": "Washington",
+            "Latitude": 38.7095,
+            "Longitude": -78.1539,
+            "CountryCode": "US",
+            "SubdivisionCode": "VA",
+            "ServiceLocation": "us-east-1",
+            "Status": "ACTIVE",
+            "CausedBy": {
+                "Networks": [{
+                    "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                    "ASNumber": 8075
+                }],
+                "AsPath": [{
+                        "ASName": "Amazon.com",
+                        "ASNumber": 16509
+                    },
+                    {
+                        "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                        "ASNumber": 8075
+                    }
+                ],
+                "NetworkEventType": "Internet"
+            },
+            "InternetHealth": {
+                "Availability": {
+                    "ExperienceScore": 100,
+                    "PercentOfTotalTrafficImpacted": 0,
+                    "PercentOfClientLocationImpacted": 0
+                },
+                "Performance": {
+                    "ExperienceScore": 0,
+                    "PercentOfTotalTrafficImpacted": 0.76,
+                    "PercentOfClientLocationImpacted": 100,
+                    "RoundTripTime": {
+                        "P50": 5,
+                        "P90": 73,
+                        "P95": 114
+                    }
+                }
+            }
+        }],
+        "Status": "RESOLVED",
+        "PercentOfTotalTrafficImpacted": 0.76,
+        "ImpactType": "LOCAL_PERFORMANCE",
+        "HealthScoreThreshold": 60
+    }

--- a/awscli/examples/internetmonitor/get-internet-event.rst
+++ b/awscli/examples/internetmonitor/get-internet-event.rst
@@ -1,0 +1,27 @@
+**To describe an event reported by an internet monitor**
+
+This example uses the ``get-internet-event`` command to describe the details reported by a specific event in an internet monitor. ::
+
+    aws internetmonitor get-internet-event \
+        --event-id ba755fe8-b4de-4e24-8b3b-19267bec227e
+
+Output::
+
+    {
+        "EventId": "ba755fe8-b4de-4e24-8b3b-19267bec227e",
+        "EventArn": "arn:aws:internetmonitor::123456789012:internet-event/ba755fe8-b4de-4e24-8b3b-19267bec227e",
+        "StartedAt": "2024-08-27T21:04:00+00:00",
+        "EndedAt": "2024-08-28T03:30:00+00:00",
+        "ClientLocation": {
+            "ASName": "CHARTER-20115",
+            "ASNumber": 20115,
+            "Country": "United States",
+            "Subdivision": "Michigan",
+            "Metro": "505",
+            "City": "Fenton",
+            "Latitude": 42.7893,
+            "Longitude": -83.7135
+        },
+        "EventType": "AVAILABILITY",
+        "EventStatus": "RESOLVED"
+    }

--- a/awscli/examples/internetmonitor/get-monitor.rst
+++ b/awscli/examples/internetmonitor/get-monitor.rst
@@ -1,0 +1,22 @@
+**To describe an existing internet monitor**
+
+This example uses the ``get-monitor`` command to describe the configuration of an existing internet monitor. ::
+
+    aws internetmonitor get-monitor \
+        --monitor-name TestMonitor
+
+Output::
+
+    {
+        "MonitorName": "TestMonitor",
+        "MonitorArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+        "Resources": ["arn:aws:ec2:us-east-1:123456789012:vpc/vpc-123456abcdef"],
+        "Status": "ACTIVE",
+        "CreatedAt": "2024-08-28T20:10:18+00:00",
+        "ModifiedAt": "2024-08-28T20:10:18+00:00",
+        "ProcessingStatus": "COLLECTING_DATA",
+        "ProcessingStatusInfo": "The monitor is OK and is collecting data-points to produce insights",
+        "Tags": {},
+        "InternetMeasurementsLogDelivery": {},
+        "TrafficPercentageToMonitor": 100
+    }

--- a/awscli/examples/internetmonitor/get-query-results.rst
+++ b/awscli/examples/internetmonitor/get-query-results.rst
@@ -1,0 +1,40 @@
+**To fetch the results of a query**
+
+This example uses the ``get-query-results`` command to fetch the results of a query performed in a monitor. ::
+
+    aws internetmonitor get-query-results \
+        --monitor-name TestMonitor \
+        --query-id AQICAHjE50ADcWtUTXGTlgtIHH4U_u4xxxxxx
+
+Output::
+
+    {
+        "Fields": [{
+            "Name": "timestamp",
+            "Type": "integer"
+        }, {
+            "Name": "availability",
+            "Type": "float"
+        }, {
+            "Name": "performance",
+            "Type": "float"
+        }, {
+            "Name": "rtt_p50",
+            "Type": "bigint"
+        }, {
+            "Name": "rtt_p90",
+            "Type": "bigint"
+        }, {
+            "Name": "rtt_p95",
+            "Type": "bigint"
+        }, {
+            "Name": "bytes_in",
+            "Type": "bigint"
+        }, {
+            "Name": "bytes_out",
+            "Type": "bigint"
+        }],
+        "Data": [
+            ["1724833200", "100.0", "100.0", "26", "68", "72", "1258", "120"]
+        ]
+    }

--- a/awscli/examples/internetmonitor/get-query-status.rst
+++ b/awscli/examples/internetmonitor/get-query-status.rst
@@ -1,0 +1,13 @@
+**To describe the status of an existing query**
+
+This example uses the ``get-query-status`` command to get a query's current status in an internet monitor. ::
+
+    aws internetmonitor get-query-status \
+        --monitor-name TestTCP \
+        --query-id AQICAHjE50ADcWtUTXGTlgtIHH4U_u4xxxxxx
+
+Output::
+
+    {
+        "Status": "SUCCEEDED"
+    }

--- a/awscli/examples/internetmonitor/list-health-events.rst
+++ b/awscli/examples/internetmonitor/list-health-events.rst
@@ -1,0 +1,70 @@
+**To list all the health events reported by an internet monitor**
+
+This example uses the ``list-health-events`` command to list all the health events reported by an internet monitor. ::
+
+    aws internetmonitor list-health-events \
+        --monitor-name TestMonitor
+
+Output::
+
+    {
+        "HealthEvents": [{
+            "EventArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor/health-event/2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+            "EventId": "2024-08-02T00-10-00Z/latency-75732d656173742d313e383037353e556e69746564205374617465733e56697267696e69613e57617368696e67746f6e",
+            "StartedAt": "2024-08-02T00:10:00+00:00",
+            "EndedAt": "2024-08-02T00:15:00+00:00",
+            "CreatedAt": "2024-08-02T00:27:12+00:00",
+            "LastUpdatedAt": "2024-08-02T00:32:05+00:00",
+            "ImpactedLocations": [{
+                "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK",
+                "ASNumber": 8075,
+                "Country": "United States",
+                "Subdivision": "Virginia",
+                "Metro": "Washington, DC (Hagrstwn)",
+                "City": "Washington",
+                "Latitude": 38.7095,
+                "Longitude": -78.1539,
+                "CountryCode": "US",
+                "SubdivisionCode": "VA",
+                "ServiceLocation": "us-east-1",
+                "Status": "ACTIVE",
+                "CausedBy": {
+                    "Networks": [{
+                        "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                        "ASNumber": 8075
+                    }],
+                    "AsPath": [{
+                            "ASName": "Amazon.com",
+                            "ASNumber": 16509
+                        },
+                        {
+                            "ASName": "MICROSOFT-CORP-MSN-AS-BLOCK - Microsoft Corporation",
+                            "ASNumber": 8075
+                        }
+                    ],
+                    "NetworkEventType": "Internet"
+                },
+                "InternetHealth": {
+                    "Availability": {
+                        "ExperienceScore": 100,
+                        "PercentOfTotalTrafficImpacted": 0,
+                        "PercentOfClientLocationImpacted": 0
+                    },
+                    "Performance": {
+                        "ExperienceScore": 0,
+                        "PercentOfTotalTrafficImpacted": 0.76,
+                        "PercentOfClientLocationImpacted": 100,
+                        "RoundTripTime": {
+                            "P50": 5,
+                            "P90": 73,
+                            "P95": 114
+                        }
+                    }
+                }
+            }],
+            "Status": "RESOLVED",
+            "PercentOfTotalTrafficImpacted": 0.76,
+            "ImpactType": "LOCAL_PERFORMANCE",
+            "HealthScoreThreshold": 60
+        }]
+    }

--- a/awscli/examples/internetmonitor/list-internet-events.rst
+++ b/awscli/examples/internetmonitor/list-internet-events.rst
@@ -1,0 +1,28 @@
+**To list the events reported by an internet monitor**
+
+This example uses the ``list-internet-events`` command to return all the events reported by an internet monitor. ::
+
+    aws internetmonitor list-internet-events
+
+Output::
+
+    {
+        "InternetEvents": [{
+            "EventId": "ba755fe8-b4de-4e24-8b3b-19267bec227e",
+            "EventArn": "arn:aws:internetmonitor::123456789012:internet-event/ba755fe8-b4de-4e24-8b3b-19267bec227e",
+            "StartedAt": "2024-08-27T21:04:00+00:00",
+            "EndedAt": "2024-08-28T03:30:00+00:00",
+            "ClientLocation": {
+                "ASName": "CHARTER-20115",
+                "ASNumber": 20115,
+                "Country": "United States",
+                "Subdivision": "Michigan",
+                "Metro": "505",
+                "City": "Fenton",
+                "Latitude": 42.7893,
+                "Longitude": -83.7135
+            },
+            "EventType": "AVAILABILITY",
+            "EventStatus": "RESOLVED"
+        }]
+    }

--- a/awscli/examples/internetmonitor/list-monitors.rst
+++ b/awscli/examples/internetmonitor/list-monitors.rst
@@ -1,0 +1,16 @@
+**To list all existing internet monitors**
+
+This example uses the ``list-monitors`` command to list all internet monitors. ::
+
+    aws internetmonitor list-monitors
+
+Output::
+
+    {
+        "Monitors": [{
+            "MonitorName": "TestMonitor",
+            "MonitorArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+            "Status": "ACTIVE",
+            "ProcessingStatus": "OK"
+        }]
+    }

--- a/awscli/examples/internetmonitor/list-tags-for-resource.rst
+++ b/awscli/examples/internetmonitor/list-tags-for-resource.rst
@@ -1,0 +1,15 @@
+**To list the tags associated with an internet monitor**
+
+This example uses the ``list-tags-for-resource`` command to list the available tags associated with an internet monitor. ::
+
+    aws internetmonitor list-tags-for-resource \
+        --resource-arn arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor
+
+Output::
+
+    {
+        "Tags": {
+            "Environment": "Prod",
+            "Type": "App"
+        }
+    }

--- a/awscli/examples/internetmonitor/start-query.rst
+++ b/awscli/examples/internetmonitor/start-query.rst
@@ -1,0 +1,16 @@
+**To start a new query in an internet monitor**
+
+This example uses the ``start-query`` command to start a new query in an internet monitor. ::
+
+    aws internetmonitor start-query \
+        --monitor-name TestMonitor \
+        --start-time 2024-08-27T00:00:00Z \
+        --end-time 2024-08-28T00:00:00Z \
+        --filter-parameters Field=country,Operator=EQUALS,Values="United States" Field=geo,Values=city \
+        --query-type TOP_LOCATIONS
+
+Output::
+
+    {
+        "QueryId": "AQICAHjE50ADcWtUTXGTlgtIHH4U_uxxxxxxxx"
+    }

--- a/awscli/examples/internetmonitor/stop-query.rst
+++ b/awscli/examples/internetmonitor/stop-query.rst
@@ -1,0 +1,9 @@
+**To stop a running query in an internet monitor**
+
+This example uses the ``stop-query`` command to stop a running query in an internet monitor. ::
+
+    aws internetmonitor stop-query \
+        --monitor-name TestMonitor \
+        --query-id AQICAHjE50ADcWtUTXGTlgtIHH4U_xxxxxxxx
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/tag-resource.rst
+++ b/awscli/examples/internetmonitor/tag-resource.rst
@@ -1,0 +1,9 @@
+**To add tags to an internet monitor**
+
+This example uses the ``tag-resource`` command to add one or more tags to an internet monitor. ::
+
+    aws internetmonitor tag-resource \
+        --resource-arn arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor \
+        --tags Environment=Prod,Type=App
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/untag-resource.rst
+++ b/awscli/examples/internetmonitor/untag-resource.rst
@@ -1,0 +1,9 @@
+**To remove tags from an internet monitor**
+
+This example uses the ``untag-resource`` command to remove one or more tags from an internet monitor. ::
+
+    aws internetmonitor untag-resource \
+        --resource-arn arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor \
+        --tag-keys Environment Type
+
+This command returns to the prompt if successful.

--- a/awscli/examples/internetmonitor/update-monitor.rst
+++ b/awscli/examples/internetmonitor/update-monitor.rst
@@ -1,0 +1,14 @@
+**To update an existing internet monitor**
+
+This example uses the ``update-monitor`` command to update an existing internet monitor to monitor an additional resource. ::
+
+    aws internetmonitor update-monitor \
+        --monitor-name TestMonitor \
+        --resources-to-add arn:aws:ec2:us-east-1:123456789012:vpc/vpc-345678defghi
+
+Output::
+
+    {
+        "MonitorArn": "arn:aws:internetmonitor:us-east-1:123456789012:monitor/TestMonitor",
+        "Status": "PENDING"
+    }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add CLI Examples for CloudWatch Internet Monitor. Link: https://docs.aws.amazon.com/cli/latest/reference/internetmonitor/#cli-aws-internetmonitor

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
