### PR TITLE
Support the `--ca-bundle` option on SSO commands

### DIFF
--- a/.changes/next-release/bugfix-sso-68327.json
+++ b/.changes/next-release/bugfix-sso-68327.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``sso``",
+  "description": "Support the ``--ca-bundle`` option on SSO commands."
+}

--- a/.changes/next-release/bugfix-sso-68327.json
+++ b/.changes/next-release/bugfix-sso-68327.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "``sso``",
-  "description": "Support the ``--ca-bundle`` option on SSO commands."
+  "description": "Support the ``--ca-bundle`` and ``--no-verify-ssl`` options on SSO commands."
 }

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -3070,11 +3070,13 @@ class BaseSSOTokenFetcher(object):
     _USER_AGENT_EXTRA = None
 
     def __init__(
-            self, sso_region, client_creator, cache=None,
+            self, sso_region, client_creator,
+            parsed_globals, cache=None,
             on_pending_authorization=None, time_fetcher=None
     ):
         self._sso_region = sso_region
         self._client_creator = client_creator
+        self._parsed_globals = parsed_globals
         self._on_pending_authorization = on_pending_authorization
 
         if time_fetcher is None:
@@ -3125,7 +3127,11 @@ class BaseSSOTokenFetcher(object):
             signature_version=botocore.UNSIGNED,
             user_agent_extra=self._USER_AGENT_EXTRA,
         )
-        return self._client_creator('sso-oidc', config=config)
+        return self._client_creator(
+            'sso-oidc',
+            config=config,
+            verify=self._parsed_globals.verify_ssl,
+        )
 
     def _generate_client_name(self, session_name):
         if session_name is None:
@@ -3170,6 +3176,7 @@ class SSOTokenFetcher(BaseSSOTokenFetcher):
         self,
         sso_region,
         client_creator,
+        parsed_globals,
         cache=None,
         on_pending_authorization=None,
         time_fetcher=None,
