### PR TITLE
[v2] End of support for macOS 10.15

### DIFF
--- a/.changes/next-release/feature-macOS-73507.json
+++ b/.changes/next-release/feature-macOS-73507.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "macOS",
+  "description": "End of support for macOS 10.15"
+}

--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,9 @@ The aws-cli package works on Python versions:
 -------
 Notices
 -------
-On 2024-06-20, support for macOS versions 10.14 and prior was dropped.
-To use up-to-date versions of AWS CLI v2, customers using macOS 10.14 or prior
-should upgrade to macOS 10.15 or later. For more information, please see
+On 2024-11-11, support for macOS version 10.15 was dropped.
+To use up-to-date versions of AWS CLI v2, customers using macOS 10.15 or prior
+should upgrade to macOS 11 or later. For more information, please see
 this `blog post <https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/>`__.
 
 

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The aws-cli package works on Python versions:
 -------
 Notices
 -------
-On 2024-11-11, support for macOS version 10.15 was dropped.
+On 2024-11-13, support for macOS version 10.15 was dropped.
 To use up-to-date versions of AWS CLI v2, customers using macOS 10.15 or prior
 should upgrade to macOS 11 or later. For more information, please see
 this `blog post <https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/>`__.

--- a/configure
+++ b/configure
@@ -2096,8 +2096,8 @@ printf "%s\n" "$with_download_deps" >&6; }
 ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
 if test "$ac_operating_system" = Darwin; then
 
-    min_version='10.15.0'
-    end_support_date='June 20, 2024'
+    min_version='11.0.0'
+    end_support_date='November 11, 2024'
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for macOS version support" >&5
 printf %s "checking for macOS version support... " >&6; }

--- a/configure
+++ b/configure
@@ -2097,7 +2097,7 @@ ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
 if test "$ac_operating_system" = Darwin; then
 
     min_version='11.0.0'
-    end_support_date='November 11, 2024'
+    end_support_date='November 13, 2024'
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for macOS version support" >&5
 printf %s "checking for macOS version support... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_SUBST(DOWNLOAD_DEPS_FLAG)
 
 ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
 if test "$ac_operating_system" = Darwin; then
-    AC_CHECK_MACOS_END_OF_SUPPORT([10.15.0], [June 20, 2024])
+    AC_CHECK_MACOS_END_OF_SUPPORT([11.0.0], [November 11, 2024])
 fi
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_SUBST(DOWNLOAD_DEPS_FLAG)
 
 ac_operating_system=`(uname -s) 2>/dev/null || echo unknown`
 if test "$ac_operating_system" = Darwin; then
-    AC_CHECK_MACOS_END_OF_SUPPORT([11.0.0], [November 11, 2024])
+    AC_CHECK_MACOS_END_OF_SUPPORT([11.0.0], [November 13, 2024])
 fi
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/macpkg/distribution.xml
+++ b/macpkg/distribution.xml
@@ -10,7 +10,7 @@
     function checkOsVersion() {
       if(system.compareVersions(system.version.ProductVersion, '11.0.0') < 0) {
         my.result.type = 'Warning';
-        my.result.message = 'On November 11, 2024, the AWS CLI v2 dropped support for macOS 10.15. Please upgrade to macOS 11 or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
+        my.result.message = 'On November 13, 2024, the AWS CLI v2 dropped support for macOS 10.15. Please upgrade to macOS 11 or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
         return false;
       }
       return true;

--- a/macpkg/distribution.xml
+++ b/macpkg/distribution.xml
@@ -8,9 +8,9 @@
     <script>
     <![CDATA[
     function checkOsVersion() {
-      if(system.compareVersions(system.version.ProductVersion, '10.15.0') < 0) {
+      if(system.compareVersions(system.version.ProductVersion, '11.0.0') < 0) {
         my.result.type = 'Warning';
-        my.result.message = 'On June 20, 2024, the AWS CLI v2 dropped support for macOS versions below 10.15.0. Please upgrade to macOS version 10.15.0 or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
+        my.result.message = 'On November 11, 2024, the AWS CLI v2 dropped support for macOS 10.15. Please upgrade to macOS 11 or later to use up-to-date versions of AWS CLI v2. For more information, please visit: https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/';
         return false;
       }
       return true;


### PR DESCRIPTION
Update macOS source distribution and PKG installer warnings following the end of support for macOS 10.15. For more, see the macOS support policy blog post:

https://aws.amazon.com/blogs/developer/macos-support-policy-updates-for-the-aws-cli-v2/