### PR TITLE
adding CLI examples for App signals

### DIFF
--- a/awscli/examples/application-signals/batch-get-service-level-objective-budget-report.rst
+++ b/awscli/examples/application-signals/batch-get-service-level-objective-budget-report.rst
@@ -1,0 +1,99 @@
+**To retrieve one or more service level objective (SLO) budget reports.**
+
+The following ``batch-get-service-level-objective-budget-report`` example retrieves one or more service level objective (SLO) budget reports. ::
+
+    aws application-signals batch-get-service-level-objective-budget-report \
+    --timestamp 1735059869 \
+    --slo-ids "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName1" "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName2"
+
+Output::
+
+    {
+        "Timestamp": "2024-12-24T22:34:29+05:30",
+        "Reports": [{
+                "Arn": "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName1",
+                "Name": "Your SLO Name",
+                "EvaluationType": "PeriodBased",
+                "BudgetStatus": "OK",
+                "Attainment": 100.0,
+                "TotalBudgetSeconds": 6048,
+                "BudgetSecondsRemaining": 6048,
+                "Sli": {
+                    "SliMetric": {
+                        "MetricDataQueries": [{
+                            "Id": "m1",
+                            "MetricStat": {
+                                "Metric": {
+                                    "Namespace": "AWS/EC2",
+                                    "MetricName": "CPUUtilization",
+                                    "Dimensions": [{
+                                        "Name": "InstanceId",
+                                        "Value": "i-0e098765432522"
+                                    }]
+                                },
+                                "Period": 60,
+                                "Stat": "Average"
+                            },
+                            "ReturnData": true
+                        }]
+                    },
+                    "MetricThreshold": 200.0,
+                    "ComparisonOperator": "LessThanOrEqualTo"
+                },
+                "Goal": {
+                    "Interval": {
+                        "RollingInterval": {
+                            "DurationUnit": "DAY",
+                            "Duration": 7
+                        }
+                    },
+                    "AttainmentGoal": 99.0,
+                    "WarningThreshold": 50.0
+                }
+            },
+            {
+                "Arn": "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName2",
+                "Name": "test",
+                "EvaluationType": "PeriodBased",
+                "BudgetStatus": "BREACHED",
+                "Attainment": 97.39583275,
+                "TotalBudgetSeconds": 86,
+                "BudgetSecondsRemaining": -2154,
+                "Sli": {
+                    "SliMetric": {
+                        "MetricDataQueries": [{
+                            "Id": "cwMetric",
+                            "MetricStat": {
+                                "Metric": {
+                                    "Namespace": "AWS/EC2",
+                                    "MetricName": "CPUUtilization",
+                                    "Dimensions": [{
+                                        "Name": "InstanceId",
+                                        "Value": "i-0e12345678922"
+                                    }]
+                                },
+                                "Period": 300,
+                                "Stat": "Average"
+                            },
+                            "ReturnData": true
+                        }]
+                    },
+                    "MetricThreshold": 5.0,
+                    "ComparisonOperator": "GreaterThan"
+                },
+                "Goal": {
+                    "Interval": {
+                        "RollingInterval": {
+                            "DurationUnit": "DAY",
+                            "Duration": 1
+                        }
+                    },
+                    "AttainmentGoal": 99.9,
+                    "WarningThreshold": 30.0
+                }
+            }
+        ],
+        "Errors": []
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/create-service-level-objective.rst
+++ b/awscli/examples/application-signals/create-service-level-objective.rst
@@ -1,0 +1,88 @@
+**To create a service level objective (SLO)**
+
+The following ``create-service-level-objective`` example creates a service level objective (SLO), which can help you ensure that your critical business operations are meeting customer expectations. ::
+
+    aws application-signals create-service-level-objective \
+        --name "SLOName" \
+        --description "Description of your SLO" \
+        --sli-config file://sli-config.json
+
+Contents of ``sli-config.json``::
+
+    {
+        "SliMetricConfig": {
+            "MetricDataQueries": [
+                {
+                    "Id": "m1",
+                    "MetricStat": {
+                        "Metric": {
+                            "Namespace": "AWS/EC2",
+                            "MetricName": "CPUUtilization",
+                            "Dimensions": [
+                                {
+                                    "Name": "InstanceId",
+                                    "Value": "i-0e5a1234561522"
+                                }
+                            ]
+                        },
+                        "Period": 60,
+                        "Stat": "Average"
+                    },
+                    "ReturnData": true
+                }
+            ]
+        },
+        "MetricThreshold": 200,
+        "ComparisonOperator": "LessThanOrEqualTo"
+    }
+    
+Output::
+
+    {
+        "Slo": {
+        "Arn": "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName",
+        "Name": "SLOName",
+        "Description": "Description of your SLO",
+        "CreatedTime": "2024-12-27T08:16:09.032000+05:30",
+        "LastUpdatedTime": "2024-12-27T08:16:09.032000+05:30",
+        "Sli": {
+            "SliMetric": {
+                "MetricDataQueries": [
+                    {
+                        "Id": "m1",
+                        "MetricStat": {
+                            "Metric": {
+                                "Namespace": "AWS/EC2",
+                                "MetricName": "CPUUtilization",
+                                "Dimensions": [
+                                    {
+                                        "Name": "InstanceId",
+                                        "Value": "i-0e59876543234522"
+                                    }
+                                ]
+                            },
+                            "Period": 60,
+                            "Stat": "Average"
+                        },
+                        "ReturnData": true
+                    }
+                ]
+            },
+            "MetricThreshold": 200.0,
+            "ComparisonOperator": "LessThanOrEqualTo"
+        },
+        "EvaluationType": "PeriodBased",
+        "Goal": {
+            "Interval": {
+                "RollingInterval": {
+                    "DurationUnit": "DAY",
+                    "Duration": 7
+                }
+            },
+            "AttainmentGoal": 99.0,
+            "WarningThreshold": 50.0
+          }
+        }
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/delete-service-level-objective.rst
+++ b/awscli/examples/application-signals/delete-service-level-objective.rst
@@ -1,0 +1,10 @@
+**To delete the specified service level objective.**
+
+The following ``delete-service-level-objective`` example deletes the specified service level objective. ::
+
+    aws application-signals delete-service-level-objective \
+        --id "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName"
+
+This command produces no output.
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/get-service-level-objective.rst
+++ b/awscli/examples/application-signals/get-service-level-objective.rst
@@ -1,0 +1,53 @@
+**To return information about one SLO created in the account**
+
+The following ``get-service-level-objective`` example returns information about one SLO created in the account. ::
+
+    aws application-signals get-service-level-objective \
+        --id "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName" 
+
+Output::
+
+    {
+        "Slo": {
+            "Arn": "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName",
+            "Name": "SLOName",
+            "Description": "Description of your SLO",
+            "CreatedTime": "2024-12-24T22:19:18.624000+05:30",
+            "LastUpdatedTime": "2024-12-24T22:19:55.280000+05:30",
+            "Sli": {
+                "SliMetric": {
+                    "MetricDataQueries": [{
+                        "Id": "m1",
+                        "MetricStat": {
+                            "Metric": {
+                                "Namespace": "AWS/EC2",
+                                "MetricName": "CPUUtilization",
+                                "Dimensions": [{
+                                    "Name": "InstanceId",
+                                    "Value": "i-0e0987654321522"
+                                }]
+                            },
+                            "Period": 60,
+                            "Stat": "Average"
+                        },
+                        "ReturnData": true
+                    }]
+                },
+                "MetricThreshold": 200.0,
+                "ComparisonOperator": "LessThanOrEqualTo"
+            },
+            "EvaluationType": "PeriodBased",
+            "Goal": {
+                "Interval": {
+                    "RollingInterval": {
+                        "DurationUnit": "DAY",
+                        "Duration": 7
+                    }
+                },
+                "AttainmentGoal": 99.0,
+                "WarningThreshold": 50.0
+            }
+        }
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/get-service.rst
+++ b/awscli/examples/application-signals/get-service.rst
@@ -1,0 +1,72 @@
+**To return information about a service discovered by Application Signals**
+
+The following ``get-service`` example returns information about a service discovered by Application Signals. ::
+
+    aws application-signals get-service \
+        --start-time 1732704000 \
+        --end-time 1732714500 \
+        --key-attributes Environment=lambda:default,Name=hello-world-python,Type=Service
+
+Output::
+
+    {
+        "Service": {
+            "KeyAttributes": {
+                "Environment": "lambda:default",
+                "Name": "hello-world-python",
+                "Type": "Service"
+            },
+            "AttributeMaps": [{
+                "Lambda.Function.Name": "hello-world-python",
+                "PlatformType": "AWS::Lambda"
+            }],
+            "MetricReferences": [{
+                "Namespace": "ApplicationSignals",
+                "MetricType": "LATENCY",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "Service",
+                    "Value": "hello-world-python"
+                }],
+                "MetricName": "Latency"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "FAULT",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "Service",
+                    "Value": "hello-world-python"
+                }],
+                "MetricName": "Fault"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "ERROR",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "Service",
+                    "Value": "hello-world-python"
+                }],
+                "MetricName": "Error"
+            }],
+            "LogGroupReferences": [{
+                "Identifier": "/aws/lambda/hello-world-python",
+                "ResourceType": "AWS::Logs::LogGroup",
+                "Type": "AWS::Resource"
+            }]
+        },
+        "StartTime": "2024-11-27T10:00:00+00:00",
+        "EndTime": "2024-11-27T14:00:01+00:00",
+        "LogGroupReferences": [{
+            "Identifier": "/aws/lambda/hello-world-python",
+            "ResourceType": "AWS::Logs::LogGroup",
+            "Type": "AWS::Resource"
+        }]
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/list-service-dependencies.rst
+++ b/awscli/examples/application-signals/list-service-dependencies.rst
@@ -1,0 +1,96 @@
+**To return a list of service dependencies of the service that you specify**
+
+The following ``list-service-dependencies`` example returns a list of service dependencies of the service that you specify. ::
+
+    aws application-signals list-service-dependencies \
+        --start-time 1732021200 \
+        --end-time 1732107600 \
+        --key-attributes Environment=api-gateway:prod, Name=PetAdoptionStatusUpdater,Type=Service
+
+Output::
+
+    {
+        "ServiceDependencies": [{
+            "OperationName": "PUT /prod",
+            "DependencyKeyAttributes": {
+                "Environment": "lambda:default",
+                "Name": "Services-name",
+                "Type": "Service"
+            },
+            "DependencyOperationName": "Invoke",
+            "MetricReferences": [{
+                "Namespace": "ApplicationSignals",
+                "MetricType": "LATENCY",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "api-gateway:prod"
+                }, {
+                    "Name": "Operation",
+                    "Value": "PUT /prod"
+                }, {
+                    "Name": "RemoteEnvironment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "RemoteOperation",
+                    "Value": "Invoke"
+                }, {
+                    "Name": "RemoteService",
+                    "Value": "Services-name"
+                }, {
+                    "Name": "Service",
+                    "Value": "PetAdoptionStatusUpdater"
+                }],
+                "MetricName": "Latency"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "FAULT",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "api-gateway:prod"
+                }, {
+                    "Name": "Operation",
+                    "Value": "PUT /prod"
+                }, {
+                    "Name": "RemoteEnvironment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "RemoteOperation",
+                    "Value": "Invoke"
+                }, {
+                    "Name": "RemoteService",
+                    "Value": "Services-name"
+                }, {
+                    "Name": "Service",
+                    "Value": "PetAdoptionStatusUpdater"
+                }],
+                "MetricName": "Fault"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "ERROR",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "api-gateway:prod"
+                }, {
+                    "Name": "Operation",
+                    "Value": "PUT /prod"
+                }, {
+                    "Name": "RemoteEnvironment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "RemoteOperation",
+                    "Value": "Invoke"
+                }, {
+                    "Name": "RemoteService",
+                    "Value": "Services-name"
+                }, {
+                    "Name": "Service",
+                    "Value": "PetAdoptionStatusUpdater"
+                }],
+                "MetricName": "Error"
+            }]
+        }],
+        "StartTime": "2024-11-19T13:00:00+00:00",
+        "EndTime": "2024-11-20T13:00:01+00:00"
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/list-service-dependents.rst
+++ b/awscli/examples/application-signals/list-service-dependents.rst
@@ -1,0 +1,36 @@
+**To return the list of dependents that invoked the specified service during the provided time range**
+
+The following ``list-service-dependents`` example returns the list of dependents that invoked the specified service during the provided time range. ::
+
+    aws application-signals list-service-dependents \
+        --start-time 1732021200 \
+        --end-time 1732107600 \
+        --key-attributes Environment=generic:default,Name=PetSite,Type=Service
+
+Output::
+
+    {
+        "ServiceDependents": [{
+            "OperationName": "",
+            "DependentKeyAttributes": {
+                "Identifier": "pet-api-canary-hao",
+                "ResourceType": "AWS::Synthetics::Canary",
+                "Type": "AWS::Resource"
+            },
+            "DependentOperationName": "",
+            "MetricReferences": []
+        }, {
+            "OperationName": "",
+            "DependentKeyAttributes": {
+                "Identifier": "PetSite",
+                "ResourceType": "AWS::Synthetics::Canary",
+                "Type": "AWS::Resource"
+            },
+            "DependentOperationName": "",
+            "MetricReferences": []
+        }],
+        "StartTime": "2024-12-24T05:00:00+00:00",
+        "EndTime": "2024-12-25T06:00:01+00:00"
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/list-service-level-objectives.rst
+++ b/awscli/examples/application-signals/list-service-level-objectives.rst
@@ -1,0 +1,17 @@
+**To return a list of SLOs created in this account.**
+
+The following ``list-service-level-objectives`` example returns a list of SLOs created in this account. ::
+
+    aws application-signals list-service-level-objectives
+
+Output::
+
+    {
+        "SloSummaries": [{
+            "Arn": "arn:aws:application-signals:us-east-1:123456789101:slo/test",
+            "Name": "test",
+            "CreatedTime": "2024-12-24T22:01:21.116000+05:30"
+        }]
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/list-service-operations.rst
+++ b/awscli/examples/application-signals/list-service-operations.rst
@@ -1,0 +1,63 @@
+**To return a list of the operations of this service that have been discovered by Application Signals**
+
+The following ``list-service-operations`` example returns a list of the operations of this service that have been discovered by Application Signals. ::
+
+    aws application-signals list-service-operations \
+        --start-time 1735017423 \
+        --end-time 1735103823 \
+        --key-attributes Environment=generic:default,Name=payforadoption,Type=Service
+
+Output::
+
+    {
+        "ServiceOperations": [{
+            "Name": "POST /api",
+            "MetricReferences": [{
+                "Namespace": "ApplicationSignals",
+                "MetricType": "LATENCY",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "generic:default"
+                }, {
+                    "Name": "Operation",
+                    "Value": "POST /api"
+                }, {
+                    "Name": "Service",
+                    "Value": "payforadoption"
+                }],
+                "MetricName": "Latency"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "FAULT",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "generic:default"
+                }, {
+                    "Name": "Operation",
+                    "Value": "POST /api"
+                }, {
+                    "Name": "Service",
+                    "Value": "payforadoption"
+                }],
+                "MetricName": "Fault"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "ERROR",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "generic:default"
+                }, {
+                    "Name": "Operation",
+                    "Value": "POST /api"
+                }, {
+                    "Name": "Service",
+                    "Value": "payforadoption"
+                }],
+                "MetricName": "Error"
+            }]
+        }],
+        "StartTime": "2024-12-24T05:00:00+00:00",
+        "EndTime": "2024-12-25T06:00:01+00:00"
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/list-services.rst
+++ b/awscli/examples/application-signals/list-services.rst
@@ -1,0 +1,61 @@
+**To return a list of services that have been discovered by Application Signals**
+
+The following ``list-services`` example returns a list of services that have been discovered by Application Signals. ::
+
+    aws application-signals list-services \
+        --start-time 1734918791 \
+        --end-time 1734965591
+
+Output::
+
+    {
+        "ServiceSummaries": [{
+            "KeyAttributes": {
+                "Environment": "lambda:default",
+                "Name": "hello-world-python",
+                "Type": "Service"
+            },
+            "AttributeMaps": [{
+                "Lambda.Function.Name": "hello-world-python",
+                "PlatformType": "AWS::Lambda"
+            }],
+            "MetricReferences": [{
+                "Namespace": "ApplicationSignals",
+                "MetricType": "LATENCY",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "Service",
+                    "Value": "hello-world-python"
+                }],
+                "MetricName": "Latency"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "FAULT",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "Service",
+                    "Value": "hello-world-python"
+                }],
+                "MetricName": "Fault"
+            }, {
+                "Namespace": "ApplicationSignals",
+                "MetricType": "ERROR",
+                "Dimensions": [{
+                    "Name": "Environment",
+                    "Value": "lambda:default"
+                }, {
+                    "Name": "Service",
+                    "Value": "hello-world-python"
+                }],
+                "MetricName": "Error"
+            }]
+        }],
+        "StartTime": "2024-11-27T10:00:00+00:00",
+        "EndTime": "2024-11-27T14:00:01+00:00"
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/list-tags-for-resource.rst
+++ b/awscli/examples/application-signals/list-tags-for-resource.rst
@@ -1,0 +1,17 @@
+**To display the tags associated with a CloudWatch resource**
+
+The following ``list-tags-for-resource`` example displays the tags associated with a CloudWatch resource. ::
+
+    aws application-signals list-tags-for-resource \
+        --resource-arn "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName"
+
+Output::
+
+    {
+        "Tags": [{
+            "Key": "test",
+            "Value": "value"
+        }]
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/start-discovery.rst
+++ b/awscli/examples/application-signals/start-discovery.rst
@@ -1,0 +1,9 @@
+**To enable this Amazon Web Services account to be able to use CloudWatch Application Signals**
+
+The following ``start-discovery`` example enables this Amazon Web Services account to be able to use CloudWatch Application Signals by creating the *AWSServiceRoleForCloudWatchApplicationSignals* service-linked role. ::
+
+    aws application-signals start-discovery
+
+This command produces no output.
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/tag-resource.rst
+++ b/awscli/examples/application-signals/tag-resource.rst
@@ -1,0 +1,11 @@
+**To assigns one or more tags (key-value pairs) to the specified CloudWatch resource, such as a service level objective**
+
+The following ``tag-resource`` example assigns one or more tags (key-value pairs) to the specified CloudWatch resource, such as a service level objective. ::
+
+    aws application-signals tag-resource \
+        --resource-arn "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName" \
+        --tags '{"Key":"test","Value":"value"}'
+
+This command produces no output.
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/untag-resource.rst
+++ b/awscli/examples/application-signals/untag-resource.rst
@@ -1,0 +1,11 @@
+**To remove one or more tags from the specified resource**
+
+The following ``untag-resource`` example removes one or more tags from the specified resource. ::
+
+    aws application-signals untag-resource \
+        --resource-arn "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName" \
+        --tag-keys "test"
+
+This command produces no output.
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/application-signals/update-service-level-objective.rst
+++ b/awscli/examples/application-signals/update-service-level-objective.rst
@@ -1,0 +1,69 @@
+**To update an existing service level objective (SLO)**
+
+The following ``update-service-level-objective`` example updates an existing service level objective (SLO). ::
+
+    aws application-signals update-service-level-objective \
+    --cli-input-json file://update-slo.json
+
+Contents of ``update-slo.json``::
+
+    {
+        "id": "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName",
+        "goal": {
+            "Interval": {
+                "RollingInterval": {
+                    "DurationUnit": "DAY",
+                    "Duration": 7
+                }
+            },
+            "AttainmentGoal": 90.0,
+            "WarningThreshold": 50.0
+        }
+    }
+
+Output::
+
+    {
+        "Slo": {
+            "Arn": "arn:aws:application-signals:us-east-1:123456789101:slo/SLOName",
+            "Name": "SLOName",
+            "Description": "Description of your SLO",
+            "CreatedTime": "2024-12-24T22:19:18.624000+05:30",
+            "LastUpdatedTime": "2024-12-27T08:51:38.278000+05:30",
+            "Sli": {
+                "SliMetric": {
+                    "MetricDataQueries": [{
+                        "Id": "m1",
+                        "MetricStat": {
+                            "Metric": {
+                                "Namespace": "AWS/EC2",
+                                "MetricName": "CPUUtilization",
+                                "Dimensions": [{
+                                    "Name": "InstanceId",
+                                    "Value": "i-00987654345222"
+                                }]
+                            },
+                            "Period": 60,
+                            "Stat": "Average"
+                        },
+                        "ReturnData": true
+                    }]
+                },
+                "MetricThreshold": 200.0,
+                "ComparisonOperator": "LessThanOrEqualTo"
+            },
+            "EvaluationType": "PeriodBased",
+            "Goal": {
+                "Interval": {
+                    "RollingInterval": {
+                        "DurationUnit": "DAY",
+                        "Duration": 7
+                    }
+                },
+                "AttainmentGoal": 90.0,
+                "WarningThreshold": 50.0
+            }
+        }
+    }
+
+For more information, see `Application Signals <https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Application-Monitoring-Sections.html>`__ in the *Amazon CloudWatch User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding CLI examples for Application signals

https://docs.aws.amazon.com/cli/latest/reference/application-signals/#cli-aws-application-signals

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
