### PR TITLE
Only set default checksum if ``request_checksum_calculation`` config is set to ``when_supported``

### DIFF
--- a/awscli/s3transfer/manager.py
+++ b/awscli/s3transfer/manager.py
@@ -515,7 +515,11 @@ class TransferManager:
                 )
 
     def _add_operation_defaults(self, extra_args):
-        set_default_checksum_algorithm(extra_args)
+        if (
+            self.client.meta.config.request_checksum_calculation
+            == "when_supported"
+        ):
+            set_default_checksum_algorithm(extra_args)
 
     def _submit_transfer(
         self, call_args, submission_task_cls, extra_main_kwargs=None


### PR DESCRIPTION
AWS CLI v2 version of https://github.com/boto/s3transfer/pull/329

> Addresses: https://github.com/boto/s3transfer/issues/327
>
> This PR checks the ``request_checksum_calculation`` config on the S3 client before setting a default checksum for both non-MPU and MPU. If ``request_checksum_calculation`` is set to ``when_supported``, the default checksum from botocore (currently `CRC32`) is applied. If ``request_checksum_calculation`` is set to ``when_required``, no default checksum is applied.