### PR TITLE
Rpcv2 protocol serializer

### DIFF
--- a/.changes/next-release/enhancement-Protocol-24013.json
+++ b/.changes/next-release/enhancement-Protocol-24013.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Protocol",
+  "description": "Adds support for the smithy-rpc-v2-cbor protocol.  If a service supports smithy-rpc-v2-cbor, this protocol will automatically be used.  For more information, see https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html"
+}

--- a/awscli/botocore/parsers.py
+++ b/awscli/botocore/parsers.py
@@ -886,7 +886,7 @@ class BaseCBORParser(ResponseParser):
             return self._parse_datetime(value)
         else:
             raise ResponseParserError(
-                f"Found CBOR tag not supported by botocore:" f" {tag}"
+                f"Found CBOR tag not supported by botocore: {tag}"
             )
 
     def _parse_datetime(self, value):
@@ -935,7 +935,7 @@ class BaseCBORParser(ResponseParser):
     # the break code, it advances past that byte and returns True so the calling
     # method knows to stop parsing that data item.
     def _handle_break_code(self, stream):
-        if int.from_bytes(stream.peek(1)[:1]) == self.BREAK_CODE:
+        if int.from_bytes(stream.peek(1)[:1], 'big') == self.BREAK_CODE:
             stream.seek(1, os.SEEK_CUR)
             return True
 

--- a/awscli/botocore/serialize.py
+++ b/awscli/botocore/serialize.py
@@ -470,7 +470,9 @@ class CBORSerializer(Serializer):
         additional_info, num_bytes = self._get_additional_info_and_num_bytes(
             length
         )
-        initial_byte = self._get_initial_byte(self.STRING_MAJOR_TYPE, length)
+        initial_byte = self._get_initial_byte(
+            self.STRING_MAJOR_TYPE, additional_info
+        )
         if num_bytes == 0:
             serialized.extend(initial_byte + encoded)
         else:

--- a/tests/unit/botocore/cbor/test_cbor_decoding.py
+++ b/tests/unit/botocore/cbor/test_cbor_decoding.py
@@ -26,9 +26,7 @@ IGNORE_CASES = [
     'map - {null}',
 ]
 
-TEST_DIR = os.path.join(
-    os.path.dirname(os.path.abspath(__file__))
-)
+TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +35,9 @@ def parser():
 
 
 def _get_cbor_decoding_success_tests():
-    success_test_file_name = os.path.join(TEST_DIR, 'decode-success-tests.json')
+    success_test_file_name = os.path.join(
+        TEST_DIR, 'decode-success-tests.json'
+    )
     success_test_data = json.load(open(success_test_file_name))
     for case in success_test_data:
         if case['description'] in IGNORE_CASES:


### PR DESCRIPTION
Ports the following botocore PRs and commits:
- https://github.com/boto/botocore/pull/3396 
- https://github.com/boto/botocore/pull/3406 
- https://github.com/boto/botocore/pull/3407/commits/938c11539541471a6be51e71b23eef0978c2b7cc 

These are currently the final changes expected to be staged before release.

*Description of changes:*

- Adds support for rpcv2 CBOR serialization, minor formatting, and minor update to the cbor string parser.

*Description of tests:*

- Ran all tests suits and CI 
- No further testing can be justified since wire-level parsing & serialization is hidden from the AWS CLI v2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
