### PR TITLE
[v2] Update Sphinx from 3.0.2 to 6.2

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -42,12 +42,6 @@ notfound_pagename = '_404'
 # to set our path prefix
 notfound_urls_prefix = '/v2/documentation/api/latest/'
 
-# For local 404.html testing uncomment lines below and put in local path
-# to the build folder on your disk
-
-# notfound_default_language = '<local path to build folder>/build'
-# notfound_default_version = 'html'
-
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,11 +38,9 @@ notfound_context = {
 }
 notfound_pagename = '_404'
 # notfound.extension changes all the relative links to links like
-# "/en/latest/_static/**" and we use "notfound_default_language" key
-# to change “en” to our path prefix
-notfound_default_language = os.environ.get(
-    'DOCS_STATIC_PATH', 'v2/documentation/api'
-)
+# "/en/latest/_static/**" and we use "notfound_urls_prefix" key
+# to set our path prefix
+notfound_urls_prefix = '/v2/documentation/api/latest/'
 
 # For local 404.html testing uncomment lines below and put in local path
 # to the build folder on your disk

--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/searchbox.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/searchbox.html
@@ -9,5 +9,5 @@
         <input type="hidden" name="area" value="default" />
     </form>
 </div>
-<script type="text/javascript">$('#searchbox').show(0);</script>
+<script>document.getElementById('searchbox').style.display = "block";</script>
 {%- endif %}

--- a/requirements-build-lock.txt
+++ b/requirements-build-lock.txt
@@ -40,9 +40,9 @@ pyinstaller==5.13.2 \
     --hash=sha256:c8e5d3489c3a7cc5f8401c2d1f48a70e588f9967e391c3b06ddac1f685f8d5d2 \
     --hash=sha256:ddcc2b36052a70052479a9e5da1af067b4496f43686ca3cdda99f8367d0627e4
     # via -r requirements-build.txt
-pyinstaller-hooks-contrib==2025.0 \
-    --hash=sha256:3c0623799c3f81a37293127f485d65894c20fd718f722cb588785a3e52581ad1 \
-    --hash=sha256:6dc0b55a1acaab2ffee36ed4a05b073aa0a22e46f25fb5c66a31e217454135ed
+pyinstaller-hooks-contrib==2025.1 \
+    --hash=sha256:130818f9e9a0a7f2261f1fd66054966a3a50c99d000981c5d1db11d3ad0c6ab2 \
+    --hash=sha256:d3c799470cbc0bda60dcc8e6b4ab976777532b77621337f2037f558905e3a8e9
     # via pyinstaller
 pywin32-ctypes==0.2.2 \
     --hash=sha256:3426e063bdd5fd4df74a14fa3cf80a0b42845a87e1d1e81f6549f9daec593a60 \
@@ -54,9 +54,9 @@ zipp==3.20.2 \
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.3.0 \
-    --hash=sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd \
-    --hash=sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686
+setuptools==75.3.2 \
+    --hash=sha256:3c1383e1038b68556a382c1e8ded8887cd20141b0eb5708a6c8d277de49364f5 \
+    --hash=sha256:90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9
     # via
     #   pyinstaller
     #   pyinstaller-hooks-contrib

--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -22,9 +22,9 @@ build==0.7.0 \
     # via
     #   -r requirements-dev.txt
     #   pip-tools
-cachetools==5.5.1 \
-    --hash=sha256:70f238fbba50383ef62e55c6aff6d9673175fe59f7c6782c7a0b9e38f4a9df95 \
-    --hash=sha256:b76651fdc3b24ead3c648bbdeeb940c1b04d365b38b4af66788f9ec4a81d42bb
+cachetools==5.5.2 \
+    --hash=sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4 \
+    --hash=sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a
     # via tox
 chardet==5.2.0 \
     --hash=sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7 \
@@ -179,9 +179,9 @@ pyinstaller==5.13.2 \
     --hash=sha256:c8e5d3489c3a7cc5f8401c2d1f48a70e588f9967e391c3b06ddac1f685f8d5d2 \
     --hash=sha256:ddcc2b36052a70052479a9e5da1af067b4496f43686ca3cdda99f8367d0627e4
     # via -r requirements-build.txt
-pyinstaller-hooks-contrib==2025.0 \
-    --hash=sha256:3c0623799c3f81a37293127f485d65894c20fd718f722cb588785a3e52581ad1 \
-    --hash=sha256:6dc0b55a1acaab2ffee36ed4a05b073aa0a22e46f25fb5c66a31e217454135ed
+pyinstaller-hooks-contrib==2025.1 \
+    --hash=sha256:130818f9e9a0a7f2261f1fd66054966a3a50c99d000981c5d1db11d3ad0c6ab2 \
+    --hash=sha256:d3c799470cbc0bda60dcc8e6b4ab976777532b77621337f2037f558905e3a8e9
     # via pyinstaller
 pyproject-api==1.8.0 \
     --hash=sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228 \
