### PR TITLE
Ignore Content-Length header when setting 'chunked' for Transfer-Encoding 

### DIFF
--- a/awscli/botocore/httpchecksum.py
+++ b/awscli/botocore/httpchecksum.py
@@ -388,7 +388,13 @@ def _apply_request_trailer_checksum(request):
         # Send the decoded content length if we can determine it. Some
         # services such as S3 may require the decoded content length
         headers["X-Amz-Decoded-Content-Length"] = str(content_length)
-
+        
+        if "Content-Length" in headers:
+            del headers["Content-Length"]
+            logger.debug(
+                "Removing the Content-Length header since 'chunked' is specified for Transfer-Encoding."
+            )
+    
     if isinstance(body, (bytes, bytearray)):
         body = io.BytesIO(body)
 

--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -1410,6 +1410,26 @@ class TestS3SigV4(BaseS3OperationTest):
         body = self.http_stubber.requests[0].body.read()
         self.assertIn(b"x-amz-checksum-crc64nvme:LF4AWqlYyh8", body)
 
+    def test_trailing_checksum_set_with_content_length_removes_header(self):
+        with self.http_stubber:
+            self.client.put_object(
+                Bucket="foo", Key="bar", Body="baz", ContentLength=123
+            )
+        sent_headers = self.get_sent_headers()
+        self.assertEqual(sent_headers["Content-Encoding"], b"aws-chunked")
+        self.assertEqual(sent_headers["Transfer-Encoding"], b"chunked")
+        self.assertEqual(
+            sent_headers["X-Amz-Trailer"], b"x-amz-checksum-crc64nvme"
+        )
+        self.assertEqual(sent_headers["X-Amz-Decoded-Content-Length"], b"3")
+        self.assertEqual(
+            sent_headers["x-amz-content-sha256"],
+            b"STREAMING-UNSIGNED-PAYLOAD-TRAILER",
+        )
+        body = self.http_stubber.requests[0].body.read()
+        self.assertIn(b"x-amz-checksum-crc64nvme:LF4AWqlYyh8", body)
+        self.assertNotIn("Content-Length", sent_headers)
+
     def test_trailing_checksum_set_empty_body(self):
         with self.http_stubber:
             self.client.put_object(Bucket='foo', Key='bar', Body='')

--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -1558,7 +1558,12 @@ class TestCanSendIntegerHeaders(BaseSessionTest):
 
     def test_int_values_with_sigv4(self):
         s3 = self.session.create_client(
-            's3', config=Config(signature_version='s3v4'))
+            "s3",
+            config=Config(
+                signature_version="s3v4",
+                request_checksum_calculation="when_required",
+            ),
+        )
         with ClientHTTPStubber(s3) as http_stubber:
             http_stubber.add_response()
             s3.upload_part(Bucket='foo', Key='bar', Body=b'foo',


### PR DESCRIPTION
> Note: This is the AWS CLI v2 version of https://github.com/boto/botocore/pull/3360

This PR removes the `Content-Length` header when a request is sent using chunked upload.

See the guidance below from [Signature Calculations for the Authorization Header: Transferring Payload in Multiple Chunks](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html) for more details 

> When transferring data in a series of chunks, you must do one of the following:
>
>Explicitly specify the total content length (object length in bytes plus metadata in each chunk) using the Content-Length >HTTP header. To do this, you must pre-compute the total length of the payload, including the metadata that you send in >each chunk, before starting your request.
>
>Specify the Transfer-Encoding HTTP header. If you include the Transfer-Encoding header and specify any value other >than identity, you must omit the Content-Length header.
>
>For all requests, you must include the x-amz-decoded-content-length header, specifying the size of the object in bytes.