### PR TITLE
Add a console_scripts entry point for aws

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup_options = dict(
     scripts=['bin/aws', 'bin/aws.cmd',
              'bin/aws_completer', 'bin/aws_zsh_completer.sh',
              'bin/aws_bash_completer'],
+    entry_points={'console_scripts': ['aws=awscli.clidriver:main']},
     packages=find_packages(exclude=['tests*']),
     include_package_data=True,
     install_requires=install_requires,


### PR DESCRIPTION
*Issue #, if available:*

Fixes #5063

*Description of changes:*

In comparison to `scripts`, setuptools's `console_scripts` mechanism is a more portable way to register CLI executables which allows setuptools to generate the executable stub script in a manner appropriate for the platform in question.  It also integrates well with bazel.  In this patch we add one for the `aws` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms the [Apache license](http://aws.amazon.com/apache2.0/), version 2.0.