@@ -285,9 +285,9 @@ tox==4.4.12 \
     --hash=sha256:740f5209d0dec19451b951ee5b1cce4a207acdc7357af84dbc8ec35bcf2c454e \
     --hash=sha256:d4be558809d86fad13f4553976b0500352630a8fbfa39ea4b1ce3bd945ba680b
     # via -r requirements-dev.txt
-virtualenv==20.29.1 \
-    --hash=sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779 \
-    --hash=sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35
+virtualenv==20.29.3 \
+    --hash=sha256:3e3d00f5807e83b234dfb6122bf37cfadf4be216c53a49ac059d02414f819170 \
+    --hash=sha256:95e39403fcf3940ac45bc717597dba16110b74506131845d9b687d5e73d947ac
     # via tox
 zipp==3.20.2 \
     --hash=sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350 \
@@ -301,13 +301,13 @@ flit-core==3.9.0 \
     --hash=sha256:72ad266176c4a3fcfab5f2930d76896059851240570ce9a98733b658cb786eba \
     --hash=sha256:7aada352fb0c7f5538c4fafeddf314d3a6a92ee8e2b1de70482329e42de70301
     # via -r requirements-base.txt
-pip==25.0 \
-    --hash=sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b \
-    --hash=sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65
+pip==25.0.1 \
+    --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
+    --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
     # via pip-tools
-setuptools==75.3.0 \
-    --hash=sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd \
-    --hash=sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686
+setuptools==75.3.2 \
+    --hash=sha256:3c1383e1038b68556a382c1e8ded8887cd20141b0eb5708a6c8d277de49364f5 \
+    --hash=sha256:90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9
     # via
     #   pip-tools
     #   pyinstaller

--- a/requirements-docs-lock.txt
+++ b/requirements-docs-lock.txt
@@ -445,6 +445,12 @@ snowballstemmer==2.2.0 \
 sphinx==6.2.0 \
     --hash=sha256:9ef22c2941bc3d0ff080d25a797f7521fc317e857395c712ddde97a19d5bb440 \
     --hash=sha256:ff1c2a1167bef9cdcd8ec71339e85fe10f26d4e9ef9382ef10b2687c876c936b
+    # via
+    #   -r requirements-docs.txt
+    #   sphinx-notfound-page
+sphinx-notfound-page==1.1.0 \
+    --hash=sha256:835dc76ff7914577a1f58d80a2c8418fb6138c0932c8da8adce4d9096fbcd389 \
+    --hash=sha256:913e1754370bb3db201d9300d458a8b8b5fb22e9246a816643a819a9ea2b8067
     # via -r requirements-docs.txt
 sphinxcontrib-applehelp==1.0.4 \
     --hash=sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228 \

--- a/requirements-docs-lock.txt
+++ b/requirements-docs-lock.txt
@@ -7,9 +7,7 @@
 alabaster==0.7.13 \
     --hash=sha256:1ee19aca801bbabb5ba3f5f258e4422dfa86f82f3e9cefb0859b283cdd7f62a3 \
     --hash=sha256:a27a4a084d5e690e16e01e03ad2b2e552c61a65469419b907243193de1a84ae2
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 awscrt==0.23.8 \
     --hash=sha256:10625c49efc19068e3308c4def129a578cdab4d1a99e15df60a4b189d79fb7fa \
     --hash=sha256:12e10e5c225ea7a4c629b659c0949f594d670882b8c7c2b30236d49873ed8ee1 \
@@ -52,13 +50,13 @@ awscrt==0.23.8 \
     --hash=sha256:f352f6e3876a774aa9b99b0e5c879eba404026d85f99c407ac60b0413d508366 \
     --hash=sha256:f435ad7572c015d02764a35450372385f075b26e4274d87b7e175f6ba9367724
     # via awscli (pyproject.toml)
-babel==2.16.0 \
-    --hash=sha256:368b5b98b37c06b7daf6696391c3240c938b37767d4584413e8438c5c435fa8b \
-    --hash=sha256:d1f3554ca26605fe173f3de0c65f750f5a42f924499bf134de6423582298e316
+babel==2.17.0 \
+    --hash=sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d \
+    --hash=sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2
     # via sphinx
-certifi==2024.12.14 \
-    --hash=sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56 \
-    --hash=sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db
+certifi==2025.1.31 \
+    --hash=sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651 \
+    --hash=sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe
     # via requests
 cffi==1.17.1 \
     --hash=sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8 \
@@ -274,6 +272,10 @@ imagesize==1.4.1 \
     --hash=sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b \
     --hash=sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a
     # via sphinx
+importlib-metadata==8.5.0 \
+    --hash=sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b \
+    --hash=sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7
+    # via sphinx
 jinja2==3.0.3 \
     --hash=sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8 \
     --hash=sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7
@@ -366,9 +368,9 @@ python-dateutil==2.9.0 \
     --hash=sha256:78e73e19c63f5b20ffa567001531680d939dc042bf7850431877645523c66709 \
     --hash=sha256:cbf2f1da5e6083ac2fbfd4da39a25f34312230110440f424a14c7558bb85d82e
     # via awscli (pyproject.toml)
