### PR TITLE
[V2] Fix device code fallback when configuring a new SSO profile

### DIFF
--- a/.changes/next-release/bugfix-configure-21065.json
+++ b/.changes/next-release/bugfix-configure-21065.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``configure``",
+  "description": "Fixed ``aws configure sso`` to honor ``--use-device-code``."
+}

--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -517,6 +517,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
             self._session,
             token_cache=self._sso_token_cache,
             on_pending_authorization=on_pending_authorization,
+            use_device_code=parsed_args.use_device_code,
             **sso_registration_args
         )
 

--- a/tests/functional/configure/test_sso.py
+++ b/tests/functional/configure/test_sso.py
@@ -69,7 +69,7 @@ class TestConfigureSSOCommand(BaseSSOTest):
         self.profile_prompt.start()
 
     def tearDown(self):
-        super().setUp()
+        super().tearDown()
         self.registration_args_prompt.stop()
         self.account_and_role_prompt.stop()
         self.region_prompt.stop()

--- a/tests/functional/configure/test_sso.py
+++ b/tests/functional/configure/test_sso.py
@@ -28,7 +28,7 @@ class TestConfigureSSO(BaseAWSCommandParamsTest):
 class TestConfigureSSOCommand(BaseSSOTest):
 
     def setUp(self):
-        super(TestConfigureSSOCommand, self).setUp()
+        super().setUp()
 
         self.registration_args_prompt = patch.object(
             ConfigureSSOCommand,
@@ -69,7 +69,7 @@ class TestConfigureSSOCommand(BaseSSOTest):
         self.profile_prompt.start()
 
     def tearDown(self):
-        super(TestConfigureSSOCommand, self).tearDown()
+        super().setUp()
         self.registration_args_prompt.stop()
         self.account_and_role_prompt.stop()
         self.region_prompt.stop()

--- a/tests/functional/configure/test_sso.py
+++ b/tests/functional/configure/test_sso.py
@@ -10,7 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from awscli.customizations.configure.sso import ConfigureSSOCommand
 from awscli.testutils import BaseAWSCommandParamsTest
+from tests.functional.sso import BaseSSOTest
+from unittest.mock import patch
 
 
 class TestConfigureSSO(BaseAWSCommandParamsTest):
@@ -20,3 +23,84 @@ class TestConfigureSSO(BaseAWSCommandParamsTest):
         cmdline = self.prefix + ' logout'
         _, err, _ = self.run_cmd(cmdline, 252)
         self.assertIn('Unknown options', err)
+
+
+class TestConfigureSSOCommand(BaseSSOTest):
+
+    def setUp(self):
+        super(TestConfigureSSOCommand, self).setUp()
+
+        self.registration_args_prompt = patch.object(
+            ConfigureSSOCommand,
+            '_prompt_for_sso_registration_args',
+            return_value={
+                'session_name': 'my-session',
+                'sso_region': 'us-east-1',
+                'start_url': 'https://identitycenter.amazonaws.com/ssoins-1234',
+            },
+        )
+
+        self.account_and_role_prompt = patch.object(
+            ConfigureSSOCommand,
+            '_prompt_for_sso_account_and_role',
+            return_value=('123456789012', 'role'),
+        )
+
+        self.region_prompt = patch.object(
+            ConfigureSSOCommand,
+            '_prompt_for_cli_default_region',
+            return_value='us-west-2',
+        )
+
+        self.output_prompt = patch.object(
+            ConfigureSSOCommand,
+            '_prompt_for_cli_output_format',
+            return_value='json',
+        )
+
+        self.profile_prompt = patch.object(
+            ConfigureSSOCommand, '_prompt_for_profile', return_value='my-profile',
+        )
+
+        self.registration_args_prompt.start()
+        self.account_and_role_prompt.start()
+        self.region_prompt.start()
+        self.output_prompt.start()
+        self.profile_prompt.start()
+
+    def tearDown(self):
+        super(TestConfigureSSOCommand, self).tearDown()
+        self.registration_args_prompt.stop()
+        self.account_and_role_prompt.stop()
+        self.region_prompt.stop()
+        self.output_prompt.stop()
+        self.profile_prompt.stop()
+
+    def test_configure_sso_implicit_auth(self):
+        self.add_oidc_auth_code_responses(
+            self.access_token,
+            include_register_response=True,
+        )
+        self.run_cmd('configure sso')
+
+    def test_configure_sso_explicit_device(self):
+        self.add_oidc_device_responses(
+            self.access_token,
+            include_register_response=True,
+        )
+        self.run_cmd('configure sso --use-device-code')
+
+    def test_configure_sso_implicit_device(self):
+        self.add_oidc_device_responses(
+            self.access_token,
+            include_register_response=True,
+        )
+
+        # The lack of a session_name should trigger the device flow
+        with patch.object(ConfigureSSOCommand,
+                          '_prompt_for_sso_registration_args',
+                          return_value={
+                              'session_name': None,
+                              'sso_region': 'us-east-1',
+                              'start_url': 'https://identitycenter.amazonaws.com/ssoins-1234'}):
+            self.run_cmd('configure sso')

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -23,63 +23,6 @@ class TestLoginCommand(BaseSSOTest):
         r'\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ'
     )
 
