### PR TITLE
Fixed ambiguous error message raised when resolving region from IMDS

### DIFF
--- a/.changes/next-release/bugfix-IMDS-70100.json
+++ b/.changes/next-release/bugfix-IMDS-70100.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "IMDS",
+  "description": "Fixed ambiguous error raised when failing to resolve a region from IMDS."
+}

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -26,6 +26,7 @@ from awscli.compat import StringIO
 from botocore.useragent import UserAgentComponent
 from botocore.utils import resolve_imds_endpoint_mode
 from botocore.utils import IMDSFetcher
+from botocore.utils import BadIMDSRequestError
 from botocore.configprovider import BaseProvider
 
 logger = logging.getLogger(__name__)
@@ -171,9 +172,17 @@ class InstanceMetadataRegionFetcher(IMDSFetcher):
             region = self._get_region()
             return region
         except self._RETRIES_EXCEEDED_ERROR_CLS:
-            logger.debug("Max number of attempts exceeded (%s) when "
-                         "attempting to retrieve data from metadata service.",
-                         self._num_attempts)
+            logger.debug(
+                "Max number of attempts exceeded (%s) when "
+                "attempting to retrieve data from metadata service.",
+                self._num_attempts
+            )
+        except BadIMDSRequestError as e:
+            logger.debug(
+                "Failed to retrieve a region from IMDS. "
+                "Region detection may not be supported from this endpoint: "
+                "%s", e.request.url
+            )
         return None
 
     def _get_region(self):


### PR DESCRIPTION
An issue raised in https://github.com/aws/aws-cli/issues/8988 points out an unhandled error in the AWS CLI region fetcher. In the base IMDS credential fetcher, this is handled by adding a debug log and turning the request into a no-op. In the CLI's region fetcher, it's treated as terminal and surfaced to the end user with an unhelpful object reference.

This was later ported to botocore in a different location (`botocore/utils.py`). I'll address that in a separate PR upstream.