### PR TITLE
Use AWS CRT instead of cryptography for EC2 decrypt password

### DIFF
--- a/awscli/customizations/ec2/decryptpassword.py
+++ b/awscli/customizations/ec2/decryptpassword.py
@@ -80,8 +80,6 @@ class LaunchKeyArgument(BaseCLIArgument):
             path = os.path.expanduser(path)
             if os.path.isfile(path):
                 self._key_path = path
-                endpoint_prefix = \
-                    self._operation_model.service_model.endpoint_prefix
                 service_id = self._operation_model.service_model.service_id
                 event = 'after-call.%s.%s' % (service_id.hyphenize(),
                                               self._operation_model.name)


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Replace use of `cryptography` methods with AWS CRT to perform password decryption when calling the `aws ec2 get-password-data` command with a supplied private key file.

Testing:

- Existing test suites cover decryption methods, and they pass.
- Manually compared results of retrieving password from the AWS Console for a Windows EC2 instance to the result using  the new implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
