### PR TITLE
Replace http links with https.

### DIFF
--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/comments.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/comments.html
@@ -6,11 +6,11 @@
     var disqus_identifier = '{{ pagename }}';
     (function() {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+      dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
   </script>
-  <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-  <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+  <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+  <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </div>
 {% endif %}


### PR DESCRIPTION
*Notes:*
- Although this code is currently unused, this may not always be true.

*Description of changes:*
- Replaces use of `http` with `https`

*Description of tests:*
- Manually confirmed the URLs work with https.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
