### PR TITLE
Add support for AWS_CLI_OUTPUT_ENCODING

### DIFF
--- a/.changes/next-release/enhancement-encoding-89319.json
+++ b/.changes/next-release/enhancement-encoding-89319.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "encoding",
+  "description": "Adds support for the ``AWS_CLI_OUTPUT_ENCODING`` environment variable, which can be used to override the locale's preferred encoding when the CLI is writing output."
+}

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -71,6 +71,8 @@ else:
 imap = map
 raw_input = input
 
+OUTPUT_ENCODING_ENV_VAR = 'AWS_CLI_OUTPUT_ENCODING'
+
 
 class StdinMissingError(Exception):
     def __init__(self):
@@ -120,7 +122,18 @@ def get_binary_stdout():
 
 
 def _get_text_writer(stream, errors):
+    set_preferred_output_encoding(stream)
     return stream
+
+
+def set_preferred_output_encoding(stream):
+    """
+    If the user specified AWS_CLI_OUTPUT_ENCODING, use that encoding
+    for the output stream. This is useful for Windows users since
+    PyInstaller 6 no longer honors PYTHONUTF8.
+    """
+    if OUTPUT_ENCODING_ENV_VAR in os.environ:
+        stream.reconfigure(encoding=os.environ[OUTPUT_ENCODING_ENV_VAR])
 
 
 def getpreferredencoding(*args, **kwargs):

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -71,6 +71,7 @@ class FullyBufferedFormatter(Formatter):
             # so that if anything wraps stdout we'll pick up those changes
             # (specifically colorama on windows wraps stdout).
             stream = self._get_default_stream()
+        compat.set_preferred_output_encoding(stream)
         # I think the interfaces between non-paginated
         # and paginated responses can still be cleaned up.
         if is_response_paginated(response):
@@ -157,6 +158,7 @@ class StreamedYAMLFormatter(Formatter):
     def __call__(self, command_name, response, stream=None):
         if stream is None:
             stream = self._get_default_stream()
+        compat.set_preferred_output_encoding(stream)
         response_stream = self._get_response_stream(response)
         for response in response_stream:
             try:

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -462,10 +462,18 @@ One option for UNIX systems is the ``LC_ALL`` environment variable. Setting
 ``LC_ALL=en_US.UTF-8``, for instance, would give you a United States English
 locale which is compatible with unicode.
 
-To set encoding used for text files different from the locale, you can use
+To set the encoding that is used when reading from text files, you can use the
 ``AWS_CLI_FILE_ENCODING`` environment variable. For example, if you use Windows
 with default encoding ``CP1252``, setting ``AWS_CLI_FILE_ENCODING=UTF-8`` would
 make CLI ignore locale encoding and open text files using ``UTF-8``.
+
+To set the encoding used for the CLI's output, you can use the
+``AWS_CLI_OUTPUT_ENCODING`` environment variable. For example, if you use Windows
+with default encoding ``CP1252``, setting ``AWS_CLI_OUTPUT_ENCODING=UTF-8`` would
+make CLI ignore the locale encoding and format its output using ``UTF-8``.
+
+Recent versions of the AWS CLI v2 may no longer respect Python's environment
+variables for configuring encoding, such as ``PYTHONUTF8`` and ``PYTHONIOENCODING``.
 
 Pager
 -----


### PR DESCRIPTION
*Issue #, if available:* N/A, should ship alongside #9194

#### Background
With the upgrade to PyInstaller 6 in #9194, CLIv2 no longer respects `PYTHONUTF8`. From the [PyInstaller changelog](https://pyinstaller.org/en/stable/CHANGES.html#id69):
> PyInstaller-frozen applications are not affected by the [PYTHONUTF8](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUTF8) environment variable anymore. To permanently enable or disable the UTF8 mode, use the X utf8_mode=1 or X utf_mode=0 [run-time option](https://pyinstaller.org/en/stable/spec-files.html#specifying-python-interpreter-options) when building the application. ([#7847](https://github.com/pyinstaller/pyinstaller/issues/7847))

We've previously recommended `PYTHONUTF8` to Windows users, see https://github.com/search?q=repo%3Aaws%2Faws-cli+PYTHONUTF8&type=issues

I'm hesitant to hardcode `X utf8_mode` at this point, as [PEP 686](https://peps.python.org/pep-0686/#backward-compatibility) cautions that this may be backwards incompatible for some Windows users (and we wouldn't have a mechanism to allow them to fallback to old behavior).

#### Changes
Now, the CLI will respect `AWS_CLI_OUTPUT_ENCODING` when writing output through one of the formatters or as the result of an exception. 

Users who cannot enable UTF-8 in the Windows locale settings can `$env:AWS_CLI_OUTPUT_ENCODING="UTF-8"`, to preserve similar behavior to `PYTHONUTF8` prior to us upgrading to PyInstaller 6.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
