### PR TITLE
Updated AWS CLI command to describe EKS cluster

### DIFF
--- a/awscli/examples/eks/describe-cluster.rst
+++ b/awscli/examples/eks/describe-cluster.rst
@@ -3,7 +3,7 @@
 The following ``describe-cluster`` example actively running EKS addon in your Amazon EKS cluster. ::
 
     aws eks describe-cluster \
-        --cluster-name my-eks-cluster
+        --name my-eks-cluster
 
 Output::
 


### PR DESCRIPTION
As per documentation, we shall be using --name option and there are no options as --cluster-name available.

*Description of changes:*
As per documentation, we shall be using --name option and there are no options as --cluster-name available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
