### PR TITLE
Add CLI examples for CloudWatch OAM and Synthetics

### DIFF
--- a/awscli/examples/oam/create-link.rst
+++ b/awscli/examples/oam/create-link.rst
@@ -1,0 +1,24 @@
+**To create a link**
+
+The following ``create-link`` example creates a link between a source account and a sink that you have created in a monitoring account. ::
+
+    aws oam create-link \
+        --label-template sourceAccount \
+        --resource-types AWS::CloudWatch::Metric \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+        "Label": "sourceAccount",
+        "LabelTemplate": "sourceAccount",
+        "ResourceTypes": [
+            "AWS::CloudWatch::Metric"
+        ],
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/create-sink.rst
+++ b/awscli/examples/oam/create-sink.rst
@@ -1,0 +1,17 @@
+**To create a sink**
+
+The following ``create-sink`` example creates a sink in the current account, so that it can be used as a monitoring account in CloudWatch cross-account observability. ::
+
+    aws oam create-sink \
+        --name DemoSink
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Name": "DemoSink",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-link.rst
+++ b/awscli/examples/oam/delete-link.rst
@@ -1,0 +1,10 @@
+**To delete a link**
+
+The following ``delete-link`` example deletes a link between a monitoring account sink and a source account. ::
+
+    aws oam delete-link \
+        --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111
+
+This command produces no output.
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/delete-sink.rst
+++ b/awscli/examples/oam/delete-sink.rst
@@ -1,0 +1,10 @@
+**To delete a sink**
+
+The following ``delete-sink`` example deletes a sink. You must delete all links to a sink before you can delete that sink. ::
+
+    aws oam delete-sink \
+        --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+This command produces no output.
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-link.rst
+++ b/awscli/examples/oam/get-link.rst
@@ -1,0 +1,22 @@
+**To return complete information about one link**
+
+The following ``get-link`` example returns complete information about a link. ::
+
+    aws oam get-link \
+        --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+        "Label": "sourceAccount",
+        "LabelTemplate": "sourceAccount",
+        "ResourceTypes": [
+            "AWS::CloudWatch::Metric"
+        ],
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-sink-policy.rst
+++ b/awscli/examples/oam/get-sink-policy.rst
@@ -1,0 +1,16 @@
+**To return the current sink policy attached to the sink**
+
+The following ``get-sink-policy`` example returns the current sink policy attached to the sink. ::
+
+    aws oam get-sink-policy \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "SinkId": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/get-sink.rst
+++ b/awscli/examples/oam/get-sink.rst
@@ -1,0 +1,17 @@
+**To return complete information about one monitoring account sink**
+
+The following ``get-sink`` example returns complete information about a monitoring account sink. ::
+
+    aws oam get-sink \
+        --identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Name": "DemoSink",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-attached-links.rst
+++ b/awscli/examples/oam/list-attached-links.rst
@@ -1,0 +1,23 @@
+**To return a list of source account links that are linked to this monitoring account sink**
+
+The following ``list-attached-links`` example returns a list of source account links that are linked to this monitoring account sink. ::
+
+    aws oam list-attached-links \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Items": [{
+            "Label": "Monitoring account",
+            "LinkArn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+            "ResourceTypes": [
+                "AWS::ApplicationInsights::Application",
+                "AWS::Logs::LogGroup",
+                "AWS::CloudWatch::Metric",
+                "AWS::XRay::Trace"
+            ]
+        }]
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-links.rst
+++ b/awscli/examples/oam/list-links.rst
@@ -1,0 +1,21 @@
+**To return a list of links for one monitoring account sink**
+
+The following ``list-links`` example returns a list of links for one monitoring account sink. Run this operation in a source account to return a list of links to monitoring account sinks that this source account has. ::
+
+    aws oam list-links
+
+Output::
+
+    {
+        "Items": [{
+            "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+            "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+            "Label": "sourceAccount",
+            "ResourceTypes": [
+                "AWS::CloudWatch::Metric"
+            ],
+            "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345"
+        }]
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-sinks.rst
+++ b/awscli/examples/oam/list-sinks.rst
@@ -1,0 +1,19 @@
+**To return the list of sinks created in the monitoring account**
+
+The following ``list-sinks`` example returns a list of sinks created in the monitoring account. Run this operation in a monitoring account. ::
+
+    aws oam list-sinks
+
+Output::
+
+    {
+        "Items": [
+            {
+                "Arn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+                "Id": "a1b2c3d4-5678-90ab-cdef-example12345",
+                "Name": "DemoSink"
+            }
+        ]
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/list-tags-for-resource.rst
+++ b/awscli/examples/oam/list-tags-for-resource.rst
@@ -1,0 +1,16 @@
+**To display the tags associated with a resource**
+
+The following ``list-tags-for-resource`` example displays the tags associated with a sink. ::
+
+    aws oam list-tags-for-resource \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "Tags": {
+            "Team": "Devops"
+        }
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/put-sink-policy.rst
+++ b/awscli/examples/oam/put-sink-policy.rst
@@ -1,0 +1,17 @@
+**To create or update the resource policy**
+
+The following ``put-sink-policy`` example creates the resource policy that grants permissions to source accounts to link to the monitoring account sink. ::
+
+    aws oam put-sink-policy \
+        --policy '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::123456789111:root"},"Action":["oam:CreateLink","oam:UpdateLink"],"Resource":"*","Condition":{"ForAllValues:StringEquals":{"oam:ResourceTypes":["AWS::Logs::LogGroup","AWS::CloudWatch::Metric","AWS::XRay::Trace","AWS::ApplicationInsights::Application"]}}}]}' \
+        --sink-identifier arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345
+
+Output::
+
+    {
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "SinkId": "a1b2c3d4-5678-90ab-cdef-example12345",
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789111:root\"},\"Action\":[\"oam:CreateLink\",\"oam:UpdateLink\"],\"Resource\":\"*\",\"Condition\":{\"ForAllValues:StringEquals\":{\"oam:ResourceTypes\":[\"AWS::Logs::LogGroup\",\"AWS::CloudWatch::Metric\",\"AWS::XRay::Trace\",\"AWS::ApplicationInsights::Application\"]}}}]}"
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/tag-resource.rst
+++ b/awscli/examples/oam/tag-resource.rst
@@ -1,0 +1,11 @@
+**To assign one or more tags to the specified resource**
+
+The following ``tag-resource`` example tags a sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. ::
+
+    aws oam tag-resource \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345 \
+        --tags team=Devops
+
+This command produces no output.
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/untag-resource.rst
+++ b/awscli/examples/oam/untag-resource.rst
@@ -1,0 +1,11 @@
+**To remove one or more tags from the specified resource.**
+
+The following ``untag-resource`` example removes a tag with the key ``team`` from sink ``arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345``. ::
+
+    aws oam untag-resource \
+        --resource-arn arn:aws:oam:us-east-2:123456789012:sink/f3f42f60-f0f2-425c-1234-12347bdd821f \
+        --tag-keys team
+
+This command produces no output.
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/oam/update-link.rst
+++ b/awscli/examples/oam/update-link.rst
@@ -1,0 +1,24 @@
+**To change what types of data are shared from a source account to its linked monitoring account sink**
+
+The following ``update-link`` example updates the link ``arn:aws:oam:us-east-2:123456789111:link/0123e691-e7ef-43fa-1234-c57c837fced0`` with resource types ``AWS::CloudWatch::Metric`` and ``AWS::Logs::LogGroup``. ::
+
+    aws oam update-link \
+        --identifier arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111 \
+        --resource-types "AWS::CloudWatch::Metric" "AWS::Logs::LogGroup"
+
+Output::
+
+    {
+        "Arn": "arn:aws:oam:us-east-2:123456789111:link/a1b2c3d4-5678-90ab-cdef-example11111",
+        "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+        "Label": "sourceAccount",
+        "LabelTemplate": "sourceAccount",
+        "ResourceTypes": [
+            "AWS::CloudWatch::Metric",
+            "AWS::Logs::LogGroup"
+        ],
+        "SinkArn": "arn:aws:oam:us-east-2:123456789012:sink/a1b2c3d4-5678-90ab-cdef-example12345",
+        "Tags": {}
+    }
+
+For more information, see `CloudWatch cross-account observability <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/associate-resource.rst
+++ b/awscli/examples/synthetics/associate-resource.rst
@@ -1,0 +1,11 @@
+**To associate a canary with a group**
+
+The following ``associate-resource`` example associates a canary with a group named ``demo_group``. ::
+
+    aws synthetics associate-resource \
+        --group-identifier demo_group \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/create-canary.rst
+++ b/awscli/examples/synthetics/create-canary.rst
@@ -1,0 +1,48 @@
+**To create a canary**
+
+The following ``create-canary`` example creates a canary named ``demo_canary``. ::
+
+    aws synthetics create-canary \
+        --name demo_canary \
+        --code '{"S3Bucket": "artifacts3bucket", "S3Key":"demo_canary.zip", "Handler": "index.lambda_handler"}' \
+        --artifact-s3-location s3://amzn-s3-demo-bucket/demo_canary.zip \
+        --execution-role-arn arn:aws:iam::123456789012:role/demo_canary_role \
+        --schedule Expression="rate(10 minutes)" \
+        --runtime-version syn-nodejs-puppeteer-9.1
+
+Output::
+
+    {
+        "Canary": {
+            "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+            "Name": "demo_canary",
+            "Code": {
+                "Handler": "index.lambda_handler"
+            },
+            "ExecutionRoleArn": "arn:aws:iam::123456789012:role/demo_canary_role",
+            "Schedule": {
+                "Expression": "rate(10 minutes)",
+                "DurationInSeconds": 0
+            },
+            "RunConfig": {
+                "TimeoutInSeconds": 600,
+                "MemoryInMB": 1000,
+                "ActiveTracing": false
+            },
+            "SuccessRetentionPeriodInDays": 31,
+            "FailureRetentionPeriodInDays": 31,
+            "Status": {
+                "State": "CREATING",
+                "StateReasonCode": "CREATE_PENDING"
+            },
+            "Timeline": {
+                "Created": "2024-10-15T19:03:08.826000+05:30",
+                "LastModified": "2024-10-15T19:03:08.826000+05:30"
+            },
+            "ArtifactS3Location": "amzn-s3-demo-bucket/demo_canary.zip",
+            "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
+            "Tags": {}
+        }
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/create-group.rst
+++ b/awscli/examples/synthetics/create-group.rst
@@ -1,0 +1,21 @@
+**To create a group**
+
+The following ``create-group`` example creates a group named ``demo_group``. ::
+
+    aws synthetics create-group \
+        --name demo_group
+
+Output::
+
+    {
+        "Group": {
+            "Id": "example123",
+            "Name": "demo_group",
+            "Arn": "arn:aws:synthetics:us-east-1:123456789012:group:example123",
+            "Tags": {},
+            "CreatedTime": "2024-10-15T14:47:23.811000+05:30",
+            "LastModifiedTime": "2024-10-15T14:47:23.811000+05:30"
+        }
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/delete-canary.rst
+++ b/awscli/examples/synthetics/delete-canary.rst
@@ -1,0 +1,10 @@
+**To permanently delete a canary**
+
+The following ``delete-canary`` example deletes a canary named ``demo_canary``. ::
+
+    aws synthetics delete-canary \
+        --name demo_canary
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/delete-group.rst
+++ b/awscli/examples/synthetics/delete-group.rst
@@ -1,0 +1,10 @@
+**To delete a group**
+
+The following ``delete-group`` example deletes a group named ``demo_group``. ::
+
+    aws synthetics delete-group \
+        --group-identifier demo_group
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/describe-canaries-last-run.rst
+++ b/awscli/examples/synthetics/describe-canaries-last-run.rst
@@ -1,0 +1,31 @@
+**To see information from the most recent run of each canary**
+
+The following ``describe-canaries-last-run`` example returns the most recent run of each canary that you have created. ::
+
+    aws synthetics describe-canaries-last-run
+
+Output::
+
+    {
+        "CanariesLastRun": [
+            {
+                "CanaryName": "demo_canary",
+                "LastRun": {
+                    "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+                    "Name": "demo_canary",
+                    "Status": {
+                        "State": "PASSED",
+                        "StateReason": "",
+                        "StateReasonCode": ""
+                    },
+                    "Timeline": {
+                        "Started": "2024-10-15T19:20:39.691000+05:30",
+                        "Completed": "2024-10-15T19:20:58.211000+05:30"
+                    },
+                    "ArtifactS3Location": "cw-syn-results-123456789012-us-east-1/canary/us-east-1/demo_canary-abc-example1234/2024/10/15/13/50-39-690"
+                }
+            }
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/describe-canaries.rst
+++ b/awscli/examples/synthetics/describe-canaries.rst
@@ -1,0 +1,48 @@
+**To list canaries in your account**
+
+The following ``describe-canaries`` example lists the details of canaries in your account. ::
+
+    aws synthetics describe-canaries
+
+Output::
+
+    {
+        "Canaries": [
+            {
+                "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+                "Name": "demo_canary",
+                "Code": {
+                    "SourceLocationArn": "arn:aws:lambda:us-east-1:123456789012:layer:cwsyn-demo_canary-a1b2c3d4-5678-90ab-cdef-example11111b8:1",
+                    "Handler": "pageLoadBlueprint.handler"
+                },
+                "ExecutionRoleArn": "arn:aws:iam::123456789012:role/service-role/CloudWatchSyntheticsRole-demo_canary-a12-a123bc456789",
+                "Schedule": {
+                    "Expression": "rate(5 minutes)",
+                    "DurationInSeconds": 0
+                },
+                "RunConfig": {
+                    "TimeoutInSeconds": 300,
+                    "MemoryInMB": 1000,
+                    "ActiveTracing": false
+                },
+                "SuccessRetentionPeriodInDays": 31,
+                "FailureRetentionPeriodInDays": 31,
+                "Status": {
+                "State": "RUNNING"
+                },
+                "Timeline": {
+                    "Created": "2024-10-15T18:55:15.168000+05:30",
+                    "LastModified": "2024-10-15T18:55:40.540000+05:30",
+                    "LastStarted": "2024-10-15T18:55:40.540000+05:30"
+                },
+                "ArtifactS3Location": "cw-syn-results-123456789012-us-east-1/canary/us-east-1/demo_canary-a12-a123bc456789",
+                "EngineArn": "arn:aws:lambda:us-east-1:123456789012:function:cwsyn-demo_canary-a1b2c3d4-5678-90ab-cdef-example111118:1",
+                "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
+                "Tags": {
+                    "blueprint": "heartbeat"
+                }
+            }
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/describe-runtime-versions.rst
+++ b/awscli/examples/synthetics/describe-runtime-versions.rst
@@ -1,0 +1,74 @@
+**To return a list of synthetics canary runtime versions**
+
+The following ``describe-runtime-versions`` example returns the list of synthetics canary runtime versions. ::
+
+    aws synthetics describe-runtime-versions
+
+Output::
+
+    {
+        "RuntimeVersions": [
+            {
+                "VersionName": "syn-nodejs-puppeteer-9.1",
+                "Description": "Security fixes and bug fix for date range error in har. Dependencies: Node JS 20.x, Puppeteer-core 22.12.1, Chromium 126.0.6478.126",
+                "ReleaseDate": "2024-10-02T05:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-9.0",
+                "Description": "Upgraded Chromium and Puppeteer. Dependencies: Node JS 20.x, Puppeteer-core 22.12.1, Chromium 126.0.6478.126",
+                "ReleaseDate": "2024-07-22T05:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-8.0",
+                "Description": "Upgraded Chromium and Puppeteer. Dependencies: Node JS 20.x, Puppeteer-core 22.10.0, Chromium 125.0.6422.112",
+                "ReleaseDate": "2024-06-21T05:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-7.0",
+                "Description": "Upgraded Chromium and Puppeteer. Dependencies: Node JS 18.x, Puppeteer-core 21.9.0, Chromium 121.0.6167.139",
+                "ReleaseDate": "2024-03-08T05:30:00+05:30"
+                },
+            {
+                "VersionName": "syn-nodejs-puppeteer-6.2",
+                "Description": "Updated shared libraries for Chromium and added ephemeral storage monitoring. Dependencies: Node JS 18.x, Puppeteer-core 19.7.0, Chromium 111.0.5563.146",
+                "ReleaseDate": "2024-02-02T05:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-6.1",
+                "Description": "Added puppeteer launch retry. Dependencies: Node JS 18.x, Puppeteer-core 19.7.0, Chromium 111.0.5563.146",
+                "ReleaseDate": "2023-11-13T05:30:00+05:30",
+                "DeprecationDate": "2024-03-08T13:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-6.0",
+                "Description": "Reduced X-Ray traces of a canary run, improved duration metric and upgraded to NodeJS 18.x. Dependencies: Node JS 18.x, Puppeteer-core 19.7.0, Chromium 111.0.5563.146",
+                "ReleaseDate": "2023-09-15T05:30:00+05:30",
+                "DeprecationDate": "2024-03-08T13:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-5.2",
+                "Description": "Updated shared libraries for Chromium. Dependencies: Node JS 16.x, Puppeteer-core 19.7.0, Chromium 111.0.5563.146",
+                "ReleaseDate": "2024-02-01T05:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-5.1",
+                "Description": "Fixes a bug about missing request headers in har. Dependencies: Node JS 16.x, Puppeteer-core 19.7.0, Chromium 111.0.5563.146",
+                "ReleaseDate": "2023-08-09T05:30:00+05:30",
+                "DeprecationDate": "2024-03-08T13:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-5.0",
+                "Description": "Upgraded Puppeteer and Chromium. Dependencies: Node JS 16.x, Puppeteer-core 19.7.0, Chromium 111.0.5563.146",
+                "ReleaseDate": "2023-07-21T05:30:00+05:30",
+                "DeprecationDate": "2024-03-08T13:30:00+05:30"
+            },
+            {
+                "VersionName": "syn-nodejs-puppeteer-4.0",
+                "Description": "Upgraded to NodeJS 16.x. Dependencies: Node JS 16.x, Puppeteer-core 5.5.0, Chromium 92.0.4512.0",
+                "ReleaseDate": "2023-05-01T05:30:00+05:30",
+                "DeprecationDate": "2024-03-08T13:30:00+05:30"
+            }
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/disassociate-resource.rst
+++ b/awscli/examples/synthetics/disassociate-resource.rst
@@ -1,0 +1,11 @@
+**To remove a canary from a group**
+
+The following ``disassociate-resource`` example removes a canary from the group named ``demo_group``. ::
+
+    aws synthetics disassociate-resource \
+        --group-identifier demo_group \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/get-canary-runs.rst
+++ b/awscli/examples/synthetics/get-canary-runs.rst
@@ -1,0 +1,29 @@
+**To retrieve a list of runs for a specified canary**
+
+The following ``get-canary-runs`` example retrieves a list of runs for the canary named ``demo_canary``. ::
+
+    aws synthetics get-canary-runs \
+        --name demo_canary
+
+Output::
+
+    {
+        "CanaryRuns": [
+            {
+                "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+                "Name": "demo_canary",
+                "Status": {
+                    "State": "PASSED",
+                    "StateReason": "",
+                    "StateReasonCode": ""
+                },
+                "Timeline": {
+                    "Started": "2024-10-16T10:38:57.013000+05:30",
+                    "Completed": "2024-10-16T10:39:25.793000+05:30"
+                },
+                "ArtifactS3Location": "cw-syn-results-123456789012-us-east-1/canary/us-east-1/demo_canary-abc-example1234/2024/10/15/13/50-39-690"
+            }
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/get-canary.rst
+++ b/awscli/examples/synthetics/get-canary.rst
@@ -1,0 +1,47 @@
+**To retrieve complete information about one canary**
+
+The following ``get-canary`` example retrieves complete information about the canary named ``demo_canary``. ::
+
+    aws synthetics get-canary \
+        --name demo_canary
+
+Output::
+
+    {
+        "Canary": {
+            "Id": "a1b2c3d4-5678-90ab-cdef-example11111",
+            "Name": "demo_canary",
+            "Code": {
+                "SourceLocationArn": "arn:aws:lambda:us-east-1:123456789012:layer:cwsyn-demo_canary-a1b2c3d4-5678-90ab-cdef-example111118:1",
+                "Handler": "pageLoadBlueprint.handler"
+            },
+            "ExecutionRoleArn": "arn:aws:iam::123456789012:role/demo_canary_role",
+            "Schedule": {
+                "Expression": "rate(10 minutes)",
+                "DurationInSeconds": 0
+            },
+            "RunConfig": {
+                "TimeoutInSeconds": 300,
+                "MemoryInMB": 1000,
+                "ActiveTracing": false
+            },
+            "SuccessRetentionPeriodInDays": 31,
+            "FailureRetentionPeriodInDays": 31,
+            "Status": {
+                "State": "RUNNING"
+            },
+            "Timeline": {
+                "Created": "2024-10-15T18:55:15.168000+05:30",
+                "LastModified": "2024-10-15T18:55:40.540000+05:30",
+                "LastStarted": "2024-10-15T18:55:40.540000+05:30"
+            },
+            "ArtifactS3Location": "cw-syn-results-123456789012-us-east-1/canary/us-east-1/demo_canary-a12-a123bc456789",
+            "EngineArn": "arn:aws:lambda:us-east-1:123456789012:function:cwsyn-demo_canary-a1b2c3d4-5678-90ab-cdef-example111118:1",
+            "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
+            "Tags": {
+                "blueprint": "heartbeat"
+            }
+        }
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/get-group.rst
+++ b/awscli/examples/synthetics/get-group.rst
@@ -1,0 +1,21 @@
+**To return information about one group**
+
+The following ``get-group`` example returns information about the group named ``demo_group``. ::
+
+    aws synthetics get-group \
+        --group-identifier demo_group
+
+Output::
+
+    {
+        "Group": {
+            "Id": "example123",
+            "Name": "demo_group",
+            "Arn": "arn:aws:synthetics:us-east-1:123456789012:group:example123",
+            "Tags": {},
+            "CreatedTime": "2024-10-15T14:47:23.811000+05:30",
+            "LastModifiedTime": "2024-10-15T14:47:23.811000+05:30"
+        }
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/list-associated-groups.rst
+++ b/awscli/examples/synthetics/list-associated-groups.rst
@@ -1,0 +1,20 @@
+**To return a list of the groups**
+
+The following ``list-associated-groups`` example returns a list of the groups associated with the canary named ``demo_canary``. ::
+
+    aws synthetics list-associated-groups \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary
+
+Output::
+
+    {
+        "Groups": [
+            {
+                "Id": "example123",
+                "Name": "demo_group",
+                "Arn": "arn:aws:synthetics:us-east-1:123456789012:group:example123"
+            }
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/list-group-resources.rst
+++ b/awscli/examples/synthetics/list-group-resources.rst
@@ -1,0 +1,16 @@
+**To return a list of the ARNs of the canaries that are associated with the specified group**
+
+The following ``list-group-resources`` example returns a list of the ARNs of the canaries that are associated with the group named ``demo_group``. ::
+
+    aws synthetics list-group-resources \
+        --group-identifier demo_group
+
+Output::
+
+    {
+        "Resources": [
+            "arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary"
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/list-groups.rst
+++ b/awscli/examples/synthetics/list-groups.rst
@@ -1,0 +1,19 @@
+**To return a list of all groups in the account**
+
+The following ``list-groups`` example returns a list of all groups in the account. ::
+
+    aws synthetics list-groups
+
+Output::
+
+    {
+        "Groups": [
+            {
+                "Id": "example123",
+                "Name": "demo_group",
+                "Arn": "arn:aws:synthetics:us-east-1:123456789012:group:example123"
+            }
+        ]
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/list-tags-for-resource.rst
+++ b/awscli/examples/synthetics/list-tags-for-resource.rst
@@ -1,0 +1,31 @@
+**Example 1: To display the tags associated with a canary**
+
+The following ``list-tags-for-resource`` example returns the tags associated with a canary named ``demo_canary``. ::
+
+    aws synthetics list-tags-for-resource \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary
+
+Output::
+
+    {
+        "Tags": {
+            "blueprint": "heartbeat"
+        }
+    }
+
+**Example 2: To display the tags associated with a group**
+
+The following ``list-tags-for-resource`` example returns the tags associated with a group named ``demo_group``. ::
+
+    aws  synthetics list-tags-for-resource \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:group:example123
+
+Output::
+
+    {
+        "Tags": {
+            "team": "Devops"
+        }
+    }
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/start-canary.rst
+++ b/awscli/examples/synthetics/start-canary.rst
@@ -1,0 +1,10 @@
+**To run a canary**
+
+The following ``start-canary`` example runs a canary named ``demo_canary``. ::
+
+    aws synthetics start-canary \
+        --name demo_canary
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/stop-canary.rst
+++ b/awscli/examples/synthetics/stop-canary.rst
@@ -1,0 +1,10 @@
+**To stop a canary**
+
+The following ``stop-canary`` example stops the canary named ``demo_canary``. ::
+
+    aws synthetics stop-canary \
+        --name demo_canary
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/tag-resource.rst
+++ b/awscli/examples/synthetics/tag-resource.rst
@@ -1,0 +1,21 @@
+**Example 1: To assign a tag to the canary**
+
+The following ``tag-resource`` example assigns a tag to the canary named ``demo_canary``. ::
+
+    aws synthetics tag-resource \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary \
+        --tags blueprint=heartbeat
+
+This command produces no output.
+
+**Example 2: To assign a tag to the group**
+
+The following ``tag-resource`` example assigns a tag to the group named ``demo_group``. ::
+
+    aws synthetics tag-resource \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:group:example123 \
+        --tags team=Devops
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/untag-resource.rst
+++ b/awscli/examples/synthetics/untag-resource.rst
@@ -1,0 +1,21 @@
+**Example 1: To remove a tag from the canary**
+
+The following ``untag-resource`` example removes a tag from the canary named ``demo_canary``. ::
+
+    aws synthetics untag-resource \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:canary:demo_canary \
+        --tag-keys blueprint
+
+This command produces no output.
+
+**Example 2: To remove a tag from the group**
+
+The following ``untag-resource`` example assigns a removes a tag from the group named ``demo_group``. ::
+
+    aws synthetics untag-resource \
+        --resource-arn arn:aws:synthetics:us-east-1:123456789012:group:example123 \
+        --tag-keys team
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/synthetics/update-canary.rst
+++ b/awscli/examples/synthetics/update-canary.rst
@@ -1,0 +1,11 @@
+**To update a canary**
+
+The following ``update-canary`` example updates the configuration of a canary named ``demo_canary``. ::
+
+    aws synthetics update-canary \
+        --name demo_canary \
+        --schedule Expression="rate(15 minutes)"
+
+This command produces no output.
+
+For more information, see `Synthetic monitoring (canaries) <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries.html>`__ in the *Amazon CloudWatch User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding example CLI commands for :
1. Amazon CloudWatch Observability Access Manager: https://docs.aws.amazon.com/cli/latest/reference/oam/
2. Amazon CloudWatch Synthetics: https://docs.aws.amazon.com/cli/latest/reference/synthetics/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
