### PR TITLE
Add support for `stringArray` and `operationContextParams`

### DIFF
--- a/.changes/next-release/enhancement-endpoints-85370.json
+++ b/.changes/next-release/enhancement-endpoints-85370.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "endpoints",
+  "description": "Add support for ``stringArray`` parameters and the ``operationContextParams`` trait when resolving service endpoints."
+}

--- a/awscli/botocore/model.py
+++ b/awscli/botocore/model.py
@@ -589,6 +589,10 @@ class OperationModel(object):
         ]
 
     @CachedProperty
+    def operation_context_parameters(self):
+        return self._operation_model.get('operationContextParams', [])
+
+    @CachedProperty
     def request_compression(self):
         return self._operation_model.get('requestcompression')
 

--- a/tests/unit/botocore/data/endpoints/test-cases/array-index.json
+++ b/tests/unit/botocore/data/endpoints/test-cases/array-index.json
@@ -1,0 +1,37 @@
+{
+  "version": "1.0",
+  "testCases": [
+    {
+      "documentation": "Access an array index at index 0",
+      "params": {
+        "ResourceList": ["resource"]
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://www.resource.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "Resolved value when array is explictly set to empty",
+      "params": {
+        "ResourceList": []
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://www.example.com"
+        }
+      }
+    },
+    {
+      "documentation": "Resolved value to default if array is unset",
+      "params": {
+      },
+      "expect": {
+        "endpoint": {
+          "url": "https://www.default1.example.com"
+        }
+      }
+    }
+  ]
+}

--- a/tests/unit/botocore/data/endpoints/valid-rules/array-index.json
+++ b/tests/unit/botocore/data/endpoints/valid-rules/array-index.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.3",
+  "parameters": {
+    "ResourceList": {
+      "required": true,
+      "default": ["default1", "default2"],
+      "type": "stringArray"
+    }
+  },
+  "rules": [
+    {
+      "documentation": "Array is set, retrieve index 0",
+      "conditions": [
+        {
+          "fn": "isSet",
+          "argv": [
+            {
+              "ref": "ResourceList"
+            }
+          ]
+        },
+        {
+          "fn": "getAttr",
+          "argv": [
+            {
+              "ref": "ResourceList"
+            },
+            "[0]"
+          ],
+          "assign": "resourceid"
+        }
+      ],
+      "endpoint": {
+        "url": "https://www.{resourceid}.example.com"
+      },
+      "type": "endpoint"
+    },
+    {
+      "documentation": "Fallback when array is unset",
+      "conditions": [],
+      "endpoint": {
+        "url": "https://www.example.com"
+      },
+      "type": "endpoint"
+    }
+  ]
+}

--- a/tests/unit/botocore/test_endpoint_provider.py
+++ b/tests/unit/botocore/test_endpoint_provider.py
@@ -134,6 +134,7 @@ def endpoint_rule():
 
 def ruleset_testcases():
     filenames = [
+        "array-index",
         "aws-region",
         "default-values",
         "eventbridge",
@@ -457,3 +458,33 @@ def test_auth_schemes_conversion_first_authtype_unknown(
     at, sc = empty_resolver.auth_schemes_to_signing_ctx(auth_schemes)
     assert at == 'bar'
     assert sc == {'region': 'ap-south-2', 'signing_name': 's3'}
+
+
+@pytest.mark.parametrize(
+    "value, path, expected_value",
+    [
+        ({"foo": ['bar']}, 'baz[0]', None),  # Missing index
+        ({"foo": ['bar']}, 'foo[1]', None),  # Out of range index
+        ({"foo": ['bar']}, 'foo[0]', "bar"),  # Named index
+        (("foo",), '[0]', "foo"),  # Bare index
+        ({"foo": {}}, 'foo.bar[0]', None),  # Missing index from split path
+        (
+            {"foo": {'bar': []}},
+            'foo.bar[0]',
+            None,
+        ),  # Out of range from split path
+        (
+            {"foo": {"bar": "baz"}},
+            'foo.bar',
+            "baz",
+        ),  # Split path with named index
+        (
+            {"foo": {"bar": ["baz"]}},
+            'foo.bar[0]',
+            "baz",
+        ),  # Split path with numeric index
+    ],
+)
+def test_get_attr(rule_lib, value, path, expected_value):
+    result = rule_lib.get_attr(value, path)
+    assert result == expected_value


### PR DESCRIPTION
_**Note for reviewers:** I intentionally did not include a changelog file, as this should not result in any user-observable changes for now, but let me know if you think we should._

*Issue #, if available:* CLI-4648

*Description of changes:*

### Primary Change
In the rules-based endpoints resolver, this adds support for:
1. `stringArray` as parameters into endpoint resolution
2. `operationContextParams` - this is a new trait in the service model, which can extract more complicated endpoint resolution parameters (including lists of strings) out of an operation's request.

This is a port of https://github.com/boto/botocore/pull/3301/.

### Supporting Changes
This includes two more PRs from `botocore`:
1. https://github.com/boto/botocore/pull/3302/ - this is fixing a bug in `get_attr`, which is a built-in function used within endpoint resolution to resolve named keys and/or indices into arrays or dicts.
2. https://github.com/boto/botocore/pull/2934 - this was an optimization made for `boto3` to reduce memory usage when using multiple `Session` objects. While this is less of an issue for the CLI given a single command invocation will typically use a single `Session`, by overriding the LRU cache we're using for `resolve_endpoint`, we can support unhashable types (i.e. `list`, which is used for our new `stringArray`), which the `lru_cache` in `functools` does not.

### Testing
In addition to porting the automated tests, I manually tested an internal, future service update that is taking advantage of this, and confirmed that the `unit` and `functional` tests pass locally against the updated model and endpoints files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