-    def add_oidc_device_responses(self, access_token,
-                                  include_register_response=True):
-        responses = [
-            # StartDeviceAuthorization response
-            {
-                'interval': 1,
-                'expiresIn': 600,
-                'userCode': 'foo',
-                'deviceCode': 'foo-device-code',
-                'verificationUri': 'https://sso.fake/device',
-                'verificationUriComplete': 'https://sso.verify',
-            },
-            # CreateToken responses
-            {
-                'Error': {
-                    'Code': 'AuthorizationPendingException',
-                    'Message': 'Authorization is still pending',
-                }
-            },
-            {
-                'expiresIn': self.expires_in,
-                'tokenType': 'Bearer',
-                'accessToken': access_token,
-            }
-        ]
-        if include_register_response:
-            responses.insert(
-                0,
-                {
-                    'clientSecretExpiresAt': self.expiration_time,
-                    'clientId': 'device-client-id',
-                    'clientSecret': 'device-client-secret',
-                }
-            )
-        self.parsed_responses = responses
-
-    def add_oidc_auth_code_responses(self, access_token,
-                                     include_register_response=True):
-        responses = [
-            # CreateToken responses
-            {
-                'expiresIn': self.expires_in,
-                'tokenType': 'Bearer',
-                'accessToken': access_token,
-            }
-        ]
-        if include_register_response:
-            responses.insert(
-                0,
-                {
-                    'clientSecretExpiresAt': self.expiration_time,
-                    'clientId': 'auth-client-id',
-                    'clientSecret': 'auth-client-secret',
-                }
-            )
-        self.parsed_responses = responses
-
     def assert_cache_contains_registration(
             self,
             start_url,

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -826,6 +826,7 @@ class TestConfigureSSOCommand:
         botocore_session,
         expected_sso_region,
         expected_start_url,
+        expected_use_device_code=False,
         expected_session_name=None,
         expected_scopes=None,
         expected_auth_handler_cls=None,
@@ -836,6 +837,7 @@ class TestConfigureSSOCommand:
             "start_url": expected_start_url,
             "on_pending_authorization": None,
             "token_cache": None,
+            "use_device_code": expected_use_device_code,
         }
         if expected_session_name is not None:
             expected_kwargs["session_name"] = expected_session_name


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This fixes an issue that was reported internally for the new authorization code + PKCE support for SSO that was released in `2.22.0`.

There is a new option `--use-device-code` for falling back to the device grant flow. It was working for `aws sso login` but not `aws configure sso`.

I added functional tests for this before I found the `test_sso` file in unit tests. But I think that's okay, since ultimately we want to make sure the option is plumbed all the way through starting from `run_cmd`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
