### PR TITLE
include aws_signing_helper to amazon/aws-cli

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,11 +125,13 @@ To use IAM Roles Anywhere, you must first complete the following:
 * Setup your trust anchors and profiles by following the `IAM Roles Anywhere documentation <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html>`
 
 Once you complete the pre-requisites, you can test your setup with the following::
-    docker run --rm -v </path/to/your/certificates>:</path/to/expose/your/certificates>:ro --entrypoint aws_signing_helper amazon/aws-cli --region <an AWS region code> --certificate </path/to/expose/your/certificates>/<yourcert.pem> --private-key </path/to/expose/your/certificates>/<yourprivatekey.pem> --profile-arn <your profile ARN> --role-arn <an AWS IAM ROLE ARN> --trust-anchor-arn <your trust anchor ARN>
+    docker run --rm -v </path/to/your/certificates>:</path/to/expose/your/certificates>:ro --entrypoint /usr/local/bin/aws_signing_helper amazon/aws-cli --region <an AWS region code> --certificate </path/to/expose/your/certificates>/<yourcert.pem> --private-key </path/to/expose/your/certificates>/<yourprivatekey.pem> --profile-arn <your profile ARN> --role-arn <an AWS IAM ROLE ARN> --trust-anchor-arn <your trust anchor ARN>
 
-To use it with the AWS CLI, first create a config file like this::
+To use it with the AWS CLI, first create a configuration file like this::
     [profile default]
-    credential_process = /usr/bin/aws_signing_helper --region <an AWS region code> --certificate </path/to/expose/your/certificates>/<yourcert.pem> --private-key </path/to/expose/your/certificates>/<yourprivatekey.pem> --profile-arn <your profile ARN> --role-arn <an AWS IAM ROLE ARN> --trust-anchor-arn <your trust anchor ARN>
+    credential_process = /usr/local/bin/aws_signing_helper --region <an AWS region code> --certificate </path/to/expose/your/certificates>/<yourcert.pem> --private-key </path/to/expose/your/certificates>/<yourprivatekey.pem> --profile-arn <your profile ARN> --role-arn <an AWS IAM ROLE ARN> --trust-anchor-arn <your trust anchor ARN>
+
+and place it in ~/.aws/config. If you place this else where, you will need to use that directory path for the next step.
 
 Then you can test an AWS command, like the following::
     docker run --rm -v </path/to/your/certificates>:</path/to/expose/your/certificates>:ro -v <path to your AWS config directory>:/root/.aws:ro amazon/aws-cli s3api list-buckets

--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ Before using aws-cli, you need to tell it about your AWS credentials.  You
 can do this in several ways:
 
 * Environment variables
+* `IAM Roles Anywhere <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/introduction.html>` with a public certificate and private key
 * Shared credentials file
 * Config file
 * IAM Role
@@ -119,6 +120,22 @@ To use environment variables, do the following::
     $ export AWS_ACCESS_KEY_ID=<access_key>
     $ export AWS_SECRET_ACCESS_KEY=<secret_key>
 
+To use IAM Roles Anywhere, you must first complete the following:
+* Have a public certificate and private key pair issued by your private certificate authority (CA). You well need the CA public certificate or an instance of `AWS Private CA <https://docs.aws.amazon.com/privateca/latest/userguide/PcaWelcome.html>` as well
+* Setup your trust anchors and profiles by following the `IAM Roles Anywhere documentation <https://docs.aws.amazon.com/rolesanywhere/latest/userguide/getting-started.html>`
+
+Once you complete the pre-requisites, you can test your setup with the following::
+    docker run --rm -v </path/to/your/certificates>:</path/to/expose/your/certificates>:ro --entrypoint aws_signing_helper amazon/aws-cli --region <an AWS region code> --certificate </path/to/expose/your/certificates>/<yourcert.pem> --private-key </path/to/expose/your/certificates>/<yourprivatekey.pem> --profile-arn <your profile ARN> --role-arn <an AWS IAM ROLE ARN> --trust-anchor-arn <your trust anchor ARN>
+
+To use it with the AWS CLI, first create a config file like this::
+    [profile default]
+    credential_process = /usr/bin/aws_signing_helper --region <an AWS region code> --certificate </path/to/expose/your/certificates>/<yourcert.pem> --private-key </path/to/expose/your/certificates>/<yourprivatekey.pem> --profile-arn <your profile ARN> --role-arn <an AWS IAM ROLE ARN> --trust-anchor-arn <your trust anchor ARN>
+
+Then you can test an AWS command, like the following::
+    docker run --rm -v </path/to/your/certificates>:</path/to/expose/your/certificates>:ro -v <path to your AWS config directory>:/root/.aws:ro amazon/aws-cli s3api list-buckets
+
+You must replace the following variables in the examples above::
+    * 
 To use the shared credentials file, create an INI formatted file like this::
 
     [default]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as installer
+FROM public.ecr.aws/amazonlinux/amazonlinux:2 AS installer
 ARG EXE_FILENAME=awscli-exe-linux-x86_64.zip
 COPY $EXE_FILENAME .
 RUN yum update -y \
@@ -9,7 +9,12 @@ RUN yum update -y \
   # into /usr/local/bin of the final stage without
   # accidentally copying over any other executables that
   # may be present in /usr/local/bin of the installer stage.
-  && ./aws/install --bin-dir /aws-cli-bin/
+  && ./aws/install --bin-dir /aws-cli-bin/ \
+  # build the IAM Roles Anywhere signing helper
+  && yum -y groupinstall 'Development Tools' && yum -y install golang-go \
+  && git clone https://github.com/aws/rolesanywhere-credential-helper.git \
+  && cd /rolesanywhere-credential-helper \
+  && make release
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
 RUN yum update -y \
@@ -17,5 +22,7 @@ RUN yum update -y \
   && yum clean all
 COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=installer /aws-cli-bin/ /usr/local/bin/
+COPY --from=installer /rolesanywhere-credential-helper/build/bin/* /usr/bin/
+
 WORKDIR /aws
 ENTRYPOINT ["/usr/local/bin/aws"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN yum update -y \
   && yum clean all
 COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=installer /aws-cli-bin/ /usr/local/bin/
-COPY --from=installer /rolesanywhere-credential-helper/build/bin/* /usr/bin/
+COPY --from=installer /rolesanywhere-credential-helper/build/bin/* /usr/local/bin/
 
 WORKDIR /aws
 ENTRYPOINT ["/usr/local/bin/aws"]


### PR DESCRIPTION
*Issue #9290 

*Description of changes:*
* add steps to build aws_signing_helper in installer stage
* copy aws_signing_helper from installer stage to final image
* add instructions how to use IAM Roles Anywhere with image


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
