### PR TITLE
Remove reference to Python version v1

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -2,8 +2,7 @@
 Building The Documentation
 ==========================
 
-Before building the documentation, make sure you have Python 3.7,
-the awscli, and all the necessary dependencies installed.  You can
+Before building the documentation, ensure you have the AWS CLI and necessary dependencies installed.  You can
 install dependencies by using the requirements-docs.txt file at the
 root of this repo::
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -2,9 +2,9 @@
 Building The Documentation
 ==========================
 
-Before building the documentation, ensure you have the AWS CLI and necessary dependencies installed.  You can
-install dependencies by using the requirements-docs.txt file at the
-root of this repo::
+Before building the documentation, ensure you have the AWS CLI and
+necessary dependencies installed.  You can install dependencies by
+using the requirements-docs.txt file at the root of this repo::
 
     pip install -r requirements-docs.txt
 


### PR DESCRIPTION
*Issue #, if available:* CLI-6149

*Description of changes:* 
- Remove the reference to Python version from this doc. It should be clear from the top level readme what versions we support.
- V2 PR: https://github.com/aws/aws-cli/pull/9398


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
