### PR TITLE
[V2] Fix examples that use the parameter --auto-scaling-group-names

### DIFF
--- a/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
+++ b/awscli/examples/autoscaling/describe-auto-scaling-groups.rst
@@ -3,7 +3,7 @@
 This example describes the specified Auto Scaling group. ::
 
     aws autoscaling describe-auto-scaling-groups \
-        --auto-scaling-group-name my-asg
+        --auto-scaling-group-names my-asg
 
 Output::
 
@@ -66,7 +66,7 @@ This example describes the specified Auto Scaling groups. It allows you to speci
 
     aws autoscaling describe-auto-scaling-groups \
         --max-items 100 \
-        --auto-scaling-group-name "group1" "group2" "group3" "group4"
+        --auto-scaling-group-names "group1" "group2" "group3" "group4"
 
 See example 1 for sample output.
 


### PR DESCRIPTION
*Description of changes:* Copying the changes in #9122  to the v2 branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
