### PR TITLE
Expand marker for model validation tests and add ability to run via the CI script

### DIFF
--- a/scripts/ci/run-tests
+++ b/scripts/ci/run-tests
@@ -48,6 +48,10 @@ def process_args(args):
             f"--cov-config={os.path.join(REPO_ROOT, '.coveragerc')} "
             f"--cov-report xml "
         )
+    if args.junit_xml_path:
+        test_args += f'--junit-xml={args.junit_xml_path} '
+    if args.markers:
+        test_args += f'-m {args.markers} '
     test_args += '--numprocesses=auto --dist=loadfile --maxprocesses=4 '
     dirs = " ".join(args.test_dirs)
 
@@ -102,6 +106,19 @@ if __name__ == "__main__":
             "Optional path to an alternate test directory to use."
         )
     )
+    parser.add_argument(
+        "--junit-xml-path",
+        default=None,
+        type=os.path.abspath,
+        help="Optional path to output a JUnit XML result file to."
+    )
+    parser.add_argument(
+        "-m",
+        "--markers",
+        default=None,
+        help="Run all tests decorated with the specified marker expression."
+    )
+
     raw_args = parser.parse_args()
     test_runner, test_args, test_dirs = process_args(raw_args)
 

--- a/tests/functional/botocore/test_h2_required.py
+++ b/tests/functional/botocore/test_h2_required.py
@@ -47,6 +47,7 @@ def _all_test_cases():
 H2_SERVICES, H2_OPERATIONS = _all_test_cases()
 
 
+@pytest.mark.validates_models
 @pytest.mark.parametrize("h2_service", H2_SERVICES)
 def test_all_uses_of_h2_are_known(h2_service):
     # Validates that a service that requires HTTP 2 for all operations is known
@@ -54,6 +55,7 @@ def test_all_uses_of_h2_are_known(h2_service):
     assert _KNOWN_SERVICES.get(h2_service) is _H2_REQUIRED, message
 
 
+@pytest.mark.validates_models
 @pytest.mark.parametrize("h2_service, operation", H2_OPERATIONS)
 def test_all_h2_operations_are_known(h2_service, operation):
     # Validates that an operation that requires HTTP 2 is known

--- a/tests/functional/botocore/test_paginator_config.py
+++ b/tests/functional/botocore/test_paginator_config.py
@@ -139,6 +139,8 @@ def _pagination_configs():
                 service_model
             )
 
+
+@pytest.mark.validates_models
 @pytest.mark.parametrize(
     "operation_name, page_config, service_model",
     _pagination_configs()

--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import pytest
 from botocore.model import OperationModel
 
 from awscli.clidriver import create_clidriver
@@ -21,6 +22,7 @@ _ALLOWED_COMMANDS = [
 ]
 
 
+@pytest.mark.validates_models
 def test_no_event_stream_unless_allowed():
     driver = create_clidriver()
     help_command = driver.create_help_command()

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -25,6 +25,7 @@ def _generate_command_tests():
             yield command_name, sub_help.command_table, top_level_params
 
 
+@pytest.mark.validates_models
 @pytest.mark.parametrize(
     "command_name, command_table, builtins",
     _generate_command_tests()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* This supports upcoming changes to our internal build system around validating the updated models provided by service teams.

1.  Adds `@pytest.mark.validates_models` (which already existed) to additional tests related to model validation
2. Adds two new options to `run-test`, to optionally support running tests only with the specified marker, and write the test results as a JunitXML file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
