### PR TITLE
Set PYINSTALLER_RESET_ENVIRONMENT automatically when launching subprocesses

### DIFF
--- a/.changes/next-release/enhancement-dependency-81647.json
+++ b/.changes/next-release/enhancement-dependency-81647.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "dependency",
+  "description": "Set ``PYINSTALLER_RESET_ENVIRONMENT`` if not already set when starting child processes. This supports using the CLI as a credential process for itself."
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -12,12 +12,11 @@ from urllib.parse import urlsplit
 from datetime import datetime
 from dateutil.tz import tzutc
 from dateutil.relativedelta import relativedelta
-from botocore.utils import parse_timestamp
+from botocore.utils import parse_timestamp, original_ld_library_path
 
 from awscli.compat import is_windows, urlparse, get_stderr_encoding, is_macos
 from awscli.customizations import utils as cli_utils
 from awscli.customizations.commands import BasicCommand
-from awscli.utils import original_ld_library_path
 from awscli.customizations.utils import uni_print
 
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -460,32 +460,6 @@ def write_exception(ex, outfile):
     outfile.write("\n")
 
 
-@contextlib.contextmanager
-def original_ld_library_path(env=None):
-    # See: https://pyinstaller.readthedocs.io/en/stable/runtime-information.html
-    # When running under pyinstaller, it will set an
-    # LD_LIBRARY_PATH to ensure it prefers its bundled version of libs.
-    # There are times where we don't want this behavior, for example when
-    # running a separate subprocess.
-    if env is None:
-        env = os.environ
-
-    value_to_put_back = env.get('LD_LIBRARY_PATH')
-    # The first case is where a user has exported an LD_LIBRARY_PATH
-    # in their env.  This will be mapped to LD_LIBRARY_PATH_ORIG.
-    if 'LD_LIBRARY_PATH_ORIG' in env:
-        env['LD_LIBRARY_PATH'] = env['LD_LIBRARY_PATH_ORIG']
-    else:
-        # Otherwise if they didn't set an LD_LIBRARY_PATH we just need
-        # to make sure this value is unset.
-        env.pop('LD_LIBRARY_PATH', None)
-    try:
-        yield
-    finally:
-        if value_to_put_back is not None:
-            env['LD_LIBRARY_PATH'] = value_to_put_back
-
-
 def dump_yaml_to_str(yaml, data):
     """Dump a Python object to a YAML-formatted string.
 

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -3508,8 +3508,21 @@ class TestOriginalLDLibraryPath(unittest.TestCase):
         env = {'OTHER_VALUE': 'foo'}
         with original_ld_library_path(env):
             self.assertIsNone(env.get('LD_LIBRARY_PATH'))
-            self.assertEqual(env, {'OTHER_VALUE': 'foo'})
+            self.assertEqual(env['OTHER_VALUE'], 'foo')
         self.assertEqual(env, {'OTHER_VALUE': 'foo'})
+
+    def test_no_pyinstaller_reset(self):
+        env = {'OTHER_VALUE': 'foo'}
+        with original_ld_library_path(env):
+            self.assertEqual(env.get('PYINSTALLER_RESET_ENVIRONMENT'), '1')
+        self.assertEqual(env, {'OTHER_VALUE': 'foo'})
+        self.assertIsNone(env.get('PYINSTALLER_RESET_ENVIRONMENT'))
+
+    def test_existing_pyinstaller_reset(self):
+        env = {'PYINSTALLER_RESET_ENVIRONMENT': '0'}
+        with original_ld_library_path(env):
+            self.assertEqual(env.get('PYINSTALLER_RESET_ENVIRONMENT'), '0')
+        self.assertEqual(env.get('PYINSTALLER_RESET_ENVIRONMENT'), '0')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-cli/issues/9336 once we upgrade PyInstaller again

*Description of changes:* PyInstaller's `PYINSTALLER_RESET_ENVIRONMENT` controls how a subprocess is opened, in case it's also a PyInstaller program.

https://pyinstaller.org/en/stable/advanced-topics.html#public-environment-variables
> Setting this environment variable to 1 causes the bootloader to reset all PyInstaller’s internal environment variables, thus causing its process to be treated as a top-level process of a new instance of the application. In onefile mode, for example, this forces the application to unpack itself again.

In PyInstaller 6.10.0 they introduced a [breaking change](https://pyinstaller.org/en/stable/CHANGES.html#id14) that inverted the default behavior of this via https://github.com/pyinstaller/pyinstaller/pull/8634. So to revert to our previous behavior, we now set this flag (unless the user has explicitly set it).

I also consolidated this logic, since we had similar methods in the vended `botocore` and the CLI code. 

### Testing
You have to actually invoke the CLI through PyInstaller's bootloader. I manually tested with a scenerio similar to #9336
```
[export]
aws_access_key_id = <redacted>
aws_secret_access_key = <redacted>

[process]
credential_process = aws configure export-credentials --profile export
```

Then test that `aws s3 ls --profile process` works.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
