### PR TITLE
Add 3.8 deprecation date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,13 +35,9 @@ The aws-cli package works on Python versions:
 Notices
 ~~~~~~~
 
-On 2022-05-30, support for Python 3.6 was ended. This follows the
-Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0494/#lifespan>`__
-for the runtime which occurred on 2021-12-23.
-
-On 2023-12-13, support for Python 3.7 was ended. This follows the
-Python Software Foundation `end of support <https://www.python.org/dev/peps/pep-0537/#lifespan>`__
-for the runtime which occurred on 2023-06-27.
+On 2025-04-22, support for Python 3.8 will end for the AWS CLI. This follows the
+Python Software Foundation `end of support <https://peps.python.org/pep-0569/#lifespan>`__
+for the runtime which occurred on 2024-10-07.
 For more information, see this `blog post <https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/>`__.
 
 *Attention!*


### PR DESCRIPTION
This PR adds a notice with target date for end of support of Python 3.8 across Boto3, Botocore and the AWS CLI v1. This follows the originally announced deprecation timeline in [our blog post](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).