### PR TITLE
[v2] Fix flaky prompt-toolkit tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -387,7 +387,7 @@ class AppRunContext:
 
 
 class PromptToolkitAppRunner:
-    _EVENT_WAIT_TIMEOUT = 3
+    _EVENT_WAIT_TIMEOUT = 5
 
     def __init__(self, app, pre_run=None):
         self.app = app

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -387,7 +387,7 @@ class AppRunContext:
 
 
 class PromptToolkitAppRunner:
-    _EVENT_WAIT_TIMEOUT = 2
+    _EVENT_WAIT_TIMEOUT = 3
 
     def __init__(self, app, pre_run=None):
         self.app = app

--- a/tests/functional/autoprompt/test_prompttoolkit.py
+++ b/tests/functional/autoprompt/test_prompttoolkit.py
@@ -143,6 +143,7 @@ class TestPromptToolkitPrompterBuffer:
         [
             (['cloudwatch', 'fake'], 'cloudwatch fake '),
             (['cloudwatch'], 'cloudwatch '),
+            (['cloud'], 'cloud'),
             (['s3', 'mv', '/path/to/file/1', 's3://path/to/file/2'],
              's3 mv /path/to/file/1 s3://path/to/file/2 '),
             (['s3', 'ls'], 's3 ls '),


### PR DESCRIPTION
The [`PromptToolkitAppRunner` test utility](https://github.com/aws/aws-cli/blob/37a410088eb035d52da38545f1c8b9330b0a95e7/tests/__init__.py#L390) only waits 2 seconds for the app to finish rendering. This causes flaky test failures because prompt-toolkit is tested using EC2 service model, which is ~3MB and can take a few seconds to load on hosts with low resources. This PR changes the test service model to CloudWatch, which is ~230KB.

Also bumps the event timeout to 5 seconds to allow more time for the app to render for input buffer tests. Unlike other flaky tests, there's not a slimmer command/model to switch to.