### PR TITLE
Fix code highlighting typo in AWS CLI S3 Configuration documentation

### DIFF
--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -40,7 +40,7 @@ and ``aws s3api``:
   on your bucket before attempting to use the endpoint. This is mutually
   exclusive with the ``use_dualstack_endpoint`` option.
 * ``use_dualstack_endpoint`` - Use the Amazon S3 dual IPv4 / IPv6 endpoint for
-  all ``s3 `` and ``s3api`` commands.  This is mutually exclusive with the
+  all ``s3`` and ``s3api`` commands.  This is mutually exclusive with the
   ``use_accelerate_endpoint`` option.
 * ``addressing_style`` - Specifies which addressing style to use. This controls
   if the bucket name is in the hostname or part of the URL. Value values are:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The trailing space caused undesired formatting in the documentation page at https://docs.aws.amazon.com/cli/latest/topic/s3-config.html

![image](https://github.com/user-attachments/assets/a77c7e15-8985-45cb-acb4-032f8670812f)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
