### PR TITLE
[v2] CloudFormation deploy docs clarifcation

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -287,9 +287,13 @@ class DeployCommand(BasicCommand):
             'dest': 'fail_on_empty_changeset',
             'default': False,
             'help_text': (
-                'Specify if the CLI should return a non-zero exit code if '
-                'there are no changes to be made to the stack. The default '
-                'behavior is to return a zero exit code.'
+                'Specify if the CLI should return a non-zero exit code '
+                'when there are no changes to be made to the stack. By '
+                'default, a non-zero exit code is returned, and this is '
+                'the same behavior that occurs when '
+                '`--fail-on-empty-changeset` is specified. If '
+                '`--no-fail-on-empty-changeset` is specified, then the '
+                'CLI will return a zero exit code.'
             )
         },
         {

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -289,11 +289,11 @@ class DeployCommand(BasicCommand):
             'help_text': (
                 'Specify if the CLI should return a non-zero exit code '
                 'when there are no changes to be made to the stack. By '
-                'default, a non-zero exit code is returned, and this is '
+                'default, a zero exit code is returned, and this is '
                 'the same behavior that occurs when '
-                '`--fail-on-empty-changeset` is specified. If '
-                '`--no-fail-on-empty-changeset` is specified, then the '
-                'CLI will return a zero exit code.'
+                '`--no-fail-on-empty-changeset` is specified. If '
+                '`--fail-on-empty-changeset` is specified, then the '
+                'CLI will return a non-zero exit code.'
             )
         },
         {


### PR DESCRIPTION
*Description of changes:*
- Clarifies the documentation of the `--fail-on-empty-changeset` and `--no-fail-on-empty-changeset` arguments of the `aws cloudformation deploy` command.
- V2 port of #9316 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
