### PR TITLE
[v2] Add protocols trait support

### DIFF
--- a/.changes/next-release/enhancement-protocols-59345.json
+++ b/.changes/next-release/enhancement-protocols-59345.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "protocols",
+  "description": "Added support for multiple protocols within a service based on performance priority."
+}

--- a/awscli/botocore/args.py
+++ b/awscli/botocore/args.py
@@ -45,6 +45,15 @@ VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG = (
     "when_required",
 )
 
+PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = (
+    'json',
+    'rest-json',
+    'rest-xml',
+    'query',
+    'ec2',
+)
+
+
 class ClientArgsCreator(object):
     def __init__(self, event_emitter, user_agent, response_parser_factory,
                  loader, exceptions_factory, config_store, user_agent_creator=None):
@@ -156,7 +165,7 @@ class ClientArgsCreator(object):
                             endpoint_bridge, region_name, endpoint_url,
                             is_secure, scoped_config):
         service_name = service_model.endpoint_prefix
-        protocol = service_model.metadata['protocol']
+        protocol = self._resolve_protocol(service_model)
         parameter_validation = True
         if client_config and not client_config.parameter_validation:
             parameter_validation = False
@@ -615,6 +624,23 @@ class ClientArgsCreator(object):
             config_key="response_checksum_validation",
             valid_options=VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG,
         )
+
+    def _resolve_protocol(self, service_model):
+        # We need to ensure `protocols` exists in the metadata before attempting to
+        # access it directly since referencing service_model.protocols directly will
+        # raise an UndefinedModelAttributeError if protocols is not defined
+        if service_model.metadata.get('protocols'):
+            for protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS:
+                if protocol in service_model.protocols:
+                    return protocol
+            raise botocore.exceptions.UnsupportedServiceProtocolsError(
+                botocore_supported_protocols=PRIORITY_ORDERED_SUPPORTED_PROTOCOLS,
+                service_supported_protocols=service_model.protocols,
+                service=service_model.service_name,
+            )
+        # If a service does not have a `protocols` trait, fall back to the legacy
+        # `protocol` trait
+        return service_model.protocol
 
     def _handle_checksum_config(
         self,

--- a/awscli/botocore/exceptions.py
+++ b/awscli/botocore/exceptions.py
@@ -751,3 +751,12 @@ class InvalidChecksumConfigError(BotoCoreError):
         'Unsupported configuration value for {config_key}. '
         'Expected one of {valid_options} but got {config_value}.'
     )
+
+
+class UnsupportedServiceProtocolsError(BotoCoreError):
+    """Error when a service does not use any protocol supported by botocore."""
+
+    fmt = (
+        'Botocore supports {botocore_supported_protocols}, but service {service} only '
+        'supports {service_supported_protocols}.'
+    )

--- a/awscli/botocore/model.py
+++ b/awscli/botocore/model.py
@@ -393,6 +393,10 @@ class ServiceModel(object):
         return self._get_metadata_property('protocol')
 
     @CachedProperty
+    def protocols(self):
+        return self._get_metadata_property('protocols')
+
+    @CachedProperty
     def endpoint_prefix(self):
         return self._get_metadata_property('endpointPrefix')
 

--- a/tests/functional/botocore/test_supported_protocols.py
+++ b/tests/functional/botocore/test_supported_protocols.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import pytest
+
+from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
+from botocore.loaders import Loader
+from botocore.session import get_session
+
+
+def _get_services_models_by_protocols_trait(has_protocol_trait):
+    session = get_session()
+    service_list = Loader().list_available_services('service-2')
+    for service in service_list:
+        service_model = session.get_service_model(service)
+        if ('protocols' in service_model.metadata) == has_protocol_trait:
+            yield service_model
+
+
+@pytest.mark.validates_models
+@pytest.mark.parametrize(
+    "service",
+    _get_services_models_by_protocols_trait(True),
+)
+def test_services_with_protocols_trait_have_supported_protocol(service):
+    service_supported_protocols = service.metadata.get('protocols', [])
+    message = f"No protocols supported for service {service.service_name}"
+    assert any(
+        protocol in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
+        for protocol in service_supported_protocols
+    ), message
+
+
+@pytest.mark.validates_models
+@pytest.mark.parametrize(
+    "service",
+    _get_services_models_by_protocols_trait(False),
+)
+def test_services_without_protocols_trait_have_supported_protocol(service):
+    message = f"Service protocol not supported for {service.service_name}"
+    assert (
+        service.metadata.get('protocol')
+        in PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
+    ), message