@@ -3178,6 +3185,7 @@ class SSOTokenFetcher(BaseSSOTokenFetcher):
         super().__init__(
             sso_region,
             client_creator,
+            parsed_globals,
             cache,
             on_pending_authorization,
             time_fetcher,
@@ -3372,6 +3380,7 @@ class SSOTokenFetcherAuth(BaseSSOTokenFetcher):
         self,
         sso_region,
         client_creator,
+        parsed_globals,
         auth_code_fetcher,
         cache=None,
         on_pending_authorization=None,
@@ -3380,6 +3389,7 @@ class SSOTokenFetcherAuth(BaseSSOTokenFetcher):
         super().__init__(
             sso_region,
             client_creator,
+            parsed_globals,
             cache,
             on_pending_authorization,
             time_fetcher,

--- a/awscli/customizations/configure/sso.py
+++ b/awscli/customizations/configure/sso.py
@@ -515,6 +515,7 @@ class ConfigureSSOCommand(BaseSSOConfigurationCommand):
         sso_registration_args = self._prompt_for_sso_registration_args()
         sso_token = self._sso_login(
             self._session,
+            parsed_globals=parsed_globals,
             token_cache=self._sso_token_cache,
             on_pending_authorization=on_pending_authorization,
             use_device_code=parsed_args.use_device_code,

--- a/awscli/customizations/sso/login.py
+++ b/awscli/customizations/sso/login.py
@@ -46,6 +46,7 @@ class LoginCommand(BaseSSOCommand):
             on_pending_authorization = PrintOnlyHandler()
         do_sso_login(
             session=self._session,
+            parsed_globals=parsed_globals,
             sso_region=sso_config['sso_region'],
             start_url=sso_config['sso_start_url'],
             on_pending_authorization=on_pending_authorization,

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -73,10 +73,18 @@ def _sso_json_dumps(obj):
     return json.dumps(obj, default=_serialize_utc_timestamp)
 
 
-def do_sso_login(session, sso_region, start_url, token_cache=None,
-                 on_pending_authorization=None, force_refresh=False,
-                 registration_scopes=None, session_name=None,
-                 use_device_code=False):
+def do_sso_login(
+        session,
+        sso_region,
+        start_url,
+        parsed_globals,
+        token_cache=None,
+        on_pending_authorization=None,
+        force_refresh=False,
+        registration_scopes=None,
+        session_name=None,
+        use_device_code=False,
+):
     if token_cache is None:
         token_cache = JSONFileCache(SSO_TOKEN_DIR, dumps_func=_sso_json_dumps)
     if on_pending_authorization is None:
@@ -90,6 +98,7 @@ def do_sso_login(session, sso_region, start_url, token_cache=None,
         token_fetcher = SSOTokenFetcherAuth(
             sso_region=sso_region,
             client_creator=session.create_client,
+            parsed_globals=parsed_globals,
             auth_code_fetcher=AuthCodeFetcher(),
             cache=token_cache,
             on_pending_authorization=on_pending_authorization,
@@ -98,6 +107,7 @@ def do_sso_login(session, sso_region, start_url, token_cache=None,
         token_fetcher = SSOTokenFetcher(
             sso_region=sso_region,
             client_creator=session.create_client,
+            parsed_globals=parsed_globals,
             cache=token_cache,
             on_pending_authorization=on_pending_authorization,
         )

--- a/tests/functional/configure/test_sso.py
+++ b/tests/functional/configure/test_sso.py
@@ -106,7 +106,7 @@ class TestConfigureSSOCommand(BaseSSOTest):
             self.run_cmd('configure sso')
 
     @patch('botocore.session.Session.create_client')
-    def test_configure_custom_ca(self, create_client_patch):
+    def test_configure_sso_custom_ca(self, create_client_patch):
         # Profile and mock responses aren't wired up so this fails with 255,
         # but it does get far enough to verify that the internal SSO-OIDC
         # client is created with the custom CA bundle
@@ -119,4 +119,20 @@ class TestConfigureSSOCommand(BaseSSOTest):
             'sso-oidc',
             config=mock.ANY,
             verify='/path/to/ca/bundle.pem',
+        )
+
+    @patch('botocore.session.Session.create_client')
+    def test_configure_sso_no_verify_ssl(self, create_client_patch):
+        # Profile and mock responses aren't wired up so this fails with 255,
+        # but it does get far enough to verify that the internal SSO-OIDC
+        # client is created with verify=False
+        self.run_cmd(
+            'configure sso --no-verify-ssl',
+            expected_rc=255,
+        )
+
+        create_client_patch.assert_called_once_with(
+            'sso-oidc',
+            config=mock.ANY,
+            verify=False,
         )

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -488,3 +488,18 @@ class TestLoginCommand(BaseSSOTest):
             config=mock.ANY,
             verify='/path/to/ca/bundle.pem'
         )
+
+    @mock.patch('botocore.session.Session.create_client')
+    def test_login_no_verify_ssl(self, create_client_patch):
+        # Profile and mock responses aren't wired up so this fails with 255,
+        # but it does get far enough to verify that the internal SSO-OIDC
+        # client is created with verify=False
+        self.run_cmd(
+            'sso login --no-verify-ssl',
+            expected_rc=255
+        )
+        create_client_patch.assert_called_once_with(
+            'sso-oidc',
+            config=mock.ANY,
+            verify=False,
+        )

--- a/tests/functional/sso/test_logout.py
+++ b/tests/functional/sso/test_logout.py
@@ -127,3 +127,16 @@ class TestLogoutCommand(BaseSSOTest):
         token = self.add_cached_token('token.json')
         self.run_cmd('sso logout', expected_rc=0)
         self.assert_file_does_not_exist(token)
+
+    @mock.patch('botocore.session.Session.create_client')
+    def test_logout_with_custom_ca(self, create_client_patch):
+        token = self.add_cached_token('token.json')
+        creds = self.add_cached_aws_credentials('sso-creds.json')
+        self.run_cmd('sso logout --ca-bundle /path/to/ca/bundle.pem')
+        create_client_patch.assert_called_once_with(
+            'sso',
+            region_name='us-west-2',
+            verify='/path/to/ca/bundle.pem',
+        )
+        self.assert_file_does_not_exist(token)
+        self.assert_file_does_not_exist(creds)

--- a/tests/functional/sso/test_logout.py
+++ b/tests/functional/sso/test_logout.py
@@ -140,3 +140,16 @@ class TestLogoutCommand(BaseSSOTest):
         )
         self.assert_file_does_not_exist(token)
         self.assert_file_does_not_exist(creds)
+
+    @mock.patch('botocore.session.Session.create_client')
+    def test_logout_no_verify_ssl(self, create_client_patch):
+        token = self.add_cached_token('token.json')
+        creds = self.add_cached_aws_credentials('sso-creds.json')
+        self.run_cmd('sso logout --no-verify-ssl')
+        create_client_patch.assert_called_once_with(
+            'sso',
+            region_name='us-west-2',
+            verify=False,
+        )
+        self.assert_file_does_not_exist(token)
+        self.assert_file_does_not_exist(creds)

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -3072,6 +3072,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
         self.sso_token_fetcher = SSOTokenFetcher(
             self.sso_region,
             client_creator=self.mock_session.create_client,
+            parsed_globals=mock.Mock(),
             cache=self.cache,
             time_fetcher=self.mock_time_fetcher,
             sleep=self.mock_sleep,
@@ -3336,6 +3337,7 @@ class TestSSOTokenFetcher(unittest.TestCase):
         self.sso_token_fetcher = SSOTokenFetcher(
             self.sso_region,
             client_creator=self.mock_session.create_client,
+            parsed_globals=mock.Mock(),
             cache=self.cache,
             time_fetcher=self.mock_time_fetcher,
             sleep=self.mock_sleep,

--- a/tests/unit/customizations/configure/test_sso.py
+++ b/tests/unit/customizations/configure/test_sso.py
@@ -834,6 +834,7 @@ class TestConfigureSSOCommand:
     ):
         expected_kwargs = {
             "sso_region": expected_sso_region,
+            "parsed_globals": mock.ANY,
             "start_url": expected_start_url,
             "on_pending_authorization": None,
             "token_cache": None,

--- a/tests/unit/customizations/sso/test_utils.py
+++ b/tests/unit/customizations/sso/test_utils.py
@@ -103,9 +103,12 @@ class TestDoSSOLogin(unittest.TestCase):
 
     def test_do_sso_login(self):
         do_sso_login(
-            session=self.session, sso_region=self.region,
-            start_url=self.start_url, token_cache=self.token_cache,
-            on_pending_authorization=self.on_pending_authorization_mock
+            session=self.session,
+            sso_region=self.region,
+            parsed_globals=mock.Mock(),
+            start_url=self.start_url,
+            token_cache=self.token_cache,
+            on_pending_authorization=self.on_pending_authorization_mock,
         )
         # We just want to make some quick checks to make sure all of the
         # parameters were plumbed in correctly.
@@ -124,9 +127,12 @@ class TestDoSSOLogin(unittest.TestCase):
             }
         ]
         do_sso_login(
-            session=self.session, sso_region=self.region,
-            start_url=self.start_url, token_cache=self.token_cache,
-            on_pending_authorization=self.on_pending_authorization_mock
+            session=self.session,
+            sso_region=self.region,
+            parsed_globals=mock.Mock(),
+            start_url=self.start_url,
+            token_cache=self.token_cache,
+            on_pending_authorization=self.on_pending_authorization_mock,
         )
         self.assert_client_called_with_start_url()
         self.assert_used_sso_region()


### PR DESCRIPTION
*Issue #, if available:* #7602

*Description of changes:*
Before, when constructing the SSO-OIDC client used inside the `aws sso login`, `aws sso logout`, and `aws configure sso` commands, we were not setting the `verify` parameter. These commands did not honor the global `--ca-bundle` and `--no-verify-ssl` options.

Now, we plumbed through `parsed_globals` to set `verify` appropriately.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