-pytz==2024.2 \
-    --hash=sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a \
-    --hash=sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725
+pytz==2025.1 \
+    --hash=sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57 \
+    --hash=sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e
     # via babel
 requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
@@ -440,50 +442,34 @@ snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a
     # via sphinx
-sphinx==3.0.2 \
-    --hash=sha256:3145d87d0962366d4c5264c39094eae3f5788d01d4b1a12294051bfe4271d91b \
-    --hash=sha256:d7c6e72c6aa229caf96af82f60a0d286a1521d42496c226fe37f5a75dcfe2941
-    # via -r requirements-docs.txt
-sphinx-notfound-page==0.4 \
-    --hash=sha256:0105a40d8a305d3e1003630d8ee99296baa08cf2a4c1ce1db8d91fbbe78f90db \
-    --hash=sha256:609fd7cd7f9ea73c030f1b67a3f2bc90f60bff87b30026fbd2bcb19c7c59c484
+sphinx==6.2.0 \
+    --hash=sha256:9ef22c2941bc3d0ff080d25a797f7521fc317e857395c712ddde97a19d5bb440 \
+    --hash=sha256:ff1c2a1167bef9cdcd8ec71339e85fe10f26d4e9ef9382ef10b2687c876c936b
     # via -r requirements-docs.txt
 sphinxcontrib-applehelp==1.0.4 \
     --hash=sha256:29d341f67fb0f6f586b23ad80e072c8e6ad0b48417db2bde114a4c9746feb228 \
     --hash=sha256:828f867945bbe39817c210a1abfd1bc4895c8b73fcaade56d45357a348a07d7e
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 sphinxcontrib-devhelp==1.0.2 \
     --hash=sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e \
     --hash=sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 sphinxcontrib-htmlhelp==2.0.1 \
     --hash=sha256:0cbdd302815330058422b98a113195c9249825d681e18f11e8b1f78a2f11efff \
     --hash=sha256:c38cb46dccf316c79de6e5515e1770414b797162b23cd3d06e67020e1d2a6903
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 sphinxcontrib-jsmath==1.0.1 \
     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 sphinxcontrib-qthelp==1.0.3 \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 sphinxcontrib-serializinghtml==1.1.5 \
     --hash=sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd \
     --hash=sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952
-    # via
-    #   -r requirements-docs.txt
-    #   sphinx
+    # via sphinx
 urllib3==1.26.20 \
     --hash=sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e \
     --hash=sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32
@@ -497,10 +483,6 @@ wcwidth==0.2.13 \
 zipp==3.20.2 \
     --hash=sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350 \
     --hash=sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29
-    # via awscli (pyproject.toml)
-
-# The following packages are considered to be unsafe in a requirements file:
-setuptools==75.3.0 \
-    --hash=sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd \
-    --hash=sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686
-    # via sphinx
+    # via
+    #   awscli (pyproject.toml)
+    #   importlib-metadata

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,3 @@
 Jinja2<3.1.0
 Sphinx==6.2
+sphinx-notfound-page==1.1.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,15 +1,2 @@
 Jinja2<3.1.0
-Sphinx==3.0.2
-sphinx-notfound-page==0.4
-# alabaster 0.7.14 dropped support for Sphinx<3.4
-# and Sphinx 3.0.2 bounds alabaster>=0.7,<0.8.
-alabaster==0.7.13
-# Latest versions of these packages support only
-# Sphinx>5, which we are not using. Set explicit pins
-# so we can continue to use Sphinx 3.
-sphinxcontrib-applehelp==1.0.4
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
+Sphinx==6.2

--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -211,13 +211,13 @@ zipp==3.20.2 \
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.0 \
-    --hash=sha256:8e0a97f7b4c47ae4a494560da84775e9e2f671d415d8d828e052efefb206b30b \
-    --hash=sha256:b6eb97a803356a52b2dd4bb73ba9e65b2ba16caa6bcb25a7497350a4e5859b65
+pip==25.0.1 \
+    --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
+    --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
     # via pip-tools
-setuptools==75.3.0 \
-    --hash=sha256:f2504966861356aa38616760c0f66568e535562374995367b4e69c7143cf6bcd \
-    --hash=sha256:fba5dd4d766e97be1b1681d98712680ae8f2f26d7881245f2ce9e40714f1a686
+setuptools==75.3.2 \
+    --hash=sha256:3c1383e1038b68556a382c1e8ded8887cd20141b0eb5708a6c8d277de49364f5 \
+    --hash=sha256:90ab613b6583fc02d5369cbca13ea26ea0e182d1df2d943ee9cbe81d4c61add9
     # via pip-tools
 wheel==0.45.1 \
     --hash=sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729 \


### PR DESCRIPTION
Changes:
- Updates Sphinx to 6.2
- Updates sphinx-notfound-page to 1.1.0
- Removes explicit pins on Sphinx dependencies since we're now on Sphinx>5
- Sphinx removed jQuery support. Only the searchbox uses it, so replace jQuery use with HTML
- sphinx-notfound-page dropped support for `notfound_default_language`. Replace it with `notfound_urls_prefix`