### PR TITLE
Ignore .venv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,14 @@ nosetests.xml
 .idea*
 src/
 
+
+# Virtualenvs
+.venv
+venv
+env
+env2
+env3
+
 # CLI docs generation
 doc/source/aws_man_pages.json
 doc/source/reference


### PR DESCRIPTION
Add .venv and venv to our .gitignore file to avoid accidental inclusion.