### PR TITLE
add API command examples for Amazon CloudWatch observabilityadmin service

### DIFF
--- a/awscli/examples/observabilityadmin/get-telemetry-evaluation-status-for-organization.rst
+++ b/awscli/examples/observabilityadmin/get-telemetry-evaluation-status-for-organization.rst
@@ -1,0 +1,13 @@
+**To get telemetry onboarding status for the organization**
+
+The following ``get-telemetry-evaluation-status-for-organization`` example returns the current onboarding status of the telemetry config feature for the organization. ::
+
+    aws observabilityadmin get-telemetry-evaluation-status-for-organization
+
+Output::
+
+    {
+        "Status": "RUNNING"
+    }
+
+For more information, see `Auditing CloudWatch telemetry configurations <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-cloudwatch.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/get-telemetry-evaluation-status.rst
+++ b/awscli/examples/observabilityadmin/get-telemetry-evaluation-status.rst
@@ -1,0 +1,13 @@
+**To get telemetry onboarding status for the account**
+
+The following ``get-telemetry-evaluation-status`` example returns the current onboarding status of the telemetry config feature in the specified account. ::
+
+    aws observabilityadmin get-telemetry-evaluation-status 
+
+Output::
+
+    {
+        "Status": "RUNNING"
+    }
+
+For more information, see `Auditing CloudWatch telemetry configurations <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-cloudwatch.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/list-resource-telemetry-for-organization.rst
+++ b/awscli/examples/observabilityadmin/list-resource-telemetry-for-organization.rst
@@ -1,0 +1,43 @@
+**To retrieve the telemetry configurations for the organization**
+
+The following ``list-resource-telemetry-for-organization`` example returns a list of telemetry configurations in the organization for AWS resources supported by telemetry config. ::
+
+    aws observabilityadmin list-resource-telemetry-for-organization \
+        --resource-types  AWS::EC2::Instance
+
+Output::
+
+    {
+        "TelemetryConfigurations": [
+            {
+                "AccountIdentifier": "111111111111",
+                "TelemetryConfigurationState": {
+                    "Logs": "NotApplicable",
+                    "Metrics": "Disabled",
+                    "Traces": "NotApplicable"
+                },
+                "ResourceType": "AWS::EC2::Instance",
+                "ResourceIdentifier": "i-a166400b",
+                "ResourceTags": {
+                    "Name": "dev"
+                },
+                "LastUpdateTimeStamp": 1733168548521
+            },
+            {
+                "AccountIdentifier": "222222222222",
+                "TelemetryConfigurationState": {
+                    "Logs": "NotApplicable",
+                    "Metrics": "Disabled",
+                    "Traces": "NotApplicable"
+                },
+                "ResourceType": "AWS::EC2::Instance",
+                "ResourceIdentifier": "i-b188560f",
+                "ResourceTags": {
+                    "Name": "apache"
+                },
+                "LastUpdateTimeStamp": 1732744260182
+            }
+        ]
+    }
+
+For more information, see `Auditing CloudWatch telemetry configurations <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-cloudwatch.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/list-resource-telemetry.rst
+++ b/awscli/examples/observabilityadmin/list-resource-telemetry.rst
@@ -1,0 +1,29 @@
+**To retrieve the telemetry configurations for the account**
+
+The following ``list-resource-telemetry`` example returns a list of telemetry configurations for AWS resources supported by telemetry config in the specified account. ::
+
+    aws observabilityadmin list-resource-telemetry \
+        --resource-types  AWS::EC2::Instance
+
+Output::
+
+    {
+        "TelemetryConfigurations": [
+            {
+                "AccountIdentifier": "111111111111",
+                "TelemetryConfigurationState": {
+                    "Logs": "NotApplicable",
+                    "Metrics": "Disabled",
+                    "Traces": "NotApplicable"
+                },
+                "ResourceType": "AWS::EC2::Instance",
+                "ResourceIdentifier": "i-0e979d278b040f856",
+                "ResourceTags": {
+                    "Name": "apache"
+                },
+                "LastUpdateTimeStamp": 1732744260182
+            }
+        ]
+    }
+
+For more information, see `Auditing CloudWatch telemetry configurations <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-cloudwatch.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/start-telemetry-evaluation-for-organization.rst
+++ b/awscli/examples/observabilityadmin/start-telemetry-evaluation-for-organization.rst
@@ -1,0 +1,9 @@
+**To enable the telemetry config feature**
+
+The following ``start-telemetry-evaluation-for-organization`` example enables the telemetry config feature for the organization. ::
+
+    aws observabilityadmin start-telemetry-evaluation-for-organization 
+
+This command produces no output.
+
+For more information, see `Turning on CloudWatch telemetry auditing <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-turn-on.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/start-telemetry-evaluation.rst
+++ b/awscli/examples/observabilityadmin/start-telemetry-evaluation.rst
@@ -1,0 +1,9 @@
+**To enable the telemetry config feature**
+
+The following ``start-telemetry-evaluation`` example enables the telemetry config feature in the specified account. ::
+
+    aws observabilityadmin start-telemetry-evaluation
+
+This command produces no output.
+
+For more information, see `Turning on CloudWatch telemetry auditing <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-turn-on.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/stop-telemetry-evaluation-for-organization.rst
+++ b/awscli/examples/observabilityadmin/stop-telemetry-evaluation-for-organization.rst
@@ -1,0 +1,9 @@
+**To disable the telemetry config feature**
+
+The following ``stop-telemetry-evaluation-for-organization`` example disables the telemetry config feature for the organization. ::
+
+    aws observabilityadmin stop-telemetry-evaluation-for-organization
+
+This command produces no output.
+
+For more information, see `Turning off CloudWatch telemetry auditing <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-turn-off.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/observabilityadmin/stop-telemetry-evaluation.rst
+++ b/awscli/examples/observabilityadmin/stop-telemetry-evaluation.rst
@@ -1,0 +1,9 @@
+**To disable the telemetry config feature**
+
+The following ``stop-telemetry-evaluation`` example disables the telemetry config feature in the specified account. ::
+
+    aws observabilityadmin stop-telemetry-evaluation
+
+This command produces no output.
+
+For more information, see `Turning off CloudWatch telemetry auditing <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/telemetry-config-turn-off.html>`__ in the *Amazon CloudWatch User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add CLI Examples for Amazon CloudWatch observabilityadmin service:

https://awscli.amazonaws.com/v2/documentation/api/latest/reference/observabilityadmin/index.html#cli-aws-observabilityadmin 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
