### PR TITLE
Add CLI examples for CloudWatch Logs-v2

### DIFF
--- a/awscli/examples/logs/associate-kms-key.rst
+++ b/awscli/examples/logs/associate-kms-key.rst
@@ -1,0 +1,11 @@
+**To associate a KMS key with the log group**
+
+The following ``associate-kms-key`` example associates KMS key with log group named ``demo-log-group``. ::
+
+    aws logs associate-kms-key \
+        --log-group-name demo-log-group \
+        --kms-key-id 1234abcd-12ab-34cd-56ef-1234567890ab
+
+This command produces no output.
+
+For more information, see `Encrypt log data in CloudWatch Logs using AWS Key Management Service <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/cancel-export-task.rst
+++ b/awscli/examples/logs/cancel-export-task.rst
@@ -1,0 +1,10 @@
+**To cancel an export task**
+
+The following ``cancel-export-task`` example cancels the export task with id ``a1b2c3d4-5678-90ab-cdef-example12345``. ::
+
+    aws logs cancel-export-task \
+        --task-id a1b2c3d4-5678-90ab-cdef-example12345
+
+This command produces no output.
+
+For more information, see `Exporting log data to Amazon S3 <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3Export.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/create-delivery.rst
+++ b/awscli/examples/logs/create-delivery.rst
@@ -1,0 +1,28 @@
+**To create a delivery**
+
+The following ``create-delivery`` example creates a delivery between a source and destination. ::
+
+    aws logs create-delivery \
+        --delivery-source-name demo-delivery-source \
+        --delivery-destination-arn arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination
+
+Output::
+
+    {
+        "delivery": {
+            "id": "Example1abcde2eCK",
+            "arn": "arn:aws:logs:us-east-1:123456789012:delivery:Example1abcde2eCK",
+            "deliverySourceName": "demo-delivery-source",
+            "deliveryDestinationArn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination",
+            "deliveryDestinationType": "CWL",
+            "recordFields": [
+                "event_timestamp",
+                "resource_id",
+                "log_level",
+                "event_message"
+            ],
+            "fieldDelimiter": ""
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/create-export-task.rst
+++ b/awscli/examples/logs/create-export-task.rst
@@ -1,0 +1,17 @@
+**To create an export task**
+
+The following ``create-export-task`` example creates an export task to export data from a log group named ``demo-log-group`` to an Amazon S3 bucket named ``amzn-s3-demo-bucket``. ::
+
+    aws logs create-export-task \
+        --log-group-name demo-log-group \
+        --from 1715918400 \
+        --to 1715920200 \
+        --destination amzn-s3-demo-bucket
+
+Output::
+
+    {
+        "taskId": "a1b2c3d4-5678-90ab-cdef-example11111"
+    }
+
+For more information, see `Exporting log data to Amazon S3 <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3Export.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/create-log-anomaly-detector.rst
+++ b/awscli/examples/logs/create-log-anomaly-detector.rst
@@ -1,0 +1,15 @@
+**To create an anomaly detector**
+
+The following ``create-log-anomaly-detector`` example creates an anomaly detector named ``demo_anomaly_detector``. ::
+
+    aws logs create-log-anomaly-detector \
+        --log-group-arn-list arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group \
+        --detector-name demo_anomaly_detector
+
+Output::
+
+    {
+        "anomalyDetectorArn": "arn:aws:logs:us-east-1:123456789012:anomaly-detector:a1b2c3d4-5678-90ab-cdef-example11111"
+    }
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-account-policy.rst
+++ b/awscli/examples/logs/delete-account-policy.rst
@@ -1,0 +1,11 @@
+**To delete a CloudWatch Logs account policy**
+
+The following ``delete-account-policy`` example deletes a CloudWatch Logs account policy. ::
+
+    aws logs delete-account-policy \
+        --policy-name Example_Data_Protection_Policy \
+        --policy-type DATA_PROTECTION_POLICY
+
+This command produces no output.
+
+For more information, see `Help protect sensitive log data with masking <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-data-protection-policy.rst
+++ b/awscli/examples/logs/delete-data-protection-policy.rst
@@ -1,0 +1,10 @@
+**To delete the data protection policy from the specified log group**
+
+The following ``delete-data-protection-policy`` example deletes the data protection policy from the log group named ``demo-log-group``. ::
+
+    aws logs delete-data-protection-policy \
+        --log-group-identifier demo-log-group
+
+This command produces no output.
+
+For more information, see `Help protect sensitive log data with masking <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-delivery-destination-policy.rst
+++ b/awscli/examples/logs/delete-delivery-destination-policy.rst
@@ -1,0 +1,10 @@
+**To delete a delivery destination policy**
+
+The following ``delete-delivery-destination-policy`` example deletes the policy for delivery destination named ``demo-delivery-destination``. ::
+
+     aws logs delete-delivery-destination-policy \
+        --delivery-destination-name demo-delivery-destination
+
+This command produces no output.
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-delivery-destination.rst
+++ b/awscli/examples/logs/delete-delivery-destination.rst
@@ -1,0 +1,10 @@
+**To delete a delivery destination**
+
+The following ``delete-delivery-destination`` example deletes a delivery destination named ``demo-delivery-destination``. ::
+
+    aws logs delete-delivery-destination \
+        --name demo-delivery-destination
+
+This command produces no output.
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-delivery-source.rst
+++ b/awscli/examples/logs/delete-delivery-source.rst
@@ -1,0 +1,10 @@
+**To delete a delivery source**
+
+The following ``delete-delivery-source`` example deletes a delivery source named ``delete-delivery-source``. ::
+
+    aws logs delete-delivery-source \
+        --name demo-delivery-source
+
+This command produces no output.
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-delivery.rst
+++ b/awscli/examples/logs/delete-delivery.rst
@@ -1,0 +1,10 @@
+**To delete a delivery**
+
+The following ``delete-delivery`` example deletes a delivery. ::
+
+    aws logs delete-delivery \
+        --id Example1abcde2eCK
+
+This command produces no output.
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-destination.rst
+++ b/awscli/examples/logs/delete-destination.rst
@@ -1,0 +1,10 @@
+**To delete the specified destination**
+
+The following ``delete-destination`` example deletes the destination named ``demoDestination``, and disables all the subscription filters that publish to it. ::
+
+    aws logs delete-destination \
+        --destination-name demoDestination
+
+This command produces no output.
+
+For more information, see `Cross-account cross-Region subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CrossAccountSubscriptions.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-log-anomaly-detector.rst
+++ b/awscli/examples/logs/delete-log-anomaly-detector.rst
@@ -1,0 +1,10 @@
+**To delete an anomaly detector**
+
+The following ``delete-log-anomaly-detector`` example deletes an anomaly detector named ``demo_anomaly_detector``. ::
+
+    aws logs delete-log-anomaly-detector \
+        --anomaly-detector-arn arn:aws:logs:us-east-1:123456789012:anomaly-detector:a1b2c3d4-5678-90ab-cdef-example11111
+
+This command produces no output.
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-metric-filter.rst
+++ b/awscli/examples/logs/delete-metric-filter.rst
@@ -1,0 +1,11 @@
+**To delete the specified metric filter**
+
+The following ``delete-metric-filter`` example deletes the metric filter named ``demoFilter``. ::
+
+    aws logs delete-metric-filter \
+        --log-group-name demo-log-group \
+        --filter-name demoMetricFilter
+
+This command produces no output.
+
+For more information, see `Creating metrics from log events using filters <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-query-definition.rst
+++ b/awscli/examples/logs/delete-query-definition.rst
@@ -1,0 +1,14 @@
+**To delete a CloudWatch Logs Insights query definition**
+
+The following ``delete-query-definition`` example deletes a saved CloudWatch Logs Insights query definition. ::
+
+    aws logs delete-query-definition \
+        --query-definition-id a1b2c3d4-5678-90ab-cdef-example11111
+
+Output::
+
+    {
+        "success": true
+    }
+
+For more information, see `Analyzing log data with CloudWatch Logs Insights <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-resource-policy.rst
+++ b/awscli/examples/logs/delete-resource-policy.rst
@@ -1,0 +1,10 @@
+**To delete a resource policy from the account**
+
+The following ``delete-resource-policy`` example deletes the resource policy named ``demo-logs-policy`` from the account. ::
+
+    aws logs delete-resource-policy \
+        --policy-name "demo-logs-policy"
+
+This command produces no output.
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/delete-subscription-filter.rst
+++ b/awscli/examples/logs/delete-subscription-filter.rst
@@ -1,0 +1,11 @@
+**To delete subscription filter**
+
+The following ``delete-subscription-filter`` example deletes the subscription filter named ``demo-subscription-filter``. ::
+
+    aws logs delete-subscription-filter \
+        --log-group-name demo-log-group \
+        --filter-name demo-subscription-filter
+
+This command produces no output.
+
+For more information, see `Real-time processing of log data with subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/describe-account-policies.rst
+++ b/awscli/examples/logs/describe-account-policies.rst
@@ -1,0 +1,23 @@
+**To return a list of all CloudWatch Logs account policies**
+
+The following ``describe-account-policies`` example returns a list of all CloudWatch Logs account policies in the account. ::
+
+    aws logs describe-account-policies \
+        --policy-type DATA_PROTECTION_POLICY
+
+Output::
+
+    {
+        "accountPolicies": [
+            {
+                "policyName": "Example_Data_Protection_Policy",
+                "policyDocument": "{\n\"Name\": \"ACCOUNT_DATA_PROTECTION_POLICY\",\n\"Description\": \"\",\n\"Version\": \"2021-06-01\",\n\"Statement\": [{\n\"Sid\": \"audit-policy\",\n\"DataIdentifier\": [\"arn:aws:dataprotection::aws:data-identifier/Address\", \"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\", \"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US\", \"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"],\n\"Operation\": {\n\"Audit\": {\n\"FindingsDestination\": {\n\"CloudWatchLogs\": {\n\"LogGroup\": \"AuditLogGroup\"\n}\n}\n}\n}\n}, {\n\"Sid\": \"redact-policy\",\n\"DataIdentifier\": [\"arn:aws:dataprotection::aws:data-identifier/Address\", \"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\", \"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US\", \"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"],\n\"Operation\": {\n\"Deidentify\": {\n\"MaskConfig\": {}\n}\n}\n}]\n}\n",
+                "lastUpdatedTime": 1724944519097,
+                "policyType": "DATA_PROTECTION_POLICY",
+                "scope": "ALL",
+                "accountId": "123456789012"
+            }
+        ]
+    }
+
+For more information, see `Account-level subscription filters <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters-AccountLevel.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-deliveries.rst
+++ b/awscli/examples/logs/describe-deliveries.rst
@@ -1,0 +1,26 @@
+**To retrieve a list of the deliveries**
+
+The following ``describe-deliveries`` example retrieves a list of the deliveries that have been created in the account. ::
+
+    aws logs describe-deliveries
+
+Output::
+
+    {
+        "deliveries": [
+            {
+                "id": "Example2abcde3eCK",
+                "arn": "arn:aws:logs:us-east-1:123456789012:delivery:Example2abcde3eCK",
+                "deliverySourceName": "demo-delivery-source",
+                "deliveryDestinationArn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination"
+            },
+            {
+                "id": "Example1abcde2eCK",
+                "arn": "arn:aws:logs:us-east-1:123456789012:delivery:Example1abcde2eCK",
+                "deliverySourceName": "example-delivery-source",
+                "deliveryDestinationArn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:example-delivery-destination"
+            }
+        ]
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-delivery-destinations.rst
+++ b/awscli/examples/logs/describe-delivery-destinations.rst
@@ -1,0 +1,38 @@
+**To retrieve a list of the delivery destinations**
+
+The following ``describe-delivery-destinations`` example retrieves a list of delivery destinations that have been created in the account. ::
+
+    aws logs describe-delivery-destinations
+
+Output::
+
+    {
+        "deliveryDestinations": [
+            {
+                "name": "KinesisFirehose",
+                "arn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:KinesisFirehose",
+                "deliveryDestinationType": "FH",
+                "deliveryDestinationConfiguration": {
+                    "destinationResourceArn": "arn:aws:firehose:us-east-1:123456789012:deliverystream/PUT-S3-Tlha6"
+                }
+            },
+            {
+                "name": "demo-delivery-destination",
+                "arn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination",
+                "deliveryDestinationType": "CWL",
+                "deliveryDestinationConfiguration": {
+                    "destinationResourceArn": "arn:aws:logs:us-east-1:123456789012:log-group:code-whisperer-logs:*"
+                }
+            },
+            {
+                "name": "example-delivery-destination",
+                "arn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:example-delivery-destination",
+                "deliveryDestinationType": "S3",
+                "deliveryDestinationConfiguration": {
+                    "destinationResourceArn": "arn:aws:s3:::code-whisperer-s3-bucket-test"
+                }
+            }
+        ]
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-delivery-sources.rst
+++ b/awscli/examples/logs/describe-delivery-sources.rst
@@ -1,0 +1,23 @@
+**To retrieve a list of the delivery sources**
+
+The following ``describe-delivery-sources`` example retrieves a list of the delivery sources that have been created in the account. ::
+
+    aws logs describe-delivery-sources
+
+Output::
+
+    {
+        "deliverySources": [
+            {
+                "name": "demo-delivery-source",
+                "arn": "arn:aws:logs:us-east-1:123456789012:delivery-source:demo-delivery-source",
+                "resourceArns": [
+                    "arn:aws:codewhisperer:us-east-1:123456789012:customization/ABC1DE2FGHI"
+                ],
+                "service": "codewhisperer",
+                "logType": "EVENT_LOGS"
+            }
+        ]
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-destinations.rst
+++ b/awscli/examples/logs/describe-destinations.rst
@@ -1,0 +1,21 @@
+**To list all your destinations**
+
+The following ``describe-destinations`` example lists all your destinations. ::
+
+    aws logs describe-destinations
+
+Output::
+
+    {
+        "destinations": [
+            {
+                "destinationName": "demoDestination",
+                "targetArn": "arn:aws:kinesis:us-east-1:123456789012:stream/RecipientStream",
+                "roleArn": "arn:aws:iam::123456789012:role/CWLtoKinesisRole",
+                "arn": "arn:aws:logs:us-east-1:123456789012:destination:demoDestination",
+                "creationTime": 1705327053863
+            }
+        ]
+    }
+
+For more information, see `Cross-account cross-Region subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CrossAccountSubscriptions.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-export-tasks.rst
+++ b/awscli/examples/logs/describe-export-tasks.rst
@@ -1,0 +1,31 @@
+**To list the export tasks**
+
+The following ``describe-export-tasks`` example lists the export tasks. ::
+
+    aws logs describe-export-tasks
+
+Output::
+
+    {
+        "exportTasks": [
+            {
+                "taskId": "a1b2c3d4-5678-90ab-cdef-example11111",
+                "taskName": "demo-log-group-1717179675832",
+                "logGroupName": "demo-log-group",
+                "from": 1716920453000,
+                "to": 1717093253000,
+                "destination": "S3BucketName",
+                "destinationPrefix": "S3BucketPrefix",
+                "status": {
+                    "code": "COMPLETED",
+                    "message": "Completed successfully"
+                },
+                "executionInfo": {
+                    "creationTime": 1717179676323,
+                    "completionTime": 1717179677871
+                }
+            }
+        ]
+    }
+
+For more information, see `Exporting log data to Amazon S3 <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/S3Export.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-metric-filters.rst
+++ b/awscli/examples/logs/describe-metric-filters.rst
@@ -1,0 +1,27 @@
+**To list the specified metric filters**
+
+The following ``describe-metric-filters`` example lists all metric filters. ::
+
+    aws logs describe-metric-filters
+
+Output::
+
+    {
+        "metricFilters": [
+            {
+                "filterName": "DemoFilter",
+                "filterPattern": "ERROR",
+                "metricTransformations": [
+                    {
+                        "metricName": "Demo_Error",
+                        "metricNamespace": "DemoNamespace",
+                        "metricValue": "1"
+                    }
+                ],
+                "creationTime": 1713432753126,
+                "logGroupName": "demo-log-group"
+            }
+        ]
+    }
+
+For more information, see `Creating metrics from log events using filters <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-queries.rst
+++ b/awscli/examples/logs/describe-queries.rst
@@ -1,0 +1,28 @@
+**To return a list of CloudWatch Logs Insights queries**
+
+The following ``describe-queries`` example returns a list of CloudWatch Logs Insights queries that are scheduled, running, or ran recently in this account. ::
+
+    aws logs describe-queries
+
+Output::
+
+    {
+        "queries": [
+            {
+                "queryId": "a1b2c3d4-5678-90ab-cdef-example11111",
+                "queryString": "SOURCE \"aws-cloudtrail-logs\" START=-3600s END=0s |\nstats count(*) by eventSource, eventName, awsRegion",
+                "status": "Complete",
+                "createTime": 1715501541961,
+                "logGroupName": "demo-log-group"
+            },
+            {
+                "queryId": "a1b2c3d4-5678-90ab-cdef-example22222",
+                "queryString": "SOURCE \"Test\" START=-2592000s END=0s |\nfields @timestamp, @message, @logStream, @log\n| sort @timestamp desc\n| limit 1000",
+                "status": "Complete",
+                "createTime": 1715501468030,
+                "logGroupName": "example-log-group"
+            }
+        ]
+    }
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-query-definitions.rst
+++ b/awscli/examples/logs/describe-query-definitions.rst
@@ -1,0 +1,32 @@
+**To return a list of saved CloudWatch Logs Insights query definitions**
+
+The following ``describe-query-definitions`` example returns a paginated list of your saved CloudWatch Logs Insights query definitions. ::
+
+    aws logs describe-query-definitions
+
+Output::
+
+    {
+        "queryDefinitions": [
+            {
+                "queryDefinitionId": "a1b2c3d4-5678-90ab-cdef-example11111",
+                "name": "Test/q1",
+                "queryString": "filter eventSource=\"ec2.amazonaws.com\"\n| stats count(*) as eventCount by eventName, awsRegion\n| sort eventCount desc",
+                "lastModified": 1715502206620,
+                "logGroupNames": [
+                    "demo-log-group"
+                ]
+            },
+            {
+                "queryDefinitionId": "a1b2c3d4-5678-90ab-cdef-example22222",
+                "name": "Test/q2",
+                "queryString": "fields @timestamp, @message\n| sort @timestamp asc\n| limit 20",
+                "lastModified": 1654327955303,
+                "logGroupNames": [
+                    "example-log-group"
+                ]
+            }
+        ]
+    }
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-resource-policies.rst
+++ b/awscli/examples/logs/describe-resource-policies.rst
@@ -1,0 +1,24 @@
+**To list the resource policies in this account**
+
+The following ``describe-resource-policies`` example returns the resource policies in this account. ::
+
+    aws logs describe-resource-policies
+
+Output::
+
+    {
+        "resourcePolicies": [
+            {
+                "policyName": "DemoPolicy",
+                "policyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"TrustEventsToStoreLogEvent\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"events.amazonaws.com\",\"delivery.logs.amazonaws.com\"]},\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Resource\":\"arn:aws:logs:us-east-2:123456789012:log-group:/*:*\"}]}",
+                "lastUpdatedTime": 1711439903440
+            },
+            {
+                "policyName": "ExamplePolicy",
+                "policyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Route53LogsToCloudWatchLogs\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"events.amazonaws.com\",\"delivery.logs.amazonaws.com\"]},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"arn:aws:logs:us-east-2:123456789012:log-group:/aws/events/*:*\"}]}",
+                "lastUpdatedTime": 1665917856059
+            }
+        ]
+    }
+
+For more information, see `Overview of managing access permissions to your CloudWatch Logs resources <Overview of managing access permissions to your CloudWatch Logs resources>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/describe-subscription-filters.rst
+++ b/awscli/examples/logs/describe-subscription-filters.rst
@@ -1,0 +1,23 @@
+**To list the subscription filters for the specified log group**
+
+The following ``describe-subscription-filters`` example lists the subscription filters for the log group named ``demo-log-group``. ::
+
+    aws logs describe-subscription-filters \
+        --log-group-name demo-log-group
+
+Output::
+
+    {
+        "subscriptionFilters": [
+            {
+                "filterName": "DemoSubscriptionFilter",
+                "logGroupName": "demo-log-group",
+                "filterPattern": "%AUTHORIZED%",
+                "destinationArn": "arn:aws:lambda:us-east-1:123456789012:function:Lambda-Subscription-Filter",
+                "distribution": "ByLogStream",
+                "creationTime": 1698474178292
+            }
+        ]
+    }
+
+For more information, see `Real-time processing of log data with subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/disassociate-kms-key.rst
+++ b/awscli/examples/logs/disassociate-kms-key.rst
@@ -1,0 +1,10 @@
+**To disassociate a KMS key with the log group**
+
+The following ``disassociate-kms-key`` example disassociates KMS key with the log group named ``demo-log-group``. ::
+
+    aws logs disassociate-kms-key \
+        --log-group-name demo-log-group
+
+This command produces no output.
+
+For more information, see `Encrypt log data in CloudWatch Logs using AWS Key Management Service <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/filter-log-events.rst
+++ b/awscli/examples/logs/filter-log-events.rst
@@ -1,0 +1,29 @@
+**To list or filter the log events from the specified log stream**
+
+The following ``filter-log-events`` example list all the log events from the log group named ``demo-log-group``. ::
+
+    aws logs filter-log-events \
+        --log-group-name demo-log-group
+
+Output::
+
+    {
+        "events": [
+            {
+                "logStreamName": "teststream",
+                "timestamp": 1712567843827,
+                "message": "Test MESSAGE1",
+                "ingestionTime": 1712567844822,
+                "eventId": "00091539120382912324200901570000096855579456010247667712"
+            },
+            {
+                "logStreamName": "2024/05/09/[$LATEST]abc1024",
+                "timestamp": 1712568068991,
+                "message": "Test MESSAGE2",
+                "ingestionTime": 1712568070017,
+                "eventId": "00001544141707904000000130886135001961903807164184002560"
+            }
+        ]
+    }
+
+For more information, see `Filter pattern syntax for metric filters, subscription filters, filter log events, and Live Tail <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-data-protection-policy.rst
+++ b/awscli/examples/logs/get-data-protection-policy.rst
@@ -1,0 +1,16 @@
+**To return information about a log group data protection policy**
+
+The following ``get-data-protection-policy`` example returns information about a log group data protection policy. ::
+
+    aws logs get-data-protection-policy \
+        --log-group-identifier "arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group"
+
+Output::
+
+    {
+        "logGroupIdentifier": "demo-log-group",
+        "policyDocument": "{\"Name\":\"data-protection-policy\",\"Description\":\"\",\"Version\":\"2021-06-01\",\"Statement\":[{\"Sid\":\"audit-policy\",\"DataIdentifier\":[\"arn:aws:dataprotection::aws:data-identifier/BankAccountNumber-US\"],\"Operation\":{\"Audit\":{\"FindingsDestination\":{\"CloudWatchLogs\":{\"LogGroup\":\"testloggroup\"}}}}},{\"Sid\":\"redact-policy\",\"DataIdentifier\":[\"arn:aws:dataprotection::aws:data-identifier/BankAccountNumber-US\"],\"Operation\":{\"Deidentify\":{\"MaskConfig\":{}}}}]}",
+        "lastUpdatedTime": 1715504021257
+    }
+
+For more information, see `Encrypt log data in CloudWatch Logs using AWS Key Management Service <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-delivery-destination-policy.rst
+++ b/awscli/examples/logs/get-delivery-destination-policy.rst
@@ -1,0 +1,16 @@
+**To retrieve delivery destination policy**
+
+The following ``get-delivery-destination`` example retrieves the policy for the delivery destination named ``demo-delivery-destination``. ::
+
+    aws logs get-delivery-destination-policy \
+        --delivery-destination-name demo-delivery-destination
+
+Output::
+
+    {
+        "policy": {
+            "deliveryDestinationPolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowLogDeliveryActions\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":\"logs:CreateDelivery\",\"Resource\":[\"arn:aws:logs:us-east-1:123456789012:delivery-source:*\",\"arn:aws:logs:us-east-1:123456789012:delivery:*\",\"arn:aws:logs:us-east-1:123456789012:delivery-destination:*\"]}]}"
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-delivery-destination.rst
+++ b/awscli/examples/logs/get-delivery-destination.rst
@@ -1,0 +1,21 @@
+**To retrieve information about a delivery destination**
+
+The following ``get-delivery-destination`` example retrieves complete information about the delivery destination named ``demo-delivery-destination``. ::
+
+    aws logs get-delivery-destination \
+        --name demo-delivery-destination
+
+Output::
+
+    {
+        "deliveryDestination": {
+            "name": "demo-delivery-destination",
+            "arn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination",
+            "deliveryDestinationType": "S3",
+            "deliveryDestinationConfiguration": {
+                "destinationResourceArn": "arn:aws:s3:::code-whisperer-s3-bucket-demo"
+            }
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-delivery-source.rst
+++ b/awscli/examples/logs/get-delivery-source.rst
@@ -1,0 +1,22 @@
+**To retrieve information about a delivery source**
+
+The following ``get-delivery-source`` example retrieves complete information about the delivery source named ``demo-delivery-source``. ::
+
+    aws logs get-delivery-source \
+        --name demo-delivery-source
+
+Output::
+
+    {
+        "deliverySource": {
+            "name": "demo-delivery-source",
+            "arn": "arn:aws:logs:us-east-1:123456789012:delivery-source:demo-delivery-source",
+            "resourceArns": [
+                "arn:aws:codewhisperer:us-east-1:123456789012:customization/ABC1DE2FGHI"
+            ],
+            "service": "codewhisperer",
+            "logType": "EVENT_LOGS"
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-delivery.rst
+++ b/awscli/examples/logs/get-delivery.rst
@@ -1,0 +1,20 @@
+**To retrieve information about a logical delivery**
+
+The following ``get-delivery`` example returns complete information about one logical delivery. ::
+
+    aws logs get-delivery \
+        --id Example1abcde2eCK 
+
+Output::
+
+    {
+        "delivery": {
+            "id": "Example1abcde2eCK",
+            "arn": "arn:aws:logs:us-east-1:123456789012:delivery:Example1abcde2eCK",
+            "deliverySourceName": "demo-delivery-source",
+            "deliveryDestinationArn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination",
+            "deliveryDestinationType": "CWL"
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-log-anomaly-detector.rst
+++ b/awscli/examples/logs/get-log-anomaly-detector.rst
@@ -1,0 +1,22 @@
+**To retrieve information about a log anomaly detector**
+
+The following ``get-log-anomaly-detector`` example retrieves information about a log anomaly detector. ::
+
+    aws logs get-log-anomaly-detector \
+        --anomaly-detector-arn arn:aws:logs:us-east-1:123456789012:anomaly-detector:b52e46a3-e66d-43bc-9b96-bb16d305cd42
+
+Output::
+
+    {
+        "detectorName": "demo_anomaly_detector",
+        "logGroupArnList": [
+            "arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group"
+        ],
+        "evaluationFrequency": "FIVE_MIN",
+        "anomalyDetectorStatus": "TRAINING",
+        "creationTimeStamp": 1729218987707,
+        "lastModifiedTimeStamp": 1729218987992,
+        "anomalyVisibilityTime": 7
+    }
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/get-log-group-fields.rst
+++ b/awscli/examples/logs/get-log-group-fields.rst
@@ -1,0 +1,14 @@
+**To return a list of the fields that are included in log events in the specified log group**
+
+The following ``get-log-group-fields`` example returns a list of the fields that are included in log events in the specified log group. ::
+
+    aws logs get-log-group-fields \
+        --log-group-name demo-log-group
+
+Output::
+
+    {
+        "logGroupFields": []
+    }
+
+For more information, see `Working with log groups and log streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/get-log-record.rst
+++ b/awscli/examples/logs/get-log-record.rst
@@ -1,0 +1,20 @@
+**To retrieve all of the fields and values of a single log event**
+
+The following ``get-log-record`` example retrieves all of the fields and values of a single log event. ::
+
+    aws logs get-log-record \
+        --log-record-pointer "ClQKGAoUODc3MzYyMTE0MTkzOnRlc3ROSFQQBxI0GhgCBl9OTrgAAAABgsQLrwAGZJl0wAAAB4IgASjqz+P7+DEw6s/j+/gxOAFAL0j2BVClAhgAIAEQABgB"
+
+Output::
+
+    {
+        "logRecord": {
+            "@ingestionTime": "1716099017288",
+            "@log": "123456789012:demo-log-group",
+            "@logStream": "DemoStream",
+            "@message": "Hello World",
+            "@timestamp": "1716099016682"
+        }
+    }
+
+For more information, see `Working with log groups and log streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/get-query-results.rst
+++ b/awscli/examples/logs/get-query-results.rst
@@ -1,0 +1,75 @@
+**To return the results from the specified query**
+
+The following ``get-query-results`` example returns the results from the specified query. ::
+
+    aws logs get-query-results \
+        --query-id 82765b94-d048-4ef8-87c1-fd19a76a9d8e
+
+Output::
+
+    {
+        "results": [
+            [
+                {
+                    "field": "@timestamp",
+                    "value": "2024-05-19 06:10:35.743"
+                },
+                {
+                    "field": "@message",
+                    "value": "Test BENCHMARK 3"
+                },
+                {
+                    "field": "@logStream",
+                    "value": "TestStream"
+                },
+                {
+                    "field": "@ptr",
+                    "value": "ClQKGAoUODc3MzYyMTE0MTkzOnRlc3ROSFQQARI0GhgCBmJoHCAAAAAAg5VGeQAGZJl2MAAAAQIgASjnpOT7+DEw3+Tk+/gxOAJAXkiwBlDfAhgAIAEQARgB"
+                }
+            ],
+            [
+                {
+                    "field": "@timestamp",
+                    "value": "2024-05-19 06:10:27.559"
+                },
+                {
+                    "field": "@message",
+                    "value": "Test BENCHMARK 2"
+                },
+                {
+                    "field": "@logStream",
+                    "value": "TestStream"
+                },
+                {
+                    "field": "@ptr",
+                    "value": "ClQKGAoUODc3MzYyMTE0MTkzOnRlc3ROSFQQARI0GhgCBmJoHCAAAAAAg5VGeQAGZJl2MAAAAQIgASjnpOT7+DEw3+Tk+/gxOAJAXkiwBlDfAhgAIAEQABgB"
+                }
+            ],
+            [
+                {
+                    "field": "@timestamp",
+                    "value": "2024-05-19 06:10:16.682"
+                },
+                {
+                    "field": "@message",
+                    "value": "Test BENCHMARK 1"
+                },
+                {
+                    "field": "@logStream",
+                    "value": "TestStream"
+                },
+                {
+                    "field": "@ptr",
+                    "value": "ClQKGAoUODc3MzYyMTE0MTkzOnRlc3ROSFQQBxI0GhgCBl9OTrgAAAABgsQLrwAGZJl0wAAAB4IgASjqz+P7+DEw6s/j+/gxOAFAL0j2BVClAhgAIAEQABgB"
+                }
+            ]
+        ],
+        "statistics": {
+            "recordsMatched": 3.0,
+            "recordsScanned": 3.0,
+            "bytesScanned": 141.0
+        },
+        "status": "Complete"
+    }
+
+For more information, see `Analyzing log data with CloudWatch Logs Insights <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/list-anomalies.rst
+++ b/awscli/examples/logs/list-anomalies.rst
@@ -1,0 +1,103 @@
+**To return a list of anomalies**
+
+The following ``list-anomalies`` example returns a list of anomalies that log anomaly detectors have found. ::
+
+    aws logs list-anomalies
+
+Output::
+
+    {
+        "anomalies": [
+            {
+                "anomalyId": "a1b2c3d4-5678-90ab-cdef-example11111",
+                "patternId": "12345678901abc12345def1a2b3c4d5f",
+                "anomalyDetectorArn": "arn:aws:logs:us-east-1:123456789012:anomaly-detector:a1b2c3d4-5678-90ab-cdef-example11111",
+                "patternString": "REPORT RequestId: <*>\tDuration: <*> ms\tBilled Duration: <*> ms\tMemory Size: <*> MB\tMax Memory Used: <*> MB\tInit Duration: <*> ms\t\n",
+                "patternRegex": "\\QREPORT RequestId: \\E.*\\Q\tDuration: \\E.*\\Q ms\tBilled Duration: \\E.*\\Q ms\tMemory Size: \\E.*\\Q MB\tMax Memory Used: \\E.*\\Q MB\tInit Duration: \\E.*\\Q ms\t\n\\E",
+                "priority": "LOW",
+                "firstSeen": 1727631180000,
+                "lastSeen": 1727631480000,
+                "description": "Unexpected value 508 for Duration 3",
+                "active": false,
+                "state": "Active",
+                "histogram": {
+                    "1727631180000": 1
+                },
+                "logSamples": [
+                    {
+                        "timestamp": 1727631190662,
+                        "message": "REPORT RequestId: a1b2c3d4-5678-90ab-cdef-example11111\tDuration: 507.04 ms\tBilled Duration: 508 ms\tMemory Size: 256 MB\tMax Memory Used: 98 MB\tInit Duration: 1075.35 ms\t\n"
+                    }
+                ],
+                "patternTokens": [
+                    {
+                        "dynamicTokenPosition": 0,
+                        "isDynamic": false,
+                        "tokenString": "REPORT",
+                        "enumerations": {}
+                    },
+                    {
+                        "dynamicTokenPosition": 1,
+                        "isDynamic": true,
+                        "tokenString": "<*>",
+                        "enumerations": {
+                            "a1b2c3d4-5678-90ab-cdef-example11111": 1
+                        }
+                    },
+                    {
+                        "dynamicTokenPosition": 3,
+                        "isDynamic": true,
+                        "tokenString": "<*>",
+                        "enumerations": {
+                            "508": 1
+                        }
+                    },
+                    {
+                        "dynamicTokenPosition": 4,
+                        "isDynamic": true,
+                        "tokenString": "<*>",
+                        "enumerations": {
+                            "256": 1
+                        }
+                    },
+                    {
+                        "dynamicTokenPosition": 0,
+                        "isDynamic": false,
+                        "tokenString": " ",
+                        "enumerations": {}
+                    },
+                    {
+                        "dynamicTokenPosition": 5,
+                        "isDynamic": true,
+                        "tokenString": "<*>",
+                        "enumerations": {
+                            "98": 1
+                        }
+                    },
+                    {
+                        "dynamicTokenPosition": 6,
+                        "isDynamic": true,
+                        "tokenString": "<*>",
+                        "enumerations": {
+                            "1075.35": 1
+                        }
+                    },
+                    {
+                        "dynamicTokenPosition": 0,
+                        "isDynamic": false,
+                        "tokenString": "\n",
+                        "enumerations": {}
+                    }
+                ],
+                "logGroupArnList": [
+                    "arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group"
+                ],
+                "suppressed": false,
+                "suppressedDate": 0,
+                "suppressedUntil": 0,
+                "isPatternLevelSuppression": false
+            }
+        ]
+    }
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/list-log-anomaly-detectors.rst
+++ b/awscli/examples/logs/list-log-anomaly-detectors.rst
@@ -1,0 +1,26 @@
+**To retrieve a list of log anomaly detectors**
+
+The following ``list-log-anomaly-detectors`` example retrieves a list of log anomaly detectors in the account. ::
+
+    aws logs list-log-anomaly-detectors
+
+Output::
+
+    {
+        "anomalyDetectors": [
+            {
+                "anomalyDetectorArn": "arn:aws:logs:us-east-1:123456789012:anomaly-detector:a1b2c3d4-5678-90ab-cdef-example11111",
+                "detectorName": "demo_anomaly_detector",
+                "logGroupArnList": [
+                    "arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group"
+                ],
+                "evaluationFrequency": "FIVE_MIN",
+                "anomalyDetectorStatus": "TRAINING",
+                "creationTimeStamp": 1729218987707,
+                "lastModifiedTimeStamp": 1729218987992,
+                "anomalyVisibilityTime": 7
+            }
+        ]
+    }
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/list-tags-for-resource.rst
+++ b/awscli/examples/logs/list-tags-for-resource.rst
@@ -1,0 +1,17 @@
+**To display the tags associated with a CloudWatch Logs resource**
+
+The following ``list-tags-for-resource`` example displays the tags associated with a CloudWatch Logs resource. ::
+
+    aws logs list-tags-for-resource \
+        --resource-arn arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group
+
+Output::
+
+    {
+        "tags": {
+            "stack": "Prod",
+            "team": "DevOps"
+        }
+    }
+
+For more information, see `Working with log groups and log streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/put-account-policy.rst
+++ b/awscli/examples/logs/put-account-policy.rst
@@ -1,0 +1,52 @@
+**To create an account-level data protection policy or subscription filter policy**
+
+The following ``put-account-policy`` example creates account-level data protection policy. ::
+
+    aws logs put-account-policy \
+        --policy-name Example_Data_Protection_Policy \
+        --policy-document file://policy.json \
+        --policy-type DATA_PROTECTION_POLICY \
+        --scope ALL
+
+Contents of ``policy.json``::
+
+    {
+        "Name": "ACCOUNT_DATA_PROTECTION_POLICY",
+        "Description": "",
+        "Version": "2021-06-01",
+        "Statement": [{
+            "Sid": "audit-policy",
+            "DataIdentifier": ["arn:aws:dataprotection::aws:data-identifier/Address", "arn:aws:dataprotection::aws:data-identifier/CreditCardNumber", "arn:aws:dataprotection::aws:data-identifier/DriversLicense-US", "arn:aws:dataprotection::aws:data-identifier/EmailAddress"],
+            "Operation": {
+                "Audit": {
+                    "FindingsDestination": {
+                        "CloudWatchLogs": {
+                            "LogGroup": "AuditLogGroup"
+                        }
+                    }
+                }
+            }
+        }, {
+            "Sid": "redact-policy",
+            "DataIdentifier": ["arn:aws:dataprotection::aws:data-identifier/Address", "arn:aws:dataprotection::aws:data-identifier/CreditCardNumber", "arn:aws:dataprotection::aws:data-identifier/DriversLicense-US", "arn:aws:dataprotection::aws:data-identifier/EmailAddress"],
+            "Operation": {
+                "Deidentify": {
+                    "MaskConfig": {}
+                }
+            }
+        }]
+    }
+
+Output::
+
+    {
+        "accountPolicy": {
+            "policyName": "Example_Data_Protection_Policy",
+            "policyDocument": "{\n\"Name\": \"ACCOUNT_DATA_PROTECTION_POLICY\",\n\"Description\": \"\",\n\"Version\": \"2021-06-01\",\n\"Statement\": [{\n\"Sid\": \"audit-policy\",\n\"DataIdentifier\": [\"arn:aws:dataprotection::aws:data-identifier/Address\", \"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\", \"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US\", \"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"],\n\"Operation\": {\n\"Audit\": {\n\"FindingsDestination\": {\n\"CloudWatchLogs\": {\n\"LogGroup\": \"AuditLogGroup\"\n}\n}\n}\n}\n}, {\n\"Sid\": \"redact-policy\",\n\"DataIdentifier\": [\"arn:aws:dataprotection::aws:data-identifier/Address\", \"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\", \"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US\", \"arn:aws:dataprotection::aws:data-identifier/EmailAddress\"],\n\"Operation\": {\n\"Deidentify\": {\n\"MaskConfig\": {}\n}\n}\n}]\n}\n",
+            "lastUpdatedTime": 1724941132142,
+            "policyType": "DATA_PROTECTION_POLICY",
+            "scope": "ALL"
+        }
+    }
+
+For more information, see `Account-level subscription filters <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters-AccountLevel.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-data-protection-policy.rst
+++ b/awscli/examples/logs/put-data-protection-policy.rst
@@ -1,0 +1,42 @@
+**To create a data protection policy for the specified log group**
+
+The following ``put-data-protection-policy`` example creates a data protection policy for the log group named ``demo-log-group``. ::
+
+    aws logs put-data-protection-policy \
+        --log-group-identifier demo-log-group \
+        --policy-document file://policy.json
+
+Contents of ``policy.json``::
+
+    {
+        "Name": "data-protection-policy",
+        "Description": "",
+        "Version": "2021-06-01",
+        "Statement": [{
+            "Sid": "audit-policy",
+            "DataIdentifier": ["arn:aws:dataprotection::aws:data-identifier/CreditCardNumber"],
+            "Operation": {
+                "Audit": {
+                    "FindingsDestination": {}
+                }
+            }
+        }, {
+            "Sid": "redact-policy",
+            "DataIdentifier": ["arn:aws:dataprotection::aws:data-identifier/CreditCardNumber"],
+            "Operation": {
+                "Deidentify": {
+                    "MaskConfig": {}
+                }
+            }
+        }]
+    }
+
+Output::
+
+    {
+        "logGroupIdentifier": "demo-log-group",
+        "policyDocument": "{\n\"Name\": \"data-protection-policy\",\n\"Description\": \"\",\n\"Version\": \"2021-06-01\",\n\"Statement\": [{\n\"Sid\": \"audit-policy\",\n\"DataIdentifier\": [\"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\"],\n\"Operation\": {\n\"Audit\": {\n\"FindingsDestination\": {}\n}\n}\n}, {\n\"Sid\": \"redact-policy\",\n\"DataIdentifier\": [\"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\"],\n\"Operation\": {\n\"Deidentify\": {\n\"MaskConfig\": {}\n}\n}\n}]\n}\n",
+        "lastUpdatedTime": 1725044223296
+    }
+
+For more information, see `Help protect sensitive log data with masking <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/mask-sensitive-log-data.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-delivery-destination-policy.rst
+++ b/awscli/examples/logs/put-delivery-destination-policy.rst
@@ -1,0 +1,40 @@
+**To create or assign an IAM policy to a destination**
+
+The following ``put-delivery-destination-policy`` example creates an IAM policy to a destination named ``demo-delivery-destination``. ::
+
+    aws logs put-delivery-destination-policy \
+        --delivery-destination-name demo-delivery-destination \
+        --delivery-destination-policy file://policy.json
+
+Contents of ``policy.json``::
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowLogDeliveryActions",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "arn:aws:iam::123456789012:root"
+                },
+                "Action": [
+                    "logs:CreateDelivery"
+                ],
+                "Resource": [
+                    "arn:aws:logs:us-east-1:123456789012:delivery-source:*",
+                    "arn:aws:logs:us-east-1:123456789012:delivery:*",
+                    "arn:aws:logs:us-east-1:123456789012:delivery-destination:*"
+                ]
+            }
+        ]
+    }
+
+Output::
+
+    {
+        "policy": {
+            "deliveryDestinationPolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowLogDeliveryActions\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::123456789012:root\"},\"Action\":\"logs:CreateDelivery\",\"Resource\":[\"arn:aws:logs:us-east-1:123456789012:delivery-source:*\",\"arn:aws:logs:us-east-1:123456789012:delivery:*\",\"arn:aws:logs:us-east-1:123456789012:delivery-destination:*\"]}]}"
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-delivery-destination.rst
+++ b/awscli/examples/logs/put-delivery-destination.rst
@@ -1,0 +1,22 @@
+**To create or update a logical delivery destination**
+
+The following ``put-delivery-destination`` example creates a logical delivery destination named ``demo-delivery-destination``. ::
+
+    aws logs put-delivery-destination \
+        --name demo-delivery-destination \
+        --delivery-destination-configuration 'destinationResourceArn=arn:aws:s3:::code-whisperer-s3-bucket-demo'
+
+Output::
+
+    {
+        "deliveryDestination": {
+            "name": "demo-delivery-destination",
+            "arn": "arn:aws:logs:us-east-1:123456789012:delivery-destination:demo-delivery-destination",
+            "deliveryDestinationType": "S3",
+            "deliveryDestinationConfiguration": {
+                "destinationResourceArn": "arn:aws:s3:::doc-example-bucket"
+            }
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-delivery-source.rst
+++ b/awscli/examples/logs/put-delivery-source.rst
@@ -1,0 +1,24 @@
+**To create or update a logical delivery source**
+
+The following ``put-delivery-source`` example creates a logical delivery source named ``demo-delivery-source``. ::
+
+    aws logs put-delivery-source \
+        --name demo-delivery-source \
+        --resource-arn arn:aws:codewhisperer:us-east-1:123456789012:customization/ABC1DE2FGHI \
+        --log-type EVENT_LOGS
+
+Output::
+
+    {
+        "deliverySource": {
+            "name": "demo-delivery-source",
+            "arn": "arn:aws:logs:us-east-1:123456789012:delivery-source:demo-delivery-source",
+            "resourceArns": [
+                "arn:aws:codewhisperer:us-east-1:123456789012:customization/ABC1DE2FGHI"
+            ],
+            "service": "codewhisperer",
+            "logType": "EVENT_LOGS"
+        }
+    }
+
+For more information, see `Enable logging from AWS services <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-destination-policy.rst
+++ b/awscli/examples/logs/put-destination-policy.rst
@@ -1,0 +1,29 @@
+**To create or update an access policy associated with an existing destination**
+
+The following ``put-destination-policy`` example creates an access policy associated with an existing destination named ``demo-destination``. ::
+
+    aws logs put-destination-policy \
+        --destination-name 'demo-destination' \
+        --access-policy file://policy.json
+
+Contents of ``policy.json``::
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "logs:*",
+            "Resource": "arn:aws:logs:us-east-1:123456789012:destination:demo-destination",
+            "Condition": {
+                "StringEquals": {
+                    "aws:PrincipalOrgID": ["o-abc123"]
+                }
+            }
+        }]
+    }
+
+This command produces no output.
+
+For more information, see `Cross-account cross-Region subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CrossAccountSubscriptions.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-destination.rst
+++ b/awscli/examples/logs/put-destination.rst
@@ -1,0 +1,23 @@
+**To create or update a destinatione**
+
+The following ``put-destination`` example creates a destination named ``demo-destination``. ::
+
+    aws logs put-destination \
+        --destination-name 'demo-destination' \
+        --target-arn 'arn:aws:kinesis:us-east-1:123456789012:stream/RecipientStream' \
+        --role-arn 'arn:aws:iam::123456789012:role/CWLtoKinesisRole'
+
+Output::
+
+    {
+        "destination": {
+            "destinationName": "demo-destination",
+            "targetArn": "arn:aws:kinesis:us-east-1:123456789012:stream/RecipientStream",
+            "roleArn": "arn:aws:iam::123456789012:role/CWLtoKinesisRole",
+            "accessPolicy": "{ \n\"Version\":\"2012-10-17\",\n\"Statement\":[ \n{ \n\"Sid\" : \"\", \n\"Effect\" : \"Allow\",\n\"Principal\" : \"*\",\n\"Action\" : \"logs:*\", \n\"Resource\" : \"arn:aws:logs:us-east-1:123456789012:destination:demo-destination\",\n\"Condition\": {\n\"StringEquals\" : {\n\"aws:PrincipalOrgID\" : [\"o-123abc\"]\n}\n}\n } \n] \n}\n",
+            "arn": "arn:aws:logs:us-east-1:123456789012:destination:demo-destination",
+            "creationTime": 1708522050176
+        }
+    }
+
+For more information, see `Cross-account cross-Region subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CrossAccountSubscriptions.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-metric-filter.rst
+++ b/awscli/examples/logs/put-metric-filter.rst
@@ -1,0 +1,13 @@
+**To create or update a metric filter**
+
+The following ``put-metric-filter`` example creates a a metric filter named ``DemoFilter``. ::
+
+    aws logs put-metric-filter \
+        --log-group-name demo-log-group \
+        --filter-name DemoFilter \
+        --filter-pattern ERROR \
+        --metric-transformations metricName=DemoMetric,metricNamespace=DemoNamespace,metricValue=1,defaultValue=0,unit=Seconds 
+
+This command produces no output.
+
+For more information, see `Creating metrics from log events using filters <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-query-definition.rst
+++ b/awscli/examples/logs/put-query-definition.rst
@@ -1,0 +1,16 @@
+**To create or update a query definition for CloudWatch Logs Insights**
+
+The following ``put-query-definition`` example creates a query definition for CloudWatch Logs Insights. ::
+
+    aws logs put-query-definition \
+        --name DemoLogsQueries/Example \
+        --log-group-names arn:aws:logs:us-east-1:123456789012:log-group:demo-log-group \
+        --query-string 'stats sum(packets) as packetsTransferred by srcAddr, dstAddr | sort packetsTransferred desc | limit 100'
+
+Output::
+
+    {
+        "queryDefinitionId": "e4ff10e7-144a-4f14-9aef-fbb8f6dd9e6a"
+    }
+
+For more information, see `Analyzing log data with CloudWatch Logs Insights <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-resource-policy.rst
+++ b/awscli/examples/logs/put-resource-policy.rst
@@ -1,0 +1,40 @@
+**To create or update a resource policy**
+
+The following ``put-resource-policy`` example creates a resource policy allowing EventBridge service to put log events to this account. ::
+
+    aws logs put-resource-policy \
+        --policy-name AllowEventBridgeEventsToCWLogs \
+        --policy-document file://policy.json
+
+Contents of ``policy.json``::
+
+    {
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Sid": "TrustEventsToStoreLogEvent",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [
+                    "events.amazonaws.com",
+                    "delivery.logs.amazonaws.com"
+                ]
+            }
+            "Action": [
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/events/*:*"
+        }]
+    }
+
+Output::
+
+    {
+        "resourcePolicy": {
+            "policyName": "AllowEventBridgeEventsToCWLogs",
+            "policyDocument": "{\n\"Version\": \"2012-10-17\",\n\"Statement\": [{\n\"Sid\": \"TrustEventsToStoreLogEvent\",\n\"Effect\": \"Allow\",\n\"Principal\": {\n\"Service\": [\"events.amazonaws.com\", \"delivery.logs.amazonaws.com\"]\n},\n\"Action\": [\"logs:CreateLogStream\", \"logs:PutLogEvents\"],\n\"Resource\": \"arn:aws:logs:us-east-1:123456789012:log-group:/aws/events/*:*\"\n}]\n}\n",
+            "lastUpdatedTime": 1724943159296
+        }
+    }
+
+For more information, see `Overview of managing access permissions to your CloudWatch Logs resources <Overview of managing access permissions to your CloudWatch Logs resources>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/put-subscription-filter.rst
+++ b/awscli/examples/logs/put-subscription-filter.rst
@@ -1,0 +1,14 @@
+**To create or update a subscription filter**
+
+The following ``put-subscription-filter`` example creates a subscription filter for the log group ``demo-log-group``. ::
+
+    aws logs put-subscription-filter \
+        --log-group-name  'demo-log-group' \
+        --filter-name 'RootAccess' \
+        --filter-pattern '{$.userIdentity.type = Root}' \
+        --destination-arn 'arn:aws:kinesis:us-east-1:123456789012:stream/DemoStream' \
+        --role-arn 'arn:aws:iam::123456789012:role/DemoCWLtoKinesisRole'
+
+This command produces no output.
+
+For more information, see `Real-time processing of log data with subscriptions <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Subscriptions.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/start-query.rst
+++ b/awscli/examples/logs/start-query.rst
@@ -1,0 +1,18 @@
+**To schedule a query of a log group using CloudWatch Logs Insights**
+
+The following ``start-query`` example performs CloudWatch Logs Insights query on the log group ``demo-log-group`` to find 25 most recently added log events. ::
+
+    aws logs start-query \
+        --log-group-name demo-log-group \
+        --start-time 1712829536000 \
+        --end-time 1712833136000 \
+        --query-string 'fields @timestamp, @message | sort @timestamp desc' \
+        --limit 25
+
+Output::
+
+    {
+        "queryId": "2dac81d5-a6a5-45d7-b355-c842b1a7c0c5"
+    }
+
+For more information, see `Analyzing log data with CloudWatch Logs Insights <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/stop-query.rst
+++ b/awscli/examples/logs/stop-query.rst
@@ -1,0 +1,14 @@
+**To stop a CloudWatch Logs Insights query**
+
+The following ``stop-query`` example stops a CloudWatch Logs Insights query that is in progress. ::
+
+    aws logs stop-query \
+        --query-id 32b642be-fe54-4b28-a62c-c27fb768a1e2
+
+Output::
+
+    {
+        "success": true
+    }
+
+For more information, see `Analyzing log data with CloudWatch Logs Insights <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/tag-resource.rst
+++ b/awscli/examples/logs/tag-resource.rst
@@ -1,0 +1,11 @@
+**To assign one or more tags to the specified CloudWatch Logs resource.**
+
+The following ``tag-resource`` example tags a log group named ``demo-log-group``. ::
+
+    aws logs tag-resource \
+        --resource-arn arn:aws:logs:us-east-1:123456789:log-group:demo-log-group \
+        --tags team=Devops
+
+This command produces no output.
+
+For more information, see `Working with log groups and log streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/test-metric-filter.rst
+++ b/awscli/examples/logs/test-metric-filter.rst
@@ -1,0 +1,26 @@
+**To test the filter pattern of a metric filter**
+
+The following ``test-metric-filter`` example tests the filter pattern ``ERROR`` against a sample of log event messages. ::
+
+    aws logs test-metric-filter \
+        --filter-pattern ERROR \
+        --log-event-messages "[ERROR] 400 BAD REQUEST" "[ERROR] 400 BAD REQUEST" "[INFO] 200 OK"
+
+Output::
+
+    {
+        "matches": [
+            {
+                "eventNumber": 1,
+                "eventMessage": "[ERROR] 400 BAD REQUEST",
+                "extractedValues": {}
+            },
+            {
+                "eventNumber": 2,
+                "eventMessage": "[ERROR] 400 BAD REQUEST",
+                "extractedValues": {}
+            }
+        ]
+    }
+
+For more information, see `Creating metrics from log events using filters <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/MonitoringLogData.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/untag-resource.rst
+++ b/awscli/examples/logs/untag-resource.rst
@@ -1,0 +1,11 @@
+**To remove one or more tags from the specified resource.**
+
+The following ``untag-resource`` example removes the tag with the key ``team`` from log group named ``demo-log-group``. ::
+
+    aws logs untag-resource \
+        --resource-arn arn:aws:logs:us-east-1:123456789:log-group:demo-log-group \
+        --tag-keys team
+
+This command produces no output.
+
+For more information, see `Working with log groups and log streams <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html>`__ in the *Amazon CloudWatch User Guide*.

--- a/awscli/examples/logs/update-anomaly.rst
+++ b/awscli/examples/logs/update-anomaly.rst
@@ -1,0 +1,13 @@
+**To suppress anomaly detection**
+
+The following ``update-anomaly`` example suppress anomaly detection for a specified anomaly or pattern. ::
+
+    aws logs update-anomaly \
+        --anomaly-detector-arn arn:aws:logs:us-east-1:123456789012:anomaly-detector:a1b2c3d4-5678-90ab-cdef-example11111 \
+        --anomaly-id a1b2c3d4-5678-90ab-cdef-example12345 \
+        --suppression-type LIMITED \
+        --suppression-period value=60,suppressionUnit=SECONDS
+
+This command produces no output.
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.

--- a/awscli/examples/logs/update-log-anomaly-detector.rst
+++ b/awscli/examples/logs/update-log-anomaly-detector.rst
@@ -1,0 +1,12 @@
+**To update a log anomaly detector**
+
+The following ``update-log-anomaly-detector`` example updates evaluation frequency of a log anomaly detector to ONE_HOUR. ::
+
+    aws logs update-log-anomaly-detector \
+        --anomaly-detector-arn arn:aws:logs:us-east-1:123456789012:anomaly-detector:a1b2c3d4-5678-90ab-cdef-example11111 \
+        --evaluation-frequency="ONE_HOUR" \
+        --enabled
+
+This command produces no output.
+
+For more information, see `Log anomaly detection <https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/LogsAnomalyDetection.html>`__ in the *Amazon CloudWatch Logs User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add example CLI commands for Amazon CloudWatch Logs: https://docs.aws.amazon.com/cli/latest/reference/logs/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.