### PR TITLE
[v2] RPCV2 CBOR Protocol Support

### DIFF
--- a/.changes/next-release/enhancement-Protocol-24013.json
+++ b/.changes/next-release/enhancement-Protocol-24013.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Protocol",
+  "description": "Adds support for the smithy-rpc-v2-cbor protocol.  If a service supports smithy-rpc-v2-cbor, this protocol will automatically be used.  For more information, see https://smithy.io/2.0/additional-specs/protocols/smithy-rpc-v2.html"
+}

--- a/awscli/botocore/args.py
+++ b/awscli/botocore/args.py
@@ -46,6 +46,7 @@ VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG = (
 )
 
 PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = (
+    'smithy-rpc-v2-cbor',
     'json',
     'rest-json',
     'rest-xml',

--- a/awscli/botocore/parsers.py
+++ b/awscli/botocore/parsers.py
@@ -886,7 +886,7 @@ class BaseCBORParser(ResponseParser):
             return self._parse_datetime(value)
         else:
             raise ResponseParserError(
-                f"Found CBOR tag not supported by botocore:" f" {tag}"
+                f"Found CBOR tag not supported by botocore: {tag}"
             )
 
     def _parse_datetime(self, value):
@@ -935,7 +935,7 @@ class BaseCBORParser(ResponseParser):
     # the break code, it advances past that byte and returns True so the calling
     # method knows to stop parsing that data item.
     def _handle_break_code(self, stream):
-        if int.from_bytes(stream.peek(1)[:1]) == self.BREAK_CODE:
+        if int.from_bytes(stream.peek(1)[:1], 'big') == self.BREAK_CODE:
             stream.seek(1, os.SEEK_CUR)
             return True
 

--- a/awscli/botocore/serialize.py
+++ b/awscli/botocore/serialize.py
@@ -40,7 +40,9 @@ and if a str/unicode type is passed in, it will be encoded as utf-8.
 import base64
 import calendar
 import datetime
+import math
 import re
+import struct
 from xml.etree import ElementTree
 
 from botocore import validate
@@ -402,6 +404,248 @@ class JSONSerializer(Serializer):
         serialized[key] = self._get_base64(value)
 
 
+class CBORSerializer(Serializer):
+    UNSIGNED_INT_MAJOR_TYPE = 0
+    NEGATIVE_INT_MAJOR_TYPE = 1
+    BLOB_MAJOR_TYPE = 2
+    STRING_MAJOR_TYPE = 3
+    LIST_MAJOR_TYPE = 4
+    MAP_MAJOR_TYPE = 5
+    TAG_MAJOR_TYPE = 6
+    FLOAT_AND_SIMPLE_MAJOR_TYPE = 7
+
+    def _serialize_data_item(self, serialized, value, shape, key=None):
+        method = getattr(self, f'_serialize_type_{shape.type_name}')
+        if method is None:
+            raise ValueError(
+                f"Unrecognized C2J type: {shape.type_name}, unable to "
+                f"serialize request"
+            )
+        method(serialized, value, shape, key)
+
+    def _serialize_type_integer(self, serialized, value, shape, key):
+        if value >= 0:
+            major_type = self.UNSIGNED_INT_MAJOR_TYPE
+        else:
+            major_type = self.NEGATIVE_INT_MAJOR_TYPE
+            # The only differences in serializing negative and positive integers is
+            # that for negative, we set the major type to 1 and set the value to -1
+            # minus the value
+            value = -1 - value
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            value
+        )
+        initial_byte = self._get_initial_byte(major_type, additional_info)
+        if num_bytes == 0:
+            serialized.extend(initial_byte)
+        else:
+            serialized.extend(initial_byte + value.to_bytes(num_bytes, "big"))
+
+    def _serialize_type_long(self, serialized, value, shape, key):
+        self._serialize_type_integer(serialized, value, shape, key)
+
+    def _serialize_type_blob(self, serialized, value, shape, key):
+        if isinstance(value, str):
+            value = value.encode('utf-8')
+        elif not isinstance(value, (bytes, bytearray)):
+            # We support file-like objects for blobs; these already have been
+            # validated to ensure they have a read method
+            value = value.read()
+        length = len(value)
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            length
+        )
+        initial_byte = self._get_initial_byte(
+            self.BLOB_MAJOR_TYPE, additional_info
+        )
+        if num_bytes == 0:
+            serialized.extend(initial_byte)
+        else:
+            serialized.extend(initial_byte + length.to_bytes(num_bytes, "big"))
+        serialized.extend(value)
+
+    def _serialize_type_string(self, serialized, value, shape, key):
+        encoded = value.encode('utf-8')
+        length = len(encoded)
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            length
+        )
+        initial_byte = self._get_initial_byte(
+            self.STRING_MAJOR_TYPE, additional_info
+        )
+        if num_bytes == 0:
+            serialized.extend(initial_byte + encoded)
+        else:
+            serialized.extend(
+                initial_byte + length.to_bytes(num_bytes, "big") + encoded
+            )
+
+    def _serialize_type_list(self, serialized, value, shape, key):
+        length = len(value)
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            length
+        )
+        initial_byte = self._get_initial_byte(
+            self.LIST_MAJOR_TYPE, additional_info
+        )
+        if num_bytes == 0:
+            serialized.extend(initial_byte)
+        else:
+            serialized.extend(initial_byte + length.to_bytes(num_bytes, "big"))
+        for item in value:
+            self._serialize_data_item(serialized, item, shape.member)
+
+    def _serialize_type_map(self, serialized, value, shape, key):
+        length = len(value)
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            length
+        )
+        initial_byte = self._get_initial_byte(
+            self.MAP_MAJOR_TYPE, additional_info
+        )
+        if num_bytes == 0:
+            serialized.extend(initial_byte)
+        else:
+            serialized.extend(initial_byte + length.to_bytes(num_bytes, "big"))
+        for key_item, item in value.items():
+            self._serialize_data_item(serialized, key_item, shape.key)
+            self._serialize_data_item(serialized, item, shape.value)
+
+    def _serialize_type_structure(self, serialized, value, shape, key):
+        if key is not None:
+            # For nested structures, we need to serialize the key first
+            self._serialize_data_item(serialized, key, shape.key_shape)
+
+        # Remove `None` values from the dictionary
+        value = {k: v for k, v in value.items() if v is not None}
+
+        map_length = len(value)
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            map_length
+        )
+        initial_byte = self._get_initial_byte(
+            self.MAP_MAJOR_TYPE, additional_info
+        )
+        if num_bytes == 0:
+            serialized.extend(initial_byte)
+        else:
+            serialized.extend(
+                initial_byte + map_length.to_bytes(num_bytes, "big")
+            )
+
+        members = shape.members
+        for member_key, member_value in value.items():
+            member_shape = members[member_key]
+            if 'name' in member_shape.serialization:
+                member_key = member_shape.serialization['name']
+            if member_value is not None:
+                self._serialize_type_string(serialized, member_key, None, None)
+                self._serialize_data_item(
+                    serialized, member_value, member_shape
+                )
+
+    def _serialize_type_timestamp(self, serialized, value, shape, key):
+        timestamp = self._convert_timestamp_to_str(value)
+        tag = 1  # Use tag 1 for unix timestamp
+        initial_byte = self._get_initial_byte(self.TAG_MAJOR_TYPE, tag)
+        serialized.extend(initial_byte)  # Tagging the timestamp
+        additional_info, num_bytes = self._get_additional_info_and_num_bytes(
+            timestamp
+        )
+
+        if num_bytes == 0:
+            initial_byte = self._get_initial_byte(
+                self.UNSIGNED_INT_MAJOR_TYPE, timestamp
+            )
+            serialized.extend(initial_byte)
+        else:
+            initial_byte = self._get_initial_byte(
+                self.UNSIGNED_INT_MAJOR_TYPE, additional_info
+            )
+            serialized.extend(
+                initial_byte + timestamp.to_bytes(num_bytes, "big")
+            )
+
+    def _serialize_type_float(self, serialized, value, shape, key):
+        if self._is_special_number(value):
+            serialized.extend(
+                self._get_bytes_for_special_numbers(value)
+            )  # Handle special values like NaN or Infinity
+        else:
+            initial_byte = self._get_initial_byte(
+                self.FLOAT_AND_SIMPLE_MAJOR_TYPE, 26
+            )
+            serialized.extend(initial_byte + struct.pack(">f", value))
+
+    def _serialize_type_double(self, serialized, value, shape, key):
+        if self._is_special_number(value):
+            serialized.extend(
+                self._get_bytes_for_special_numbers(value)
+            )  # Handle special values like NaN or Infinity
+        else:
+            initial_byte = self._get_initial_byte(
+                self.FLOAT_AND_SIMPLE_MAJOR_TYPE, 27
+            )
+            serialized.extend(initial_byte + struct.pack(">d", value))
+
+    def _serialize_type_boolean(self, serialized, value, shape, key):
+        additional_info = 21 if value else 20
+        serialized.extend(
+            self._get_initial_byte(
+                self.FLOAT_AND_SIMPLE_MAJOR_TYPE, additional_info
+            )
+        )
+
+    def _get_additional_info_and_num_bytes(self, value):
+        # Values under 24 can be stored in the initial byte and don't need further
+        # encoding
+        if value < 24:
+            return value, 0
+        # Values between 24 and 255 (inclusive) can be stored in 1 byte and
+        # correspond to additional info 24
+        elif value < 256:
+            return 24, 1
+        # Values up to 65535 can be stored in two bytes and correspond to additional
+        # info 25
+        elif value < 65536:
+            return 25, 2
+        # Values up to 4294967296 can be stored in four bytes and correspond to
+        # additional info 26
+        elif value < 4294967296:
+            return 26, 4
+        # The maximum number of bytes in a definite length data items is 8 which
+        # to additional info 27
+        else:
+            return 27, 8
+
+    def _get_initial_byte(self, major_type, additional_info):
+        # The highest order three bits are the major type, so we need to bitshift the
+        # major type by 5
+        major_type_bytes = major_type << 5
+        return (major_type_bytes | additional_info).to_bytes(1, "big")
+
+    def _is_special_number(self, value):
+        return any(
+            [
+                value == float('inf'),
+                value == float('-inf'),
+                math.isnan(value),
+            ]
+        )
+
+    def _get_bytes_for_special_numbers(self, value):
+        additional_info = 25
+        initial_byte = self._get_initial_byte(
+            self.FLOAT_AND_SIMPLE_MAJOR_TYPE, additional_info
+        )
+        if value == float('inf'):
+            return initial_byte + struct.pack(">H", 0x7C00)
+        elif value == float('-inf'):
+            return initial_byte + struct.pack(">H", 0xFC00)
+        elif math.isnan(value):
+            return initial_byte + struct.pack(">H", 0x7E00)
+
+
 class BaseRestSerializer(Serializer):
     """Base class for rest protocols.
 
@@ -628,6 +872,42 @@ class BaseRestSerializer(Serializer):
             return value
 
 
+class BaseRpcV2Serializer(Serializer):
+    """Base class for RPCv2 protocols.
+    The only variance between the various RPCv2 protocols is the
+    way that the body is serialized.  All other aspects (headers, uri, etc.)
+    are the same and logic for serializing those aspects lives here.
+    Subclasses must implement the ``_serialize_body_params``  and
+    ``_serialize_headers`` methods.
+    """
+
+    def serialize_to_request(self, parameters, operation_model):
+        serialized = self._create_default_request()
+        service_name = operation_model.service_model.metadata['targetPrefix']
+        operation_name = operation_model.name
+        serialized['url_path'] = (
+            f'/service/{service_name}/operation/{operation_name}'
+        )
+
+        input_shape = operation_model.input_shape
+        if input_shape is not None:
+            self._serialize_payload(parameters, serialized, input_shape)
+
+        self._serialize_headers(serialized, operation_model)
+
+        return serialized
+
+    def _serialize_payload(self, parameters, serialized, shape):
+        body_payload = self._serialize_body_params(parameters, shape)
+        serialized['body'] = body_payload
+
+    def _serialize_headers(self, serialized, operation_model):
+        raise NotImplementedError("_serialize_headers")
+
+    def _serialize_body_params(self, parameters, shape):
+        raise NotImplementedError("_serialize_body_params")
+
+
 class RestJSONSerializer(BaseRestSerializer, JSONSerializer):
 
     def _serialize_empty_body(self):
@@ -757,10 +1037,35 @@ class RestXMLSerializer(BaseRestSerializer):
         node.text = str(params)
 
 
+class RpcV2CBORSerializer(BaseRpcV2Serializer, CBORSerializer):
+    TIMESTAMP_FORMAT = 'unixtimestamp'
+
+    def _serialize_body_params(self, parameters, input_shape):
+        body = bytearray()
+        self._serialize_data_item(body, parameters, input_shape)
+        return bytes(body)
+
+    def _serialize_headers(self, serialized, operation_model):
+        serialized['headers']['smithy-protocol'] = 'rpc-v2-cbor'
+
+        if operation_model.has_event_stream_output:
+            header_val = 'application/vnd.amazon.eventstream'
+        else:
+            header_val = 'application/cbor'
+
+        has_body = serialized['body'] != b''
+        has_content_type = has_header('Content-Type', serialized['headers'])
+
+        serialized['headers']['Accept'] = header_val
+        if not has_content_type and has_body:
+            serialized['headers']['Content-Type'] = header_val
+
+
 SERIALIZERS = {
     'ec2': EC2Serializer,
     'query': QuerySerializer,
     'json': JSONSerializer,
     'rest-json': RestJSONSerializer,
     'rest-xml': RestXMLSerializer,
+    'smithy-rpc-v2-cbor': RpcV2CBORSerializer,
 }

--- a/tests/unit/botocore/cbor/decode-error-tests.json
+++ b/tests/unit/botocore/cbor/decode-error-tests.json
@@ -1,0 +1,282 @@
+[
+  {
+    "description": "TestDecode_InvalidArgument - map/2 - arg len 2 greater than remaining buf len",
+    "input": "b900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - tag/1 - arg len 1 greater than remaining buf len",
+    "input": "d8",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - major7/float64 - incomplete float64 at end of buf",
+    "input": "fb00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - negint/4 - arg len 4 greater than remaining buf len",
+    "input": "3a000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - negint/8 - arg len 8 greater than remaining buf len",
+    "input": "3b00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - string/4 - arg len 4 greater than remaining buf len",
+    "input": "7a000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - map/1 - arg len 1 greater than remaining buf len",
+    "input": "b8",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - map/4 - arg len 4 greater than remaining buf len",
+    "input": "ba000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - tag/2 - arg len 2 greater than remaining buf len",
+    "input": "d900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - uint/1 - arg len 1 greater than remaining buf len",
+    "input": "18",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - string/1 - arg len 1 greater than remaining buf len",
+    "input": "78",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - string/8 - arg len 8 greater than remaining buf len",
+    "input": "7b00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - string/2 - arg len 2 greater than remaining buf len",
+    "input": "7900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - list/2 - arg len 2 greater than remaining buf len",
+    "input": "9900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - slice/1 - arg len 1 greater than remaining buf len",
+    "input": "58",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - slice/4 - arg len 4 greater than remaining buf len",
+    "input": "5a000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - slice/8 - arg len 8 greater than remaining buf len",
+    "input": "5b00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - negint/? - unexpected minor value 31",
+    "input": "3f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - tag/8 - arg len 8 greater than remaining buf len",
+    "input": "db00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - uint/2 - arg len 2 greater than remaining buf len",
+    "input": "1900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - uint/8 - arg len 8 greater than remaining buf len",
+    "input": "1b00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - negint/2 - arg len 2 greater than remaining buf len",
+    "input": "3900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - negint/1 - arg len 1 greater than remaining buf len",
+    "input": "38",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - list/8 - arg len 8 greater than remaining buf len",
+    "input": "9b00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - tag/4 - arg len 4 greater than remaining buf len",
+    "input": "da000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - major7/float32 - incomplete float32 at end of buf",
+    "input": "fa000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - uint/4 - arg len 4 greater than remaining buf len",
+    "input": "1a000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - slice/2 - arg len 2 greater than remaining buf len",
+    "input": "5900",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - list/4 - arg len 4 greater than remaining buf len",
+    "input": "9a000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - tag/? - unexpected minor value 31",
+    "input": "df",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - major7/? - unexpected minor value 31",
+    "input": "ff",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - uint/? - unexpected minor value 31",
+    "input": "1f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - list/1 - arg len 1 greater than remaining buf len",
+    "input": "98",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidArgument - map/8 - arg len 8 greater than remaining buf len",
+    "input": "bb00000000000000",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidList - [] / eof after head - unexpected end of payload",
+    "input": "81",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidList - [] / invalid item - arg len 1 greater than remaining buf len",
+    "input": "8118",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidList - [_ ] / no break - expected break marker",
+    "input": "9f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidList - [_ ] / invalid item - arg len 1 greater than remaining buf len",
+    "input": "9f18",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidMap - {} / invalid key - slice len 1 greater than remaining buf len",
+    "input": "a17801",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidMap - {} / invalid value - arg len 1 greater than remaining buf len",
+    "input": "a163666f6f18",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidMap - {_ } / no break - expected break marker",
+    "input": "bf",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidMap - {_ } / invalid key - slice len 1 greater than remaining buf len",
+    "input": "bf7801",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidMap - {_ } / invalid value - arg len 1 greater than remaining buf len",
+    "input": "bf63666f6f18",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidMap - {} / eof after head - unexpected end of payload",
+    "input": "a1",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - slice/1, not enough bytes - slice len 1 greater than remaining buf len",
+    "input": "5801",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - slice/?, nested indefinite - nested indefinite slice",
+    "input": "5f5f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - string/?, no break - expected break marker",
+    "input": "7f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - string/?, nested indefinite - nested indefinite slice",
+    "input": "7f7f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - string/?, invalid nested definite - decode subslice: slice len 1 greater than remaining buf len",
+    "input": "7f7801",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - slice/?, no break - expected break marker",
+    "input": "5f",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - slice/?, invalid nested major - unexpected major type 3 in indefinite slice",
+    "input": "5f60",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - slice/?, invalid nested definite - decode subslice: slice len 1 greater than remaining buf len",
+    "input": "5f5801",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - string/1, not enough bytes - slice len 1 greater than remaining buf len",
+    "input": "7801",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidSlice - string/?, invalid nested major - unexpected major type 2 in indefinite slice",
+    "input": "7f40",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidTag - invalid value - arg len 1 greater than remaining buf len",
+    "input": "c118",
+    "error": true
+  },
+  {
+    "description": "TestDecode_InvalidTag - eof - unexpected end of payload",
+    "input": "c1",
+    "error": true
+  }
+]

--- a/tests/unit/botocore/cbor/decode-success-tests.json
+++ b/tests/unit/botocore/cbor/decode-success-tests.json
@@ -1,0 +1,1528 @@
+[
+  {
+    "description": "atomic - uint/0/max",
+    "input": "17",
+    "expect": {
+      "uint": 23
+    }
+  },
+  {
+    "description": "atomic - uint/2/min",
+    "input": "190000",
+    "expect": {
+      "uint": 0
+    }
+  },
+  {
+    "description": "atomic - uint/8/min",
+    "input": "1b0000000000000000",
+    "expect": {
+      "uint": 0
+    }
+  },
+  {
+    "description": "atomic - negint/1/min",
+    "input": "3800",
+    "expect": {
+      "negint": -1
+    }
+  },
+  {
+    "description": "atomic - negint/2/min",
+    "input": "390000",
+    "expect": {
+      "negint": -1
+    }
+  },
+  {
+    "description": "atomic - false",
+    "input": "f4",
+    "expect": {
+      "bool": false
+    }
+  },
+  {
+    "description": "atomic - uint/1/min",
+    "input": "1800",
+    "expect": {
+      "uint": 0
+    }
+  },
+  {
+    "description": "atomic - negint/8/min",
+    "input": "3b0000000000000000",
+    "expect": {
+      "negint": -1
+    }
+  },
+  {
+    "description": "atomic - float64/+Inf",
+    "input": "fb7ff0000000000000",
+    "expect": {
+      "float64": 9218868437227405312
+    }
+  },
+  {
+    "description": "atomic - uint/4/min",
+    "input": "1a00000000",
+    "expect": {
+      "uint": 0
+    }
+  },
+  {
+    "description": "atomic - null",
+    "input": "f6",
+    "expect": {
+      "null": {}
+    }
+  },
+  {
+    "description": "atomic - negint/2/max",
+    "input": "39ffff",
+    "expect": {
+      "negint": -65536
+    }
+  },
+  {
+    "description": "atomic - negint/8/max",
+    "input": "3bfffffffffffffffe",
+    "expect": {
+      "negint": -18446744073709551615
+    }
+  },
+  {
+    "description": "atomic - float32/1.625",
+    "input": "fa3fd00000",
+    "expect": {
+      "float32": 1070596096
+    }
+  },
+  {
+    "description": "atomic - uint/0/min",
+    "input": "00",
+    "expect": {
+      "uint": 0
+    }
+  },
+  {
+    "description": "atomic - uint/1/max",
+    "input": "18ff",
+    "expect": {
+      "uint": 255
+    }
+  },
+  {
+    "description": "atomic - uint/8/max",
+    "input": "1bffffffffffffffff",
+    "expect": {
+      "uint": 18446744073709551615
+    }
+  },
+  {
+    "description": "atomic - negint/1/max",
+    "input": "38ff",
+    "expect": {
+      "negint": -256
+    }
+  },
+  {
+    "description": "atomic - negint/4/min",
+    "input": "3a00000000",
+    "expect": {
+      "negint": -1
+    }
+  },
+  {
+    "description": "atomic - float64/1.625",
+    "input": "fb3ffa000000000000",
+    "expect": {
+      "float64": 4609997168567123968
+    }
+  },
+  {
+    "description": "atomic - uint/2/max",
+    "input": "19ffff",
+    "expect": {
+      "uint": 65535
+    }
+  },
+  {
+    "description": "atomic - negint/0/max",
+    "input": "37",
+    "expect": {
+      "negint": -24
+    }
+  },
+  {
+    "description": "atomic - negint/4/max",
+    "input": "3affffffff",
+    "expect": {
+      "negint": -4294967296
+    }
+  },
+  {
+    "description": "atomic - uint/4/max",
+    "input": "1affffffff",
+    "expect": {
+      "uint": 4294967295
+    }
+  },
+  {
+    "description": "atomic - negint/0/min",
+    "input": "20",
+    "expect": {
+      "negint": -1
+    }
+  },
+  {
+    "description": "atomic - true",
+    "input": "f5",
+    "expect": {
+      "bool": true
+    }
+  },
+  {
+    "description": "atomic - float32/+Inf",
+    "input": "fa7f800000",
+    "expect": {
+      "float32": 2139095040
+    }
+  },
+  {
+    "description": "definite slice - len = 0",
+    "input": "40",
+    "expect": {
+      "bytestring": []
+    }
+  },
+  {
+    "description": "definite slice - len \u003e 0",
+    "input": "43666f6f",
+    "expect": {
+      "bytestring": [
+        102,
+        111,
+        111
+      ]
+    }
+  },
+  {
+    "description": "definite string - len = 0",
+    "input": "60",
+    "expect": {
+      "string": ""
+    }
+  },
+  {
+    "description": "definite string - len \u003e 0",
+    "input": "63666f6f",
+    "expect": {
+      "string": "foo"
+    }
+  },
+  {
+    "description": "indefinite slice - len = 0",
+    "input": "5fff",
+    "expect": {
+      "bytestring": []
+    }
+  },
+  {
+    "description": "indefinite slice - len = 0, explicit",
+    "input": "5f40ff",
+    "expect": {
+      "bytestring": []
+    }
+  },
+  {
+    "description": "indefinite slice - len = 0, len \u003e 0",
+    "input": "5f4043666f6fff",
+    "expect": {
+      "bytestring": [
+        102,
+        111,
+        111
+      ]
+    }
+  },
+  {
+    "description": "indefinite slice - len \u003e 0, len = 0",
+    "input": "5f43666f6f40ff",
+    "expect": {
+      "bytestring": [
+        102,
+        111,
+        111
+      ]
+    }
+  },
+  {
+    "description": "indefinite slice - len \u003e 0, len \u003e 0",
+    "input": "5f43666f6f43666f6fff",
+    "expect": {
+      "bytestring": [
+        102,
+        111,
+        111,
+        102,
+        111,
+        111
+      ]
+    }
+  },
+  {
+    "description": "indefinite string - len = 0",
+    "input": "7fff",
+    "expect": {
+      "string": ""
+    }
+  },
+  {
+    "description": "indefinite string - len = 0, explicit",
+    "input": "7f60ff",
+    "expect": {
+      "string": ""
+    }
+  },
+  {
+    "description": "indefinite string - len = 0, len \u003e 0",
+    "input": "7f6063666f6fff",
+    "expect": {
+      "string": "foo"
+    }
+  },
+  {
+    "description": "indefinite string - len \u003e 0, len = 0",
+    "input": "7f63666f6f60ff",
+    "expect": {
+      "string": "foo"
+    }
+  },
+  {
+    "description": "indefinite string - len \u003e 0, len \u003e 0",
+    "input": "7f63666f6f63666f6fff",
+    "expect": {
+      "string": "foofoo"
+    }
+  },
+  {
+    "description": "list - [float64]",
+    "input": "81fb7ff0000000000000",
+    "expect": {
+      "list": [
+        {
+          "float64": 9218868437227405312
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/4/min]",
+    "input": "9f3a00000000ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/1/min]",
+    "input": "811800",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/4/min]",
+    "input": "9f1a00000000ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/0/max]",
+    "input": "8117",
+    "expect": {
+      "list": [
+        {
+          "uint": 23
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/1/max]",
+    "input": "8118ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 255
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/2/min]",
+    "input": "81390000",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/8/min]",
+    "input": "813b0000000000000000",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/2/min]",
+    "input": "9f190000ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/0/min]",
+    "input": "8100",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/0/min]",
+    "input": "8120",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/0/max]",
+    "input": "8137",
+    "expect": {
+      "list": [
+        {
+          "negint": -24
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/1/min]",
+    "input": "813800",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/1/max]",
+    "input": "8138ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -256
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/4/max]",
+    "input": "813affffffff",
+    "expect": {
+      "list": [
+        {
+          "negint": -4294967296
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/4/max]",
+    "input": "9f1affffffffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 4294967295
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/0/max]",
+    "input": "9f37ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -24
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/2/min]",
+    "input": "81190000",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ false]",
+    "input": "9ff4ff",
+    "expect": {
+      "list": [
+        {
+          "bool": false
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ float32]",
+    "input": "9ffa7f800000ff",
+    "expect": {
+      "list": [
+        {
+          "float32": 2139095040
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/1/max]",
+    "input": "9f38ffff",
+    "expect": {
+      "list": [
+        {
+          "negint": -256
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/8/max]",
+    "input": "811bffffffffffffffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 18446744073709551615
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/4/min]",
+    "input": "813a00000000",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/8/max]",
+    "input": "813bfffffffffffffffe",
+    "expect": {
+      "list": [
+        {
+          "negint": -18446744073709551615
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/2/min]",
+    "input": "9f390000ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/4/max]",
+    "input": "9f3affffffffff",
+    "expect": {
+      "list": [
+        {
+          "negint": -4294967296
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ true]",
+    "input": "9ff5ff",
+    "expect": {
+      "list": [
+        {
+          "bool": true
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ null]",
+    "input": "9ff6ff",
+    "expect": {
+      "list": [
+        {
+          "null": {}
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/8/min]",
+    "input": "811b0000000000000000",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [null]",
+    "input": "81f6",
+    "expect": {
+      "list": [
+        {
+          "null": {}
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/1/min]",
+    "input": "9f1800ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/1/max]",
+    "input": "9f18ffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 255
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/2/max]",
+    "input": "9f19ffffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 65535
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/8/min]",
+    "input": "9f1b0000000000000000ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/8/min]",
+    "input": "9f3b0000000000000000ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ float64]",
+    "input": "9ffb7ff0000000000000ff",
+    "expect": {
+      "list": [
+        {
+          "float64": 9218868437227405312
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/4/min]",
+    "input": "811a00000000",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [true]",
+    "input": "81f5",
+    "expect": {
+      "list": [
+        {
+          "bool": true
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [float32]",
+    "input": "81fa7f800000",
+    "expect": {
+      "list": [
+        {
+          "float32": 2139095040
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/0/min]",
+    "input": "9f00ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 0
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/0/max]",
+    "input": "9f17ff",
+    "expect": {
+      "list": [
+        {
+          "uint": 23
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ uint/8/max]",
+    "input": "9f1bffffffffffffffffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 18446744073709551615
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/1/min]",
+    "input": "9f3800ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/2/max]",
+    "input": "9f39ffffff",
+    "expect": {
+      "list": [
+        {
+          "negint": -65536
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/2/max]",
+    "input": "8119ffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 65535
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [negint/2/max]",
+    "input": "8139ffff",
+    "expect": {
+      "list": [
+        {
+          "negint": -65536
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [false]",
+    "input": "81f4",
+    "expect": {
+      "list": [
+        {
+          "bool": false
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/0/min]",
+    "input": "9f20ff",
+    "expect": {
+      "list": [
+        {
+          "negint": -1
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [_ negint/8/max]",
+    "input": "9f3bfffffffffffffffeff",
+    "expect": {
+      "list": [
+        {
+          "negint": -18446744073709551615
+        }
+      ]
+    }
+  },
+  {
+    "description": "list - [uint/4/max]",
+    "input": "811affffffff",
+    "expect": {
+      "list": [
+        {
+          "uint": 4294967295
+        }
+      ]
+    }
+  },
+  {
+    "description": "map - {uint/0/min}",
+    "input": "a163666f6f00",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/4/max}",
+    "input": "a163666f6f1affffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 4294967295
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/0/min}",
+    "input": "a163666f6f20",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ float32}",
+    "input": "bf63666f6ffa7f800000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "float32": 2139095040
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {false}",
+    "input": "a163666f6ff4",
+    "expect": {
+      "map": {
+        "foo": {
+          "bool": false
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {float32}",
+    "input": "a163666f6ffa7f800000",
+    "expect": {
+      "map": {
+        "foo": {
+          "float32": 2139095040
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/0/max}",
+    "input": "bf63666f6f17ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 23
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/2/min}",
+    "input": "bf63666f6f390000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ false}",
+    "input": "bf63666f6ff4ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "bool": false
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/8/min}",
+    "input": "a163666f6f1b0000000000000000",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/0/max}",
+    "input": "bf63666f6f37ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -24
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ null}",
+    "input": "bf63666f6ff6ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "null": {}
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/1/min}",
+    "input": "a163666f6f1800",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/1/min}",
+    "input": "bf63666f6f1800ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/8/max}",
+    "input": "bf63666f6f1bffffffffffffffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 18446744073709551615
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/0/min}",
+    "input": "bf63666f6f20ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/1/min}",
+    "input": "bf63666f6f3800ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/1/max}",
+    "input": "bf63666f6f38ffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -256
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/2/max}",
+    "input": "bf63666f6f39ffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -65536
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/4/min}",
+    "input": "bf63666f6f3a00000000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ true}",
+    "input": "bf63666f6ff5ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "bool": true
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/2/max}",
+    "input": "a163666f6f19ffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 65535
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/8/max}",
+    "input": "a163666f6f1bffffffffffffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 18446744073709551615
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/0/max}",
+    "input": "a163666f6f37",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -24
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/1/max}",
+    "input": "a163666f6f38ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -256
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/2/max}",
+    "input": "a163666f6f39ffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -65536
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/4/min}",
+    "input": "a163666f6f3a00000000",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/8/max}",
+    "input": "a163666f6f3bfffffffffffffffe",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -18446744073709551615
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {float64}",
+    "input": "a163666f6ffb7ff0000000000000",
+    "expect": {
+      "map": {
+        "foo": {
+          "float64": 9218868437227405312
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/0/min}",
+    "input": "bf63666f6f00ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/4/min}",
+    "input": "bf63666f6f1a00000000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/8/min}",
+    "input": "bf63666f6f1b0000000000000000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/1/max}",
+    "input": "a163666f6f18ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 255
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/2/min}",
+    "input": "a163666f6f390000",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/8/min}",
+    "input": "a163666f6f3b0000000000000000",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {true}",
+    "input": "a163666f6ff5",
+    "expect": {
+      "map": {
+        "foo": {
+          "bool": true
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/2/min}",
+    "input": "bf63666f6f190000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/8/min}",
+    "input": "bf63666f6f3b0000000000000000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/8/max}",
+    "input": "bf63666f6f3bfffffffffffffffeff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -18446744073709551615
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/0/max}",
+    "input": "a163666f6f17",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 23
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/4/max}",
+    "input": "a163666f6f3affffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -4294967296
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {null}",
+    "input": "a163666f6ff6",
+    "expect": {
+      "map": {
+        "foo": {
+          "null": {}
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/4/max}",
+    "input": "bf63666f6f1affffffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 4294967295
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ float64}",
+    "input": "bf63666f6ffb7ff0000000000000ff",
+    "expect": {
+      "map": {
+        "foo": {
+          "float64": 9218868437227405312
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/2/min}",
+    "input": "a163666f6f190000",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {uint/4/min}",
+    "input": "a163666f6f1a00000000",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 0
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {negint/1/min}",
+    "input": "a163666f6f3800",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -1
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/1/max}",
+    "input": "bf63666f6f18ffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 255
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ uint/2/max}",
+    "input": "bf63666f6f19ffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "uint": 65535
+        }
+      }
+    }
+  },
+  {
+    "description": "map - {_ negint/4/max}",
+    "input": "bf63666f6f3affffffffff",
+    "expect": {
+      "map": {
+        "foo": {
+          "negint": -4294967296
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 0/min",
+    "input": "c001",
+    "expect": {
+      "tag": {
+        "id": 0,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 1/min",
+    "input": "d80001",
+    "expect": {
+      "tag": {
+        "id": 0,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 1/max",
+    "input": "d8ff01",
+    "expect": {
+      "tag": {
+        "id": 255,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 4/min",
+    "input": "da0000000001",
+    "expect": {
+      "tag": {
+        "id": 0,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 8/min",
+    "input": "db000000000000000001",
+    "expect": {
+      "tag": {
+        "id": 0,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 0/max",
+    "input": "d701",
+    "expect": {
+      "tag": {
+        "id": 23,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 2/min",
+    "input": "d9000001",
+    "expect": {
+      "tag": {
+        "id": 0,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 2/max",
+    "input": "d9ffff01",
+    "expect": {
+      "tag": {
+        "id": 65535,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 4/max",
+    "input": "daffffffff01",
+    "expect": {
+      "tag": {
+        "id": 4294967295,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  },
+  {
+    "description": "tag - 8/max",
+    "input": "dbffffffffffffffff01",
+    "expect": {
+      "tag": {
+        "id": 18446744073709551615,
+        "value": {
+          "uint": 1
+        }
+      }
+    }
+  }
+]

--- a/tests/unit/botocore/cbor/test_cbor_decoding.py
+++ b/tests/unit/botocore/cbor/test_cbor_decoding.py
@@ -26,9 +26,7 @@ IGNORE_CASES = [
     'map - {null}',
 ]
 
-TEST_DIR = os.path.join(
-    os.path.dirname(os.path.abspath(__file__))
-)
+TEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)))
 
 
 @pytest.fixture(scope="module")
@@ -37,7 +35,9 @@ def parser():
 
 
 def _get_cbor_decoding_success_tests():
-    success_test_file_name = os.path.join(TEST_DIR, 'decode-success-tests.json')
+    success_test_file_name = os.path.join(
+        TEST_DIR, 'decode-success-tests.json'
+    )
     success_test_data = json.load(open(success_test_file_name))
     for case in success_test_data:
         if case['description'] in IGNORE_CASES:

--- a/tests/unit/botocore/cbor/test_cbor_decoding.py
+++ b/tests/unit/botocore/cbor/test_cbor_decoding.py
@@ -1,0 +1,132 @@
+import json
+import os
+import struct
+
+import pytest
+
+from botocore.parsers import ResponseParserError, RpcV2CBORParser
+
+IGNORE_CASES = [
+    # We ignore all the tag tests since none of them are supported tags in AWS.
+    # The majority of these aren't even defined tags in CBOR and just test that we
+    # can properly parse the number
+    'tag - 0/min',
+    'tag - 1/min',
+    'tag - 2/min',
+    'tag - 4/min',
+    'tag - 8/min',
+    'tag - 0/max',
+    'tag - 1/max',
+    'tag - 2/max',
+    'tag - 4/max',
+    'tag - 8/max',
+    # We are expected to drop keys with null values, which is the opposite of the
+    # assertion in these two map tests
+    'map - {_ null}',
+    'map - {null}',
+]
+
+TEST_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__))
+)
+
+
+@pytest.fixture(scope="module")
+def parser():
+    return RpcV2CBORParser()
+
+
+def _get_cbor_decoding_success_tests():
+    success_test_file_name = os.path.join(TEST_DIR, 'decode-success-tests.json')
+    success_test_data = json.load(open(success_test_file_name))
+    for case in success_test_data:
+        if case['description'] in IGNORE_CASES:
+            continue
+        yield case['description'], case['input'], case['expect']
+
+
+def _get_cbor_decoding_error_tests():
+    error_test_file_name = os.path.join(TEST_DIR, 'decode-error-tests.json')
+    error_test_data = json.load(open(error_test_file_name))
+    for case in error_test_data:
+        yield case['description'], case['input'], case['error']
+
+
+@pytest.mark.parametrize(
+    "json_description, input, expect", _get_cbor_decoding_success_tests()
+)
+def test_cbor_decoding_success(json_description, input, expect, parser):
+    stream = parser.get_peekable_stream_from_bytes(bytearray.fromhex(input))
+    parsed = parser.parse_data_item(stream)
+    _assert_expected_value(parsed, expect)
+
+
+@pytest.mark.parametrize(
+    "json_description, input, error", _get_cbor_decoding_error_tests()
+)
+def test_cbor_decoding_error(json_description, input, error, parser):
+    stream = parser.get_peekable_stream_from_bytes(bytearray.fromhex(input))
+    with pytest.raises(ResponseParserError):
+        parser.parse_data_item(stream)
+
+
+def assert_null(actual):
+    assert actual is None
+
+
+def assert_bytestring(actual, value):
+    assert actual == bytes(value)
+
+
+def assert_list(actual, value):
+    assert isinstance(actual, list)
+    for act_val, exp_val in zip(actual, value):
+        _assert_expected_value(act_val, exp_val)
+
+
+def assert_map(actual, value):
+    assert isinstance(actual, dict)
+    for key, val in value.items():
+        assert key in actual
+        _assert_expected_value(actual[key], val)
+
+
+def assert_tag(actual, value):
+    assert actual.tag == value['id']
+    assert actual.value == value['value']['uint']
+
+
+def assert_float(actual, expected_key, value):
+    struct_format = '<f' if expected_key == 'float32' else '<d'
+    packed_value = struct.pack(
+        '<I' if expected_key == 'float32' else '<Q', value
+    )
+    unpacked_value = struct.unpack(struct_format, packed_value)[0]
+    assert actual == unpacked_value
+
+
+def assert_default(actual, value):
+    assert actual == value
+
+
+ASSERTION_MAP = {
+    'null': assert_null,
+    'undefined': assert_null,
+    'bytestring': assert_bytestring,
+    'list': assert_list,
+    'map': assert_map,
+    'tag': assert_tag,
+    'float32': assert_float,
+    'float64': assert_float,
+}
+
+
+def _assert_expected_value(actual, expected):
+    for expected_key, value in expected.items():
+        assertion_func = ASSERTION_MAP.get(expected_key, assert_default)
+        if expected_key in ['null']:
+            assertion_func(actual)
+        elif expected_key in ['float32', 'float64']:
+            assertion_func(actual, expected_key, value)
+        else:
+            assertion_func(actual, value)

--- a/tests/unit/botocore/protocols/input/smithy-rpc-v2-cbor.json
+++ b/tests/unit/botocore/protocols/input/smithy-rpc-v2-cbor.json
@@ -1,0 +1,988 @@
+[
+    {
+        "description": "Test cases for EmptyInputOutput operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "EmptyStructure": {
+                "type": "structure",
+                "members": {}
+            }
+        },
+        "cases": [
+            {
+                "id": "empty_input",
+                "given": {
+                    "name": "EmptyInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "EmptyStructure"
+                    }
+                },
+                "description": "When Input structure is empty we write CBOR equivalent of {}",
+                "params": {},
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/EmptyInputOutput",
+                    "body": "v/8=",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "forbidHeaders": [
+                        "X-Amz-Target"
+                    ],
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for NoInputOutput operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {},
+        "cases": [
+            {
+                "id": "no_input",
+                "given": {
+                    "name": "NoInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    }
+                },
+                "description": "Body is empty and no Content-Type header if no input",
+                "params": {},
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/NoInputOutput",
+                    "body": "",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "forbidHeaders": [
+                        "Content-Type",
+                        "X-Amz-Target"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for OptionalInputOutput operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "SimpleStructure": {
+                "type": "structure",
+                "members": {
+                    "value": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "optional_input",
+                "given": {
+                    "name": "OptionalInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SimpleStructure"
+                    }
+                },
+                "description": "When input is empty we write CBOR equivalent of {}",
+                "params": {},
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/OptionalInputOutput",
+                    "body": "v/8=",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "forbidHeaders": [
+                        "X-Amz-Target"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RecursiveShapes operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "RecursiveShapesInputOutput": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "RecursiveShapesInputOutputNested1"
+                    }
+                }
+            },
+            "RecursiveShapesInputOutputNested1": {
+                "type": "structure",
+                "members": {
+                    "foo": {
+                        "shape": "String"
+                    },
+                    "nested": {
+                        "shape": "RecursiveShapesInputOutputNested2"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "RecursiveShapesInputOutputNested2": {
+                "type": "structure",
+                "members": {
+                    "bar": {
+                        "shape": "String"
+                    },
+                    "recursiveMember": {
+                        "shape": "RecursiveShapesInputOutputNested1"
+                    }
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborRecursiveShapes",
+                "given": {
+                    "name": "RecursiveShapes",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RecursiveShapesInputOutput"
+                    }
+                },
+                "description": "Serializes recursive structures",
+                "params": {
+                    "nested": {
+                        "foo": "Foo1",
+                        "nested": {
+                            "bar": "Bar1",
+                            "recursiveMember": {
+                                "foo": "Foo2",
+                                "nested": {
+                                    "bar": "Bar2"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RecursiveShapes",
+                    "body": "v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8=",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RpcV2CborDenseMaps operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "RpcV2CborDenseMapsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "denseStructMap": {
+                        "shape": "DenseStructMap"
+                    },
+                    "denseNumberMap": {
+                        "shape": "DenseNumberMap"
+                    },
+                    "denseBooleanMap": {
+                        "shape": "DenseBooleanMap"
+                    },
+                    "denseStringMap": {
+                        "shape": "DenseStringMap"
+                    },
+                    "denseSetMap": {
+                        "shape": "DenseSetMap"
+                    }
+                }
+            },
+            "DenseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "DenseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                }
+            },
+            "DenseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                }
+            },
+            "DenseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "DenseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborMaps",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "Serializes maps",
+                "params": {
+                    "denseStructMap": {
+                        "foo": {
+                            "hi": "there"
+                        },
+                        "baz": {
+                            "hi": "bye"
+                        }
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps",
+                    "body": "oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ==",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSerializesZeroValuesInMaps",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
+                "params": {
+                    "denseNumberMap": {
+                        "x": 0
+                    },
+                    "denseBooleanMap": {
+                        "x": false
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps",
+                    "body": "om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A==",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSerializesDenseSetMap",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "A request that contains a dense map of sets.",
+                "params": {
+                    "denseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborDenseMaps",
+                    "body": "oWtkZW5zZVNldE1hcKJheIBheYJhYWFi",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RpcV2CborLists operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "RpcV2CborListInputOutput": {
+                "type": "structure",
+                "members": {
+                    "stringList": {
+                        "shape": "StringList"
+                    },
+                    "stringSet": {
+                        "shape": "StringSet"
+                    },
+                    "integerList": {
+                        "shape": "IntegerList"
+                    },
+                    "booleanList": {
+                        "shape": "BooleanList"
+                    },
+                    "timestampList": {
+                        "shape": "TimestampList"
+                    },
+                    "enumList": {
+                        "shape": "FooEnumList"
+                    },
+                    "intEnumList": {
+                        "shape": "IntegerEnumList"
+                    },
+                    "nestedStringList": {
+                        "shape": "NestedStringList"
+                    },
+                    "structureList": {
+                        "shape": "StructureList"
+                    },
+                    "blobList": {
+                        "shape": "BlobList"
+                    }
+                }
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember"
+                }
+            },
+            "BlobList": {
+                "type": "list",
+                "member": {
+                    "shape": "Blob"
+                }
+            },
+            "Blob": {
+                "type": "blob"
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String"
+                    },
+                    "b": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborLists",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Serializes RpcV2 Cbor lists",
+                "params": {
+                    "stringList": [
+                        "foo",
+                        "bar"
+                    ],
+                    "stringSet": [
+                        "foo",
+                        "bar"
+                    ],
+                    "integerList": [
+                        1,
+                        2
+                    ],
+                    "booleanList": [
+                        true,
+                        false
+                    ],
+                    "timestampList": [
+                        1398796238,
+                        1398796238
+                    ],
+                    "enumList": [
+                        "Foo",
+                        "0"
+                    ],
+                    "intEnumList": [
+                        1,
+                        2
+                    ],
+                    "nestedStringList": [
+                        [
+                            "foo",
+                            "bar"
+                        ],
+                        [
+                            "baz",
+                            "qux"
+                        ]
+                    ],
+                    "structureList": [
+                        {
+                            "a": "1",
+                            "b": "2"
+                        },
+                        {
+                            "a": "3",
+                            "b": "4"
+                        }
+                    ],
+                    "blobList": [
+                        "foo",
+                        "bar"
+                    ]
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborLists",
+                    "body": "v2pzdHJpbmdMaXN0gmNmb29jYmFyaXN0cmluZ1NldIJjZm9vY2JhcmtpbnRlZ2VyTGlzdIIBAmtib29sZWFuTGlzdIL19G10aW1lc3RhbXBMaXN0gsH7QdTX+/OAAADB+0HU1/vzgAAAaGVudW1MaXN0gmNGb29hMGtpbnRFbnVtTGlzdIIBAnBuZXN0ZWRTdHJpbmdMaXN0goJjZm9vY2JhcoJjYmF6Y3F1eG1zdHJ1Y3R1cmVMaXN0gqJhYWExYWJhMqJhYWEzYWJhNGhibG9iTGlzdIJDZm9vQ2Jhcv8=",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborListsEmpty",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Serializes empty JSON lists",
+                "params": {
+                    "stringList": []
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborLists",
+                    "body": "v2pzdHJpbmdMaXN0n///",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborListsEmptyUsingDefiniteLength",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Serializes empty JSON definite length lists",
+                "params": {
+                    "stringList": []
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/RpcV2CborLists",
+                    "body": "oWpzdHJpbmdMaXN0gA==",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SimpleScalarProperties operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "SimpleScalarStructure": {
+                "type": "structure",
+                "members": {
+                    "trueBooleanValue": {
+                        "shape": "Boolean"
+                    },
+                    "falseBooleanValue": {
+                        "shape": "Boolean"
+                    },
+                    "byteValue": {
+                        "shape": "Integer"
+                    },
+                    "doubleValue": {
+                        "shape": "Double"
+                    },
+                    "floatValue": {
+                        "shape": "Float"
+                    },
+                    "integerValue": {
+                        "shape": "Integer"
+                    },
+                    "longValue": {
+                        "shape": "Long"
+                    },
+                    "shortValue": {
+                        "shape": "Integer"
+                    },
+                    "stringValue": {
+                        "shape": "String"
+                    },
+                    "blobValue": {
+                        "shape": "Blob"
+                    }
+                }
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "Blob": {
+                "type": "blob"
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborSimpleScalarProperties",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Serializes simple scalar properties",
+                "params": {
+                    "byteValue": 5,
+                    "doubleValue": 1.889,
+                    "falseBooleanValue": false,
+                    "floatValue": 7.625,
+                    "integerValue": 256,
+                    "longValue": 9873,
+                    "shortValue": 9898,
+                    "stringValue": "simple",
+                    "trueBooleanValue": true,
+                    "blobValue": "foo"
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+                    "body": "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w==",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborClientDoesntSerializeNullStructureValues",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "RpcV2 Cbor should not serialize null structure values",
+                "params": {
+                    "stringValue": null
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+                    "body": "v/8=",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsNaNFloatInputs",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports handling NaN float values.",
+                "params": {
+                    "doubleValue": "NaN",
+                    "floatValue": "NaN"
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+                    "body": "v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsInfinityFloatInputs",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports handling Infinity float values.",
+                "params": {
+                    "doubleValue": "Infinity",
+                    "floatValue": "Infinity"
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+                    "body": "v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsNegativeInfinityFloatInputs",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "input": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports handling Infinity float values.",
+                "params": {
+                    "doubleValue": "-Infinity",
+                    "floatValue": "-Infinity"
+                },
+                "serialized": {
+                    "method": "POST",
+                    "uri": "/service/RpcV2Protocol/operation/SimpleScalarProperties",
+                    "body": "v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/",
+                    "headers": {
+                        "Accept": "application/cbor",
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "requireHeaders": [
+                        "Content-Length"
+                    ]
+                }
+            }
+        ]
+    }
+]

--- a/tests/unit/botocore/protocols/output/smithy-rpc-v2-cbor.json
+++ b/tests/unit/botocore/protocols/output/smithy-rpc-v2-cbor.json
@@ -1,0 +1,1620 @@
+[
+    {
+        "description": "Test cases for EmptyInputOutput operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "EmptyStructure": {
+                "type": "structure",
+                "members": {}
+            }
+        },
+        "cases": [
+            {
+                "id": "empty_output",
+                "given": {
+                    "name": "EmptyInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "EmptyStructure"
+                    }
+                },
+                "description": "When output structure is empty we write CBOR equivalent of {}",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v/8="
+                }
+            },
+            {
+                "id": "empty_output_no_body",
+                "given": {
+                    "name": "EmptyInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "EmptyStructure"
+                    }
+                },
+                "description": "When output structure is empty the client should accept an empty body",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": ""
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for Float16 operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "Float16Output": {
+                "type": "structure",
+                "members": {
+                    "value": {
+                        "shape": "Double"
+                    }
+                }
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborFloat16Inf",
+                "given": {
+                    "name": "Float16",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "Float16Output"
+                    }
+                },
+                "description": "Ensures that clients can correctly parse float16 +Inf.",
+                "result": {
+                    "value": "Infinity"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWV2YWx1Zfl8AA=="
+                }
+            },
+            {
+                "id": "RpcV2CborFloat16NegInf",
+                "given": {
+                    "name": "Float16",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "Float16Output"
+                    }
+                },
+                "description": "Ensures that clients can correctly parse float16 -Inf.",
+                "result": {
+                    "value": "-Infinity"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWV2YWx1Zfn8AA=="
+                }
+            },
+            {
+                "id": "RpcV2CborFloat16LSBNaN",
+                "given": {
+                    "name": "Float16",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "Float16Output"
+                    }
+                },
+                "description": "Ensures that clients can correctly parse float16 NaN with high LSB.",
+                "result": {
+                    "value": "NaN"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWV2YWx1Zfl8AQ=="
+                }
+            },
+            {
+                "id": "RpcV2CborFloat16MSBNaN",
+                "given": {
+                    "name": "Float16",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "Float16Output"
+                    }
+                },
+                "description": "Ensures that clients can correctly parse float16 NaN with high MSB.",
+                "result": {
+                    "value": "NaN"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWV2YWx1Zfl+AA=="
+                }
+            },
+            {
+                "id": "RpcV2CborFloat16Subnormal",
+                "given": {
+                    "name": "Float16",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "Float16Output"
+                    }
+                },
+                "description": "Ensures that clients can correctly parse a subnormal float16.",
+                "result": {
+                    "value": 4.76837158203125E-6
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWV2YWx1ZfkAUA=="
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for FractionalSeconds operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "FractionalSecondsOutput": {
+                "type": "structure",
+                "members": {
+                    "datetime": {
+                        "shape": "DateTime"
+                    }
+                }
+            },
+            "DateTime": {
+                "type": "timestamp",
+                "timestampFormat": "iso8601"
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborDateTimeWithFractionalSeconds",
+                "given": {
+                    "name": "FractionalSeconds",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "FractionalSecondsOutput"
+                    }
+                },
+                "description": "Ensures that clients can correctly parse timestamps with fractional seconds",
+                "result": {
+                    "datetime": 9.46845296123E8
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2hkYXRldGltZcH7Qcw32zgPvnf/"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for GreetingWithErrors operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "InvalidGreeting": {
+                "type": "structure",
+                "members": {
+                    "Message": {
+                        "shape": "String"
+                    }
+                },
+                "documentation": "<p>This error is thrown when an invalid greeting value is provided.</p>",
+                "exception": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborInvalidGreetingError",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "InvalidGreeting"
+                        }
+                    ]
+                },
+                "description": "Parses simple RpcV2 Cbor errors",
+                "errorCode": "InvalidGreeting",
+                "errorMessage": "Hi",
+                "error": {
+                    "Message": "Hi"
+                },
+                "response": {
+                    "status_code": 400,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2ZfX3R5cGV4LnNtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNJbnZhbGlkR3JlZXRpbmdnTWVzc2FnZWJIaf8="
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for GreetingWithErrors operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "ComplexError": {
+                "type": "structure",
+                "members": {
+                    "TopLevel": {
+                        "shape": "String"
+                    },
+                    "Nested": {
+                        "shape": "ComplexNestedErrorData"
+                    }
+                },
+                "documentation": "<p>This error is thrown when a request is invalid.</p>",
+                "exception": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "ComplexNestedErrorData": {
+                "type": "structure",
+                "members": {
+                    "Foo": {
+                        "shape": "String"
+                    }
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborComplexError",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "ComplexError"
+                        }
+                    ]
+                },
+                "description": "Parses a complex error with no message member",
+                "errorCode": "ComplexError",
+                "error": {
+                    "TopLevel": "Top level",
+                    "Nested": {
+                        "Foo": "bar"
+                    }
+                },
+                "response": {
+                    "status_code": 400,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3JoVG9wTGV2ZWxpVG9wIGxldmVsZk5lc3RlZL9jRm9vY2Jhcv//"
+                }
+            },
+            {
+                "id": "RpcV2CborEmptyComplexError",
+                "given": {
+                    "name": "GreetingWithErrors",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "documentation": "<p>This operation has three possible return values:</p> <ol> <li>A successful response in the form of GreetingWithErrorsOutput</li> <li>An InvalidGreeting error.</li> <li>A ComplexError error.</li> </ol> <p>Implementations must be able to successfully take a response and properly deserialize successful and error responses.</p>",
+                    "idempotent": true,
+                    "errors": [
+                        {
+                            "shape": "ComplexError"
+                        }
+                    ]
+                },
+                "errorCode": "ComplexError",
+                "error": {},
+                "response": {
+                    "status_code": 400,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2ZfX3R5cGV4K3NtaXRoeS5wcm90b2NvbHRlc3RzLnJwY3YyQ2JvciNDb21wbGV4RXJyb3L/"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for NoInputOutput operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {},
+        "cases": [
+            {
+                "id": "no_output",
+                "given": {
+                    "name": "NoInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    }
+                },
+                "description": "A `Content-Type` header should not be set if the response body is empty.",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": ""
+                }
+            },
+            {
+                "id": "NoOutputClientAllowsEmptyCbor",
+                "given": {
+                    "name": "NoInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    }
+                },
+                "description": "Clients should accept a CBOR empty struct if there is no output.",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v/8="
+                }
+            },
+            {
+                "id": "NoOutputClientAllowsEmptyBody",
+                "given": {
+                    "name": "NoInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    }
+                },
+                "description": "Clients should accept an empty body if there is no output and\nshould not raise an error if the `Content-Type` header is set.",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": ""
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for OptionalInputOutput operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "SimpleStructure": {
+                "type": "structure",
+                "members": {
+                    "value": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "optional_output",
+                "given": {
+                    "name": "OptionalInputOutput",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleStructure"
+                    }
+                },
+                "description": "When output is empty we write CBOR equivalent of {}",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v/8="
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RecursiveShapes operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "RecursiveShapesInputOutput": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "RecursiveShapesInputOutputNested1"
+                    }
+                }
+            },
+            "RecursiveShapesInputOutputNested1": {
+                "type": "structure",
+                "members": {
+                    "foo": {
+                        "shape": "String"
+                    },
+                    "nested": {
+                        "shape": "RecursiveShapesInputOutputNested2"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "RecursiveShapesInputOutputNested2": {
+                "type": "structure",
+                "members": {
+                    "bar": {
+                        "shape": "String"
+                    },
+                    "recursiveMember": {
+                        "shape": "RecursiveShapesInputOutputNested1"
+                    }
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborRecursiveShapes",
+                "given": {
+                    "name": "RecursiveShapes",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RecursiveShapesInputOutput"
+                    }
+                },
+                "description": "Serializes recursive structures",
+                "result": {
+                    "nested": {
+                        "foo": "Foo1",
+                        "nested": {
+                            "bar": "Bar1",
+                            "recursiveMember": {
+                                "foo": "Foo2",
+                                "nested": {
+                                    "bar": "Bar2"
+                                }
+                            }
+                        }
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2ZuZXN0ZWS/Y2Zvb2RGb28xZm5lc3RlZL9jYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyv2Nmb29kRm9vMmZuZXN0ZWS/Y2JhcmRCYXIy//////8="
+                }
+            },
+            {
+                "id": "RpcV2CborRecursiveShapesUsingDefiniteLength",
+                "given": {
+                    "name": "RecursiveShapes",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RecursiveShapesInputOutput"
+                    }
+                },
+                "description": "Deserializes recursive structures encoded using a map with definite length",
+                "result": {
+                    "nested": {
+                        "foo": "Foo1",
+                        "nested": {
+                            "bar": "Bar1",
+                            "recursiveMember": {
+                                "foo": "Foo2",
+                                "nested": {
+                                    "bar": "Bar2"
+                                }
+                            }
+                        }
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWZuZXN0ZWSiY2Zvb2RGb28xZm5lc3RlZKJjYmFyZEJhcjFvcmVjdXJzaXZlTWVtYmVyomNmb29kRm9vMmZuZXN0ZWShY2JhcmRCYXIy"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RpcV2CborDenseMaps operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "RpcV2CborDenseMapsInputOutput": {
+                "type": "structure",
+                "members": {
+                    "denseStructMap": {
+                        "shape": "DenseStructMap"
+                    },
+                    "denseNumberMap": {
+                        "shape": "DenseNumberMap"
+                    },
+                    "denseBooleanMap": {
+                        "shape": "DenseBooleanMap"
+                    },
+                    "denseStringMap": {
+                        "shape": "DenseStringMap"
+                    },
+                    "denseSetMap": {
+                        "shape": "DenseSetMap"
+                    }
+                }
+            },
+            "DenseStructMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "GreetingStruct"
+                }
+            },
+            "DenseNumberMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Integer"
+                }
+            },
+            "DenseBooleanMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "Boolean"
+                }
+            },
+            "DenseStringMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "String"
+                }
+            },
+            "DenseSetMap": {
+                "type": "map",
+                "key": {
+                    "shape": "String"
+                },
+                "value": {
+                    "shape": "StringSet"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "GreetingStruct": {
+                "type": "structure",
+                "members": {
+                    "hi": {
+                        "shape": "String"
+                    }
+                }
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborMaps",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "Deserializes maps",
+                "result": {
+                    "denseStructMap": {
+                        "foo": {
+                            "hi": "there"
+                        },
+                        "baz": {
+                            "hi": "bye"
+                        }
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oW5kZW5zZVN0cnVjdE1hcKJjZm9voWJoaWV0aGVyZWNiYXqhYmhpY2J5ZQ=="
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesZeroValuesInMaps",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "Ensure that 0 and false are sent over the wire in all maps and lists",
+                "result": {
+                    "denseNumberMap": {
+                        "x": 0
+                    },
+                    "denseBooleanMap": {
+                        "x": false
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "om5kZW5zZU51bWJlck1hcKFheABvZGVuc2VCb29sZWFuTWFwoWF49A=="
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesDenseSetMap",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "A response that contains a dense map of sets",
+                "result": {
+                    "denseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWtkZW5zZVNldE1hcKJheIBheYJhYWFi"
+                }
+            },
+            {
+                "id": "RpcV2CborDeserializesDenseSetMapAndSkipsNull",
+                "given": {
+                    "name": "RpcV2CborDenseMaps",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborDenseMapsInputOutput"
+                    },
+                    "documentation": "<p>The example tests basic map serialization.</p>"
+                },
+                "description": "Clients SHOULD tolerate seeing a null value in a dense map, and they SHOULD\ndrop the null key-value pair.",
+                "result": {
+                    "denseSetMap": {
+                        "x": [],
+                        "y": [
+                            "a",
+                            "b"
+                        ]
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWtkZW5zZVNldE1hcKNheIBheYJhYWFiYXr2"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for RpcV2CborLists operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "RpcV2CborListInputOutput": {
+                "type": "structure",
+                "members": {
+                    "stringList": {
+                        "shape": "StringList"
+                    },
+                    "stringSet": {
+                        "shape": "StringSet"
+                    },
+                    "integerList": {
+                        "shape": "IntegerList"
+                    },
+                    "booleanList": {
+                        "shape": "BooleanList"
+                    },
+                    "timestampList": {
+                        "shape": "TimestampList"
+                    },
+                    "enumList": {
+                        "shape": "FooEnumList"
+                    },
+                    "intEnumList": {
+                        "shape": "IntegerEnumList"
+                    },
+                    "nestedStringList": {
+                        "shape": "NestedStringList"
+                    },
+                    "structureList": {
+                        "shape": "StructureList"
+                    },
+                    "blobList": {
+                        "shape": "BlobList"
+                    }
+                }
+            },
+            "StringList": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "StringSet": {
+                "type": "list",
+                "member": {
+                    "shape": "String"
+                }
+            },
+            "IntegerList": {
+                "type": "list",
+                "member": {
+                    "shape": "Integer"
+                }
+            },
+            "BooleanList": {
+                "type": "list",
+                "member": {
+                    "shape": "Boolean"
+                }
+            },
+            "TimestampList": {
+                "type": "list",
+                "member": {
+                    "shape": "Timestamp"
+                }
+            },
+            "FooEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "FooEnum"
+                }
+            },
+            "IntegerEnumList": {
+                "type": "list",
+                "member": {
+                    "shape": "IntegerEnum"
+                }
+            },
+            "NestedStringList": {
+                "type": "list",
+                "member": {
+                    "shape": "StringList"
+                },
+                "documentation": "<p>A list of lists of strings.</p>"
+            },
+            "StructureList": {
+                "type": "list",
+                "member": {
+                    "shape": "StructureListMember"
+                }
+            },
+            "BlobList": {
+                "type": "list",
+                "member": {
+                    "shape": "Blob"
+                }
+            },
+            "Blob": {
+                "type": "blob"
+            },
+            "StructureListMember": {
+                "type": "structure",
+                "members": {
+                    "a": {
+                        "shape": "String"
+                    },
+                    "b": {
+                        "shape": "String"
+                    }
+                }
+            },
+            "String": {
+                "type": "string"
+            },
+            "IntegerEnum": {
+                "type": "integer",
+                "box": true
+            },
+            "FooEnum": {
+                "type": "string",
+                "enum": [
+                    "Foo",
+                    "Baz",
+                    "Bar",
+                    "1",
+                    "0"
+                ]
+            },
+            "Timestamp": {
+                "type": "timestamp"
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborLists",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Serializes RpcV2 Cbor lists",
+                "result": {
+                    "stringList": [
+                        "foo",
+                        "bar"
+                    ],
+                    "stringSet": [
+                        "foo",
+                        "bar"
+                    ],
+                    "integerList": [
+                        1,
+                        2
+                    ],
+                    "booleanList": [
+                        true,
+                        false
+                    ],
+                    "timestampList": [
+                        1398796238,
+                        1398796238
+                    ],
+                    "enumList": [
+                        "Foo",
+                        "0"
+                    ],
+                    "intEnumList": [
+                        1,
+                        2
+                    ],
+                    "nestedStringList": [
+                        [
+                            "foo",
+                            "bar"
+                        ],
+                        [
+                            "baz",
+                            "qux"
+                        ]
+                    ],
+                    "structureList": [
+                        {
+                            "a": "1",
+                            "b": "2"
+                        },
+                        {
+                            "a": "3",
+                            "b": "4"
+                        }
+                    ],
+                    "blobList": [
+                        "foo",
+                        "bar"
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2pzdHJpbmdMaXN0n2Nmb29jYmFy/2lzdHJpbmdTZXSfY2Zvb2NiYXL/a2ludGVnZXJMaXN0nwEC/2tib29sZWFuTGlzdJ/19P9tdGltZXN0YW1wTGlzdJ/B+0HU1/vzgAAAwftB1Nf784AAAP9oZW51bUxpc3SfY0Zvb2Ew/2tpbnRFbnVtTGlzdJ8BAv9wbmVzdGVkU3RyaW5nTGlzdJ+fY2Zvb2NiYXL/n2NiYXpjcXV4//9tc3RydWN0dXJlTGlzdJ+/YWFhMWFiYTL/v2FhYTNhYmE0//9oYmxvYkxpc3SfQ2Zvb0NiYXL//w=="
+                }
+            },
+            {
+                "id": "RpcV2CborListsEmpty",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Serializes empty RpcV2 Cbor lists",
+                "result": {
+                    "stringList": []
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2pzdHJpbmdMaXN0n///"
+                }
+            },
+            {
+                "id": "RpcV2CborIndefiniteStringInsideIndefiniteListCanDeserialize",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Can deserialize indefinite length text strings inside an indefinite length list",
+                "result": {
+                    "stringList": [
+                        "An example indefinite string, which will be chunked, on each comma",
+                        "Another example indefinite string with only one chunk",
+                        "This is a plain string"
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2pzdHJpbmdMaXN0n394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n//8="
+                }
+            },
+            {
+                "id": "RpcV2CborIndefiniteStringInsideDefiniteListCanDeserialize",
+                "given": {
+                    "name": "RpcV2CborLists",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "RpcV2CborListInputOutput"
+                    },
+                    "documentation": "<p>This test case serializes JSON lists for the following cases for both input and output:</p> <ol> <li>Normal lists.</li> <li>Normal sets.</li> <li>Lists of lists.</li> <li>Lists of structures.</li> </ol>",
+                    "idempotent": true
+                },
+                "description": "Can deserialize indefinite length text strings inside a definite length list",
+                "result": {
+                    "stringList": [
+                        "An example indefinite string, which will be chunked, on each comma",
+                        "Another example indefinite string with only one chunk",
+                        "This is a plain string"
+                    ]
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "oWpzdHJpbmdMaXN0g394HUFuIGV4YW1wbGUgaW5kZWZpbml0ZSBzdHJpbmcsdyB3aGljaCB3aWxsIGJlIGNodW5rZWQsbiBvbiBlYWNoIGNvbW1h/394NUFub3RoZXIgZXhhbXBsZSBpbmRlZmluaXRlIHN0cmluZyB3aXRoIG9ubHkgb25lIGNodW5r/3ZUaGlzIGlzIGEgcGxhaW4gc3RyaW5n"
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for SimpleScalarProperties operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "SimpleScalarStructure": {
+                "type": "structure",
+                "members": {
+                    "trueBooleanValue": {
+                        "shape": "Boolean"
+                    },
+                    "falseBooleanValue": {
+                        "shape": "Boolean"
+                    },
+                    "byteValue": {
+                        "shape": "Integer"
+                    },
+                    "doubleValue": {
+                        "shape": "Double"
+                    },
+                    "floatValue": {
+                        "shape": "Float"
+                    },
+                    "integerValue": {
+                        "shape": "Integer"
+                    },
+                    "longValue": {
+                        "shape": "Long"
+                    },
+                    "shortValue": {
+                        "shape": "Integer"
+                    },
+                    "stringValue": {
+                        "shape": "String"
+                    },
+                    "blobValue": {
+                        "shape": "Blob"
+                    }
+                }
+            },
+            "Boolean": {
+                "type": "boolean",
+                "box": true
+            },
+            "Integer": {
+                "type": "integer",
+                "box": true
+            },
+            "Double": {
+                "type": "double",
+                "box": true
+            },
+            "Float": {
+                "type": "float",
+                "box": true
+            },
+            "Long": {
+                "type": "long",
+                "box": true
+            },
+            "String": {
+                "type": "string"
+            },
+            "Blob": {
+                "type": "blob"
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborSimpleScalarProperties",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Serializes simple scalar properties",
+                "result": {
+                    "trueBooleanValue": true,
+                    "falseBooleanValue": false,
+                    "byteValue": 5,
+                    "doubleValue": 1.889,
+                    "floatValue": 7.625,
+                    "integerValue": 256,
+                    "shortValue": 9898,
+                    "stringValue": "simple",
+                    "blobValue": "foo"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v3B0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb2//"
+                }
+            },
+            {
+                "id": "RpcV2CborSimpleScalarPropertiesUsingDefiniteLength",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Deserializes simple scalar properties encoded using a map with definite length",
+                "result": {
+                    "trueBooleanValue": true,
+                    "falseBooleanValue": false,
+                    "byteValue": 5,
+                    "doubleValue": 1.889,
+                    "floatValue": 7.625,
+                    "integerValue": 256,
+                    "shortValue": 9898,
+                    "stringValue": "simple",
+                    "blobValue": "foo"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "qXB0cnVlQm9vbGVhblZhbHVl9XFmYWxzZUJvb2xlYW5WYWx1ZfRpYnl0ZVZhbHVlBWtkb3VibGVWYWx1Zfs//jlYEGJN02pmbG9hdFZhbHVl+kD0AABsaW50ZWdlclZhbHVlGQEAanNob3J0VmFsdWUZJqprc3RyaW5nVmFsdWVmc2ltcGxlaWJsb2JWYWx1ZUNmb28="
+                }
+            },
+            {
+                "id": "RpcV2CborClientDoesntDeserializeNullStructureValues",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "RpcV2 Cbor should not deserialize null structure values",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2tzdHJpbmdWYWx1Zfb/"
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsNaNFloatOutputs",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports handling NaN float values.",
+                "result": {
+                    "doubleValue": "NaN",
+                    "floatValue": "NaN"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2tkb3VibGVWYWx1Zft/+AAAAAAAAGpmbG9hdFZhbHVl+n/AAAD/"
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsInfinityFloatOutputs",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports handling Infinity float values.",
+                "result": {
+                    "doubleValue": "Infinity",
+                    "floatValue": "Infinity"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2tkb3VibGVWYWx1Zft/8AAAAAAAAGpmbG9hdFZhbHVl+n+AAAD/"
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsNegativeInfinityFloatOutputs",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports handling Negative Infinity float values.",
+                "result": {
+                    "doubleValue": "-Infinity",
+                    "floatValue": "-Infinity"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/"
+                }
+            },
+            {
+                "id": "RpcV2CborSupportsUpcastingDataOnDeserialize",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "Supports upcasting from a smaller byte representation of the same data type.",
+                "result": {
+                    "doubleValue": 1.5,
+                    "floatValue": 7.625,
+                    "integerValue": 56,
+                    "longValue": 256,
+                    "shortValue": 10
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2tkb3VibGVWYWx1Zfk+AGpmbG9hdFZhbHVl+UegbGludGVnZXJWYWx1ZRg4aWxvbmdWYWx1ZRkBAGpzaG9ydFZhbHVlCv8="
+                }
+            },
+            {
+                "id": "RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients",
+                "given": {
+                    "name": "SimpleScalarProperties",
+                    "http": {
+                        "method": "POST",
+                        "requestUri": "/"
+                    },
+                    "output": {
+                        "shape": "SimpleScalarStructure"
+                    }
+                },
+                "description": "The client should skip over additional fields that are not part of the structure. This allows a\nclient generated against an older Smithy model to be able to communicate with a server that is\ngenerated against a newer Smithy model.",
+                "result": {
+                    "byteValue": 5,
+                    "doubleValue": 1.889,
+                    "falseBooleanValue": false,
+                    "floatValue": 7.625,
+                    "integerValue": 256,
+                    "longValue": 9873,
+                    "shortValue": 9898,
+                    "stringValue": "simple",
+                    "trueBooleanValue": true,
+                    "blobValue": "foo"
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"
+                    },
+                    "body": "v2lieXRlVmFsdWUFa2RvdWJsZVZhbHVl+z/+OVgQYk3TcWZhbHNlQm9vbGVhblZhbHVl9GpmbG9hdFZhbHVl+kD0AABrZXh0cmFPYmplY3S/c2luZGVmaW5pdGVMZW5ndGhNYXC/a3dpdGhBbkFycmF5nwECA///cWRlZmluaXRlTGVuZ3RoTWFwo3J3aXRoQURlZmluaXRlQXJyYXmDAQIDeB1hbmRTb21lSW5kZWZpbml0ZUxlbmd0aFN0cmluZ3gfdGhhdCBoYXMsIGJlZW4gY2h1bmtlZCBvbiBjb21tYWxub3JtYWxTdHJpbmdjZm9vanNob3J0VmFsdWUZJw9uc29tZU90aGVyRmllbGR2dGhpcyBzaG91bGQgYmUgc2tpcHBlZP9saW50ZWdlclZhbHVlGQEAaWxvbmdWYWx1ZRkmkWpzaG9ydFZhbHVlGSaqa3N0cmluZ1ZhbHVlZnNpbXBsZXB0cnVlQm9vbGVhblZhbHVl9WlibG9iVmFsdWVDZm9v/w=="
+                }
+            }
+        ]
+    },
+    {
+        "description": "Test cases for HttpPayloadWithUnion operation",
+        "metadata": {
+            "protocol": "smithy-rpc-v2-cbor",
+            "protocols": [
+                "smithy-rpc-v2-cbor"
+            ],
+            "apiVersion": "2020-07-14",
+            "targetPrefix": "RpcV2Protocol"
+        },
+        "shapes": {
+            "HttpPayloadWithUnionInputOutput": {
+                "type": "structure",
+                "members": {
+                    "nested": {
+                        "shape": "UnionPayload"
+                    }
+                },
+                "payload": "nested"
+            },
+            "UnionPayload": {
+                "type": "structure",
+                "members": {
+                    "greeting": {
+                        "shape": "String"
+                    }
+                },
+                "union": true
+            },
+            "String": {
+                "type": "string"
+            }
+        },
+        "cases": [
+            {
+                "id": "RpcV2CborPayloadWithUnion",
+                "given": {
+                    "name": "HttpPayloadWithUnion",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/HttpPayloadWithUnion",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "HttpPayloadWithUnionInputOutput"
+                    },
+                    "documentation": "<p>This example serializes a union in the payload.</p>",
+                    "idempotent": true
+                },
+                "description": "Serializes a union in the payload.",
+                "result": {
+                    "nested": {
+                        "greeting": "hello"
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Type": "application/cbor",
+                        "smithy-protocol": "rpc-v2-cbor"                    },
+                    "body": "oWZuZXN0ZWShaGdyZWV0aW5nZWhlbGxv"
+                }
+            },
+            {
+                "id": "RpcV2CborPayloadWithUnsetUnion",
+                "given": {
+                    "name": "HttpPayloadWithUnion",
+                    "http": {
+                        "method": "PUT",
+                        "requestUri": "/HttpPayloadWithUnion",
+                        "responseCode": 200
+                    },
+                    "output": {
+                        "shape": "HttpPayloadWithUnionInputOutput"
+                    },
+                    "documentation": "<p>This example serializes a union in the payload.</p>",
+                    "idempotent": true
+                },
+                "description": "No payload is sent if the union has no value.",
+                "result": {},
+                "response": {
+                    "status_code": 200,
+                    "headers": {
+                        "Content-Length": "0"
+                    },
+                    "body": "v2tkb3VibGVWYWx1Zfv/8AAAAAAAAGpmbG9hdFZhbHVl+v+AAAD/"
+                }
+            }
+        ]
+    }
+]

--- a/tests/unit/botocore/protocols/protocol-tests-ignore-list.json
+++ b/tests/unit/botocore/protocols/protocol-tests-ignore-list.json
@@ -68,6 +68,14 @@
           "IgnoreQueryParamsInResponse"
         ]
       }
+    },
+    "smithy-rpc-v2-cbor": {
+      "output": {
+        "cases": [
+          "RpcV2CborExtraFieldsInTheBodyShouldBeSkippedByClients",
+          "RpcV2CborDeserializesDenseSetMapAndSkipsNull"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
*Description of changes:*
- Adds support for RPCV2 parsing and serialization. Includes updates to relevant tests, e.g. protocol tests. 
- The following (already approved) PRs are included in this PR. No other changes are included:
  - #9367 
  - #9381 

*Description of tests:*
- Ran all CI and test suites
- No further testing can be justified since wire-level parsing & serialization is hidden from the AWS CLI v2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
