### PR TITLE
[v2] Add query compatibility mode header

### DIFF
--- a/.changes/next-release/enhancement-protocol-90080.json
+++ b/.changes/next-release/enhancement-protocol-90080.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "protocol",
+  "description": "Added support for header enabling service migration off the AWS Query protocol."
+}

--- a/awscli/botocore/handlers.py
+++ b/awscli/botocore/handlers.py
@@ -1151,6 +1151,12 @@ def _update_status_code(response, **kwargs):
         http_response.status_code = parsed_status_code
 
 
+def add_query_compatibility_header(model, params, **kwargs):
+    if not model.service_model.is_query_compatible:
+        return
+    params['headers']['x-amzn-query-mode'] = 'true'
+
+
 # This is a list of (event_name, handler).
 # When a Session is created, everything in this list will be
 # automatically registered with that Session.
@@ -1201,7 +1207,7 @@ BUILTIN_HANDLERS = [
     ('docs.response-example.s3.*.complete-section', document_expires_shape),
     ('docs.response-params.s3.*.complete-section', document_expires_shape),
     ('before-endpoint-resolution.s3', customize_endpoint_resolver_builtins),
-
+    ('before-call', add_query_compatibility_header),
     ('before-call.s3', add_expect_header),
     ('before-call.glacier', add_glacier_version),
     ('before-call.api-gateway', add_accept_header),

--- a/awscli/botocore/model.py
+++ b/awscli/botocore/model.py
@@ -446,6 +446,10 @@ class ServiceModel(object):
     def signature_version(self, value):
         self._signature_version = value
 
+    @CachedProperty
+    def is_query_compatible(self):
+        return 'awsQueryCompatible' in self.metadata
+
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__, self.service_name)
 

--- a/tests/functional/botocore/test_sqs.py
+++ b/tests/functional/botocore/test_sqs.py
@@ -1,0 +1,32 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+from tests import BaseSessionTest, ClientHTTPStubber
+
+
+class BaseSQSOperationTest(BaseSessionTest):
+    def setUp(self):
+        super().setUp()
+        self.region = "us-west-2"
+        self.client = self.session.create_client("sqs", self.region)
+        self.http_stubber = ClientHTTPStubber(self.client)
+
+
+class SQSQueryCompatibleTest(BaseSQSOperationTest):
+    def test_query_compatibility_mode_header_sent(self):
+        with self.http_stubber as stub:
+            stub.add_response()
+            self.client.delete_queue(QueueUrl="not-a-real-queue-botocore")
+            request = self.http_stubber.requests[0]
+            assert 'x-amzn-query-mode' in request.headers
+            assert request.headers['x-amzn-query-mode'] == b'true'

--- a/tests/unit/botocore/test_handlers.py
+++ b/tests/unit/botocore/test_handlers.py
@@ -1699,3 +1699,20 @@ def test_document_response_params_without_expires(document_expires_mocks):
     mocks['section'].get_section.assert_not_called()
     mocks['param_section'].add_new_section.assert_not_called()
     mocks['doc_section'].write.assert_not_called()
+
+
+def test_add_query_compatibility_header():
+    service_model = ServiceModel({'metadata': {'awsQueryCompatible': {}}})
+    operation_model = OperationModel(mock.Mock(), service_model)
+    request_dict = {'headers': {}}
+    handlers.add_query_compatibility_header(operation_model, request_dict)
+    assert 'x-amzn-query-mode' in request_dict['headers']
+    assert request_dict['headers']['x-amzn-query-mode'] == 'true'
+
+
+def test_does_not_add_query_compatibility_header():
+    service_model = ServiceModel({'metadata': {}})
+    operation_model = OperationModel(mock.Mock(), service_model)
+    request_dict = {'headers': {}}
+    handlers.add_query_compatibility_header(operation_model, request_dict)
+    assert 'x-amzn-query-mode' not in request_dict['headers']


### PR DESCRIPTION
Port of https://github.com/boto/botocore/pull/3295

Adds a header `x-amzn-query-mode` with value `true` if the service model's metadata has a `awsQueryCompatible` key ([example in SQS](https://github.com/aws/aws-cli/blob/d9b2f70e0f7d6628b1f9d2b8957b15ecbdbafc7c/awscli/botocore/data/sqs/2012-11-05/service-2.json#L5-L6)).

Tested functional behavior by running `aws sqs list-queues` and checking `aws history show`:
```
[0] HTTP request sent
at time: 2024-11-18 15:25:14.591
to URL: https://sqs.us-west-2.amazonaws.com/
with method: POST
with headers: {
    ...
    "X-Amz-Target": "AmazonSQS.ListQueues",
    "x-amzn-query-mode": "true" # This is what we want to see.
}
with body: {}
```

I also had to create a new file `tests/functional/botocore/test_sqs.py`. I didn't port the 1 existing test ([see here](https://github.com/boto/botocore/blob/baca980d92fc59f7ab845a0395f23d107c190194/tests/functional/test_sqs.py#L28)) because it's making sure the modeled exception is raised rather than `ClientError`, but the AWS CLI always raises `ClientError`.