### PR TITLE
[v2] Fix sdist lockfile test

### DIFF
--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -29,7 +29,7 @@ def should_read_line(line):
 
 def read_lock_file(path):
     with open(path, 'r') as f:
-        lines = f.read().split('\n')
+        lines = f.read().strip('\n').split('\n')
 
     # Find source files
     source_files = get_source_files(lines)


### PR DESCRIPTION
[GitHub Action that runs on Python 3.12 and macOS 13 is failing sdist tests](https://github.com/aws/aws-cli/actions/runs/13552377342/job/37878861338?pr=9324) because 1 of the lockfiles is generated with a newline at the end. This commit strips leading/trailing newlines to ensure consistent comparisons.