### PR TITLE
Fix non-deterministic S3 test failure.

### DIFF
--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -725,9 +725,9 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[1][0].name, 'UploadPart')
         self.assertEqual(self.operations_called[1][1]['ChecksumAlgorithm'], 'CRC32')
         self.assertEqual(self.operations_called[3][0].name, 'CompleteMultipartUpload')
-        self.assertIn({'ETag': 'foo-e1', 'ChecksumCRC32': 'foo-1', 'PartNumber': 1},
+        self.assertIn({'ETag': 'foo-e1', 'ChecksumCRC32': 'foo-1', 'PartNumber': mock.ANY},
                       self.operations_called[3][1]['MultipartUpload']['Parts'])
-        self.assertIn({'ETag': 'foo-e2', 'ChecksumCRC32': 'foo-2', 'PartNumber': 2},
+        self.assertIn({'ETag': 'foo-e2', 'ChecksumCRC32': 'foo-2', 'PartNumber': mock.ANY},
                       self.operations_called[3][1]['MultipartUpload']['Parts'])
 
     def test_copy_with_checksum_algorithm_crc32(self):


### PR DESCRIPTION
*Description of changes:*
- Replace a hard-coded part number with `mock.ANY` to prevent non-deterministic test failures.

*Description of tests:*
- Ran the updates test locally and observed it passes.

*Relevant links:*
- [v2 PR](https://github.com/aws/aws-cli/pull/9068)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
