### PR TITLE
Set inject_host_prefix to None for client config when setting global arguments

### DIFF
--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -118,7 +118,7 @@ def _resolve_timeout(session, parsed_args, arg_name):
 
 def _update_default_client_config(session, arg_name, arg_value):
     current_default_config = session.get_default_client_config()
-    new_default_config = Config(**{arg_name: arg_value})
+    new_default_config = Config(**{arg_name: arg_value}, inject_host_prefix=None)
     if current_default_config is not None:
         new_default_config = current_default_config.merge(new_default_config)
     session.set_default_client_config(new_default_config)


### PR DESCRIPTION
*Issue #, if available:*

Related: https://github.com/boto/botocore/pull/3361

*Description of changes:*

The ability to disable host prefix injection is being added to the Python SDK `botocore` via environment variables and configuration file. By default, the `Config` object sets `inject_host_prefix=True` when setting global argument values for all clients, which overrides the env variable or config file settings. 

This change sets it to `None` so the config store can resolve it (from `AWS_DISABLE_HOST_PREFIX_INJECTION` and `disable_host_prefix_injection`). The config store resolver has a default of `False` which maintains the current default behavior of adding the host prefix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
