### PR TITLE
Add support to shorthand syntax for loading parameters from files

### DIFF
--- a/.changes/next-release/feature-shorthand-60511.json
+++ b/.changes/next-release/feature-shorthand-60511.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "shorthand",
+  "description": "Adds support to shorthand syntax for loading parameters from files via the ``@=`` assignment operator."
+}

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -18,7 +18,7 @@ from botocore.awsrequest import AWSRequest
 from botocore.exceptions import ProfileNotFound
 from botocore.httpsession import URLLib3Session
 
-from awscli.argprocess import ParamError
+from awscli import argprocess
 from awscli.compat import compat_open
 
 logger = logging.getLogger(__name__)
@@ -183,7 +183,7 @@ class URIArgumentHandler:
         try:
             return get_paramfile(value, self._prefixes)
         except ResourceLoadingError as e:
-            raise ParamError(param.cli_name, str(e))
+            raise argprocess.ParamError(param.cli_name, str(e))
 
 
 def get_paramfile(path, cases):

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -161,7 +161,7 @@ class ShorthandParser:
         """
         self._input_value = value
         self._index = 0
-        self._resolve_paramfiles = False
+        self._should_resolve_paramfiles = False
         return self._parameter()
 
     def _parameter(self):
@@ -187,10 +187,10 @@ class ShorthandParser:
         # keyval = key "=" [values] / key "@=" [file-optional-values]
         # file-optional-values = file://value / fileb://value / value
         key = self._key()
-        self._resolve_paramfiles = False
+        self._should_resolve_paramfiles = False
         try:
             self._expect('@', consume_whitespace=True)
-            self._resolve_paramfiles = True
+            self._should_resolve_paramfiles = True
         except ShorthandParseSyntaxError:
             pass
         self._expect('=', consume_whitespace=True)
@@ -271,7 +271,7 @@ class ShorthandParser:
         if result is not None:
             consumed = self._consume_matched_regex(result)
             processed = consumed.replace('\\,', ',').rstrip()
-            return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
+            return self._resolve_paramfiles(processed) if self._should_resolve_paramfiles else processed
         return ''
 
     def _explicit_list(self):
@@ -302,10 +302,10 @@ class ShorthandParser:
         keyvals = {}
         while self._current() != '}':
             key = self._key()
-            self._resolve_paramfiles = False
+            self._should_resolve_paramfiles = False
             try:
                 self._expect('@', consume_whitespace=True)
-                self._resolve_paramfiles = True
+                self._should_resolve_paramfiles = True
             except ShorthandParseSyntaxError:
                 pass
             self._expect('=', consume_whitespace=True)
@@ -331,7 +331,7 @@ class ShorthandParser:
         # val-escaped-single  = %x20-26 / %x28-7F / escaped-escape /
         #                       (escape single-quote)
         processed = self._consume_quoted(self._SINGLE_QUOTED, escaped_char="'")
-        return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
+        return self._resolve_paramfiles(processed) if self._should_resolve_paramfiles else processed
 
     def _consume_quoted(self, regex, escaped_char=None):
         value = self._must_consume_regex(regex)[1:-1]
@@ -342,7 +342,7 @@ class ShorthandParser:
 
     def _double_quoted_value(self):
         processed = self._consume_quoted(self._DOUBLE_QUOTED, escaped_char='"')
-        return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
+        return self._resolve_paramfiles(processed) if self._should_resolve_paramfiles else processed
 
     def _second_value(self):
         if self._current() == "'":
@@ -352,9 +352,9 @@ class ShorthandParser:
         else:
             consumed = self._must_consume_regex(self._SECOND_VALUE)
             processed = consumed.replace('\\,', ',').rstrip()
-            return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
+            return self._resolve_paramfiles(processed) if self._should_resolve_paramfiles else processed
 
-    def _should_resolve_paramfiles(self, val):
+    def _resolve_paramfiles(self, val):
         if (paramfile := get_paramfile(val, LOCAL_PREFIX_MAP)) is not None:
             return paramfile
         return val

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -42,6 +42,7 @@ necessary to maintain backwards compatibility.  This is done in the
 import re
 import string
 
+from awscli.paramfile import LOCAL_PREFIX_MAP, get_paramfile
 from awscli.utils import is_document_type
 
 _EOF = object()
@@ -160,6 +161,7 @@ class ShorthandParser:
         """
         self._input_value = value
         self._index = 0
+        self._resolve_paramfiles = False
         return self._parameter()
 
     def _parameter(self):
@@ -182,8 +184,15 @@ class ShorthandParser:
         return params
 
     def _keyval(self):
-        # keyval = key "=" [values]
+        # keyval = key "=" [values] / key "@=" [file-optional-values]
+        # file-optional-values = file://value / fileb://value / value
         key = self._key()
