### PR TITLE
[v2] SSOTokenLoader Expiration Check

### DIFF
--- a/.changes/next-release/enhancement-sso-83899.json
+++ b/.changes/next-release/enhancement-sso-83899.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``sso``",
+  "description": "Updates legacy token auth flow to check if cached legacy tokens are expired according to the local clock. If expired, it will raise an ``UnauthorizedSSOTokenError`` instead of sending an expired token to Identity Center's ``GetRoleCredentials`` API."
+}

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -2050,11 +2050,8 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
             # raise an UnauthorizedSSOTokenError if the loaded legacy token
             # is expired to save a call to GetRoleCredentials with an
             # expired token.
-            print(f'expiresAt field to be passed to parse function: {token_dict["expiresAt"]}')
-            print(f'entire cached token: {token_dict}')
             expiration = dateutil.parser.parse(token_dict['expiresAt'])
             remaining = total_seconds(expiration - self._time_fetcher())
-            print(f'remaining: {remaining}')
             if remaining <= 0:
                 raise UnauthorizedSSOTokenError()
 

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -234,10 +234,6 @@ def _local_now():
     return datetime.datetime.now(tzlocal())
 
 
-def _utc_now():
-    return datetime.datetime.now(tzutc())
-
-
 def _parse_if_needed(value):
     if isinstance(value, datetime.datetime):
         return value
@@ -1995,7 +1991,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
     def __init__(self, start_url, sso_region, role_name, account_id,
                  client_creator, token_loader=None, cache=None,
                  expiry_window_seconds=None, token_provider=None,
-                 sso_session_name=None, time_fetcher=_utc_now):
+                 sso_session_name=None, time_fetcher=_local_now):
         self._client_creator = client_creator
         self._sso_region = sso_region
         self._role_name = role_name

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -1991,7 +1991,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
     def __init__(self, start_url, sso_region, role_name, account_id,
                  client_creator, token_loader=None, cache=None,
                  expiry_window_seconds=None, token_provider=None,
-                 sso_session_name=None, time_fetcher=_local_now):
+                 sso_session_name=None, time_fetcher=_utc_now):
         self._client_creator = client_creator
         self._sso_region = sso_region
         self._role_name = role_name

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -234,6 +234,10 @@ def _local_now():
     return datetime.datetime.now(tzlocal())
 
 
+def _utc_now():
+    return datetime.datetime.now(tzutc())
+
+
 def _parse_if_needed(value):
     if isinstance(value, datetime.datetime):
         return value

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -2050,6 +2050,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
             # raise an UnauthorizedSSOTokenError if the loaded legacy token
             # is expired to save a call to GetRoleCredentials with an
             # expired token.
+            print(f'expiresAt field to be passed to parse function: {token_dict["expiresAt"]}')
             expiration = dateutil.parser.parse(token_dict['expiresAt'])
             remaining = total_seconds(expiration - self._time_fetcher())
             if remaining <= 0:

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -1991,7 +1991,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
     def __init__(self, start_url, sso_region, role_name, account_id,
                  client_creator, token_loader=None, cache=None,
                  expiry_window_seconds=None, token_provider=None,
-                 sso_session_name=None):
+                 sso_session_name=None, time_fetcher=_local_now):
         self._client_creator = client_creator
         self._sso_region = sso_region
         self._role_name = role_name
@@ -2000,6 +2000,7 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
         self._token_loader = token_loader
         self._token_provider = token_provider
         self._sso_session_name = sso_session_name
+        self._time_fetcher = time_fetcher
         super(SSOCredentialFetcher, self).__init__(
             cache, expiry_window_seconds
         )
@@ -2049,8 +2050,8 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
             # raise an UnauthorizedSSOTokenError if the loaded legacy token
             # is expired to save a call to GetRoleCredentials with an
             # expired token.