--- a/tests/unit/botocore/test_args.py
+++ b/tests/unit/botocore/test_args.py
@@ -17,12 +17,16 @@ import botocore.config
 from tests import get_botocore_default_config_mapping, mock, unittest
 
 from botocore import args
+from botocore.args import PRIORITY_ORDERED_SUPPORTED_PROTOCOLS
 from botocore import exceptions
 from botocore.client import ClientEndpointBridge
 from botocore.config import Config
 from botocore.configprovider import ConfigValueStore
+from botocore.exceptions import UnsupportedServiceProtocolsError
 from botocore.hooks import HierarchicalEmitter
 from botocore.model import ServiceModel
+from botocore.parsers import PROTOCOL_PARSERS
+from botocore.serialize import SERIALIZERS
 from botocore.useragent import UserAgentString
 
 
@@ -66,9 +70,12 @@ class TestCreateClientArgs(unittest.TestCase):
         service_model = mock.Mock(ServiceModel)
         service_model.service_name = service_name
         service_model.endpoint_prefix = service_name
+        service_model.protocol = 'query'
+        service_model.protocols = ['query']
         service_model.metadata = {
             'serviceFullName': 'MyService',
-            'protocol': 'query'
+            'protocol': 'query',
+            'protocols': ['query'],
         }
         service_model.operation_names = []
         return service_model
@@ -108,6 +115,19 @@ class TestCreateClientArgs(unittest.TestCase):
         }
         call_kwargs.update(**override_kwargs)
         return self.args_create.get_client_args(**call_kwargs)
+
+    def call_compute_client_args(self, **override_kwargs):
+        call_kwargs = {
+            'service_model': self.service_model,
+            'client_config': None,
+            'endpoint_bridge': self.bridge,
+            'region_name': self.region,
+            'is_secure': True,
+            'endpoint_url': self.endpoint_url,
+            'scoped_config': {},
+        }
+        call_kwargs.update(**override_kwargs)
+        return self.args_create.compute_client_args(**call_kwargs)
 
     def assert_create_endpoint_call(self, mock_endpoint, **override_kwargs):
         call_kwargs = {
@@ -521,6 +541,25 @@ class TestCreateClientArgs(unittest.TestCase):
         with self.assertRaises(exceptions.InvalidChecksumConfigError):
             self.call_get_client_args()
 
+    def test_protocol_resolution_without_protocols_trait(self):
+        del self.service_model.protocols
+        del self.service_model.metadata['protocols']
+        client_args = self.call_compute_client_args()
+        self.assertEqual(client_args['protocol'], 'query')
+
+    def test_protocol_resolution_picks_highest_supported(self):
+        self.service_model.protocol = 'query'
+        self.service_model.protocols = ['query', 'json']
+        client_args = self.call_compute_client_args()
+        self.assertEqual(client_args['protocol'], 'json')
+
+    def test_protocol_raises_error_for_unsupported_protocol(self):
+        self.service_model.protocols = ['wrongprotocol']
+        with self.assertRaisesRegex(
+            UnsupportedServiceProtocolsError, self.service_model.service_name
+        ):
+            self.call_compute_client_args()
+
 
 class TestEndpointResolverBuiltins(unittest.TestCase):
     def setUp(self):
@@ -734,3 +773,21 @@ class TestEndpointResolverBuiltins(unittest.TestCase):
             legacy_endpoint_url='https://my.legacy.endpoint.com',
         )
         self.assertEqual(bins['SDK::Endpoint'], None)
+
+
+class TestProtocolPriorityList:
+    def test_all_parsers_accounted_for(self):
+        assert set(PRIORITY_ORDERED_SUPPORTED_PROTOCOLS) == set(
+            PROTOCOL_PARSERS.keys()
+        ), (
+            "The map of protocol names to parsers is out of sync with the priority "
+            "ordered list of protocols supported by botocore"
+        )
+
+    def test_all_serializers_accounted_for(self):
+        assert set(PRIORITY_ORDERED_SUPPORTED_PROTOCOLS) == set(
+            SERIALIZERS.keys()
+        ), (
+            "The map of protocol names to serializers is out of sync with the "
+            "priority ordered list of protocols supported by botocore"
+        )


### PR DESCRIPTION
This is a port of https://github.com/boto/botocore/pull/3376 to our vendored botocore.

*Description of changes:*
* Add support for protocols trait on service models.
* Selects the highest priority supported protocol.
* Falls back to legacy `protocol` trait if service model does not define `protocols` trait.

*Description of tests:*
* Ran and passed all tests (unit, functional, integration, etc.)
* No further CLI-specific tests are needed because the CLI is protocol-agnostic; protocol behavior is fully contained within botocore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
