### PR TITLE
Cloudformation deploy docs

### DIFF
--- a/.changes/next-release/enhancement-cloudformation-89421.json
+++ b/.changes/next-release/enhancement-cloudformation-89421.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``cloudformation``",
+  "description": "Clarifies the documentation of the CloudFormation deploy."
+}

--- a/.changes/next-release/enhancement-cloudformation-89421.json
+++ b/.changes/next-release/enhancement-cloudformation-89421.json
@@ -1,5 +1,0 @@
-{
-  "type": "enhancement",
-  "category": "``cloudformation``",
-  "description": "Clarifies the documentation of the CloudFormation deploy command."
-}

--- a/.changes/next-release/enhancement-cloudformation-89421.json
+++ b/.changes/next-release/enhancement-cloudformation-89421.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "``cloudformation``",
-  "description": "Clarifies the documentation of the CloudFormation deploy."
+  "description": "Clarifies the documentation of the CloudFormation deploy command."
 }

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -224,12 +224,13 @@ class DeployCommand(BasicCommand):
             'dest': 'fail_on_empty_changeset',
             'default': True,
             'help_text': (
-                'Control the exit code returned by the CLI when there are ' 
-                'no changes to be made to the stack. By default, '
-                'a non-zero exit code is returned, and this is the same '
-                'behavior that occurs when `--fail-on-empty-changeset` '
-                'is specified. If `--no-fail-on-empty-changeset` is '
-                'specified, then the CLI will return a zero exit code.'
+                'Specify if the CLI should return a non-zero exit code '
+                'when there are no changes to be made to the stack. By '
+                'default, a non-zero exit code is returned, and this is '
+                'the same behavior that occurs when '
+                '`--fail-on-empty-changeset` is specified. If '
+                '`--no-fail-on-empty-changeset` is specified, then the '
+                'CLI will return a zero exit code.'
             )
         },
         {

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -224,9 +224,12 @@ class DeployCommand(BasicCommand):
             'dest': 'fail_on_empty_changeset',
             'default': True,
             'help_text': (
-                'Specify if the CLI should return a non-zero exit code if '
-                'there are no changes to be made to the stack. The default '
-                'behavior is to return a non-zero exit code.'
+                'Control the exit code returned by the CLI when there are ' 
+                'no changes to be made to the stack. By default, '
+                'a non-zero exit code is returned, and this is the same '
+                'behavior that occurs when `--fail-on-empty-changeset` '
+                'is specified. If `--no-fail-on-empty-changeset` is '
+                'specified, then the CLI will return a zero exit code.'
             )
         },
         {


### PR DESCRIPTION
*Description of changes:*
- Clarifies the documentation of the `--fail-on-empty-changeset` and `--no-fail-on-empty-changeset` arguments of the `aws cloudformation deploy` command.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
