### PR TITLE
Relax symlink verification when building MacOS executables

### DIFF
--- a/.changes/next-release/bugfix-dependency-14770.json
+++ b/.changes/next-release/bugfix-dependency-14770.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "dependency",
+  "description": "Relax symlink verification when building MacOS executables"
+}

--- a/exe/pyinstaller/aws.spec
+++ b/exe/pyinstaller/aws.spec
@@ -25,6 +25,9 @@ if platform.system() == "Darwin":
         if dest.startswith('Python.framework/Versions/') and dest.endswith('/Python'):
             # and move it to the top
             dest = 'Python'
+        if dest.startswith('Python3.framework/Versions/') and dest.endswith('/Python3'):
+            # and move it to the top
+            dest = 'Python3'
         updated_binaries.append((dest, src, typecode))
     aws_a.binaries = updated_binaries
 
@@ -34,15 +37,10 @@ if platform.system() == "Darwin":
     for dest, src, typecode in aws_a.datas:
         if (dest.startswith('Python.framework/') or (dest == 'Python' and typecode == 'SYMLINK')):
             continue
+        if (dest.startswith('Python3.framework/') or (dest == 'Python3' and typecode == 'SYMLINK')):
+            continue
         updated_datas.append((dest, src, typecode))
     aws_a.datas = updated_datas
-
-    # Verify that there are no remaining symlinks
-    for dest, src, typecode in aws_a.datas:
-        if typecode == 'SYMLINK':
-            raise ValueError((f'Symlink ({dest} -> {src}) found in table of contents. '
-                'Our downstream packaging and signing code does not support symlinks, '
-                'so this requires investigation.'))
 
 aws_pyz = PYZ(aws_a.pure, aws_a.zipped_data, cipher=block_cipher)
 aws_exe = EXE(aws_pyz,

--- a/exe/pyinstaller/aws_completer.spec
+++ b/exe/pyinstaller/aws_completer.spec
@@ -26,6 +26,9 @@ if platform.system() == "Darwin":
         if dest.startswith('Python.framework/Versions/') and dest.endswith('/Python'):
             # and move it to the top
             dest = 'Python'
+        elif dest.startswith('Python3.framework/Versions/') and dest.endswith('/Python3'):
+            # and move it to the top
+            dest = 'Python3'
         updated_binaries.append((dest, src, typecode))
     completer_a.binaries = updated_binaries
 
@@ -35,15 +38,10 @@ if platform.system() == "Darwin":
     for dest, src, typecode in completer_a.datas:
         if (dest.startswith('Python.framework/') or (dest == 'Python' and typecode == 'SYMLINK')):
             continue
+        elif (dest.startswith('Python3.framework/') or (dest == 'Python3' and typecode == 'SYMLINK')):
+            continue
         updated_datas.append((dest, src, typecode))
     completer_a.datas = updated_datas
-
-    # Verify that there are no remaining symlinks
-    for dest, src, typecode in completer_a.datas:
-        if typecode == 'SYMLINK':
-            raise ValueError((f'Symlink ({dest} -> {src}) found in table of contents. '
-                'Our downstream packaging and signing code does not support symlinks, '
-                'so this requires investigation.'))
 
 completer_pyz = PYZ(completer_a.pure, completer_a.zipped_data, cipher=block_cipher)
 completer_exe = EXE(completer_pyz,


### PR DESCRIPTION
*Issue #, if available:* #9393

*Description of changes:* 
1. The handling of the Python executable introduced in #9382 only applied to `Python` and not `Python3`. I reproduced in a 3.9 virtualenv locally.
2. I removed the symlink verification that we added to ensure compatibility with the internal signing+notarization code. I'll look into moving this validation close to there, I think doing it here can potentially impact those building from source who don't need to sign + notarize.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
