### PR TITLE
Use AWS CRT instead of cryptography for Cloudfront url signing

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -10,14 +10,12 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import hashlib
 import sys
 import time
 import random
 
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
-from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from awscrt.crypto import RSA, RSASignatureAlgorithm
 
 from botocore.utils import parse_to_aware_datetime
 from botocore.signers import CloudFrontSigner
@@ -258,9 +256,11 @@ class SignCommand(BasicCommand):
 
 class RSASigner(object):
     def __init__(self, private_key):
-        backend = default_backend()
         key_bytes = private_key.encode('utf8')
-        self.priv_key = load_pem_private_key(key_bytes, None, backend)
+        self.priv_key = RSA.new_private_key_from_pem_data(key_bytes)
 
     def sign(self, message):
-        return self.priv_key.sign(message, PKCS1v15(), hashes.SHA1())
+        return self.priv_key.sign(
+            RSASignatureAlgorithm.PKCS1_5_SHA1,
+            hashlib.sha1(message).digest()
+        )

--- a/tests/functional/cloudfront/test_sign.py
+++ b/tests/functional/cloudfront/test_sign.py
@@ -64,9 +64,17 @@ class TestSign(BaseAWSCommandParamsTest):
         cmdline = (
             self.prefix + '--private-key file://' + self.private_key_file +
             ' --date-less-than 2016-1-1')
+        expected_signature = (
+            "UiEmtMsInU-gXoa1O7-bTRJmZ~ocphB0ONMxyEHs2r8Y9dwzeB~DkbgzPMX3jbdb"
+            "wIwVX3f4VcY4HBLdPSkbF~D6KbUlxPw1ju8mlXeu2C436XxZdrJrrJaiEDaTpKsl"
+            "Xpn9ngaCzVfCVPfkC3a0NBWBySi5ezCG2yzb0c-djNgI1wkogwtmtZuOxAoKF1sR"
+            "TyFX9ZitUiUIl~65nkJ94s~GGwxzTf1kMi7Wdm~9rFrJpx0O7nJEBy5O578s2UHr"
+            "ejtwyedUR5BqXTkgu~A51NcjAN9LErATV7SVBYicoZ76AOfB-TKay7g6-MWCK6-T"
+            "-4Q5x6XH4yzII3JpbCmVwA__"
+        )
         expected_params = {
             'Key-Pair-Id': ['my_id'],
-            'Expires': ['1451606400'], 'Signature': [mock.ANY]}
+            'Expires': ['1451606400'], 'Signature': [expected_signature]}
         self.assertDesiredUrl(
             self.run_cmd(cmdline)[0], 'http://example.com/hi', expected_params)
 
@@ -74,8 +82,16 @@ class TestSign(BaseAWSCommandParamsTest):
         cmdline = (
             self.prefix + '--private-key file://' + self.private_key_file +
             ' --date-less-than 2016-1-1 --ip-address 12.34.56.78')
+        expected_signature = (
+            "Vw-WG18WJJXim7YSGWS-zW~XmFB9MjCDOvgC~2Gz-1wiMQzCrXzYYbSE7-aF6JGO"
+            "Ob5ewArpMqmu2g5mohnqgieZX1NY6IOteDoXYgqaNj1DafHWQD6UJ3IKVfkxISU9"
+            "OmFPoG7H~VSPWEzOxdjOqdIPvAU2pW2mJ5oWu2aL62s0VVtLGCAm-DahiSQisl0J"
+            "bzpPyG1pofvPbT75qc71r9uiqSAbPjUF5nmLCZazVnFjDkj3zIgMRYa5aV54VDa6"
+            "-wEizzmjQ3-m6UMoYgcGHQXEjoFIWTfpZvbZBYkmK9lk3d16cgvaHafTJ-CPegn1"
+            "bKxfgNEjSAoPWS0OvBkRmg__"
+        )
         expected_params = {
             'Key-Pair-Id': ['my_id'],
-            'Policy': [mock.ANY], 'Signature': [mock.ANY]}
+            'Policy': [mock.ANY], 'Signature': [expected_signature]}
         self.assertDesiredUrl(
             self.run_cmd(cmdline)[0], 'http://example.com/hi', expected_params)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Replace use of `cryptography` methods with AWS CRT methods to perform CloudFront URL  when calling the `aws cloudfront sign` [command](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/cloudfront/sign.html) (commit fdd8ddd651b2c51e20efab79d2cb7a661f22525b).

### Testing

All unit and functional tests pass.

I manually ran the `aws cloudfront sign` command before and after the change and did a `diff` of the generated URL, which were identical. I added a test that confirms with an expected signature to be sure that the required hashing/padding is used.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