-            expiration = dateutil.parser.parse(token_dict["expiresAt"])
-            remaining = total_seconds(expiration - _local_now())
+            expiration = dateutil.parser.parse(token_dict['expiresAt'])
+            remaining = total_seconds(expiration - self._time_fetcher())
             if remaining <= 0:
                 raise UnauthorizedSSOTokenError()
 

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -2051,8 +2051,10 @@ class SSOCredentialFetcher(CachedCredentialFetcher):
             # is expired to save a call to GetRoleCredentials with an
             # expired token.
             print(f'expiresAt field to be passed to parse function: {token_dict["expiresAt"]}')
+            print(f'entire cached token: {token_dict}')
             expiration = dateutil.parser.parse(token_dict['expiresAt'])
             remaining = total_seconds(expiration - self._time_fetcher())
+            print(f'remaining: {remaining}')
             if remaining <= 0:
                 raise UnauthorizedSSOTokenError()
 

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -308,10 +308,6 @@ def is_global_accesspoint(context):
     return is_global
 
 
-def _utc_now():
-    return datetime.datetime.now(tzutc())
-
-
 class _RetriesExceededError(Exception):
     """Internal exception used when the number of retries are exceeded."""
     pass

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -3672,6 +3672,12 @@ class SSOTokenLoader(object):
         cache_key = self._generate_cache_key(start_url, session_name)
         self._cache[cache_key] = token
 
+    def _is_expired(self):
+        # TODO get this hooked up
+        expiration = self._frozen_token.expiration
+        remaining = total_seconds(expiration - self._time_fetcher())
+        return remaining <= 0
+
     def __call__(self, start_url, session_name=None):
         cache_key = self._generate_cache_key(start_url, session_name)
         logger.debug(f'Checking for cached token at: {cache_key}')
@@ -3686,6 +3692,8 @@ class SSOTokenLoader(object):
         if 'accessToken' not in token or 'expiresAt' not in token:
             error_msg = f'Token for {start_url} is invalid'
             raise SSOTokenLoadError(error_msg=error_msg)
+
+        # TODO check if token is expired
         return token
 
 

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -74,7 +74,8 @@ from botocore.exceptions import (
     UnsupportedS3ArnError,
     UnsupportedS3ConfigurationError,
     UnsupportedS3ControlArnError,
-    UnsupportedS3ControlConfigurationError, UnauthorizedSSOTokenError,
+    UnsupportedS3ControlConfigurationError,
+    UnauthorizedSSOTokenError,
 )
 from dateutil.tz import tzutc
 from urllib3.exceptions import LocationParseError

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -596,10 +596,12 @@ class TestAssumeRole(BaseAssumeRoleTest):
                 'expiration': int(expiration),
             }
         }
+        print(f"roleCredentials mocked response: {sso_role_response}")
         sso_stubber.add_response('get_role_credentials', sso_role_response)
 
         expected_creds = self.create_random_credentials()
         assume_role_response = self.create_assume_role_response(expected_creds)
+        print(f"assume_role response created: {assume_role_response}")
         sts_stubber.add_response('assume_role', assume_role_response)
 
         actual_creds = session.get_credentials()

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 import sys
 
 import pytest
