### PR TITLE
Remove payload length cap from event stream messages, and correct checksum validation placement

### DIFF
--- a/.changes/next-release/enhancement-protocol-93756.json
+++ b/.changes/next-release/enhancement-protocol-93756.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "protocol",
+  "description": "The CLI no longer validates payload size for event streams. This is to facilitate varying payload requirements across AWS services."
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Ports the following botocore PRs to CLI V2:
1. https://github.com/boto/botocore/pull/3254
2. https://github.com/boto/botocore/pull/3371/
    * Note: I removed the now-unsued exception rather then deprecating, since V2 users can't be referencing it like boto users would. 

I manually tested a happy-path for `aws s3api select-object-content` since that's the sole command that uses this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
