### PR TITLE
Add precommit for linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+exclude: "\
+    ^(\
+    .changes|\
+    .github|\
+    awscli/examples|\
+    awscli/topics|\
+    awscli/botocore|\
+    awscli/s3transfer|\
+    awscli/doc|\
+    exe/assets|\
+    tests/functional/cloudformation/deploy_templates/booleans/input.yml|\
+    tests/functional/cloudformation/deploy_templates/nested-tag/input.yml|\
+    tests/|\
+    CHANGELOG.rst|\
+    configure\
+    )"
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v4.5.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.8
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,7 +67,7 @@ Also, ensure your commit messages match this format::
     Describe your changes in the imperative mood, e.g.
     "Add foo to bar", "Update foo component for bar",
     "Fix race condition for foo".
-    
+
     The body of the commit message can include:
 
     * an explanation of the problem and what this change
@@ -119,6 +119,28 @@ can run these commands::
 
 When you push to your remote, the output will contain a URL you
 can use to open a pull request.
+
+Codestyle
+---------
+This project uses `ruff <https://github.com/astral-sh/ruff>`__ to enforce
+codstyle requirements. We've codified this process using a tool called
+`pre-commit <https://pre-commit.com/>`__. pre-commit allows us to specify a
+config file with all tools required for code linting, and surfaces either a
+git commit hook, or single command, for enforcing these.
+
+To validate your pull request prior to publishing, you can use the following
+`installation guide <https://pre-commit.com/#install>`__ to setup pre-commit.
+
+If you don't want to use the git commit hook, you can run the below command
+to automatically perform the codestyle validation:
+
+.. code-block:: bash
+
+    $ pre-commit run
+
+This will automatically perform simple updates (such as white space clean up)
+and provide a list of any failing checks. After these are addressed,
+you can commit the changes prior to publishing the pull request.
 
 
 Reporting Issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,3 +134,64 @@ markers = [
 
 [tool.black]
 line-length = 80
+
+[tool.ruff]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+force-exclude = true
+
+# Format same as Black.
+line-length = 79
+indent-width = 4
+
+[tool.ruff.lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+select = ["E4", "E7", "E9", "F", "I", "UP"]
+ignore = ["F401"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings, spaces for indents
+# and trailing commas.
+quote-style = "preserve"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+docstring-code-format = false
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
*Description of changes:*

First in a series of commits to lint and format the `v2` branch of this repository.

Adds a precommit hook configuration file and enables whitespace linting, `isort` for imports, and `ruff` to lint and format.  It adds configuration to `pyproject.toml` for `ruff` as well with the same configuration as the `develop` branch, with the exception of ignoring unused imports (`F401`). This exception will be dropped at a later date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