-from dateutil.tz import tzlocal
+from dateutil.tz import tzlocal, tzutc
 from botocore.exceptions import CredentialRetrievalError
 
 from tests import (
@@ -165,8 +165,8 @@ class BaseAssumeRoleTest(BaseEnvVar):
         shutil.rmtree(self.tempdir)
         super(BaseAssumeRoleTest, self).tearDown()
 
-    def some_future_time(self):
-        timeobj = datetime.now(tzlocal())
+    def some_future_time(self, tzinfo=tzlocal):
+        timeobj = datetime.now(tzinfo())
         return timeobj + timedelta(hours=24)
 
     def create_assume_role_response(self, credentials, expiration=None):
@@ -559,7 +559,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
         token_cache_key = 'f395038c92f1828cbb3991d2d6152d326b895606'
         cached_token = {
             'accessToken': 'a.token',
-            'expiresAt': self.some_future_time(),
+            'expiresAt': self.some_future_time(tzutc),
         }
         print(f'cached expires: {cached_token["expiresAt"]}')
         print(f'cached expires: {cached_token["expiresAt"].isoformat()}')

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 import sys
 
 import pytest
-from dateutil.tz import tzlocal, tzutc
+from dateutil.tz import tzlocal
 from botocore.exceptions import CredentialRetrievalError
 
 from tests import (

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -165,8 +165,8 @@ class BaseAssumeRoleTest(BaseEnvVar):
         shutil.rmtree(self.tempdir)
         super(BaseAssumeRoleTest, self).tearDown()
 
-    def some_future_time(self, tzinfo=tzlocal):
-        timeobj = datetime.now(tzinfo())
+    def some_future_time(self):
+        timeobj = datetime.now(tzlocal())
         return timeobj + timedelta(hours=24)
 
     def create_assume_role_response(self, credentials, expiration=None):
@@ -559,11 +559,8 @@ class TestAssumeRole(BaseAssumeRoleTest):
         token_cache_key = 'f395038c92f1828cbb3991d2d6152d326b895606'
         cached_token = {
             'accessToken': 'a.token',
-            'expiresAt': self.some_future_time(tzutc),
+            'expiresAt': self.some_future_time().strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
-        print(f'cached expires: {cached_token["expiresAt"]}')
-        print(f'cached expires: {cached_token["expiresAt"].isoformat()}')
-        print(f'cached token: {cached_token}')
         temp_cache = JSONFileCache(self.tempdir)
         temp_cache[token_cache_key] = cached_token
 
@@ -597,12 +594,10 @@ class TestAssumeRole(BaseAssumeRoleTest):
                 'expiration': int(expiration),
             }
         }
-        print(f"roleCredentials mocked response: {sso_role_response}")
         sso_stubber.add_response('get_role_credentials', sso_role_response)
 
         expected_creds = self.create_random_credentials()
         assume_role_response = self.create_assume_role_response(expected_creds)
-        print(f"assume_role response created: {assume_role_response}")
         sts_stubber.add_response('assume_role', assume_role_response)
 
         actual_creds = session.get_credentials()

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -561,6 +561,8 @@ class TestAssumeRole(BaseAssumeRoleTest):
             'accessToken': 'a.token',
             'expiresAt': self.some_future_time(),
         }
+        print(f'cached expires: {cached_token["expiresAt"]}')
+        print(f'cached expires: {cached_token["expiresAt"].isoformat()}')
         temp_cache = JSONFileCache(self.tempdir)
         temp_cache[token_cache_key] = cached_token
 

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -563,6 +563,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
         }
         print(f'cached expires: {cached_token["expiresAt"]}')
         print(f'cached expires: {cached_token["expiresAt"].isoformat()}')
+        print(f'cached token: {cached_token}')
         temp_cache = JSONFileCache(self.tempdir)
         temp_cache[token_cache_key] = cached_token
 

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -3390,9 +3390,10 @@ class TestSSOCredentialFetcher(unittest.TestCase):
             create_mock_client, token_loader=self.loader,
             cache=self.cache, time_fetcher=mock.Mock(return_value=now)
         )
+        # since the cached token is expired, an UnauthorizedSSOTokenError should be 
+        # raised and GetRoleCredentials should not be called.
         with self.assertRaises(botocore.exceptions.UnauthorizedSSOTokenError):
             fetcher.fetch_credentials()
-
         self.assertFalse(mock_client.get_role_credentials.called)
 
 

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -3312,18 +3312,21 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         self.account_id = '1234567890'
         self.access_token = {
             'accessToken': 'some.sso.token',
+            'expiresAt': '2018-10-18T22:26:40Z'
         }
         # This is just an arbitrary point in time we can pin to
         self.now = datetime(2008, 9, 23, 12, 26, 40, tzinfo=tzutc())
         # The SSO endpoint uses ms whereas the OIDC endpoint uses seconds
         self.now_timestamp = 1222172800000
 
