### PR TITLE
[v2] User agent 2.1: Track client features

### DIFF
--- a/.changes/next-release/enhancement-useragent-38914.json
+++ b/.changes/next-release/enhancement-useragent-38914.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "useragent",
+  "description": "Update user agent string to include client feature use."
+}

--- a/awscli/botocore/args.py
+++ b/awscli/botocore/args.py
@@ -27,7 +27,7 @@ from botocore.endpoint import EndpointCreator
 from botocore.regions import EndpointResolverBuiltins as EPRBuiltins
 from botocore.regions import EndpointRulesetResolver
 from botocore.signers import RequestSigner
-from botocore.useragent import UserAgentString
+from botocore.useragent import UserAgentString, register_feature_id
 from botocore.utils import ensure_boolean, is_s3_accelerate_url
 
 logger = logging.getLogger(__name__)
@@ -180,6 +180,8 @@ class ClientArgsCreator(object):
             client_config=client_config,
             endpoint_url=endpoint_url,
         )
+        if configured_endpoint_url is not None:
+            register_feature_id('ENDPOINT_OVERRIDE')
 
         endpoint_config = self._compute_endpoint_config(
             service_name=service_name,

--- a/awscli/botocore/context.py
+++ b/awscli/botocore/context.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+NOTE: All classes and functions in this module are considered private and are
+subject to abrupt breaking changes. Please do not use them directly.
+"""
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from copy import deepcopy
+from dataclasses import dataclass, field
+from functools import wraps
+from typing import Set
+
+
+@dataclass
+class ClientContext:
+    """
+    Encapsulation of objects tracked within the ``_context`` context variable.
+
+    ``features`` is a set responsible for storing features used during
+    preparation of an AWS request. ``botocore.useragent.register_feature_id``
+    is used to add to this set.
+    """
+
+    features: Set[str] = field(default_factory=set)
+
+
+_context = ContextVar("_context")
+
+
+def get_context():
+    """Get the current ``_context`` context variable if set, else None."""
+    return _context.get(None)
+
+
+def set_context(ctx):
+    """Set the current ``_context`` context variable.
+
+    :type ctx: ClientContext
+    :param ctx: Client context object to set as the current context variable.
+
+    :rtype: contextvars.Token
+    :returns: Token object used to revert the context variable to what it was
+        before the corresponding set.
+    """
+    token = _context.set(ctx)
+    return token
+
+
+def reset_context(token):
+    """Reset the current ``_context`` context variable.
+
+    :type token: contextvars.Token
+    :param token: Token object to reset the context variable.
+    """
+    _context.reset(token)
+
+
+@contextmanager
+def start_as_current_context(ctx=None):
+    """
+    Context manager that copies the passed or current context object and sets
+    it as the current context variable. If no context is found, a new
+    ``ClientContext`` object is created. It mainly ensures the context variable
+    is reset to the previous value once the executed code returns.
+
+    Example usage:
+
+        def my_feature():
+            with start_as_current_context():
+                register_feature_id('MY_FEATURE')
+                pass
+
+    :type ctx: ClientContext
+    :param ctx: The client context object to set as the new context variable.
+        If not provided, the current or a new context variable is used.
+    """
+    current = ctx or get_context()
+    if current is None:
+        new = ClientContext()
+    else:
+        new = deepcopy(current)
+    token = set_context(new)
+    try:
+        yield
+    finally:
+        reset_context(token)
+
+
+def with_current_context(hook=None):
+    """
+    Decorator that wraps ``start_as_current_context`` and optionally invokes a
+    hook within the newly-set context. This is just syntactic sugar to avoid
+    indenting existing code under the context manager.
+
+    Example usage:
+
+        @with_current_context(partial(register_feature_id, 'MY_FEATURE'))
+        def my_feature():
+            pass
+
+    :type hook: callable
+    :param hook: A callable that will be invoked within the scope of the
+        ``start_as_current_context`` context manager.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with start_as_current_context():
+                if hook:
+                    hook()
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/awscli/botocore/crt/auth.py
+++ b/awscli/botocore/crt/auth.py
@@ -25,6 +25,7 @@ from botocore.auth import (
 )
 from botocore.compat import HTTPHeaders, parse_qs, urlsplit, urlunsplit
 from botocore.exceptions import NoCredentialsError
+from botocore.useragent import register_feature_id
 from botocore.utils import percent_encode_sequence
 
 
@@ -242,6 +243,7 @@ class CrtSigV4AsymAuth(BaseSigner):
         self._expiration_in_seconds = None
 
     def add_auth(self, request):
+        register_feature_id("SIGV4A_SIGNING")
         if self.credentials is None:
             raise NoCredentialsError()
 

--- a/awscli/botocore/paginate.py
+++ b/awscli/botocore/paginate.py
@@ -14,11 +14,14 @@
 import base64
 import json
 import logging
+from functools import partial
 from itertools import tee
 
 import jmespath
 from botocore.compat import zip
+from botocore.context import with_current_context
 from botocore.exceptions import PaginationError
+from botocore.useragent import register_feature_id
 from botocore.utils import merge_dicts, set_value_from_jmespath
 
 log = logging.getLogger(__name__)
@@ -325,6 +328,7 @@ class PageIterator(object):
                 # Yield result directly if it is not a list.
                 yield results
 
+    @with_current_context(partial(register_feature_id, 'PAGINATOR'))
     def _make_request(self, current_kwargs):
         return self._method(**current_kwargs)
 

--- a/awscli/botocore/session.py
+++ b/awscli/botocore/session.py
@@ -45,6 +45,7 @@ from botocore.configprovider import (
     ConfigValueStore,
     create_botocore_default_config_mapping,
 )
+from botocore.context import get_context, with_current_context
 from botocore.errorfactory import ClientExceptionsFactory
 from botocore.exceptions import (
     ConfigNotFound,
@@ -745,6 +746,7 @@ class Session(object):
     def lazy_register_component(self, name, component):
         self._components.lazy_register_component(name, component)
 
+    @with_current_context()
     def create_client(self, service_name, region_name=None,
                       use_ssl=True, verify=None, endpoint_url=None,
                       aws_access_key_id=None, aws_secret_access_key=None,
@@ -865,6 +867,8 @@ class Session(object):
             client_name=service_name,
             config_store=config_store,
         )
+
+        user_agent_creator.set_client_features(get_context().features)
 
         client_creator = botocore.client.ClientCreator(
             loader, endpoint_resolver, self.user_agent(), event_emitter,

--- a/awscli/botocore/useragent.py
+++ b/awscli/botocore/useragent.py
@@ -22,6 +22,7 @@ configuration options:
 * The ``user_agent_extra`` field in the :py:class:`botocore.config.Config`.
 
 """
+import logging
 import os
 import platform
 from copy import copy
@@ -29,8 +30,13 @@ from string import ascii_letters, digits
 from typing import NamedTuple, Optional
 
 from botocore import __version__ as botocore_version
+from botocore.context import get_context
 
-_USERAGENT_ALLOWED_CHARACTERS = ascii_letters + digits + "!$%&'*+-.^_`|~"
+
+logger = logging.getLogger(__name__)
+
+
+_USERAGENT_ALLOWED_CHARACTERS = ascii_letters + digits + "!$%&'*+-.^_`|~,"
 _USERAGENT_ALLOWED_OS_NAMES = (
     'windows',
     'linux',
@@ -47,12 +53,37 @@ _USERAGENT_PLATFORM_NAME_MAPPINGS = {'darwin': 'macos'}
 # using their existing values. Uses uppercase "B" with all other characters
 # lowercase.
 _USERAGENT_SDK_NAME = 'Botocore'
+_USERAGENT_FEATURE_MAPPINGS = {
+    'WAITER': 'B',
+    'PAGINATOR': 'C',
+    'S3_TRANSFER': 'G',
+    'ENDPOINT_OVERRIDE': 'N',
+    'SIGV4A_SIGNING': 'S',
+}
+
+
+def register_feature_id(feature_id):
+    """Adds metric value to the current context object's ``features`` set.
+    :type feature_id: str
+    :param feature_id: The name of the feature to register. Value must be a key
+        in the ``_USERAGENT_FEATURE_MAPPINGS`` dict.
+    """
+    ctx = get_context()
+    if ctx is None:
+        # Never register features outside the scope of a
+        # ``botocore.context.start_as_current_context`` context manager.
+        # Otherwise, the context variable won't be reset and features will
+        # bleed into all subsequent requests. Return instead of raising an
+        # exception since this function could be invoked in a public interface.
+        return
+    if val := _USERAGENT_FEATURE_MAPPINGS.get(feature_id):
+        ctx.features.add(val)
 
 
 def sanitize_user_agent_string_component(raw_str, allow_hash):
     """Replaces all not allowed characters in the string with a dash ("-").
 
-    Allowed characters are ASCII alphanumerics and ``!$%&'*+-.^_`|~``. If
+    Allowed characters are ASCII alphanumerics and ``!$%&'*+-.^_`|~,``. If
     ``allow_hash`` is ``True``, "#"``" is also allowed.
 
     :type raw_str: str
@@ -69,19 +100,41 @@ def sanitize_user_agent_string_component(raw_str, allow_hash):
     )
 
 
+class UserAgentComponentSizeConfig:
+    """
+    Configures the max size of a built user agent string component and the
+    delimiter used to truncate the string if the size is above the max.
+    """
+
+    def __init__(self, max_size_in_bytes: int, delimiter: str):
+        self.max_size_in_bytes = max_size_in_bytes
+        self.delimiter = delimiter
+        self._validate_input()
+
+    def _validate_input(self):
+        if self.max_size_in_bytes < 1:
+            raise ValueError(
+                f'Invalid `max_size_in_bytes`: {self.max_size_in_bytes}. '
+                'Value must be a positive integer.'
+            )
+
+
 class UserAgentComponent(NamedTuple):
     """
     Component of a Botocore User-Agent header string in the standard format.
 
-    Each component consists of a prefix, a name, and a value. In the string
-    representation these are combined in the format ``prefix/name#value``.
+    Each component consists of a prefix, a name, a value, and a size_config.
+    In the string representation these are combined in the format
+    ``prefix/name#value``.
 
-    This class is considered private and is subject to abrupt breaking changes.
+    ``size_config`` configures the max size and truncation strategy for the
+    built user agent string component.
     """
 
     prefix: str
     name: str
     value: Optional[str] = None
+    size_config: Optional[UserAgentComponentSizeConfig] = None
 
     def to_string(self):
         """Create string like 'prefix/name#value' from a UserAgentComponent."""
@@ -92,11 +145,39 @@ class UserAgentComponent(NamedTuple):
             self.name, allow_hash=False
         )
         if self.value is None or self.value == '':
-            return f'{clean_prefix}/{clean_name}'
-        clean_value = sanitize_user_agent_string_component(
-            self.value, allow_hash=True
-        )
-        return f'{clean_prefix}/{clean_name}#{clean_value}'
+            clean_string = f'{clean_prefix}/{clean_name}'
+        else:
+            clean_value = sanitize_user_agent_string_component(
+                self.value, allow_hash=True
+            )
+            clean_string = f'{clean_prefix}/{clean_name}#{clean_value}'
+        if self.size_config is not None:
+            clean_string = self._truncate_string(
+                clean_string,
+                self.size_config.max_size_in_bytes,
+                self.size_config.delimiter,
+            )
+        return clean_string
+
+    def _truncate_string(self, string, max_size, delimiter):
+        """
+        Pop ``delimiter``-separated values until encoded string is less than or
+        equal to ``max_size``.
+        """
+        orig = string
+        while len(string.encode('utf-8')) > max_size:
+            parts = string.split(delimiter)
+            parts.pop()
+            string = delimiter.join(parts)
+
+        if string == '':
+            logger.debug(
+                f"User agent component `{orig}` could not be truncated to "
+                f"`{max_size}` bytes with delimiter "
+                f"`{delimiter}` without losing all contents. "
+                f"Value will be omitted from user agent string."
+            )
+        return string
 
 
 class RawStringUserAgentComponent:
@@ -191,9 +272,9 @@ class UserAgentString:
         self._session_user_agent_extra = None
 
         self._client_config = None
-        self._uses_paginator = None
-        self._uses_waiter = None
-        self._uses_resource = None
+
+        # Component that can be set with ``set_client_features()``
+        self._client_features = None
 
     @classmethod
     def from_environment(cls):
@@ -231,6 +312,15 @@ class UserAgentString:
         self._session_user_agent_extra = session_user_agent_extra
         return self
 
+    def set_client_features(self, features):
+        """
+        Persist client-specific features registered before or during client
+        creation.
+        :type features: Set[str]
+        :param features: A set of client-specific features.
+        """
+        self._client_features = features
+
     def with_client_config(self, client_config):
         """
         Create a copy with all original values and client-specific values.
@@ -258,7 +348,7 @@ class UserAgentString:
 
         components = [
             *self._build_sdk_metadata(),
-            RawStringUserAgentComponent('ua/2.0'),
+            RawStringUserAgentComponent('ua/2.1'),
             *self._build_os_metadata(),
             *self._build_architecture_metadata(),
             *self._build_language_metadata(),
@@ -269,7 +359,9 @@ class UserAgentString:
             *self._build_extra(),
         ]
 
-        return ' '.join([comp.to_string() for comp in components])
+        return ' '.join(
+            [comp.to_string() for comp in components if comp.to_string()]
+        )
 
     def _build_sdk_metadata(self):
         """
@@ -396,12 +488,23 @@ class UserAgentString:
 
     def _build_feature_metadata(self):
         """
-        Build the features components of the User-Agent header string.
+        Build the features component of the User-Agent header string.
 
-        Botocore currently does not report any features. This may change in a
-        future version.
+        Returns a single component with prefix "m" followed by a list of
+        comma-separated metric values.
         """
-        return []
+        ctx = get_context()
+        context_features = set() if ctx is None else ctx.features
+        client_features = self._client_features or set()
+        features = client_features.union(context_features)
+        if not features:
+            return []
+        size_config = UserAgentComponentSizeConfig(1024, ',')
+        return [
+            UserAgentComponent(
+                'm', ','.join(features), size_config=size_config
+            )
+        ]
 
     def _build_config_metadata(self):
         """
@@ -470,6 +573,13 @@ class UserAgentString:
         if self._client_config.user_agent_extra:
             components.append(self._client_config.user_agent_extra)
         return ' '.join(components)
+
+    def rebuild_and_replace_user_agent_handler(
+        self, operation_name, request, **kwargs
+    ):
+        ua_string = self.to_string()
+        if request.headers.get('User-Agent'):
+            request.headers.replace_header('User-Agent', ua_string)
 
 
 def _get_crt_version():

--- a/awscli/botocore/waiter.py
+++ b/awscli/botocore/waiter.py
@@ -12,9 +12,13 @@
 # language governing permissions and limitations under the License.
 import logging
 import time
+from functools import partial
 
 import jmespath
+
+from botocore.context import with_current_context
 from botocore.docs.docstring import WaiterDocstring
+from botocore.useragent import register_feature_id
 from botocore.utils import get_service_module_name
 
 from . import xform_name
@@ -315,6 +319,7 @@ class Waiter(object):
         self.name = name
         self.config = config
 
+    @with_current_context(partial(register_feature_id, 'WAITER'))
     def wait(self, **kwargs):
         acceptors = list(self.config.acceptors)
         current_state = 'waiting'

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -22,6 +22,7 @@ import distro
 import botocore.session
 from botocore import xform_name
 from botocore.compat import copy_kwargs, OrderedDict
+from botocore.context import start_as_current_context
 from botocore.history import get_global_history_recorder
 from botocore.configprovider import InstanceVarProvider
 from botocore.configprovider import EnvironmentProvider
@@ -91,7 +92,8 @@ u''.encode('idna')
 
 
 def main():
-    return AWSCLIEntryPoint().main(sys.argv[1:])
+    with start_as_current_context():
+        return AWSCLIEntryPoint().main(sys.argv[1:])
 
 
 def create_clidriver(args=None):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -15,6 +15,7 @@ import logging
 import sys
 
 from botocore.client import Config
+from botocore.useragent import register_feature_id
 from botocore.utils import is_s3express_bucket, ensure_boolean
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
@@ -783,6 +784,7 @@ class PresignCommand(S3Command):
 class S3TransferCommand(S3Command):
     def _run_main(self, parsed_args, parsed_globals):
         super(S3TransferCommand, self)._run_main(parsed_args, parsed_globals)
+        register_feature_id('S3_TRANSFER')
         self._convert_path_args(parsed_args)
         params = self._get_params(parsed_args, parsed_globals, self._session)
         source_client, transfer_client = self._get_source_and_transfer_clients(

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -15,7 +15,6 @@ import logging
 import sys
 
 from botocore.client import Config
-from botocore.useragent import register_feature_id
 from botocore.utils import is_s3express_bucket, ensure_boolean
 from dateutil.parser import parse
 from dateutil.tz import tzlocal
@@ -784,7 +783,6 @@ class PresignCommand(S3Command):
 class S3TransferCommand(S3Command):
     def _run_main(self, parsed_args, parsed_globals):
         super(S3TransferCommand, self)._run_main(parsed_args, parsed_globals)
-        register_feature_id('S3_TRANSFER')
         self._convert_path_args(parsed_args)
         params = self._get_params(parsed_args, parsed_globals, self._session)
         source_client, transfer_client = self._get_source_and_transfer_clients(

--- a/awscli/s3transfer/crt.py
+++ b/awscli/s3transfer/crt.py
@@ -42,6 +42,7 @@ from botocore import UNSIGNED
 from botocore.compat import urlsplit
 from botocore.config import Config
 from botocore.exceptions import NoCredentialsError
+from botocore.useragent import register_feature_id
 from botocore.utils import ArnParser, InvalidArnException, is_s3express_bucket
 
 from s3transfer.constants import FULL_OBJECT_CHECKSUM_ARGS, MB
@@ -310,6 +311,7 @@ class CRTTransferManager:
         self._semaphore.release()
 
     def _submit_transfer(self, request_type, call_args):
+        register_feature_id('S3_TRANSFER')
         on_done_after_calls = [self._release_semaphore]
         coordinator = CRTTransferCoordinator(
             transfer_id=self._id_counter,

--- a/awscli/s3transfer/manager.py
+++ b/awscli/s3transfer/manager.py
@@ -15,6 +15,8 @@ import logging
 import re
 import threading
 
+from botocore.useragent import register_feature_id
+
 from s3transfer.bandwidth import BandwidthLimiter, LeakyBucket
 from s3transfer.constants import (
     ALLOWED_DOWNLOAD_ARGS,
@@ -524,6 +526,7 @@ class TransferManager:
     def _submit_transfer(
         self, call_args, submission_task_cls, extra_main_kwargs=None
     ):
+        register_feature_id('S3_TRANSFER')
         if not extra_main_kwargs:
             extra_main_kwargs = {}
 

--- a/tests/functional/test_useragent.py
+++ b/tests/functional/test_useragent.py
@@ -10,7 +10,7 @@ def assert_expected_user_agent(result, service, operation):
     assert ' md/arch#' in ua_string
     assert ' md/prompt#off' in ua_string
     assert f' md/command#{service}.{operation}' in ua_string
-    assert ' ua/2.0 ' in ua_string
+    assert ' ua/2.1 ' in ua_string
     assert ' os/' in ua_string
     assert ' lang/python' in ua_string
     assert ' cfg/' in ua_string

--- a/tests/functional/test_useragent.py
+++ b/tests/functional/test_useragent.py
@@ -31,3 +31,5 @@ def test_user_agent_for_customization():
     operation = 'ls'
     result = cli_runner.run([service, operation])
     assert_expected_user_agent(result, service, operation)
+    ua_string = result.aws_requests[0].http_requests[0].headers['User-Agent']
+    assert 'm/C' in ua_string

--- a/tests/unit/botocore/conftest.py
+++ b/tests/unit/botocore/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from botocore.context import ClientContext, reset_context, set_context
+
+
+@pytest.fixture
+def client_context():
+    ctx = ClientContext()
+    token = set_context(ctx)
+    yield ctx
+    reset_context(token)

--- a/tests/unit/botocore/test_context.py
+++ b/tests/unit/botocore/test_context.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+
+from botocore.context import (
+    ClientContext,
+    get_context,
+    reset_context,
+    set_context,
+    start_as_current_context,
+    with_current_context,
+)
+
+
+@pytest.fixture
+def custom_context():
+    ctx = ClientContext()
+    ctx.features.add('CUSTOM')
+    return ctx
+
+
+class TestContext:
+    def test_get_context_returns_none(self):
+        ctx = get_context()
+        assert ctx is None
+
+    def test_get_context_returns_current(self, client_context):
+        ctx = get_context()
+        assert ctx == client_context
+
+    def test_set_context(self, custom_context):
+        token = set_context(custom_context)
+        ctx = get_context()
+        assert ctx == custom_context
+        reset_context(token)
+
+    def test_start_as_current_context(self):
+        with start_as_current_context():
+            ctx = get_context()
+            ctx.features.add('FOO')
+            assert ctx.features == {'FOO'}
+        ctx = get_context()
+        assert ctx is None
+
+    def test_nested_start_as_current_context(self):
+        with start_as_current_context():
+            ctx = get_context()
+            ctx.features.add('FOO')
+            with start_as_current_context():
+                ctx = get_context()
+                ctx.features.add('BAR')
+                assert ctx.features == {'FOO', 'BAR'}
+            ctx = get_context()
+            assert ctx.features == {'FOO'}
+        ctx = get_context()
+        assert ctx is None
+
+    def test_start_as_current_context_with_param(self, custom_context):
+        with start_as_current_context(custom_context):
+            ctx = get_context()
+            assert ctx.features == {'CUSTOM'}
+
+    def test_with_current_context(self):
+        @with_current_context()
+        def do_something():
+            ctx = get_context()
+            assert ctx is not None
+
+        do_something()
+
+    def test_with_current_context_with_hook(self):
+        def register_fake():
+            ctx = get_context()
+            ctx.features.add('FOO')
+
+        @with_current_context(register_fake)
+        def do_something():
+            ctx = get_context()
+            assert ctx.features == {'FOO'}
+
+        do_something()


### PR DESCRIPTION
Ports https://github.com/boto/botocore/pull/3389 and https://github.com/boto/s3transfer/pull/335

I also added a CLI-specific change to wrap the CLI entrypoint under the `start_as_current_context` context manager so future work can add CLI-specific features.

```
> aws s3 cp myfile s3://mybucket
> aws history show

...
"User-Agent": "aws-cli/2.24.14 ... m/G cfg/retry-mode#standard ..."
...
```