### PR TITLE
Relax pre-commit config to run on whole codebase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,22 @@ exclude: "\
     ^(\
     .changes|\
     .github|\
+    CHANGELOG.rst|\
+    configure|\
     awscli/examples|\
     awscli/topics|\
-    awscli/botocore|\
-    awscli/s3transfer|\
-    awscli/doc|\
+    awscli/botocore/data|\
+    awscli/botocore/vendored|\
+    awscli/botocore/compat.py|\
+    awscli/s3transfer/compat.py|\
+    doc/source/guzzle_sphinx_theme|\
     exe/assets|\
+    tests/functional/botocore/endpoint-rules|\
     tests/functional/cloudformation/deploy_templates/booleans/input.yml|\
     tests/functional/cloudformation/deploy_templates/nested-tag/input.yml|\
-    tests/|\
-    CHANGELOG.rst|\
-    configure\
+    tests/unit/botocore/auth/aws4_testsuite|\
+    tests/unit/botocore/data/endpoints/|\
+    tests/unit/botocore/response_parsing/xml\
     )"
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,6 @@ exclude = [
     "node_modules",
     "site-packages",
     "venv",
-    "tests/*/botocore/",
-    "tests/*/s3transfer/",
-    "doc/source/guzzle_sphinx_theme",
 ]
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change allows pre-commit to run everywhere. The exclusion list is an intersection of the configuration from both the upstream botocore and s3transfer repositories.

The pre-commit hook is still not enabled by default, and is not run in GitHub CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
