### PR TITLE
Remove old years from copyright in License.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2012-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"). You
 may not use this file except in compliance with the License. A copy of

--- a/macpkg/resources/LICENSE.txt
+++ b/macpkg/resources/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2012-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"). You
 may not use this file except in compliance with the License. A copy of


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Removed the old years from the copyright statement in the license.

The one appears here in the Mac installer, which looks out-of-date:
<img width="613" alt="image" src="https://github.com/user-attachments/assets/a3b23128-d0b5-4983-ac63-b7f1ca025268" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