+        self._resolve_paramfiles = False
+        try:
+            self._expect('@', consume_whitespace=True)
+            self._resolve_paramfiles = True
+        except ShorthandParseSyntaxError:
+            pass
         self._expect('=', consume_whitespace=True)
         values = self._values()
         return key, values
@@ -261,7 +270,8 @@ class ShorthandParser:
         result = self._FIRST_VALUE.match(self._input_value[self._index :])
         if result is not None:
             consumed = self._consume_matched_regex(result)
-            return consumed.replace('\\,', ',').rstrip()
+            processed = consumed.replace('\\,', ',').rstrip()
+            return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
         return ''
 
     def _explicit_list(self):
@@ -292,6 +302,12 @@ class ShorthandParser:
         keyvals = {}
         while self._current() != '}':
             key = self._key()
+            self._resolve_paramfiles = False
+            try:
+                self._expect('@', consume_whitespace=True)
+                self._resolve_paramfiles = True
+            except ShorthandParseSyntaxError:
+                pass
             self._expect('=', consume_whitespace=True)
             v = self._explicit_values()
             self._consume_whitespace()
@@ -314,7 +330,8 @@ class ShorthandParser:
         # single-quoted-value = %x27 *(val-escaped-single) %x27
         # val-escaped-single  = %x20-26 / %x28-7F / escaped-escape /
         #                       (escape single-quote)
-        return self._consume_quoted(self._SINGLE_QUOTED, escaped_char="'")
+        processed = self._consume_quoted(self._SINGLE_QUOTED, escaped_char="'")
+        return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
 
     def _consume_quoted(self, regex, escaped_char=None):
         value = self._must_consume_regex(regex)[1:-1]
@@ -324,7 +341,8 @@ class ShorthandParser:
         return value
 
     def _double_quoted_value(self):
-        return self._consume_quoted(self._DOUBLE_QUOTED, escaped_char='"')
+        processed = self._consume_quoted(self._DOUBLE_QUOTED, escaped_char='"')
+        return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
 
     def _second_value(self):
         if self._current() == "'":
@@ -333,7 +351,13 @@ class ShorthandParser:
             return self._double_quoted_value()
         else:
             consumed = self._must_consume_regex(self._SECOND_VALUE)
-            return consumed.replace('\\,', ',').rstrip()
+            processed = consumed.replace('\\,', ',').rstrip()
+            return self._should_resolve_paramfiles(processed) if self._resolve_paramfiles else processed
+
+    def _should_resolve_paramfiles(self, val):
+        if (paramfile := get_paramfile(val, LOCAL_PREFIX_MAP)) is not None:
+            return paramfile
+        return val
 
     def _expect(self, char, consume_whitespace=False):
         if consume_whitespace:

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -13,7 +13,13 @@
 from awscli.testutils import mock, unittest, FileCreator
 from awscli.testutils import skip_if_windows
 
-from awscli.paramfile import get_paramfile, ResourceLoadingError, LOCAL_PREFIX_MAP, register_uri_param_handler
+from awscli.paramfile import (
+    get_paramfile,
+    ResourceLoadingError,
+    LOCAL_PREFIX_MAP,
+    REMOTE_PREFIX_MAP,
+    register_uri_param_handler,
+)
 from botocore.session import Session
 from botocore.exceptions import ProfileNotFound
 

--- a/tests/unit/test_paramfile.py
+++ b/tests/unit/test_paramfile.py
@@ -13,9 +13,7 @@
 from awscli.testutils import mock, unittest, FileCreator
 from awscli.testutils import skip_if_windows
 
-from awscli.paramfile import get_paramfile, ResourceLoadingError
-from awscli.paramfile import LOCAL_PREFIX_MAP, REMOTE_PREFIX_MAP
-from awscli.paramfile import register_uri_param_handler
+from awscli.paramfile import get_paramfile, ResourceLoadingError, LOCAL_PREFIX_MAP, register_uri_param_handler
 from botocore.session import Session
 from botocore.exceptions import ProfileNotFound
 


### PR DESCRIPTION
*Description of changes:*
- Enable support for loading files into nested parameters via usage of `file://` or `fileb://` prefix.

*Description of tests:*
- Added unit test cases to ensure the parser works against the expected grammar updates.
- Added a test suite to verify that the parser correctly loads contents from local files as expected.
- Ran and passed all existing and new tests.
- Manually tested the feature via self-crafted input.

*Usage Example:*
For example, suppose there is a file named `tagval.txt` located at `path/to/tagval.txt` on the host machine with contents `TagValue`.

` 
aws codecommit tag-resource --resource-arn <RESOURCE_ARN> --tags TagKey@=file://path/to/tagval.txt
`

The above command will parse the tags parameter as `"tags": {"TagKey": "TagValue"}}`. Notice the need for the assignment operator `@=`. This operator is required to prevent breaking existing customers that may be using a nested parameter value that happens to start with `file://` already.

*Relevant Links:*
- [v2 PR](https://github.com/aws/aws-cli/pull/9012)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
