### PR TITLE
Fix v2 cherry-pick GH action

### DIFF
--- a/.github/workflows/doc-pr-cherry-pick.yml
+++ b/.github/workflows/doc-pr-cherry-pick.yml
@@ -27,7 +27,9 @@ jobs:
         run: |
           gh pr checkout $PR_NUMBER
           PR_COMMITS=$(gh pr view $PR_NUMBER --json commits --jq '.commits[].oid')
-          echo "PR_COMMITS=$PR_COMMITS" >> $GITHUB_OUTPUT
+          echo "PR_COMMITS<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$PR_COMMITS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.inputs.pr_number }}


### PR DESCRIPTION
Fix a bug in the `Cherry-Pick PR to v2` GitHub action where PRs with multiple commits fail to process. I followed the GitHub actions docs multiline strings (in the case of multiple commits separated by newlines): https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings

Manual testing:
* `develop` PR with multiple commits: https://github.com/aws/aws-cli/pull/8579
* GitHub action run off this branch: https://github.com/aws/aws-cli/actions/runs/12835417936/job/35794804085
* Created `v2` PR: https://github.com/aws/aws-cli/pull/9230

Also for single commit PRs:
* `develop` PR with single commit: https://github.com/aws/aws-cli/pull/9227
* GitHub action run off this branch: https://github.com/aws/aws-cli/actions/runs/12835518568/job/35795110722
* Created `v2` PR: https://github.com/aws/aws-cli/pull/9232