### PR TITLE
Update pip in bootstrap

### DIFF
--- a/requirements/download-deps/bootstrap-lock.txt
+++ b/requirements/download-deps/bootstrap-lock.txt
@@ -10,9 +10,9 @@ flit-core==3.9.0 \
     --hash=sha256:72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba \
     --hash=sha256:7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301
     # via -r requirements/download-deps/../bootstrap.txt
-pip==24.2 \
-    --hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2 \
-    --hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
+pip==24.3.1 \
+    --hash=sha256:3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed \
+    --hash=sha256:ebcb60557f2aefabc2e0f918751cd24ea0d56d8ec5445fe1807f1d2109660b99
     # via -r requirements/download-deps/../bootstrap.txt
 setuptools==71.1.0 \
     --hash=sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936 \

--- a/requirements/download-deps/bootstrap-win-lock.txt
+++ b/requirements/download-deps/bootstrap-win-lock.txt
@@ -10,9 +10,9 @@ flit-core==3.9.0 \
     --hash=sha256:72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba \
     --hash=sha256:7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301
     # via -r requirements\download-deps\../bootstrap.txt
-pip==24.2 \
-    --hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2 \
-    --hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
+pip==24.3.1 \
+    --hash=sha256:3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed \
+    --hash=sha256:ebcb60557f2aefabc2e0f918751cd24ea0d56d8ec5445fe1807f1d2109660b99
     # via -r requirements\download-deps\../bootstrap.txt
 setuptools==71.1.0 \
     --hash=sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936 \

--- a/requirements/download-deps/portable-exe-lock.txt
+++ b/requirements/download-deps/portable-exe-lock.txt
@@ -200,9 +200,9 @@ pyinstaller==5.13.2 \
     --hash=sha256:c8e5d3489c3a7cc5f8401c2d1f48a70e588f9967e391c3b06ddac1f685f8d5d2 \
     --hash=sha256:ddcc2b36052a70052479a9e5da1af067b4496f43686ca3cdda99f8367d0627e4
     # via -r requirements/portable-exe-extras.txt
-pyinstaller-hooks-contrib==2024.8 \
-    --hash=sha256:0057fe9a5c398d3f580e73e58793a1d4a8315ca91c3df01efea1c14ed557825a \
-    --hash=sha256:29b68d878ab739e967055b56a93eb9b58e529d5b054fbab7a2f2bacf80cef3e2
+pyinstaller-hooks-contrib==2024.9 \
+    --hash=sha256:1ddf9ba21d586afa84e505bb5c65fca10b22500bf3fdb89ee2965b99da53b891 \
+    --hash=sha256:4793869f370d1dc4806c101efd2890e3c3e703467d8d27bb5a3db005ebfb008d
     # via pyinstaller
 python-dateutil==2.9.0 \
     --hash=sha256:78e73e19c63f5b20ffa567001531680d939dc042bf7850431877645523c66709 \

--- a/requirements/download-deps/portable-exe-win-lock.txt
+++ b/requirements/download-deps/portable-exe-win-lock.txt
@@ -198,9 +198,9 @@ pyinstaller==5.13.2 \
     --hash=sha256:c8e5d3489c3a7cc5f8401c2d1f48a70e588f9967e391c3b06ddac1f685f8d5d2 \
     --hash=sha256:ddcc2b36052a70052479a9e5da1af067b4496f43686ca3cdda99f8367d0627e4
     # via -r requirements\portable-exe-extras.txt
-pyinstaller-hooks-contrib==2024.8 \
-    --hash=sha256:0057fe9a5c398d3f580e73e58793a1d4a8315ca91c3df01efea1c14ed557825a \
-    --hash=sha256:29b68d878ab739e967055b56a93eb9b58e529d5b054fbab7a2f2bacf80cef3e2
+pyinstaller-hooks-contrib==2024.9 \
+    --hash=sha256:1ddf9ba21d586afa84e505bb5c65fca10b22500bf3fdb89ee2965b99da53b891 \
+    --hash=sha256:4793869f370d1dc4806c101efd2890e3c3e703467d8d27bb5a3db005ebfb008d
     # via pyinstaller
 python-dateutil==2.9.0 \
     --hash=sha256:78e73e19c63f5b20ffa567001531680d939dc042bf7850431877645523c66709 \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A new version of `pip` ([24.3.1](https://pypi.org/project/pip/24.3.1/)) was released on October 27, 2024. This is causing the lockfile test to fail since a [newer version](https://github.com/aws/aws-cli/blob/b54b44d86c759052d8f5357c5b7a9054f1a03030/requirements/bootstrap.txt#L1) is allowed in our requirements than the one currently in the [lockfile](https://github.com/aws/aws-cli/blob/b54b44d86c759052d8f5357c5b7a9054f1a03030/requirements/download-deps/bootstrap-lock.txt#L13):

- Test: https://github.com/aws/aws-cli/blob/b54b44d86c759052d8f5357c5b7a9054f1a03030/tests/backends/build_system/functional/test_lock_files.py
- Example failure: https://github.com/aws/aws-cli/actions/runs/11673639581/job/32504778903#step:5:92

```
=========================== short test summary info ============================
FAILED backends/build_system/functional/test_lock_files.py::test_lock_files_are_up_to_date - AssertionError: assert 'pip==24.3.1 ...bb10c083ce8\n' == 'pip==24.2 \\...bb10c083ce8\n'
  - pip==24.2 \
  ?         ^
  + pip==24.3.1 \
  ?         ^^^
  -     --hash=sha256:2cd581cf58ab7fcfca4ce8efa6dcacd0de5bf8d0a3eb9ec927e07405f4d9e2a2 \
  -     --hash=sha256:5b5e490b5e9cb275c879595064adce9ebd31b854e3e803740b72f9ccf34a45b8
  +     --hash=sha256:3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed \
  +     --hash=sha256:ebcb60557f2aefabc2e0f918751cd24ea0d56d8ec5445fe1807f1d2109660b99
    setuptools==71.1.0 \
        --hash=sha256:032d42ee9fb536e33087fb66cac5f840eb9391ed05637b3f2a76a7c8fb477936 \
        --hash=sha256:33874fdc59b3188304b2e7c80d9029097ea31627180896fb549c578ceb8a0855
    wheel==0.38.4 \
        --hash=sha256:965f5259b566725405b05e7cf774052044b1ed30119b5d586b2703aafe8719ac \
        --hash=sha256:b60533f3f5d530e971d6737ca6d58681ee434818fab630c83a734bb10c083ce8
======= 1 failed, 76 passed, 9 skipped, 2 warnings in 1054.42s (0:17:34) =======
```

To resolve, I used the regenerate lockfiles GitHub Action to update the lockfiles.

This also updates a transitive dependency of `pyinstaller`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
