### PR TITLE
Follow IllegalLocationConstraintException redirects for S3

### DIFF
--- a/.changes/next-release/bugfix-s3-2088.json
+++ b/.changes/next-release/bugfix-s3-2088.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Follow ``IllegalLocationConstraintException`` redirects for ``s3``."
+}

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -1544,6 +1544,10 @@ class S3RegionRedirectorv2:
             0
         ].status_code in (301, 302, 307)
         is_permanent_redirect = error_code == 'PermanentRedirect'
+        is_opt_in_region_redirect = (
+            error_code == 'IllegalLocationConstraintException'
+            and operation.name != 'CreateBucket'
+        )
         if not any(
             [
                 is_special_head_object,
@@ -1551,6 +1555,7 @@ class S3RegionRedirectorv2:
                 is_permanent_redirect,
                 is_special_head_bucket,
                 is_redirect_status,
+                is_opt_in_region_redirect,
             ]
         ):
             return


### PR DESCRIPTION
*Issue #, if available:* Port of https://github.com/boto/botocore/pull/3303

*Description of changes:* 
* **Before**: When making a request to S3 to a region that is different from where the bucket is homed, the CLI currently follows `301 PermanentRedirect` redirects. It did not follow the `400 IllegalLocationConstraintException` redirect that is returned when sending a request to a standard region for a bucket that is homed in an opt-in region.
* **Now**: The CLI follows `400 IllegalLocationConstraintException` redirects too.

```
# Before
% aws s3api list-objects-v2 --bucket <us-east-1-bucket> --region ap-south-2

An error occurred (IllegalLocationConstraintException) when calling the ListObjectsV2 operation: The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.

# After
% aws s3api list-objects-v2 --bucket <us-east-1-bucket> --region ap-south-2
{
    "Contents": [
        {
...
```
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
