### PR TITLE
Revert "Use CRT for cloudfront url signing"

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -10,12 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import hashlib
 import sys
 import time
 import random
 
-from awscrt.crypto import RSA, RSASignatureAlgorithm
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 
 from botocore.utils import parse_to_aware_datetime
 from botocore.signers import CloudFrontSigner
@@ -256,11 +258,9 @@ class SignCommand(BasicCommand):
 
 class RSASigner(object):
     def __init__(self, private_key):
+        backend = default_backend()
         key_bytes = private_key.encode('utf8')
-        self.priv_key = RSA.new_private_key_from_pem_data(key_bytes)
+        self.priv_key = load_pem_private_key(key_bytes, None, backend)
 
     def sign(self, message):
-        return self.priv_key.sign(
-            RSASignatureAlgorithm.PKCS1_5_SHA1,
-            hashlib.sha1(message).digest()
-        )
+        return self.priv_key.sign(message, PKCS1v15(), hashes.SHA1())


### PR DESCRIPTION
This reverts commit 2ecf7c5a32bc4256754ef5f291319d273c6c0bbb.

*Issue #, if available:*

*Description of changes:*

Switching from `cryptography` to `awscrt` for cryptographic operations lost the ability to use PKCS8-like public keys (those that start with a header `BEGIN PUBLIC KEY`). Reverting this change to restore the previous behavior until the functionality can be added to `awscrt`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
