### PR TITLE
Only run symlink verification for Darwin during installer builds

### DIFF
--- a/exe/pyinstaller/aws_completer.spec
+++ b/exe/pyinstaller/aws_completer.spec
@@ -1,4 +1,5 @@
 # -*- mode: python -*-
+import platform
 
 block_cipher = None
 exe_name = "aws_completer"
@@ -18,30 +19,31 @@ completer_a = Analysis(['../../bin/aws_completer'],
 # Replace the Python.framework directory with a top-level Python executable
 # This is easier for our internal signing and notarization code,
 # since we're not signing via PyInstaller
-updated_binaries = []
-for dest, src, typecode in completer_a.binaries:
-    # Look for the actual Python executable, regardless of the version
-    if dest.startswith('Python.framework/Versions/') and dest.endswith('/Python'):
-        # and move it to the top
-        dest = 'Python'
-    updated_binaries.append((dest, src, typecode))
-completer_a.binaries = updated_binaries
+if platform.system() == "Darwin":
+    updated_binaries = []
+    for dest, src, typecode in completer_a.binaries:
+        # Look for the actual Python executable, regardless of the version
+        if dest.startswith('Python.framework/Versions/') and dest.endswith('/Python'):
+            # and move it to the top
+            dest = 'Python'
+        updated_binaries.append((dest, src, typecode))
+    completer_a.binaries = updated_binaries
 
-# Remove the symlinks and the Info.plist related to Python.framework
-# since we're using the top-level executable above
-updated_datas = []
-for dest, src, typecode in completer_a.datas:
-    if (dest.startswith('Python.framework/') or (dest == 'Python' and typecode == 'SYMLINK')):
-        continue
-    updated_datas.append((dest, src, typecode))
-completer_a.datas = updated_datas
+    # Remove the symlinks and the Info.plist related to Python.framework
+    # since we're using the top-level executable above
+    updated_datas = []
+    for dest, src, typecode in completer_a.datas:
+        if (dest.startswith('Python.framework/') or (dest == 'Python' and typecode == 'SYMLINK')):
+            continue
+        updated_datas.append((dest, src, typecode))
+    completer_a.datas = updated_datas
 
-# Verify that there are no remaining symlinks
-for dest, src, typecode in completer_a.datas:
-    if typecode == 'SYMLINK':
-        raise ValueError((f'Symlink ({dest} -> {src}) found in table of contents. '
-            'Our downstream packaging and signing code does not support symlinks, '
-            'so this requires investigation.'))
+    # Verify that there are no remaining symlinks
+    for dest, src, typecode in completer_a.datas:
+        if typecode == 'SYMLINK':
+            raise ValueError((f'Symlink ({dest} -> {src}) found in table of contents. '
+                'Our downstream packaging and signing code does not support symlinks, '
+                'so this requires investigation.'))
 
 completer_pyz = PYZ(completer_a.pure, completer_a.zipped_data, cipher=block_cipher)
 completer_exe = EXE(completer_pyz,


### PR DESCRIPTION
*Issue #, if available:* #9331

*Description of changes:*
When we first upgraded to PyInstaller 6 via #9194 (which was reverted via #9332), we adjusted the table-of-contents to remove symlinks related to the Python executable. This was intended for the Mac build, since our internal signing + notarization process wasn't able to sign nested framework bundles without changes.

I added verification at the time to throw an error if any additional symlinks are detected during future PyInstaller upgrades, since we likely would need to adjust the layout and/or signing code again.

However building the CLI Alpine results in a symlink to`libgcc_s-7393e603.so.1` as reported by #9331.

This PR relaxes the symlink verification check to permit this, however the file does end up being duplicated since our post-PyInstaller moving/zipping/installation code will replace symlinks with a copy of the destination file. This seems okay in this case, since it's only ~200KB and we're working to remove the `cryptography` dependency that is pulling this in.


### Testing
We have an internal backlog item to add Alpine to our automated test coverage. For now I tested manually using a Dockerfile similar to the one we have in the [instructions here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-source-install.html#source-getting-started-install-workflows).
```
FROM python:3.11.11-alpine3.20

SHELL ["/bin/ash", "-eo", "pipefail", "-c"]

WORKDIR /target

COPY aws-cli/ .

# Grab install dependencies
RUN apk add --no-cache \
      cmake~=3.29 \
      curl~=8 \
      dpkg~=1.22 \
      g++~=13.2.1 \
      gcc~=13.2.1 \
      libc-dev~=1.2.5 \
      libcrypto3~=3.3.3 \
      libffi-dev~=3.4.6 \
      libssl3~=3.3.3 \
      make~=4.4 \
      openssl-dev~=3.3.3 \
      openssl~=3.3.3 \
      upx~=4 \
  \
  && ./configure --with-download-deps --with-install-type=portable-exe \
  && make && make install

ENTRYPOINT ["/bin/ash"]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