+        self.mock_time_fetcher = mock.Mock(return_value=self.now)
+
         self.loader = mock.Mock(spec=SSOTokenLoader)
         self.loader.return_value = self.access_token
         self.fetcher = SSOCredentialFetcher(
             self.start_url, self.sso_region, self.role_name, self.account_id,
             self.mock_session.create_client, token_loader=self.loader,
-            cache=self.cache,
+            cache=self.cache, time_fetcher=self.mock_time_fetcher
         )
 
     def test_can_fetch_credentials(self):

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -3396,7 +3396,6 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         self.assertFalse(mock_client.get_role_credentials.called)
 
 
-
 class TestSSOProvider(unittest.TestCase):
     def setUp(self):
         self.sso = Session().create_client('sso', region_name='us-east-1')

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -3318,7 +3318,6 @@ class TestSSOCredentialFetcher(unittest.TestCase):
         self.now = datetime(2008, 9, 23, 12, 26, 40, tzinfo=tzutc())
         # The SSO endpoint uses ms whereas the OIDC endpoint uses seconds
         self.now_timestamp = 1222172800000
-
         self.mock_time_fetcher = mock.Mock(return_value=self.now)
 
         self.loader = mock.Mock(spec=SSOTokenLoader)


### PR DESCRIPTION
*Description of changes:*
- Updated `SSOTokenLoader` to check if the cached legacy token is expired according to the local clock. If expired, it will raise an `UnauthorizedSSOTokenError` instead of sending an expired token to Identity Center's `GetRoleCredentials` API.
- Added a unit test to verify when an expired token is cached, that GetRoleCredentials is not called and `UnauthorizedSSOTokenError` is raised.

*Description of tests:*
- Ran all test suites (unit, functional, integration, etc.)
- The following manual workflow was completed to test the code.
  1. Login to a user account using the legacy flow via `aws sso login`.
  2. Let the cached token expire.
  3. Ran a command using the SSO profile (e.g. `aws s3 ls --profile SSOProfile --debug`)
  4. Verified an `UnauthorizedSSOTokenError` was raised, and checked the stacktrace (pasted below) to verify this exception was raised _without_  `GetRoleCredentials` being called.

**Stacktrace from manual workflow on this branch**

```
 File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 519, in _protected_refresh
    metadata = self._refresh_using()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 660, in fetch_credentials
    return self._get_cached_credentials()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 670, in _get_cached_credentials
    response = self._get_credentials()
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 2056, in _get_credentials
    raise UnauthorizedSSOTokenError()
```

**Stacktrace from manual workflow on v2**

```
Traceback (most recent call last):
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 518, in _protected_refresh
    metadata = self._refresh_using()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 659, in fetch_credentials
    return self._get_cached_credentials()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 669, in _get_cached_credentials
    response = self._get_credentials()
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 2055, in _get_credentials
    raise UnauthorizedSSOTokenError()
botocore.exceptions.UnauthorizedSSOTokenError: The SSO session associated with this profile has expired or is otherwise invalid. To refresh this SSO session run aws sso login with the corresponding profile.
2025-03-13 10:45:14,232 - MainThread - awscli.clidriver - DEBUG - Exception caught in main()
Traceback (most recent call last):
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/credentials.py", line 2053, in _get_credentials
    response = client.get_role_credentials(**kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/client.py", line 365, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/context.py", line 124, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/aemous/GitHub/aws-cli2/awscli/botocore/client.py", line 752, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.UnauthorizedException: An error occurred (UnauthorizedException) when calling the GetRoleCredentials operation: Session token not found or invalid
```

Notice the above exception is raised due to a returned `UnauthorizedException` from `GetRoleCredentials`, while this is not the case in the previous stacktrace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
