### PR TITLE
Pin Python version of source dist tests until PyInstaller upgrade

### DIFF
--- a/.github/workflows/source-dist-tests.yml
+++ b/.github/workflows/source-dist-tests.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/source-dist-tests.yml
+++ b/.github/workflows/source-dist-tests.yml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # pinning specific versions of 3.9 and 3.10 until we upgrade to PyInstaller 6
+        python-version: ["3.8", "3.9.20", "3.10.15", "3.11", "3.12"]
         # macOS pinned to 13 due to 14+ defaulting to arm64 hardware
         os: [ubuntu-latest, macOS-13, windows-latest]
 

--- a/.github/workflows/source-dist-tests.yml
+++ b/.github/workflows/source-dist-tests.yml
@@ -17,7 +17,16 @@ jobs:
         python-version: ["3.8", "3.9.20", "3.10.15", "3.11", "3.12"]
         # macOS pinned to 13 due to 14+ defaulting to arm64 hardware
         os: [ubuntu-latest, macOS-13, windows-latest]
-
+        exclude: # setup-python doesn't build for Windows, and these are source-only
+          - os: windows-latest
+            python-version: "3.9.20"
+          - os: windows-latest
+            python-version: "3.10.15"
+        include: # but add back earlier patch versions for Windows
+          - os: windows-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Pinning the Python versions of 3.9 and 3.10 that are still compatible with our current PyInstaller version until we address the issues that led to #9332



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
