### PR TITLE
Use randomized bucket names for S3 integration tests.

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -32,6 +32,7 @@ import sys
 import tempfile
 import time
 import unittest
+import uuid
 from pprint import pformat
 from subprocess import PIPE, Popen
 from unittest import mock
@@ -219,7 +220,9 @@ def random_bucket_name(prefix='awscli-s3integ-', num_random=15):
     :returns: The name of a randomly generated bucket name as a string.
 
     """
-    return prefix + random_chars(num_random)
+    timestamp = int(time.time())
+    unique_id = str(uuid.uuid4())
+    return f"{prefix}{timestamp}{unique_id}"
 
 
 class BaseCLIDriverTest(unittest.TestCase):

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -209,7 +209,7 @@ def random_chars(num_chars):
     return binascii.hexlify(os.urandom(int(num_chars / 2))).decode('ascii')
 
 
-def random_bucket_name(prefix='awscli-s3integ-', num_random=15):
+def random_bucket_name(prefix='awscli-s3integ', num_random=15):
     """Generate a random S3 bucket name.
 
     :param prefix: A prefix to use in the bucket name.  Useful
@@ -220,9 +220,7 @@ def random_bucket_name(prefix='awscli-s3integ-', num_random=15):
     :returns: The name of a randomly generated bucket name as a string.
 
     """
-    timestamp = int(time.time())
-    unique_id = str(uuid.uuid4())
-    return f"{prefix}{timestamp}{unique_id}"
+    return f"{prefix}-{random_chars(num_random)}-{int(time.time())}"
 
 
 class BaseCLIDriverTest(unittest.TestCase):

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -45,6 +45,7 @@ from awscli.customizations.scalarparse import add_scalar_parsers, identity
 # Using the same log name as testutils.py
 LOG = logging.getLogger('awscli.tests.integration')
 _SHARED_BUCKET = random_bucket_name()
+_NON_EXISTENT_BUCKET = random_bucket_name()
 _DEFAULT_REGION = 'us-west-2'
 _DEFAULT_AZ = 'usw2-az1'
 _SHARED_DIR_BUCKET = f'{random_bucket_name()}--{_DEFAULT_AZ}--x-s3'
@@ -86,6 +87,17 @@ def setup_module():
     s3.delete_public_access_block(
         Bucket=_SHARED_BUCKET
     )
+
+    # Validate that "_NON_EXISTENT_BUCKET" doesn't exist.
+    waiter = s3.get_waiter('bucket_not_exists')
+    try:
+        waiter.wait(Bucket=_NON_EXISTENT_BUCKET)
+    except Exception as e:
+        LOG.debug(
+            f"The following bucket was unexpectedly discovered: {_NON_EXISTENT_BUCKET}",
+            e,
+            exc_info=True,
+        )
 
 
 def clear_out_bucket(bucket, delete_bucket=False):
@@ -307,9 +319,8 @@ class TestMoveCommand(BaseS3IntegrationTest):
                          len(file_contents.getvalue()))
 
     def test_mv_to_nonexistent_bucket(self):
-        bucket_name = random_bucket_name()
         full_path = self.files.create_file('foo.txt', 'this is foo.txt')
-        p = aws(f's3 mv {full_path} s3://{bucket_name}/foo.txt')
+        p = aws(f's3 mv {full_path} s3://{_NON_EXISTENT_BUCKET}/foo.txt')
         self.assertEqual(p.rc, 1)
 
     def test_cant_move_file_onto_itself_small_file(self):
@@ -519,9 +530,8 @@ class TestCp(BaseS3IntegrationTest):
                          "aborted after receiving Ctrl-C: %s" % uploads_after)
 
     def test_cp_to_nonexistent_bucket(self):
-        bucket_name = random_bucket_name()
         foo_txt = self.files.create_file('foo.txt', 'this is foo.txt')
-        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/foo.txt')
+        p = aws(f's3 cp {foo_txt} s3://{_NON_EXISTENT_BUCKET}/foo.txt')
         self.assertEqual(p.rc, 1)
 
     def test_cp_empty_file(self):
@@ -533,8 +543,7 @@ class TestCp(BaseS3IntegrationTest):
         self.assertTrue(self.key_exists(bucket_name, 'foo.txt'))
 
     def test_download_non_existent_key(self):
-        bucket_name = random_bucket_name()
-        p = aws(f's3 cp s3://{bucket_name}/foo.txt foo.txt')
+        p = aws(f's3 cp s3://{_NON_EXISTENT_BUCKET}/foo.txt foo.txt')
         self.assertEqual(p.rc, 1)
         expected_err_msg = (
             'An error occurred (404) when calling the '
@@ -1226,7 +1235,7 @@ class TestLs(BaseS3IntegrationTest):
         self.assert_no_errors(p)
 
     def test_ls_non_existent_bucket(self):
-        p = aws('s3 ls s3://foobara99842u4wbts829381')
+        p = aws(f's3 ls s3://{_NON_EXISTENT_BUCKET}')
         self.assertEqual(p.rc, 255)
         self.assertIn(
             ('An error occurred (NoSuchBucket) when calling the '
@@ -1363,8 +1372,7 @@ class TestOutput(BaseS3IntegrationTest):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
-        bucket_name = random_bucket_name()
-        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/')
+        p = aws(f's3 cp {foo_txt} s3://{_NON_EXISTENT_BUCKET}/')
         # Check that there were errors and that the error was print to stderr.
         self.assertEqual(p.rc, 1)
         self.assertIn('upload failed', p.stderr)
@@ -1373,8 +1381,7 @@ class TestOutput(BaseS3IntegrationTest):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
-        bucket_name = random_bucket_name()
-        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/ --quiet')
+        p = aws(f's3 cp {foo_txt} s3://{_NON_EXISTENT_BUCKET}/ --quiet')
         # Check that there were errors and that the error was not
         # print to stderr.
         self.assertEqual(p.rc, 1)
@@ -1384,8 +1391,7 @@ class TestOutput(BaseS3IntegrationTest):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
-        bucket_name = random_bucket_name()
-        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/ --only-show-errors')
+        p = aws(f's3 cp {foo_txt} s3://{_NON_EXISTENT_BUCKET}/ --only-show-errors')
         # Check that there were errors and that the error was print to stderr.
         self.assertEqual(p.rc, 1)
         self.assertIn('upload failed', p.stderr)

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -307,8 +307,9 @@ class TestMoveCommand(BaseS3IntegrationTest):
                          len(file_contents.getvalue()))
 
     def test_mv_to_nonexistent_bucket(self):
+        bucket_name = random_bucket_name()
         full_path = self.files.create_file('foo.txt', 'this is foo.txt')
-        p = aws('s3 mv %s s3://bad-noexist-13143242/foo.txt' % (full_path,))
+        p = aws(f's3 mv {full_path} s3://{bucket_name}/foo.txt')
         self.assertEqual(p.rc, 1)
 
     def test_cant_move_file_onto_itself_small_file(self):
@@ -518,8 +519,9 @@ class TestCp(BaseS3IntegrationTest):
                          "aborted after receiving Ctrl-C: %s" % uploads_after)
 
     def test_cp_to_nonexistent_bucket(self):
+        bucket_name = random_bucket_name()
         foo_txt = self.files.create_file('foo.txt', 'this is foo.txt')
-        p = aws('s3 cp %s s3://noexist-bucket-foo-bar123/foo.txt' % (foo_txt,))
+        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/foo.txt')
         self.assertEqual(p.rc, 1)
 
     def test_cp_empty_file(self):
@@ -531,7 +533,8 @@ class TestCp(BaseS3IntegrationTest):
         self.assertTrue(self.key_exists(bucket_name, 'foo.txt'))
 
     def test_download_non_existent_key(self):
-        p = aws('s3 cp s3://jasoidfjasdjfasdofijasdf/foo.txt foo.txt')
+        bucket_name = random_bucket_name()
+        p = aws(f's3 cp s3://{bucket_name}/foo.txt foo.txt')
         self.assertEqual(p.rc, 1)
         expected_err_msg = (
             'An error occurred (404) when calling the '
@@ -1360,7 +1363,8 @@ class TestOutput(BaseS3IntegrationTest):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
-        p = aws('s3 cp %s s3://non-existant-bucket/' % foo_txt)
+        bucket_name = random_bucket_name()
+        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/')
         # Check that there were errors and that the error was print to stderr.
         self.assertEqual(p.rc, 1)
         self.assertIn('upload failed', p.stderr)
@@ -1369,7 +1373,8 @@ class TestOutput(BaseS3IntegrationTest):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
-        p = aws('s3 cp %s s3://non-existant-bucket/ --quiet' % foo_txt)
+        bucket_name = random_bucket_name()
+        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/ --quiet')
         # Check that there were errors and that the error was not
         # print to stderr.
         self.assertEqual(p.rc, 1)
@@ -1379,8 +1384,8 @@ class TestOutput(BaseS3IntegrationTest):
         foo_txt = self.files.create_file('foo.txt', 'foo contents')
 
         # Copy file into bucket.
-        p = aws('s3 cp %s s3://non-existant-bucket/ --only-show-errors'
-                % foo_txt)
+        bucket_name = random_bucket_name()
+        p = aws(f's3 cp {foo_txt} s3://{bucket_name}/ --only-show-errors')
         # Check that there were errors and that the error was print to stderr.
         self.assertEqual(p.rc, 1)
         self.assertIn('upload failed', p.stderr)


### PR DESCRIPTION
This change updates existing S3 integration tests to more away from static names and instead use randomized bucket names consistent with other tests.
