### PR TITLE
Lint unsafe fixes UP030, UP031, UP032 for f-strings

### DIFF
--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -257,9 +257,8 @@ class BaseInternalAliasCommand(BaseAliasCommand):
             alias_args = shlex.split(self._alias_value)
         except ValueError as e:
             raise InvalidAliasException(
-                'Value of alias "%s" could not be parsed. '
-                'Received error: %s when parsing:\n%s'
-                % (self._alias_name, e, self._alias_value)
+                f'Value of alias "{self._alias_name}" could not be parsed. '
+                f'Received error: {e} when parsing:\n{self._alias_value}'
             )
 
         alias_args = [arg.strip(os.linesep) for arg in alias_args]
@@ -301,9 +300,8 @@ class BaseInternalAliasCommand(BaseAliasCommand):
             if arg_parser.get_default(parsed_param) != value:
                 if parsed_param in self.UNSUPPORTED_GLOBAL_PARAMETERS:
                     raise InvalidAliasException(
-                        'Global parameter "--%s" detected in alias "%s" '
+                        f'Global parameter "--{parsed_param}" detected in alias "{self._alias_name}" '
                         'which is not supported in subcommand aliases.'
-                        % (parsed_param, self._alias_name)
                     )
                 else:
                     global_params_to_update.append(parsed_param)

--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -24,7 +24,7 @@ HELP_BLURB = (
 )
 USAGE = (
     "aws [options] <command> <subcommand> [<subcommand> ...] [parameters]\n"
-    "%s" % HELP_BLURB
+    f"{HELP_BLURB}"
 )
 
 
@@ -85,9 +85,9 @@ class CLIArgParser(argparse.ArgumentParser):
                 msg.append(' | '.join(current))
             possible = get_close_matches(value, action.choices, cutoff=0.8)
             if possible:
-                extra = ['\n\nInvalid choice: %r, maybe you meant:\n' % value]
+                extra = [f'\n\nInvalid choice: {value!r}, maybe you meant:\n']
                 for word in possible:
-                    extra.append('  * %s' % word)
+                    extra.append(f'  * {word}')
                 msg.extend(extra)
             raise argparse.ArgumentError(action, '\n'.join(msg))
 
@@ -154,7 +154,7 @@ class MainArgParser(CLIArgParser):
     def _create_choice_help(self, choices):
         help_str = ''
         for choice in sorted(choices):
-            help_str += '* %s\n' % choice
+            help_str += f'* {choice}\n'
         return help_str
 
     def _build(self, command_table, version_string, argument_table):

--- a/awscli/arguments.py
+++ b/awscli/arguments.py
@@ -482,7 +482,7 @@ class CLIArgument(BaseCLIArgument):
         service_name = self._operation_model.service_model.service_name
         operation_name = xform_name(self._operation_model.name, '-')
         override = self._emit_first_response(
-            'process-cli-arg.%s.%s' % (service_name, operation_name),
+            f'process-cli-arg.{service_name}.{operation_name}',
             param=self.argument_model,
             cli_argument=self,
             value=value,
@@ -584,7 +584,7 @@ class BooleanArgument(CLIArgument):
         # ourselves for the negative service.  We then insert both into the
         # arg table.
         argument_table[self.name] = self
-        negative_name = 'no-%s' % self.name
+        negative_name = f'no-{self.name}'
         negative_version = self.__class__(
             negative_name,
             self.argument_model,

--- a/awscli/autocomplete/completer.py
+++ b/awscli/autocomplete/completer.py
@@ -81,15 +81,7 @@ class CompletionResult:
         )
 
     def __repr__(self):
-        return '%s(%s, %s, %s, %s, %s, %s)' % (
-            self.__class__.__name__,
-            self.name,
-            self.starting_index,
-            self.required,
-            self.cli_type_name,
-            self.help_text,
-            self.display_text,
-        )
+        return f'{self.__class__.__name__}({self.name}, {self.starting_index}, {self.required}, {self.cli_type_name}, {self.help_text}, {self.display_text})'
 
 
 class BaseCompleter:

--- a/awscli/autocomplete/db.py
+++ b/awscli/autocomplete/db.py
@@ -10,7 +10,7 @@ LOG = logging.getLogger(__name__)
 # of our shipped distributable, but for now we'll add this to our cache
 # dir.
 INDEX_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
-INDEX_FILE = os.path.join(INDEX_DIR, '%s.index' % cli_version)
+INDEX_FILE = os.path.join(INDEX_DIR, f'{cli_version}.index')
 BUILTIN_INDEX_FILE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     'data',

--- a/awscli/autocomplete/local/basic.py
+++ b/awscli/autocomplete/local/basic.py
@@ -119,7 +119,7 @@ class FilePathCompleter(BaseCompleter):
             # PathCompleter makes really strange suggestions for lonely ~
             # "username/", so in this case we handle it by ourselves
             if filename_part == '~':
-                return [CompletionResult(''.join([prefix, '~%s' % os.sep]))]
+                return [CompletionResult(''.join([prefix, f'~{os.sep}']))]
             dirname = os.path.dirname(filename_part)
             if dirname and dirname != os.sep:
                 dirname = f'{dirname}{os.sep}'
@@ -238,7 +238,7 @@ class ModelIndexCompleter(BaseCompleter):
                 results.append(
                     self._outfile_filter(
                         CompletionResult(
-                            '--%s' % arg_name,
+                            f'--{arg_name}',
                             starting_index=offset,
                             required=arg_data.required,
                             cli_type_name=arg_data.type_name,
@@ -269,7 +269,7 @@ class ModelIndexCompleter(BaseCompleter):
                 )
             global_param_completions.append(
                 CompletionResult(
-                    '--%s' % arg_name,
+                    f'--{arg_name}',
                     starting_index=offset,
                     required=False,
                     cli_type_name=type_name,
@@ -342,10 +342,7 @@ class ShorthandCompleter(BaseCompleter):
     def _set_results_name(self, results, fragment):
         for result in results:
             name_part_len = len(fragment) - len(result.name)
-            result.name = "%s%s" % (
-                fragment[:name_part_len],
-                result.display_text,
-            )
+            result.name = f"{fragment[:name_part_len]}{result.display_text}"
         return results
 
     def _close_brackets(self, fragment):
@@ -405,7 +402,7 @@ class ShorthandCompleter(BaseCompleter):
 
     def _get_completion(self, arg_model, parsed_input):
         completion = getattr(
-            self, "_get_prompt_for_%s" % arg_model.type_name, self._no_prompt
+            self, f"_get_prompt_for_{arg_model.type_name}", self._no_prompt
         )(arg_model, parsed_input)
         if completion is None:
             return []
@@ -532,7 +529,7 @@ class ShorthandCompleter(BaseCompleter):
         results = []
         for member_name, member in arg_model.members.items():
             if member_name not in entered_keys:
-                display_text = '%s=%s' % (
+                display_text = '{}={}'.format(
                     member_name,
                     self._VALUE_PREFIXES.get(member.type_name, ''),
                 )
@@ -607,9 +604,8 @@ class QueryCompleter(BaseCompleter):
         )
         for completion in completions:
             name_part_len = len(fragment) - len(completion.name)
-            completion.name = "%s%s" % (
-                fragment[:name_part_len],
-                completion.display_text,
+            completion.name = (
+                f"{fragment[:name_part_len]}{completion.display_text}"
             )
         return completions
 

--- a/awscli/autocomplete/local/indexer.py
+++ b/awscli/autocomplete/local/indexer.py
@@ -130,7 +130,7 @@ class ModelIndexer:
                 command=name, parent=parent, arg_table=command.arg_table
             )
             self._generate_command_index(
-                command.subcommand_table, parent='%s.%s' % (parent, name)
+                command.subcommand_table, parent=f'{parent}.{name}'
             )
 
     def _generate_table_indexes(self):

--- a/awscli/autoprompt/history.py
+++ b/awscli/autoprompt/history.py
@@ -37,7 +37,7 @@ class HistoryDriver(FileHistory):
             return reversed(commands)
         except Exception as e:
             LOG.debug(
-                'Exception on loading prompt history: %s' % e, exc_info=True
+                f'Exception on loading prompt history: {e}', exc_info=True
             )
             return []
 

--- a/awscli/autoprompt/output.py
+++ b/awscli/autoprompt/output.py
@@ -69,8 +69,9 @@ class OutputGetter:
         output = parsed.global_params.get('output') or session_output
         if output not in self._output_formats:
             error_message = (
-                "Bad value for --output: %s\n\nValid values are: %s"
-                % (output, ', '.join(self._output_formats))
+                "Bad value for --output: {}\n\nValid values are: {}".format(
+                    output, ', '.join(self._output_formats)
+                )
             )
         return output, error_message
 
@@ -98,7 +99,7 @@ class OutputGetter:
         try:
             self._current_expression = jmespath.compile(query)
         except jmespath.exceptions.ParseError as e:
-            error_message = "Bad value for --query: %s\n\n%s" % (query, str(e))
+            error_message = f"Bad value for --query: {query}\n\n{str(e)}"
         except jmespath.exceptions.EmptyExpressionError:
             self._current_expression = None
         except Exception:

--- a/awscli/autoprompt/prompttoolkit.py
+++ b/awscli/autoprompt/prompttoolkit.py
@@ -294,7 +294,7 @@ class PromptToolkitCompleter(Completer):
             )
         except Exception as e:
             LOG.debug(
-                'Exception caught in PromptToolkitCompleter: %s' % e,
+                f'Exception caught in PromptToolkitCompleter: {e}',
                 exc_info=True,
             )
 

--- a/awscli/bcdoc/docevents.py
+++ b/awscli/bcdoc/docevents.py
@@ -38,18 +38,18 @@ DOC_EVENTS = {
 def generate_events(session, help_command):
     # Now generate the documentation events
     session.emit(
-        'doc-breadcrumbs.%s' % help_command.event_class,
+        f'doc-breadcrumbs.{help_command.event_class}',
         help_command=help_command,
     )
     session.emit(
-        'doc-title.%s' % help_command.event_class, help_command=help_command
+        f'doc-title.{help_command.event_class}', help_command=help_command
     )
     session.emit(
-        'doc-description.%s' % help_command.event_class,
+        f'doc-description.{help_command.event_class}',
         help_command=help_command,
     )
     session.emit(
-        'doc-synopsis-start.%s' % help_command.event_class,
+        f'doc-synopsis-start.{help_command.event_class}',
         help_command=help_command,
     )
     if help_command.arg_table:
@@ -63,17 +63,16 @@ def generate_events(session, help_command):
             ):
                 continue
             session.emit(
-                'doc-synopsis-option.%s.%s'
-                % (help_command.event_class, arg_name),
+                f'doc-synopsis-option.{help_command.event_class}.{arg_name}',
                 arg_name=arg_name,
                 help_command=help_command,
             )
     session.emit(
-        'doc-synopsis-end.%s' % help_command.event_class,
+        f'doc-synopsis-end.{help_command.event_class}',
         help_command=help_command,
     )
     session.emit(
-        'doc-options-start.%s' % help_command.event_class,
+        f'doc-options-start.{help_command.event_class}',
         help_command=help_command,
     )
     if help_command.arg_table:
@@ -83,26 +82,25 @@ def generate_events(session, help_command):
             ):
                 continue
             session.emit(
-                'doc-option.%s.%s' % (help_command.event_class, arg_name),
+                f'doc-option.{help_command.event_class}.{arg_name}',
                 arg_name=arg_name,
                 help_command=help_command,
             )
             session.emit(
-                'doc-option-example.%s.%s'
-                % (help_command.event_class, arg_name),
+                f'doc-option-example.{help_command.event_class}.{arg_name}',
                 arg_name=arg_name,
                 help_command=help_command,
             )
     session.emit(
-        'doc-options-end.%s' % help_command.event_class,
+        f'doc-options-end.{help_command.event_class}',
         help_command=help_command,
     )
     session.emit(
-        'doc-global-option.%s' % help_command.event_class,
+        f'doc-global-option.{help_command.event_class}',
         help_command=help_command,
     )
     session.emit(
-        'doc-subitems-start.%s' % help_command.event_class,
+        f'doc-subitems-start.{help_command.event_class}',
         help_command=help_command,
     )
     if help_command.command_table:
@@ -112,33 +110,32 @@ def generate_events(session, help_command):
             ):
                 continue
             session.emit(
-                'doc-subitem.%s.%s' % (help_command.event_class, command_name),
+                f'doc-subitem.{help_command.event_class}.{command_name}',
                 command_name=command_name,
                 help_command=help_command,
             )
     session.emit(
-        'doc-subitems-end.%s' % help_command.event_class,
+        f'doc-subitems-end.{help_command.event_class}',
         help_command=help_command,
     )
     session.emit(
-        'doc-examples.%s' % help_command.event_class, help_command=help_command
+        f'doc-examples.{help_command.event_class}', help_command=help_command
     )
     session.emit(
-        'doc-output.%s' % help_command.event_class, help_command=help_command
+        f'doc-output.{help_command.event_class}', help_command=help_command
     )
     session.emit(
-        'doc-relateditems-start.%s' % help_command.event_class,
+        f'doc-relateditems-start.{help_command.event_class}',
         help_command=help_command,
     )
     if help_command.related_items:
         for related_item in sorted(help_command.related_items):
             session.emit(
-                'doc-relateditem.%s.%s'
-                % (help_command.event_class, related_item),
+                f'doc-relateditem.{help_command.event_class}.{related_item}',
                 help_command=help_command,
                 related_item=related_item,
             )
     session.emit(
-        'doc-relateditems-end.%s' % help_command.event_class,
+        f'doc-relateditems-end.{help_command.event_class}',
         help_command=help_command,
     )

--- a/awscli/bcdoc/docstringparser.py
+++ b/awscli/bcdoc/docstringparser.py
@@ -81,9 +81,9 @@ class HTMLTree:
 
     def _doc_has_handler(self, tag, is_start):
         if is_start:
-            handler_name = 'start_%s' % tag
+            handler_name = f'start_{tag}'
         else:
-            handler_name = 'end_%s' % tag
+            handler_name = f'end_{tag}'
 
         return hasattr(self.doc.style, handler_name)
 
@@ -135,12 +135,12 @@ class TagNode(StemNode):
         self._write_end(doc)
 
     def _write_start(self, doc):
-        handler_name = 'start_%s' % self.tag
+        handler_name = f'start_{self.tag}'
         if hasattr(doc.style, handler_name):
             getattr(doc.style, handler_name)(self.attrs)
 
     def _write_end(self, doc):
-        handler_name = 'end_%s' % self.tag
+        handler_name = f'end_{self.tag}'
         if hasattr(doc.style, handler_name):
             getattr(doc.style, handler_name)()
 
@@ -180,7 +180,7 @@ class DataNode(Node):
     def __init__(self, data, parent=None):
         super(DataNode, self).__init__(parent)
         if not isinstance(data, str):
-            raise ValueError("Expecting string type, %s given." % type(data))
+            raise ValueError(f"Expecting string type, {type(data)} given.")
         self.data = data
 
     def lstrip(self):

--- a/awscli/bcdoc/restdoc.py
+++ b/awscli/bcdoc/restdoc.py
@@ -46,7 +46,7 @@ class ReSTDocument:
         """
         Write content on a newline.
         """
-        self._write('%s%s\n' % (self.style.spaces(), content))
+        self._write(f'{self.style.spaces()}{content}\n')
 
     def peek_write(self):
         """

--- a/awscli/bcdoc/style.py
+++ b/awscli/bcdoc/style.py
@@ -32,7 +32,7 @@ class BaseStyle:
         self._indent = value
 
     def new_paragraph(self):
-        return '\n%s' % self.spaces()
+        return f'\n{self.spaces()}'
 
     def indent(self):
         self._indent += 1
@@ -71,10 +71,10 @@ class ReSTStyle(BaseStyle):
         self.list_depth = 0
 
     def new_paragraph(self):
-        self.doc.write('\n\n%s' % self.spaces())
+        self.doc.write(f'\n\n{self.spaces()}')
 
     def new_line(self):
-        self.doc.write('\n%s' % self.spaces())
+        self.doc.write(f'\n{self.spaces()}')
 
     def _start_inline(self, markup):
         self.doc.write(markup)
@@ -121,12 +121,12 @@ class ReSTStyle(BaseStyle):
     def ref(self, title, link=None):
         if link is None:
             link = title
-        self.doc.write(':doc:`%s <%s>`' % (title, link))
+        self.doc.write(f':doc:`{title} <{link}>`')
 
     def _heading(self, s, border_char):
         border = border_char * len(s)
         self.new_paragraph()
-        self.doc.write('%s\n%s\n%s' % (border, s, border))
+        self.doc.write(f'{border}\n{s}\n{border}')
         self.new_paragraph()
 
     def h1(self, s):
@@ -152,11 +152,11 @@ class ReSTStyle(BaseStyle):
 
     def start_p(self, attrs=None):
         if self.do_p:
-            self.doc.write('\n\n%s' % self.spaces())
+            self.doc.write(f'\n\n{self.spaces()}')
 
     def end_p(self):
         if self.do_p:
-            self.doc.write('\n\n%s' % self.spaces())
+            self.doc.write(f'\n\n{self.spaces()}')
 
     def start_code(self, attrs=None):
         self.doc.do_translation = True
@@ -217,13 +217,13 @@ class ReSTStyle(BaseStyle):
         self.doc.do_translation = True
 
     def link_target_definition(self, refname, link):
-        self.doc.writeln('.. _%s: %s' % (refname, link))
+        self.doc.writeln(f'.. _{refname}: {link}')
 
     def sphinx_reference_label(self, label, text=None):
         if text is None:
             text = label
         if self.doc.target == 'html':
-            self.doc.write(':ref:`%s <%s>`' % (text, label))
+            self.doc.write(f':ref:`{text} <{label}>`')
         else:
             self.doc.write(text)
 
@@ -236,14 +236,14 @@ class ReSTStyle(BaseStyle):
                 if ':' in last_write:
                     last_write = last_write.replace(':', r'\:')
                 self.doc.push_write(last_write)
-                self.doc.push_write(' <%s>`__' % self.a_href)
+                self.doc.push_write(f' <{self.a_href}>`__')
             elif last_write == '`':
                 # Look at start_a().  It will do a self.doc.write('`')
                 # which is the start of the link title.  If that is the
                 # case then there was no link text.  We should just
                 # use an inline link.  The syntax of this is
                 # `<http://url>`_
-                self.doc.push_write('`<%s>`__' % self.a_href)
+                self.doc.push_write(f'`<{self.a_href}>`__')
             else:
                 self.doc.push_write(self.a_href)
                 self.doc.hrefs[self.a_href] = self.a_href
@@ -344,9 +344,9 @@ class ReSTStyle(BaseStyle):
             self.li(item)
         else:
             if file_name:
-                self.doc.writeln('  %s' % file_name)
+                self.doc.writeln(f'  {file_name}')
             else:
-                self.doc.writeln('  %s' % item)
+                self.doc.writeln(f'  {item}')
 
     def hidden_toctree(self):
         if self.doc.target == 'html':
@@ -363,11 +363,11 @@ class ReSTStyle(BaseStyle):
         if title is not None:
             self.doc.writeln(title)
         if depth is not None:
-            self.doc.writeln('   :depth: %s' % depth)
+            self.doc.writeln(f'   :depth: {depth}')
 
     def start_sphinx_py_class(self, class_name):
         self.new_paragraph()
-        self.doc.write('.. py:class:: %s' % class_name)
+        self.doc.write(f'.. py:class:: {class_name}')
         self.indent()
         self.new_paragraph()
 
@@ -377,9 +377,9 @@ class ReSTStyle(BaseStyle):
 
     def start_sphinx_py_method(self, method_name, parameters=None):
         self.new_paragraph()
-        content = '.. py:method:: %s' % method_name
+        content = f'.. py:method:: {method_name}'
         if parameters is not None:
-            content += '(%s)' % parameters
+            content += f'({parameters})'
         self.doc.write(content)
         self.indent()
         self.new_paragraph()
@@ -390,7 +390,7 @@ class ReSTStyle(BaseStyle):
 
     def start_sphinx_py_attr(self, attr_name):
         self.new_paragraph()
-        self.doc.write('.. py:attribute:: %s' % attr_name)
+        self.doc.write(f'.. py:attribute:: {attr_name}')
         self.indent()
         self.new_paragraph()
 
@@ -405,12 +405,12 @@ class ReSTStyle(BaseStyle):
 
     def external_link(self, title, link):
         if self.doc.target == 'html':
-            self.doc.write('`%s <%s>`_' % (title, link))
+            self.doc.write(f'`{title} <{link}>`_')
         else:
             self.doc.write(title)
 
     def internal_link(self, title, page):
         if self.doc.target == 'html':
-            self.doc.write(':doc:`%s <%s>`' % (title, page))
+            self.doc.write(f':doc:`{title} <{page}>`')
         else:
             self.doc.write(title)

--- a/awscli/bcdoc/textwriter.py
+++ b/awscli/bcdoc/textwriter.py
@@ -191,7 +191,7 @@ class TextTranslator(nodes.NodeVisitor):
     def visit_desc_signature(self, node):
         self.new_state(0)
         if node.parent['objtype'] in ('class', 'exception'):
-            self.add_text('%s ' % node.parent['objtype'])
+            self.add_text('{} '.format(node.parent['objtype']))
 
     def depart_desc_signature(self, node):
         # XXX: wrap signatures in a way that makes sense
@@ -300,7 +300,7 @@ class TextTranslator(nodes.NodeVisitor):
         self.new_state(len(self._footnote) + 3)
 
     def depart_footnote(self, node):
-        self.end_state(first='[%s] ' % self._footnote)
+        self.end_state(first=f'[{self._footnote}] ')
 
     def visit_citation(self, node):
         if len(node) and isinstance(node[0], nodes.label):
@@ -310,7 +310,7 @@ class TextTranslator(nodes.NodeVisitor):
         self.new_state(len(self._citlabel) + 3)
 
     def depart_citation(self, node):
-        self.end_state(first='[%s] ' % self._citlabel)
+        self.end_state(first=f'[{self._citlabel}] ')
 
     def visit_label(self, node):
         raise nodes.SkipNode
@@ -519,7 +519,7 @@ class TextTranslator(nodes.NodeVisitor):
         elif self.list_counter[-1] == -2:
             pass
         else:
-            self.end_state(first='%s. ' % self.list_counter[-1], end=None)
+            self.end_state(first=f'{self.list_counter[-1]}. ', end=None)
 
     def visit_definition_list_item(self, node):
         self._li_has_classifier = len(node) >= 2 and isinstance(
@@ -699,7 +699,7 @@ class TextTranslator(nodes.NodeVisitor):
 
     def depart_abbreviation(self, node):
         if node.hasattr('explanation'):
-            self.add_text(' (%s)' % node['explanation'])
+            self.add_text(' ({})'.format(node['explanation']))
 
     def visit_title_reference(self, node):
         self.add_text('*')
@@ -726,11 +726,11 @@ class TextTranslator(nodes.NodeVisitor):
         pass
 
     def visit_footnote_reference(self, node):
-        self.add_text('[%s]' % node.astext())
+        self.add_text(f'[{node.astext()}]')
         raise nodes.SkipNode
 
     def visit_citation_reference(self, node):
-        self.add_text('[%s]' % node.astext())
+        self.add_text(f'[{node.astext()}]')
         raise nodes.SkipNode
 
     def visit_Text(self, node):
@@ -759,7 +759,7 @@ class TextTranslator(nodes.NodeVisitor):
 
     def visit_system_message(self, node):
         self.new_state(0)
-        self.add_text('<SYSTEM MESSAGE: %s>' % node.astext())
+        self.add_text(f'<SYSTEM MESSAGE: {node.astext()}>')
         self.end_state()
         raise nodes.SkipNode
 

--- a/awscli/botocore/auth.py
+++ b/awscli/botocore/auth.py
@@ -130,7 +130,7 @@ class SigV2Auth(BaseSigner):
         path = split.path
         if len(path) == 0:
             path = '/'
-        string_to_sign = '%s\n%s\n%s\n' % (request.method, split.netloc, path)
+        string_to_sign = f'{request.method}\n{split.netloc}\n{path}\n'
         lhmac = hmac.new(
             self.credentials.secret_key.encode('utf-8'), digestmod=sha256
         )
@@ -199,8 +199,7 @@ class SigV3Auth(BaseSigner):
         new_hmac.update(request.headers['Date'].encode('utf-8'))
         encoded_signature = encodebytes(new_hmac.digest()).strip()
         signature = (
-            'AWS3-HTTPS AWSAccessKeyId=%s,Algorithm=%s,Signature=%s'
-            % (
+            'AWS3-HTTPS AWSAccessKeyId={},Algorithm={},Signature={}'.format(
                 self.credentials.access_key,
                 'HmacSHA256',
                 encoded_signature.decode('utf-8'),
@@ -271,7 +270,7 @@ class SigV4Auth(BaseSigner):
         # Sort by the URI-encoded key names, and in the case of
         # repeated keys, then sort by the value.
         for key, value in sorted(key_val_pairs):
-            sorted_key_vals.append('%s=%s' % (key, value))
+            sorted_key_vals.append(f'{key}={value}')
         canonical_query_string = '&'.join(sorted_key_vals)
         return canonical_query_string
 
@@ -287,7 +286,7 @@ class SigV4Auth(BaseSigner):
             # Sort by the URI-encoded key names, and in the case of
             # repeated keys, then sort by the value.
             for key, value in sorted(key_val_pairs):
-                sorted_key_vals.append('%s=%s' % (key, value))
+                sorted_key_vals.append(f'{key}={value}')
             canonical_query_string = '&'.join(sorted_key_vals)
         return canonical_query_string
 
@@ -304,7 +303,7 @@ class SigV4Auth(BaseSigner):
             value = ','.join(
                 self._header_value(v) for v in headers_to_sign.get_all(key)
             )
-            headers.append('%s:%s' % (key, ensure_unicode(value)))
+            headers.append(f'{key}:{ensure_unicode(value)}')
         return '\n'.join(headers)
 
     def _header_value(self, value):
@@ -316,7 +315,7 @@ class SigV4Auth(BaseSigner):
         return ' '.join(value.split())
 
     def signed_headers(self, headers_to_sign):
-        l = ['%s' % n.lower().strip() for n in set(headers_to_sign)]
+        l = [f'{n.lower().strip()}' for n in set(headers_to_sign)]
         l = sorted(l)
         return ';'.join(l)
 
@@ -437,10 +436,10 @@ class SigV4Auth(BaseSigner):
         self._inject_signature_to_request(request, signature)
 
     def _inject_signature_to_request(self, request, signature):
-        l = ['AWS4-HMAC-SHA256 Credential=%s' % self.scope(request)]
+        l = [f'AWS4-HMAC-SHA256 Credential={self.scope(request)}']
         headers_to_sign = self.headers_to_sign(request)
-        l.append('SignedHeaders=%s' % self.signed_headers(headers_to_sign))
-        l.append('Signature=%s' % signature)
+        l.append(f'SignedHeaders={self.signed_headers(headers_to_sign)}')
+        l.append(f'Signature={signature}')
         request.headers['Authorization'] = ', '.join(l)
         return request
 
@@ -688,7 +687,7 @@ class S3ExpressQueryAuth(S3ExpressAuth):
         # Rather than calculating an "Authorization" header, for the query
         # param quth, we just append an 'X-Amz-Signature' param to the end
         # of the query string.
-        request.url += '&X-Amz-Signature=%s' % signature
+        request.url += f'&X-Amz-Signature={signature}'
 
     def _normalize_url_path(self, path):
         # For S3, we do not normalize the path.
@@ -784,7 +783,7 @@ class SigV4QueryAuth(SigV4Auth):
         # Rather than calculating an "Authorization" header, for the query
         # param quth, we just append an 'X-Amz-Signature' param to the end
         # of the query string.
-        request.url += '&X-Amz-Signature=%s' % signature
+        request.url += f'&X-Amz-Signature={signature}'
 
 
 class S3SigV4QueryAuth(SigV4QueryAuth):

--- a/awscli/botocore/awsrequest.py
+++ b/awscli/botocore/awsrequest.py
@@ -275,9 +275,9 @@ def prepare_request_dict(
         percent_encode_sequence = botocore.utils.percent_encode_sequence
         encoded_query_string = percent_encode_sequence(r['query_string'])
         if '?' not in url:
-            url += '?%s' % encoded_query_string
+            url += f'?{encoded_query_string}'
         else:
-            url += '&%s' % encoded_query_string
+            url += f'&{encoded_query_string}'
     r['url'] = url
     r['context'] = context
     if context is None:
@@ -371,7 +371,7 @@ class AWSRequestPreparer:
         url = original.url
         if original.params:
             params = urlencode(list(original.params.items()), doseq=True)
-            url = '%s?%s' % (url, params)
+            url = f'{url}?{params}'
         return url
 
     def _prepare_headers(self, original, prepared_body=None):

--- a/awscli/botocore/config.py
+++ b/awscli/botocore/config.py
@@ -336,14 +336,13 @@ class Config:
                 user_provided_options[key] = value
             # The key must exist in the available options
             else:
-                raise TypeError('Got unexpected keyword argument \'%s\'' % key)
+                raise TypeError(f'Got unexpected keyword argument \'{key}\'')
 
         # The number of args should not be longer than the allowed
         # options
         if len(args) > len(option_order):
             raise TypeError(
-                'Takes at most %s arguments (%s given)'
-                % (len(option_order), len(args))
+                f'Takes at most {len(option_order)} arguments ({len(args)} given)'
             )
 
         # Iterate through the args passed through to the constructor and map
@@ -352,8 +351,7 @@ class Config:
             # If it a kwarg was specified for the arg, then error out
             if option_order[i] in user_provided_options:
                 raise TypeError(
-                    'Got multiple values for keyword argument \'%s\''
-                    % (option_order[i])
+                    f'Got multiple values for keyword argument \'{option_order[i]}\''
                 )
             user_provided_options[option_order[i]] = arg
 

--- a/awscli/botocore/configprovider.py
+++ b/awscli/botocore/configprovider.py
@@ -560,7 +560,7 @@ class ChainProvider(BaseProvider):
         return value
 
     def __repr__(self):
-        return '[%s]' % ', '.join([str(p) for p in self._providers])
+        return '[{}]'.format(', '.join([str(p) for p in self._providers]))
 
 
 class InstanceVarProvider(BaseProvider):
@@ -586,10 +586,7 @@ class InstanceVarProvider(BaseProvider):
         return value
 
     def __repr__(self):
-        return 'InstanceVarProvider(instance_var=%s, session=%s)' % (
-            self._instance_var,
-            self._session,
-        )
+        return f'InstanceVarProvider(instance_var={self._instance_var}, session={self._session})'
 
 
 class ScopedConfigProvider(BaseProvider):
@@ -620,10 +617,7 @@ class ScopedConfigProvider(BaseProvider):
         return scoped_config.get(self._config_var_name)
 
     def __repr__(self):
-        return 'ScopedConfigProvider(config_var_name=%s, session=%s)' % (
-            self._config_var_name,
-            self._session,
-        )
+        return f'ScopedConfigProvider(config_var_name={self._config_var_name}, session={self._session})'
 
 
 class EnvironmentProvider(BaseProvider):
@@ -648,7 +642,7 @@ class EnvironmentProvider(BaseProvider):
         return None
 
     def __repr__(self):
-        return 'EnvironmentProvider(name=%s, env=%s)' % (self._name, self._env)
+        return f'EnvironmentProvider(name={self._name}, env={self._env})'
 
 
 class SectionConfigProvider(BaseProvider):
@@ -688,13 +682,8 @@ class SectionConfigProvider(BaseProvider):
 
     def __repr__(self):
         return (
-            'SectionConfigProvider(section_name=%s, '
-            'session=%s, override_providers=%s)'
-            % (
-                self._section_name,
-                self._session,
-                self._override_providers,
-            )
+            f'SectionConfigProvider(section_name={self._section_name}, '
+            f'session={self._session}, override_providers={self._override_providers})'
         )
 
 
@@ -709,7 +698,7 @@ class ConstantProvider(BaseProvider):
         return self._value
 
     def __repr__(self):
-        return 'ConstantProvider(value=%s)' % self._value
+        return f'ConstantProvider(value={self._value})'
 
 
 class ConfiguredEndpointProvider(BaseProvider):

--- a/awscli/botocore/credentials.py
+++ b/awscli/botocore/credentials.py
@@ -791,7 +791,7 @@ class BaseAssumeRoleCredentialFetcher(CachedCredentialFetcher):
         )
 
     def _generate_assume_role_name(self):
-        self._role_session_name = 'botocore-session-%s' % (int(time.time()))
+        self._role_session_name = f'botocore-session-{int(time.time())}'
         self._assume_kwargs['RoleSessionName'] = self._role_session_name
         self._using_default_session_name = True
 
@@ -897,7 +897,7 @@ class AssumeRoleCredentialFetcher(BaseAssumeRoleCredentialFetcher):
         mfa_serial = assume_role_kwargs.get('SerialNumber')
 
         if mfa_serial is not None:
-            prompt = 'Enter MFA code for %s: ' % mfa_serial
+            prompt = f'Enter MFA code for {mfa_serial}: '
             token_code = self._mfa_prompter(prompt)
             assume_role_kwargs['TokenCode'] = token_code
 
@@ -1083,8 +1083,8 @@ class ProcessProvider(CredentialProvider):
             raise CredentialRetrievalError(
                 provider=self.METHOD,
                 error_msg=(
-                    "Unsupported version '%s' for credential process "
-                    "provider, supported versions: 1" % version
+                    f"Unsupported version '{version}' for credential process "
+                    "provider, supported versions: 1"
                 ),
             )
         try:
@@ -1098,7 +1098,7 @@ class ProcessProvider(CredentialProvider):
         except KeyError as e:
             raise CredentialRetrievalError(
                 provider=self.METHOD,
-                error_msg="Missing required key in response: %s" % e,
+                error_msg=f"Missing required key in response: {e}",
             )
 
     @property
@@ -1666,8 +1666,8 @@ class AssumeRoleProvider(CredentialProvider):
         if credential_source is not None and source_profile is not None:
             raise InvalidConfigError(
                 error_msg=(
-                    'The profile "%s" contains both source_profile and '
-                    'credential_source.' % profile_name
+                    f'The profile "{profile_name}" contains both source_profile and '
+                    'credential_source.'
                 )
             )
         elif credential_source is None and source_profile is None:
@@ -1686,16 +1686,15 @@ class AssumeRoleProvider(CredentialProvider):
         if self._credential_sourcer is None:
             raise InvalidConfigError(
                 error_msg=(
-                    'The credential_source "%s" is specified in profile "%s", '
+                    f'The credential_source "{credential_source}" is specified in profile "{parent_profile}", '
                     'but no source provider was configured.'
-                    % (credential_source, parent_profile)
                 )
             )
         if not self._credential_sourcer.is_supported(credential_source):
             raise InvalidConfigError(
                 error_msg=(
-                    'The credential source "%s" referenced in profile "%s" is not '
-                    'valid.' % (credential_source, parent_profile)
+                    f'The credential source "{credential_source}" referenced in profile "{parent_profile}" is not '
+                    'valid.'
                 )
             )
 
@@ -1714,9 +1713,8 @@ class AssumeRoleProvider(CredentialProvider):
         if source_profile_name not in profiles:
             raise InvalidConfigError(
                 error_msg=(
-                    'The source_profile "%s" referenced in '
-                    'the profile "%s" does not exist.'
-                    % (source_profile_name, parent_profile_name)
+                    f'The source_profile "{source_profile_name}" referenced in '
+                    f'the profile "{parent_profile_name}" does not exist.'
                 )
             )
 
@@ -1817,7 +1815,7 @@ class AssumeRoleProvider(CredentialProvider):
                 provider=credential_source,
                 error_msg=(
                     'No credentials found in credential_source referenced '
-                    'in profile %s' % profile_name
+                    f'in profile {profile_name}'
                 ),
             )
         return credentials
@@ -2355,8 +2353,8 @@ class SSOProvider(CredentialProvider):
             missing = ', '.join(missing_config_vars)
             raise InvalidConfigError(
                 error_msg=(
-                    'The profile "%s" is configured to use SSO but is missing '
-                    'required configuration: %s' % (profile_name, missing)
+                    f'The profile "{profile_name}" is configured to use SSO but is missing '
+                    f'required configuration: {missing}'
                 )
             )
         return config

--- a/awscli/botocore/crt/auth.py
+++ b/awscli/botocore/crt/auth.py
@@ -116,10 +116,10 @@ class CrtSigV4Auth(BaseSigner):
             array = []
             for param, value in aws_request.params.items():
                 value = str(value)
-                array.append('%s=%s' % (param, value))
+                array.append(f'{param}={value}')
             crt_path = crt_path + '?' + '&'.join(array)
         elif url_parts.query:
-            crt_path = '%s?%s' % (crt_path, url_parts.query)
+            crt_path = f'{crt_path}?{url_parts.query}'
 
         crt_headers = awscrt.http.HttpHeaders(aws_request.headers.items())
 
@@ -314,10 +314,10 @@ class CrtSigV4AsymAuth(BaseSigner):
             array = []
             for param, value in aws_request.params.items():
                 value = str(value)
-                array.append('%s=%s' % (param, value))
+                array.append(f'{param}={value}')
             crt_path = crt_path + '?' + '&'.join(array)
         elif url_parts.query:
-            crt_path = '%s?%s' % (crt_path, url_parts.query)
+            crt_path = f'{crt_path}?{url_parts.query}'
 
         crt_headers = awscrt.http.HttpHeaders(aws_request.headers.items())
 

--- a/awscli/botocore/discovery.py
+++ b/awscli/botocore/discovery.py
@@ -185,8 +185,7 @@ class EndpointDiscoveryManager:
         if not self._always_discover and not discovery_required:
             # Discovery set to only run on required operations
             logger.debug(
-                'Optional discovery disabled. Skipping discovery for Operation: %s'
-                % operation
+                f'Optional discovery disabled. Skipping discovery for Operation: {operation}'
             )
             return None
 
@@ -228,12 +227,12 @@ class EndpointDiscoveryHandler:
 
     def register(self, events, service_id):
         events.register(
-            'before-parameter-build.%s' % service_id, self.gather_identifiers
+            f'before-parameter-build.{service_id}', self.gather_identifiers
         )
         events.register_first(
-            'request-created.%s' % service_id, self.discover_endpoint
+            f'request-created.{service_id}', self.discover_endpoint
         )
-        events.register('needs-retry.%s' % service_id, self.handle_retries)
+        events.register(f'needs-retry.{service_id}', self.handle_retries)
 
     def gather_identifiers(self, params, model, context, **kwargs):
         endpoint_discovery = model.endpoint_discovery

--- a/awscli/botocore/docs/bcdoc/docstringparser.py
+++ b/awscli/botocore/docs/bcdoc/docstringparser.py
@@ -81,9 +81,9 @@ class HTMLTree:
 
     def _doc_has_handler(self, tag, is_start):
         if is_start:
-            handler_name = 'start_%s' % tag
+            handler_name = f'start_{tag}'
         else:
-            handler_name = 'end_%s' % tag
+            handler_name = f'end_{tag}'
 
         return hasattr(self.doc.style, handler_name)
 
@@ -135,12 +135,12 @@ class TagNode(StemNode):
         self._write_end(doc)
 
     def _write_start(self, doc):
-        handler_name = 'start_%s' % self.tag
+        handler_name = f'start_{self.tag}'
         if hasattr(doc.style, handler_name):
             getattr(doc.style, handler_name)(self.attrs)
 
     def _write_end(self, doc):
-        handler_name = 'end_%s' % self.tag
+        handler_name = f'end_{self.tag}'
         if hasattr(doc.style, handler_name):
             getattr(doc.style, handler_name)()
 
@@ -180,7 +180,7 @@ class DataNode(Node):
     def __init__(self, data, parent=None):
         super(DataNode, self).__init__(parent)
         if not isinstance(data, str):
-            raise ValueError("Expecting string type, %s given." % type(data))
+            raise ValueError(f"Expecting string type, {type(data)} given.")
         self.data = data
 
     def lstrip(self):

--- a/awscli/botocore/docs/bcdoc/restdoc.py
+++ b/awscli/botocore/docs/bcdoc/restdoc.py
@@ -45,7 +45,7 @@ class ReSTDocument:
         """
         Write content on a newline.
         """
-        self._write('%s%s\n' % (self.style.spaces(), content))
+        self._write(f'{self.style.spaces()}{content}\n')
 
     def peek_write(self):
         """

--- a/awscli/botocore/docs/bcdoc/style.py
+++ b/awscli/botocore/docs/bcdoc/style.py
@@ -32,7 +32,7 @@ class BaseStyle:
         self._indent = value
 
     def new_paragraph(self):
-        return '\n%s' % self.spaces()
+        return f'\n{self.spaces()}'
 
     def indent(self):
         self._indent += 1
@@ -71,10 +71,10 @@ class ReSTStyle(BaseStyle):
         self.list_depth = 0
 
     def new_paragraph(self):
-        self.doc.write('\n\n%s' % self.spaces())
+        self.doc.write(f'\n\n{self.spaces()}')
 
     def new_line(self):
-        self.doc.write('\n%s' % self.spaces())
+        self.doc.write(f'\n{self.spaces()}')
 
     def _start_inline(self, markup):
         self.doc.write(markup)
@@ -121,12 +121,12 @@ class ReSTStyle(BaseStyle):
     def ref(self, title, link=None):
         if link is None:
             link = title
-        self.doc.write(':doc:`%s <%s>`' % (title, link))
+        self.doc.write(f':doc:`{title} <{link}>`')
 
     def _heading(self, s, border_char):
         border = border_char * len(s)
         self.new_paragraph()
-        self.doc.write('%s\n%s\n%s' % (border, s, border))
+        self.doc.write(f'{border}\n{s}\n{border}')
         self.new_paragraph()
 
     def h1(self, s):
@@ -152,11 +152,11 @@ class ReSTStyle(BaseStyle):
 
     def start_p(self, attrs=None):
         if self.do_p:
-            self.doc.write('\n\n%s' % self.spaces())
+            self.doc.write(f'\n\n{self.spaces()}')
 
     def end_p(self):
         if self.do_p:
-            self.doc.write('\n\n%s' % self.spaces())
+            self.doc.write(f'\n\n{self.spaces()}')
 
     def start_code(self, attrs=None):
         self.doc.do_translation = True
@@ -217,13 +217,13 @@ class ReSTStyle(BaseStyle):
         self.doc.do_translation = True
 
     def link_target_definition(self, refname, link):
-        self.doc.writeln('.. _%s: %s' % (refname, link))
+        self.doc.writeln(f'.. _{refname}: {link}')
 
     def sphinx_reference_label(self, label, text=None):
         if text is None:
             text = label
         if self.doc.target == 'html':
-            self.doc.write(':ref:`%s <%s>`' % (text, label))
+            self.doc.write(f':ref:`{text} <{label}>`')
         else:
             self.doc.write(text)
 
@@ -236,14 +236,14 @@ class ReSTStyle(BaseStyle):
                 if ':' in last_write:
                     last_write = last_write.replace(':', r'\:')
                 self.doc.push_write(last_write)
-                self.doc.push_write(' <%s>`__' % self.a_href)
+                self.doc.push_write(f' <{self.a_href}>`__')
             elif last_write == '`':
                 # Look at start_a().  It will do a self.doc.write('`')
                 # which is the start of the link title.  If that is the
                 # case then there was no link text.  We should just
                 # use an inline link.  The syntax of this is
                 # `<http://url>`_
-                self.doc.push_write('`<%s>`__' % self.a_href)
+                self.doc.push_write(f'`<{self.a_href}>`__')
             else:
                 self.doc.push_write(self.a_href)
                 self.doc.hrefs[self.a_href] = self.a_href
@@ -344,9 +344,9 @@ class ReSTStyle(BaseStyle):
             self.li(item)
         else:
             if file_name:
-                self.doc.writeln('  %s' % file_name)
+                self.doc.writeln(f'  {file_name}')
             else:
-                self.doc.writeln('  %s' % item)
+                self.doc.writeln(f'  {item}')
 
     def hidden_toctree(self):
         if self.doc.target == 'html':
@@ -363,11 +363,11 @@ class ReSTStyle(BaseStyle):
         if title is not None:
             self.doc.writeln(title)
         if depth is not None:
-            self.doc.writeln('   :depth: %s' % depth)
+            self.doc.writeln(f'   :depth: {depth}')
 
     def start_sphinx_py_class(self, class_name):
         self.new_paragraph()
-        self.doc.write('.. py:class:: %s' % class_name)
+        self.doc.write(f'.. py:class:: {class_name}')
         self.indent()
         self.new_paragraph()
 
@@ -377,9 +377,9 @@ class ReSTStyle(BaseStyle):
 
     def start_sphinx_py_method(self, method_name, parameters=None):
         self.new_paragraph()
-        content = '.. py:method:: %s' % method_name
+        content = f'.. py:method:: {method_name}'
         if parameters is not None:
-            content += '(%s)' % parameters
+            content += f'({parameters})'
         self.doc.write(content)
         self.indent()
         self.new_paragraph()
@@ -390,7 +390,7 @@ class ReSTStyle(BaseStyle):
 
     def start_sphinx_py_attr(self, attr_name):
         self.new_paragraph()
-        self.doc.write('.. py:attribute:: %s' % attr_name)
+        self.doc.write(f'.. py:attribute:: {attr_name}')
         self.indent()
         self.new_paragraph()
 
@@ -405,12 +405,12 @@ class ReSTStyle(BaseStyle):
 
     def external_link(self, title, link):
         if self.doc.target == 'html':
-            self.doc.write('`%s <%s>`_' % (title, link))
+            self.doc.write(f'`{title} <{link}>`_')
         else:
             self.doc.write(title)
 
     def internal_link(self, title, page):
         if self.doc.target == 'html':
-            self.doc.write(':doc:`%s <%s>`' % (title, page))
+            self.doc.write(f':doc:`{title} <{page}>`')
         else:
             self.doc.write(title)

--- a/awscli/botocore/docs/client.py
+++ b/awscli/botocore/docs/client.py
@@ -53,7 +53,7 @@ class ClientDocumenter:
             self._client.meta.service_model
         )
         section.write(
-            'A low-level client representing %s' % official_service_name
+            f'A low-level client representing {official_service_name}'
         )
         section.style.new_line()
         section.include_doc_string(
@@ -69,13 +69,11 @@ class ClientDocumenter:
         section.style.new_line()
         class_name = self._client.__class__.__name__
         for method_name in sorted(client_methods):
-            section.style.li(
-                ':py:meth:`~%s.Client.%s`' % (class_name, method_name)
-            )
+            section.style.li(f':py:meth:`~{class_name}.Client.{method_name}`')
 
     def _add_class_signature(self, section):
         section.style.start_sphinx_py_class(
-            class_name='%s.Client' % self._client.__class__.__name__
+            class_name=f'{self._client.__class__.__name__}.Client'
         )
 
     def _add_client_creation_example(self, section):
@@ -113,15 +111,15 @@ class ClientDocumenter:
         error_section.style.new_line()
         client_name = self._client.__class__.__name__
         for error in operation_model.error_shapes:
-            class_name = '%s.Client.exceptions.%s' % (client_name, error.name)
-            error_section.style.li(':py:class:`%s`' % class_name)
+            class_name = f'{client_name}.Client.exceptions.{error.name}'
+            error_section.style.li(f':py:class:`{class_name}`')
 
     def _add_model_driven_method(self, section, method_name):
         service_model = self._client.meta.service_model
         operation_name = self._client.meta.method_to_api_mapping[method_name]
         operation_model = service_model.operation_model(operation_name)
 
-        example_prefix = 'response = client.%s' % method_name
+        example_prefix = f'response = client.{method_name}'
         document_model_driven_method(
             section,
             method_name,
@@ -209,7 +207,7 @@ class ClientExceptionsDocumenter:
 
     def _exception_class_name(self, shape):
         cls_name = self._client.__class__.__name__
-        return '%s.Client.exceptions.%s' % (cls_name, shape.name)
+        return f'{cls_name}.Client.exceptions.{shape.name}'
 
     def _add_exceptions_list(self, section):
         error_shapes = self._client.meta.service_model.error_shapes
@@ -223,7 +221,7 @@ class ClientExceptionsDocumenter:
         section.style.new_line()
         for shape in error_shapes:
             class_name = self._exception_class_name(shape)
-            section.style.li(':py:class:`%s`' % class_name)
+            section.style.li(f':py:class:`{class_name}`')
 
     def _add_exception_classes(self, section):
         for shape in self._client.meta.service_model.error_shapes:
@@ -254,7 +252,7 @@ class ClientExceptionsDocumenter:
         section.write('...')
         section.style.dedent()
         section.style.new_line()
-        section.write('except client.exceptions.%s as e:' % shape.name)
+        section.write(f'except client.exceptions.{shape.name} as e:')
         section.style.indent()
         section.style.new_line()
         section.write('print(e.response)')

--- a/awscli/botocore/docs/example.py
+++ b/awscli/botocore/docs/example.py
@@ -66,7 +66,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
     ):
         if 'enum' in shape.metadata:
             for i, enum in enumerate(shape.metadata['enum']):
-                section.write('\'%s\'' % enum)
+                section.write(f'\'{enum}\'')
                 if i < len(shape.metadata['enum']) - 1:
                     section.write('|')
         else:
@@ -105,7 +105,7 @@ class BaseExampleDocumenter(ShapeDocumenter):
             if exclude and param in exclude:
                 continue
             param_section = section.add_new_section(param)
-            param_section.write('\'%s\': ' % param)
+            param_section.write(f'\'{param}\': ')
             param_shape = input_members[param]
             param_value_section = param_section.add_new_section(
                 'member-value', context={'shape': param_shape.name}

--- a/awscli/botocore/docs/method.py
+++ b/awscli/botocore/docs/method.py
@@ -210,7 +210,7 @@ def document_model_driven_method(
     if service_uid is not None:
         method_intro_section.style.new_paragraph()
         method_intro_section.write("See also: ")
-        link = '%s/%s/%s' % (AWS_DOC_BASE, service_uid, operation_model.name)
+        link = f'{AWS_DOC_BASE}/{service_uid}/{operation_model.name}'
         method_intro_section.style.external_link(
             title="AWS API Documentation", link=link
         )

--- a/awscli/botocore/docs/paginator.py
+++ b/awscli/botocore/docs/paginator.py
@@ -39,8 +39,7 @@ class PaginatorDocumenter:
         # List the available paginators and then document each paginator.
         for paginator_name in paginator_names:
             section.style.li(
-                ':py:class:`%s.Paginator.%s`'
-                % (self._client.__class__.__name__, paginator_name)
+                f':py:class:`{self._client.__class__.__name__}.Paginator.{paginator_name}`'
             )
             self._add_paginator(section, paginator_name)
 
@@ -49,16 +48,14 @@ class PaginatorDocumenter:
 
         # Docment the paginator class
         section.style.start_sphinx_py_class(
-            class_name='%s.Paginator.%s'
-            % (self._client.__class__.__name__, paginator_name)
+            class_name=f'{self._client.__class__.__name__}.Paginator.{paginator_name}'
         )
         section.style.start_codeblock()
         section.style.new_line()
 
         # Document how to instantiate the paginator.
         section.write(
-            'paginator = client.get_paginator(\'%s\')'
-            % xform_name(paginator_name)
+            f'paginator = client.get_paginator(\'{xform_name(paginator_name)}\')'
         )
         section.style.end_codeblock()
         section.style.new_line()

--- a/awscli/botocore/docs/params.py
+++ b/awscli/botocore/docs/params.py
@@ -162,7 +162,7 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
         name_section = section.add_new_section('param-name')
         name_section.write('- ')
         if name is not None:
-            name_section.style.bold('%s ' % name)
+            name_section.style.bold(f'{name} ')
         type_section = section.add_new_section('param-type')
         self._document_non_top_level_param_type(type_section, shape)
 
@@ -184,7 +184,7 @@ class ResponseParamsDocumenter(BaseParamsDocumenter):
                     '    as follows'
                 )
                 tagged_union_members_str = ', '.join(
-                    ['``%s``' % key for key in shape.members.keys()]
+                    [f'``{key}``' for key in shape.members.keys()]
                 )
                 unknown_code_example = (
                     '\'SDK_UNKNOWN_MEMBER\': '
@@ -249,17 +249,17 @@ class RequestParamsDocumenter(BaseParamsDocumenter):
             py_type = py_type_name(shape.type_name)
         if is_top_level_param:
             type_section = section.add_new_section('param-type')
-            type_section.write(':type %s: %s' % (name, py_type))
+            type_section.write(f':type {name}: {py_type}')
             end_type_section = type_section.add_new_section('end-param-type')
             end_type_section.style.new_line()
             name_section = section.add_new_section('param-name')
-            name_section.write(':param %s: ' % name)
+            name_section.write(f':param {name}: ')
 
         else:
             name_section = section.add_new_section('param-name')
             name_section.write('- ')
             if name is not None:
-                name_section.style.bold('%s ' % name)
+                name_section.style.bold(f'{name} ')
             type_section = section.add_new_section('param-type')
             self._document_non_top_level_param_type(type_section, shape)
 
@@ -282,7 +282,7 @@ class RequestParamsDocumenter(BaseParamsDocumenter):
                     '    following top level keys can be set: %s. '
                 )
                 tagged_union_members_str = ', '.join(
-                    ['``%s``' % key for key in shape.members.keys()]
+                    [f'``{key}``' for key in shape.members.keys()]
                 )
                 tagged_union_docs.write(note % (tagged_union_members_str))
             documentation_section.include_doc_string(shape.documentation)

--- a/awscli/botocore/docs/service.py
+++ b/awscli/botocore/docs/service.py
@@ -60,7 +60,7 @@ class ServiceDocumenter:
         section.style.h1(self._client.__class__.__name__)
         service_id = self._client.meta.service_model.service_id.hyphenize()
         self._event_emitter.emit(
-            'docs.%s.%s' % ('title', service_id), section=section
+            'docs.{}.{}'.format('title', service_id), section=section
         )
 
     def table_of_contents(self, section):

--- a/awscli/botocore/docs/shape.py
+++ b/awscli/botocore/docs/shape.py
@@ -76,7 +76,7 @@ class ShapeDocumenter:
                 param_type = 'document'
             getattr(
                 self,
-                'document_shape_type_%s' % param_type,
+                f'document_shape_type_{param_type}',
                 self.document_shape_default,
             )(
                 section,
@@ -90,24 +90,13 @@ class ShapeDocumenter:
             )
             if is_top_level_param:
                 self._event_emitter.emit(
-                    'docs.%s.%s.%s.%s'
-                    % (
-                        self.EVENT_NAME,
-                        self._service_id,
-                        self._operation_name,
-                        name,
-                    ),
+                    f'docs.{self.EVENT_NAME}.{self._service_id}.{self._operation_name}.{name}',
                     section=section,
                 )
             at_overlying_method_section = len(history) == 1
             if at_overlying_method_section:
                 self._event_emitter.emit(
-                    'docs.%s.%s.%s.complete-section'
-                    % (
-                        self.EVENT_NAME,
-                        self._service_id,
-                        self._operation_name,
-                    ),
+                    f'docs.{self.EVENT_NAME}.{self._service_id}.{self._operation_name}.complete-section',
                     section=section,
                 )
             history.pop()

--- a/awscli/botocore/docs/sharedexample.py
+++ b/awscli/botocore/docs/sharedexample.py
@@ -104,14 +104,14 @@ class SharedExampleDocumenter:
         dict_section = section.add_new_section('dict-value')
         self._start_nested_value(dict_section, '{')
         for key, val in value.items():
-            path.append('.%s' % key)
+            path.append(f'.{key}')
             item_section = dict_section.add_new_section(key)
             item_section.style.new_line()
             item_comment = self._get_comment(path, comments)
             if item_comment:
                 item_section.write(item_comment)
                 item_section.style.new_line()
-            item_section.write("'%s': " % key)
+            item_section.write(f"'{key}': ")
 
             # Shape could be none if there is no output besides ResponseMetadata
             item_shape = None
@@ -131,7 +131,7 @@ class SharedExampleDocumenter:
         param_section = section.add_new_section('param-values')
         self._start_nested_value(param_section, '(')
         for key, val in value.items():
-            path.append('.%s' % key)
+            path.append(f'.{key}')
             item_section = param_section.add_new_section(key)
             item_section.style.new_line()
             item_comment = self._get_comment(path, comments)
@@ -156,7 +156,7 @@ class SharedExampleDocumenter:
         for index, val in enumerate(value):
             item_section = list_section.add_new_section(index)
             item_section.style.new_line()
-            path.append('[%s]' % index)
+            path.append(f'[{index}]')
             item_comment = self._get_comment(path, comments)
             if item_comment:
                 item_section.write(item_comment)
@@ -170,17 +170,17 @@ class SharedExampleDocumenter:
         # We do the string conversion because this might accept a type that
         # we don't specifically address.
         safe_value = escape_controls(value)
-        section.write("'%s'," % str(safe_value))
+        section.write(f"'{str(safe_value)}',")
 
     def _document_number(self, section, value, path):
-        section.write("%s," % str(value))
+        section.write(f"{str(value)},")
 
     def _document_datetime(self, section, value, path):
         datetime_tuple = parse_timestamp(value).timetuple()
         datetime_str = str(datetime_tuple[0])
         for i in range(1, len(datetime_tuple)):
             datetime_str += ", " + str(datetime_tuple[i])
-        section.write("datetime(%s)," % datetime_str)
+        section.write(f"datetime({datetime_str}),")
 
     def _get_comment(self, path, comments):
         key = re.sub(r'^\.', '', ''.join(path))

--- a/awscli/botocore/docs/waiter.py
+++ b/awscli/botocore/docs/waiter.py
@@ -33,23 +33,21 @@ class WaiterDocumenter:
         section.writeln('The available waiters are:')
         for waiter_name in self._service_waiter_model.waiter_names:
             section.style.li(
-                ':py:class:`%s.Waiter.%s`'
-                % (self._client.__class__.__name__, waiter_name)
+                f':py:class:`{self._client.__class__.__name__}.Waiter.{waiter_name}`'
             )
             self._add_single_waiter(section, waiter_name)
 
     def _add_single_waiter(self, section, waiter_name):
         section = section.add_new_section(waiter_name)
         section.style.start_sphinx_py_class(
-            class_name='%s.Waiter.%s'
-            % (self._client.__class__.__name__, waiter_name)
+            class_name=f'{self._client.__class__.__name__}.Waiter.{waiter_name}'
         )
 
         # Add example on how to instantiate waiter.
         section.style.start_codeblock()
         section.style.new_line()
         section.write(
-            'waiter = client.get_waiter(\'%s\')' % xform_name(waiter_name)
+            f'waiter = client.get_waiter(\'{xform_name(waiter_name)}\')'
         )
         section.style.end_codeblock()
 

--- a/awscli/botocore/endpoint.py
+++ b/awscli/botocore/endpoint.py
@@ -103,7 +103,7 @@ class Endpoint:
             self.http_session = URLLib3Session()
 
     def __repr__(self):
-        return '%s(%s)' % (self._endpoint_prefix, self.host)
+        return f'{self._endpoint_prefix}({self.host})'
 
     def make_request(self, operation_model, request_dict):
         logger.debug(
@@ -204,7 +204,7 @@ class Endpoint:
             )
         service_id = operation_model.service_model.service_id.hyphenize()
         self._event_emitter.emit(
-            'response-received.%s.%s' % (service_id, operation_model.name),
+            f'response-received.{service_id}.{operation_model.name}',
             **kwargs_to_emit,
         )
         return success_response, exception
@@ -223,10 +223,7 @@ class Endpoint:
                 },
             )
             service_id = operation_model.service_model.service_id.hyphenize()
-            event_name = 'before-send.%s.%s' % (
-                service_id,
-                operation_model.name,
-            )
+            event_name = f'before-send.{service_id}.{operation_model.name}'
             responses = self._event_emitter.emit(event_name, request=request)
             http_response = first_non_none_response(responses)
             if http_response is None:
@@ -310,7 +307,7 @@ class Endpoint:
         caught_exception=None,
     ):
         service_id = operation_model.service_model.service_id.hyphenize()
-        event_name = 'needs-retry.%s.%s' % (service_id, operation_model.name)
+        event_name = f'needs-retry.{service_id}.{operation_model.name}'
         responses = self._event_emitter.emit(
             event_name,
             response=response,
@@ -359,7 +356,7 @@ class EndpointCreator:
         if not is_valid_endpoint_url(
             endpoint_url
         ) and not is_valid_ipv6_endpoint_url(endpoint_url):
-            raise ValueError("Invalid endpoint: %s" % endpoint_url)
+            raise ValueError(f"Invalid endpoint: {endpoint_url}")
 
         if proxies is None:
             proxies = self._get_proxies(endpoint_url)

--- a/awscli/botocore/errorfactory.py
+++ b/awscli/botocore/errorfactory.py
@@ -49,8 +49,9 @@ class BaseClientExceptions:
             for exception_cls in self._code_to_exception.values()
         ]
         raise AttributeError(
-            '%r object has no attribute %r. Valid exceptions are: %s'
-            % (self, name, ', '.join(exception_cls_names))
+            '{!r} object has no attribute {!r}. Valid exceptions are: {}'.format(
+                self, name, ', '.join(exception_cls_names)
+            )
         )
 
 

--- a/awscli/botocore/eventstream.py
+++ b/awscli/botocore/eventstream.py
@@ -32,7 +32,7 @@ class DuplicateHeader(ParserError):
     """Duplicate header found in the event."""
 
     def __init__(self, header):
-        message = 'Duplicate header present: "%s"' % header
+        message = f'Duplicate header present: "{header}"'
         super(DuplicateHeader, self).__init__(message)
 
 
@@ -40,10 +40,7 @@ class InvalidHeadersLength(ParserError):
     """Headers length is longer than the maximum."""
 
     def __init__(self, length):
-        message = 'Header length of %s exceeded the maximum of %s' % (
-            length,
-            _MAX_HEADERS_LENGTH,
-        )
+        message = f'Header length of {length} exceeded the maximum of {_MAX_HEADERS_LENGTH}'
         super(InvalidHeadersLength, self).__init__(message)
 
 
@@ -51,10 +48,7 @@ class ChecksumMismatch(ParserError):
     """Calculated checksum did not match the expected checksum."""
 
     def __init__(self, expected, calculated):
-        message = 'Checksum mismatch: expected 0x%08x, calculated 0x%08x' % (
-            expected,
-            calculated,
-        )
+        message = f'Checksum mismatch: expected 0x{expected:08x}, calculated 0x{calculated:08x}'
         super(ChecksumMismatch, self).__init__(message)
 
 

--- a/awscli/botocore/exceptions.py
+++ b/awscli/botocore/exceptions.py
@@ -531,9 +531,8 @@ class ClientError(Exception):
             metadata = response['ResponseMetadata']
             if metadata.get('MaxAttemptsReached', False):
                 if 'RetryAttempts' in metadata:
-                    retry_info = (
-                        ' (reached max retries: %s)'
-                        % metadata['RetryAttempts']
+                    retry_info = ' (reached max retries: {})'.format(
+                        metadata['RetryAttempts']
                     )
         return retry_info
 

--- a/awscli/botocore/handlers.py
+++ b/awscli/botocore/handlers.py
@@ -217,8 +217,7 @@ def generate_idempotent_uuid(params, model, **kwargs):
         if name not in params:
             params[name] = str(uuid.uuid4())
             logger.debug(
-                "injecting idempotency token (%s) into param '%s'."
-                % (params[name], name)
+                f"injecting idempotency token ({params[name]}) into param '{name}'."
             )
 
 
@@ -247,9 +246,8 @@ def validate_bucket_name(params, **kwargs):
     bucket = params['Bucket']
     if not VALID_BUCKET.search(bucket) and not VALID_S3_ARN.search(bucket):
         error_msg = (
-            'Invalid bucket name "%s": Bucket name must match '
-            'the regex "%s" or be an ARN matching the regex "%s"'
-            % (bucket, VALID_BUCKET.pattern, VALID_S3_ARN.pattern)
+            f'Invalid bucket name "{bucket}": Bucket name must match '
+            f'the regex "{VALID_BUCKET.pattern}" or be an ARN matching the regex "{VALID_S3_ARN.pattern}"'
         )
         raise ParamValidationError(report=error_msg)
 
@@ -403,16 +401,16 @@ def _quote_source_header_from_dict(source_dict):
         key = source_dict['Key']
         version_id = source_dict.get('VersionId')
         if VALID_S3_ARN.search(bucket):
-            final = '%s/object/%s' % (bucket, key)
+            final = f'{bucket}/object/{key}'
         else:
-            final = '%s/%s' % (bucket, key)
+            final = f'{bucket}/{key}'
     except KeyError as e:
         raise ParamValidationError(
-            report='Missing required parameter: %s' % str(e)
+            report=f'Missing required parameter: {str(e)}'
         )
     final = percent_encode(final, safe=SAFE_CHARS + '/')
     if version_id is not None:
-        final += '?versionId=%s' % version_id
+        final += f'?versionId={version_id}'
     return final
 
 
@@ -590,8 +588,8 @@ def validate_ascii_metadata(params, **kwargs):
         except UnicodeEncodeError:
             error_msg = (
                 'Non ascii characters found in S3 metadata '
-                'for key "%s", value: "%s".  \nS3 metadata can only '
-                'contain ASCII characters. ' % (key, value)
+                f'for key "{key}", value: "{value}".  \nS3 metadata can only '
+                'contain ASCII characters. '
             )
             raise ParamValidationError(report=error_msg)
 
@@ -719,10 +717,10 @@ def check_openssl_supports_tls_version_1_2(**kwargs):
         openssl_version_tuple = ssl.OPENSSL_VERSION_INFO
         if openssl_version_tuple < (1, 0, 1):
             warnings.warn(
-                'Currently installed openssl version: %s does not '
+                f'Currently installed openssl version: {ssl.OPENSSL_VERSION} does not '
                 'support TLS 1.2, which is required for use of iot-data. '
                 'Please use python installed with openssl version 1.0.1 or '
-                'higher.' % (ssl.OPENSSL_VERSION),
+                'higher.',
                 UnsupportedTLSVersionWarning,
             )
     # We cannot check the openssl version on python2.6, so we should just

--- a/awscli/botocore/hooks.py
+++ b/awscli/botocore/hooks.py
@@ -169,7 +169,7 @@ class BaseEventHooks:
 
     def _verify_is_callable(self, func):
         if not callable(func):
-            raise ValueError("Event handler %s must be callable." % func)
+            raise ValueError(f"Event handler {func} must be callable.")
 
     def _verify_accept_kwargs(self, func):
         """Verifies a callable accepts kwargs
@@ -183,8 +183,8 @@ class BaseEventHooks:
         try:
             if not accepts_kwargs(func):
                 raise ValueError(
-                    "Event handler %s must accept keyword "
-                    "arguments (**kwargs)" % func
+                    f"Event handler {func} must accept keyword "
+                    "arguments (**kwargs)"
                 )
         except TypeError:
             return False
@@ -313,20 +313,20 @@ class HierarchicalEmitter(BaseEventHooks):
                 if unique_id_uses_count:
                     if not count:
                         raise ValueError(
-                            "Initial registration of  unique id %s was "
+                            f"Initial registration of  unique id {unique_id} was "
                             "specified to use a counter. Subsequent register "
                             "calls to unique id must specify use of a counter "
-                            "as well." % unique_id
+                            "as well."
                         )
                     else:
                         self._unique_id_handlers[unique_id]['count'] += 1
                 else:
                     if count:
                         raise ValueError(
-                            "Initial registration of unique id %s was "
+                            f"Initial registration of unique id {unique_id} was "
                             "specified to not use a counter. Subsequent "
                             "register calls to unique id must specify not to "
-                            "use a counter as well." % unique_id
+                            "use a counter as well."
                         )
                 return
             else:
@@ -363,9 +363,9 @@ class HierarchicalEmitter(BaseEventHooks):
             if unique_id_uses_count:
                 if count is None:
                     raise ValueError(
-                        "Initial registration of unique id %s was specified to "
+                        f"Initial registration of unique id {unique_id} was specified to "
                         "use a counter. Subsequent unregister calls to unique "
-                        "id must specify use of a counter as well." % unique_id
+                        "id must specify use of a counter as well."
                     )
                 elif count == 1:
                     handler = self._unique_id_handlers.pop(unique_id)[
@@ -377,10 +377,10 @@ class HierarchicalEmitter(BaseEventHooks):
             else:
                 if count:
                     raise ValueError(
-                        "Initial registration of unique id %s was specified "
+                        f"Initial registration of unique id {unique_id} was specified "
                         "to not use a counter. Subsequent unregister calls "
                         "to unique id must specify not to use a counter as "
-                        "well." % unique_id
+                        "well."
                     )
                 handler = self._unique_id_handlers.pop(unique_id)['handler']
         try:
@@ -529,7 +529,7 @@ class _PrefixTrie:
                     del current_node['children'][key_parts[index]]
             else:
                 raise ValueError(
-                    "key is not in trie: %s" % '.'.join(key_parts)
+                    "key is not in trie: {}".format('.'.join(key_parts))
                 )
 
     def __copy__(self):

--- a/awscli/botocore/loaders.py
+++ b/awscli/botocore/loaders.py
@@ -408,7 +408,7 @@ class Loader:
     def _find_extras(self, service_name, type_name, api_version):
         """Creates an iterator over all the extras data."""
         for extras_type in self.extras_types:
-            extras_name = '%s.%s-extras' % (type_name, extras_type)
+            extras_name = f'{type_name}.{extras_type}-extras'
             full_path = os.path.join(service_name, api_version, extras_name)
 
             try:

--- a/awscli/botocore/model.py
+++ b/awscli/botocore/model.py
@@ -203,7 +203,7 @@ class Shape:
         return self._shape_resolver.resolve_shape_ref(shape_ref)
 
     def __repr__(self):
-        return "<%s(%s)>" % (self.__class__.__name__, self.name)
+        return f"<{self.__class__.__name__}({self.name})>"
 
     @property
     def event_stream_name(self):
@@ -463,8 +463,7 @@ class ServiceModel:
             return self.metadata[name]
         except KeyError:
             raise UndefinedModelAttributeError(
-                '"%s" not defined in the metadata of the model: %s'
-                % (name, self)
+                f'"{name}" not defined in the metadata of the model: {self}'
             )
 
     # Signature version is one of the rare properties
@@ -486,7 +485,7 @@ class ServiceModel:
         return 'awsQueryCompatible' in self.metadata
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, self.service_name)
+        return f'{self.__class__.__name__}({self.service_name})'
 
 
 class OperationModel:
@@ -719,7 +718,7 @@ class OperationModel:
         return None
 
     def __repr__(self):
-        return '%s(name=%s)' % (self.__class__.__name__, self.name)
+        return f'{self.__class__.__name__}(name={self.name})'
 
 
 class ShapeResolver:
@@ -746,7 +745,7 @@ class ShapeResolver:
             shape_cls = self.SHAPE_CLASSES.get(shape_model['type'], Shape)
         except KeyError:
             raise InvalidShapeError(
-                "Shape is missing required key 'type': %s" % shape_model
+                f"Shape is missing required key 'type': {shape_model}"
             )
         if member_traits:
             shape_model = shape_model.copy()
@@ -771,7 +770,7 @@ class ShapeResolver:
                 shape_name = member_traits.pop('shape')
             except KeyError:
                 raise InvalidShapeReferenceError(
-                    "Invalid model, missing shape reference: %s" % shape_ref
+                    f"Invalid model, missing shape reference: {shape_ref}"
                 )
             return self.get_shape_by_name(shape_name, member_traits)
 
@@ -886,7 +885,9 @@ class DenormalizedStructureBuilder:
         ]:
             shapes[shape_name] = self._build_scalar(model)
         else:
-            raise InvalidShapeError("Unknown shape type: %s" % model['type'])
+            raise InvalidShapeError(
+                "Unknown shape type: {}".format(model['type'])
+            )
 
     def _build_structure(self, model, shapes):
         members = OrderedDict()
@@ -976,4 +977,4 @@ class ShapeNameGenerator:
         """
         self._name_cache[type_name] += 1
         current_index = self._name_cache[type_name]
-        return '%sType%s' % (type_name.capitalize(), current_index)
+        return f'{type_name.capitalize()}Type{current_index}'

--- a/awscli/botocore/monitoring.py
+++ b/awscli/botocore/monitoring.py
@@ -192,7 +192,7 @@ class BaseMonitorEvent:
         self.timestamp = timestamp
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self.__dict__)
+        return f'{self.__class__.__name__}({self.__dict__!r})'
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -377,9 +377,8 @@ class CSMSerializer:
     def _validate_client_id(self, csm_client_id):
         if len(csm_client_id) > self._MAX_CLIENT_ID_LENGTH:
             raise ValueError(
-                'The value provided for csm_client_id: %s exceeds the '
-                'maximum length of %s characters'
-                % (csm_client_id, self._MAX_CLIENT_ID_LENGTH)
+                f'The value provided for csm_client_id: {csm_client_id} exceeds the '
+                f'maximum length of {self._MAX_CLIENT_ID_LENGTH} characters'
             )
 
     def serialize(self, event):

--- a/awscli/botocore/paginate.py
+++ b/awscli/botocore/paginate.py
@@ -182,7 +182,7 @@ class PaginatorModel:
             single_paginator_config = self._paginator_config[operation_name]
         except KeyError:
             raise ValueError(
-                "Paginator for operation does not exist: %s" % operation_name
+                f"Paginator for operation does not exist: {operation_name}"
             )
         return single_paginator_config
 
@@ -230,7 +230,7 @@ class PageIterator:
     @resume_token.setter
     def resume_token(self, value):
         if not isinstance(value, dict):
-            raise ValueError("Bad starting token: %s" % value)
+            raise ValueError(f"Bad starting token: {value}")
 
         if 'boto_truncate_amount' in value:
             token_keys = sorted(self._input_token + ['boto_truncate_amount'])
@@ -241,7 +241,7 @@ class PageIterator:
         if token_keys == dict_keys:
             self._resume_token = self._token_encoder.encode(value)
         else:
-            raise ValueError("Bad starting token: %s" % value)
+            raise ValueError(f"Bad starting token: {value}")
 
     @property
     def non_aggregate_part(self):
@@ -320,7 +320,7 @@ class PageIterator:
                 ):
                     message = (
                         "The same next token was received "
-                        "twice: %s" % next_token
+                        f"twice: {next_token}"
                     )
                     raise PaginationError(message=message)
                 self._inject_token_into_kwargs(current_kwargs, next_token)
@@ -546,7 +546,7 @@ class PageIterator:
         """
         log.debug(
             "Attempting to fall back to old starting token parser. For "
-            "token: %s" % self._starting_token
+            f"token: {self._starting_token}"
         )
         if self._starting_token is None:
             return None
@@ -577,7 +577,7 @@ class PageIterator:
         len_deprecated_token = len(deprecated_token)
         len_input_token = len(self._input_token)
         if len_deprecated_token > len_input_token:
-            raise ValueError("Bad starting token: %s" % self._starting_token)
+            raise ValueError(f"Bad starting token: {self._starting_token}")
         elif len_deprecated_token < len_input_token:
             log.debug(
                 "Old format starting token does not contain all input "

--- a/awscli/botocore/parsers.py
+++ b/awscli/botocore/parsers.py
@@ -325,21 +325,19 @@ class ResponseParser:
         }
 
     def _do_parse(self, response, shape):
-        raise NotImplementedError("%s._do_parse" % self.__class__.__name__)
+        raise NotImplementedError(f"{self.__class__.__name__}._do_parse")
 
     def _do_error_parse(self, response, shape):
-        raise NotImplementedError(
-            "%s._do_error_parse" % self.__class__.__name__
-        )
+        raise NotImplementedError(f"{self.__class__.__name__}._do_error_parse")
 
     def _do_modeled_error_parse(self, response, shape, parsed):
         raise NotImplementedError(
-            "%s._do_modeled_error_parse" % self.__class__.__name__
+            f"{self.__class__.__name__}._do_modeled_error_parse"
         )
 
     def _parse_shape(self, shape, node):
         handler = getattr(
-            self, '_handle_%s' % shape.type_name, self._default_handle
+            self, f'_handle_{shape.type_name}', self._default_handle
         )
         return handler(shape, node)
 
@@ -434,7 +432,7 @@ class BaseXMLResponseParser(ResponseParser):
                 elif tag_name == value_location_name:
                     val_name = self._parse_shape(value_shape, single_pair)
                 else:
-                    raise ResponseParserError("Unknown tag: %s" % tag_name)
+                    raise ResponseParserError(f"Unknown tag: {tag_name}")
             parsed[key_name] = val_name
         return parsed
 
@@ -542,9 +540,8 @@ class BaseXMLResponseParser(ResponseParser):
             root = parser.close()
         except XMLParseError as e:
             raise ResponseParserError(
-                "Unable to parse response (%s), "
-                "invalid XML received. Further retries may succeed:\n%s"
-                % (e, xml_string)
+                f"Unable to parse response ({e}), "
+                f"invalid XML received. Further retries may succeed:\n{xml_string}"
             )
         return root
 

--- a/awscli/botocore/regions.py
+++ b/awscli/botocore/regions.py
@@ -261,7 +261,7 @@ class EndpointResolver(BaseEndpointResolver):
         ):
             error_msg = (
                 "Dualstack endpoints are currently not supported"
-                " for %s partition" % partition_name
+                f" for {partition_name} partition"
             )
             raise EndpointVariantError(tags=['dualstack'], error_msg=error_msg)
 
@@ -357,8 +357,7 @@ class EndpointResolver(BaseEndpointResolver):
 
         if endpoint_data.get('deprecated'):
             LOG.warning(
-                'Client is configured with the deprecated endpoint: %s'
-                % (endpoint_name)
+                f'Client is configured with the deprecated endpoint: {endpoint_name}'
             )
 
         service_defaults = service_data.get('defaults', {})
@@ -370,10 +369,7 @@ class EndpointResolver(BaseEndpointResolver):
                 tags, endpoint_data, service_defaults, partition_defaults
             )
             if result == {}:
-                error_msg = "Endpoint does not exist for %s in region %s" % (
-                    service_name,
-                    endpoint_name,
-                )
+                error_msg = f"Endpoint does not exist for {service_name} in region {endpoint_name}"
                 raise EndpointVariantError(tags=tags, error_msg=error_msg)
             self._merge_keys(endpoint_data, result)
         else:
@@ -500,7 +496,7 @@ class EndpointRulesetResolver:
             operation_model, call_args, request_context
         )
         LOG.debug(
-            'Calling endpoint provider with parameters: %s' % provider_params
+            f'Calling endpoint provider with parameters: {provider_params}'
         )
         try:
             provider_result = self._provider.resolve_endpoint(
@@ -514,7 +510,7 @@ class EndpointRulesetResolver:
                 raise
             else:
                 raise botocore_exception from ex
-        LOG.debug('Endpoint provider result: %s' % provider_result.url)
+        LOG.debug(f'Endpoint provider result: {provider_result.url}')
 
         # The endpoint provider does not support non-secure transport.
         if not self._use_ssl and provider_result.url.startswith('https://'):
@@ -657,7 +653,7 @@ class EndpointRulesetResolver:
         customized_builtins = copy.copy(self._builtins)
         # Handlers are expected to modify the builtins dict in place.
         self._event_emitter.emit(
-            'before-endpoint-resolution.%s' % service_id,
+            f'before-endpoint-resolution.{service_id}',
             builtins=customized_builtins,
             model=operation_model,
             params=call_args,

--- a/awscli/botocore/retries/standard.py
+++ b/awscli/botocore/retries/standard.py
@@ -46,7 +46,7 @@ def register_retry_handler(client, max_attempts=DEFAULT_MAX_ATTEMPTS):
     service_id = client.meta.service_model.service_id
     service_event_name = service_id.hyphenize()
     client.meta.events.register(
-        'after-call.%s' % service_event_name, retry_quota.release_retry_quota
+        f'after-call.{service_event_name}', retry_quota.release_retry_quota
     )
 
     handler = RetryHandler(
@@ -58,9 +58,9 @@ def register_retry_handler(client, max_attempts=DEFAULT_MAX_ATTEMPTS):
         retry_quota=retry_quota,
     )
 
-    unique_id = 'retry-config-%s' % service_event_name
+    unique_id = f'retry-config-{service_event_name}'
     client.meta.events.register(
-        'needs-retry.%s' % service_event_name,
+        f'needs-retry.{service_event_name}',
         handler.needs_retry,
         unique_id=unique_id,
     )

--- a/awscli/botocore/session.py
+++ b/awscli/botocore/session.py
@@ -517,18 +517,12 @@ class Session:
 
         """
         if truncate:
-            return '%s/%s' % (self.user_agent_name, self.user_agent_version)
-        base = '%s/%s Python/%s %s/%s' % (
-            self.user_agent_name,
-            self.user_agent_version,
-            platform.python_version(),
-            platform.system(),
-            platform.release(),
-        )
+            return f'{self.user_agent_name}/{self.user_agent_version}'
+        base = f'{self.user_agent_name}/{self.user_agent_version} Python/{platform.python_version()} {platform.system()}/{platform.release()}'
         if os.environ.get('AWS_EXECUTION_ENV') is not None:
-            base += ' exec-env/%s' % os.environ.get('AWS_EXECUTION_ENV')
+            base += ' exec-env/{}'.format(os.environ.get('AWS_EXECUTION_ENV'))
         if self.user_agent_extra:
-            base += ' %s' % self.user_agent_extra
+            base += f' {self.user_agent_extra}'
 
         return base
 
@@ -758,9 +752,9 @@ class Session:
         except ValueError:
             if name in ['endpoint_resolver', 'exceptions_factory']:
                 warnings.warn(
-                    'Fetching the %s component with the get_component() '
+                    f'Fetching the {name} component with the get_component() '
                     'method is deprecated as the component has always been '
-                    'considered an internal interface of botocore' % name,
+                    'considered an internal interface of botocore',
                     DeprecationWarning,
                 )
                 return self._internal_components.get_component(name)
@@ -1069,7 +1063,7 @@ class ComponentLocator:
         try:
             return self._components[name]
         except KeyError:
-            raise ValueError("Unknown component: %s" % name)
+            raise ValueError(f"Unknown component: {name}")
 
     def register_component(self, name, component):
         self._components[name] = component

--- a/awscli/botocore/signers.py
+++ b/awscli/botocore/signers.py
@@ -419,14 +419,18 @@ class CloudFrontSigner:
         if isinstance(policy, str):
             policy = policy.encode('utf8')
         if date_less_than is not None:
-            params = ['Expires=%s' % int(datetime2timestamp(date_less_than))]
+            params = [f'Expires={int(datetime2timestamp(date_less_than))}']
         else:
-            params = ['Policy=%s' % self._url_b64encode(policy).decode('utf8')]
+            params = [
+                'Policy={}'.format(self._url_b64encode(policy).decode('utf8'))
+            ]
         signature = self.rsa_signer(policy)
         params.extend(
             [
-                'Signature=%s' % self._url_b64encode(signature).decode('utf8'),
-                'Key-Pair-Id=%s' % self.key_id,
+                'Signature={}'.format(
+                    self._url_b64encode(signature).decode('utf8')
+                ),
+                f'Key-Pair-Id={self.key_id}',
             ]
         )
         return self._build_url(url, params)
@@ -543,7 +547,7 @@ def generate_db_auth_token(self, DBHostname, Port, DBUsername, Region=None):
     # netloc would be treated as a path component. To work around this we
     # introduce https here and remove it once we're done processing it.
     scheme = 'https://'
-    endpoint_url = '%s%s:%s' % (scheme, DBHostname, Port)
+    endpoint_url = f'{scheme}{DBHostname}:{Port}'
     prepare_request_dict(request_dict, endpoint_url)
     presigned_url = self._request_signer.generate_presigned_url(
         operation_name='connect',

--- a/awscli/botocore/stub.py
+++ b/awscli/botocore/stub.py
@@ -239,8 +239,7 @@ class Stubber:
     def _add_response(self, method, service_response, expected_params):
         if not hasattr(self.client, method):
             raise ValueError(
-                "Client %s does not have method: %s"
-                % (self.client.meta.service_model.service_name, method)
+                f"Client {self.client.meta.service_model.service_name} does not have method: {method}"
             )
 
         # Create a successful http response
@@ -350,7 +349,7 @@ class Stubber:
         if name != model.name:
             raise StubResponseError(
                 operation_name=model.name,
-                reason='Operation mismatch: found response for %s.' % name,
+                reason=f'Operation mismatch: found response for {name}.',
             )
 
     def _get_response_handler(self, model, params, context, **kwargs):
@@ -371,16 +370,14 @@ class Stubber:
             if param not in params or expected_params[param] != params[param]:
                 raise StubAssertionError(
                     operation_name=model.name,
-                    reason='Expected parameters:\n%s,\nbut received:\n%s'
-                    % (pformat(expected_params), pformat(params)),
+                    reason=f'Expected parameters:\n{pformat(expected_params)},\nbut received:\n{pformat(params)}',
                 )
 
         # Ensure there are no extra params hanging around
         if sorted(expected_params.keys()) != sorted(params.keys()):
             raise StubAssertionError(
                 operation_name=model.name,
-                reason='Expected parameters:\n%s,\nbut received:\n%s'
-                % (pformat(expected_params), pformat(params)),
+                reason=f'Expected parameters:\n{pformat(expected_params)},\nbut received:\n{pformat(params)}',
             )
 
     def _should_not_stub(self, context):

--- a/awscli/botocore/utils.py
+++ b/awscli/botocore/utils.py
@@ -381,7 +381,7 @@ class IMDSFetcher:
         else:
             chosen_base_url = METADATA_BASE_URL
 
-        logger.debug("IMDS ENDPOINT: %s" % chosen_base_url)
+        logger.debug(f"IMDS ENDPOINT: {chosen_base_url}")
         if not is_valid_uri(chosen_base_url):
             raise InvalidIMDSEndpointError(endpoint=chosen_base_url)
 
@@ -728,11 +728,11 @@ def percent_encode_sequence(mapping, safe=SAFE_CHARS):
         if isinstance(value, list):
             for element in value:
                 encoded_pairs.append(
-                    '%s=%s' % (percent_encode(key), percent_encode(element))
+                    f'{percent_encode(key)}={percent_encode(element)}'
                 )
         else:
             encoded_pairs.append(
-                '%s=%s' % (percent_encode(key), percent_encode(value))
+                f'{percent_encode(key)}={percent_encode(value)}'
             )
     return '&'.join(encoded_pairs)
 
@@ -790,7 +790,7 @@ def _parse_timestamp_with_tzinfo(value, tzinfo):
         # enforce that GMT == UTC.
         return dateutil.parser.parse(value, tzinfos={'GMT': tzutc()})
     except (TypeError, ValueError) as e:
-        raise ValueError('Invalid timestamp "%s": %s' % (value, e))
+        raise ValueError(f'Invalid timestamp "{value}": {e}')
 
 
 def parse_timestamp(value):
@@ -837,7 +837,7 @@ def parse_timestamp(value):
                 exc_info=e,
             )
     raise RuntimeError(
-        'Unable to calculate correct timezone offset for "%s"' % value
+        f'Unable to calculate correct timezone offset for "{value}"'
     )
 
 
@@ -1387,9 +1387,7 @@ def _get_new_endpoint(original_endpoint, new_endpoint, use_new_scheme=True):
         '',
     )
     final_endpoint = urlunsplit(final_endpoint_components)
-    logger.debug(
-        'Updating URI from %s to %s' % (original_endpoint, final_endpoint)
-    )
+    logger.debug(f'Updating URI from {original_endpoint} to {final_endpoint}')
     return final_endpoint
 
 
@@ -1647,17 +1645,16 @@ class S3RegionRedirectorv2:
 
         if new_region is None:
             logger.debug(
-                "S3 client configured for region %s but the bucket %s is not "
+                f"S3 client configured for region {client_region} but the bucket {bucket} is not "
                 "in that region and the proper region could not be "
-                "automatically determined." % (client_region, bucket)
+                "automatically determined."
             )
             return
 
         logger.debug(
-            "S3 client configured for region %s but the bucket %s is in region"
-            " %s; Please configure the proper region to avoid multiple "
+            f"S3 client configured for region {client_region} but the bucket {bucket} is in region"
+            f" {new_region}; Please configure the proper region to avoid multiple "
             "unnecessary redirects and signing attempts."
-            % (client_region, bucket, new_region)
         )
         # Adding the new region to _cache will make construct_endpoint() to
         # use the new region as value for the AWS::Region builtin parameter.
@@ -1845,17 +1842,16 @@ class S3RegionRedirector:
 
         if new_region is None:
             logger.debug(
-                "S3 client configured for region %s but the bucket %s is not "
+                f"S3 client configured for region {client_region} but the bucket {bucket} is not "
                 "in that region and the proper region could not be "
-                "automatically determined." % (client_region, bucket)
+                "automatically determined."
             )
             return
 
         logger.debug(
-            "S3 client configured for region %s but the bucket %s is in region"
-            " %s; Please configure the proper region to avoid multiple "
+            f"S3 client configured for region {client_region} but the bucket {bucket} is in region"
+            f" {new_region}; Please configure the proper region to avoid multiple "
             "unnecessary redirects and signing attempts."
-            % (client_region, bucket, new_region)
         )
         endpoint = self._endpoint_resolver.resolve('s3', new_region)
         endpoint = endpoint['endpoint_url']
@@ -1940,8 +1936,8 @@ class ArnParser:
         arn_parts = arn.split(':', 5)
         if len(arn_parts) < 6:
             raise InvalidArnException(
-                'Provided ARN: %s must be of the format: '
-                'arn:partition:service:region:account:resource' % arn
+                f'Provided ARN: {arn} must be of the format: '
+                'arn:partition:service:region:account:resource'
             )
         return {
             'partition': arn_parts[1],
@@ -2124,8 +2120,8 @@ class S3EndpointSetter:
                 raise UnsupportedS3ConfigurationError(
                     msg=(
                         'Client is configured to use the FIPS psuedo region '
-                        'for "%s", but S3 Accelerate does not have any FIPS '
-                        'compatible endpoints.' % (self._region)
+                        f'for "{self._region}", but S3 Accelerate does not have any FIPS '
+                        'compatible endpoints.'
                     )
                 )
             switch_host_s3_accelerate(request=request, **kwargs)
@@ -2145,9 +2141,8 @@ class S3EndpointSetter:
         if 'outpost_name' in request.context['s3_accesspoint']:
             raise UnsupportedS3AccesspointConfigurationError(
                 msg=(
-                    'Client is configured to use the FIPS psuedo-region "%s", '
+                    f'Client is configured to use the FIPS psuedo-region "{self._region}", '
                     'but outpost ARNs do not support FIPS endpoints.'
-                    % (self._region)
                 )
             )
         # Transforming psuedo region to actual region
@@ -2159,11 +2154,10 @@ class S3EndpointSetter:
                 raise UnsupportedS3AccesspointConfigurationError(
                     msg=(
                         'Client is configured to use the FIPS psuedo-region '
-                        'for "%s", but the access-point ARN provided is for '
-                        'the "%s" region. For clients using a FIPS '
+                        f'for "{self._region}", but the access-point ARN provided is for '
+                        f'the "{accesspoint_region}" region. For clients using a FIPS '
                         'psuedo-region calls to access-point ARNs in another '
                         'region are not allowed.'
-                        % (self._region, accesspoint_region)
                     )
                 )
 
@@ -2174,8 +2168,8 @@ class S3EndpointSetter:
             raise UnsupportedS3AccesspointConfigurationError(
                 msg=(
                     'Client is configured to use the global psuedo-region '
-                    '"%s". When providing access-point ARNs a regional '
-                    'endpoint must be specified.' % self._region
+                    f'"{self._region}". When providing access-point ARNs a regional '
+                    'endpoint must be specified.'
                 )
             )
 
@@ -2191,10 +2185,9 @@ class S3EndpointSetter:
         if request_partition != self._partition:
             raise UnsupportedS3AccesspointConfigurationError(
                 msg=(
-                    'Client is configured for "%s" partition, but access-point'
-                    ' ARN provided is for "%s" partition. The client and '
+                    f'Client is configured for "{self._partition}" partition, but access-point'
+                    f' ARN provided is for "{request_partition}" partition. The client and '
                     ' access-point partition must be the same.'
-                    % (self._partition, request_partition)
                 )
             )
         s3_service = request.context['s3_accesspoint'].get('service')
@@ -2270,7 +2263,7 @@ class S3EndpointSetter:
             )
         )
         logger.debug(
-            'Updating URI from %s to %s' % (request.url, accesspoint_endpoint)
+            f'Updating URI from {request.url} to {accesspoint_endpoint}'
         )
         request.url = accesspoint_endpoint
 
@@ -2301,7 +2294,7 @@ class S3EndpointSetter:
     def _get_accesspoint_netloc(self, request_context, region_name):
         s3_accesspoint = request_context['s3_accesspoint']
         accesspoint_netloc_components = [
-            '%s-%s' % (s3_accesspoint['name'], s3_accesspoint['account']),
+            '{}-{}'.format(s3_accesspoint['name'], s3_accesspoint['account']),
         ]
         outpost_name = s3_accesspoint.get('outpost_name')
         if self._endpoint_url:
@@ -2332,7 +2325,7 @@ class S3EndpointSetter:
 
     def _inject_fips_if_needed(self, component, request_context):
         if self._use_fips_endpoint:
-            return '%s-fips' % component
+            return f'{component}-fips'
         return component
 
     def _get_accesspoint_path(self, original_path, request_context):
@@ -2510,18 +2503,17 @@ class S3ControlEndpointSetter:
             if arn_region != self._region:
                 error_msg = (
                     'The use_arn_region configuration is disabled but '
-                    'received arn for "%s" when the client is configured '
-                    'to use "%s"'
-                ) % (arn_region, self._region)
+                    f'received arn for "{arn_region}" when the client is configured '
+                    f'to use "{self._region}"'
+                )
                 raise UnsupportedS3ControlConfigurationError(msg=error_msg)
         request_partion = request.context['arn_details']['partition']
         if request_partion != self._partition:
             raise UnsupportedS3ControlConfigurationError(
                 msg=(
-                    'Client is configured for "%s" partition, but arn '
-                    'provided is for "%s" partition. The client and '
+                    f'Client is configured for "{self._partition}" partition, but arn '
+                    f'provided is for "{request_partion}" partition. The client and '
                     'arn partition must be the same.'
-                    % (self._partition, request_partion)
                 )
             )
         if self._s3_config.get('use_accelerate_endpoint'):
@@ -2572,7 +2564,7 @@ class S3ControlEndpointSetter:
             )
         )
         logger.debug(
-            'Updating URI from %s to %s' % (request.url, arn_details_endpoint)
+            f'Updating URI from {request.url} to {arn_details_endpoint}'
         )
         request.url = arn_details_endpoint
 
@@ -2721,8 +2713,8 @@ class S3ControlArnParamHandler:
         if 'AccountId' in params and params['AccountId'] != account_id:
             error_msg = (
                 'Account ID in arn does not match the AccountId parameter '
-                'provided: "%s"'
-            ) % params['AccountId']
+                'provided: "{}"'
+            ).format(params['AccountId'])
             raise UnsupportedS3ControlArnError(
                 arn=arn_details['original'],
                 msg=error_msg,
@@ -2993,7 +2985,7 @@ class ContainerMetadataFetcher:
             raise MetadataRetrievalError(error_msg=error_msg)
 
     def full_url(self, relative_uri):
-        return 'http://%s%s' % (self.IP_ADDRESS, relative_uri)
+        return f'http://{self.IP_ADDRESS}{relative_uri}'
 
 
 def get_environ_proxies(url):

--- a/awscli/botocore/validate.py
+++ b/awscli/botocore/validate.py
@@ -106,21 +106,20 @@ class ValidationErrors:
         error_type, name, additional = error
         name = self._get_name(name)
         if error_type == 'missing required field':
-            return 'Missing required parameter in %s: "%s"' % (
+            return 'Missing required parameter in {}: "{}"'.format(
                 name,
                 additional['required_name'],
             )
         elif error_type == 'unknown field':
-            return 'Unknown parameter in %s: "%s", must be one of: %s' % (
+            return 'Unknown parameter in {}: "{}", must be one of: {}'.format(
                 name,
                 additional['unknown_param'],
                 ', '.join(additional['valid_names']),
             )
         elif error_type == 'invalid type':
             return (
-                'Invalid type for parameter %s, value: %s, type: %s, '
-                'valid types: %s'
-                % (
+                'Invalid type for parameter {}, value: {}, type: {}, '
+                'valid types: {}'.format(
                     name,
                     additional['param'],
                     str(type(additional['param'])),
@@ -130,27 +129,28 @@ class ValidationErrors:
         elif error_type == 'invalid range':
             min_allowed = additional['min_allowed']
             return (
-                'Invalid value for parameter %s, value: %s, '
-                'valid min value: %s'
-                % (name, additional['param'], min_allowed)
+                'Invalid value for parameter {}, value: {}, '
+                'valid min value: {}'.format(
+                    name, additional['param'], min_allowed
+                )
             )
         elif error_type == 'invalid length':
             min_allowed = additional['min_allowed']
             return (
-                'Invalid length for parameter %s, value: %s, '
-                'valid min length: %s'
-                % (name, additional['param'], min_allowed)
+                'Invalid length for parameter {}, value: {}, '
+                'valid min length: {}'.format(
+                    name, additional['param'], min_allowed
+                )
             )
         elif error_type == 'unable to encode to json':
-            return 'Invalid parameter %s must be json serializable: %s' % (
+            return 'Invalid parameter {} must be json serializable: {}'.format(
                 name,
                 additional['type_error'],
             )
         elif error_type == 'invalid type for document':
             return (
-                'Invalid type for document parameter %s, value: %s, type: %s, '
-                'valid types: %s'
-                % (
+                'Invalid type for document parameter {}, value: {}, type: {}, '
+                'valid types: {}'.format(
                     name,
                     additional['param'],
                     str(type(additional['param'])),
@@ -160,13 +160,16 @@ class ValidationErrors:
         elif error_type == 'more than one input':
             return (
                 'Invalid number of parameters set for tagged union structure'
-                ' %s. Can only set one of the following keys: %s.'
-                % (name, '. '.join(additional['members']))
+                ' {}. Can only set one of the following keys: {}.'.format(
+                    name, '. '.join(additional['members'])
+                )
             )
         elif error_type == 'empty input':
             return (
                 'Must set one of the following keys for tagged union'
-                'structure %s: %s.' % (name, '. '.join(additional['members']))
+                'structure {}: {}.'.format(
+                    name, '. '.join(additional['members'])
+                )
             )
 
     def _get_name(self, name):
@@ -213,7 +216,7 @@ class ParamValidator:
         if special_validator:
             special_validator(params, shape, errors, name)
         else:
-            getattr(self, '_validate_%s' % shape.type_name)(
+            getattr(self, f'_validate_{shape.type_name}')(
                 params, shape, errors, name
             )
 
@@ -286,7 +289,7 @@ class ParamValidator:
                 params[param],
                 shape.members[param],
                 errors,
-                '%s.%s' % (name, param),
+                f'{name}.{param}',
             )
 
     @type_check(valid_types=(str,))
@@ -306,17 +309,15 @@ class ParamValidator:
         member_shape = shape.member
         range_check(name, len(param), shape, 'invalid length', errors)
         for i, item in enumerate(param):
-            self._validate(item, member_shape, errors, '%s[%s]' % (name, i))
+            self._validate(item, member_shape, errors, f'{name}[{i}]')
 
     @type_check(valid_types=(dict,))
     def _validate_map(self, param, shape, errors, name):
         key_shape = shape.key
         value_shape = shape.value
         for key, value in param.items():
-            self._validate(
-                key, key_shape, errors, "%s (key: %s)" % (name, key)
-            )
-            self._validate(value, value_shape, errors, '%s.%s' % (name, key))
+            self._validate(key, key_shape, errors, f"{name} (key: {key})")
+            self._validate(value, value_shape, errors, f'{name}.{key}')
 
     @type_check(valid_types=(int,))
     def _validate_integer(self, param, shape, errors, name):

--- a/awscli/botocore/waiter.py
+++ b/awscli/botocore/waiter.py
@@ -66,8 +66,7 @@ def create_waiter_with_client(waiter_name, waiter_model, client):
 
     # Rename the waiter class based on the type of waiter.
     waiter_class_name = str(
-        '%s.Waiter.%s'
-        % (get_service_module_name(client.meta.service_model), waiter_name)
+        f'{get_service_module_name(client.meta.service_model)}.Waiter.{waiter_name}'
     )
 
     # Create the new waiter class
@@ -129,8 +128,8 @@ class WaiterModel:
             raise WaiterConfigError(
                 error_msg=(
                     "Unsupported waiter version, supported version "
-                    "must be: %s, but version of waiter config "
-                    "is: %s" % (self.SUPPORTED_VERSION, version)
+                    f"must be: {self.SUPPORTED_VERSION}, but version of waiter config "
+                    f"is: {version}"
                 )
             )
 
@@ -138,7 +137,7 @@ class WaiterModel:
         try:
             single_waiter_config = self._waiter_config[waiter_name]
         except KeyError:
-            raise ValueError("Waiter does not exist: %s" % waiter_name)
+            raise ValueError(f"Waiter does not exist: {waiter_name}")
         return SingleWaiterConfig(single_waiter_config)
 
 
@@ -180,28 +179,17 @@ class AcceptorConfig:
     @property
     def explanation(self):
         if self.matcher == 'path':
-            return 'For expression "%s" we matched expected path: "%s"' % (
-                self.argument,
-                self.expected,
-            )
+            return f'For expression "{self.argument}" we matched expected path: "{self.expected}"'
         elif self.matcher == 'pathAll':
-            return (
-                'For expression "%s" all members matched excepted path: "%s"'
-                % (self.argument, self.expected)
-            )
+            return f'For expression "{self.argument}" all members matched excepted path: "{self.expected}"'
         elif self.matcher == 'pathAny':
-            return (
-                'For expression "%s" we matched expected path: "%s" at least once'
-                % (self.argument, self.expected)
-            )
+            return f'For expression "{self.argument}" we matched expected path: "{self.expected}" at least once'
         elif self.matcher == 'status':
-            return 'Matched expected HTTP status code: %s' % self.expected
+            return f'Matched expected HTTP status code: {self.expected}'
         elif self.matcher == 'error':
-            return 'Matched expected service error code: %s' % self.expected
+            return f'Matched expected service error code: {self.expected}'
         else:
-            return (
-                'No explanation for unknown waiter type: "%s"' % self.matcher
-            )
+            return f'No explanation for unknown waiter type: "{self.matcher}"'
 
     def _create_matcher_func(self):
         # An acceptor function is a callable that takes a single value.  The
@@ -224,7 +212,7 @@ class AcceptorConfig:
             return self._create_error_matcher()
         else:
             raise WaiterConfigError(
-                error_msg="Unknown acceptor: %s" % self.matcher
+                error_msg=f"Unknown acceptor: {self.matcher}"
             )
 
     def _create_path_matcher(self):
@@ -367,8 +355,7 @@ class Waiter:
                     # can just handle here by raising an exception.
                     raise WaiterError(
                         name=self.name,
-                        reason='An error occurred (%s): %s'
-                        % (
+                        reason='An error occurred ({}): {}'.format(
                             response['Error'].get('Code', 'Unknown'),
                             response['Error'].get('Message', 'Unknown'),
                         ),
@@ -380,9 +367,7 @@ class Waiter:
                 )
                 return
             if current_state == 'failure':
-                reason = 'Waiter encountered a terminal failure state: %s' % (
-                    acceptor.explanation
-                )
+                reason = f'Waiter encountered a terminal failure state: {acceptor.explanation}'
                 raise WaiterError(
                     name=self.name,
                     reason=reason,
@@ -392,10 +377,7 @@ class Waiter:
                 if last_matched_acceptor is None:
                     reason = 'Max attempts exceeded'
                 else:
-                    reason = (
-                        'Max attempts exceeded. Previously accepted state: %s'
-                        % (acceptor.explanation)
-                    )
+                    reason = f'Max attempts exceeded. Previously accepted state: {acceptor.explanation}'
                 raise WaiterError(
                     name=self.name,
                     reason=reason,

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -114,7 +114,7 @@ class CLIDocumentEventHandler:
                 doc.write(' . ')
                 full_cmd_list.append(cmd)
                 full_cmd_name = ' '.join(full_cmd_list)
-                doc.write(':ref:`%s <cli:%s>`' % (cmd, full_cmd_name))
+                doc.write(f':ref:`{cmd} <cli:{full_cmd_name}>`')
             doc.write(' ]')
 
     def doc_title(self, help_command, **kwargs):
@@ -123,7 +123,7 @@ class CLIDocumentEventHandler:
         reference = help_command.event_class.replace('.', ' ')
         if reference != 'aws':
             reference = 'aws ' + reference
-        doc.writeln('.. _cli:%s:' % reference)
+        doc.writeln(f'.. _cli:{reference}:')
         doc.style.h1(help_command.name)
 
     def doc_description(self, help_command, **kwargs):
@@ -137,7 +137,7 @@ class CLIDocumentEventHandler:
         doc = help_command.doc
         doc.style.h2('Synopsis')
         doc.style.start_codeblock()
-        doc.writeln('%s' % help_command.name)
+        doc.writeln(f'{help_command.name}')
 
     def doc_synopsis_option(self, arg_name, help_command, **kwargs):
         doc = help_command.doc
@@ -151,15 +151,15 @@ class CLIDocumentEventHandler:
             )
             self._documented_arg_groups.append(argument.group_name)
         elif argument.cli_name.startswith('--'):
-            option_str = '%s <value>' % argument.cli_name
+            option_str = f'{argument.cli_name} <value>'
         else:
-            option_str = '<%s>' % argument.cli_name
+            option_str = f'<{argument.cli_name}>'
         if not (
             argument.required
             or getattr(argument, '_DOCUMENT_AS_REQUIRED', False)
         ):
-            option_str = '[%s]' % option_str
-        doc.writeln('%s' % option_str)
+            option_str = f'[{option_str}]'
+        doc.writeln(f'{option_str}')
 
     def doc_synopsis_end(self, help_command, **kwargs):
         doc = help_command.doc
@@ -186,16 +186,15 @@ class CLIDocumentEventHandler:
                 return
             name = ' | '.join(
                 [
-                    '``%s``' % a.cli_name
+                    f'``{a.cli_name}``'
                     for a in self._arg_groups[argument.group_name]
                 ]
             )
             self._documented_arg_groups.append(argument.group_name)
         else:
-            name = '``%s``' % argument.cli_name
+            name = f'``{argument.cli_name}``'
         doc.write(
-            '%s (%s)\n'
-            % (
+            '{} ({})\n'.format(
                 name,
                 self._get_argument_type_name(
                     argument.argument_model, argument.cli_type_name
@@ -228,7 +227,7 @@ class CLIDocumentEventHandler:
         doc = help_command.doc
         doc.write('* ')
         doc.style.sphinx_reference_label(
-            label='cli:%s' % related_item, text=related_item
+            label=f'cli:{related_item}', text=related_item
         )
         doc.write('\n')
 
@@ -240,7 +239,7 @@ class CLIDocumentEventHandler:
                 doc.write('Possible values:')
                 doc.style.start_ul()
                 for enum in model.enum:
-                    doc.style.li('``%s``' % enum)
+                    doc.style.li(f'``{enum}``')
                 doc.style.end_ul()
 
     def _document_nested_structure(self, model, doc):
@@ -281,9 +280,9 @@ class CLIDocumentEventHandler:
             member_shape, member_shape.type_name
         )
         if member_name:
-            doc.write('%s -> (%s)' % (member_name, type_name))
+            doc.write(f'{member_name} -> ({type_name})')
         else:
-            doc.write('(%s)' % type_name)
+            doc.write(f'({type_name})')
         doc.style.indent()
         doc.style.new_paragraph()
         doc.include_doc_string(docs)
@@ -358,7 +357,7 @@ class ProviderDocumentEventHandler(CLIDocumentEventHandler):
 
     def doc_subitem(self, command_name, help_command, **kwargs):
         doc = help_command.doc
-        file_name = '%s/index' % command_name
+        file_name = f'{command_name}/index'
         doc.style.tocitem(command_name, file_name=file_name)
 
 
@@ -409,7 +408,7 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
         # direct the subitem to the command's index because
         # it has more subcommands to be documented.
         if len(subcommand_table) > 0:
-            file_name = '%s/index' % command_name
+            file_name = f'{command_name}/index'
             doc.style.tocitem(command_name, file_name=file_name)
         else:
             doc.style.tocitem(command_name)
@@ -438,11 +437,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             return
         doc.style.new_paragraph()
         doc.write("See also: ")
-        link = '%s/%s/%s' % (
-            self.AWS_DOC_BASE,
-            service_uid,
-            operation_model.name,
-        )
+        link = f'{self.AWS_DOC_BASE}/{service_uid}/{operation_model.name}'
         doc.style.external_link(title="AWS API Documentation", link=link)
         doc.writeln('')
 
@@ -450,12 +445,12 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         if operation_uses_document_types(help_command.obj):
             help_command.doc.style.new_paragraph()
             help_command.doc.writeln(
-                '``%s`` uses document type values. Document types follow the '
+                f'``{help_command.name}`` uses document type values. Document types follow the '
                 'JSON data model where valid values are: strings, numbers, '
                 'booleans, null, arrays, and objects. For command input, '
                 'options and nested parameters that are labeled with the type '
                 '``document`` must be provided as JSON. Shorthand syntax does '
-                'not support document types.' % help_command.name
+                'not support document types.'
             )
 
     def _json_example_value_name(
@@ -466,13 +461,13 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         if isinstance(argument_model, StringShape):
             if argument_model.enum and include_enum_values:
                 choices = argument_model.enum
-                return '|'.join(['"%s"' % c for c in choices])
+                return '|'.join([f'"{c}"' for c in choices])
             else:
                 return '"string"'
         elif argument_model.type_name == 'boolean':
             return 'true|false'
         else:
-            return '%s' % argument_model.type_name
+            return f'{argument_model.type_name}'
 
     def _json_example(self, doc, argument_model, stack):
         if argument_model.name in stack:
@@ -493,8 +488,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             doc.write('[')
             if argument_model.member.type_name in SCALAR_TYPES:
                 doc.write(
-                    '%s, ...'
-                    % self._json_example_value_name(argument_model.member)
+                    f'{self._json_example_value_name(argument_model.member)}, ...'
                 )
             else:
                 doc.style.indent()
@@ -509,7 +503,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             doc.write('{')
             doc.style.indent()
             key_string = self._json_example_value_name(argument_model.key)
-            doc.write('%s: ' % key_string)
+            doc.write(f'{key_string}: ')
             if argument_model.value.type_name in SCALAR_TYPES:
                 doc.write(self._json_example_value_name(argument_model.value))
             else:
@@ -539,20 +533,16 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             member_type_name = member_model.type_name
             if member_type_name in SCALAR_TYPES:
                 doc.write(
-                    '"%s": %s'
-                    % (
-                        member_name,
-                        self._json_example_value_name(member_model),
-                    )
+                    f'"{member_name}": {self._json_example_value_name(member_model)}'
                 )
             elif member_type_name == 'structure':
-                doc.write('"%s": ' % member_name)
+                doc.write(f'"{member_name}": ')
                 self._json_example(doc, member_model, stack)
             elif member_type_name == 'map':
-                doc.write('"%s": ' % member_name)
+                doc.write(f'"{member_name}": ')
                 self._json_example(doc, member_model, stack)
             elif member_type_name == 'list':
-                doc.write('"%s": ' % member_name)
+                doc.write(f'"{member_name}": ')
                 self._json_example(doc, member_model, stack)
             if i < len(members) - 1:
                 doc.write(',')
@@ -608,7 +598,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             example_type = self._json_example_value_name(
                 member, include_enum_values=False
             )
-            doc.write('%s %s ...' % (example_type, example_type))
+            doc.write(f'{example_type} {example_type} ...')
             if isinstance(member, StringShape) and member.enum:
                 # If we have enum values, we can tell the user
                 # exactly what valid values they can provide.
@@ -627,7 +617,7 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
         doc.style.new_paragraph()
         doc.write("Where valid values are:\n")
         for value in enum_values:
-            doc.write("    %s\n" % value)
+            doc.write(f"    {value}\n")
         doc.write("\n")
 
     def doc_output(self, help_command, event_name, **kwargs):
@@ -669,7 +659,7 @@ class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
         doc = help_command.doc
         doc.style.new_paragraph()
         doc.style.link_target_definition(
-            refname='cli:aws help %s' % self.help_command.name, link=''
+            refname=f'cli:aws help {self.help_command.name}', link=''
         )
         doc.style.h1('AWS CLI Topic Guide')
 
@@ -714,9 +704,9 @@ class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
                 )
                 doc.write('* ')
                 doc.style.sphinx_reference_label(
-                    label='cli:aws help %s' % topic_name, text=topic_name
+                    label=f'cli:aws help {topic_name}', text=topic_name
                 )
-                doc.write(': %s\n' % description)
+                doc.write(f': {description}\n')
         # Add a hidden toctree to make sure everything is connected in
         # the document.
         doc.style.hidden_toctree()
@@ -740,7 +730,7 @@ class TopicDocumentEventHandler(TopicListerDocumentEventHandler):
         doc = help_command.doc
         doc.style.new_paragraph()
         doc.style.link_target_definition(
-            refname='cli:aws help %s' % self.help_command.name, link=''
+            refname=f'cli:aws help {self.help_command.name}', link=''
         )
         title = self._topic_tag_db.get_tag_single_value(
             help_command.name, 'title'

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -150,7 +150,7 @@ def _get_linux_distribution():
         linux_distribution = distro.id()
         version = distro.major_version()
         if version:
-            linux_distribution += '.%s' % version
+            linux_distribution += f'.{version}'
     except Exception:
         pass
     return linux_distribution
@@ -665,7 +665,7 @@ class ServiceCommand(CLICommand):
                 operation_caller=CLIOperationCaller(self.session),
             )
         self.session.emit(
-            'building-command-table.%s' % self._name,
+            f'building-command-table.{self._name}',
             command_table=command_table,
             session=self.session,
             command_object=self,
@@ -773,7 +773,7 @@ class ServiceOperation:
         subcommand_table = OrderedDict()
         full_name = '_'.join([c.name for c in self.lineage])
         self._session.emit(
-            'building-command-table.%s' % full_name,
+            f'building-command-table.{full_name}',
             command_table=subcommand_table,
             session=self._session,
             command_object=self,
@@ -803,10 +803,7 @@ class ServiceOperation:
     def __call__(self, args, parsed_globals):
         # Once we know we're trying to call a particular operation
         # of a service we can go ahead and load the parameters.
-        event = 'before-building-argument-table-parser.%s.%s' % (
-            self._parent_name,
-            self._name,
-        )
+        event = f'before-building-argument-table-parser.{self._parent_name}.{self._name}'
         self._emit(
             event,
             argument_table=self.arg_table,
@@ -832,16 +829,16 @@ class ServiceOperation:
             remaining.append(parsed_args.help)
         if remaining:
             raise UnknownArgumentError(
-                "Unknown options: %s" % ', '.join(remaining)
+                "Unknown options: {}".format(', '.join(remaining))
             )
-        event = 'operation-args-parsed.%s.%s' % (self._parent_name, self._name)
+        event = f'operation-args-parsed.{self._parent_name}.{self._name}'
         self._emit(
             event, parsed_args=parsed_args, parsed_globals=parsed_globals
         )
         call_parameters = self._build_call_parameters(
             parsed_args, self.arg_table
         )
-        event = 'calling-command.%s.%s' % (self._parent_name, self._name)
+        event = f'calling-command.{self._parent_name}.{self._name}'
         override = self._emit_first_non_none_response(
             event,
             call_parameters=call_parameters,
@@ -941,7 +938,7 @@ class ServiceOperation:
             arg_object.add_to_arg_table(argument_table)
         LOG.debug(argument_table)
         self._emit(
-            'building-argument-table.%s.%s' % (self._parent_name, self._name),
+            f'building-argument-table.{self._parent_name}.{self._name}',
             operation_model=self._operation_model,
             session=self._session,
             command=self,

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -113,7 +113,7 @@ def ensure_text_type(s):
         return s
     if isinstance(s, bytes):
         return s.decode('utf-8')
-    raise ValueError("Expected str, unicode or bytes, received %s." % type(s))
+    raise ValueError(f"Expected str, unicode or bytes, received {type(s)}.")
 
 
 def get_binary_stdin():
@@ -334,7 +334,7 @@ def _windows_shell_quote(s):
     if ' ' in new_s or '\t' in new_s:
         # If there are any spaces or tabs then the string needs to be double
         # quoted.
-        return '"%s"' % new_s
+        return f'"{new_s}"'
     return new_s
 
 

--- a/awscli/customizations/argrename.py
+++ b/awscli/customizations/argrename.py
@@ -125,13 +125,13 @@ def register_arg_renames(cli):
     for original, new_name in ARGUMENT_RENAMES.items():
         event_portion, original_arg_name = original.rsplit('.', 1)
         cli.register(
-            'building-argument-table.%s' % event_portion,
+            f'building-argument-table.{event_portion}',
             rename_arg(original_arg_name, new_name),
         )
     for original, new_name in HIDDEN_ALIASES.items():
         event_portion, original_arg_name = original.rsplit('.', 1)
         cli.register(
-            'building-argument-table.%s' % event_portion,
+            f'building-argument-table.{event_portion}',
             hidden_alias(original_arg_name, new_name),
         )
 

--- a/awscli/customizations/arguments.py
+++ b/awscli/customizations/arguments.py
@@ -26,7 +26,7 @@ def resolve_given_outfile_path(path):
         return
     outfile = os.path.expanduser(os.path.expandvars(path))
     if not os.access(os.path.dirname(os.path.abspath(outfile)), os.W_OK):
-        raise ParamValidationError('Unable to write to file: %s' % outfile)
+        raise ParamValidationError(f'Unable to write to file: {outfile}')
     return outfile
 
 
@@ -106,8 +106,8 @@ class QueryOutFileArgument(StatefulArgument):
         # Generate default help_text if text was not provided.
         if 'help_text' not in kwargs:
             kwargs['help_text'] = (
-                'Saves the command output contents of %s '
-                'to the given filename' % self.query
+                f'Saves the command output contents of {self.query} '
+                'to the given filename'
             )
         super(QueryOutFileArgument, self).__init__(name, *args, **kwargs)
 

--- a/awscli/customizations/awslambda.py
+++ b/awscli/customizations/awslambda.py
@@ -145,7 +145,7 @@ class ReplacedZipFileArgument(CLIArgument):
 
     def __init__(self, *args, **kwargs):
         super(ReplacedZipFileArgument, self).__init__(*args, **kwargs)
-        self._cli_name = '--%s' % kwargs['name']
+        self._cli_name = '--{}'.format(kwargs['name'])
         self._param_to_replace = kwargs['serialized_name']
 
     def add_to_params(self, parameters, value):
@@ -155,9 +155,9 @@ class ReplacedZipFileArgument(CLIArgument):
         if 'ZipFile' in unpacked:
             raise ParamValidationError(
                 "ZipFile cannot be provided "
-                "as part of the %s argument.  "
+                f"as part of the {self._cli_name} argument.  "
                 "Please use the '--zip-file' "
-                "option instead to specify a zip file." % self._cli_name
+                "option instead to specify a zip file."
             )
         if parameters.get(self._param_to_replace):
             parameters[self._param_to_replace].update(unpacked)

--- a/awscli/customizations/binaryformat.py
+++ b/awscli/customizations/binaryformat.py
@@ -57,7 +57,7 @@ class Base64DecodeVisitor(ModelVisitor):
         try:
             parent[name] = base64.b64decode(value)
         except (binascii.Error, TypeError):
-            raise InvalidBase64Error('Invalid base64: "%s"' % value)
+            raise InvalidBase64Error(f'Invalid base64: "{value}"')
 
 
 class BinaryFormatHandler:

--- a/awscli/customizations/cliinput.py
+++ b/awscli/customizations/cliinput.py
@@ -66,7 +66,7 @@ class CliInputArgument(OverrideRequiredArgsArgument):
             raise ParamError(
                 self.cli_name,
                 "Invalid type: expecting map, "
-                "received %s" % type(loaded_params),
+                f"received {type(loaded_params)}",
             )
         self._update_call_parameters(call_parameters, loaded_params)
 

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -80,7 +80,7 @@ def register(event_handler):
 
 
 def unique_string(prefix='cli'):
-    return '%s-%s-%s' % (prefix, int(time.time()), random.randint(1, 1000000))
+    return f'{prefix}-{int(time.time())}-{random.randint(1, 1000000)}'
 
 
 def _add_paths(argument_table, **kwargs):

--- a/awscli/customizations/cloudtrail/utils.py
+++ b/awscli/customizations/cloudtrail/utils.py
@@ -29,7 +29,7 @@ def get_trail_by_arn(cloudtrail_client, trail_arn):
     for trail in trails:
         if trail.get("TrailARN", None) == trail_arn:
             return trail
-    raise ValueError("A trail could not be found for %s" % trail_arn)
+    raise ValueError(f"A trail could not be found for {trail_arn}")
 
 
 def format_date(date):
@@ -46,7 +46,7 @@ def parse_date(date_string):
     try:
         return parser.parse(date_string)
     except ValueError:
-        raise ValueError("Unable to parse date value: %s" % date_string)
+        raise ValueError(f"Unable to parse date value: {date_string}")
 
 
 class PublicKeyProvider:
@@ -95,6 +95,5 @@ class PublicKeyProvider:
                 return key["Value"]
 
         raise RuntimeError(
-            "No public keys found for key with fingerprint: %s"
-            % public_key_fingerprint
+            f"No public keys found for key with fingerprint: {public_key_fingerprint}"
         )

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -136,7 +136,7 @@ class CodeCommitGetCommand(BasicCommand):
         return parsed
 
     def extract_url(self, parameters):
-        url = '{0}://{1}/{2}'.format(
+        url = '{}://{}/{}'.format(
             parameters['protocol'], parameters['host'], parameters['path']
         )
         return url
@@ -173,7 +173,7 @@ class CodeCommitGetCommand(BasicCommand):
         logger.debug('StringToSign:\n%s', string_to_sign)
         signature = signer.signature(string_to_sign, request)
         logger.debug('Signature:\n%s', signature)
-        return '{0}Z{1}'.format(request.context['timestamp'], signature)
+        return '{}Z{}'.format(request.context['timestamp'], signature)
 
 
 class CodeCommitCommand(BasicCommand):

--- a/awscli/customizations/codedeploy/deregister.py
+++ b/awscli/customizations/codedeploy/deregister.py
@@ -102,7 +102,7 @@ class Deregister(BasicCommand):
             sys.stdout.write('Tags:')
             for tag in params.tags:
                 sys.stdout.write(
-                    ' Key={0},Value={1}'.format(tag['Key'], tag['Value'])
+                    ' Key={},Value={}'.format(tag['Key'], tag['Value'])
                 )
             sys.stdout.write('\n')
 

--- a/awscli/customizations/codedeploy/locationargs.py
+++ b/awscli/customizations/codedeploy/locationargs.py
@@ -114,7 +114,7 @@ class LocationArgument(CustomArgument):
         if value is None:
             return
         parsed = self._session.emit_first_non_none_response(
-            'process-cli-arg.codedeploy.%s' % self.name,
+            f'process-cli-arg.codedeploy.{self.name}',
             param=self.argument_model,
             cli_argument=self,
             value=value,

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -145,8 +145,7 @@ class Push(BasicCommand):
                     params.version = upload_response['VersionId']
             except Exception as e:
                 raise RuntimeError(
-                    'Failed to upload \'%s\' to \'%s\': %s'
-                    % (params.source, params.s3_location, str(e))
+                    f'Failed to upload \'{params.source}\' to \'{params.s3_location}\': {str(e)}'
                 )
         self._register_revision(params)
 

--- a/awscli/customizations/codedeploy/utils.py
+++ b/awscli/customizations/codedeploy/utils.py
@@ -131,6 +131,6 @@ def validate_s3_location(params, arg_name):
                 params.key = matcher.group(2)
             else:
                 raise ParamValidationError(
-                    '--{0} must specify the Amazon S3 URL format as '
+                    '--{} must specify the Amazon S3 URL format as '
                     's3://<bucket>/<key>.'.format(arg_name.replace('_', '-'))
                 )

--- a/awscli/customizations/commands.py
+++ b/awscli/customizations/commands.py
@@ -138,8 +138,8 @@ class BasicCommand(CLICommand):
         # an arg parser and parse them.
         self._subcommand_table = self._build_subcommand_table()
         self._arg_table = self._build_arg_table()
-        event = 'before-building-argument-table-parser.%s' % ".".join(
-            self.lineage_names
+        event = 'before-building-argument-table-parser.{}'.format(
+            ".".join(self.lineage_names)
         )
         self._session.emit(
             event,
@@ -177,7 +177,7 @@ class BasicCommand(CLICommand):
             # a chance to process and override its value.
             if self._should_allow_plugins_override(cli_argument, value):
                 override = self._session.emit_first_non_none_response(
-                    'process-cli-arg.%s.%s' % ('custom', self.name),
+                    'process-cli-arg.{}.{}'.format('custom', self.name),
                     cli_argument=cli_argument,
                     value=value,
                     operation=None,
@@ -204,7 +204,7 @@ class BasicCommand(CLICommand):
             # function for this top level command.
             if remaining:
                 raise ParamValidationError(
-                    "Unknown options: %s" % ','.join(remaining)
+                    "Unknown options: {}".format(','.join(remaining))
                 )
             rc = self._run_main(parsed_args, parsed_globals)
             if rc is None:
@@ -239,7 +239,7 @@ class BasicCommand(CLICommand):
             subcommand_table[subcommand_name] = subcommand_class(self._session)
         name = '_'.join([c.name for c in self.lineage])
         self._session.emit(
-            'building-command-table.%s' % name,
+            f'building-command-table.{name}',
             command_table=subcommand_table,
             session=self._session,
             command_object=self,
@@ -277,7 +277,7 @@ class BasicCommand(CLICommand):
         arg_table = OrderedDict()
         name = '_'.join([c.name for c in self.lineage])
         self._session.emit(
-            'building-arg-table.%s' % name, arg_table=self.ARG_TABLE
+            f'building-arg-table.{name}', arg_table=self.ARG_TABLE
         )
         for arg_data in self.ARG_TABLE:
             # If a custom schema was passed in, create the argument_model
@@ -328,9 +328,9 @@ class BasicCommand(CLICommand):
     def _raise_usage_error(self):
         lineage = ' '.join([c.name for c in self.lineage])
         error_msg = (
-            "usage: aws [options] %s <subcommand> "
+            f"usage: aws [options] {lineage} <subcommand> "
             "[parameters]\naws: error: too few arguments"
-        ) % lineage
+        )
         raise ParamValidationError(error_msg)
 
     def _add_customization_to_user_agent(self):
@@ -447,14 +447,14 @@ class BasicDocHandler(OperationDocumentEventHandler):
                 )
                 self._documented_arg_groups.append(argument.group_name)
             elif argument.cli_type_name == 'boolean':
-                option_str = '%s' % argument.cli_name
+                option_str = f'{argument.cli_name}'
             elif argument.nargs == '+':
-                option_str = "%s <value> [<value>...]" % argument.cli_name
+                option_str = f"{argument.cli_name} <value> [<value>...]"
             else:
-                option_str = '%s <value>' % argument.cli_name
+                option_str = f'{argument.cli_name} <value>'
             if not (argument.required or argument.positional_arg):
-                option_str = '[%s]' % option_str
-            doc.writeln('%s' % option_str)
+                option_str = f'[{option_str}]'
+            doc.writeln(f'{option_str}')
 
         else:
             # A synopsis has been provided so we don't need to write

--- a/awscli/customizations/configservice/getstatus.py
+++ b/awscli/customizations/configservice/getstatus.py
@@ -60,12 +60,12 @@ class GetStatusCommand(BasicCommand):
     def _check_configure_recorder_status(self, configuration_recorder):
         # Get the name of the recorder and print it out.
         name = configuration_recorder['name']
-        sys.stdout.write('name: %s\n' % name)
+        sys.stdout.write(f'name: {name}\n')
 
         # Get the recording status and print it out.
         recording = configuration_recorder['recording']
         recording_map = {False: 'OFF', True: 'ON'}
-        sys.stdout.write('recorder: %s\n' % recording_map[recording])
+        sys.stdout.write(f'recorder: {recording_map[recording]}\n')
 
         # If the recorder is on, get the last status and print it out.
         if recording:
@@ -81,7 +81,7 @@ class GetStatusCommand(BasicCommand):
     def _check_delivery_channel_status(self, delivery_channel):
         # Get the name of the delivery channel and print it out.
         name = delivery_channel['name']
-        sys.stdout.write('name: %s\n' % name)
+        sys.stdout.write(f'name: {name}\n')
 
         # Obtain the various delivery statuses.
         stream_delivery = delivery_channel['configStreamDeliveryInfo']
@@ -98,7 +98,11 @@ class GetStatusCommand(BasicCommand):
 
     def _check_last_status(self, status, status_name=''):
         last_status = status['lastStatus']
-        sys.stdout.write('last %sstatus: %s\n' % (status_name, last_status))
+        sys.stdout.write(f'last {status_name}status: {last_status}\n')
         if last_status == "FAILURE":
-            sys.stdout.write('error code: %s\n' % status['lastErrorCode'])
-            sys.stdout.write('message: %s\n' % status['lastErrorMessage'])
+            sys.stdout.write(
+                'error code: {}\n'.format(status['lastErrorCode'])
+            )
+            sys.stdout.write(
+                'message: {}\n'.format(status['lastErrorMessage'])
+            )

--- a/awscli/customizations/configservice/subscribe.py
+++ b/awscli/customizations/configservice/subscribe.py
@@ -158,9 +158,9 @@ class S3BucketHelper:
         bucket_exists = self._check_bucket_exists(bucket)
         if not bucket_exists:
             self._create_bucket(bucket)
-            sys.stdout.write('Using new S3 bucket: %s\n' % bucket)
+            sys.stdout.write(f'Using new S3 bucket: {bucket}\n')
         else:
-            sys.stdout.write('Using existing S3 bucket: %s\n' % bucket)
+            sys.stdout.write(f'Using existing S3 bucket: {bucket}\n')
         return bucket, key
 
     def _check_bucket_exists(self, bucket):
@@ -185,9 +185,9 @@ class SNSTopicHelper:
         if not self._check_is_arn(sns_topic):
             response = self._sns_client.create_topic(Name=sns_topic)
             sns_topic_arn = response['TopicArn']
-            sys.stdout.write('Using new SNS topic: %s\n' % sns_topic_arn)
+            sys.stdout.write(f'Using new SNS topic: {sns_topic_arn}\n')
         else:
-            sys.stdout.write('Using existing SNS topic: %s\n' % sns_topic_arn)
+            sys.stdout.write(f'Using existing SNS topic: {sns_topic_arn}\n')
         return sns_topic_arn
 
     def _check_is_arn(self, sns_topic):

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -45,7 +45,7 @@ class InteractivePrompter:
     def get_value(self, current_value, config_name, prompt_text=''):
         if config_name in ('aws_access_key_id', 'aws_secret_access_key'):
             current_value = mask_value(current_value)
-        response = compat_input("%s [%s]: " % (prompt_text, current_value))
+        response = compat_input(f"{prompt_text} [{current_value}]: ")
         if not response:
             # If the user hits enter, we return a value of None
             # instead of an empty string.  That way we can determine

--- a/awscli/customizations/configure/get.py
+++ b/awscli/customizations/configure/get.py
@@ -57,7 +57,7 @@ class ConfigureGetCommand(BasicCommand):
         else:
             value = self._get_dotted_config_value(varname)
 
-        LOG.debug('Config value retrieved: %s' % value)
+        LOG.debug(f'Config value retrieved: {value}')
 
         if isinstance(value, str):
             self._stream.write(value)
@@ -67,8 +67,8 @@ class ConfigureGetCommand(BasicCommand):
             # TODO: add support for this. We would need to print it off in
             # the same format as the config file.
             self._error_stream.write(
-                'varname (%s) must reference a value, not a section or '
-                'sub-section.' % varname
+                f'varname ({varname}) must reference a value, not a section or '
+                'sub-section.'
             )
             return 1
         else:

--- a/awscli/customizations/configure/importer.py
+++ b/awscli/customizations/configure/importer.py
@@ -94,7 +94,7 @@ class ConfigureImportCommand(BasicCommand):
                 config_path,
                 profile_prefix=self._profile_prefix,
             )
-        import_msg = 'Successfully imported %s profile(s)\n' % len(credentials)
+        import_msg = f'Successfully imported {len(credentials)} profile(s)\n'
         uni_print(import_msg, out_file=self._out_stream)
 
     def _run_main(self, parsed_args, parsed_globals):

--- a/awscli/customizations/configure/listprofiles.py
+++ b/awscli/customizations/configure/listprofiles.py
@@ -30,5 +30,5 @@ class ListProfilesCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         for profile in self._session.available_profiles:
-            uni_print('%s\n' % profile, out_file=self._out_stream)
+            uni_print(f'{profile}\n', out_file=self._out_stream)
         return 0

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -93,7 +93,7 @@ class ConfigFileWriter:
         with open(config_filename, 'a') as f:
             if needs_newline:
                 f.write('\n')
-            f.write('[%s]\n' % section_name)
+            f.write(f'[{section_name}]\n')
             contents = []
             self._insert_new_values(
                 line_number=0, contents=contents, new_values=new_values
@@ -148,7 +148,7 @@ class ConfigFileWriter:
                     # out now.
                     if not isinstance(new_values[key_name], dict):
                         option_value = new_values[key_name]
-                        new_line = '%s = %s\n' % (key_name, option_value)
+                        new_line = f'{key_name} = {option_value}\n'
                         contents[j] = new_line
                         del new_values[key_name]
                     else:
@@ -182,7 +182,7 @@ class ConfigFileWriter:
                 key_name = match.group(1).strip()
                 if key_name in values:
                     option_value = values[key_name]
-                    new_line = '%s%s = %s\n' % (
+                    new_line = '{}{} = {}\n'.format(
                         ' ' * current_indent,
                         key_name,
                         option_value,
@@ -208,21 +208,19 @@ class ConfigFileWriter:
         for key, value in list(new_values.items()):
             if isinstance(value, dict):
                 subindent = indent + '    '
-                new_contents.append('%s%s =\n' % (indent, key))
+                new_contents.append(f'{indent}{key} =\n')
                 for subkey, subval in list(value.items()):
-                    new_contents.append(
-                        '%s%s = %s\n' % (subindent, subkey, subval)
-                    )
+                    new_contents.append(f'{subindent}{subkey} = {subval}\n')
             else:
-                new_contents.append('%s%s = %s\n' % (indent, key, value))
+                new_contents.append(f'{indent}{key} = {value}\n')
             del new_values[key]
         contents.insert(line_number + 1, ''.join(new_contents))
 
     def _matches_section(self, match, section_name):
         parts = section_name.split(' ')
-        unquoted_match = match.group(0) == '[%s]' % section_name
+        unquoted_match = match.group(0) == f'[{section_name}]'
         if len(parts) > 1:
-            quoted_match = match.group(0) == '[%s "%s"]' % (
+            quoted_match = match.group(0) == '[{} "{}"]'.format(
                 parts[0],
                 ' '.join(parts[1:]),
             )

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -61,7 +61,7 @@ class DocSectionNotFoundError(Exception):
 
 class ParameterDefinitionError(ParamValidationError):
     def __init__(self, msg):
-        full_msg = "Error in parameter: %s\n" % msg
+        full_msg = f"Error in parameter: {msg}\n"
         super(ParameterDefinitionError, self).__init__(full_msg)
         self.msg = msg
 
@@ -103,8 +103,7 @@ def document_translation(help_command, **kwargs):
             # This should never happen, but in the rare case that it does
             # we should be raising something with a helpful error message.
             raise DocSectionNotFoundError(
-                'Could not find the "output" section for the command: %s'
-                % help_command
+                f'Could not find the "output" section for the command: {help_command}'
             )
     doc.write('======\nOutput\n======')
     doc.write(
@@ -341,7 +340,7 @@ class ParameterValuesInlineArgument(CustomArgument):
                     parameter_object[key] = value
             except IndexError:
                 raise ParameterDefinitionError(
-                    "Invalid inline parameter format: %s" % argument
+                    f"Invalid inline parameter format: {argument}"
                 )
         parsed = {'values': parameter_object}
         parameter_values = translator.definition_to_parameter_values(parsed)
@@ -445,8 +444,9 @@ class ListRunsCommand(BasicCommand):
         for status in statuses:
             if status not in self.VALID_STATUS:
                 raise ParamValidationError(
-                    "Invalid status: %s, must be one of: %s"
-                    % (status, ', '.join(self.VALID_STATUS))
+                    "Invalid status: {}, must be one of: {}".format(
+                        status, ', '.join(self.VALID_STATUS)
+                    )
                 )
 
     def _list_runs(self, parsed_args, parsed_globals):

--- a/awscli/customizations/datapipeline/translator.py
+++ b/awscli/customizations/datapipeline/translator.py
@@ -18,7 +18,7 @@ from awscli.customizations.exceptions import ParamValidationError
 
 class PipelineDefinitionError(ParamValidationError):
     def __init__(self, msg, definition):
-        full_msg = "Error in pipeline definition: %s\n" % msg
+        full_msg = f"Error in pipeline definition: {msg}\n"
         super(PipelineDefinitionError, self).__init__(full_msg)
         self.msg = msg
         self.definition = definition
@@ -80,7 +80,7 @@ def definition_to_api_objects(definition):
             element_id = element.pop('id')
         except KeyError:
             raise PipelineDefinitionError(
-                'Missing "id" key of element: %s' % json.dumps(element),
+                f'Missing "id" key of element: {json.dumps(element)}',
                 definition,
             )
         api_object = {'id': element_id}
@@ -107,7 +107,7 @@ def definition_to_api_parameters(definition):
             parameter_id = element.pop('id')
         except KeyError:
             raise PipelineDefinitionError(
-                'Missing "id" key of parameter: %s' % json.dumps(element),
+                f'Missing "id" key of parameter: {json.dumps(element)}',
                 definition,
             )
         parameter_object = {'id': parameter_id}

--- a/awscli/customizations/dlm/createdefaultrole.py
+++ b/awscli/customizations/dlm/createdefaultrole.py
@@ -91,13 +91,8 @@ class CreateDefaultRole(BasicCommand):
             'choices': [RESOURCE_TYPE_SNAPSHOT, RESOURCE_TYPE_IMAGE],
             'help_text': (
                 "<p>The resource type for which the role needs to be created."
-                " The available options are '%s' and '%s'."
-                " This parameter defaults to '%s'.</p>"
-                % (
-                    RESOURCE_TYPE_SNAPSHOT,
-                    RESOURCE_TYPE_IMAGE,
-                    RESOURCE_TYPE_SNAPSHOT,
-                )
+                f" The available options are '{RESOURCE_TYPE_SNAPSHOT}' and '{RESOURCE_TYPE_IMAGE}'."
+                f" This parameter defaults to '{RESOURCE_TYPE_SNAPSHOT}'.</p>"
             ),
         },
     ]

--- a/awscli/customizations/dynamodb/exceptions.py
+++ b/awscli/customizations/dynamodb/exceptions.py
@@ -27,7 +27,7 @@ class EmptyExpressionError(DDBError, ParamValidationError):
 class LexerError(DDBError, ParamValidationError):
     def __init__(self, expression, position, message):
         underline = ' ' * position + '^'
-        error_message = '%s\n%s\n%s' % (message, expression, underline)
+        error_message = f'{message}\n{expression}\n{underline}'
         super(LexerError, self).__init__(error_message)
 
 

--- a/awscli/customizations/dynamodb/extractor.py
+++ b/awscli/customizations/dynamodb/extractor.py
@@ -49,67 +49,71 @@ class AttributeExtractor:
         return num_substituted + self._index_offset
 
     def _visit(self, node):
-        method = getattr(self, '_visit_%s' % node['type'])
+        method = getattr(self, '_visit_{}'.format(node['type']))
         return method(node)
 
     def _visit_comparator(self, node):
         left = self._visit(node['children'][0])
         right = self._visit(node['children'][1])
-        expression = '%s%s %s' % (left, self.COMPARATORS[node['value']], right)
+        expression = '{}{} {}'.format(
+            left, self.COMPARATORS[node['value']], right
+        )
         return expression
 
     def _visit_identifier(self, node):
-        identifier_replacement = '#n%s' % self._substitution_index()
+        identifier_replacement = f'#n{self._substitution_index()}'
         self._identifiers[identifier_replacement] = node['value']
-        return '%s ' % identifier_replacement
+        return f'{identifier_replacement} '
 
     def _visit_path_identifier(self, node):
         left = self._visit(node['children'][0]).strip()
         right = self._visit(node['children'][1])
-        return '%s.%s' % (left, right)
+        return f'{left}.{right}'
 
     def _visit_index_identifier(self, node):
         left = self._visit(node['children'][0]).strip()
-        return '%s[%s] ' % (left, node['value'])
+        return '{}[{}] '.format(left, node['value'])
 
     def _visit_literal(self, node):
-        literal_replacement = ':n%s' % self._substitution_index()
+        literal_replacement = f':n{self._substitution_index()}'
         self._literals[literal_replacement] = node['value']
-        return '%s ' % literal_replacement
+        return f'{literal_replacement} '
 
     def _visit_sequence(self, node):
         visited_children = []
         for child in node['children']:
             visited_children.append(self._visit(child).strip())
-        return '%s' % ', '.join(visited_children)
+        return '{}'.format(', '.join(visited_children))
 
     def _visit_or_expression(self, node):
         left = self._visit(node['children'][0])
         right = self._visit(node['children'][1])
-        return '%sOR %s' % (left, right)
+        return f'{left}OR {right}'
 
     def _visit_and_expression(self, node):
         left = self._visit(node['children'][0])
         right = self._visit(node['children'][1])
-        return '%sAND %s' % (left, right)
+        return f'{left}AND {right}'
 
     def _visit_not_expression(self, node):
-        return 'NOT %s' % self._visit(node['children'][0])
+        return 'NOT {}'.format(self._visit(node['children'][0]))
 
     def _visit_subexpression(self, node):
-        return '( %s) ' % self._visit(node['children'][0])
+        return '( {}) '.format(self._visit(node['children'][0]))
 
     def _visit_function(self, node):
-        return '%s(%s) ' % (node['value'], self._visit_sequence(node).strip())
+        return '{}({}) '.format(
+            node['value'], self._visit_sequence(node).strip()
+        )
 
     def _visit_in_expression(self, node):
-        return '%sIN (%s) ' % (
+        return '{}IN ({}) '.format(
             self._visit(node['children'][0]),
             self._visit(node['children'][1]).strip(),
         )
 
     def _visit_between_expression(self, node):
-        return '%sBETWEEN %sAND %s' % (
+        return '{}BETWEEN {}AND {}'.format(
             self._visit(node['children'][0]),
             self._visit(node['children'][1]),
             self._visit(node['children'][2]),

--- a/awscli/customizations/dynamodb/lexer.py
+++ b/awscli/customizations/dynamodb/lexer.py
@@ -73,7 +73,7 @@ class Lexer:
                 yield self._consume_comparator()
             else:
                 raise LexerError(
-                    message='Unrecognized character %s' % self._current,
+                    message=f'Unrecognized character {self._current}',
                     expression=self._expression,
                     position=self._position,
                 )
@@ -202,7 +202,7 @@ class Lexer:
             buff += self._current
             if self._next() not in self.DIGITS:
                 raise LexerError(
-                    message='Invalid fractional character %s' % self._current,
+                    message=f'Invalid fractional character {self._current}',
                     position=self._position,
                     expression=self._expression,
                 )
@@ -212,7 +212,7 @@ class Lexer:
             buff += self._current
             if self._next() not in self.INT_CHARS and self._current != '+':
                 raise LexerError(
-                    message='Invalid exponential character %s' % self._current,
+                    message=f'Invalid exponential character {self._current}',
                     position=self._position,
                     expression=self._expression,
                 )
@@ -232,7 +232,7 @@ class Lexer:
             buff += self._current
         if not is_positive and len(buff) < 2:
             raise LexerError(
-                message='Unknown token %s' % buff,
+                message=f'Unknown token {buff}',
                 position=self._position,
                 expression=self._expression,
             )
@@ -310,7 +310,7 @@ class Lexer:
             if self._current is None:
                 # We're at the EOF.
                 raise LexerError(
-                    message="Unclosed %s delimiter" % delimiter,
+                    message=f"Unclosed {delimiter} delimiter",
                     position=start,
                     expression=self._expression,
                 )

--- a/awscli/customizations/dynamodb/parser.py
+++ b/awscli/customizations/dynamodb/parser.py
@@ -300,7 +300,7 @@ class Parser:
                     token=self._current,
                     expression=self._expression,
                     message=(
-                        'Keys must be of type `str`, found `%s`' % type(key)
+                        f'Keys must be of type `str`, found `{type(key)}`'
                     ),
                 )
             self._advance_if_match('literal')

--- a/awscli/customizations/dynamodb/transform.py
+++ b/awscli/customizations/dynamodb/transform.py
@@ -38,7 +38,7 @@ class ParameterTransformer:
     ):
         type_name = model.type_name
         if type_name in ['structure', 'map', 'list']:
-            getattr(self, '_transform_%s' % type_name)(
+            getattr(self, f'_transform_{type_name}')(
                 model, params, transformation, target_shape
             )
 

--- a/awscli/customizations/dynamodb/types.py
+++ b/awscli/customizations/dynamodb/types.py
@@ -54,8 +54,9 @@ class Binary:
     def __init__(self, value):
         if not isinstance(value, BINARY_TYPES):
             raise TypeError(
-                'Value must be of the following types: %s.'
-                % ', '.join([str(t) for t in BINARY_TYPES])
+                'Value must be of the following types: {}.'.format(
+                    ', '.join([str(t) for t in BINARY_TYPES])
+                )
             )
         self.value = value
 
@@ -68,7 +69,7 @@ class Binary:
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Binary(%r)' % self.value
+        return f'Binary({self.value!r})'
 
     def __str__(self):
         return self.value
@@ -105,7 +106,7 @@ class TypeSerializer:
             dictionaries can be directly passed to botocore methods.
         """
         dynamodb_type = self._get_dynamodb_type(value)
-        serializer = getattr(self, '_serialize_%s' % dynamodb_type.lower())
+        serializer = getattr(self, f'_serialize_{dynamodb_type.lower()}')
         return {dynamodb_type: serializer(value)}
 
     def _get_dynamodb_type(self, value):
@@ -142,7 +143,7 @@ class TypeSerializer:
             dynamodb_type = LIST
 
         else:
-            msg = 'Unsupported type "%s" for value "%s"' % (type(value), value)
+            msg = f'Unsupported type "{type(value)}" for value "{value}"'
             raise TypeError(msg)
 
         return dynamodb_type
@@ -267,12 +268,10 @@ class TypeDeserializer:
         dynamodb_type = list(value.keys())[0]
         try:
             deserializer = getattr(
-                self, '_deserialize_%s' % dynamodb_type.lower()
+                self, f'_deserialize_{dynamodb_type.lower()}'
             )
         except AttributeError:
-            raise TypeError(
-                'Dynamodb type %s is not supported' % dynamodb_type
-            )
+            raise TypeError(f'Dynamodb type {dynamodb_type} is not supported')
         return deserializer(value[dynamodb_type])
 
     def _deserialize_null(self, value):

--- a/awscli/customizations/ec2/decryptpassword.py
+++ b/awscli/customizations/ec2/decryptpassword.py
@@ -85,10 +85,7 @@ class LaunchKeyArgument(BaseCLIArgument):
             if os.path.isfile(path):
                 self._key_path = path
                 service_id = self._operation_model.service_model.service_id
-                event = 'after-call.%s.%s' % (
-                    service_id.hyphenize(),
-                    self._operation_model.name,
-                )
+                event = f'after-call.{service_id.hyphenize()}.{self._operation_model.name}'
                 self._session.register(event, self._decrypt_password_data)
             else:
                 msg = (

--- a/awscli/customizations/ec2/secgroupsimplify.py
+++ b/awscli/customizations/ec2/secgroupsimplify.py
@@ -60,9 +60,9 @@ def _check_args(parsed_args, **kwargs):
         for key in ('protocol', 'port', 'cidr', 'source_group', 'group_owner'):
             if arg_dict[key]:
                 msg = (
-                    'The --%s option is not compatible '
+                    f'The --{key} option is not compatible '
                     'with the --ip-permissions option '
-                ) % key
+                )
                 raise ParamValidationError(msg)
 
 

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -162,13 +162,13 @@ class UpdateKubeconfigCommand(BasicCommand):
 
             if updating_existing:
                 uni_print(
-                    "Updated context {0} in {1}\n".format(
+                    "Updated context {} in {}\n".format(
                         new_context_dict["name"], config.path
                     )
                 )
             else:
                 uni_print(
-                    "Added new context {0} to {1}\n".format(
+                    "Added new context {} to {}\n".format(
                         new_context_dict["name"], config.path
                     )
                 )
@@ -284,7 +284,7 @@ class EKSClient:
                 "UPDATING",
             ]:
                 raise EKSClusterError(
-                    "Cluster status is {0}".format(
+                    "Cluster status is {}".format(
                         self._cluster_description["status"]
                     )
                 )

--- a/awscli/customizations/emr/applicationutils.py
+++ b/awscli/customizations/emr/applicationutils.py
@@ -62,8 +62,8 @@ def build_applications(region, parsed_applications, ami_version=None):
                 )
             else:
                 raise ParamValidationError(
-                    'aws: error: AMI version %s is not '
-                    'compatible with HBase.' % ami_version
+                    f'aws: error: AMI version {ami_version} is not '
+                    'compatible with HBase.'
                 )
         elif app_name == constants.IMPALA:
             ba_list.append(

--- a/awscli/customizations/emr/command.py
+++ b/awscli/customizations/emr/command.py
@@ -60,10 +60,10 @@ class Command(BasicCommand):
             ]
 
         if configs_added:
-            LOG.debug("Updated arguments with configs: %s" % configs_added)
+            LOG.debug(f"Updated arguments with configs: {configs_added}")
         else:
             LOG.debug("No configs applied")
-        LOG.debug("Running command with args: %s" % parsed_args)
+        LOG.debug(f"Running command with args: {parsed_args}")
 
     def _get_applicable_configurations(self, parsed_args, parsed_configs):
         # We need to find the applicable configurations by applying

--- a/awscli/customizations/emr/emrutils.py
+++ b/awscli/customizations/emr/emrutils.py
@@ -261,7 +261,7 @@ def join(values, separator=',', lastSeparator='and'):
     elif len(values) == 1:
         return values[0]
     else:
-        separator = '%s ' % separator
+        separator = f'{separator} '
         return ' '.join(
             [separator.join(values[:-1]), lastSeparator, values[-1]]
         )

--- a/awscli/customizations/emr/ssh.py
+++ b/awscli/customizations/emr/ssh.py
@@ -29,7 +29,7 @@ class Socks(Command):
     NAME = 'socks'
     DESCRIPTION = (
         'Create a socks tunnel on port 8157 from your machine '
-        'to the master.\n%s' % KEY_PAIR_FILE_HELP_TEXT
+        f'to the master.\n{KEY_PAIR_FILE_HELP_TEXT}'
     )
     ARG_TABLE = [
         {
@@ -91,7 +91,7 @@ class Socks(Command):
 class SSH(Command):
     NAME = 'ssh'
     DESCRIPTION = (
-        'SSH into master node of the cluster.\n%s' % KEY_PAIR_FILE_HELP_TEXT
+        f'SSH into master node of the cluster.\n{KEY_PAIR_FILE_HELP_TEXT}'
     )
     ARG_TABLE = [
         {
@@ -155,9 +155,7 @@ class SSH(Command):
 
 class Put(Command):
     NAME = 'put'
-    DESCRIPTION = (
-        'Put file onto the master node.\n%s' % KEY_PAIR_FILE_HELP_TEXT
-    )
+    DESCRIPTION = f'Put file onto the master node.\n{KEY_PAIR_FILE_HELP_TEXT}'
     ARG_TABLE = [
         {
             'name': 'cluster-id',
@@ -219,7 +217,7 @@ class Put(Command):
 
 class Get(Command):
     NAME = 'get'
-    DESCRIPTION = 'Get file from master node.\n%s' % KEY_PAIR_FILE_HELP_TEXT
+    DESCRIPTION = f'Get file from master node.\n{KEY_PAIR_FILE_HELP_TEXT}'
     ARG_TABLE = [
         {
             'name': 'cluster-id',

--- a/awscli/customizations/flatten.py
+++ b/awscli/customizations/flatten.py
@@ -187,7 +187,7 @@ class FlattenArguments:
             overwritten = False
 
             LOG.debug(
-                'Flattening {0} argument {1} into {2}'.format(
+                'Flattening {} argument {} into {}'.format(
                     command.name,
                     name,
                     ', '.join(

--- a/awscli/customizations/gamelift/getlog.py
+++ b/awscli/customizations/gamelift/getlog.py
@@ -51,8 +51,7 @@ class GetGameSessionLogCommand(BasicCommand):
         contents = urlopen(url)
 
         sys.stdout.write(
-            'Downloading log archive for game session %s...\r'
-            % args.game_session_id
+            f'Downloading log archive for game session {args.game_session_id}...\r'
         )
 
         with open(args.save_as, 'wb') as f:
@@ -61,7 +60,7 @@ class GetGameSessionLogCommand(BasicCommand):
 
         sys.stdout.write(
             'Successfully downloaded log archive for game '
-            'session %s to %s\n' % (args.game_session_id, args.save_as)
+            f'session {args.game_session_id} to {args.save_as}\n'
         )
 
         return 0

--- a/awscli/customizations/gamelift/uploadbuild.py
+++ b/awscli/customizations/gamelift/uploadbuild.py
@@ -65,9 +65,8 @@ class UploadBuildCommand(BasicCommand):
         # Validate a build directory
         if not validate_directory(args.build_root):
             sys.stderr.write(
-                'Fail to upload %s. '
+                f'Fail to upload {args.build_root}. '
                 'The build root directory is empty or does not exist.\n'
-                % (args.build_root)
             )
 
             return 255
@@ -106,7 +105,7 @@ class UploadBuildCommand(BasicCommand):
         s3_transfer_mgr = S3Transfer(s3_client)
 
         try:
-            fd, temporary_zipfile = tempfile.mkstemp('%s.zip' % build_id)
+            fd, temporary_zipfile = tempfile.mkstemp(f'{build_id}.zip')
             zip_directory(temporary_zipfile, args.build_root)
             s3_transfer_mgr.upload_file(
                 temporary_zipfile,
@@ -122,8 +121,8 @@ class UploadBuildCommand(BasicCommand):
             os.remove(temporary_zipfile)
 
         sys.stdout.write(
-            'Successfully uploaded %s to AWS GameLift\n'
-            'Build ID: %s\n' % (args.build_root, build_id)
+            f'Successfully uploaded {args.build_root} to AWS GameLift\n'
+            f'Build ID: {build_id}\n'
         )
 
         return 0
@@ -172,12 +171,6 @@ class ProgressPercentage:
             if self._size > 0:
                 percentage = (self._seen_so_far / self._size) * 100
                 sys.stdout.write(
-                    "\r%s  %s / %s  (%.2f%%)"
-                    % (
-                        self._label,
-                        human_readable_size(self._seen_so_far),
-                        human_readable_size(self._size),
-                        percentage,
-                    )
+                    f"\r{self._label}  {human_readable_size(self._seen_so_far)} / {human_readable_size(self._size)}  ({percentage:.2f}%)"
                 )
                 sys.stdout.flush()

--- a/awscli/customizations/generatecliskeleton.py
+++ b/awscli/customizations/generatecliskeleton.py
@@ -98,7 +98,7 @@ class GenerateCliSkeletonArgument(OverrideRequiredArgsArgument):
             return
         arg_value = parsed_args.generate_cli_skeleton
         return getattr(
-            self, '_generate_%s_skeleton' % arg_value.replace('-', '_')
+            self, '_generate_{}_skeleton'.format(arg_value.replace('-', '_'))
         )(call_parameters=call_parameters, parsed_globals=parsed_globals)
 
     def _generate_yaml_input_skeleton(self, **kwargs):
@@ -214,7 +214,7 @@ class YAMLArgumentGenerator(ArgumentGenerator):
             skeleton.yaml_add_eol_comment('# ' + comment, member_name)
 
     def _get_enums_comment_content(self, enums):
-        return 'Valid values are: %s.' % ', '.join(enums)
+        return 'Valid values are: {}.'.format(', '.join(enums))
 
     def _generate_type_map(self, shape, stack):
         # YAML has support for ordered maps, so don't use ordereddicts

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -54,7 +54,7 @@ def resolve_types(parsed_args, **kwargs):
 def _resolve_arg(parsed_args, name):
     value = getattr(parsed_args, name, None)
     if value is not None:
-        new_value = getattr(sys.modules[__name__], '_resolve_%s' % name)(value)
+        new_value = getattr(sys.modules[__name__], f'_resolve_{name}')(value)
         setattr(parsed_args, name, new_value)
 
 
@@ -62,9 +62,7 @@ def _resolve_query(value):
     try:
         return jmespath.compile(value)
     except Exception as e:
-        raise ParamValidationError(
-            "Bad value for --query %s: %s" % (value, str(e))
-        )
+        raise ParamValidationError(f"Bad value for --query {value}: {str(e)}")
 
 
 def _resolve_endpoint_url(value):
@@ -73,9 +71,9 @@ def _resolve_endpoint_url(value):
     # that contains a scheme, so we'll verify that up front.
     if not parsed.scheme:
         raise ParamValidationError(
-            'Bad value for --endpoint-url "%s": scheme is '
+            f'Bad value for --endpoint-url "{value}": scheme is '
             'missing.  Must be of the form '
-            'http://<hostname>/ or https://<hostname>/' % value
+            'http://<hostname>/ or https://<hostname>/'
         )
     return value
 

--- a/awscli/customizations/history/db.py
+++ b/awscli/customizations/history/db.py
@@ -167,15 +167,12 @@ class DatabaseRecordWriter:
 
 class DatabaseRecordReader:
     _ORDERING = 'ORDER BY timestamp'
-    _GET_LAST_ID_RECORDS = (
-        """
+    _GET_LAST_ID_RECORDS = f"""
         SELECT * FROM records
         WHERE id =
         (SELECT id FROM records WHERE timestamp =
-        (SELECT max(timestamp) FROM records)) %s;"""
-        % _ORDERING
-    )
-    _GET_RECORDS_BY_ID = 'SELECT * from records where id = ? %s' % _ORDERING
+        (SELECT max(timestamp) FROM records)) {_ORDERING};"""
+    _GET_RECORDS_BY_ID = f'SELECT * from records where id = ? {_ORDERING}'
     _GET_ALL_RECORDS = (
         'SELECT a.id AS id_a, '
         '    b.id AS id_b, '
@@ -186,7 +183,7 @@ class DatabaseRecordReader:
         'where a.event_type == "CLI_ARGUMENTS" AND '
         '    b.event_type = "CLI_RC" AND '
         '    id_a == id_b '
-        '%s DESC' % _ORDERING
+        f'{_ORDERING} DESC'
     )
 
     def __init__(self, connection):

--- a/awscli/customizations/history/list.py
+++ b/awscli/customizations/history/list.py
@@ -93,11 +93,11 @@ class TextFormatter:
         json_value = json.loads(args)
         formatted = ' '.join(json_value[:2])
         if len(formatted) >= arg_width:
-            formatted = '%s...' % formatted[: arg_width - 4]
+            formatted = f'{formatted[: arg_width - 4]}...'
         return formatted
 
     def _format_record(self, record):
-        fmt_string = "{0:<%s}{1:<%s}{2:<%s}{3}\n" % (
+        fmt_string = "{{0:<{}}}{{1:<{}}}{{2:<{}}}{{3}}\n".format(
             self._col_widths['id_a'],
             self._col_widths['timestamp'],
             self._col_widths['args'],

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -196,7 +196,7 @@ class DetailedFormatter(Formatter):
         formatted_title = title
         api_num = self._get_api_num(event_record)
         if api_num is not None:
-            formatted_title = ('[%s] ' % api_num) + formatted_title
+            formatted_title = (f'[{api_num}] ') + formatted_title
         formatted_title = self._color_if_configured(formatted_title, 'title')
         formatted_title += '\n'
 

--- a/awscli/customizations/iamvirtmfa.py
+++ b/awscli/customizations/iamvirtmfa.py
@@ -38,7 +38,7 @@ OUTPUT_HELP = (
 )
 BOOTSTRAP_HELP = (
     'Method to use to seed the virtual MFA.  '
-    'Valid values are: %s | %s' % CHOICES
+    'Valid values are: {} | {}'.format(*CHOICES)
 )
 
 

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -53,7 +53,7 @@ class BaseLogEventsFormatter:
 
 class ShortLogEventsFormatter(BaseLogEventsFormatter):
     def display_log_event(self, log_event):
-        log_event = '%s %s' % (
+        log_event = '{} {}'.format(
             self._format_timestamp(log_event['timestamp']),
             log_event['message'],
         )
@@ -67,7 +67,7 @@ class ShortLogEventsFormatter(BaseLogEventsFormatter):
 
 class DetailedLogEventsFormatter(BaseLogEventsFormatter):
     def display_log_event(self, log_event):
-        log_event = '%s %s %s' % (
+        log_event = '{} {} {}'.format(
             self._format_timestamp(log_event['timestamp']),
             self._color_if_configured(
                 log_event['logStreamName'], self._STREAM_NAME_COLOR
@@ -84,7 +84,7 @@ class DetailedLogEventsFormatter(BaseLogEventsFormatter):
 
 class PrettyJSONLogEventsFormatter(BaseLogEventsFormatter):
     def display_log_event(self, log_event):
-        log_event = '%s %s %s' % (
+        log_event = '{} {} {}'.format(
             self._format_timestamp(log_event['timestamp']),
             self._color_if_configured(
                 log_event['logStreamName'], self._STREAM_NAME_COLOR
@@ -96,7 +96,7 @@ class PrettyJSONLogEventsFormatter(BaseLogEventsFormatter):
     def _format_pretty_json(self, log_message):
         try:
             loaded_json = json.loads(log_message)
-            return '\n%s' % json.dumps(loaded_json, indent=4)
+            return f'\n{json.dumps(loaded_json, indent=4)}'
         except json.decoder.JSONDecodeError:
             pass
         return log_message

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -227,9 +227,9 @@ class OpsWorksRegister(BasicCommand):
         if args.hostname:
             if not HOSTNAME_RE.match(args.hostname):
                 raise ParamValidationError(
-                    "Invalid hostname: '%s'. Hostnames must consist of "
+                    f"Invalid hostname: '{args.hostname}'. Hostnames must consist of "
                     "letters, digits and dashes only and must not start or "
-                    "end with a dash." % args.hostname
+                    "end with a dash."
                 )
 
     def retrieve_stack(self, args):
@@ -302,12 +302,11 @@ class OpsWorksRegister(BasicCommand):
 
             if not instances:
                 raise ValueError(
-                    "Did not find any instance matching %s." % args.target
+                    f"Did not find any instance matching {args.target}."
                 )
             elif len(instances) > 1:
                 raise ValueError(
-                    "Found multiple instances matching %s: %s."
-                    % (
+                    "Found multiple instances matching {}: {}.".format(
                         args.target,
                         ", ".join(i['InstanceId'] for i in instances),
                     )
@@ -329,8 +328,8 @@ class OpsWorksRegister(BasicCommand):
                 for instance in instances
             ):
                 raise ValueError(
-                    "Invalid hostname: '%s'. Hostnames must be unique within "
-                    "a stack." % args.hostname
+                    f"Invalid hostname: '{args.hostname}'. Hostnames must be unique within "
+                    "a stack."
                 )
 
         if args.infrastructure_class == 'ec2' and args.local:
@@ -397,7 +396,9 @@ class OpsWorksRegister(BasicCommand):
             return
 
         LOG.debug("Creating the IAM group if necessary")
-        group_name = "OpsWorks-%s" % clean_for_iam(self._stack['StackId'])
+        group_name = "OpsWorks-{}".format(
+            clean_for_iam(self._stack['StackId'])
+        )
         try:
             self.iam.create_group(GroupName=group_name, Path=IAM_PATH)
             LOG.debug("Created IAM group %s", group_name)
@@ -414,12 +415,12 @@ class OpsWorksRegister(BasicCommand):
 
         # create the IAM user, trying alternatives if it already exists
         LOG.debug("Creating an IAM user")
-        base_username = "OpsWorks-%s-%s" % (
+        base_username = "OpsWorks-{}-{}".format(
             shorten_name(clean_for_iam(self._stack['Name']), 25),
             shorten_name(clean_for_iam(self._name_for_iam), 25),
         )
         for try_ in range(20):
-            username = base_username + ("+%s" % try_ if try_ else "")
+            username = base_username + (f"+{try_}" if try_ else "")
             try:
                 self.iam.create_user(UserName=username, Path=IAM_PATH)
             except ClientError as e:
@@ -514,12 +515,12 @@ class OpsWorksRegister(BasicCommand):
                 else:
                     call = 'plink'
                     if args.username:
-                        call += ' -l "%s"' % args.username
+                        call += f' -l "{args.username}"'
                     if args.private_key:
-                        call += ' -i "%s"' % args.private_key
-                    call += ' "%s"' % self._use_address
+                        call += f' -i "{args.private_key}"'
+                    call += f' "{self._use_address}"'
                     call += ' -m'
-                call += ' "%s"' % script_file.name
+                call += f' "{script_file.name}"'
 
                 subprocess.check_call(call, shell=True)
             finally:
@@ -580,8 +581,7 @@ class OpsWorksRegister(BasicCommand):
     @staticmethod
     def _to_ruby_yaml(parameters):
         return "\n".join(
-            ":%s: %s" % (k, json.dumps(v))
-            for k, v in sorted(parameters.items())
+            f":{k}: {json.dumps(v)}" for k, v in sorted(parameters.items())
         )
 
 

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -107,26 +107,20 @@ def add_paging_description(help_command, **kwargs):
         return
     help_command.doc.style.new_paragraph()
     help_command.doc.writeln(
-        (
-            '``%s`` is a paginated operation. Multiple API calls may be issued '
-            'in order to retrieve the entire data set of results. You can '
-            'disable pagination by providing the ``--no-paginate`` argument.'
-        )
-        % help_command.name
+        f'``{help_command.name}`` is a paginated operation. Multiple API calls may be issued '
+        'in order to retrieve the entire data set of results. You can '
+        'disable pagination by providing the ``--no-paginate`` argument.'
     )
     # Only include result key information if it is present.
     if paginator_config.get('result_key'):
         queries = paginator_config['result_key']
         if type(queries) is not list:
             queries = [queries]
-        queries = ", ".join([('``%s``' % s) for s in queries])
+        queries = ", ".join([(f'``{s}``') for s in queries])
         help_command.doc.writeln(
-            (
-                'When using ``--output text`` and the ``--query`` argument on a '
-                'paginated response, the ``--query`` argument must extract data '
-                'from the results of the following query expressions: %s'
-            )
-            % queries
+            'When using ``--output text`` and the ``--query`` argument on a '
+            'paginated response, the ``--query`` argument must extract data '
+            f'from the results of the following query expressions: {queries}'
         )
 
 
@@ -171,8 +165,8 @@ def unify_paging_params(
         if type_name not in PageArgument.type_map:
             raise TypeError(
                 (
-                    'Unsupported pagination type {0} for operation {1}'
-                    ' and parameter {2}'
+                    'Unsupported pagination type {} for operation {}'
+                    ' and parameter {}'
                 ).format(
                     type_name,
                     operation_model.name,
@@ -295,7 +289,7 @@ def ensure_paging_params_not_set(parsed_args, shadowed_args):
         )
         raise ParamValidationError(
             "Cannot specify --no-paginate along with pagination "
-            "arguments: %s" % converted_params
+            f"arguments: {converted_params}"
         )
 
 

--- a/awscli/customizations/putmetricdata.py
+++ b/awscli/customizations/putmetricdata.py
@@ -130,7 +130,7 @@ def insert_first_element(name):
 
 class PutMetricArgument(CustomArgument):
     def add_to_params(self, parameters, value):
-        method_name = '_add_param_%s' % self.name.replace('-', '_')
+        method_name = '_add_param_{}'.format(self.name.replace('-', '_'))
         return getattr(self, method_name)(parameters, value)
 
     @insert_first_element('MetricData')

--- a/awscli/customizations/rekognition.py
+++ b/awscli/customizations/rekognition.py
@@ -36,7 +36,7 @@ def register_rekognition_detect_labels(cli):
         operation, old_param = target.rsplit('.', 1)
         doc_string_addendum = IMAGE_DOCSTRING_ADDENDUM % new_param
         cli.register(
-            'building-argument-table.rekognition.%s' % operation,
+            f'building-argument-table.rekognition.{operation}',
             NestedBlobArgumentHoister(
                 source_arg=old_param,
                 source_arg_blob_member='Bytes',

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -80,18 +80,16 @@ class FileDecodingError(Exception):
     """Raised when there was an issue decoding the file."""
 
     ADVICE = (
-        "Please check your locale settings.  The filename was decoded as: %s\n"
+        f"Please check your locale settings.  The filename was decoded as: {sys.getfilesystemencoding()}\n"
         "On posix platforms, check the LC_CTYPE environment variable."
-        % (sys.getfilesystemencoding())
     )
 
     def __init__(self, directory, filename):
         self.directory = directory
         self.file_name = filename
         self.error_message = (
-            'There was an error trying to decode the the file %s in '
-            'directory "%s". \n%s'
-            % (repr(self.file_name), self.directory, self.ADVICE)
+            f'There was an error trying to decode the the file {repr(self.file_name)} in '
+            f'directory "{self.directory}". \n{self.ADVICE}'
         )
         super(FileDecodingError, self).__init__(self.error_message)
 
@@ -396,7 +394,7 @@ class FileGenerator:
             # The key does not exist so we'll raise a more specific
             # error message here.
             response = e.response.copy()
-            response['Error']['Message'] = 'Key "%s" does not exist' % key
+            response['Error']['Message'] = f'Key "{key}" does not exist'
             raise ClientError(response, 'HeadObject')
         response['Size'] = int(response.pop('ContentLength'))
         last_update = parse(response['LastModified'])

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -188,7 +188,7 @@ class ResultRecorder(BaseResultHandler):
         if not isinstance(result, BaseResult):
             raise ValueError(
                 'Any result using _get_ongoing_dict_key must subclass from '
-                'BaseResult. Provided result is of type: %s' % type(result)
+                f'BaseResult. Provided result is of type: {type(result)}'
             )
         key_parts = []
         for result_property in [result.transfer_type, result.src, result.dest]:

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -304,19 +304,18 @@ class BaseTransferRequestSubmitter:
         if not self._cli_params.get('force_glacier_transfer'):
             if not fileinfo.is_glacier_compatible():
                 LOGGER.debug(
-                    'Encountered glacier object s3://%s. Not performing '
-                    '%s on object.' % (fileinfo.src, fileinfo.operation_name)
+                    f'Encountered glacier object s3://{fileinfo.src}. Not performing '
+                    f'{fileinfo.operation_name} on object.'
                 )
                 if not self._cli_params.get('ignore_glacier_warnings'):
                     warning = create_warning(
                         's3://' + fileinfo.src,
                         'Object is of storage class GLACIER. Unable to '
-                        'perform %s operations on GLACIER objects. You must '
+                        f'perform {fileinfo.operation_name} operations on GLACIER objects. You must '
                         'restore the object to be able to perform the '
-                        'operation. See aws s3 %s help for additional '
+                        f'operation. See aws s3 {fileinfo.operation_name} help for additional '
                         'parameter options to ignore or force these '
-                        'transfers.'
-                        % (fileinfo.operation_name, fileinfo.operation_name),
+                        'transfers.',
                     )
                     self._result_queue.put(warning)
                 return True
@@ -387,10 +386,7 @@ class UploadRequestSubmitter(BaseTransferRequestSubmitter):
     def _warn_if_too_large(self, fileinfo):
         if getattr(fileinfo, 'size') and fileinfo.size > MAX_UPLOAD_SIZE:
             file_path = relative_path(fileinfo.src)
-            warning_message = "File %s exceeds s3 upload limit of %s." % (
-                file_path,
-                human_readable_size(MAX_UPLOAD_SIZE),
-            )
+            warning_message = f"File {file_path} exceeds s3 upload limit of {human_readable_size(MAX_UPLOAD_SIZE)}."
             warning = create_warning(
                 file_path, warning_message, skip_file=False
             )

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -857,7 +857,7 @@ class ListCommand(S3Command):
             str(last_mod.minute).zfill(2),
             str(last_mod.second).zfill(2),
         )
-        last_mod_str = "%s-%s-%s %s:%s:%s" % last_mod_tup
+        last_mod_str = "{}-{}-{} {}:{}:{}".format(*last_mod_tup)
         return last_mod_str.ljust(19, ' ')
 
     def _make_size_str(self, size):
@@ -1141,7 +1141,7 @@ class MbCommand(S3Command):
 
         if not parsed_args.path.startswith('s3://'):
             raise ParamValidationError(
-                "%s\nError: Invalid argument type" % self.USAGE
+                f"{self.USAGE}\nError: Invalid argument type"
             )
         bucket, _ = split_s3_bucket_key(parsed_args.path)
 
@@ -1158,11 +1158,11 @@ class MbCommand(S3Command):
         # TODO: Consolidate how we handle return codes and errors
         try:
             self.client.create_bucket(**params)
-            uni_print("make_bucket: %s\n" % bucket)
+            uni_print(f"make_bucket: {bucket}\n")
             return 0
         except Exception as e:
             uni_print(
-                "make_bucket failed: %s %s\n" % (parsed_args.path, e),
+                f"make_bucket failed: {parsed_args.path} {e}\n",
                 sys.stderr,
             )
             return 1
@@ -1188,14 +1188,14 @@ class RbCommand(S3Command):
 
         if not parsed_args.path.startswith('s3://'):
             raise ParamValidationError(
-                "%s\nError: Invalid argument type" % self.USAGE
+                f"{self.USAGE}\nError: Invalid argument type"
             )
         bucket, key = split_s3_bucket_key(parsed_args.path)
 
         if key:
             raise ParamValidationError(
                 'Please specify a valid bucket name only. '
-                'E.g. s3://%s' % bucket
+                f'E.g. s3://{bucket}'
             )
 
         if parsed_args.force:
@@ -1203,11 +1203,11 @@ class RbCommand(S3Command):
 
         try:
             self.client.delete_bucket(Bucket=bucket)
-            uni_print("remove_bucket: %s\n" % bucket)
+            uni_print(f"remove_bucket: {bucket}\n")
             return 0
         except Exception as e:
             uni_print(
-                "remove_bucket failed: %s %s\n" % (parsed_args.path, e),
+                f"remove_bucket failed: {parsed_args.path} {e}\n",
                 sys.stderr,
             )
             return 1
@@ -1613,7 +1613,9 @@ class CommandParameters:
         if 'locals3' == params['paths_type'] and not params['is_stream']:
             if not os.path.exists(params['src']):
                 raise RuntimeError(
-                    'The user-provided path %s does not exist.' % params['src']
+                    'The user-provided path {} does not exist.'.format(
+                        params['src']
+                    )
                 )
         # If the operation is downloading to a directory that does not exist,
         # create the directories so no warnings are thrown during the syncing
@@ -1740,7 +1742,7 @@ class CommandParameters:
             'locallocal': [],
         }
         paths_type = ''
-        usage = "usage: aws s3 %s %s" % (self.cmd, self.usage)
+        usage = f"usage: aws s3 {self.cmd} {self.usage}"
         for i in range(len(paths)):
             if paths[i].startswith('s3://'):
                 paths_type = paths_type + 's3'
@@ -1750,7 +1752,7 @@ class CommandParameters:
             self.parameters['paths_type'] = paths_type
         else:
             raise ParamValidationError(
-                "%s\nError: Invalid argument type" % usage
+                f"{usage}\nError: Invalid argument type"
             )
 
     def add_region(self, parsed_globals):
@@ -1790,14 +1792,14 @@ class CommandParameters:
         if self.parameters.get(sse_c_type):
             if not self.parameters.get(sse_c_key_type):
                 raise ParamValidationError(
-                    'If %s is specified, %s must be specified '
-                    'as well.' % (sse_c_type_param, sse_c_key_type_param)
+                    f'If {sse_c_type_param} is specified, {sse_c_key_type_param} must be specified '
+                    'as well.'
                 )
         if self.parameters.get(sse_c_key_type):
             if not self.parameters.get(sse_c_type):
                 raise ParamValidationError(
-                    'If %s is specified, %s must be specified '
-                    'as well.' % (sse_c_key_type_param, sse_c_type_param)
+                    f'If {sse_c_key_type_param} is specified, {sse_c_type_param} must be specified '
+                    'as well.'
                 )
 
     def _validate_sse_c_copy_source_for_paths(self):

--- a/awscli/customizations/s3/subscribers.py
+++ b/awscli/customizations/s3/subscribers.py
@@ -165,8 +165,8 @@ class ProvideLastModifiedTimeSubscriber(OnDoneFilteredSubscriber):
             utils.set_file_utime(filename, int(mod_timestamp))
         except Exception as e:
             warning_message = (
-                'Successfully Downloaded %s but was unable to update the '
-                'last modified time. %s' % (filename, e)
+                f'Successfully Downloaded {filename} but was unable to update the '
+                f'last modified time. {e}'
             )
             self._result_queue.put(
                 utils.create_warning(filename, warning_message)
@@ -184,7 +184,7 @@ class DirectoryCreatorSubscriber(BaseSubscriber):
         except OSError as e:
             if not e.errno == errno.EEXIST:
                 raise CreateDirectoryError(
-                    "Could not create directory %s: %s" % (d, e)
+                    f"Could not create directory {d}: {e}"
                 )
 
 
@@ -198,7 +198,7 @@ class CopyPropsSubscriberFactory:
         copy_props = self._cli_params.get('copy_props', 'default').replace(
             '-', '_'
         )
-        return getattr(self, '_get_%s_subscribers' % copy_props)(fileinfo)
+        return getattr(self, f'_get_{copy_props}_subscribers')(fileinfo)
 
     def _get_none_subscribers(self, fileinfo):
         return [

--- a/awscli/customizations/s3/syncstrategy/base.py
+++ b/awscli/customizations/s3/syncstrategy/base.py
@@ -70,8 +70,8 @@ class BaseSync:
     def _check_sync_type(self, sync_type):
         if sync_type not in VALID_SYNC_TYPES:
             raise ParamValidationError(
-                "Unknown sync_type: %s.\n"
-                "Valid options are %s." % (sync_type, VALID_SYNC_TYPES)
+                f"Unknown sync_type: {sync_type}.\n"
+                f"Valid options are {VALID_SYNC_TYPES}."
             )
 
     @property

--- a/awscli/customizations/s3/transferconfig.py
+++ b/awscli/customizations/s3/transferconfig.py
@@ -107,11 +107,11 @@ class RuntimeConfig:
                     runtime_config[attr] = int(value)
                 else:
                     raise InvalidConfigError(
-                        'Invalid rate: %s. The value must be expressed '
+                        f'Invalid rate: {value}. The value must be expressed '
                         'as an integer in terms of bytes per second '
                         '(e.g. 10485760) or a rate in terms of bytes '
                         'per second (e.g. 10MB/s or 800KB/s) or bits per '
-                        'second (e.g. 10Mb/s or 800Kb/s)' % value
+                        'second (e.g. 10Mb/s or 800Kb/s)'
                     )
 
     def _human_readable_rate_to_int(self, value):
@@ -180,7 +180,7 @@ class RuntimeConfig:
 
     def _error_positive_value(self, name, value):
         raise InvalidConfigError(
-            "Value for %s must be a positive integer: %s" % (name, value)
+            f"Value for {name} must be a positive integer: {value}"
         )
 
     def _error_invalid_choice(self, name, value):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -91,7 +91,7 @@ def human_readable_size(value):
     for i, suffix in enumerate(HUMANIZE_SUFFIXES):
         unit = base ** (i + 2)
         if round((bytes_int / unit) * base) < base:
-            return '%.1f %s' % ((base * bytes_int / unit), suffix)
+            return f'{base * bytes_int / unit:.1f} {suffix}'
 
 
 def human_readable_to_int(value):
@@ -114,7 +114,7 @@ def human_readable_to_int(value):
         try:
             return int(value)
         except ValueError:
-            raise ValueError("Invalid size value: %s" % value)
+            raise ValueError(f"Invalid size value: {value}")
     else:
         multiplier = SIZE_SUFFIX[suffix]
         return int(value[: -len(suffix)]) * multiplier
@@ -254,9 +254,7 @@ def get_file_stat(path):
     try:
         stats = os.stat(path)
     except OSError as e:
-        raise ValueError(
-            'Could not retrieve file stat of "%s": %s' % (path, e)
-        )
+        raise ValueError(f'Could not retrieve file stat of "{path}": {e}')
 
     try:
         update_time = datetime.fromtimestamp(stats.st_mtime, tzlocal())

--- a/awscli/customizations/s3errormsg.py
+++ b/awscli/customizations/s3errormsg.py
@@ -44,7 +44,7 @@ def enhance_error_msg(parsed, **kwargs):
     elif _is_permanent_redirect_message(parsed):
         endpoint = parsed['Error']['Endpoint']
         message = parsed['Error']['Message']
-        new_message = message[:-1] + ': %s\n' % endpoint
+        new_message = message[:-1] + f': {endpoint}\n'
         new_message += REGION_ERROR_MSG
         parsed['Error']['Message'] = new_message
     elif _is_kms_sigv4_error_message(parsed):

--- a/awscli/customizations/s3events.py
+++ b/awscli/customizations/s3events.py
@@ -59,8 +59,7 @@ def replace_event_stream_docs(help_command, **kwargs):
             # This should never happen, but in the rare case that it does
             # we should be raising something with a helpful error message.
             raise DocSectionNotFoundError(
-                'Could not find the "output" section for the command: %s'
-                % help_command
+                f'Could not find the "output" section for the command: {help_command}'
             )
     doc.write('======\nOutput\n======\n')
     doc.write(

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -223,12 +223,6 @@ class ProgressPercentage(BaseSubscriber):
             self._seen_so_far += bytes_transferred
             percentage = (self._seen_so_far / self._size) * 100
             sys.stderr.write(
-                "\rUploading to %s  %s / %s  (%.2f%%)"
-                % (
-                    self._remote_path,
-                    self._seen_so_far,
-                    self._size,
-                    percentage,
-                )
+                f"\rUploading to {self._remote_path}  {self._seen_so_far} / {self._size}  ({percentage:.2f}%)"
             )
             sys.stderr.flush()

--- a/awscli/customizations/servicecatalog/generatebase.py
+++ b/awscli/customizations/servicecatalog/generatebase.py
@@ -34,7 +34,7 @@ class GenerateBaseCommand(BasicCommand):
                 parsed_args.file_path, get_s3_path(parsed_args.file_path)
             )
         except OSError:
-            raise RuntimeError("%s cannot be found" % parsed_args.file_path)
+            raise RuntimeError(f"{parsed_args.file_path} cannot be found")
 
     def get_and_validate_region(self, parsed_globals):
         region = parsed_globals.region

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -332,8 +332,8 @@ class BaseSSOCommand(BasicCommand):
 
         if missing:
             error_msg = (
-                'Missing the following required SSO configuration values: %s. '
-            ) % ', '.join(missing)
+                'Missing the following required SSO configuration values: {}. '
+            ).format(', '.join(missing))
             raise InvalidSSOConfigError(error_msg)
 
         return sso_config
@@ -342,9 +342,9 @@ class BaseSSOCommand(BasicCommand):
         sso_config, missing = self._get_required_config_vars(scoped_config)
         if missing:
             raise InvalidSSOConfigError(
-                'Missing the following required SSO configuration values: %s. '
+                'Missing the following required SSO configuration values: {}. '
                 'To make sure this profile is properly configured to use SSO, '
-                'please run: aws configure sso' % ', '.join(missing)
+                'please run: aws configure sso'.format(', '.join(missing))
             )
         return sso_config
 

--- a/awscli/customizations/streamingoutputarg.py
+++ b/awscli/customizations/streamingoutputarg.py
@@ -92,7 +92,7 @@ class StreamingOutputArgument(BaseCLIArgument):
         service_id = self._operation_model.service_model.service_id.hyphenize()
         operation_name = self._operation_model.name
         self._session.register(
-            'after-call.%s.%s' % (service_id, operation_name), self.save_file
+            f'after-call.{service_id}.{operation_name}', self.save_file
         )
 
     def save_file(self, parsed, **kwargs):

--- a/awscli/customizations/timestampformat.py
+++ b/awscli/customizations/timestampformat.py
@@ -74,7 +74,7 @@ def add_timestamp_parser(session, **kwargs):
         timestamp_parser = iso_format
     else:
         raise ConfigurationError(
-            'Unknown cli_timestamp_format value: %s, valid values'
-            ' are "wire" or "iso8601"' % timestamp_format
+            f'Unknown cli_timestamp_format value: {timestamp_format}, valid values'
+            ' are "wire" or "iso8601"'
         )
     factory.set_parser_defaults(timestamp_parser=timestamp_parser)

--- a/awscli/customizations/toplevelbool.py
+++ b/awscli/customizations/toplevelbool.py
@@ -76,14 +76,14 @@ def pull_up_bool(argument_table, event_handler, **kwargs):
                     serialized_name=value._serialized_name,
                 )
                 argument_table[value.name] = new_arg
-                negative_name = 'no-%s' % value.name
+                negative_name = f'no-{value.name}'
                 negative_arg = NegativeBooleanParameter(
                     negative_name,
                     arg_model,
                     value._operation_model,
                     value._event_emitter,
                     action='store_true',
-                    dest='no_%s' % new_arg.py_name,
+                    dest=f'no_{new_arg.py_name}',
                     group_name=value.name,
                     serialized_name=value._serialized_name,
                 )
@@ -104,8 +104,8 @@ def validate_boolean_mutex_groups(boolean_pairs, parsed_args, **kwargs):
             and getattr(parsed_args, negative.py_name) is not _NOT_SPECIFIED
         ):
             raise ParamValidationError(
-                'Cannot specify both the "%s" option and '
-                'the "%s" option.' % (positive.cli_name, negative.cli_name)
+                f'Cannot specify both the "{positive.cli_name}" option and '
+                f'the "{negative.cli_name}" option.'
             )
 
 

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -114,9 +114,9 @@ def validate_mutually_exclusive(parsed_args, *groups):
             current_group = key_group
         elif not key_group == current_group:
             raise ParamValidationError(
-                'The key "%s" cannot be specified when one '
+                'The key "{}" cannot be specified when one '
                 'of the following keys are also specified: '
-                '%s' % (key, ', '.join(current_group))
+                '{}'.format(key, ', '.join(current_group))
             )
 
 
@@ -239,7 +239,7 @@ def _strip_xml_from_documentation(documentation):
         # to make sure the dom parser will look at all elements in the
         # docstring as some docstrings may not have xml nodes that do
         # not all belong to the same root node.
-        xml_doc = '<doc>%s</doc>' % documentation
+        xml_doc = f'<doc>{documentation}</doc>'
         xml_dom = xml.dom.minidom.parseString(xml_doc)
     except xml.parsers.expat.ExpatError:
         return documentation

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -187,7 +187,7 @@ class WaiterStateDocBuilder:
         # description about what resource is looked at.
         if matcher in ['path', 'pathAny', 'pathAll']:
             resource_description = (
-                'JMESPath query %s returns ' % acceptor.argument
+                f'JMESPath query {acceptor.argument} returns '
             )
             # Prepend the resource description to the template description
             success_description = resource_description + success_description
@@ -197,13 +197,13 @@ class WaiterStateDocBuilder:
 
     def _build_operation_description(self, operation):
         operation_name = xform_name(operation).replace('_', '-')
-        return 'when polling with ``%s``.' % operation_name
+        return f'when polling with ``{operation_name}``.'
 
     def _build_polling_description(self, delay, max_attempts):
         description = (
-            ' It will poll every %s seconds until a successful state '
+            f' It will poll every {delay} seconds until a successful state '
             'has been reached. This will exit with a return code of 255 '
-            'after %s failed checks.' % (delay, max_attempts)
+            f'after {max_attempts} failed checks.'
         )
         return description
 

--- a/awscli/customizations/wizard/commands.py
+++ b/awscli/customizations/wizard/commands.py
@@ -26,7 +26,7 @@ def register_wizard_commands(event_handlers):
 def _register_wizards_for_commands(commands, event_handlers):
     for command in commands:
         event_handlers.register(
-            'building-command-table.%s' % command, _add_wizard_command
+            f'building-command-table.{command}', _add_wizard_command
         )
 
 
@@ -100,7 +100,7 @@ class TopLevelWizardCommand(BasicCommand):
             self._runner[version].run(loaded)
         else:
             raise ParamValidationError(
-                'Definition file has unsupported version %s ' % version
+                f'Definition file has unsupported version {version} '
             )
 
     def create_help_command(self):

--- a/awscli/customizations/wizard/core.py
+++ b/awscli/customizations/wizard/core.py
@@ -579,7 +579,7 @@ class SharedConfigAPI:
         if profile is not None:
             section = profile
             if profile != 'default':
-                section = 'profile %s' % section
+                section = f'profile {section}'
             config_params['__section__'] = section
         config_params.update(values)
         config_filename = os.path.expanduser(

--- a/awscli/customizations/wizard/loader.py
+++ b/awscli/customizations/wizard/loader.py
@@ -91,7 +91,7 @@ class WizardLoader:
         except OSError:
             raise WizardNotExistError(
                 "Wizard does not exist for command "
-                "'%s', name: '%s'" % (command_name, wizard_name)
+                f"'{command_name}', name: '{wizard_name}'"
             )
 
     def _load_yaml(self, contents):

--- a/awscli/customizations/wizard/ui/__init__.py
+++ b/awscli/customizations/wizard/ui/__init__.py
@@ -26,7 +26,7 @@ class Prompter:
 class UIPrompter(Prompter):
     def prompt(self, display_text, choices=None):
         if not choices:
-            return prompt_toolkit.prompt('%s: ' % display_text)
+            return prompt_toolkit.prompt(f'{display_text}: ')
         else:
             prompt_toolkit.print_formatted_text(display_text)
             if isinstance(choices[0], str):
@@ -63,5 +63,5 @@ class UIFilePrompter:
 
     def prompt(self, display_text):
         return prompt_toolkit.prompt(
-            '%s: ' % display_text, completer=self._completer
+            f'{display_text}: ', completer=self._completer
         )

--- a/awscli/customizations/wizard/ui/selectmenu.py
+++ b/awscli/customizations/wizard/ui/selectmenu.py
@@ -146,7 +146,7 @@ class SelectionMenuControl(UIControl):
 
         text, tw = _trim_text(item, menu_width - self._format_overhead)
         padding = ' ' * (menu_width - self._format_overhead - tw)
-        return [(style_str, '%s %s%s  ' % (cursor, text, padding))]
+        return [(style_str, f'{cursor} {text}{padding}  ')]
 
     def create_content(self, width, height):
         def get_line(i):

--- a/awscli/formatter.py
+++ b/awscli/formatter.py
@@ -220,7 +220,7 @@ class TableFormatter(FullyBufferedFormatter):
                 initial_section=False, column_separator='|', styler=styler
             )
         else:
-            raise ValueError("Unknown color option: %s" % args.color)
+            raise ValueError(f"Unknown color option: {args.color}")
 
     def _format_response(self, command_name, response, stream):
         if self._build_table(command_name, response):
@@ -379,6 +379,6 @@ CLI_OUTPUT_FORMATS = {
 
 def get_formatter(format_type, args):
     if format_type not in CLI_OUTPUT_FORMATS:
-        raise ValueError("Unknown output type: %s" % format_type)
+        raise ValueError(f"Unknown output type: {format_type}")
     format_type_cls = CLI_OUTPUT_FORMATS[format_type]
     return format_type_cls(args)

--- a/awscli/help.py
+++ b/awscli/help.py
@@ -41,7 +41,7 @@ LOG = logging.getLogger('awscli.help')
 class ExecutableNotFoundError(Exception):
     def __init__(self, executable_name):
         super(ExecutableNotFoundError, self).__init__(
-            'Could not find executable named "%s"' % executable_name
+            f'Could not find executable named "{executable_name}"'
         )
 
 
@@ -140,7 +140,7 @@ class PosixHelpRenderer(PagingHelpRenderer):
         cmdline = self.get_pager_cmdline()
         if not self._exists_on_path(cmdline[0]):
             LOG.debug(
-                "Pager '%s' not found in PATH, printing raw help." % cmdline[0]
+                f"Pager '{cmdline[0]}' not found in PATH, printing raw help."
             )
             self.output_stream.write(output.decode('utf-8') + "\n")
             self.output_stream.flush()

--- a/awscli/paramfile.py
+++ b/awscli/paramfile.py
@@ -83,14 +83,12 @@ def get_file(prefix, path, mode):
             return f.read()
     except UnicodeDecodeError:
         raise ResourceLoadingError(
-            'Unable to load paramfile (%s), text contents could '
+            f'Unable to load paramfile ({file_path}), text contents could '
             'not be decoded.  If this is a binary file, please use the '
-            'fileb:// prefix instead of the file:// prefix.' % file_path
+            'fileb:// prefix instead of the file:// prefix.'
         )
     except OSError as e:
-        raise ResourceLoadingError(
-            'Unable to load paramfile %s: %s' % (path, e)
-        )
+        raise ResourceLoadingError(f'Unable to load paramfile {path}: {e}')
 
 
 LOCAL_PREFIX_MAP = {

--- a/awscli/s3transfer/__init__.py
+++ b/awscli/s3transfer/__init__.py
@@ -822,8 +822,8 @@ class S3Transfer:
         for kwarg in actual:
             if kwarg not in allowed:
                 raise ValueError(
-                    "Invalid extra_args key '%s', "
-                    "must be one of: %s" % (kwarg, ', '.join(allowed))
+                    "Invalid extra_args key '{}', "
+                    "must be one of: {}".format(kwarg, ', '.join(allowed))
                 )
 
     def _ranged_download(

--- a/awscli/s3transfer/constants.py
+++ b/awscli/s3transfer/constants.py
@@ -34,5 +34,5 @@ FULL_OBJECT_CHECKSUM_ARGS = [
     'ChecksumSHA256',
 ]
 
-USER_AGENT = 's3transfer/%s' % s3transfer.__version__
-PROCESS_USER_AGENT = '%s processpool' % USER_AGENT
+USER_AGENT = f's3transfer/{s3transfer.__version__}'
+PROCESS_USER_AGENT = f'{USER_AGENT} processpool'

--- a/awscli/s3transfer/copies.py
+++ b/awscli/s3transfer/copies.py
@@ -280,7 +280,7 @@ class CopySubmissionTask(SubmissionTask):
             raise TypeError(
                 'Expecting dictionary formatted: '
                 '{"Bucket": bucket_name, "Key": key} '
-                'but got %s or type %s.' % (copy_source, type(copy_source))
+                f'but got {copy_source} or type {type(copy_source)}.'
             )
 
     def _extra_upload_part_args(self, extra_args):

--- a/awscli/s3transfer/futures.py
+++ b/awscli/s3transfer/futures.py
@@ -294,8 +294,8 @@ class TransferCoordinator:
         with self._lock:
             if self.done():
                 raise RuntimeError(
-                    'Unable to transition from done state %s to non-done '
-                    'state %s.' % (self.status, desired_state)
+                    f'Unable to transition from done state {self.status} to non-done '
+                    f'state {desired_state}.'
                 )
             self._status = desired_state
 
@@ -397,7 +397,7 @@ class TransferCoordinator:
         # We do not want a callback interrupting the process, especially
         # in the failure cleanups. So log and catch, the exception.
         except Exception:
-            logger.debug("Exception raised in %s." % callback, exc_info=True)
+            logger.debug(f"Exception raised in {callback}.", exc_info=True)
 
 
 class BoundedExecutor:

--- a/awscli/s3transfer/manager.py
+++ b/awscli/s3transfer/manager.py
@@ -155,8 +155,8 @@ class TransferConfig:
         for attr, attr_val in self.__dict__.items():
             if attr_val is not None and attr_val <= 0:
                 raise ValueError(
-                    'Provided parameter %s of value %s must be greater than '
-                    '0.' % (attr, attr_val)
+                    f'Provided parameter {attr} of value {attr_val} must be greater than '
+                    '0.'
                 )
 
 
@@ -503,16 +503,16 @@ class TransferManager:
                 match = pattern.match(bucket)
                 if match:
                     raise ValueError(
-                        'TransferManager methods do not support %s '
-                        'resource. Use direct client calls instead.' % resource
+                        f'TransferManager methods do not support {resource} '
+                        'resource. Use direct client calls instead.'
                     )
 
     def _validate_all_known_args(self, actual, allowed):
         for kwarg in actual:
             if kwarg not in allowed:
                 raise ValueError(
-                    "Invalid extra_args key '%s', "
-                    "must be one of: %s" % (kwarg, ', '.join(allowed))
+                    "Invalid extra_args key '{}', "
+                    "must be one of: {}".format(kwarg, ', '.join(allowed))
                 )
 
     def _add_operation_defaults(self, extra_args):

--- a/awscli/s3transfer/subscribers.py
+++ b/awscli/s3transfer/subscribers.py
@@ -33,14 +33,13 @@ class BaseSubscriber:
             subscriber_method = getattr(cls, 'on_' + subscriber_type)
             if not callable(subscriber_method):
                 raise InvalidSubscriberMethodError(
-                    'Subscriber method %s must be callable.'
-                    % subscriber_method
+                    f'Subscriber method {subscriber_method} must be callable.'
                 )
 
             if not accepts_kwargs(subscriber_method):
                 raise InvalidSubscriberMethodError(
-                    'Subscriber method %s must accept keyword '
-                    'arguments (**kwargs)' % subscriber_method
+                    f'Subscriber method {subscriber_method} must accept keyword '
+                    'arguments (**kwargs)'
                 )
 
     def on_queued(self, future, **kwargs):

--- a/awscli/s3transfer/utils.py
+++ b/awscli/s3transfer/utils.py
@@ -636,7 +636,7 @@ class TaskSemaphore:
         """
         logger.debug("Acquiring %s", tag)
         if not self._semaphore.acquire(blocking):
-            raise NoResourcesAvailable("Cannot acquire tag '%s'" % tag)
+            raise NoResourcesAvailable(f"Cannot acquire tag '{tag}'")
 
     def release(self, tag, acquire_token):
         """Release the semaphore
@@ -694,7 +694,7 @@ class SlidingWindowSemaphore(TaskSemaphore):
         try:
             if self._count == 0:
                 if not blocking:
-                    raise NoResourcesAvailable("Cannot acquire tag '%s'" % tag)
+                    raise NoResourcesAvailable(f"Cannot acquire tag '{tag}'")
                 else:
                     while self._count == 0:
                         self._condition.wait()
@@ -716,7 +716,7 @@ class SlidingWindowSemaphore(TaskSemaphore):
         self._condition.acquire()
         try:
             if tag not in self._tag_sequences:
-                raise ValueError("Attempted to release unknown tag: %s" % tag)
+                raise ValueError(f"Attempted to release unknown tag: {tag}")
             max_sequence = self._tag_sequences[tag]
             if self._lowest_sequence[tag] == sequence_number:
                 # We can immediately process this request and free up
@@ -743,7 +743,7 @@ class SlidingWindowSemaphore(TaskSemaphore):
             else:
                 raise ValueError(
                     "Attempted to release unknown sequence number "
-                    "%s for tag: %s" % (sequence_number, tag)
+                    f"{sequence_number} for tag: {tag}"
                 )
         finally:
             self._condition.release()
@@ -781,13 +781,13 @@ class ChunksizeAdjuster:
         if current_chunksize > self.max_size:
             logger.debug(
                 "Chunksize greater than maximum chunksize. "
-                "Setting to %s from %s." % (self.max_size, current_chunksize)
+                f"Setting to {self.max_size} from {current_chunksize}."
             )
             return self.max_size
         elif current_chunksize < self.min_size:
             logger.debug(
                 "Chunksize less than minimum chunksize. "
-                "Setting to %s from %s." % (self.min_size, current_chunksize)
+                f"Setting to {self.min_size} from {current_chunksize}."
             )
             return self.min_size
         else:
@@ -804,8 +804,7 @@ class ChunksizeAdjuster:
         if chunksize != current_chunksize:
             logger.debug(
                 "Chunksize would result in the number of parts exceeding the "
-                "maximum. Setting to %s from %s."
-                % (chunksize, current_chunksize)
+                f"maximum. Setting to {chunksize} from {current_chunksize}."
             )
 
         return chunksize

--- a/awscli/schema.py
+++ b/awscli/schema.py
@@ -170,4 +170,4 @@ class ShapeNameGenerator:
     def new_shape_name(self, type_name):
         self._name_cache[type_name] += 1
         current_index = self._name_cache[type_name]
-        return '%sType%s' % (type_name.capitalize(), current_index)
+        return f'{type_name.capitalize()}Type{current_index}'

--- a/awscli/shorthand.py
+++ b/awscli/shorthand.py
@@ -78,7 +78,7 @@ class ShorthandParseError(Exception):
             next_newline = self.index + self.value[self.index :].index('\n')
             consumed = self.value[:next_newline]
             remaining = self.value[next_newline:]
-        return '%s\n%s%s' % (consumed, (' ' * num_spaces) + '^', remaining)
+        return '{}\n{}{}'.format(consumed, (' ' * num_spaces) + '^', remaining)
 
 
 class ShorthandParseSyntaxError(ShorthandParseError):
@@ -91,11 +91,7 @@ class ShorthandParseSyntaxError(ShorthandParseError):
         super(ShorthandParseSyntaxError, self).__init__(msg)
 
     def _construct_msg(self):
-        msg = ("Expected: '%s', received: '%s' for input:\n %s") % (
-            self.expected,
-            self.actual,
-            self._error_location(),
-        )
+        msg = f"Expected: '{self.expected}', received: '{self.actual}' for input:\n {self._error_location()}"
         return msg
 
 
@@ -109,10 +105,10 @@ class DuplicateKeyInObjectError(ShorthandParseError):
 
     def _construct_msg(self):
         msg = (
-            "Second instance of key \"%s\" encountered for input:\n%s\n"
+            f"Second instance of key \"{self.key}\" encountered for input:\n{self._error_location()}\n"
             "This is often because there is a preceding \",\" instead of a "
             "space."
-        ) % (self.key, self._error_location())
+        )
         return msg
 
 
@@ -347,7 +343,7 @@ class ShorthandParser:
     def _consume_quoted(self, regex, escaped_char=None):
         value = self._must_consume_regex(regex)[1:-1]
         if escaped_char is not None:
-            value = value.replace("\\%s" % escaped_char, escaped_char)
+            value = value.replace(f"\\{escaped_char}", escaped_char)
             value = value.replace("\\\\", "\\")
         return value
 
@@ -399,7 +395,7 @@ class ShorthandParser:
         if result is not None:
             return self._consume_matched_regex(result)
         raise ShorthandParseSyntaxError(
-            self._input_value, '<%s>' % regex.name, '<none>', self._index
+            self._input_value, f'<{regex.name}>', '<none>', self._index
         )
 
     def _consume_matched_regex(self, result):
@@ -432,9 +428,7 @@ class ModelVisitor:
         self._visit({}, model, '', params)
 
     def _visit(self, parent, shape, name, value):
-        method = getattr(
-            self, '_visit_%s' % shape.type_name, self._visit_scalar
-        )
+        method = getattr(self, f'_visit_{shape.type_name}', self._visit_scalar)
         method(parent, shape, name, value)
 
     def _visit_structure(self, parent, shape, name, value):
@@ -480,7 +474,7 @@ class BackCompatVisitor(ModelVisitor):
                 raise ShorthandParseError(
                     'Shorthand syntax does not support document types. Use '
                     'JSON input for top-level argument to specify nested '
-                    'parameter: %s' % member_name
+                    f'parameter: {member_name}'
                 )
 
     def _visit_list(self, parent, shape, name, value):

--- a/awscli/table.py
+++ b/awscli/table.py
@@ -390,10 +390,7 @@ class Section:
         self._max_widths = []
 
     def __repr__(self):
-        return (
-            "Section(title=%s, headers=%s, indent_level=%s, num_rows=%s)"
-            % (self.title, self.headers, self.indent_level, len(self.rows))
-        )
+        return f"Section(title={self.title}, headers={self.headers}, indent_level={self.indent_level}, num_rows={len(self.rows)})"
 
     def calculate_column_widths(self, padding=0, max_width=None):
         # postcondition: sum(widths) == max_width
@@ -458,8 +455,8 @@ class Section:
             self._num_cols = len(row)
         if len(row) != self._num_cols:
             raise ValueError(
-                "Row should have %s elements, instead "
-                "it has %s" % (self._num_cols, len(row))
+                f"Row should have {self._num_cols} elements, instead "
+                f"it has {len(row)}"
             )
         row = self._format_row(row)
         self.rows.append(row)

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -147,7 +147,7 @@ def temporary_file(mode):
 
     """
     temporary_directory = tempfile.mkdtemp()
-    basename = 'tmpfile-%s' % str(random_chars(8))
+    basename = f'tmpfile-{str(random_chars(8))}'
     full_filename = os.path.join(temporary_directory, basename)
     open(full_filename, 'w').close()
     try:
@@ -284,9 +284,8 @@ class BaseAWSHelpOutputTest(BaseCLIDriverTest):
     def assert_contains(self, contains):
         if contains not in self.renderer.rendered_contents:
             self.fail(
-                "The expected contents:\n%s\nwere not in the "
-                "actual rendered contents:\n%s"
-                % (contains, self.renderer.rendered_contents)
+                f"The expected contents:\n{contains}\nwere not in the "
+                f"actual rendered contents:\n{self.renderer.rendered_contents}"
             )
 
     def assert_contains_with_count(self, contains, count):
@@ -302,9 +301,8 @@ class BaseAWSHelpOutputTest(BaseCLIDriverTest):
     def assert_not_contains(self, contents):
         if contents in self.renderer.rendered_contents:
             self.fail(
-                "The contents:\n%s\nwere not suppose to be in the "
-                "actual rendered contents:\n%s"
-                % (contents, self.renderer.rendered_contents)
+                f"The contents:\n{contents}\nwere not suppose to be in the "
+                f"actual rendered contents:\n{self.renderer.rendered_contents}"
             )
 
     def assert_text_order(self, *args, **kwargs):
@@ -319,13 +317,12 @@ class BaseAWSHelpOutputTest(BaseCLIDriverTest):
         for i, index in enumerate(arg_indices[1:], 1):
             if index == -1:
                 self.fail(
-                    'The string %r was not found in the contents: %s'
-                    % (args[index], contents)
+                    f'The string {args[index]!r} was not found in the contents: {contents}'
                 )
             if index < previous:
                 self.fail(
-                    'The string %r came before %r, but was suppose to come '
-                    'after it.\n%s' % (args[i], args[i - 1], contents)
+                    f'The string {args[i]!r} came before {args[i - 1]!r}, but was suppose to come '
+                    f'after it.\n{contents}'
                 )
             previous = index
 
@@ -478,8 +475,8 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
                 self.fail(
                     "Actual params did not match expected params.\n"
                     "Expected:\n\n"
-                    "%s\n"
-                    "Actual:\n\n%s\n" % (pformat(params), pformat(last_kwargs))
+                    f"{pformat(params)}\n"
+                    f"Actual:\n\n{pformat(last_kwargs)}\n"
                 )
         return stdout, stderr, rc
 
@@ -506,8 +503,8 @@ class BaseAWSCommandParamsTest(unittest.TestCase):
         self.assertEqual(
             rc,
             expected_rc,
-            "Unexpected rc (expected: %s, actual: %s) for command: %s\n"
-            "stdout:\n%sstderr:\n%s" % (expected_rc, rc, cmd, stdout, stderr),
+            f"Unexpected rc (expected: {expected_rc}, actual: {rc}) for command: {cmd}\n"
+            f"stdout:\n{stdout}stderr:\n{stderr}",
         )
         return stdout, stderr, rc
 
@@ -560,8 +557,8 @@ class BaseCLIWireResponseTest(unittest.TestCase):
         self.assertEqual(
             rc,
             expected_rc,
-            "Unexpected rc (expected: %s, actual: %s) for command: %s\n"
-            "stdout:\n%sstderr:\n%s" % (expected_rc, rc, cmd, stdout, stderr),
+            f"Unexpected rc (expected: {expected_rc}, actual: {rc}) for command: {cmd}\n"
+            f"stdout:\n{stdout}stderr:\n{stderr}",
         )
         return stdout, stderr, rc
 
@@ -710,8 +707,8 @@ def aws(
     if 'AWS_TEST_COMMAND' in os.environ:
         aws_command = os.environ['AWS_TEST_COMMAND']
     else:
-        aws_command = 'python %s' % get_aws_cmd()
-    full_command = '%s %s' % (aws_command, command)
+        aws_command = f'python {get_aws_cmd()}'
+    full_command = f'{aws_command} {command}'
     stdout_encoding = get_stdout_encoding()
     INTEG_LOG.debug("Running command: %s", full_command)
     env = os.environ.copy()
@@ -762,8 +759,7 @@ def _wait_and_collect_mem(process):
         get_memory = _get_memory_with_ps
     else:
         raise ValueError(
-            "Can't collect memory for process on platform %s."
-            % platform.system()
+            f"Can't collect memory for process on platform {platform.system()}."
         )
     memory = []
     while process.poll() is None:
@@ -848,8 +844,8 @@ class BaseS3CLICommand(unittest.TestCase):
         self.assertEqual(len(actual_contents), len(expected_contents))
         if actual_contents != expected_contents:
             self.fail(
-                "Contents for %s/%s do not match (but they "
-                "have the same length)" % (bucket, key)
+                f"Contents for {bucket}/{key} do not match (but they "
+                "have the same length)"
             )
 
     def delete_public_access_block(self, bucket_name):
@@ -1021,7 +1017,7 @@ class BaseS3CLICommand(unittest.TestCase):
         self.assertEqual(
             p.rc,
             0,
-            "Non zero rc (%s) received: %s" % (p.rc, p.stdout + p.stderr),
+            f"Non zero rc ({p.rc}) received: {p.stdout + p.stderr}",
         )
         self.assertNotIn("Error:", p.stderr)
         self.assertNotIn("failed:", p.stderr)
@@ -1113,4 +1109,6 @@ class ConsistencyWaiter:
 
     def _fail_message(self, attempts, successes):
         format_args = (attempts, successes)
-        return 'Failed after %s attempts, only had %s successes' % format_args
+        return 'Failed after {} attempts, only had {} successes'.format(
+            *format_args
+        )

--- a/awscli/text.py
+++ b/awscli/text.py
@@ -64,7 +64,7 @@ def _partition_list(item):
 def _format_scalar_list(elements, identifier, stream):
     if identifier is not None:
         for item in elements:
-            stream.write('%s\t%s\n' % (identifier.upper(), item))
+            stream.write(f'{identifier.upper()}\t{item}\n')
     else:
         # For a bare list, just print the contents.
         stream.write('\t'.join([str(item) for item in elements]))

--- a/awscli/topictags.py
+++ b/awscli/topictags.py
@@ -201,8 +201,7 @@ class TopicTagDB:
                 self._add_tag_to_dict(topic_name, tag, tag_values)
             else:
                 raise ValueError(
-                    "Tag %s found under topic %s is not supported."
-                    % (tag, topic_name)
+                    f"Tag {tag} found under topic {topic_name} is not supported."
                 )
 
     def _add_topic_name_to_dict(self, topic_name):
@@ -296,8 +295,8 @@ class TopicTagDB:
         if value is not None:
             if len(value) != 1:
                 raise ValueError(
-                    'Tag %s for topic %s has value %s. Expected a single '
-                    'element in list.' % (tag, topic_name, value)
+                    f'Tag {tag} for topic {topic_name} has value {value}. Expected a single '
+                    'element in list.'
                 )
             value = value[0]
         return value

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -228,7 +228,7 @@ def _split_with_quotes(value):
     try:
         parts = list(csv.reader(StringIO(value), escapechar='\\'))[0]
     except csv.Error:
-        raise ValueError("Bad csv value: %s" % value)
+        raise ValueError(f"Bad csv value: {value}")
     iter_parts = iter(parts)
     new_parts = []
     for part in iter_parts:
@@ -499,7 +499,7 @@ class ShapeWalker:
         if shape.name in stack:
             return
         stack.append(shape.name)
-        getattr(self, '_walk_%s' % shape.type_name, self._default_scalar_walk)(
+        getattr(self, f'_walk_{shape.type_name}', self._default_scalar_walk)(
             shape, visitor, stack
         )
         stack.pop()

--- a/backends/build_system/exe.py
+++ b/backends/build_system/exe.py
@@ -103,4 +103,4 @@ class ExeBuilder:
         ]
         for location in locations:
             self._utils.rmtree(location)
-            print("Deleted build directory: %s" % location)
+            print(f"Deleted build directory: {location}")

--- a/backends/build_system/utils.py
+++ b/backends/build_system/utils.py
@@ -235,19 +235,19 @@ class Utils:
         return subprocess.run(args, **kwargs)
 
     def copy_file(self, src: str, dst: str):
-        print("Copying file %s -> %s" % (src, dst))
+        print(f"Copying file {src} -> {dst}")
         shutil.copy2(src, dst)
 
     def copy_directory_contents_into(self, src: str, dst: str):
-        print("Copying contents of %s into %s" % (src, dst))
+        print(f"Copying contents of {src} into {dst}")
         shutil.copytree(src, dst, dirs_exist_ok=True)
 
     def copy_directory(self, src: str, dst: str):
-        print("Copying %s -> %s" % (src, dst))
+        print(f"Copying {src} -> {dst}")
         shutil.copytree(src, dst)
 
     def update_metadata(self, dirname, **kwargs):
-        print("Update metadata values %s" % kwargs)
+        print(f"Update metadata values {kwargs}")
         metadata_file = os.path.join(
             dirname, "awscli", "data", "metadata.json"
         )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -122,7 +122,7 @@ pygments_style = 'guzzle_sphinx_theme.GuzzleStyle'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "AWS CLI %s Command Reference" % release
+html_title = f"AWS CLI {release} Command Reference"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 # html_short_title = None

--- a/doc/source/crosslinker.py
+++ b/doc/source/crosslinker.py
@@ -73,11 +73,7 @@ class AWSCLICrossLinkGenerator:
     def _generate_cross_link(self, service_name, operation_name):
         if operation_name not in self._service_operations[service_name]:
             return self.SERVICE_BASE % service_name
-        return '%s/%s/%s.html' % (
-            self.BASE_URL,
-            service_name,
-            self._service_operations[service_name][operation_name],
-        )
+        return f'{self.BASE_URL}/{service_name}/{self._service_operations[service_name][operation_name]}.html'
 
     def _is_catchall_regex(self, parts):
         # This is the catch-all regex used as a safety net
@@ -122,9 +118,9 @@ def create_goto_links_iter(session):
         if uid is None:
             continue
         for operation_name in m.operation_names:
-            yield '/goto/{toolname}/%s/%s' % (uid, operation_name)
+            yield f'/goto/{{toolname}}/{uid}/{operation_name}'
         # We also want to yield a catch-all link for the service.
-        yield '/goto/{toolname}/%s/(.*)' % uid
+        yield f'/goto/{{toolname}}/{uid}/(.*)'
     # And a catch-all for the entire tool.
     yield '/goto/{toolname}/(.*)'
 
@@ -133,7 +129,7 @@ def create_rewrite_rule(incoming_link, redirect):
     # Given an incoming_link (/goto/aws-cli/...) and the
     # URL it should redirect to, generate the actual
     # rewrite rule.
-    return 'RewriteRule ^%s$ %s [L,R,NE]\n' % (incoming_link, redirect)
+    return f'RewriteRule ^{incoming_link}$ {redirect} [L,R,NE]\n'
 
 
 def generate_all_cross_links(session, out_file):

--- a/doc/source/htmlgen
+++ b/doc/source/htmlgen
@@ -37,7 +37,7 @@ def do_service(
     driver, ref_path, service_name, service_command, is_top_level_service=True
 ):
     if is_top_level_service:
-        print('...%s' % service_name)
+        print(f'...{service_name}')
     service_path = os.path.join(ref_path, service_name)
     if not os.path.isdir(service_path):
         os.mkdir(service_path)
@@ -68,7 +68,7 @@ def do_service(
 
 
 def do_topic(driver, topic_path, topic_help_command):
-    print('...%s' % topic_help_command.name)
+    print(f'...{topic_help_command.name}')
     file_path = os.path.join(topic_path, topic_help_command.name + '.rst')
     topic_help_command.doc.target = 'html'
     topic_help_command.renderer = FileRenderer(file_path)

--- a/scripts/ci/install
+++ b/scripts/ci/install
@@ -31,4 +31,4 @@ if os.path.isdir("dist") and os.listdir("dist"):
     shutil.rmtree("dist")
 run("python -m build")
 wheel_dist = glob.glob(os.path.join("dist", "*.whl"))[0]
-run("pip install %s" % wheel_dist)
+run(f"pip install {wheel_dist}")

--- a/scripts/ci/install-benchmark
+++ b/scripts/ci/install-benchmark
@@ -30,10 +30,10 @@ def clone_s3_transfer_repo():
     if os.path.isdir('s3transfer'):
         shutil.rmtree('s3transfer')
     check_call(
-        'git clone https://github.com/%s/s3transfer.git' % GIT_OWNER,
+        f'git clone https://github.com/{GIT_OWNER}/s3transfer.git',
         shell=True,
     )
-    check_call('cd s3transfer && git checkout %s' % PERF_BRANCH, shell=True)
+    check_call(f'cd s3transfer && git checkout {PERF_BRANCH}', shell=True)
 
 
 def pip_install_s3transfer_and_deps():
@@ -42,7 +42,7 @@ def pip_install_s3transfer_and_deps():
         'cd s3transfer && pip install -r requirements-dev.txt', shell=True
     )
     check_call('pip install "caf>=0.1.0,<1.0.0"', shell=True)
-    check_call('cd %s && pip install -e .' % REPO_ROOT, shell=True)
+    check_call(f'cd {REPO_ROOT} && pip install -e .', shell=True)
 
 
 def create_workdir():

--- a/scripts/ci/install-build-system
+++ b/scripts/ci/install-build-system
@@ -26,7 +26,7 @@ def main(sdist_path=None):
         wheel_dist = _build_sdist_and_wheel()
     else:
         wheel_dist = _build_wheel(sdist_path)
-    run("pip install %s" % wheel_dist)
+    run(f"pip install {wheel_dist}")
 
 
 def _build_wheel(sdist_path):

--- a/scripts/ci/run-benchmark
+++ b/scripts/ci/run-benchmark
@@ -70,7 +70,7 @@ def _collect_metadata():
     # This helps us make more meaningful comparison.
     metadata = {
         'python_version': platform.python_version(),
-        'os': '%s/%s' % (platform.system(), platform.release()),
+        'os': f'{platform.system()}/{platform.release()}',
     }
     _inject_package_info(awscli, metadata)
     _inject_package_info(s3transfer, metadata)
@@ -100,7 +100,7 @@ def _get_git_version(package):
         .communicate()[0]
         .strip()
     )
-    return '%s (%s)' % (git_sha, git_branch)
+    return f'{git_sha} ({git_branch})'
 
 
 def main(args):
@@ -129,18 +129,16 @@ def benchmark(bucket, results_dir, num_iterations=1):
         os.makedirs(results)
         benchmark_cp = os.path.join(perf_dir, 'benchmark-cp')
         run(
-            benchmark_cp + ' --recursive --num-iterations %s '
-            '--source %s --dest %s --result-dir %s --no-cleanup'
-            % (num_iterations, local_dir, s3_location, results)
+            benchmark_cp + f' --recursive --num-iterations {num_iterations} '
+            f'--source {local_dir} --dest {s3_location} --result-dir {results} --no-cleanup'
         )
 
         # 10k download
         results = os.path.join(results_dir, 'download-10k-small')
         os.makedirs(results)
         run(
-            benchmark_cp + ' --recursive --num-iterations %s '
-            '--source %s --dest %s --result-dir %s'
-            % (num_iterations, s3_location, local_dir, results)
+            benchmark_cp + f' --recursive --num-iterations {num_iterations} '
+            f'--source {s3_location} --dest {local_dir} --result-dir {results}'
         )
 
         # 10k rm
@@ -148,9 +146,8 @@ def benchmark(bucket, results_dir, num_iterations=1):
         os.makedirs(results)
         benchmark_rm = os.path.join(perf_dir, 'benchmark-rm')
         run(
-            benchmark_rm + ' --recursive --num-iterations %s '
-            '--target %s --result-dir %s'
-            % (num_iterations, s3_location, results)
+            benchmark_rm + f' --recursive --num-iterations {num_iterations} '
+            f'--target {s3_location} --result-dir {results}'
         )
     finally:
         # Note that the delete-10k-small benchmark restores
@@ -166,18 +163,16 @@ def benchmark(bucket, results_dir, num_iterations=1):
         results = os.path.join(results_dir, 'upload-10gb')
         os.makedirs(results)
         run(
-            benchmark_cp + ' --recursive --num-iterations %s '
-            '--source %s --dest %s --result-dir %s --no-cleanup'
-            % (num_iterations, local_dir, s3_location, results)
+            benchmark_cp + f' --recursive --num-iterations {num_iterations} '
+            f'--source {local_dir} --dest {s3_location} --result-dir {results} --no-cleanup'
         )
 
         # 10gb download
         results = os.path.join(results_dir, 'download-10gb')
         os.makedirs(results)
         run(
-            benchmark_cp + ' --recursive --num-iterations %s '
-            '--source %s --dest %s --result-dir %s'
-            % (num_iterations, s3_location, local_dir, results)
+            benchmark_cp + f' --recursive --num-iterations {num_iterations} '
+            f'--source {s3_location} --dest {local_dir} --result-dir {results}'
         )
     finally:
         # Not benchmarking a single rm call since it's just a single call

--- a/scripts/ci/upload-benchmark
+++ b/scripts/ci/upload-benchmark
@@ -17,7 +17,7 @@ DATE_FORMAT = "%Y-%m-%d-%H-%M-%S-"
 def main(args):
     source = get_latest_results_directory(args.directory)
     run_id = source.split(os.sep)[-1]
-    destination = '%s/%s' % (args.bucket, run_id)
+    destination = f'{args.bucket}/{run_id}'
     check_call(f'aws s3 cp --recursive {source} {destination}', shell=True)
 
 
@@ -38,7 +38,7 @@ def get_latest_results_directory(parent):
         if os.path.isdir(directory) and _is_result_dir_format(d):
             return directory
 
-    raise ValueError("No valid result directories found in %s" % parent)
+    raise ValueError(f"No valid result directories found in {parent}")
 
 
 def _is_result_dir_format(directory):

--- a/scripts/gen-server-completions
+++ b/scripts/gen-server-completions
@@ -47,8 +47,8 @@ def generate_completion_data(args):
         )
         to_json = _pretty_json_dump(completion_data)
         if args.only_print:
-            print("File: %s" % out_filename)
-            print("Contents:\n%s\n" % to_json)
+            print(f"File: {out_filename}")
+            print(f"Contents:\n{to_json}\n")
         else:
             _write_data_to_file(out_filename, to_json)
 

--- a/scripts/install
+++ b/scripts/install
@@ -71,7 +71,7 @@ def cd(dirname):
 
 
 def run(cmd):
-    sys.stdout.write("Running cmd: %s\n" % cmd)
+    sys.stdout.write(f"Running cmd: {cmd}\n")
     p = subprocess.Popen(
         cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
@@ -105,7 +105,7 @@ def _create_virtualenv_internal(location, working_dir):
     # On py3 we use the built in venv to create our virtualenv.
     # There's a bug with sys.executable on external virtualenv
     # that causes installation failures.
-    run('%s -m venv %s' % (sys.executable, location))
+    run(f'{sys.executable} -m venv {location}')
 
 
 def _create_virtualenv_external(location, working_dir):
@@ -121,8 +121,8 @@ def _create_virtualenv_external(location, working_dir):
         # so we can listdir()[0] it.
         with cd(os.listdir('.')[0]):
             run(
-                ('%s virtualenv.py --no-download ' '--python %s %s')
-                % (sys.executable, sys.executable, location)
+                f'{sys.executable} virtualenv.py --no-download '
+                f'--python {sys.executable} {location}'
             )
 
 
@@ -161,8 +161,7 @@ def pip_install_packages(install_dir):
 
     with cd(PACKAGES_DIR):
         run(
-            '%s install %s --find-links file://%s %s'
-            % (pip_script, INSTALL_ARGS, PACKAGES_DIR, cli_tarball)
+            f'{pip_script} install {INSTALL_ARGS} --find-links file://{PACKAGES_DIR} {cli_tarball}'
         )
 
 
@@ -176,21 +175,19 @@ def _install_setup_deps(pip_script, setup_package_dir):
         setup_package_dir, 'setuptools_scm'
     )
     run(
-        '%s install --no-binary :all: --no-cache-dir --no-index '
-        '--find-links file://%s %s'
-        % (pip_script, setup_package_dir, setuptools_scm_tarball)
+        f'{pip_script} install --no-binary :all: --no-cache-dir --no-index '
+        f'--find-links file://{setup_package_dir} {setuptools_scm_tarball}'
     )
     wheel_tarball = _get_package_tarball(setup_package_dir, 'wheel')
     run(
-        '%s install --no-binary :all: --no-cache-dir --no-index '
-        '--find-links file://%s %s'
-        % (pip_script, setup_package_dir, wheel_tarball)
+        f'{pip_script} install --no-binary :all: --no-cache-dir --no-index '
+        f'--find-links file://{setup_package_dir} {wheel_tarball}'
     )
 
 
 def create_symlink(real_location, symlink_name):
     if os.path.isfile(symlink_name):
-        print("Symlink already exists: %s" % symlink_name)
+        print(f"Symlink already exists: {symlink_name}")
         print("Removing symlink.")
         os.remove(symlink_name)
     symlink_dir_name = os.path.dirname(symlink_name)
@@ -256,9 +253,9 @@ def main():
         if opts.bin_location and create_symlink(
             real_location, opts.bin_location
         ):
-            print("You can now run: %s --version" % opts.bin_location)
+            print(f"You can now run: {opts.bin_location} --version")
         else:
-            print("You can now run: %s --version" % real_location)
+            print(f"You can now run: {real_location} --version")
     finally:
         shutil.rmtree(working_dir)
 

--- a/scripts/install_deps.py
+++ b/scripts/install_deps.py
@@ -19,8 +19,7 @@ def get_package_tarball(package_dir, package_prefix):
     )
     if len(package_filenames) == 0:
         raise InstallationError(
-            "Unable to find local package starting with %s prefix."
-            % package_prefix
+            f"Unable to find local package starting with {package_prefix} prefix."
         )
     # We only expect a single package from the downloader
     return package_filenames[0]
@@ -29,8 +28,7 @@ def get_package_tarball(package_dir, package_prefix):
 def install_local_package(package_dir, package, pip_script="pip"):
     with cd(package_dir):
         run(
-            "%s install %s --find-links file://%s %s"
-            % (pip_script, INSTALL_ARGS, package_dir, package)
+            f"{pip_script} install {INSTALL_ARGS} --find-links file://{package_dir} {package}"
         )
 
 
@@ -49,7 +47,7 @@ def pip_install_packages(package_dir):
     )
 
     # Windows can't replace a running pip.exe, so we need to work around
-    run("%s -m pip install pip==%s" % (local_python, PINNED_PIP_VERSION))
+    run(f"{local_python} -m pip install pip=={PINNED_PIP_VERSION}")
 
     # Install or update prerequisite build packages
     setup_requires_dir = os.path.join(package_dir, "setup")

--- a/scripts/installers/make-docker
+++ b/scripts/installers/make-docker
@@ -45,7 +45,7 @@ def _ensure_docker_is_available():
     except (OSError, BadRCError) as e:
         raise RuntimeError(
             'Docker must be installed to run this script. Received '
-            'following error from docker --version: %s' % e
+            f'following error from docker --version: {e}'
         )
 
 
@@ -97,7 +97,7 @@ def _docker_save(tags, output):
     if not os.path.exists(parent_dir):
         os.makedirs(parent_dir)
     run(['docker', 'save', '--output', output] + tags)
-    print('Saved image at: %s' % output)
+    print(f'Saved image at: {output}')
 
 
 def main():
@@ -107,7 +107,7 @@ def main():
         default=DEFAULT_EXE_ZIP,
         help=(
             'The name of the exe zip to build into the Docker image. By '
-            'default the exe located at: %s' % DEFAULT_EXE_ZIP
+            f'default the exe located at: {DEFAULT_EXE_ZIP}'
         ),
     )
     parser.add_argument(
@@ -115,7 +115,7 @@ def main():
         default=DEFAULT_DOCKER_OUTPUT,
         help=(
             'The name of the file to save the Docker image. By default, '
-            'this will be saved at: %s' % DEFAULT_DOCKER_OUTPUT
+            f'this will be saved at: {DEFAULT_DOCKER_OUTPUT}'
         ),
     )
     parser.add_argument(
@@ -125,7 +125,7 @@ def main():
         help=(
             'The tags to give the image. This is the value provided to the '
             '`-t` flag when running `docker build`. By default, the image '
-            'will have the tags: %s' % ''.join(DEFAULT_TAGS)
+            'will have the tags: {}'.format(''.join(DEFAULT_TAGS))
         ),
     )
     parsed_args = parser.parse_args()

--- a/scripts/installers/make-exe
+++ b/scripts/installers/make-exe
@@ -34,7 +34,7 @@ def make_exe(exe_zipfile, cleanup=True, ac_index=None):
         do_make_exe(workdir, exe_zipfile, ac_index)
         if cleanup:
             cleanup_build()
-    print('Exe build is available at: %s' % exe_zipfile)
+    print(f'Exe build is available at: {exe_zipfile}')
 
 
 def do_make_exe(workdir, exe_zipfile, ac_index):
@@ -65,22 +65,22 @@ def delete_existing_exe_build():
 
 def pyinstaller(specfile):
     aws_spec_path = os.path.join(PYINSTALLER_DIR, specfile)
-    print(run('pyinstaller %s' % (aws_spec_path), cwd=PYINSTALLER_DIR))
+    print(run(f'pyinstaller {aws_spec_path}', cwd=PYINSTALLER_DIR))
     return os.path.join(PYINSTALLER_DIR, 'dist', os.path.splitext(specfile)[0])
 
 
 def copy_directory(src, dst):
-    print('Copying %s -> %s' % (src, dst))
+    print(f'Copying {src} -> {dst}')
     shutil.copytree(src, dst)
 
 
 def copy_directory_contents_into(src, dst):
-    print('Copying contents of %s into %s' % (src, dst))
+    print(f'Copying contents of {src} into {dst}')
     copy_tree(src, dst)
 
 
 def copy_file(src, dst):
-    print('Copying file %s -> %s' % (src, dst))
+    print(f'Copying file {src} -> {dst}')
     shutil.copy2(src, dst)
 
 
@@ -91,7 +91,7 @@ def cleanup_build():
     ]
     for location in locations:
         shutil.rmtree(location)
-        print('Deleted build directory: %s' % location)
+        print(f'Deleted build directory: {location}')
 
 
 def main():
@@ -101,8 +101,8 @@ def main():
         default=os.path.join(ROOT, 'dist', DEFAULT_OUTPUT_ZIP),
         help=(
             'The name of the file to save the exe zip. By default, '
-            'this will be saved in "dist/%s" directory in the root of the '
-            'awscli.' % DEFAULT_OUTPUT_ZIP
+            f'this will be saved in "dist/{DEFAULT_OUTPUT_ZIP}" directory in the root of the '
+            'awscli.'
         ),
     )
     parser.add_argument(

--- a/scripts/installers/make-macpkg
+++ b/scripts/installers/make-macpkg
@@ -51,11 +51,10 @@ def do_make_pkg(workdir, pkg_name):
             (
                 'pkgbuild --identifier com.amazon.aws.cli2 '
                 '--root ./stage '
-                '--scripts %s '
-                '--version %s '
-                '%s'
-            )
-            % (SCRIPTS_DIR, version, TEMP_PKG_NAME),
+                f'--scripts {SCRIPTS_DIR} '
+                f'--version {version} '
+                f'{TEMP_PKG_NAME}'
+            ),
             cwd=workdir,
         )
     )
@@ -65,8 +64,9 @@ def do_make_pkg(workdir, pkg_name):
         )
         print(
             run(
-                ('productbuild --distribution %s --resources %s %s')
-                % (DISTRIBUTION_PATH, formatted_resource_dir, PKG_NAME),
+                (
+                    f'productbuild --distribution {DISTRIBUTION_PATH} --resources {formatted_resource_dir} {PKG_NAME}'
+                ),
                 cwd=workdir,
             )
         )
@@ -76,7 +76,7 @@ def do_make_pkg(workdir, pkg_name):
 def get_version(output_dir):
     exe_dir = os.path.join(output_dir, 'stage', 'aws-cli')
     exe_path = os.path.join(exe_dir, EXE_NAME)
-    result = run('%s --version' % exe_path, cwd=exe_dir).strip()
+    result = run(f'{exe_path} --version', cwd=exe_dir).strip()
     version = result.split(' ')[0].split('/')[1]
     return version
 
@@ -107,7 +107,7 @@ def main():
         default=os.path.join(ROOT, 'dist', PKG_NAME),
         help=(
             'The output PKG name. By default, this will be '
-            '"dist/%s" in the root of the awscli.' % PKG_NAME
+            f'"dist/{PKG_NAME}" in the root of the awscli.'
         ),
     )
     parser.add_argument(
@@ -115,7 +115,7 @@ def main():
         default=os.path.join(ROOT, 'dist', EXE_ZIP_NAME),
         help=(
             'The exe used to build the PKG. By default, this will be the'
-            '"dist/%s" zipfile in the root of the awscli.' % EXE_ZIP_NAME
+            f'"dist/{EXE_ZIP_NAME}" zipfile in the root of the awscli.'
         ),
     )
     args = parser.parse_args()

--- a/scripts/installers/sign-exe
+++ b/scripts/installers/sign-exe
@@ -33,7 +33,7 @@ def _sign_exe_zip(exe_zipfile, signature_filename, key_name):
     if key_name:
         options.extend(['--local-user', key_name])
     options = ' '.join(options)
-    run('gpg ' + options + ' --detach-sign %s' % exe_zipfile)
+    run('gpg ' + options + f' --detach-sign {exe_zipfile}')
 
 
 def main():
@@ -43,7 +43,7 @@ def main():
         default=os.path.join(ROOT, 'dist', SIGNATURE_FILENAME),
         help=(
             'The output signature file. By default, this will be '
-            '"dist/%s" in the root of the awscli.' % SIGNATURE_FILENAME
+            f'"dist/{SIGNATURE_FILENAME}" in the root of the awscli.'
         ),
     )
     parser.add_argument(
@@ -51,7 +51,7 @@ def main():
         default=os.path.join(ROOT, 'dist', EXE_ZIP_NAME),
         help=(
             'The exe zip to sign. By default, this will be the'
-            '"dist/%s" zipfile in the root of the awscli.' % EXE_ZIP_NAME
+            f'"dist/{EXE_ZIP_NAME}" zipfile in the root of the awscli.'
         ),
     )
     parser.add_argument(

--- a/scripts/installers/test-installer
+++ b/scripts/installers/test-installer
@@ -49,9 +49,9 @@ class InstallerTester:
         env = os.environ.copy()
         aws_cmd = self.get_aws_cmd()
         self._assert_aws_cmd(aws_cmd)
-        sys.stdout.write('Setting test command to "%s"\n' % aws_cmd)
+        sys.stdout.write(f'Setting test command to "{aws_cmd}"\n')
         env['AWS_TEST_COMMAND'] = aws_cmd
-        run('nosetests -v -s %s' % SMOKE_TEST_PATH, env=env)
+        run(f'nosetests -v -s {SMOKE_TEST_PATH}', env=env)
         return 0
 
     def cleanup(self):
@@ -60,7 +60,7 @@ class InstallerTester:
     def _assert_aws_cmd(self, aws_cmd):
         # Do a quick --version check to make sure we can execute
         # the provided command
-        run('%s --version' % aws_cmd)
+        run(f'{aws_cmd} --version')
 
 
 class ExeTester(InstallerTester):
@@ -82,8 +82,7 @@ class ExeTester(InstallerTester):
             extract_zip(self._installer_location, workdir)
             install_script = os.path.join(workdir, 'aws', 'install')
             run(
-                '%s --install-dir %s --bin-dir %s'
-                % (install_script, install_dir, bin_dir)
+                f'{install_script} --install-dir {install_dir} --bin-dir {bin_dir}'
             )
 
     def cleanup(self):
@@ -100,17 +99,17 @@ class PkgTester(InstallerTester):
     _PKG_ID = 'com.amazon.aws.cli2'
 
     def get_aws_cmd(self):
-        value = run('%s %s check' % (sys.executable, UNINSTALL_MAC_PKG_PATH))
+        value = run(f'{sys.executable} {UNINSTALL_MAC_PKG_PATH} check')
         match = re.search('installed at (.+)?\n', value)
         base_path = match.group(1)
         cmd_path = os.path.join(base_path, EXE_NAME)
         return cmd_path
 
     def setup(self):
-        run('sudo installer -pkg %s -target /' % self._installer_location)
+        run(f'sudo installer -pkg {self._installer_location} -target /')
 
     def cleanup(self):
-        run('sudo %s %s uninstall' % (sys.executable, UNINSTALL_MAC_PKG_PATH))
+        run(f'sudo {sys.executable} {UNINSTALL_MAC_PKG_PATH} uninstall')
 
     def __call__(self):
         assert (

--- a/scripts/installers/uninstall-mac-pkg
+++ b/scripts/installers/uninstall-mac-pkg
@@ -43,21 +43,21 @@ def uninstall():
     # Finally we forget the package receipt.
     _forget()
 
-    print('Successfully uninstalled AWS CLI from %s' % root_dir)
+    print(f'Successfully uninstalled AWS CLI from {root_dir}')
     return 0
 
 
 def _get_root_dir():
-    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False)
+    lines = run(f'pkgutil --pkg-info {_PKG_ID} /', echo=False)
     output = _PKGUTIL_PATTERN.search(lines)
     path = os.path.join(output.group('volume'), output.group('location'))
     return path
 
 
 def _get_file_list(root):
-    lines = run(
-        'pkgutil --only-files --files %s /' % _PKG_ID, echo=False
-    ).split('\n')
+    lines = run(f'pkgutil --only-files --files {_PKG_ID} /', echo=False).split(
+        '\n'
+    )
     pkg_file_list = [os.path.join(root, line) for line in lines if line]
     extra_files = _read_install_metadata(root)
     return pkg_file_list + extra_files
@@ -77,9 +77,9 @@ def _read_install_metadata(root):
 
 
 def _get_dir_list(root):
-    lines = run(
-        'pkgutil --only-dirs --files %s /' % _PKG_ID, echo=False
-    ).split('\n')
+    lines = run(f'pkgutil --only-dirs --files {_PKG_ID} /', echo=False).split(
+        '\n'
+    )
     # Longer directory names are listed first to force them to come before
     # their parent directories. This ensures that child directories are
     # deleted before their parents.
@@ -105,24 +105,26 @@ def _forget():
     # Forget is the pkgutil command to delete the pkg installer receipt.
     # Once the files have been deleted, the pkgutil command will continue to
     # report that they are installed until the pkg id has been forgotten.
-    run('pkgutil --forget %s' % _PKG_ID, echo=False)
+    run(f'pkgutil --forget {_PKG_ID}', echo=False)
 
 
 def check():
     assert _is_installed(), 'Could not find AWS CLI installation.'
 
-    lines = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False)
+    lines = run(f'pkgutil --pkg-info {_PKG_ID} /', echo=False)
     output = _PKGUTIL_PATTERN.search(lines)
     root = os.path.join(output.group('volume'), output.group('location'))
     print(
-        'Found AWS CLI version %s installed at %s'
-        % (output.group('version'), root)
+        'Found AWS CLI version {} installed at {}'.format(
+            output.group('version'), root
+        )
     )
     print(
-        'Installed on %s'
-        % datetime.fromtimestamp(int(output.group('install_time')))
+        'Installed on {}'.format(
+            datetime.fromtimestamp(int(output.group('install_time')))
+        )
     )
-    command = 'sudo %s uninstall' % os.path.abspath(__file__)
+    command = f'sudo {os.path.abspath(__file__)} uninstall'
     print('To uninstall run the command:')
     print(command)
     return 0
@@ -130,7 +132,7 @@ def check():
 
 def _is_installed():
     try:
-        result = run('pkgutil --pkg-info %s /' % _PKG_ID, echo=False)
+        result = run(f'pkgutil --pkg-info {_PKG_ID} /', echo=False)
     except BadRCError:
         return False
     return True

--- a/scripts/make-bundle
+++ b/scripts/make-bundle
@@ -56,16 +56,14 @@ def cd(dirname):
 
 
 def run(cmd):
-    sys.stdout.write("Running cmd: %s\n" % cmd)
+    sys.stdout.write(f"Running cmd: {cmd}\n")
     p = subprocess.Popen(
         cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     stdout, stderr = p.communicate()
     rc = p.wait()
     if p.returncode != 0:
-        raise BadRCError(
-            "Bad rc (%s) for cmd '%s': %s" % (rc, cmd, stderr + stdout)
-        )
+        raise BadRCError(f"Bad rc ({rc}) for cmd '{cmd}': {stderr + stdout}")
     return stdout
 
 
@@ -84,8 +82,7 @@ def download_package_tarballs(dirname, packages):
     with cd(dirname):
         for package, package_version in packages:
             run(
-                '%s -m pip download %s==%s %s'
-                % (sys.executable, package, package_version, PIP_DOWNLOAD_ARGS)
+                f'{sys.executable} -m pip download {package}=={package_version} {PIP_DOWNLOAD_ARGS}'
             )
 
 
@@ -93,8 +90,7 @@ def download_cli_deps(scratch_dir):
     awscli_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     with cd(scratch_dir):
         run(
-            'pip download -c %s %s %s'
-            % (CONSTRAINTS_FILE, PIP_DOWNLOAD_ARGS, awscli_dir)
+            f'pip download -c {CONSTRAINTS_FILE} {PIP_DOWNLOAD_ARGS} {awscli_dir}'
         )
 
 
@@ -109,7 +105,7 @@ def add_cli_sdist(scratch_dir):
     if os.path.exists(os.path.join(awscli_dir, 'dist')):
         shutil.rmtree(os.path.join(awscli_dir, 'dist'))
     with cd(awscli_dir):
-        run('%s setup.py sdist' % sys.executable)
+        run(f'{sys.executable} setup.py sdist')
         filename = os.listdir('dist')[0]
         shutil.move(
             os.path.join('dist', filename), os.path.join(scratch_dir, filename)
@@ -141,12 +137,10 @@ def zip_dir(scratch_dir):
 def verify_preconditions():
     # The pip version looks like:
     # 'pip 1.4.1 from ....'
-    pip_version = (
-        run('%s -m pip --version' % sys.executable).strip().split()[1]
-    )
+    pip_version = run(f'{sys.executable} -m pip --version').strip().split()[1]
     # Virtualenv version just has the version string: '1.14.5\n'
     virtualenv_version = run(
-        '%s -m virtualenv --version' % sys.executable
+        f'{sys.executable} -m virtualenv --version'
     ).strip()
     _min_version_required('9.0.1', pip_version, 'pip')
     _min_version_required('15.1.0', virtualenv_version, 'virtualenv')
@@ -161,8 +155,8 @@ def _min_version_required(min_version, actual_version, name):
         if int(actual_version_part) >= int(min_version_part):
             return
     raise ValueError(
-        "%s requires at least version %s, but version %s was "
-        "found." % (name, min_version, actual_version)
+        f"{name} requires at least version {min_version}, but version {actual_version} was "
+        "found."
     )
 
 
@@ -170,7 +164,7 @@ def main():
     verify_preconditions()
     scratch_dir = create_scratch_dir()
     package_dir = os.path.join(scratch_dir, 'packages')
-    print("Bundle dir at: %s" % scratch_dir)
+    print(f"Bundle dir at: {scratch_dir}")
     download_package_tarballs(
         package_dir,
         packages=EXTRA_RUNTIME_DEPS,
@@ -190,7 +184,7 @@ def main():
     add_cli_sdist(package_dir)
     create_bootstrap_script(scratch_dir)
     zip_filename = zip_dir(scratch_dir)
-    print("Zipped bundle installer is at: %s" % zip_filename)
+    print(f"Zipped bundle installer is at: {zip_filename}")
 
 
 if __name__ == '__main__':

--- a/scripts/new-change
+++ b/scripts/new-change
@@ -120,7 +120,7 @@ def get_values_from_editor(args):
         f.flush()
         env = os.environ
         editor = env.get('VISUAL', env.get('EDITOR', 'vim'))
-        p = subprocess.Popen('%s %s' % (editor, f.name), shell=True)
+        p = subprocess.Popen(f'{editor} {f.name}', shell=True)
         p.communicate()
         with open(f.name) as f:
             filled_in_contents = f.read()
@@ -133,11 +133,7 @@ def replace_issue_references(parsed, repo_name):
 
     def linkify(match):
         number = match.group()[1:]
-        return '`%s <https://github.com/%s/issues/%s>`__' % (
-            match.group(),
-            repo_name,
-            number,
-        )
+        return f'`{match.group()} <https://github.com/{repo_name}/issues/{number}>`__'
 
     new_description = re.sub('#\d+', linkify, description)
     parsed['description'] = new_description
@@ -158,11 +154,11 @@ def write_new_change(parsed_values):
         type_name=parsed_values['type'], summary=short_summary
     )
     possible_filename = os.path.join(
-        dirname, '%s-%s.json' % (filename, str(random.randint(1, 100000)))
+        dirname, f'{filename}-{str(random.randint(1, 100000))}.json'
     )
     while os.path.isfile(possible_filename):
         possible_filename = os.path.join(
-            dirname, '%s-%s.json' % (filename, str(random.randint(1, 100000)))
+            dirname, f'{filename}-{str(random.randint(1, 100000))}.json'
         )
     with open(possible_filename, 'w') as f:
         f.write(json.dumps(parsed_values, indent=2) + "\n")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -16,7 +16,7 @@ class BadRCError(Exception):
 
 def run(cmd, cwd=None, env=None, echo=True):
     if echo:
-        sys.stdout.write("Running cmd: %s\n" % cmd)
+        sys.stdout.write(f"Running cmd: {cmd}\n")
     kwargs = {
         'shell': True,
         'stdout': subprocess.PIPE,
@@ -32,9 +32,7 @@ def run(cmd, cwd=None, env=None, echo=True):
     stdout, stderr = p.communicate()
     output = stdout.decode('utf-8') + stderr.decode('utf-8')
     if p.returncode != 0:
-        raise BadRCError(
-            "Bad rc (%s) for cmd '%s': %s" % (p.returncode, cmd, output)
-        )
+        raise BadRCError(f"Bad rc ({p.returncode}) for cmd '{cmd}': {output}")
     return output
 
 
@@ -85,7 +83,7 @@ def virtualenv_enabled():
 
 
 def update_metadata(dirname, **kwargs):
-    print('Update metadata values %s' % kwargs)
+    print(f'Update metadata values {kwargs}')
     metadata_file = os.path.join(dirname, 'awscli', 'data', 'metadata.json')
     with open(metadata_file) as f:
         metadata = json.load(f)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -182,8 +182,7 @@ class SessionStubber:
     def assert_no_remaining_responses(self):
         if len(self._responses) != 0:
             raise AssertionError(
-                "The following queued responses are remaining: %s"
-                % self._responses
+                f"The following queued responses are remaining: {self._responses}"
             )
 
     def _capture_aws_request(self, params, model, context, **kwargs):
@@ -234,9 +233,8 @@ class AWSResponse(BaseResponse):
 
     def __repr__(self):
         return (
-            'AWSResponse(service_name=%r, operation_name=%r, '
-            'parsed_response=%r)'
-            % (self._service_name, self._operation_name, self._parsed_response)
+            f'AWSResponse(service_name={self._service_name!r}, operation_name={self._operation_name!r}, '
+            f'parsed_response={self._parsed_response!r})'
         )
 
     def _get_service_model(self):
@@ -313,11 +311,7 @@ class AWSRequest:
         self.http_requests = []
 
     def __repr__(self):
-        return 'AWSRequest(service_name=%r, operation_name=%r, params=%r)' % (
-            self.service_name,
-            self.operation_name,
-            self.params,
-        )
+        return f'AWSRequest(service_name={self.service_name!r}, operation_name={self.operation_name!r}, params={self.params!r})'
 
     def __eq__(self, other):
         return (
@@ -338,12 +332,7 @@ class HTTPRequest:
         self.body = body
 
     def __repr__(self):
-        return 'HTTPRequest(method=%r, url=%r, headers=%r, body=%r)' % (
-            self.method,
-            self.url,
-            self.headers,
-            self.body,
-        )
+        return f'HTTPRequest(method={self.method!r}, url={self.url!r}, headers={self.headers!r}, body={self.body!r})'
 
     def __eq__(self, other):
         return (

--- a/tests/functional/awslambda/test_function.py
+++ b/tests/functional/awslambda/test_function.py
@@ -40,7 +40,7 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline = self.prefix
         cmdline += ' --function-name myfunction --runtime myruntime'
         cmdline += ' --role myrole --handler myhandler'
-        cmdline += ' --zip-file fileb://%s' % self.zip_file
+        cmdline += f' --zip-file fileb://{self.zip_file}'
         result = {
             'FunctionName': 'myfunction',
             'Runtime': 'myruntime',
@@ -73,7 +73,7 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline += ' --function-name myfunction --runtime myruntime'
         cmdline += ' --role myrole --handler myhandler'
         cmdline += ' --code S3Bucket=mybucket,S3Key=mykey,S3ObjectVersion=vs'
-        cmdline += ' --zip-file fileb://%s' % self.zip_file
+        cmdline += f' --zip-file fileb://{self.zip_file}'
         result = {
             'FunctionName': 'myfunction',
             'Runtime': 'myruntime',
@@ -114,7 +114,7 @@ class TestCreateFunction(BaseLambdaTests):
         cmdline += ' --function-name myfunction --runtime myruntime'
         cmdline += ' --role myrole --handler myhandler'
         # Note file:// instead of fileb://
-        cmdline += ' --zip-file file://%s' % self.zip_file
+        cmdline += f' --zip-file file://{self.zip_file}'
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         # Ensure we mention fileb:// to give the user an idea of
         # where to go next.
@@ -127,7 +127,7 @@ class TestPublishLayerVersion(BaseLambdaTests):
     def test_publish_layer_version_with_file(self):
         cmdline = self.prefix
         cmdline += ' --layer-name mylayer'
-        cmdline += ' --zip-file fileb://%s' % self.zip_file
+        cmdline += f' --zip-file fileb://{self.zip_file}'
         result = {
             'LayerName': 'mylayer',
             'Content': {'ZipFile': self.zip_file_contents},
@@ -154,7 +154,7 @@ class TestPublishLayerVersion(BaseLambdaTests):
         cmdline += ' --layer-name mylayer'
         cmdline += ' --content'
         cmdline += ' S3Bucket=mybucket,S3Key=mykey,S3ObjectVersion=vs'
-        cmdline += ' --zip-file fileb://%s' % self.zip_file
+        cmdline += f' --zip-file fileb://{self.zip_file}'
         result = {
             'LayerName': 'mylayer',
             'Content': {
@@ -190,7 +190,7 @@ class TestPublishLayerVersion(BaseLambdaTests):
         cmdline = self.prefix
         cmdline += ' --layer-name mylayer'
         # Note file:// instead of fileb://
-        cmdline += ' --zip-file file://%s' % self.zip_file
+        cmdline += f' --zip-file file://{self.zip_file}'
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         # Ensure we mention fileb:// to give the user an idea of
         # where to go next.
@@ -211,7 +211,7 @@ class TestUpdateFunctionCode(BaseLambdaTests):
     def test_using_fileb_prefix_succeeds(self):
         cmdline = self.prefix
         cmdline += ' --function-name myfunction'
-        cmdline += ' --zip-file fileb://%s' % self.zip_file
+        cmdline += f' --zip-file fileb://{self.zip_file}'
         result = {
             'FunctionName': 'myfunction',
             'ZipFile': self.zip_file_contents,

--- a/tests/functional/botocore/csm/test_monitoring.py
+++ b/tests/functional/botocore/csm/test_monitoring.py
@@ -104,7 +104,7 @@ def _configured_session(case_configuration, listener_port):
 def _setup_shared_config(fileobj, shared_config_options, environ):
     fileobj.write('[default]\n')
     for key, value in shared_config_options.items():
-        fileobj.write('%s = %s\n' % (key, value))
+        fileobj.write(f'{key} = {value}\n')
     fileobj.flush()
     environ['AWS_CONFIG_FILE'] = fileobj.name
 

--- a/tests/functional/botocore/docs/__init__.py
+++ b/tests/functional/botocore/docs/__init__.py
@@ -54,7 +54,7 @@ class BaseDocsFunctionalTest(unittest.TestCase):
 
     def get_method_document_block(self, operation_name, contents):
         contents = contents.decode('utf-8')
-        start_method_document = '  .. py:method:: %s(' % operation_name
+        start_method_document = f'  .. py:method:: {operation_name}('
         start_index = contents.find(start_method_document)
         self.assertNotEqual(start_index, -1, 'Method is not found in contents')
         contents = contents[start_index:]
@@ -66,7 +66,7 @@ class BaseDocsFunctionalTest(unittest.TestCase):
 
     def get_parameter_document_block(self, param_name, contents):
         contents = contents.decode('utf-8')
-        start_param_document = '    :type %s:' % param_name
+        start_param_document = f'    :type {param_name}:'
         start_index = contents.find(start_param_document)
         self.assertNotEqual(start_index, -1, 'Param is not found in contents')
         contents = contents[start_index:]
@@ -100,7 +100,7 @@ class BaseDocsFunctionalTest(unittest.TestCase):
 
         # Ensure it is not in the example.
         self.assert_not_contains_line(
-            '%s=\'string\'' % param_name, method_contents
+            f'{param_name}=\'string\'', method_contents
         )
 
         # Ensure it is in the params.

--- a/tests/functional/botocore/docs/test_lex.py
+++ b/tests/functional/botocore/docs/test_lex.py
@@ -21,11 +21,11 @@ class TestLexDocs(BaseDocsFunctionalTest):
         self.assert_contains_lines_in_order(
             [
                 '**Request Syntax**',
-                'sessionAttributes=%s,' % self.TYPE_STRING,
+                f'sessionAttributes={self.TYPE_STRING},',
                 ':type sessionAttributes: JSON serializable',
                 '**Response Syntax**',
-                '\'slots\': %s,' % self.TYPE_STRING,
-                '\'sessionAttributes\': %s' % self.TYPE_STRING,
+                f'\'slots\': {self.TYPE_STRING},',
+                f'\'sessionAttributes\': {self.TYPE_STRING}',
                 '**slots** (JSON serializable)',
                 '**sessionAttributes** (JSON serializable)',
             ],

--- a/tests/functional/botocore/docs/test_s3.py
+++ b/tests/functional/botocore/docs/test_s3.py
@@ -63,7 +63,7 @@ class TestS3Docs(BaseDocsFunctionalTest):
             "{'Bucket': 'string', 'Key': 'string', 'VersionId': 'string'}"
         )
         self.assert_contains_line(
-            "CopySource='string' or %s" % dict_form, content
+            f"CopySource='string' or {dict_form}", content
         )
 
     def test_copy_source_param_docs_also_modified(self):

--- a/tests/functional/botocore/test_alias.py
+++ b/tests/functional/botocore/test_alias.py
@@ -81,6 +81,8 @@ def _can_use_parameter_in_client_call(session, case, use_alias=True):
         getattr(client, operation)(**params)
     except ParamValidationError as e:
         raise AssertionError(
-            'Expecting %s to be valid parameter for %s.%s but received '
-            '%s.' % (case['new_name'], case['service'], case['operation'], e)
+            'Expecting {} to be valid parameter for {}.{} but received '
+            '{}.'.format(
+                case['new_name'], case['service'], case['operation'], e
+            )
         )

--- a/tests/functional/botocore/test_credentials.py
+++ b/tests/functional/botocore/test_credentials.py
@@ -129,9 +129,8 @@ class TestCredentialRefreshRaces(unittest.TestCase):
         max_calls_allowed = math.ceil((end - start) / 2.0) + 1
         self.assertTrue(
             creds.refresh_counter <= max_calls_allowed,
-            "Too many cred refreshes, max: %s, actual: %s, "
-            "time_delta: %.4f"
-            % (max_calls_allowed, creds.refresh_counter, (end - start)),
+            f"Too many cred refreshes, max: {max_calls_allowed}, actual: {creds.refresh_counter}, "
+            f"time_delta: {end - start:.4f}",
         )
 
     def test_no_race_for_immediate_advisory_expiration(self):
@@ -208,9 +207,9 @@ class BaseAssumeRoleTest(BaseEnvVar):
 
     def create_random_credentials(self):
         return Credentials(
-            'fake-%s' % random_chars(15),
-            'fake-%s' % random_chars(35),
-            'fake-%s' % random_chars(45),
+            f'fake-{random_chars(15)}',
+            f'fake-{random_chars(35)}',
+            f'fake-{random_chars(45)}',
             # The account_id gets resolved from the
             # Arn in create_assume_role_response().
             account_id='1234567890',
@@ -246,10 +245,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
         credential_process = os.path.join(
             current_dir, 'utils', 'credentialprocess.py'
         )
-        self.credential_process = '%s %s' % (
-            sys.executable,
-            credential_process,
-        )
+        self.credential_process = f'{sys.executable} {credential_process}'
 
     def mock_provider(self, provider_cls):
         mock_instance = mock.Mock(spec=provider_cls)
@@ -493,7 +489,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
             'role_arn = arn:aws:iam::123456789:role/RoleA\n'
             'source_profile = B\n'
             '[profile B]\n'
-            'credential_process = %s\n' % self.credential_process
+            f'credential_process = {self.credential_process}\n'
         )
         self.write_config(config)
 
@@ -526,7 +522,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
             'source_profile = B\n'
             '[profile B]\n'
             'role_arn = arn:aws:iam::123456789:role/RoleB\n'
-            'web_identity_token_file = %s\n' % token_path
+            f'web_identity_token_file = {token_path}\n'
         )
         self.write_config(config)
 
@@ -567,7 +563,7 @@ class TestAssumeRole(BaseAssumeRoleTest):
             'role_arn = arn:aws:iam::123456789:role/RoleA\n'
             'source_profile = B\n'
             '[profile B]\n'
-            'web_identity_token_file = %s\n' % token_path
+            f'web_identity_token_file = {token_path}\n'
         )
         self.write_config(config)
 
@@ -831,8 +827,8 @@ class TestAssumeRoleWithWebIdentity(BaseAssumeRoleTest):
             '[profile A]\n'
             'role_arn = arn:aws:iam::123456789:role/RoleA\n'
             'role_session_name = sname\n'
-            'web_identity_token_file = %s\n'
-        ) % self.token_file
+            f'web_identity_token_file = {self.token_file}\n'
+        )
         self.write_config(config)
         expected_params = {
             'RoleArn': 'arn:aws:iam::123456789:role/RoleA',
@@ -860,8 +856,8 @@ class TestAssumeRoleWithWebIdentity(BaseAssumeRoleTest):
             '[profile A]\n'
             'role_arn = arn:aws:iam::123456789:role/RoleA\n'
             'role_session_name = aname\n'
-            'web_identity_token_file = %s\n'
-        ) % self.token_file
+            f'web_identity_token_file = {self.token_file}\n'
+        )
         self.write_config(config)
 
         different_token = os.path.join(self.tempdir, str(uuid.uuid4()))
@@ -884,10 +880,7 @@ class TestProcessProvider(unittest.TestCase):
         credential_process = os.path.join(
             current_dir, 'utils', 'credentialprocess.py'
         )
-        self.credential_process = '%s %s' % (
-            sys.executable,
-            credential_process,
-        )
+        self.credential_process = f'{sys.executable} {credential_process}'
         self.environ = os.environ.copy()
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()

--- a/tests/functional/botocore/test_discovery.py
+++ b/tests/functional/botocore/test_discovery.py
@@ -61,7 +61,7 @@ class TestEndpointDiscovery(FunctionalSessionTest):
 
     def set_endpoint_discovery_config_file(self, fileobj, config_val):
         fileobj.write(
-            '[default]\n' 'endpoint_discovery_enabled=%s\n' % config_val
+            '[default]\n' f'endpoint_discovery_enabled={config_val}\n'
         )
         fileobj.flush()
         self.environ['AWS_CONFIG_FILE'] = fileobj.name

--- a/tests/functional/botocore/test_h2_required.py
+++ b/tests/functional/botocore/test_h2_required.py
@@ -53,7 +53,7 @@ H2_SERVICES, H2_OPERATIONS = _all_test_cases()
 @pytest.mark.parametrize("h2_service", H2_SERVICES)
 def test_all_uses_of_h2_are_known(h2_service):
     # Validates that a service that requires HTTP 2 for all operations is known
-    message = 'Found unknown HTTP 2 service: %s' % h2_service
+    message = f'Found unknown HTTP 2 service: {h2_service}'
     assert _KNOWN_SERVICES.get(h2_service) is _H2_REQUIRED, message
 
 
@@ -62,5 +62,5 @@ def test_all_uses_of_h2_are_known(h2_service):
 def test_all_h2_operations_are_known(h2_service, operation):
     # Validates that an operation that requires HTTP 2 is known
     known_operations = _KNOWN_SERVICES.get(h2_service, [])
-    message = 'Found unknown HTTP 2 operation: %s.%s' % (h2_service, operation)
+    message = f'Found unknown HTTP 2 operation: {h2_service}.{operation}'
     assert operation in known_operations, message

--- a/tests/functional/botocore/test_paginator_config.py
+++ b/tests/functional/botocore/test_paginator_config.py
@@ -158,8 +158,7 @@ def _validate_known_pagination_keys(page_config):
     for key in page_config:
         if key not in KNOWN_PAGE_KEYS:
             raise AssertionError(
-                "Unknown key '%s' in pagination config: %s"
-                % (key, page_config)
+                f"Unknown key '{key}' in pagination config: {page_config}"
             )
 
 
@@ -167,7 +166,7 @@ def _valiate_result_key_exists(page_config):
     if 'result_key' not in page_config:
         raise AssertionError(
             "Required key 'result_key' is missing "
-            "from pagination config: %s" % page_config
+            f"from pagination config: {page_config}"
         )
 
 
@@ -175,7 +174,7 @@ def _validate_referenced_operation_exists(operation_name, service_model):
     if operation_name not in service_model.operation_names:
         raise AssertionError(
             "Pagination config refers to operation that "
-            "does not exist: %s" % operation_name
+            f"does not exist: {operation_name}"
         )
 
 
@@ -185,7 +184,7 @@ def _validate_operation_has_output(operation_name, service_model):
     if output is None or not output.members:
         raise AssertionError(
             "Pagination config refers to operation "
-            "that does not have any output: %s" % operation_name
+            f"that does not have any output: {operation_name}"
         )
 
 
@@ -199,17 +198,16 @@ def _validate_input_keys_match(operation_name, page_config, service_model):
     for token in input_tokens:
         if token not in valid_input_names:
             raise AssertionError(
-                "input_token '%s' refers to a non existent "
-                "input member for operation: %s" % (token, operation_name)
+                f"input_token '{token}' refers to a non existent "
+                f"input member for operation: {operation_name}"
             )
     if 'limit_key' in page_config:
         limit_key = page_config['limit_key']
         if limit_key not in valid_input_names:
             raise AssertionError(
-                "limit_key '%s' refers to a non existent "
-                "input member for operation: %s, valid keys: "
-                "%s"
-                % (
+                "limit_key '{}' refers to a non existent "
+                "input member for operation: {}, valid keys: "
+                "{}".format(
                     limit_key,
                     operation_name,
                     ', '.join(list(valid_input_names)),
@@ -233,30 +231,25 @@ def _validate_output_keys_match(operation_name, page_config, service_model):
         else:
             if output_key not in output_members:
                 raise AssertionError(
-                    "Pagination key '%s' refers to an output "
-                    "member that does not exist: %s" % (key_name, output_key)
+                    f"Pagination key '{key_name}' refers to an output "
+                    f"member that does not exist: {output_key}"
                 )
             output_members.remove(output_key)
 
     for member in list(output_members):
-        key = "%s.%s.%s" % (service_model.service_name, operation_name, member)
+        key = f"{service_model.service_name}.{operation_name}.{member}"
         if key in KNOWN_EXTRA_OUTPUT_KEYS:
             output_members.remove(member)
 
     if output_members:
         for member in output_members:
-            key = "%s.%s.%s" % (
-                service_model.service_name,
-                operation_name,
-                member,
-            )
+            key = f"{service_model.service_name}.{operation_name}.{member}"
             with open('/tmp/blah', 'a') as f:
-                f.write("'%s',\n" % key)
+                f.write(f"'{key}',\n")
         raise AssertionError(
             "There are member names in the output shape of "
-            "%s that are not accounted for in the pagination "
-            "config for service %s: %s"
-            % (
+            "{} that are not accounted for in the pagination "
+            "config for service {}: {}".format(
                 operation_name,
                 service_model.service_name,
                 ', '.join(output_members),
@@ -276,7 +269,7 @@ def _validate_jmespath_compiles(expression):
     except JMESPathError as e:
         raise AssertionError(
             "Invalid JMESPath expression used "
-            "in pagination config: %s\nerror: %s" % (expression, e)
+            f"in pagination config: {expression}\nerror: {e}"
         )
 
 

--- a/tests/functional/botocore/test_regions.py
+++ b/tests/functional/botocore/test_regions.py
@@ -451,7 +451,7 @@ def test_single_service_region_endpoint(
     result = bridge.resolve(service_name, region_name)
     scheme = urlparse(expected_endpoint).scheme
     if not scheme:
-        expected_endpoint = 'https://%s' % expected_endpoint
+        expected_endpoint = f'https://{expected_endpoint}'
     assert result['endpoint_url'] == expected_endpoint
 
 

--- a/tests/functional/botocore/test_retry.py
+++ b/tests/functional/botocore/test_retry.py
@@ -41,7 +41,7 @@ class TestRetry(BaseSessionTest):
             for _ in range(num_responses):
                 http_stubber.add_response(status=status, body=body)
             with self.assertRaisesRegex(
-                ClientError, 'reached max retries: %s' % num_retries
+                ClientError, f'reached max retries: {num_retries}'
             ):
                 yield
             self.assertEqual(len(http_stubber.requests), num_responses)

--- a/tests/functional/botocore/test_s3.py
+++ b/tests/functional/botocore/test_s3.py
@@ -1346,7 +1346,7 @@ class TestWriteGetObjectResponse(BaseS3ClientConfigurationTest):
             self.assert_signing_region(request, region)
             expected_endpoint = (
                 'endpoint-io.a1c1d5c7.s3-object-lambda.'
-                '%s.amazonaws.com' % region
+                f'{region}.amazonaws.com'
             )
             self.assert_endpoint(request, expected_endpoint)
 
@@ -3476,7 +3476,7 @@ def _verify_presigned_url_addressing(
     # We're not trying to verify the params for URL presigning,
     # those are tested elsewhere.  We just care about the hostname/path.
     parts = urlsplit(url)
-    actual = '%s://%s%s' % parts[:3]
+    actual = '{}://{}{}'.format(*parts[:3])
     assert actual == expected_url
 
 

--- a/tests/functional/botocore/test_s3_control_redirects.py
+++ b/tests/functional/botocore/test_s3_control_redirects.py
@@ -376,12 +376,9 @@ def _assert_test_case(test_case, client, stubber):
         exception_cls = getattr(exceptions, assertions['exception'])
         if exception_raised is None:
             raise RuntimeError(
-                'Expected exception "%s" was not raised' % exception_cls
+                f'Expected exception "{exception_cls}" was not raised'
             )
-        error_msg = ('Expected exception "%s", got "%s"') % (
-            exception_cls,
-            type(exception_raised),
-        )
+        error_msg = f'Expected exception "{exception_cls}", got "{type(exception_raised)}"'
         assert isinstance(exception_raised, exception_cls), error_msg
     else:
         assert len(stubber.requests) == 1

--- a/tests/functional/botocore/test_six_imports.py
+++ b/tests/functional/botocore/test_six_imports.py
@@ -35,20 +35,18 @@ class SixImportChecker(ast.NodeVisitor):
             if getattr(alias, 'name', '') == 'six':
                 line = self._get_line_content(self.filename, node.lineno)
                 raise AssertionError(
-                    "A bare 'import six' was found in %s:\n"
-                    "\n%s: %s\n"
+                    f"A bare 'import six' was found in {self.filename}:\n"
+                    f"\n{node.lineno}: {line}\n"
                     "Please use 'from botocore.compat import six' instead"
-                    % (self.filename, node.lineno, line)
                 )
 
     def visit_ImportFrom(self, node):
         if node.module == 'six':
             line = self._get_line_content(self.filename, node.lineno)
             raise AssertionError(
-                "A bare 'from six import ...' was found in %s:\n"
-                "\n%s:%s\n"
+                f"A bare 'from six import ...' was found in {self.filename}:\n"
+                f"\n{node.lineno}:{line}\n"
                 "Please use 'from botocore.compat import six' instead"
-                % (self.filename, node.lineno, line)
             )
 
     def _get_line_content(self, filename, lineno):

--- a/tests/functional/botocore/test_sts.py
+++ b/tests/functional/botocore/test_sts.py
@@ -62,7 +62,7 @@ class TestSTSEndpoints(BaseSessionTest):
         )
 
     def set_sts_regional_for_config_file(self, fileobj, config_val):
-        fileobj.write('[default]\n' 'sts_regional_endpoints=%s\n' % config_val)
+        fileobj.write('[default]\n' f'sts_regional_endpoints={config_val}\n')
         fileobj.flush()
         self.environ['AWS_CONFIG_FILE'] = fileobj.name
 

--- a/tests/functional/botocore/test_waiter_config.py
+++ b/tests/functional/botocore/test_waiter_config.py
@@ -113,30 +113,25 @@ def _lint_single_waiter(client, waiter_name, service_model):
         # * matcher has a known value
         acceptors = waiter.config.acceptors
     except Exception as e:
-        raise AssertionError(
-            "Could not create waiter '%s': %s" % (waiter_name, e)
-        )
+        raise AssertionError(f"Could not create waiter '{waiter_name}': {e}")
     operation_name = waiter.config.operation
     # Needs to reference an existing operation name.
     if operation_name not in service_model.operation_names:
         raise AssertionError(
-            "Waiter config references unknown "
-            "operation: %s" % operation_name
+            "Waiter config references unknown " f"operation: {operation_name}"
         )
     # Needs to have at least one acceptor.
     if not waiter.config.acceptors:
         raise AssertionError(
             "Waiter config must have at least "
-            "one acceptor state: %s" % waiter.name
+            f"one acceptor state: {waiter.name}"
         )
     op_model = service_model.operation_model(operation_name)
     for acceptor in acceptors:
         _validate_acceptor(acceptor, op_model, waiter.name)
 
     if not waiter.name.isalnum():
-        raise AssertionError(
-            "Waiter name %s is not alphanumeric." % waiter_name
-        )
+        raise AssertionError(f"Waiter name {waiter_name} is not alphanumeric.")
 
 
 def _validate_schema(validator, waiter_json):
@@ -151,10 +146,9 @@ def _validate_acceptor(acceptor, op_model, waiter_name):
         # The JMESPath expression should have the potential to match something
         # in the response shape.
         output_shape = op_model.output_shape
-        assert output_shape is not None, (
-            "Waiter '%s' has JMESPath expression with no output shape: %s"
-            % (waiter_name, op_model)
-        )
+        assert (
+            output_shape is not None
+        ), f"Waiter '{waiter_name}' has JMESPath expression with no output shape: {op_model}"
         # We want to check if the JMESPath expression makes sense.
         # To do this, we'll generate sample output and evaluate the
         # JMESPath expression against the output.  We'll then
@@ -163,13 +157,12 @@ def _validate_acceptor(acceptor, op_model, waiter_name):
         if search_result is None:
             raise AssertionError(
                 "JMESPath expression did not match "
-                "anything for waiter '%s': %s" % (waiter_name, expression)
+                f"anything for waiter '{waiter_name}': {expression}"
             )
         if acceptor.matcher in ['pathAll', 'pathAny']:
             assert isinstance(search_result, list), (
-                "Attempted to use '%s' matcher in waiter '%s' "
-                "with non list result in JMESPath expression: %s"
-                % (acceptor.matcher, waiter_name, expression)
+                f"Attempted to use '{acceptor.matcher}' matcher in waiter '{waiter_name}' "
+                f"with non list result in JMESPath expression: {expression}"
             )
 
 

--- a/tests/functional/cloudformation/test_deploy.py
+++ b/tests/functional/cloudformation/test_deploy.py
@@ -47,8 +47,9 @@ class TestDeployCommand(BaseAWSCommandParamsTest):
         # needs to have valid JSON content.
         path = self.files.create_file('template.json', '{}')
         self.command = (
-            'cloudformation deploy --template-file %s ' '--stack-name Stack'
-        ) % path
+            f'cloudformation deploy --template-file {path} '
+            '--stack-name Stack'
+        )
 
     def tearDown(self):
         self.files.remove_all()
@@ -82,8 +83,9 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
         }'''
         path = self.files.create_file('template.json', template)
         self.command = (
-            'cloudformation deploy --template-file %s ' '--stack-name Stack '
-        ) % path
+            f'cloudformation deploy --template-file {path} '
+            '--stack-name Stack '
+        )
 
     def _assert_parameters_parsed(self):
         self.assertEqual(
@@ -105,7 +107,7 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
     def test_parameter_overrides_from_inline_original_json(self):
         original_like_json = ['Key1=Value1', 'Key2=Value2']
         path = self.create_json_file('param.json', original_like_json)
-        self.command += ' --parameter-overrides file://%s' % path
+        self.command += f' --parameter-overrides file://{path}'
         self.run_cmd(self.command)
         self._assert_parameters_parsed()
 
@@ -116,7 +118,7 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
             '{"ParameterKey":"Key2",'
             '"ParameterValue":"Value2"}]'
         )
-        self.command += ' --parameter-overrides %s' % cf_like_json
+        self.command += f' --parameter-overrides {cf_like_json}'
         self.run_cmd(self.command)
         self._assert_parameters_parsed()
 
@@ -126,7 +128,7 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
             {'ParameterKey': 'Key2', 'ParameterValue': 'Value2'},
         ]
         path = self.create_json_file('param.json', cf_like_json)
-        self.command += ' --parameter-overrides file://%s' % path
+        self.command += f' --parameter-overrides file://{path}'
         self.run_cmd(self.command)
         self._assert_parameters_parsed()
 
@@ -134,7 +136,7 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
         codepipeline_like_json = (
             '{"Parameters":{"Key1":"Value1",' '"Key2":"Value2"}}'
         )
-        self.command += ' --parameter-overrides %s' % codepipeline_like_json
+        self.command += f' --parameter-overrides {codepipeline_like_json}'
         self.run_cmd(self.command)
         self._assert_parameters_parsed()
 
@@ -143,14 +145,14 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
             'Parameters': {'Key1': 'Value1', 'Key2': 'Value2'}
         }
         path = self.create_json_file('param.json', codepipeline_like_json)
-        self.command += ' --parameter-overrides file://%s' % path
+        self.command += f' --parameter-overrides file://{path}'
         self.run_cmd(self.command)
         self._assert_parameters_parsed()
 
     def test_parameter_overrides_from_original_json_file(self):
         original_like_json = ['Key1=Value1', 'Key2=Value2']
         path = self.create_json_file('param.json', original_like_json)
-        self.command += ' --parameter-overrides file://%s' % path
+        self.command += f' --parameter-overrides file://{path}'
         self.run_cmd(self.command, expected_rc=0)
         self._assert_parameters_parsed()
 
@@ -164,13 +166,13 @@ class TestDeployCommandParameterOverrides(TestDeployCommand):
             {'ParameterKey': 'Key2', 'ParameterValue': 'Value2'},
         ]
         path = self.create_json_file('param.json', invalid_cf_like_json)
-        self.command += ' --parameter-overrides file://%s' % path
+        self.command += f' --parameter-overrides file://{path}'
         _, err, _ = self.run_cmd(self.command, expected_rc=252)
         self.assertTrue('JSON passed to --parameter-overrides must be' in err)
 
     def test_parameter_overrides_from_invalid_json(self):
         cf_like_json = {'SomeKey': [{'RedundantKey': 'RedundantValue'}]}
         path = self.create_json_file('param.json', cf_like_json)
-        self.command += ' --parameter-overrides file://%s' % path
+        self.command += f' --parameter-overrides file://{path}'
         _, err, _ = self.run_cmd(self.command, expected_rc=252)
         self.assertTrue('JSON passed to --parameter-overrides must be' in err)

--- a/tests/functional/cloudformation/test_package.py
+++ b/tests/functional/cloudformation/test_package.py
@@ -95,7 +95,7 @@ def test_known_templates(input_template, output_template):
 
     assert result == expected, (
         '\nAcutal template:\n'
-        '%s'
+        f'{result}'
         '\nDiffers from expected template:\n'
-        '%s' % (result, expected)
+        f'{expected}'
     )

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -142,14 +142,13 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time %s "
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
                 "--region us-east-1 --verbose"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            ),
             0,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tvalid' % digest_provider.digests[0],
+            f'Digest file\ts3://1/{digest_provider.digests[0]}\tvalid',
             stdout,
         )
 
@@ -159,12 +158,11 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, key_provider, digest_provider, validator
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s --verbose"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
             0,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tvalid' % digest_provider.digests[0],
+            f'Digest file\ts3://1/{digest_provider.digests[0]}\tvalid',
             stdout,
         )
 
@@ -176,18 +174,15 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, key_provider, digest_provider, validator
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s --verbose"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
             1,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: not found'
-            % digest_provider.digests[1],
+            f'Digest file\ts3://1/{digest_provider.digests[1]}\tINVALID: not found',
             stderr,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: not found'
-            % digest_provider.digests[3],
+            f'Digest file\ts3://1/{digest_provider.digests[3]}\tINVALID: not found',
             stderr,
         )
 
@@ -199,8 +194,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, key_provider, digest_provider, validator
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time '%s'"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}'",
             0,
         )
         self.assertIn(
@@ -219,13 +213,12 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, key_provider, digest_provider, validator
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
             1,
         )
         self.assertIn('invalid error', stderr)
         self.assertIn(
-            'Results requested for %s to ' % format_display_date(START_DATE),
+            f'Results requested for {format_display_date(START_DATE)} to ',
             stdout,
         )
         self.assertIn(
@@ -241,10 +234,9 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time %s "
-                "--end-time %s --verbose"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG),
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
+                f"--end-time {END_TIME_ARG} --verbose"
+            ),
             0,
         )
         self.assertIn(
@@ -271,15 +263,13 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                'cloudtrail validate-logs --trail-arn %s --start-time %s '
-                '--end-time %s'
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG),
+                f'cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} '
+                f'--end-time {END_TIME_ARG}'
+            ),
             0,
         )
         self.assertIn(
-            'Results requested for %s to %s\nNo digests found'
-            % (format_display_date(START_DATE), format_display_date(END_DATE)),
+            f'Results requested for {format_display_date(START_DATE)} to {format_display_date(END_DATE)}\nNo digests found',
             stdout,
         )
 
@@ -294,15 +284,13 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time '%s' "
-                "--end-time '%s'"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG),
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}' "
+                f"--end-time '{END_TIME_ARG}'"
+            ),
             0,
         )
         self.assertIn(
-            'Results requested for %s to %s\nNo digests found'
-            % (format_display_date(START_DATE), format_display_date(END_DATE)),
+            f'Results requested for {format_display_date(START_DATE)} to {format_display_date(END_DATE)}\nNo digests found',
             stdout,
         )
 
@@ -315,15 +303,13 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time '%s' "
-                "--end-time '%s'"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG),
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}' "
+                f"--end-time '{END_TIME_ARG}'"
+            ),
             1,
         )
         self.assertIn(
-            'Results requested for %s to %s\nNo valid digests found in range'
-            % (format_display_date(START_DATE), format_display_date(END_DATE)),
+            f'Results requested for {format_display_date(START_DATE)} to {format_display_date(END_DATE)}\nNo valid digests found in range',
             stdout,
         )
 
@@ -340,10 +326,9 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time "
-                "--region us-east-1 '%s'"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time "
+                f"--region us-east-1 '{START_TIME_ARG}'"
+            ),
             1,
         )
         self.assertIn(
@@ -365,8 +350,7 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, key_provider, digest_provider, validator
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s --verbose"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
             0,
         )
         self.assertIn('s3://1/key1', stdout)
@@ -400,14 +384,13 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, mock.Mock(), digest_provider, mock.Mock()
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
             1,
         )
         self.assertIn(
             (
-                'Digest file\ts3://1/%s\tINVALID: has been moved from its '
-                'original location' % key_name
+                f'Digest file\ts3://1/{key_name}\tINVALID: has been moved from its '
+                'original location'
             ),
             stderr,
         )
@@ -422,12 +405,11 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
             self._mock_traverser, mock.Mock(), digest_provider, mock.Mock()
         )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s"
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
             1,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: invalid format' % key_name,
+            f'Digest file\ts3://1/{key_name}\tINVALID: invalid format',
             stderr,
         )
 
@@ -454,15 +436,13 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time %s "
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
                 "--region us-east-1"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            ),
             1,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: signature verification failed'
-            % key,
+            f'Digest file\ts3://1/{key}\tINVALID: signature verification failed',
             stderr,
         )
 
@@ -482,30 +462,29 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         )
         stdout, stderr, rc = self.run_cmd(
             (
-                "cloudtrail validate-logs --trail-arn %s --start-time %s "
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
                 "--region us-east-1 --verbose"
-            )
-            % (TEST_TRAIL_ARN, START_TIME_ARG),
+            ),
             0,
         )
         self.assertIn(
-            'Digest file\ts3://3/%s\tvalid' % digest_provider.digests[0],
+            f'Digest file\ts3://3/{digest_provider.digests[0]}\tvalid',
             stdout,
         )
         self.assertIn(
-            'Digest file\ts3://2/%s\tvalid' % digest_provider.digests[1],
+            f'Digest file\ts3://2/{digest_provider.digests[1]}\tvalid',
             stdout,
         )
         self.assertIn(
-            'Digest file\ts3://2/%s\tvalid' % digest_provider.digests[2],
+            f'Digest file\ts3://2/{digest_provider.digests[2]}\tvalid',
             stdout,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tvalid' % digest_provider.digests[3],
+            f'Digest file\ts3://1/{digest_provider.digests[3]}\tvalid',
             stdout,
         )
         self.assertIn(
-            'Digest file\ts3://1/%s\tvalid' % digest_provider.digests[4],
+            f'Digest file\ts3://1/{digest_provider.digests[4]}\tvalid',
             stdout,
         )
 
@@ -530,8 +509,7 @@ class TestCloudTrailCommandWithMissingLogs(BaseCloudTrailCommandTest):
                 validator,
             )
             stdout, stderr, rc = self.run_cmd(
-                "cloudtrail validate-logs --trail-arn %s --start-time '%s'"
-                % (TEST_TRAIL_ARN, START_TIME_ARG),
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}'",
                 1,
             )
             self.assertIn(

--- a/tests/functional/configure/test_addmodel.py
+++ b/tests/functional/configure/test_addmodel.py
@@ -50,8 +50,8 @@ class TestAddModel(BaseAWSCommandParamsTest):
         self.files.remove_all()
 
     def test_add_model(self):
-        cmdline = self.prefix + ' --service-model %s' % json.dumps(
-            self.service_definition, separators=(',', ':')
+        cmdline = self.prefix + ' --service-model {}'.format(
+            json.dumps(self.service_definition, separators=(',', ':'))
         )
         self.run_cmd(cmdline)
 
@@ -68,8 +68,8 @@ class TestAddModel(BaseAWSCommandParamsTest):
         )
 
     def test_add_model_with_unicode(self):
-        cmdline = self.prefix + ' --service-model %s' % json.dumps(
-            self.service_unicode_definition, separators=(',', ':')
+        cmdline = self.prefix + ' --service-model {}'.format(
+            json.dumps(self.service_unicode_definition, separators=(',', ':'))
         )
         self.run_cmd(cmdline)
 
@@ -86,8 +86,8 @@ class TestAddModel(BaseAWSCommandParamsTest):
         )
 
     def test_add_model_with_service_name(self):
-        cmdline = self.prefix + ' --service-model %s' % json.dumps(
-            self.service_definition, separators=(',', ':')
+        cmdline = self.prefix + ' --service-model {}'.format(
+            json.dumps(self.service_definition, separators=(',', ':'))
         )
         cmdline += ' --service-name override-name'
         self.run_cmd(cmdline)

--- a/tests/functional/datapipeline/test_list_runs.py
+++ b/tests/functional/datapipeline/test_list_runs.py
@@ -36,13 +36,9 @@ class TestDataPipelineQueryObjects(BaseAWSCommandParamsTest):
         start_date = '2017-10-22T00:37:21'
         end_date = '2017-10-26T00:37:21'
         pipeline_id = 'pipeline-id'
-        args = '--pipeline-id %s --start-interval %s,%s' % (
-            pipeline_id,
-            start_date,
-            end_date,
-        )
+        args = f'--pipeline-id {pipeline_id} --start-interval {start_date},{end_date}'
         command = self.prefix + args
-        object_ids = ['object-id-%s' % i for i in range(150)]
+        object_ids = [f'object-id-{i}' for i in range(150)]
         objects = self._generate_pipeline_objects(object_ids)
 
         self.parsed_responses = [

--- a/tests/functional/ddb/test_put.py
+++ b/tests/functional/ddb/test_put.py
@@ -78,7 +78,7 @@ class TestPut(BaseAWSCommandParamsTest):
 
     def test_batch_write_multiple_batches(self):
         items = ', '.join(["{foo: bar}" for _ in range(40)])
-        command = ['ddb', 'put', 'mytable', '[%s]' % items]
+        command = ['ddb', 'put', 'mytable', f'[{items}]']
         self.run_cmd(command, expected_rc=0)
         operations_called = [o[0].name for o in self.operations_called]
         self.assertEqual(
@@ -115,7 +115,7 @@ class TestPut(BaseAWSCommandParamsTest):
         ]
 
         items = ', '.join(["{foo: bar}" for _ in range(40)])
-        command = ['ddb', 'put', 'mytable', '[%s]' % items]
+        command = ['ddb', 'put', 'mytable', f'[{items}]']
         self.run_cmd(command, expected_rc=0)
         operations_called = [o[0].name for o in self.operations_called]
         self.assertEqual(
@@ -174,7 +174,7 @@ class TestPut(BaseAWSCommandParamsTest):
         with open(filename, 'w') as f:
             f.write('{foo: bar}\n')
 
-        command = ['ddb', 'put', 'mytable', 'file://%s' % filename]
+        command = ['ddb', 'put', 'mytable', f'file://{filename}']
         expected_params = {
             'TableName': 'mytable',
             'ReturnConsumedCapacity': 'NONE',

--- a/tests/functional/dependencies/test_colorama.py
+++ b/tests/functional/dependencies/test_colorama.py
@@ -75,12 +75,7 @@ class TestPosix(unittest.TestCase):
         # also depends on the strip=False behavior to pass on windows.
         self.assertEqual(
             captured.stdout.getvalue(),
-            '%sfoo%sbar%s'
-            % (
-                self._ANSI_FORE_RED,
-                self._ANSI_RESET_ALL,
-                self._ANSI_RESET_ALL,
-            ),
+            f'{self._ANSI_FORE_RED}foo{self._ANSI_RESET_ALL}bar{self._ANSI_RESET_ALL}',
         )
 
     def test_colorama_does_not_strip(self):
@@ -91,7 +86,7 @@ class TestPosix(unittest.TestCase):
             sys.stdout.write(content)
             self.assertEqual(
                 captured.stdout.getvalue(),
-                '%sfoo%s' % (self._ANSI_FORE_BLUE, self._ANSI_RESET_ALL),
+                f'{self._ANSI_FORE_BLUE}foo{self._ANSI_RESET_ALL}',
             )
 
     def test_colorama_does_not_strip_non_tty(self):
@@ -100,5 +95,5 @@ class TestPosix(unittest.TestCase):
             sys.stdout.write(content)
             self.assertEqual(
                 captured.stdout.getvalue(),
-                '%sfoo%s' % (self._ANSI_FORE_BLUE, self._ANSI_RESET_ALL),
+                f'{self._ANSI_FORE_BLUE}foo{self._ANSI_RESET_ALL}',
             )

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -151,8 +151,8 @@ def verify_no_http_links(filename):
         marker_idx = error_line.find('http://') - 1
         marker_line = (" " * marker_idx) + '^'
         raise AssertionError(
-            'Found http:// link in the examples file %s, line %s\n'
-            '%s\n%s' % (filename, error_line_number, error_line, marker_line)
+            f'Found http:// link in the examples file {filename}, line {error_line_number}\n'
+            f'{error_line}\n{marker_line}'
         )
 
 
@@ -171,8 +171,8 @@ def verify_has_only_ascii_chars(filename):
             error_text = '\n'.join([bad_text, underlined])
             line_number = bytes_content[:offset].count(b'\n') + 1
             raise AssertionError(
-                "Non ascii characters found in the examples file %s, line %s:"
-                "\n\n%s\n" % (filename, line_number, error_text)
+                f"Non ascii characters found in the examples file {filename}, line {line_number}:"
+                f"\n\n{error_text}\n"
             )
 
 
@@ -211,7 +211,7 @@ def _make_error_msg(filename, errors):
         lines = f.readlines()
     relative_name = filename[len(EXAMPLES_DIR) + 1 :]
     failure_message = [
-        'The file "%s" contains invalid RST: ' % relative_name,
+        f'The file "{relative_name}" contains invalid RST: ',
         '',
     ]
     for error in errors:
@@ -224,8 +224,8 @@ def _make_error_msg(filename, errors):
         if line_number > 0:
             line_number -= 1
         current_message = [
-            'Line %s: %s' % (error['line_number'], error['msg']),
-            '  %s' % lines[line_number],
+            'Line {}: {}'.format(error['line_number'], error['msg']),
+            f'  {lines[line_number]}',
         ]
         failure_message.extend(current_message)
     return '\n'.join(failure_message)
@@ -271,8 +271,8 @@ class CommandValidator:
             command_parts = shlex.split(command)[1:]
         except Exception as e:
             raise AssertionError(
-                "Failed to parse this example as shell command: %s\n\n"
-                "Error:\n%s\n" % (command, e)
+                f"Failed to parse this example as shell command: {command}\n\n"
+                f"Error:\n{e}\n"
             )
         # Strip off the 'aws ' part and break it out into a list.
         parsed_args, remaining = self._parse_next_command(
@@ -297,7 +297,7 @@ class CommandValidator:
             # Yes...we have to catch SystemExit. argparse raises this
             # when you have an invalid command.
             error_msg = [
-                'Invalid CLI command: %s\n\n' % original_cmd,
+                f'Invalid CLI command: {original_cmd}\n\n',
             ]
             if errors:
                 error_msg.extend(errors)

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -390,8 +390,9 @@ class TestEnumDocsArentDuplicated(BaseAWSHelpOutputTest):
             contents.count("CREATE_IN_PROGRESS") == 1,
             (
                 "Enum param was only suppose to be appear once in "
-                "rendered doc output, appeared: %s"
-                % contents.count("CREATE_IN_PROGRESS")
+                "rendered doc output, appeared: {}".format(
+                    contents.count("CREATE_IN_PROGRESS")
+                )
             ),
         )
 
@@ -484,7 +485,7 @@ class TestAliases(BaseAWSHelpOutputTest):
 
     def add_alias(self, alias_name, alias_value):
         with open(self.alias_file, 'a+') as f:
-            f.write('%s = %s\n' % (alias_name, alias_value))
+            f.write(f'{alias_name} = {alias_value}\n')
 
     def test_alias_not_in_main_help(self):
         self.add_alias('my-alias', 'ec2 describe-regions')

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -77,7 +77,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
         policy_signature = 'a5SmoLOxoM0MHpOdC25nE7KIafg='
         args = ' --instance-id i-12345678 --owner-akid AKIAIOSFODNN7EXAMPLE'
         args += ' --owner-sak wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
-        args += ' --bucket mybucket --prefix foobar --policy %s' % base64policy
+        args += f' --bucket mybucket --prefix foobar --policy {base64policy}'
         args_list = (self.prefix + args).split()
         result = {
             'InstanceId': 'i-12345678',
@@ -96,10 +96,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
     def test_both(self):
         captured = StringIO()
         json = """{"S3":{"Bucket":"foobar","Prefix":"fiebaz"}}"""
-        args = (
-            ' --instance-id i-12345678 --owner-akid blah --owner-sak blah --storage %s'
-            % json
-        )
+        args = f' --instance-id i-12345678 --owner-akid blah --owner-sak blah --storage {json}'
         args_list = (self.prefix + args).split()
         _, stderr, _ = self.assert_params_for_cmd(args_list, expected_rc=252)
         self.assertIn('Mixing the --storage option', stderr)

--- a/tests/functional/ec2/test_describe_volumes.py
+++ b/tests/functional/ec2/test_describe_volumes.py
@@ -56,5 +56,5 @@ class TestDescribeVolumes(BaseAWSCommandParamsTest):
             'params.json', json.dumps(params)
         )
 
-        command = self.prefix + ' --cli-input-json file://%s' % file_path
+        command = self.prefix + f' --cli-input-json file://{file_path}'
         self.assert_params_for_cmd(command, params)

--- a/tests/functional/ec2/test_get_password_data.py
+++ b/tests/functional/ec2/test_get_password_data.py
@@ -43,7 +43,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
         output = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]
         self.assertIn('"InstanceId": "i-12345678"', output)
         self.assertIn('"Timestamp": "2013-07-27T18:29:23.000Z"', output)
-        self.assertIn('"PasswordData": "%s"' % PASSWORD_DATA, output)
+        self.assertIn(f'"PasswordData": "{PASSWORD_DATA}"', output)
 
     def test_nonexistent_priv_launch_key(self):
         args = ' --instance-id i-12345678 --priv-launch-key foo.pem'
@@ -58,7 +58,7 @@ class TestGetPasswordData(BaseAWSCommandParamsTest):
 
     def test_priv_launch_key(self):
         key_path = os.path.join(os.path.dirname(__file__), 'testcli.pem')
-        args = ' --instance-id i-12345678 --priv-launch-key %s' % key_path
+        args = f' --instance-id i-12345678 --priv-launch-key {key_path}'
         cmdline = self.prefix + args
         result = {'InstanceId': 'i-12345678'}
         output = self.assert_params_for_cmd(cmdline, result, expected_rc=0)[0]

--- a/tests/functional/ec2/test_run_instances.py
+++ b/tests/functional/ec2/test_run_instances.py
@@ -42,7 +42,7 @@ class TestRunInstances(BaseAWSCommandParamsTest):
             with compat_open(tmp.name, 'w') as f:
                 f.write(data)
                 f.flush()
-                args = ' --image-id foo --user-data file://%s' % f.name
+                args = f' --image-id foo --user-data file://{f.name}'
                 result = {
                     'ImageId': 'foo',
                     'MaxCount': 1,

--- a/tests/functional/ec2/test_security_group_operations.py
+++ b/tests/functional/ec2/test_security_group_operations.py
@@ -153,7 +153,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
             '[{"FromPort":8000,"ToPort":9000,'
             '"IpProtocol":"tcp","IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]'
         )
-        args = self.prefix + '--group-name foobar --ip-permissions %s' % json
+        args = self.prefix + f'--group-name foobar --ip-permissions {json}'
         result = {
             'GroupName': 'foobar',
             'IpPermissions': [
@@ -172,9 +172,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
             '[{"FromPort":8000,"ToPort":9000,"IpProtocol":"tcp",'
             '"IpRanges":[{"CidrIp":"192.168.100.0/24"}]}]'
         )
-        args = (
-            self.prefix + '--group-id sg-12345678 --ip-permissions %s' % json
-        )
+        args = self.prefix + f'--group-id sg-12345678 --ip-permissions {json}'
         result = {
             'GroupId': 'sg-12345678',
             'IpPermissions': [
@@ -195,7 +193,7 @@ class TestAuthorizeSecurityGroupIngress(BaseAWSCommandParamsTest):
         )
         args = (
             self.prefix
-            + '--group-name foobar --port 100 --ip-permissions %s' % json
+            + f'--group-name foobar --port 100 --ip-permissions {json}'
         )
         self.assert_params_for_cmd(args, expected_rc=252)
 

--- a/tests/functional/eks/test_get_token.py
+++ b/tests/functional/eks/test_get_token.py
@@ -79,7 +79,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_get_token(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         response = self.run_get_token(cmd)
         self.assertEqual(
             response,
@@ -97,7 +97,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_query_nested_object(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         cmd += ' --query status'
         response = self.run_get_token(cmd)
         self.assertEqual(
@@ -109,7 +109,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
         )
 
     def test_query_value(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         cmd += ' --query apiVersion'
         response = self.run_get_token(cmd)
         self.assertEqual(
@@ -120,7 +120,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_output_text(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         cmd += ' --output text'
         stdout, _, _ = self.run_cmd(cmd)
         self.assertIn("ExecCredential", stdout)
@@ -130,7 +130,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
     @mock.patch('awscli.customizations.eks.get_token.datetime')
     def test_output_table(self, mock_datetime):
         mock_datetime.utcnow.return_value = datetime(2019, 10, 23, 23, 0, 0, 0)
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         cmd += ' --output table'
         stdout, _, _ = self.run_cmd(cmd)
         self.assertIn("ExecCredential", stdout)
@@ -138,12 +138,12 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
         self.assertIn("2019-10-23T23:14:00Z", stdout)
 
     def test_url(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         response = self.run_get_token(cmd)
         self.assert_url_correct(response)
 
     def test_url_with_region(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         cmd += ' --region us-west-2'
         response = self.run_get_token(cmd)
         self.assert_url_correct(
@@ -153,8 +153,8 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
         )
 
     def test_url_with_arn(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
-        cmd += ' --role-arn %s' % self.role_arn
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
+        cmd += f' --role-arn {self.role_arn}'
         self.parsed_responses = [
             {
                 "Credentials": {
@@ -174,7 +174,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
         self.assert_url_correct(response, has_session_token=True)
 
     def test_token_has_no_padding(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         num_rounds = 100
         # It is difficult to patch everything out to get an exact
         # reproduceable token. So to make sure there is no padding, we
@@ -185,7 +185,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             self.assertNotIn('=', response['status']['token'])
 
     def test_url_different_partition(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         cmd += ' --region cn-north-1'
         response = self.run_get_token(cmd)
         self.assert_url_correct(
@@ -196,7 +196,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     def test_api_version_discovery_deprecated(self):
         self.set_kubernetes_exec_info('v1alpha1')
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         stdout, stderr, _ = self.run_cmd(cmd)
         response = json.loads(stdout)
 
@@ -219,7 +219,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
             '"apiVersion":"client.authentication.k8s.io/v1alpha1",'
             '"spec":{"interactive":true}}'
         )
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         stdout, stderr, _ = self.run_cmd(cmd)
         response = json.loads(stdout)
 
@@ -237,7 +237,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
         )
 
     def test_api_version_discovery_empty(self):
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         stdout, stderr, _ = self.run_cmd(cmd)
         response = json.loads(stdout)
 
@@ -253,7 +253,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     def test_api_version_discovery_v1(self):
         self.set_kubernetes_exec_info('v1')
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         stdout, stderr, _ = self.run_cmd(cmd)
         response = json.loads(stdout)
 
@@ -266,7 +266,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     def test_api_version_discovery_v1beta1(self):
         self.set_kubernetes_exec_info('v1beta1')
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         stdout, stderr, _ = self.run_cmd(cmd)
         response = json.loads(stdout)
 
@@ -279,7 +279,7 @@ class TestGetTokenCommand(BaseAWSCommandParamsTest):
 
     def test_api_version_discovery_unknown(self):
         self.set_kubernetes_exec_info('v2')
-        cmd = 'eks get-token --cluster-name %s' % self.cluster_name
+        cmd = f'eks get-token --cluster-name {self.cluster_name}'
         stdout, stderr, _ = self.run_cmd(cmd)
         response = json.loads(stdout)
 

--- a/tests/functional/elasticbeanstalk/test_update_configuration_template.py
+++ b/tests/functional/elasticbeanstalk/test_update_configuration_template.py
@@ -26,7 +26,7 @@ class TestUpdateConfigurationTemplate(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --application-name FooBar'
         cmdline += ' --template-name x86_64_m1_medium_config'
-        cmdline += ' --option-settings file://%s' % data_path
+        cmdline += f' --option-settings file://{data_path}'
         cmdline += ' --description This_is_a_test'
         result = {
             'ApplicationName': 'FooBar',

--- a/tests/functional/elb/test_register_instances_with_load_balancer.py
+++ b/tests/functional/elb/test_register_instances_with_load_balancer.py
@@ -62,7 +62,7 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         data_path = os.path.join(os.path.dirname(__file__), 'test.json')
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
-        cmdline += ' --instances file://%s' % data_path
+        cmdline += f' --instances file://{data_path}'
         self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_json_file_with_spaces(self):
@@ -71,7 +71,7 @@ class TestRegisterInstancesWithLoadBalancer(BaseAWSCommandParamsTest):
         )
         cmdline = self.prefix
         cmdline += ' --load-balancer-name my-lb'
-        cmdline += ' --instances file://%s' % data_path
+        cmdline += f' --instances file://{data_path}'
         self.assert_params_for_cmd(cmdline, TWO_INSTANCE_EXPECTED)
 
     def test_two_instance_shorthand(self):

--- a/tests/functional/gamelift/test_get_game_session_log.py
+++ b/tests/functional/gamelift/test_get_game_session_log.py
@@ -38,7 +38,7 @@ class TestGetGameSessionLog(BaseAWSCommandParamsTest):
     def test_get_game_session_log(self):
         cmdline = self.prefix
         cmdline += ' --game-session-id mysession'
-        cmdline += ' --save-as %s' % self.filename
+        cmdline += f' --save-as {self.filename}'
 
         self.parsed_responses = [{'PreSignedUrl': 'myurl'}]
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=0)
@@ -58,6 +58,6 @@ class TestGetGameSessionLog(BaseAWSCommandParamsTest):
         # Ensure the output is as expected
         self.assertIn(
             'Successfully downloaded log archive for game session '
-            'mysession to %s' % self.filename,
+            f'mysession to {self.filename}',
             stdout,
         )

--- a/tests/functional/gamelift/test_upload_build.py
+++ b/tests/functional/gamelift/test_upload_build.py
@@ -30,7 +30,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
         self.files.create_file('tmpfile', 'Some contents')
         cmdline = self.prefix
         cmdline += ' --name mybuild --build-version myversion'
-        cmdline += ' --build-root %s' % self.files.rootdir
+        cmdline += f' --build-root {self.files.rootdir}'
 
         self.parsed_responses = [
             {'Build': {'BuildId': 'myid'}},
@@ -70,7 +70,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
 
         # Check the output of the command.
         self.assertIn(
-            'Successfully uploaded %s to AWS GameLift' % self.files.rootdir,
+            f'Successfully uploaded {self.files.rootdir} to AWS GameLift',
             stdout,
         )
         self.assertIn('Build ID: myid', stdout)
@@ -79,7 +79,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
         self.files.create_file('tmpfile', 'Some contents')
         cmdline = self.prefix
         cmdline += ' --name mybuild --build-version myversion'
-        cmdline += ' --build-root %s' % self.files.rootdir
+        cmdline += f' --build-root {self.files.rootdir}'
         cmdline += ' --operating-system WINDOWS_2012'
 
         self.parsed_responses = [
@@ -124,7 +124,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
 
         # Check the output of the command.
         self.assertIn(
-            'Successfully uploaded %s to AWS GameLift' % self.files.rootdir,
+            f'Successfully uploaded {self.files.rootdir} to AWS GameLift',
             stdout,
         )
         self.assertIn('Build ID: myid', stdout)
@@ -132,7 +132,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
     def test_upload_build_with_empty_directory(self):
         cmdline = self.prefix
         cmdline += ' --name mybuild --build-version myversion'
-        cmdline += ' --build-root %s' % self.files.rootdir
+        cmdline += f' --build-root {self.files.rootdir}'
 
         self.parsed_responses = [
             {'Build': {'BuildId': 'myid'}},
@@ -150,9 +150,8 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
 
         self.assertIn(
-            'Fail to upload %s. '
-            'The build root directory is empty or does not exist.\n'
-            % self.files.rootdir,
+            f'Fail to upload {self.files.rootdir}. '
+            'The build root directory is empty or does not exist.\n',
             stderr,
         )
 
@@ -161,7 +160,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
 
         cmdline = self.prefix
         cmdline += ' --name mybuild --build-version myversion'
-        cmdline += ' --build-root %s' % dir_not_exist
+        cmdline += f' --build-root {dir_not_exist}'
 
         self.parsed_responses = [
             {'Build': {'BuildId': 'myid'}},
@@ -179,16 +178,15 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
 
         self.assertIn(
-            'Fail to upload %s. '
-            'The build root directory is empty or does not exist.\n'
-            % dir_not_exist,
+            f'Fail to upload {dir_not_exist}. '
+            'The build root directory is empty or does not exist.\n',
             stderr,
         )
 
     def test_upload_build_with_nonprovided_directory(self):
         cmdline = self.prefix
         cmdline += ' --name mybuild --build-version myversion'
-        cmdline += ' --build-root %s' % '""'
+        cmdline += ' --build-root {}'.format('""')
 
         self.parsed_responses = [
             {'Build': {'BuildId': 'myid'}},
@@ -206,8 +204,10 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=255)
 
         self.assertIn(
-            'Fail to upload %s. '
-            'The build root directory is empty or does not exist.\n' % '""',
+            'Fail to upload {}. '
+            'The build root directory is empty or does not exist.\n'.format(
+                '""'
+            ),
             stderr,
         )
 
@@ -215,7 +215,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
         self.files.create_file('tmpfile', 'Some contents')
         cmdline = self.prefix
         cmdline += ' --name mybuild --build-version myversion'
-        cmdline += ' --build-root %s' % self.files.rootdir
+        cmdline += f' --build-root {self.files.rootdir}'
         cmdline += ' --server-sdk-version 4.0.2'
 
         self.parsed_responses = [
@@ -260,7 +260,7 @@ class TestUploadBuild(BaseAWSCommandParamsTest):
 
         # Check the output of the command.
         self.assertIn(
-            'Successfully uploaded %s to AWS GameLift' % self.files.rootdir,
+            f'Successfully uploaded {self.files.rootdir} to AWS GameLift',
             stdout,
         )
         self.assertIn('Build ID: myid', stdout)

--- a/tests/functional/history/test_list.py
+++ b/tests/functional/history/test_list.py
@@ -45,7 +45,7 @@ class TestListCommand(BaseHistoryCommandParamsTest):
             'to the config file.'
         )
         self.assertEqual('', ensure_text_type(out))
-        self.assertEqual('\n%s\n' % error_message, ensure_text_type(err))
+        self.assertEqual(f'\n{error_message}\n', ensure_text_type(err))
 
     def test_show_one_call_present(self):
         self.parsed_responses = [

--- a/tests/functional/iam/test_create_virtual_mfa_device.py
+++ b/tests/functional/iam/test_create_virtual_mfa_device.py
@@ -92,9 +92,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         self.addCleanup(self.remove_file_if_exists, outfile)
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
-        cmdline += (
-            ' --outfile %s --bootstrap-method Base32StringSeed' % outfile
-        )
+        cmdline += f' --outfile {outfile} --bootstrap-method Base32StringSeed'
         result = {"VirtualMFADeviceName": 'fiebaz'}
         self.assert_params_for_cmd(cmdline, result)
         self.assertTrue(os.path.exists(outfile))
@@ -104,7 +102,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         self.addCleanup(self.remove_file_if_exists, outfile)
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
-        cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
+        cmdline += f' --outfile {outfile} --bootstrap-method QRCodePNG'
         result = {"VirtualMFADeviceName": 'fiebaz'}
         self.assert_params_for_cmd(cmdline, result)
         self.assertTrue(os.path.exists(outfile))
@@ -114,7 +112,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         self.addCleanup(self.remove_file_if_exists, outfile)
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
-        cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
+        cmdline += f' --outfile {outfile} --bootstrap-method QRCodePNG'
         self.assert_params_for_cmd(cmdline, expected_rc=252)
 
     def test_relative_filename(self):
@@ -122,7 +120,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         self.addCleanup(self.remove_file_if_exists, outfile)
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
-        cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
+        cmdline += f' --outfile {outfile} --bootstrap-method QRCodePNG'
         result = {"VirtualMFADeviceName": 'fiebaz'}
         self.assert_params_for_cmd(cmdline, result)
         self.assertTrue(os.path.exists(outfile))
@@ -132,7 +130,7 @@ class TestCreateVirtualMFADevice(BaseAWSCommandParamsTest):
         self.addCleanup(self.remove_file_if_exists, outfile)
         cmdline = self.prefix
         cmdline += ' --virtual-mfa-device-name fiebaz'
-        cmdline += ' --outfile %s --bootstrap-method QRCodePNG' % outfile
+        cmdline += f' --outfile {outfile} --bootstrap-method QRCodePNG'
         self.assert_params_for_cmd(cmdline, expected_rc=252)
 
     def test_bad_response(self):

--- a/tests/functional/logs/test_tail.py
+++ b/tests/functional/logs/test_tail.py
@@ -45,7 +45,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail(self):
         stdout, _, _ = self.assert_params_for_cmd(
-            'logs tail %s' % self.group_name,
+            f'logs tail {self.group_name}',
             params={
                 'logGroupName': self.group_name,
                 'interleaved': True,
@@ -54,8 +54,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
         )
         self.assertEqual(
             stdout,
-            '%s %s %s'
-            % (self.formatted_log_timestamp, self.stream_name, self.message),
+            f'{self.formatted_log_timestamp} {self.stream_name} {self.message}',
         )
 
     def test_tail_paginated(self):
@@ -84,7 +83,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
                 ],
             },
         ]
-        stdout, _, _ = self.run_cmd('logs tail %s' % self.group_name)
+        stdout, _, _ = self.run_cmd(f'logs tail {self.group_name}')
         self.assertEqual(len(self.operations_called), 2)
         self.assertEqual(self.operations_called[0][0].name, 'FilterLogEvents')
         self.assertEqual(
@@ -107,8 +106,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
         )
         self.assertEqual(
             stdout,
-            '%s %s %s'
-            % (self.formatted_log_timestamp, self.stream_name, self.message)
+            f'{self.formatted_log_timestamp} {self.stream_name} {self.message}'
             * 2,
         )
 
@@ -140,16 +138,11 @@ class TestTailCommand(BaseAWSCommandParamsTest):
         with mock.patch('time.sleep') as mock_sleep:
             mock_sleep.side_effect = [None, KeyboardInterrupt]
             stdout, _, _ = self.run_cmd(
-                'logs tail %s --follow' % self.group_name
+                f'logs tail {self.group_name} --follow'
             )
             self.assertEqual(
                 stdout,
-                '%s %s %s'
-                % (
-                    self.formatted_log_timestamp,
-                    self.stream_name,
-                    self.message,
-                )
+                f'{self.formatted_log_timestamp} {self.stream_name} {self.message}'
                 * 2,
             )
 
@@ -162,7 +155,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
             'awscli.customizations.logs.tail.datetime', new=datetime_mock
         ):
             self.assert_params_for_cmd(
-                'logs tail %s' % self.group_name,
+                f'logs tail {self.group_name}',
                 params={
                     'logGroupName': self.group_name,
                     'interleaved': True,
@@ -172,7 +165,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_with_since(self):
         self.assert_params_for_cmd(
-            'logs tail %s --since 1970-01-01T00:00:01' % self.group_name,
+            f'logs tail {self.group_name} --since 1970-01-01T00:00:01',
             params={
                 'logGroupName': self.group_name,
                 'interleaved': True,
@@ -189,7 +182,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
             'awscli.customizations.logs.tail.datetime', new=datetime_mock
         ):
             self.assert_params_for_cmd(
-                'logs tail %s --since 1s' % self.group_name,
+                f'logs tail {self.group_name} --since 1s',
                 params={
                     'logGroupName': self.group_name,
                     'interleaved': True,
@@ -199,7 +192,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_with_filter_pattern(self):
         self.assert_params_for_cmd(
-            'logs tail %s --filter-pattern Pattern' % self.group_name,
+            f'logs tail {self.group_name} --filter-pattern Pattern',
             params={
                 'logGroupName': self.group_name,
                 'interleaved': True,
@@ -210,31 +203,25 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_with_short_format(self):
         stdout, _, _ = self.run_cmd(
-            'logs tail %s --format short' % self.group_name
+            f'logs tail {self.group_name} --format short'
         )
         self.assertEqual(
             stdout,
-            '%s %s' % (self.formatted_short_log_timestamp, self.message),
+            f'{self.formatted_short_log_timestamp} {self.message}',
         )
 
     def test_tail_with_color_on(self):
-        stdout, _, _ = self.run_cmd(
-            'logs tail %s --color on' % self.group_name
-        )
+        stdout, _, _ = self.run_cmd(f'logs tail {self.group_name} --color on')
         self.assertEqual(
             stdout,
-            "\x1b[32m%s\x1b[0m \x1b[36m%s\x1b[0m %s"
-            % (self.formatted_log_timestamp, self.stream_name, self.message),
+            f"\x1b[32m{self.formatted_log_timestamp}\x1b[0m \x1b[36m{self.stream_name}\x1b[0m {self.message}",
         )
 
     def test_tail_with_color_off(self):
-        stdout, _, _ = self.run_cmd(
-            'logs tail %s --color off' % self.group_name
-        )
+        stdout, _, _ = self.run_cmd(f'logs tail {self.group_name} --color off')
         self.assertEqual(
             stdout,
-            "%s %s %s"
-            % (self.formatted_log_timestamp, self.stream_name, self.message),
+            f"{self.formatted_log_timestamp} {self.stream_name} {self.message}",
         )
 
     def test_tail_no_color_when_tty(self):
@@ -242,17 +229,15 @@ class TestTailCommand(BaseAWSCommandParamsTest):
             'awscli.customizations.logs.tail.is_a_tty'
         ) as mock_is_a_tty:
             mock_is_a_tty.return_value = True
-            stdout, _, _ = self.run_cmd('logs tail %s' % self.group_name)
+            stdout, _, _ = self.run_cmd(f'logs tail {self.group_name}')
         self.assertEqual(
             stdout,
-            "\x1b[32m%s\x1b[0m \x1b[36m%s\x1b[0m %s"
-            % (self.formatted_log_timestamp, self.stream_name, self.message),
+            f"\x1b[32m{self.formatted_log_timestamp}\x1b[0m \x1b[36m{self.stream_name}\x1b[0m {self.message}",
         )
 
     def test_tail_with_log_stream_names(self):
         self.assert_params_for_cmd(
-            'logs tail %s --log-stream-names foo-stream bar-stream'
-            % self.group_name,
+            f'logs tail {self.group_name} --log-stream-names foo-stream bar-stream',
             params={
                 'logGroupName': self.group_name,
                 'interleaved': True,
@@ -263,7 +248,7 @@ class TestTailCommand(BaseAWSCommandParamsTest):
 
     def test_tail_with_log_stream_name_prefix(self):
         self.assert_params_for_cmd(
-            'logs tail %s --log-stream-name-prefix foo' % self.group_name,
+            f'logs tail {self.group_name} --log-stream-name-prefix foo',
             params={
                 'logGroupName': self.group_name,
                 'interleaved': True,

--- a/tests/functional/opsworks/test_create_layer.py
+++ b/tests/functional/opsworks/test_create_layer.py
@@ -30,7 +30,7 @@ class TestCreateLayer(BaseAWSCommandParamsTest):
         cmdline += ' --type rails-app'
         cmdline += ' --name Rails_App_Server'
         cmdline += ' --enable-auto-healing'
-        cmdline += ' --attributes file://%s' % data_path
+        cmdline += f' --attributes file://{data_path}'
         cmdline += ' --shortname foo'
         result = {
             'StackId': '35959772-cd1e-4082-8346-79096d4179f2',

--- a/tests/functional/rekognition/test_image_parameters.py
+++ b/tests/functional/rekognition/test_image_parameters.py
@@ -34,8 +34,8 @@ class TestCompareFaces(BaseRekognitionTest):
         second_file_bytes = open(second_temp_file, 'rb').read()
 
         cmdline = self.prefix
-        cmdline += ' --source-image-bytes fileb://%s' % self.temp_file
-        cmdline += ' --target-image-bytes fileb://%s' % second_temp_file
+        cmdline += f' --source-image-bytes fileb://{self.temp_file}'
+        cmdline += f' --target-image-bytes fileb://{second_temp_file}'
         result = {
             'SourceImage': {'Bytes': self.temp_file_bytes},
             'TargetImage': {'Bytes': second_file_bytes},
@@ -58,7 +58,7 @@ class TestDetectFaces(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {'Image': {'Bytes': self.temp_file_bytes}}
         self.assert_params_for_cmd(cmdline, result)
 
@@ -74,7 +74,7 @@ class TestDetectLabels(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {'Image': {'Bytes': self.temp_file_bytes}}
         self.assert_params_for_cmd(cmdline, result)
 
@@ -90,7 +90,7 @@ class TestDetectModerationLabels(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {'Image': {'Bytes': self.temp_file_bytes}}
         self.assert_params_for_cmd(cmdline, result)
 
@@ -106,7 +106,7 @@ class TestDetectText(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {'Image': {'Bytes': self.temp_file_bytes}}
         self.assert_params_for_cmd(cmdline, result)
 
@@ -123,7 +123,7 @@ class TestIndexFaces(BaseRekognitionTest):
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
         cmdline += ' --collection-id foobar'
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {
             'CollectionId': 'foobar',
             'Image': {'Bytes': self.temp_file_bytes},
@@ -143,7 +143,7 @@ class TestRecognizeCelebrities(BaseRekognitionTest):
 
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {'Image': {'Bytes': self.temp_file_bytes}}
         self.assert_params_for_cmd(cmdline, result)
 
@@ -160,7 +160,7 @@ class TestSearchFacesByImage(BaseRekognitionTest):
     def test_image_file_does_populate_bytes_param(self):
         cmdline = self.prefix
         cmdline += ' --collection-id foobar'
-        cmdline += ' --image-bytes fileb://%s' % self.temp_file
+        cmdline += f' --image-bytes fileb://{self.temp_file}'
         result = {
             'CollectionId': 'foobar',
             'Image': {'Bytes': self.temp_file_bytes},

--- a/tests/functional/route53/test_resource_id.py
+++ b/tests/functional/route53/test_resource_id.py
@@ -53,7 +53,7 @@ class TestChangeResourceRecord(BaseAWSCommandParamsTest):
 
     def test_full_resource_id(self):
         args = ' --hosted-zone-id /change/ZD3IYMVP1KDDM'
-        args += ' --change-batch %s' % CHANGEBATCH_JSON
+        args += f' --change-batch {CHANGEBATCH_JSON}'
         cmdline = self.prefix + args
         expected = {
             "HostedZoneId": "ZD3IYMVP1KDDM",

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -64,9 +64,8 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
             if expected_operation_with_params == actual_operation_with_params:
                 return
         self.fail(
-            'Expected request: %s does not match any of the actual requests '
-            'made: %s'
-            % (expected_operation_with_params, actual_operations_with_params)
+            f'Expected request: {expected_operation_with_params} does not match any of the actual requests '
+            f'made: {actual_operations_with_params}'
         )
 
     def head_object_response(self, **override_kwargs):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -40,7 +40,7 @@ class BaseCPCommandTest(BaseS3TransferCommandTest):
 class TestCPCommand(BaseCPCommandTest):
     def test_operations_used_in_upload(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -53,7 +53,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_key_name_added_when_only_bucket_provided(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/' % (self.prefix, full_path)
+        cmdline = f'{self.prefix} {full_path} s3://bucket/'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -70,7 +70,7 @@ class TestCPCommand(BaseCPCommandTest):
         full_path = self.files.create_file('foo.txt', 'mycontent')
         # Here we're saying s3://bucket instead of s3://bucket/
         # This should still work the same as if we added the trailing slash.
-        cmdline = '%s %s s3://bucket' % (self.prefix, full_path)
+        cmdline = f'{self.prefix} {full_path} s3://bucket'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -117,9 +117,8 @@ class TestCPCommand(BaseCPCommandTest):
     def test_upload_grants(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
         cmdline = (
-            '%s %s s3://bucket/key.txt --grants read=id=foo '
+            f'{self.prefix} {full_path} s3://bucket/key.txt --grants read=id=foo '
             'full=id=bar readacl=id=biz writeacl=id=baz'
-            % (self.prefix, full_path)
         )
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
@@ -147,10 +146,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_upload_expires(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --expires 90' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --expires 90'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -166,10 +162,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_upload_standard_ia(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --storage-class STANDARD_IA' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --storage-class STANDARD_IA'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -185,10 +178,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_upload_onezone_ia(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --storage-class ONEZONE_IA' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --storage-class ONEZONE_IA'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -204,10 +194,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_upload_intelligent_tiering(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = (
-            '%s %s s3://bucket/key.txt --storage-class INTELLIGENT_TIERING'
-            % (self.prefix, full_path)
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --storage-class INTELLIGENT_TIERING'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -223,10 +210,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_upload_glacier(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --storage-class GLACIER' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --storage-class GLACIER'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -242,10 +226,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_upload_deep_archive(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --storage-class DEEP_ARCHIVE' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --storage-class DEEP_ARCHIVE'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -264,10 +245,7 @@ class TestCPCommand(BaseCPCommandTest):
             {"ContentLength": "100", "LastModified": "00:00:00Z"},
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
-        cmdline = '%s s3://bucket/key.txt %s' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} s3://bucket/key.txt {self.files.rootdir}'
         self.run_cmd(cmdline, expected_rc=0)
         # The only operations we should have called are HeadObject/GetObject.
         self.assertEqual(
@@ -280,10 +258,7 @@ class TestCPCommand(BaseCPCommandTest):
         self.parsed_responses = [
             {'ETag': '"foo-1"', 'Contents': [], 'CommonPrefixes': []},
         ]
-        cmdline = '%s s3://bucket/key.txt %s --recursive' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} s3://bucket/key.txt {self.files.rootdir} --recursive'
         self.run_cmd(cmdline, expected_rc=0)
         # We called ListObjectsV2 but had no objects to download, so
         # we only have a single ListObjectsV2 operation being called.
@@ -316,7 +291,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_website_redirect_ignore_paramfile(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --website-redirect %s' % (
+        cmdline = '{} {} s3://bucket/key.txt --website-redirect {}'.format(
             self.prefix,
             full_path,
             'http://someserver',
@@ -360,8 +335,8 @@ class TestCPCommand(BaseCPCommandTest):
             {'ETag': '"foo-1"'},
         ]
         cmdline = (
-            '%s s3://bucket/key.txt s3://bucket/key2.txt'
-            ' --metadata KeyName=Value' % self.prefix
+            f'{self.prefix} s3://bucket/key.txt s3://bucket/key2.txt'
+            ' --metadata KeyName=Value'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
@@ -379,9 +354,9 @@ class TestCPCommand(BaseCPCommandTest):
             {"ContentLength": "100", "LastModified": "00:00:00Z"},
             {'ETag': '"foo-1"'},
         ]
-        cmdline = '%s %s s3://bucket/key2.txt' ' --metadata KeyName=Value' % (
-            self.prefix,
-            full_path,
+        cmdline = (
+            f'{self.prefix} {full_path} s3://bucket/key2.txt'
+            ' --metadata KeyName=Value'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
@@ -400,9 +375,9 @@ class TestCPCommand(BaseCPCommandTest):
             {'ETag': '"foo-2"'},
             {},
         ]
-        cmdline = '%s %s s3://bucket/key2.txt' ' --metadata KeyName=Value' % (
-            self.prefix,
-            full_path,
+        cmdline = (
+            f'{self.prefix} {full_path} s3://bucket/key2.txt'
+            ' --metadata KeyName=Value'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
@@ -421,8 +396,8 @@ class TestCPCommand(BaseCPCommandTest):
             {'ETag': '"foo-1"'},
         ]
         cmdline = (
-            '%s s3://bucket/key.txt s3://bucket/key2.txt'
-            ' --metadata-directive REPLACE' % self.prefix
+            f'{self.prefix} s3://bucket/key.txt s3://bucket/key2.txt'
+            ' --metadata-directive REPLACE'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
@@ -436,10 +411,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_no_metadata_directive_for_non_copy(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket --metadata-directive REPLACE' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket --metadata-directive REPLACE'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -452,7 +424,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_cp_succeeds_with_mimetype_errors(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt' % (self.prefix, full_path)
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -466,7 +438,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_cp_fails_with_utime_errors_but_continues(self):
         full_path = self.files.create_file('foo.txt', '')
-        cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)
+        cmdline = f'{self.prefix} s3://bucket/key.txt {full_path}'
         self.parsed_responses = [
             {"ContentLength": "100", "LastModified": "00:00:00Z"},
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
@@ -492,10 +464,7 @@ class TestCPCommand(BaseCPCommandTest):
             },
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
-        cmdline = (
-            '%s s3://bucket/foo %s --recursive --force-glacier-transfer'
-            % (self.prefix, self.files.rootdir)
-        )
+        cmdline = f'{self.prefix} s3://bucket/foo {self.files.rootdir} --recursive --force-glacier-transfer'
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
             len(self.operations_called), 2, self.operations_called
@@ -518,9 +487,8 @@ class TestCPCommand(BaseCPCommandTest):
                 'CommonPrefixes': [],
             }
         ]
-        cmdline = '%s s3://bucket/foo %s --recursive' % (
-            self.prefix,
-            self.files.rootdir,
+        cmdline = (
+            f'{self.prefix} s3://bucket/foo {self.files.rootdir} --recursive'
         )
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         self.assertEqual(
@@ -537,7 +505,7 @@ class TestCPCommand(BaseCPCommandTest):
                 'StorageClass': 'GLACIER',
             },
         ]
-        cmdline = '%s s3://bucket/key.txt .' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key.txt .'
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         # There should not have been a download attempted because the
         # operation was skipped because it is glacier incompatible.
@@ -553,7 +521,7 @@ class TestCPCommand(BaseCPCommandTest):
                 'StorageClass': 'DEEP_ARCHIVE',
             },
         ]
-        cmdline = '%s s3://bucket/key.txt .' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key.txt .'
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         # There should not have been a download attempted because the
         # operation was skipped because it is glacier
@@ -570,7 +538,7 @@ class TestCPCommand(BaseCPCommandTest):
                 'StorageClass': 'GLACIER',
             },
         ]
-        cmdline = '%s s3://bucket/key.txt .' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key.txt .'
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         # There should not have been a download attempted because the
         # operation was skipped because it is glacier incompatible.
@@ -586,7 +554,7 @@ class TestCPCommand(BaseCPCommandTest):
                 'StorageClass': 'DEEP_ARCHIVE',
             },
         ]
-        cmdline = '%s s3://bucket/key.txt .' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key.txt .'
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         # There should not have been a download attempted because the
         # operation was skipped because it is glacier
@@ -604,7 +572,7 @@ class TestCPCommand(BaseCPCommandTest):
             },
         ]
         cmdline = (
-            '%s s3://bucket/key.txt . --ignore-glacier-warnings' % self.prefix
+            f'{self.prefix} s3://bucket/key.txt . --ignore-glacier-warnings'
         )
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=0)
         # There should not have been a download attempted because the
@@ -622,7 +590,7 @@ class TestCPCommand(BaseCPCommandTest):
             },
         ]
         cmdline = (
-            '%s s3://bucket/key.txt . --ignore-glacier-warnings' % self.prefix
+            f'{self.prefix} s3://bucket/key.txt . --ignore-glacier-warnings'
         )
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=0)
         # There should not have been a download attempted because the
@@ -633,7 +601,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_cp_with_sse_flag(self):
         full_path = self.files.create_file('foo.txt', 'contents')
-        cmdline = '%s %s s3://bucket/key.txt --sse' % (self.prefix, full_path)
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --sse'
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
@@ -651,10 +619,7 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_cp_with_sse_c_flag(self):
         full_path = self.files.create_file('foo.txt', 'contents')
-        cmdline = '%s %s s3://bucket/key.txt --sse-c --sse-c-key foo' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --sse-c --sse-c-key foo'
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
@@ -680,10 +645,7 @@ class TestCPCommand(BaseCPCommandTest):
         )
         with open(key_path, 'wb') as f:
             f.write(key_contents)
-        cmdline = (
-            '%s %s s3://bucket/key.txt --sse-c --sse-c-key fileb://%s'
-            % (self.prefix, file_path, key_path)
-        )
+        cmdline = f'{self.prefix} {file_path} s3://bucket/key.txt --sse-c --sse-c-key fileb://{key_path}'
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
@@ -730,9 +692,8 @@ class TestCPCommand(BaseCPCommandTest):
         with open(key_path, 'wb') as f:
             f.write(key_contents)
         cmdline = (
-            '%s s3://bucket-one/key.txt s3://bucket/key.txt '
-            '--sse-c-copy-source --sse-c-copy-source-key fileb://%s'
-            % (self.prefix, key_path)
+            f'{self.prefix} s3://bucket-one/key.txt s3://bucket/key.txt '
+            f'--sse-c-copy-source --sse-c-copy-source-key fileb://{key_path}'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 2)
@@ -753,10 +714,7 @@ class TestCPCommand(BaseCPCommandTest):
     # up the tests
     def test_cp_upload_with_sse_kms_and_key_id(self):
         full_path = self.files.create_file('foo.txt', 'contents')
-        cmdline = (
-            '%s %s s3://bucket/key.txt --sse aws:kms --sse-kms-key-id foo'
-            % (self.prefix, full_path)
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --sse aws:kms --sse-kms-key-id foo'
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 1)
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
@@ -782,8 +740,8 @@ class TestCPCommand(BaseCPCommandTest):
         ]
         full_path = self.files.create_file('foo.txt', 'a' * 10 * (1024**2))
         cmdline = (
-            '%s %s s3://bucket/key.txt --copy-props none '
-            '--sse aws:kms --sse-kms-key-id foo' % (self.prefix, full_path)
+            f'{self.prefix} {full_path} s3://bucket/key.txt --copy-props none '
+            '--sse aws:kms --sse-kms-key-id foo'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 4)
@@ -811,8 +769,8 @@ class TestCPCommand(BaseCPCommandTest):
             {},  # CopyObject
         ]
         cmdline = (
-            '%s s3://bucket/key1.txt s3://bucket/key2.txt '
-            '--sse aws:kms --sse-kms-key-id foo' % self.prefix
+            f'{self.prefix} s3://bucket/key1.txt s3://bucket/key2.txt '
+            '--sse aws:kms --sse-kms-key-id foo'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 2)
@@ -840,8 +798,8 @@ class TestCPCommand(BaseCPCommandTest):
             {},  # CompleteMultipartUpload
         ]
         cmdline = (
-            '%s s3://bucket/key1.txt s3://bucket/key2.txt --copy-props none '
-            '--sse aws:kms --sse-kms-key-id foo' % self.prefix
+            f'{self.prefix} s3://bucket/key1.txt s3://bucket/key2.txt --copy-props none '
+            '--sse aws:kms --sse-kms-key-id foo'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(len(self.operations_called), 5)
@@ -862,7 +820,7 @@ class TestCPCommand(BaseCPCommandTest):
         )
 
     def test_cannot_use_recursive_with_stream(self):
-        cmdline = '%s - s3://bucket/key.txt --recursive' % self.prefix
+        cmdline = f'{self.prefix} - s3://bucket/key.txt --recursive'
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn(
             'Streaming currently is only compatible with non-recursive cp '
@@ -947,8 +905,8 @@ class TestCPCommand(BaseCPCommandTest):
             {},
         ]
         cmdline = (
-            '%s %s s3://bucket/key2.txt'
-            ' --checksum-algorithm CRC32' % (self.prefix, full_path)
+            f'{self.prefix} {full_path} s3://bucket/key2.txt'
+            ' --checksum-algorithm CRC32'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
@@ -1173,9 +1131,8 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
 
     def test_single_upload(self):
         full_path = self.files.create_file('myfile', 'mycontent')
-        cmdline = '%s %s s3://mybucket/mykey --request-payer' % (
-            self.prefix,
-            full_path,
+        cmdline = (
+            f'{self.prefix} {full_path} s3://mybucket/mykey --request-payer'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
@@ -1195,9 +1152,8 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
 
     def test_multipart_upload(self):
         full_path = self.files.create_file('myfile', 'a' * 10 * (1024**2))
-        cmdline = '%s %s s3://mybucket/mykey --request-payer' % (
-            self.prefix,
-            full_path,
+        cmdline = (
+            f'{self.prefix} {full_path} s3://mybucket/mykey --request-payer'
         )
 
         self.parsed_responses = [
@@ -1262,10 +1218,7 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
 
     def test_recursive_upload(self):
         self.files.create_file('myfile', 'mycontent')
-        cmdline = '%s %s s3://mybucket/ --request-payer --recursive' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} {self.files.rootdir} s3://mybucket/ --request-payer --recursive'
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [
@@ -1283,10 +1236,7 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         )
 
     def test_single_download(self):
-        cmdline = '%s s3://mybucket/mykey %s --request-payer' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} s3://mybucket/mykey {self.files.rootdir} --request-payer'
         self.parsed_responses = [
             self.head_object_response(),
             self.get_object_response(),
@@ -1305,10 +1255,7 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         )
 
     def test_ranged_download(self):
-        cmdline = '%s s3://mybucket/mykey %s --request-payer' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} s3://mybucket/mykey {self.files.rootdir} --request-payer'
         self.parsed_responses = [
             self.head_object_response(ContentLength=10 * (1024**2)),
             self.get_object_response(),
@@ -1337,10 +1284,7 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         )
 
     def test_recursive_download(self):
-        cmdline = '%s s3://mybucket/ %s --request-payer --recursive' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} s3://mybucket/ {self.files.rootdir} --request-payer --recursive'
         self.parsed_responses = [
             self.list_objects_response(['mykey']),
             self.get_object_response(),
@@ -1536,8 +1480,8 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
     def test_upload(self):
         filename = self.files.create_file('myfile', 'mycontent')
         cmdline = self.prefix
-        cmdline += ' %s' % filename
-        cmdline += ' s3://%s/mykey' % self.accesspoint_arn
+        cmdline += f' {filename}'
+        cmdline += f' s3://{self.accesspoint_arn}/mykey'
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [self.put_object_request(self.accesspoint_arn, 'mykey')]
@@ -1546,8 +1490,8 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
     def test_recusive_upload(self):
         self.files.create_file('myfile', 'mycontent')
         cmdline = self.prefix
-        cmdline += ' %s' % self.files.rootdir
-        cmdline += ' s3://%s/' % self.accesspoint_arn
+        cmdline += f' {self.files.rootdir}'
+        cmdline += f' s3://{self.accesspoint_arn}/'
         cmdline += ' --recursive'
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
@@ -1556,8 +1500,8 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
 
     def test_download(self):
         cmdline = self.prefix
-        cmdline += ' s3://%s/mykey' % self.accesspoint_arn
-        cmdline += ' %s' % self.files.rootdir
+        cmdline += f' s3://{self.accesspoint_arn}/mykey'
+        cmdline += f' {self.files.rootdir}'
         self.parsed_responses = [
             self.head_object_response(),
             self.get_object_response(),
@@ -1572,8 +1516,8 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
 
     def test_recursive_download(self):
         cmdline = self.prefix
-        cmdline += ' s3://%s' % self.accesspoint_arn
-        cmdline += ' %s' % self.files.rootdir
+        cmdline += f' s3://{self.accesspoint_arn}'
+        cmdline += f' {self.files.rootdir}'
         cmdline += ' --recursive'
         self.parsed_responses = [
             self.list_objects_response(['mykey']),
@@ -1589,9 +1533,9 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
 
     def test_copy(self):
         cmdline = self.prefix
-        cmdline += ' s3://%s/mykey' % self.accesspoint_arn
+        cmdline += f' s3://{self.accesspoint_arn}/mykey'
         accesspoint_arn_dest = self.accesspoint_arn + '-dest'
-        cmdline += ' s3://%s' % accesspoint_arn_dest
+        cmdline += f' s3://{accesspoint_arn_dest}'
         self.parsed_responses = [
             self.head_object_response(),
             self.copy_object_response(),
@@ -1611,9 +1555,9 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
 
     def test_recursive_copy(self):
         cmdline = self.prefix
-        cmdline += ' s3://%s' % self.accesspoint_arn
+        cmdline += f' s3://{self.accesspoint_arn}'
         accesspoint_arn_dest = self.accesspoint_arn + '-dest'
-        cmdline += ' s3://%s' % accesspoint_arn_dest
+        cmdline += f' s3://{accesspoint_arn_dest}'
         cmdline += ' --recursive'
         self.parsed_responses = [
             self.list_objects_response(['mykey']),
@@ -1636,8 +1580,8 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
         mrap_arn = 'arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap'
         filename = self.files.create_file('myfile', 'mycontent')
         cmdline = self.prefix
-        cmdline += ' %s' % filename
-        cmdline += ' s3://%s/mykey' % mrap_arn
+        cmdline += f' {filename}'
+        cmdline += f' s3://{mrap_arn}/mykey'
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [self.put_object_request(mrap_arn, 'mykey')]
@@ -1647,8 +1591,8 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
         mrap_arn = 'arn:aws:s3::123456789012:accesspoint/mfzwi23gnjvgw.mrap'
         filename = self.files.create_file('myfile', 'mycontent')
         cmdline = self.prefix
-        cmdline += ' %s' % filename
-        cmdline += ' s3://%s/mykey' % mrap_arn
+        cmdline += f' {filename}'
+        cmdline += f' s3://{mrap_arn}/mykey'
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [self.put_object_request(mrap_arn, 'mykey')]
@@ -1673,23 +1617,21 @@ class BaseCopyPropsCpCommandTest(BaseCPCommandTest):
         self.tags_over_2k = {'tag-key': 'value' * (2 * 1024)}
 
     def get_s3_cp_copy_command(self, copy_props=None):
-        cmdline = self.prefix + 's3://%s/%s s3://%s/%s' % (
-            self.source_bucket,
-            self.source_key,
-            self.target_bucket,
-            self.target_key,
+        cmdline = (
+            self.prefix
+            + f's3://{self.source_bucket}/{self.source_key} s3://{self.target_bucket}/{self.target_key}'
         )
         if copy_props:
-            cmdline += ' --copy-props %s' % copy_props
+            cmdline += f' --copy-props {copy_props}'
         return cmdline
 
     def get_recursive_s3_copy_command(self, copy_props=None):
-        cmdline = self.prefix + 's3://%s/ s3://%s/ --recursive' % (
-            self.source_bucket,
-            self.target_bucket,
+        cmdline = (
+            self.prefix
+            + f's3://{self.source_bucket}/ s3://{self.target_bucket}/ --recursive'
         )
         if copy_props:
-            cmdline += ' --copy-props %s' % copy_props
+            cmdline += f' --copy-props {copy_props}'
         return cmdline
 
     def copy_object_request(

--- a/tests/functional/s3/test_ls_command.py
+++ b/tests/functional/s3/test_ls_command.py
@@ -45,8 +45,9 @@ class TestLSCommand(BaseS3TransferCommandTest):
         time_local = parser.parse(time_utc).astimezone(tz.tzlocal())
         self.assertEqual(
             stdout,
-            '%s        100 foo/bar.txt\n'
-            % time_local.strftime('%Y-%m-%d %H:%M:%S'),
+            '{}        100 foo/bar.txt\n'.format(
+                time_local.strftime('%Y-%m-%d %H:%M:%S')
+            ),
         )
 
     def test_errors_out_with_extra_arguments(self):
@@ -224,12 +225,12 @@ class TestLSCommand(BaseS3TransferCommandTest):
         # is specific to your tzinfo, so shift the timezone to your local's.
         time_local = parser.parse(time_utc).astimezone(tz.tzlocal())
         time_fmt = time_local.strftime('%Y-%m-%d %H:%M:%S')
-        self.assertIn('%s     1 Byte onebyte.txt\n' % time_fmt, stdout)
-        self.assertIn('%s    1.0 KiB onekilobyte.txt\n' % time_fmt, stdout)
-        self.assertIn('%s    1.0 MiB onemegabyte.txt\n' % time_fmt, stdout)
-        self.assertIn('%s    1.0 GiB onegigabyte.txt\n' % time_fmt, stdout)
-        self.assertIn('%s    1.0 TiB oneterabyte.txt\n' % time_fmt, stdout)
-        self.assertIn('%s    1.0 PiB onepetabyte.txt\n' % time_fmt, stdout)
+        self.assertIn(f'{time_fmt}     1 Byte onebyte.txt\n', stdout)
+        self.assertIn(f'{time_fmt}    1.0 KiB onekilobyte.txt\n', stdout)
+        self.assertIn(f'{time_fmt}    1.0 MiB onemegabyte.txt\n', stdout)
+        self.assertIn(f'{time_fmt}    1.0 GiB onegigabyte.txt\n', stdout)
+        self.assertIn(f'{time_fmt}    1.0 TiB oneterabyte.txt\n', stdout)
+        self.assertIn(f'{time_fmt}    1.0 PiB onepetabyte.txt\n', stdout)
 
     def test_summarize(self):
         time_utc = "2014-01-09T20:45:49.000Z"
@@ -386,7 +387,7 @@ class TestLSCommand(BaseS3TransferCommandTest):
     def test_accesspoint_arn(self):
         self.parsed_responses = [self.list_objects_response(['bar.txt'])]
         arn = 'arn:aws:s3:us-west-2:123456789012:accesspoint/endpoint'
-        self.run_cmd('s3 ls s3://%s' % arn, expected_rc=0)
+        self.run_cmd(f's3 ls s3://{arn}', expected_rc=0)
         call_args = self.operations_called[0][1]
         self.assertEqual(call_args['Bucket'], arn)
 

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -28,13 +28,13 @@ class TestMvCommand(BaseS3TransferCommandTest):
     prefix = 's3 mv '
 
     def test_cant_mv_object_onto_itself(self):
-        cmdline = '%s s3://bucket/key s3://bucket/key' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key s3://bucket/key'
         stderr = self.run_cmd(cmdline, expected_rc=252)[1]
         self.assertIn('Cannot mv a file onto itself', stderr)
 
     def test_cant_mv_object_with_implied_name(self):
         # The "key" key name is implied in the dst argument.
-        cmdline = '%s s3://bucket/key s3://bucket/' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key s3://bucket/'
         stderr = self.run_cmd(cmdline, expected_rc=252)[1]
         self.assertIn('Cannot mv a file onto itself', stderr)
 
@@ -62,7 +62,7 @@ class TestMvCommand(BaseS3TransferCommandTest):
 
     def test_website_redirect_ignore_paramfile(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket/key.txt --website-redirect %s' % (
+        cmdline = '{} {} s3://bucket/key.txt --website-redirect {}'.format(
             self.prefix,
             full_path,
             'http://someserver',
@@ -86,8 +86,8 @@ class TestMvCommand(BaseS3TransferCommandTest):
             {'ETag': '"foo-2"'},
         ]
         cmdline = (
-            '%s s3://bucket/key.txt s3://bucket/key2.txt'
-            ' --metadata-directive REPLACE' % self.prefix
+            f'{self.prefix} s3://bucket/key.txt s3://bucket/key2.txt'
+            ' --metadata-directive REPLACE'
         )
         self.run_cmd(cmdline, expected_rc=0)
         self.assertEqual(
@@ -102,10 +102,7 @@ class TestMvCommand(BaseS3TransferCommandTest):
 
     def test_no_metadata_directive_for_non_copy(self):
         full_path = self.files.create_file('foo.txt', 'mycontent')
-        cmdline = '%s %s s3://bucket --metadata-directive REPLACE' % (
-            self.prefix,
-            full_path,
-        )
+        cmdline = f'{self.prefix} {full_path} s3://bucket --metadata-directive REPLACE'
         self.parsed_responses = [
             {'ETag': '"c8afdb36c52cf4727836669019e69222"'}
         ]
@@ -117,10 +114,7 @@ class TestMvCommand(BaseS3TransferCommandTest):
         self.assertNotIn('MetadataDirective', self.operations_called[0][1])
 
     def test_download_move_with_request_payer(self):
-        cmdline = '%s s3://mybucket/mykey %s --request-payer' % (
-            self.prefix,
-            self.files.rootdir,
-        )
+        cmdline = f'{self.prefix} s3://mybucket/mykey {self.files.rootdir} --request-payer'
 
         self.parsed_responses = [
             # Response for HeadObject

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -37,7 +37,7 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
 
     def enable_addressing_mode_in_config(self, fileobj, mode):
         fileobj.write(
-            "[default]\n" "s3 =\n" "    addressing_style = %s\n" % mode
+            "[default]\n" "s3 =\n" f"    addressing_style = {mode}\n"
         )
         fileobj.flush()
         self.environ['AWS_CONFIG_FILE'] = fileobj.name
@@ -137,7 +137,7 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
     def test_handles_expires_in(self):
         expires_in = 1000
         stdout = self.get_presigned_url_for_cmd(
-            self.prefix + 's3://bucket/key --expires-in %s' % expires_in
+            self.prefix + f's3://bucket/key --expires-in {expires_in}'
         )
 
         self.assert_presigned_url_matches(

--- a/tests/functional/s3/test_rm_command.py
+++ b/tests/functional/s3/test_rm_command.py
@@ -22,7 +22,7 @@ class TestRmCommand(BaseS3TransferCommandTest):
     prefix = 's3 rm'
 
     def test_operations_used(self):
-        cmdline = '%s s3://bucket/key.txt' % self.prefix
+        cmdline = f'{self.prefix} s3://bucket/key.txt'
         self.run_cmd(cmdline, expected_rc=0)
         # The only operation we should have called is DeleteObject.
         self.assertEqual(
@@ -38,7 +38,7 @@ class TestRmCommand(BaseS3TransferCommandTest):
         self.assertIn('(dryrun) delete: s3://bucket/key.txt', stdout)
 
     def test_delete_with_request_payer(self):
-        cmdline = '%s s3://mybucket/mykey --request-payer' % self.prefix
+        cmdline = f'{self.prefix} s3://mybucket/mykey --request-payer'
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [
@@ -54,7 +54,7 @@ class TestRmCommand(BaseS3TransferCommandTest):
         )
 
     def test_recursive_delete_with_requests(self):
-        cmdline = '%s s3://mybucket/ --recursive --request-payer' % self.prefix
+        cmdline = f'{self.prefix} s3://mybucket/ --recursive --request-payer'
         self.parsed_responses = [
             self.list_objects_response(['mykey']),
             self.empty_response(),

--- a/tests/functional/s3/test_s3_object_lambda.py
+++ b/tests/functional/s3/test_s3_object_lambda.py
@@ -32,7 +32,7 @@ class TestObjectLambdaHandling(BaseAWSCommandParamsTest):
             'arn:aws:s3-object-lambda:us-west-2:123456789012:'
             'accesspoint:my-accesspoint'
         )
-        object_lambda_arn_with_key = '%s/my-key' % object_lambda_arn
+        object_lambda_arn_with_key = f'{object_lambda_arn}/my-key'
         for prefix in self.prefixes:
             cmdline = prefix.format(object_lambda_arn=object_lambda_arn)
             _, stderr, _ = self.run_cmd(cmdline, 252)
@@ -48,7 +48,7 @@ class TestObjectLambdaHandling(BaseAWSCommandParamsTest):
             'arn:aws:s3-object-lambda:us-west-2:123456789012:'
             'accesspoint/my-accesspoint'
         )
-        object_lambda_arn_with_key = '%s/my-key' % object_lambda_arn
+        object_lambda_arn_with_key = f'{object_lambda_arn}/my-key'
         for prefix in self.prefixes:
             cmdline = prefix.format(object_lambda_arn=object_lambda_arn)
             _, stderr, _ = self.run_cmd(cmdline, 252)

--- a/tests/functional/s3api/test_list_objects.py
+++ b/tests/functional/s3api/test_list_objects.py
@@ -61,7 +61,7 @@ class TestListObjects(BaseAWSCommandParamsTest):
         token = {"Marker": "foo"}
         token = base64.b64encode(json.dumps(token).encode('utf-8'))
         token = token.decode('utf-8')
-        cmdline += ' --starting-token %s' % token
+        cmdline += f' --starting-token {token}'
         self.assert_params_for_cmd(
             cmdline,
             {'Bucket': 'mybucket', 'Marker': 'foo', 'EncodingType': 'url'},

--- a/tests/functional/s3api/test_put_bucket_tagging.py
+++ b/tests/functional/s3api/test_put_bucket_tagging.py
@@ -40,7 +40,7 @@ class TestPutBucketTagging(BaseAWSCommandParamsTest):
     def test_simple(self):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
-        cmdline += ' --tagging %s' % TAGSET
+        cmdline += f' --tagging {TAGSET}'
         expected = {
             'Bucket': 'mybucket',
             'Tagging': {

--- a/tests/functional/s3api/test_put_object.py
+++ b/tests/functional/s3api/test_put_object.py
@@ -48,7 +48,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
         cmdline += ' --key mykey'
-        cmdline += ' --body %s' % self.file_path
+        cmdline += f' --body {self.file_path}'
         result = {
             'uri_params': {'Bucket': 'mybucket', 'Key': 'mykey'},
             'headers': {'Expect': '100-continue'},
@@ -61,7 +61,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --bucket mybucket'
         cmdline += ' --key mykey'
-        cmdline += ' --body %s' % self.file_path
+        cmdline += f' --body {self.file_path}'
         cmdline += ' --acl public-read'
         cmdline += ' --content-encoding x-gzip'
         cmdline += ' --content-type text/plain'
@@ -97,7 +97,7 @@ class TestPutObject(BaseAWSCommandParamsTest):
         cmdline += ' --bucket mybucket'
         cmdline += ' --key mykey'
         cmdline += ' --sse-customer-algorithm AES256'
-        cmdline += ' --sse-customer-key fileb://%s' % filename
+        cmdline += f' --sse-customer-key fileb://{filename}'
         expected = {
             'Bucket': 'mybucket',
             'Key': 'mykey',

--- a/tests/functional/s3transfer/test_copy.py
+++ b/tests/functional/s3transfer/test_copy.py
@@ -396,7 +396,7 @@ class TestMultipartCopy(BaseCopyTest):
             if extra_expected_params:
                 if 'ChecksumAlgorithm' in extra_expected_params:
                     name = extra_expected_params['ChecksumAlgorithm']
-                    checksum_member = 'Checksum%s' % name.upper()
+                    checksum_member = f'Checksum{name.upper()}'
                     response = upload_part_response['service_response']
                     response['CopyPartResult'][checksum_member] = 'sum%s==' % (
                         i + 1

--- a/tests/functional/s3transfer/test_crt.py
+++ b/tests/functional/s3transfer/test_crt.py
@@ -80,7 +80,7 @@ class TestCRTTransferManager(unittest.TestCase):
             'myfile', self.expected_content, mode='wb'
         )
         self.expected_path = "/" + self.bucket + "/" + self.key
-        self.expected_host = "s3.%s.amazonaws.com" % (self.region)
+        self.expected_host = f"s3.{self.region}.amazonaws.com"
         self.expected_s3express_host = f'{self.s3express_bucket}.s3express-usw2-az5.us-west-2.amazonaws.com'
         self.expected_s3express_path = f'/{self.key}'
         self.expected_mrap_host = (

--- a/tests/functional/s3transfer/test_download.py
+++ b/tests/functional/s3transfer/test_download.py
@@ -141,7 +141,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         # Make sure the file exists
         self.assertTrue(os.path.exists(self.filename))
         # Make sure the random temporary file does not exist
-        possible_matches = glob.glob('%s*' % self.filename + os.extsep)
+        possible_matches = glob.glob(f'{self.filename}*' + os.extsep)
         self.assertEqual(possible_matches, [])
 
     def test_download_for_fileobj(self):
@@ -201,7 +201,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
             future.result()
         # Make sure the actual file and the temporary do not exist
         # by globbing for the file and any of its extensions
-        possible_matches = glob.glob('%s*' % self.filename)
+        possible_matches = glob.glob(f'{self.filename}*')
         self.assertEqual(possible_matches, [])
 
     def test_download_with_nonexistent_directory(self):

--- a/tests/functional/s3transfer/test_upload.py
+++ b/tests/functional/s3transfer/test_upload.py
@@ -94,7 +94,7 @@ class BaseUploadTest(BaseGeneralInterfaceTest):
                 data=params['Body'],
             )
             self.client.meta.events.emit(
-                'request-created.s3.%s' % model.name,
+                f'request-created.s3.{model.name}',
                 request=request,
                 operation_name=model.name,
             )

--- a/tests/functional/servicecatalog/test_generate_createproduct.py
+++ b/tests/functional/servicecatalog/test_generate_createproduct.py
@@ -68,35 +68,26 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
     def build_cmd_line(self):
         cmd_line = self.prefix
         if self.template_path:
-            cmd_line += ' --file-path %s' % self.template_path
+            cmd_line += f' --file-path {self.template_path}'
         if self.bucket_name:
-            cmd_line += ' --bucket-name %s' % self.bucket_name
+            cmd_line += f' --bucket-name {self.bucket_name}'
         if self.product_name:
-            cmd_line += ' --product-name %s' % self.product_name
-        cmd_line += ' --tags %s' % self.tags
+            cmd_line += f' --product-name {self.product_name}'
+        cmd_line += f' --tags {self.tags}'
         if self.product_owner:
-            cmd_line += ' --product-owner %s' % self.product_owner
+            cmd_line += f' --product-owner {self.product_owner}'
         if self.product_type:
-            cmd_line += ' --product-type %s' % self.product_type
+            cmd_line += f' --product-type {self.product_type}'
         if self.provisioning_artifact_name:
-            cmd_line += (
-                ' --provisioning-artifact-name %s'
-                % self.provisioning_artifact_name
-            )
+            cmd_line += f' --provisioning-artifact-name {self.provisioning_artifact_name}'
         if self.provisioning_artifact_description:
-            cmd_line += (
-                ' --provisioning-artifact-description %s'
-                % self.provisioning_artifact_description
-            )
+            cmd_line += f' --provisioning-artifact-description {self.provisioning_artifact_description}'
         if self.provisioning_artifact_type:
-            cmd_line += (
-                ' --provisioning-artifact-type %s'
-                % self.provisioning_artifact_type
-            )
-        cmd_line += ' --product-description %s' % self.product_description
-        cmd_line += ' --product-distributor %s' % self.product_distributor
-        cmd_line += ' --support-description %s' % self.support_description
-        cmd_line += ' --support-email %s' % self.support_email
+            cmd_line += f' --provisioning-artifact-type {self.provisioning_artifact_type}'
+        cmd_line += f' --product-description {self.product_description}'
+        cmd_line += f' --product-distributor {self.product_distributor}'
+        cmd_line += f' --support-description {self.support_description}'
+        cmd_line += f' --support-email {self.support_email}'
         return cmd_line
 
     def setUp(self):

--- a/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
+++ b/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
@@ -48,26 +48,17 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
     def build_cmd_line(self):
         cmd_line = self.prefix
         if self.template_path:
-            cmd_line += ' --file-path %s' % self.template_path
+            cmd_line += f' --file-path {self.template_path}'
         if self.bucket_name:
-            cmd_line += ' --bucket-name %s' % self.bucket_name
+            cmd_line += f' --bucket-name {self.bucket_name}'
         if self.provisioning_artifact_name:
-            cmd_line += (
-                ' --provisioning-artifact-name %s'
-                % self.provisioning_artifact_name
-            )
+            cmd_line += f' --provisioning-artifact-name {self.provisioning_artifact_name}'
         if self.provisioning_artifact_description:
-            cmd_line += (
-                ' --provisioning-artifact-description %s'
-                % self.provisioning_artifact_description
-            )
+            cmd_line += f' --provisioning-artifact-description {self.provisioning_artifact_description}'
         if self.provisioning_artifact_type:
-            cmd_line += (
-                ' --provisioning-artifact-type %s'
-                % self.provisioning_artifact_type
-            )
+            cmd_line += f' --provisioning-artifact-type {self.provisioning_artifact_type}'
         if self.product_id:
-            cmd_line += ' --product-id %s' % self.product_id
+            cmd_line += f' --product-id {self.product_id}'
         return cmd_line
 
     def setUp(self):

--- a/tests/functional/sqs/test_add_permission.py
+++ b/tests/functional/sqs/test_add_permission.py
@@ -21,7 +21,7 @@ class TestAddPermission(BaseAWSCommandParamsTest):
 
     def test_all_param(self):
         cmdline = self.prefix
-        cmdline += ' --queue-url %s' % self.queue_url
+        cmdline += f' --queue-url {self.queue_url}'
         cmdline += ' --aws-account-ids 888888888888'
         cmdline += ' --actions SendMessage'
         cmdline += ' --label FooBarLabel'
@@ -35,7 +35,7 @@ class TestAddPermission(BaseAWSCommandParamsTest):
 
     def test_multiple_accounts(self):
         cmdline = self.prefix
-        cmdline += ' --queue-url %s' % self.queue_url
+        cmdline += f' --queue-url {self.queue_url}'
         cmdline += ' --aws-account-ids 888888888888 999999999999'
         cmdline += ' --actions SendMessage'
         cmdline += ' --label FooBarLabel'
@@ -49,7 +49,7 @@ class TestAddPermission(BaseAWSCommandParamsTest):
 
     def test_multiple_actions(self):
         cmdline = self.prefix
-        cmdline += ' --queue-url %s' % self.queue_url
+        cmdline += f' --queue-url {self.queue_url}'
         cmdline += ' --aws-account-ids 888888888888'
         cmdline += ' --actions SendMessage ReceiveMessage'
         cmdline += ' --label FooBarLabel'

--- a/tests/functional/sqs/test_change_message_visibility.py
+++ b/tests/functional/sqs/test_change_message_visibility.py
@@ -22,8 +22,8 @@ class TestChangeMessageVisibility(BaseAWSCommandParamsTest):
 
     def test_all_params(self):
         cmdline = self.prefix
-        cmdline += ' --queue-url %s' % self.queue_url
-        cmdline += ' --receipt-handle %s' % self.receipt_handle
+        cmdline += f' --queue-url {self.queue_url}'
+        cmdline += f' --receipt-handle {self.receipt_handle}'
         cmdline += ' --visibility-timeout 30'
         result = {
             'QueueUrl': self.queue_url,

--- a/tests/functional/sqs/test_create_queue.py
+++ b/tests/functional/sqs/test_create_queue.py
@@ -21,7 +21,7 @@ class TestCreateQueue(BaseAWSCommandParamsTest):
 
     def test_simple(self):
         cmdline = self.prefix
-        cmdline += ' --queue-name %s' % self.queue_name
+        cmdline += f' --queue-name {self.queue_name}'
         result = {'QueueName': self.queue_name}
         self.assert_params_for_cmd(cmdline, result)
 

--- a/tests/functional/sqs/test_get_queue_attributes.py
+++ b/tests/functional/sqs/test_get_queue_attributes.py
@@ -20,18 +20,18 @@ class TestGetQueueAttributes(BaseAWSCommandParamsTest):
     queue_url = 'https://queue.amazonaws.com/4444/testcli'
 
     def test_no_attr(self):
-        cmdline = self.prefix + ' --queue-url %s' % self.queue_url
+        cmdline = self.prefix + f' --queue-url {self.queue_url}'
         result = {'QueueUrl': self.queue_url}
         self.assert_params_for_cmd(cmdline, result)
 
     def test_all(self):
-        cmdline = self.prefix + ' --queue-url %s' % self.queue_url
+        cmdline = self.prefix + f' --queue-url {self.queue_url}'
         cmdline += ' --attribute-names All'
         result = {'QueueUrl': self.queue_url, 'AttributeNames': ['All']}
         self.assert_params_for_cmd(cmdline, result)
 
     def test_one(self):
-        cmdline = self.prefix + ' --queue-url %s' % self.queue_url
+        cmdline = self.prefix + f' --queue-url {self.queue_url}'
         cmdline += ' --attribute-names VisibilityTimeout'
         result = {
             'QueueUrl': self.queue_url,
@@ -40,7 +40,7 @@ class TestGetQueueAttributes(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(cmdline, result)
 
     def test_two(self):
-        cmdline = self.prefix + ' --queue-url %s' % self.queue_url
+        cmdline = self.prefix + f' --queue-url {self.queue_url}'
         cmdline += ' --attribute-names VisibilityTimeout QueueArn'
         result = {
             'QueueUrl': self.queue_url,

--- a/tests/functional/sqs/test_purge_queue.py
+++ b/tests/functional/sqs/test_purge_queue.py
@@ -21,7 +21,7 @@ class TestPurgeQueue(BaseAWSCommandParamsTest):
     def test_simple(self):
         url = 'https://foo.bar/queue'
         cmdline = self.prefix
-        cmdline += ' --queue-url %s' % url
+        cmdline += f' --queue-url {url}'
         result = {'QueueUrl': url}
         self.assert_params_for_cmd(cmdline, result)
 

--- a/tests/functional/sqs/test_set_queue_attributes.py
+++ b/tests/functional/sqs/test_set_queue_attributes.py
@@ -20,7 +20,7 @@ class TestSetQueueAttributes(BaseAWSCommandParamsTest):
     queue_url = 'https://queue.amazonaws.com/4444/testcli'
 
     def test_one(self):
-        cmdline = self.prefix + ' --queue-url %s' % self.queue_url
+        cmdline = self.prefix + f' --queue-url {self.queue_url}'
         cmdline += ' --attributes {"VisibilityTimeout":"15"}'
         result = {
             'QueueUrl': self.queue_url,
@@ -29,7 +29,7 @@ class TestSetQueueAttributes(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(cmdline, result)
 
     def test_shorthand(self):
-        cmdline = self.prefix + ' --queue-url %s' % self.queue_url
+        cmdline = self.prefix + f' --queue-url {self.queue_url}'
         cmdline += ' --attributes VisibilityTimeout=15'
         result = {
             'QueueUrl': self.queue_url,

--- a/tests/functional/sso/test_login.py
+++ b/tests/functional/sso/test_login.py
@@ -243,7 +243,7 @@ class TestLoginCommand(BaseSSOTest):
         )
 
     def test_login_device_partially_missing_sso_configuration(self):
-        content = '[default]\n' 'sso_start_url=%s\n' % self.start_url
+        content = '[default]\n' f'sso_start_url={self.start_url}\n'
         self.set_config_file_content(content=content)
         _, stderr, _ = self.run_cmd(
             'sso login --use-device-code', expected_rc=253

--- a/tests/functional/test_alias.py
+++ b/tests/functional/test_alias.py
@@ -68,7 +68,7 @@ class TestAliases(BaseAWSCommandParamsTest):
 
     def add_alias(self, alias_name, alias_value):
         with open(self.alias_file, 'a+') as f:
-            f.write('%s = %s\n' % (alias_name, alias_value))
+            f.write(f'{alias_name} = {alias_value}\n')
 
     def assert_single_operation_called(
         self, cmdline, service_name, operation_name, params
@@ -242,7 +242,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         # The external alias is tested by using mkdir; a command that
         # is universal for the various OS's we support
         directory_to_make = os.path.join(self.files.rootdir, 'newdir')
-        self.add_alias('mkdir', '!mkdir %s' % directory_to_make)
+        self.add_alias('mkdir', f'!mkdir {directory_to_make}')
         self.run_cmd('mkdir')
         self.assertTrue(os.path.isdir(directory_to_make))
 
@@ -251,7 +251,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         # is universal for the various OS's we support
         directory_to_make = os.path.join(self.files.rootdir, 'newdir')
         self.add_alias('mkdir', '!mkdir')
-        self.run_cmd('mkdir %s' % directory_to_make)
+        self.run_cmd(f'mkdir {directory_to_make}')
         self.assertTrue(os.path.isdir(directory_to_make))
 
     def test_external_alias_with_quoted_arguments(self):
@@ -266,7 +266,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         # is universal for the various OS's we support
         directory_to_make = os.path.join(self.files.rootdir, 'newdir')
         self.add_alias('mkdir', '!f() { mkdir "${1}"; }; f')
-        self.run_cmd('mkdir %s' % directory_to_make)
+        self.run_cmd(f'mkdir {directory_to_make}')
         self.assertTrue(os.path.isdir(directory_to_make))
 
     def test_operation_level_alias_with_additonal_params(self):
@@ -332,7 +332,7 @@ class TestAliases(BaseAWSCommandParamsTest):
         with open(self.alias_file, 'a+') as f:
             f.write('[command ec2]\n')
             f.write('mkdir = !mkdir\n')
-        self.run_cmd('ec2 mkdir %s' % directory_to_make)
+        self.run_cmd(f'ec2 mkdir {directory_to_make}')
         self.assertTrue(os.path.isdir(directory_to_make))
 
     def test_can_create_bag_of_options_alias(self):

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -149,16 +149,15 @@ class TestPlugins(BaseCLIDriverTest):
     def test_plugins_loaded_from_specified_path(self):
         self.create_config(
             '[plugins]\n'
-            'cli_legacy_plugin_path = %s\n'
-            'myplugin = %s\n'
-            % (self.plugins_site_packages, self.plugin_module_name)
+            f'cli_legacy_plugin_path = {self.plugins_site_packages}\n'
+            f'myplugin = {self.plugin_module_name}\n'
         )
         clidriver = create_clidriver()
         self.assert_plugin_loaded(clidriver)
 
     def test_plugins_are_not_loaded_when_path_specified(self):
         self.create_config(
-            '[plugins]\n' 'myplugin = %s\n' % self.plugin_module_name
+            '[plugins]\n' f'myplugin = {self.plugin_module_name}\n'
         )
         clidriver = create_clidriver()
         self.assert_plugin_not_loaded(clidriver)
@@ -170,8 +169,8 @@ class TestPlugins(BaseCLIDriverTest):
         )
         self.create_config(
             '[plugins]\n'
-            'cli_legacy_plugin_path = %s\n'
-            'myplugin = %s\n' % (plugin_path, self.plugin_module_name)
+            f'cli_legacy_plugin_path = {plugin_path}\n'
+            f'myplugin = {self.plugin_module_name}\n'
         )
         clidriver = create_clidriver()
         self.assert_plugin_loaded(clidriver)

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -35,16 +35,14 @@ class TestCLIInputJSON(BaseCLIInputArgumentTest):
     def test_cli_input_json_no_exta_args(self):
         # Run a head command using the input json
         cmdline = (
-            's3api head-object --cli-input-json file://%s'
-        ) % self.input_file
+            f's3api head-object --cli-input-json file://{self.input_file}'
+        )
         self.assert_params_for_cmd(
             cmdline, params={'Bucket': 'bucket', 'Key': 'key'}
         )
 
     def test_cli_input_json_can_override_param(self):
-        cmdline = (
-            's3api head-object --key bar --cli-input-json file://%s'
-        ) % self.input_file
+        cmdline = f's3api head-object --key bar --cli-input-json file://{self.input_file}'
         self.assert_params_for_cmd(cmdline, {'Bucket': 'bucket', 'Key': 'bar'})
 
     def test_cli_input_json_not_from_file(self):
@@ -116,7 +114,7 @@ class TestCLIInputYAML(BaseCLIInputArgumentTest):
             's3api',
             'list-objects-v2',
             '--cli-input-yaml',
-            'file://%s' % filename,
+            f'file://{filename}',
         ]
         self.assert_params_for_cmd(
             command, {'Bucket': 'test-bucket', 'EncodingType': 'url'}

--- a/tests/functional/test_document_types.py
+++ b/tests/functional/test_document_types.py
@@ -130,9 +130,9 @@ class TestDocumentTypeIO(BaseAWSCommandParamsTest):
 
     def nested_doctype_shorthand_error(self, parameter_name, member_name):
         return (
-            "Error parsing parameter '%s': Shorthand syntax does not support "
+            f"Error parsing parameter '{parameter_name}': Shorthand syntax does not support "
             "document types. Use JSON input for top-level argument to specify "
-            "nested parameter: %s" % (parameter_name, member_name)
+            f"nested parameter: {member_name}"
         )
 
     def test_can_provide_json_for_doc_type(self):

--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -31,7 +31,7 @@ def test_no_event_stream_unless_allowed():
                 op_help = sub_command.create_help_command()
                 model = op_help.obj
                 if isinstance(model, OperationModel):
-                    full_command = '%s %s' % (command_name, sub_name)
+                    full_command = f'{command_name} {sub_name}'
                     if (
                         model.has_event_stream_input
                         or model.has_event_stream_output
@@ -40,9 +40,9 @@ def test_no_event_stream_unless_allowed():
                             continue
                         supported_commands = '\n'.join(_ALLOWED_COMMANDS)
                         errors.append(
-                            'The "%s" command uses event streams '
+                            f'The "{full_command}" command uses event streams '
                             'which is only supported for these operations:\n'
-                            '%s' % (full_command, supported_commands)
+                            f'{supported_commands}'
                         )
     if errors:
         raise AssertionError('\n' + '\n'.join(errors))

--- a/tests/functional/test_output.py
+++ b/tests/functional/test_output.py
@@ -61,7 +61,7 @@ class TestOutput(BaseAWSCommandParamsTest):
 
     def write_cli_pager_config(self, pager):
         config_file = self.files.create_file(
-            'config', '[default]\n' 'cli_pager = %s\n' % pager
+            'config', '[default]\n' f'cli_pager = {pager}\n'
         )
         self.environ['AWS_CONFIG_FILE'] = config_file
         self.driver = create_clidriver()

--- a/tests/functional/test_paramfile.py
+++ b/tests/functional/test_paramfile.py
@@ -32,7 +32,7 @@ class BaseTestCLIFollowParamFile(BaseAWSCommandParamsTest):
     def assert_param_expansion_is_correct(
         self, provided_param, expected_param
     ):
-        cmd = '%s %s' % (self.prefix, provided_param)
+        cmd = f'{self.prefix} {provided_param}'
         # We do not care about the return code here. All that is of interest
         # is what happened to the arguments before they were passed to botocore
         # which we get from the params={} key. For binary types we will fail in
@@ -51,7 +51,7 @@ class TestCLIFollowParamFileDefault(BaseTestCLIFollowParamFile):
 
     def test_does_use_file_prefix(self):
         path = self.files.create_file('foobar.txt', 'file content')
-        param = 'file://%s' % path
+        param = f'file://{path}'
         self.assert_param_expansion_is_correct(
             provided_param=param, expected_param='file content'
         )
@@ -61,7 +61,7 @@ class TestCLIFollowParamFileDefault(BaseTestCLIFollowParamFile):
         # not work for this parameter, however we still record the raw
         # parameter that we passed, which is all this test is concerend about.
         path = self.files.create_file('foobar.txt', b'file content', mode='wb')
-        param = 'fileb://%s' % path
+        param = f'fileb://{path}'
         self.assert_param_expansion_is_correct(
             provided_param=param, expected_param=b'file content'
         )
@@ -76,14 +76,14 @@ class TestCLIUseEncodingFromEnv(BaseTestCLIFollowParamFile):
 
     def test_does_use_encoding_utf8(self):
         self.environ['AWS_CLI_FILE_ENCODING'] = 'utf-8'
-        param = 'file://%s' % self.path
+        param = f'file://{self.path}'
         self.assert_param_expansion_is_correct(
             provided_param=param, expected_param='經理'
         )
 
     def test_does_use_encoding_cp1251(self):
         self.environ['AWS_CLI_FILE_ENCODING'] = 'cp1251'
-        param = 'file://%s' % self.path
+        param = f'file://{self.path}'
         self.assert_param_expansion_is_correct(
             provided_param=param, expected_param='з¶“зђ†'
         )

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -64,7 +64,7 @@ def test_no_shadowed_builtins(command_name, command_table, builtins):
                 # Then we are shadowing or prefixing a top level argument
                 errors.append(
                     'Shadowing/Prefixing a top level option: '
-                    '%s.%s.%s' % (command_name, sub_name, arg_name)
+                    f'{command_name}.{sub_name}.{arg_name}'
                 )
     if errors:
         raise AssertionError('\n' + '\n'.join(errors))

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -22,5 +22,5 @@ class TestWriteException(unittest.TestCase):
             write_exception(ex, outfile)
             outfile.seek(0)
 
-            expected_output = "\n%s\n" % error_message
+            expected_output = f"\n{error_message}\n"
             self.assertEqual(outfile.read(), expected_output)

--- a/tests/functional/translate/test_import_terminology.py
+++ b/tests/functional/translate/test_import_terminology.py
@@ -31,7 +31,7 @@ class TestImortTerminology(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --name myterminology --merge-strategy OVERWRITE'
         cmdline += ' --terminology-data Format=CSV'
-        cmdline += ' --data-file fileb://%s' % self.temp_file
+        cmdline += f' --data-file fileb://{self.temp_file}'
         result = {
             'Name': 'myterminology',
             'MergeStrategy': 'OVERWRITE',
@@ -46,7 +46,7 @@ class TestImortTerminology(BaseAWSCommandParamsTest):
         cmdline = self.prefix
         cmdline += ' --name myterminology --merge-strategy OVERWRITE'
         cmdline += ' --terminology-data Format=TMX'
-        cmdline += ' --data-file fileb://%s' % self.temp_file
+        cmdline += f' --data-file fileb://{self.temp_file}'
         result = {
             'Name': 'myterminology',
             'MergeStrategy': 'OVERWRITE',
@@ -80,7 +80,7 @@ class TestImortTerminology(BaseAWSCommandParamsTest):
     def test_import_terminology_with_no_format(self):
         cmdline = self.prefix
         cmdline += ' --name myterminology --merge-strategy OVERWRITE'
-        cmdline += ' --data-file fileb://%s' % self.temp_file
+        cmdline += f' --data-file fileb://{self.temp_file}'
         stdout, stderr, rc = self.run_cmd(cmdline, expected_rc=252)
         self.assertIn(
             'Missing required parameter in TerminologyData: "Format"', stderr

--- a/tests/functional/translate/test_translate_document.py
+++ b/tests/functional/translate/test_translate_document.py
@@ -32,7 +32,7 @@ class TestTranslateDocument(BaseAWSCommandParamsTest):
         cmdline += " --source-language-code FOO"
         cmdline += " --target-language-code BAR"
         cmdline += " --document ContentType=datatype"
-        cmdline += " --document-content fileb://%s" % self.temp_file
+        cmdline += f" --document-content fileb://{self.temp_file}"
         result = {
             "Document": {
                 "Content": self.temp_file_contents,
@@ -61,7 +61,7 @@ class TestTranslateDocument(BaseAWSCommandParamsTest):
         cmdline += " --source-language-code FOO"
         cmdline += " --target-language-code BAR"
         cmdline += " --document Content=data,ContentType=datatype"
-        cmdline += " --document-content fileb://%s" % self.temp_file
+        cmdline += f" --document-content fileb://{self.temp_file}"
 
         stdout, stderr, rc = self.assert_params_for_cmd(
             cmdline, expected_rc=252

--- a/tests/integration/botocore/test_client_http.py
+++ b/tests/integration/botocore/test_client_http.py
@@ -23,7 +23,7 @@ from tests import mock, unittest
 class TestClientHTTPBehavior(unittest.TestCase):
     def setUp(self):
         self.port = unused_port()
-        self.localhost = 'http://localhost:%s/' % self.port
+        self.localhost = f'http://localhost:{self.port}/'
         self.session = botocore.session.get_session()
         # We need to set fake credentials to ensure credentials aren't searched
         # for which might make additional API calls (assume role, etc).
@@ -31,7 +31,7 @@ class TestClientHTTPBehavior(unittest.TestCase):
 
     @unittest.skip('Test has suddenly become extremely flakey.')
     def test_can_proxy_https_request_with_auth(self):
-        proxy_url = 'http://user:pass@localhost:%s/' % self.port
+        proxy_url = f'http://user:pass@localhost:{self.port}/'
         config = Config(proxies={'https': proxy_url}, region_name='us-west-1')
         client = self.session.create_client('ec2', config=config)
 
@@ -51,7 +51,7 @@ class TestClientHTTPBehavior(unittest.TestCase):
 
     @unittest.skip('Proxy cannot connect to service when run in CodeBuild.')
     def test_proxy_request_includes_host_header(self):
-        proxy_url = 'http://user:pass@localhost:%s/' % self.port
+        proxy_url = f'http://user:pass@localhost:{self.port}/'
         config = Config(
             proxies={'https': proxy_url},
             proxies_config={'proxy_use_forwarding_for_https': True},

--- a/tests/integration/botocore/test_cloudformation.py
+++ b/tests/integration/botocore/test_cloudformation.py
@@ -26,7 +26,7 @@ class TestCloudformation(unittest.TestCase):
         # it handles the case when a stack does not exist.
         with self.assertRaises(ClientError):
             self.client.get_template(
-                StackName='does-not-exist-%s' % random_chars(10)
+                StackName=f'does-not-exist-{random_chars(10)}'
             )
 
 

--- a/tests/integration/botocore/test_cognito_identity.py
+++ b/tests/integration/botocore/test_cognito_identity.py
@@ -23,7 +23,7 @@ class TestCognitoIdentity(unittest.TestCase):
         )
 
     def test_can_create_and_delete_identity_pool(self):
-        pool_name = 'test%s' % random_chars(10)
+        pool_name = f'test{random_chars(10)}'
         response = self.client.create_identity_pool(
             IdentityPoolName=pool_name, AllowUnauthenticatedIdentities=True
         )

--- a/tests/integration/botocore/test_credentials.py
+++ b/tests/integration/botocore/test_credentials.py
@@ -167,7 +167,7 @@ class TestAssumeRoleCredentials(BaseEnvVar):
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "arn:aws:iam::%s:root" % account_id},
+                    "Principal": {"AWS": f"arn:aws:iam::{account_id}:root"},
                     "Action": "sts:AssumeRole",
                 }
             ],
@@ -264,7 +264,7 @@ class TestAssumeRoleCredentials(BaseEnvVar):
                 else:
                     raise
 
-        raise Exception("Unable to assume role %s" % role_arn)
+        raise Exception(f"Unable to assume role {role_arn}")
 
     def create_assume_policy(self, role_arn):
         policy_document = {

--- a/tests/integration/botocore/test_elastictranscoder.py
+++ b/tests/integration/botocore/test_elastictranscoder.py
@@ -39,7 +39,7 @@ class TestElasticTranscoder(unittest.TestCase):
         self.iam_client = self.session.create_client('iam', 'us-east-1')
 
     def create_bucket(self):
-        bucket_name = 'ets-bucket-1-%s' % random_chars(50)
+        bucket_name = f'ets-bucket-1-{random_chars(50)}'
         self.s3_client.create_bucket(Bucket=bucket_name)
         waiter = self.s3_client.get_waiter('bucket_exists')
         waiter.wait(Bucket=bucket_name)
@@ -47,7 +47,7 @@ class TestElasticTranscoder(unittest.TestCase):
         return bucket_name
 
     def create_iam_role(self):
-        role_name = 'ets-role-name-1-%s' % random_chars(10)
+        role_name = f'ets-role-name-1-{random_chars(10)}'
         parsed = self.iam_client.create_role(
             RoleName=role_name, AssumeRolePolicyDocument=DEFAULT_ROLE_POLICY
         )
@@ -69,7 +69,7 @@ class TestElasticTranscoder(unittest.TestCase):
         input_bucket = self.create_bucket()
         output_bucket = self.create_bucket()
         role = self.create_iam_role()
-        pipeline_name = 'botocore-test-create-%s' % random_chars(10)
+        pipeline_name = f'botocore-test-create-{random_chars(10)}'
 
         parsed = self.client.create_pipeline(
             InputBucket=input_bucket,

--- a/tests/integration/botocore/test_s3.py
+++ b/tests/integration/botocore/test_s3.py
@@ -294,8 +294,7 @@ class TestS3BaseWithBucket(BaseS3ClientTest):
                 # Sleep and try again.
                 time.sleep(2)
         self.fail(
-            "Expected to see %s uploads, instead saw: %s"
-            % (num_uploads, amount_seen)
+            f"Expected to see {num_uploads} uploads, instead saw: {amount_seen}"
         )
 
     def create_client(self):
@@ -359,7 +358,7 @@ class TestS3Objects(TestS3BaseWithBucket):
     @pytest.mark.slow
     def test_can_paginate(self):
         for i in range(5):
-            key_name = 'key%s' % i
+            key_name = f'key{i}'
             self.create_object(key_name)
         # Eventual consistency.
         time.sleep(3)
@@ -373,7 +372,7 @@ class TestS3Objects(TestS3BaseWithBucket):
     @pytest.mark.slow
     def test_can_paginate_with_page_size(self):
         for i in range(5):
-            key_name = 'key%s' % i
+            key_name = f'key{i}'
             self.create_object(key_name)
         # Eventual consistency.
         time.sleep(3)
@@ -390,9 +389,9 @@ class TestS3Objects(TestS3BaseWithBucket):
     @pytest.mark.slow
     def test_result_key_iters(self):
         for i in range(5):
-            key_name = 'key/%s/%s' % (i, i)
+            key_name = f'key/{i}/{i}'
             self.create_object(key_name)
-            key_name2 = 'key/%s' % i
+            key_name2 = f'key/{i}'
             self.create_object(key_name2)
         time.sleep(3)
         paginator = self.client.get_paginator('list_objects')
@@ -576,7 +575,7 @@ class TestS3Objects(TestS3BaseWithBucket):
         threads = []
         for i in range(10):
             t = threading.Thread(
-                target=self.create_object_catch_exceptions, args=('foo%s' % i,)
+                target=self.create_object_catch_exceptions, args=(f'foo{i}',)
             )
             t.daemon = True
             threads.append(t)
@@ -587,13 +586,12 @@ class TestS3Objects(TestS3BaseWithBucket):
         self.assertEqual(
             self.caught_exceptions,
             [],
-            "Unexpectedly caught exceptions: %s" % self.caught_exceptions,
+            f"Unexpectedly caught exceptions: {self.caught_exceptions}",
         )
         self.assertEqual(
             len(set(self.auth_paths)),
             10,
-            "Expected 10 unique auth paths, instead received: %s"
-            % (self.auth_paths),
+            f"Expected 10 unique auth paths, instead received: {self.auth_paths}",
         )
 
     def test_non_normalized_key_paths(self):
@@ -636,7 +634,7 @@ class TestS3Copy(TestS3BaseWithBucket):
         self.client.copy_object(
             Bucket=self.bucket_name,
             Key=key_name2,
-            CopySource='%s/%s' % (self.bucket_name, key_name),
+            CopySource=f'{self.bucket_name}/{key_name}',
         )
 
         # Now verify we can retrieve the copied object.
@@ -651,7 +649,7 @@ class TestS3Copy(TestS3BaseWithBucket):
         self.client.copy_object(
             Bucket=self.bucket_name,
             Key=key_name2,
-            CopySource='%s/%s' % (self.bucket_name, key_name),
+            CopySource=f'{self.bucket_name}/{key_name}',
         )
 
         # Now verify we can retrieve the copied object.
@@ -680,7 +678,7 @@ class TestS3Copy(TestS3BaseWithBucket):
         parsed = self.client.copy_object(
             Bucket=self.bucket_name,
             Key=copied_key,
-            CopySource='%s/%s' % (self.bucket_name, key_name),
+            CopySource=f'{self.bucket_name}/{key_name}',
             MetadataDirective='REPLACE',
             Metadata={"mykey": "myvalue", "mykey2": "myvalue2"},
         )
@@ -730,11 +728,10 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
         )
         self.assertTrue(
             presigned_url.startswith(
-                'https://%s.s3.us-east-1.amazonaws.com/%s'
-                % (self.bucket_name, self.key)
+                f'https://{self.bucket_name}.s3.us-east-1.amazonaws.com/{self.key}'
             ),
             "Host was suppose to be the us-east-1 endpoint, instead "
-            "got: %s" % presigned_url,
+            f"got: {presigned_url}",
         )
         # Try to retrieve the object using the presigned url.
         self.assertEqual(http_get(presigned_url).data, b'foo')
@@ -766,10 +763,10 @@ class TestS3PresignUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.us-east-1.amazonaws.com/' % self.bucket_name
+                f'https://{self.bucket_name}.s3.us-east-1.amazonaws.com/'
             ),
             "Host was suppose to use us-east-1 endpoint, instead "
-            "got: %s" % post_args['url'],
+            "got: {}".format(post_args['url']),
         )
 
         r = http_post(post_args['url'], data=post_args['fields'], files=files)
@@ -803,11 +800,10 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
 
         self.assertTrue(
             presigned_url.startswith(
-                'https://s3.us-west-2.amazonaws.com/%s/%s'
-                % (self.bucket_name, self.key)
+                f'https://s3.us-west-2.amazonaws.com/{self.bucket_name}/{self.key}'
             ),
             "Host was suppose to be the us-west-2 endpoint, instead "
-            "got: %s" % presigned_url,
+            f"got: {presigned_url}",
         )
         # Try to retrieve the object using the presigned url.
         self.assertEqual(http_get(presigned_url).data, b'foo')
@@ -839,10 +835,11 @@ class TestS3PresignNonUsStandard(BaseS3PresignTest):
         # Make sure the correct endpoint is being used
         self.assertTrue(
             post_args['url'].startswith(
-                'https://%s.s3.us-west-2.amazonaws.com/' % self.bucket_name
+                f'https://{self.bucket_name}.s3.us-west-2.amazonaws.com/'
             ),
-            "Host was suppose to use DNS style, instead "
-            "got: %s" % post_args['url'],
+            "Host was suppose to use DNS style, instead " "got: {}".format(
+                post_args['url']
+            ),
         )
 
         r = http_post(post_args['url'], data=post_args['fields'], files=files)
@@ -1292,7 +1289,7 @@ class TestRegionRedirect(BaseS3ClientTest):
             )
             self.assertEqual(response.get('ContentLength'), len(key))
         except ClientError as e:
-            self.fail("S3 Client failed to redirect Head Object: %s" % e)
+            self.fail(f"S3 Client failed to redirect Head Object: {e}")
 
 
 class TestBucketWithVersions(BaseS3ClientTest):

--- a/tests/integration/botocore/test_session.py
+++ b/tests/integration/botocore/test_session.py
@@ -31,7 +31,7 @@ class TestCanChangeParsing(unittest.TestCase):
         dates = [bucket['CreationDate'] for bucket in parsed['Buckets']]
         self.assertTrue(
             all(isinstance(date, str) for date in dates),
-            "Expected all str types but instead got: %s" % dates,
+            f"Expected all str types but instead got: {dates}",
         )
 
     def test_maps_service_name_when_overriden(self):

--- a/tests/integration/botocore/test_smoke.py
+++ b/tests/integration/botocore/test_smoke.py
@@ -326,7 +326,7 @@ def test_client_can_retry_request_properly(
         except ClientError as e:
             assert False, (
                 'Request was not retried properly, '
-                'received error:\n%s' % pformat(e)
+                f'received error:\n{pformat(e)}'
             )
         # Ensure we used the stubber as we're not using it in strict mode
         assert len(http_stubber.responses) == 0, 'Stubber was not used!'

--- a/tests/integration/botocore/test_waiters.py
+++ b/tests/integration/botocore/test_waiters.py
@@ -24,7 +24,7 @@ class TestWaiterForDynamoDB(unittest.TestCase):
         self.client = self.session.create_client('dynamodb', 'us-west-2')
 
     def test_create_table_and_wait(self):
-        table_name = 'botocoretest-%s' % random_chars(10)
+        table_name = f'botocoretest-{random_chars(10)}'
         self.client.create_table(
             TableName=table_name,
             ProvisionedThroughput={

--- a/tests/integration/customizations/history/test_show.py
+++ b/tests/integration/customizations/history/test_show.py
@@ -44,8 +44,7 @@ class TestShow(unittest.TestCase):
             new_pos = contents.find(line)
             if new_pos < current_pos:
                 self.fail(
-                    'Line: "%s" should have came after line: "%s"'
-                    % (line, prev_line)
+                    f'Line: "{line}" should have came after line: "{prev_line}"'
                 )
             prev_line = line
             current_pos = new_pos

--- a/tests/integration/customizations/test_waiters.py
+++ b/tests/integration/customizations/test_waiters.py
@@ -26,7 +26,7 @@ class TestDynamoDBWait(unittest.TestCase):
     @pytest.mark.slow
     def test_wait_table_exists(self):
         # Create a table.
-        table_name = 'awscliddb-%s' % random_chars(10)
+        table_name = f'awscliddb-{random_chars(10)}'
         self.client.create_table(
             TableName=table_name,
             ProvisionedThroughput={
@@ -42,8 +42,7 @@ class TestDynamoDBWait(unittest.TestCase):
 
         # Wait for the table to be active.
         p = aws(
-            'dynamodb wait table-exists --table-name %s --region us-west-2'
-            % table_name
+            f'dynamodb wait table-exists --table-name {table_name} --region us-west-2'
         )
         self.assertEqual(p.rc, 0)
 

--- a/tests/integration/s3transfer/test_crt.py
+++ b/tests/integration/s3transfer/test_crt.py
@@ -510,6 +510,6 @@ class TestCRTS3Transfers(BaseTransferManagerIntegTest):
             future.result()
             self.assertEqual(err.name, 'AWS_ERROR_S3_CANCELED')
 
-        possible_matches = glob.glob('%s*' % download_path)
+        possible_matches = glob.glob(f'{download_path}*')
         self.assertEqual(possible_matches, [])
         self._assert_subscribers_called()

--- a/tests/integration/s3transfer/test_download.py
+++ b/tests/integration/s3transfer/test_download.py
@@ -99,7 +99,7 @@ class TestDownload(BaseTransferManagerIntegTest):
                     future.cancel()
                     raise RuntimeError(
                         "Download transfer did not start after waiting for "
-                        "%s seconds." % timeout
+                        f"{timeout} seconds."
                     )
                 # Raise an exception which should cause the preceding
                 # download to cancel and exit quickly
@@ -125,7 +125,7 @@ class TestDownload(BaseTransferManagerIntegTest):
 
         # Make sure the actual file and the temporary do not exist
         # by globbing for the file and any of its extensions
-        possible_matches = glob.glob('%s*' % download_path)
+        possible_matches = glob.glob(f'{download_path}*')
         self.assertEqual(possible_matches, [])
 
     @skip_if_using_serial_implementation(
@@ -183,7 +183,7 @@ class TestDownload(BaseTransferManagerIntegTest):
 
         # For the transfer that did get cancelled, make sure the temporary
         # file got removed.
-        possible_matches = glob.glob('%s*' % future.meta.call_args.fileobj)
+        possible_matches = glob.glob(f'{future.meta.call_args.fileobj}*')
         self.assertEqual(possible_matches, [])
 
     def test_progress_subscribers_on_download(self):
@@ -281,5 +281,5 @@ class TestDownload(BaseTransferManagerIntegTest):
         except Exception as e:
             self.fail(
                 'Should have been able to download to /dev/null but received '
-                'following exception %s' % e
+                f'following exception {e}'
             )

--- a/tests/integration/s3transfer/test_upload.py
+++ b/tests/integration/s3transfer/test_upload.py
@@ -94,7 +94,7 @@ class TestUpload(BaseTransferManagerIntegTest):
                     future.cancel()
                     raise RuntimeError(
                         "Download transfer did not start after waiting for "
-                        "%s seconds." % timeout
+                        f"{timeout} seconds."
                     )
                 # Raise an exception which should cause the preceding
                 # download to cancel and exit quickly

--- a/tests/integration/test_assume_role.py
+++ b/tests/integration/test_assume_role.py
@@ -42,7 +42,7 @@ class TestAssumeRoleCredentials(unittest.TestCase):
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "arn:aws:iam::%s:root" % account_id},
+                    "Principal": {"AWS": f"arn:aws:iam::{account_id}:root"},
                     "Action": "sts:AssumeRole",
                 }
             ],
@@ -129,7 +129,7 @@ class TestAssumeRoleCredentials(unittest.TestCase):
                 attempts_remaining -= 1
             time.sleep(delay)
 
-        raise Exception("Unable to assume role %s" % role_arn)
+        raise Exception(f"Unable to assume role {role_arn}")
 
     def create_assume_policy(self, role_arn):
         policy_document = {
@@ -153,12 +153,12 @@ class TestAssumeRoleCredentials(unittest.TestCase):
 
     def assert_s3_read_only_profile(self, profile_name):
         # Calls to S3 should succeed
-        command = 's3api list-buckets --profile %s' % profile_name
+        command = f's3api list-buckets --profile {profile_name}'
         result = aws(command, env_vars=self.environ)
         self.assertEqual(result.rc, 0, result.stderr)
 
         # Calls to other services should not
-        command = 'iam list-groups --profile %s' % profile_name
+        command = f'iam list-groups --profile {profile_name}'
         result = aws(command, env_vars=self.environ)
         self.assertNotEqual(result.rc, 0, result.stdout)
         self.assertIn('AccessDenied', result.stderr)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -156,7 +156,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         self.assertIn(
             "The filter 'bad-filter' is invalid",
             p.stderr,
-            "stdout: %s, stderr: %s" % (p.stdout, p.stderr),
+            f"stdout: {p.stdout}, stderr: {p.stderr}",
         )
 
     def test_param_with_file(self):
@@ -166,7 +166,7 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         with open(param_file, 'w') as f:
             f.write('[{"Name": "instance-id", "Values": ["i-123"]}]')
         self.addCleanup(os.remove, param_file)
-        p = aws('ec2 describe-instances --filters file://%s' % param_file)
+        p = aws(f'ec2 describe-instances --filters file://{param_file}')
         self.assertEqual(p.rc, 0)
         self.assertIn('Reservations', p.json)
 
@@ -181,8 +181,9 @@ class TestBasicCommandFunctionality(unittest.TestCase):
             bucket=bucket_name, key='foobar', content='foobar contents'
         )
         p = aws(
-            's3api get-object --bucket %s --key foobar %s'
-            % (bucket_name, os.path.join(d, 'foobar'))
+            's3api get-object --bucket {} --key foobar {}'.format(
+                bucket_name, os.path.join(d, 'foobar')
+            )
         )
         self.assertEqual(p.rc, 0)
         with open(os.path.join(d, 'foobar')) as f:
@@ -208,16 +209,17 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         )
 
         p = aws(
-            's3api get-object --bucket %s --key foo %s'
-            % (bucket_name, os.path.join(d, 'foo')),
+            's3api get-object --bucket {} --key foo {}'.format(
+                bucket_name, os.path.join(d, 'foo')
+            ),
             env_vars=env_vars,
         )
         # Should have credential issues.
         self.assertEqual(p.rc, 254)
 
         p = aws(
-            's3api get-object --bucket %s --key foo '
-            '%s --no-sign-request' % (bucket_name, os.path.join(d, 'foo')),
+            's3api get-object --bucket {} --key foo '
+            '{} --no-sign-request'.format(bucket_name, os.path.join(d, 'foo')),
             env_vars=env_vars,
         )
 
@@ -238,10 +240,10 @@ class TestBasicCommandFunctionality(unittest.TestCase):
         self.put_object(
             bucket=bucket_name, key='foobar', content='foobar contents'
         )
-        p = aws('s3api list-objects --bucket %s --no-paginate' % bucket_name)
+        p = aws(f's3api list-objects --bucket {bucket_name} --no-paginate')
         self.assertEqual(p.rc, 0, p.stdout + p.stderr)
 
-        p = aws('s3api list-objects --bucket %s' % bucket_name)
+        p = aws(f's3api list-objects --bucket {bucket_name}')
         self.assertEqual(p.rc, 0, p.stdout + p.stderr)
 
     def test_top_level_options_debug(self):
@@ -458,8 +460,8 @@ class TestGlobalArgs(BaseS3CLICommand):
         self.put_object(bucket_name, 'foo2.txt', contents=b'bar')
         self.put_object(bucket_name, 'foo3.txt', contents=b'bar')
         p = aws(
-            's3api list-objects --bucket %s '
-            '--no-paginate --output json' % bucket_name
+            f's3api list-objects --bucket {bucket_name} '
+            '--no-paginate --output json'
         )
         # A really simple way to check that --no-paginate was
         # honored is to see if we have all the mirrored input
@@ -476,8 +478,8 @@ class TestGlobalArgs(BaseS3CLICommand):
         self.put_object(bucket_name, 'foo2.txt', contents=b'bar')
         self.put_object(bucket_name, 'foo3.txt', contents=b'bar')
         p = aws(
-            's3api list-objects --bucket %s '
-            '--max-keys 1 --no-paginate --output json' % bucket_name
+            f's3api list-objects --bucket {bucket_name} '
+            '--max-keys 1 --no-paginate --output json'
         )
         self.assert_no_errors(p)
         response_json = p.json
@@ -489,8 +491,8 @@ class TestGlobalArgs(BaseS3CLICommand):
         self.put_object(bucket_name, 'foo2.txt', contents=b'bar')
         self.put_object(bucket_name, 'foo3.txt', contents=b'bar')
         p = aws(
-            's3api list-objects --bucket %s '
-            '--max-items 1 --output json' % bucket_name
+            f's3api list-objects --bucket {bucket_name} '
+            '--max-items 1 --output json'
         )
         self.assert_no_errors(p)
         response_json = p.json
@@ -500,8 +502,8 @@ class TestGlobalArgs(BaseS3CLICommand):
         bucket_name = self.create_bucket()
         self.put_object(bucket_name, 'foo.txt', contents=b'bar')
         p = aws(
-            's3api list-objects --bucket %s '
-            '--query Contents[].Key --output json' % bucket_name
+            f's3api list-objects --bucket {bucket_name} '
+            '--query Contents[].Key --output json'
         )
         self.assert_no_errors(p)
         response_json = p.json
@@ -522,8 +524,7 @@ class TestGlobalArgs(BaseS3CLICommand):
         env['AWS_ACCESS_KEY_ID'] = 'foo'
         env['AWS_SECRET_ACCESS_KEY'] = 'bar'
         p = aws(
-            's3api head-object --bucket %s --key public --no-sign-request'
-            % bucket_name,
+            f's3api head-object --bucket {bucket_name} --key public --no-sign-request',
             env_vars=env,
         )
         self.assert_no_errors(p)
@@ -532,8 +533,7 @@ class TestGlobalArgs(BaseS3CLICommand):
         # Should fail because we're not signing the request but the object is
         # private.
         p = aws(
-            's3api head-object --bucket %s --key private --no-sign-request'
-            % bucket_name,
+            f's3api head-object --bucket {bucket_name} --key private --no-sign-request',
             env_vars=env,
         )
         self.assertEqual(p.rc, 254)

--- a/tests/unit/autocomplete/test_completer.py
+++ b/tests/unit/autocomplete/test_completer.py
@@ -593,7 +593,7 @@ class TestFilePathCompleter(unittest.TestCase):
         parsed = self.parser.parse('aws --profile file://~')
         self.assertEqual(
             list(self.completer.complete(parsed)),
-            [CompletionResult('file://~%s' % os.sep, 0, False)],
+            [CompletionResult(f'file://~{os.sep}', 0, False)],
         )
 
     def test_complete_pass_correct_prefix(self):

--- a/tests/unit/autocomplete/test_parser.py
+++ b/tests/unit/autocomplete/test_parser.py
@@ -247,11 +247,9 @@ def _assert_parses_to(command_line, expected):
     result = p.parse(command_line)
     for key, value in vars(expected).items():
         actual = getattr(result, key)
-        assert getattr(result, key) == value, '%r != %r for attribute: %r' % (
-            actual,
-            value,
-            key,
-        )
+        assert (
+            getattr(result, key) == value
+        ), f'{actual!r} != {value!r} for attribute: {key!r}'
 
 
 def _generate_command_chunks():
@@ -307,7 +305,7 @@ class TestCanParseCLICommand(unittest.TestCase):
             self.assertEqual(
                 actual_value,
                 value,
-                '%r != %r (attr: %r)' % (actual_value, value, key),
+                f'{actual_value!r} != {value!r} (attr: {key!r})',
             )
 
     def assert_parsed_s3api_result_correct(self, result):

--- a/tests/unit/botocore/auth/test_signers.py
+++ b/tests/unit/botocore/auth/test_signers.py
@@ -212,7 +212,7 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
     def test_query_string_params_in_urls(self):
         if not hasattr(self.AuthClass, 'canonical_query_string'):
             raise unittest.SkipTest(
-                '%s does not expose interim steps' % self.AuthClass.__name__
+                f'{self.AuthClass.__name__} does not expose interim steps'
             )
 
         request = AWSRequest()
@@ -761,7 +761,7 @@ class BaseS3PresignPostTest(unittest.TestCase):
         }
 
         self.request = AWSRequest()
-        self.request.url = 'https://s3.amazonaws.com/%s' % self.bucket
+        self.request.url = f'https://s3.amazonaws.com/{self.bucket}'
         self.request.method = 'POST'
 
         self.request.context['s3-presign-post-fields'] = self.fields
@@ -829,7 +829,7 @@ class TestS3SigV4Post(BaseS3PresignPostTest):
 
     def test_empty_fields_and_policy(self):
         self.request = AWSRequest()
-        self.request.url = 'https://s3.amazonaws.com/%s' % self.bucket
+        self.request.url = f'https://s3.amazonaws.com/{self.bucket}'
         self.request.method = 'POST'
         self.auth.add_auth(self.request)
 

--- a/tests/unit/botocore/auth/test_sigv4.py
+++ b/tests/unit/botocore/auth/test_sigv4.py
@@ -122,7 +122,7 @@ def create_request_from_raw_request(raw_request):
     # so we need decode this into utf-8.
     if isinstance(raw.path, str):
         raw.path = raw.path.encode('iso-8859-1').decode('utf-8')
-    url = 'https://%s%s' % (host, raw.path)
+    url = f'https://{host}{raw.path}'
     if '?' in url:
         split_url = urlsplit(url)
         params = dict(parse_qsl(split_url.query))
@@ -192,9 +192,9 @@ def _test_crt_signature_version_4(test_case):
 
 def assert_equal(actual, expected, raw_request, part):
     if actual != expected:
-        message = "The %s did not match" % part
-        message += "\nACTUAL:%r !=\nEXPECT:%r" % (actual, expected)
-        message += '\nThe raw request was:\n%s' % raw_request
+        message = f"The {part} did not match"
+        message += f"\nACTUAL:{actual!r} !=\nEXPECT:{expected!r}"
+        message += f'\nThe raw request was:\n{raw_request}'
         raise AssertionError(message)
 
 

--- a/tests/unit/botocore/docs/test_utils.py
+++ b/tests/unit/botocore/docs/test_utils.py
@@ -197,7 +197,7 @@ class TestHideParamFromOperations(BaseDocsTest):
 
     def test_hides_params_from_doc_string(self):
         section = self.doc_structure.add_new_section(self.name)
-        param_signature = ':param %s: ' % self.name
+        param_signature = f':param {self.name}: '
         section.write(param_signature)
         self.assert_contains_line(param_signature)
         self.param.hide_param(
@@ -209,7 +209,7 @@ class TestHideParamFromOperations(BaseDocsTest):
     def test_hides_param_from_example(self):
         structure = self.doc_structure.add_new_section('structure-value')
         section = structure.add_new_section(self.name)
-        example = '%s: \'string\'' % self.name
+        example = f'{self.name}: \'string\''
         section.write(example)
         self.assert_contains_line(example)
         self.param.hide_param(

--- a/tests/unit/botocore/response_parsing/test_response_parsing.py
+++ b/tests/unit/botocore/response_parsing/test_response_parsing.py
@@ -41,7 +41,7 @@ def _test_parsed_response(xmlfile, operation_model, expected):
     response = {'body': response_body, 'status_code': 200, 'headers': {}}
     for case in SPECIAL_CASES:
         if case in xmlfile:
-            print("SKIP: %s" % xmlfile)
+            print(f"SKIP: {xmlfile}")
             return
     if 'errors' in xmlfile:
         response['status_code'] = 400
@@ -80,7 +80,7 @@ def _test_parsed_response(xmlfile, operation_model, expected):
         pretty_d1 = pprint.pformat(d1, width=1).splitlines()
         pretty_d2 = pprint.pformat(d2, width=1).splitlines()
         diff = '\n' + '\n'.join(difflib.ndiff(pretty_d1, pretty_d2))
-        raise AssertionError("Dicts are not equal:\n%s" % diff)
+        raise AssertionError(f"Dicts are not equal:\n{diff}")
 
 
 def _convert_bytes_to_str(parsed):
@@ -131,15 +131,13 @@ def _xml_test_cases():
         data_path = os.path.join(os.path.dirname(__file__), 'xml')
         data_path = os.path.join(data_path, dp)
         session = create_session()
-        xml_files = glob.glob('%s/*.xml' % data_path)
+        xml_files = glob.glob(f'{data_path}/*.xml')
         service_names = set()
         for fn in xml_files:
             service_names.add(os.path.split(fn)[1].split('-')[0])
         for service_name in service_names:
             service_model = session.get_service_model(service_name)
-            service_xml_files = glob.glob(
-                '%s/%s-*.xml' % (data_path, service_name)
-            )
+            service_xml_files = glob.glob(f'{data_path}/{service_name}-*.xml')
             for xmlfile in service_xml_files:
                 expected = _get_expected_parsed_result(xmlfile)
                 operation_model = _get_operation_model(service_model, xmlfile)

--- a/tests/unit/botocore/test_credentials.py
+++ b/tests/unit/botocore/test_credentials.py
@@ -2944,9 +2944,9 @@ class ProfileProvider:
 
     def load(self):
         return Credentials(
-            '%s-access-key' % self._profile_name,
-            '%s-secret-key' % self._profile_name,
-            '%s-token' % self._profile_name,
+            f'{self._profile_name}-access-key',
+            f'{self._profile_name}-secret-key',
+            f'{self._profile_name}-token',
             self.METHOD,
         )
 
@@ -3134,7 +3134,7 @@ class TestContainerProvider(BaseEnvVar):
         self.assertIsNone(creds)
 
     def full_url(self, url):
-        return 'http://%s%s' % (ContainerMetadataFetcher.IP_ADDRESS, url)
+        return f'http://{ContainerMetadataFetcher.IP_ADDRESS}{url}'
 
     def create_fetcher(self):
         fetcher = mock.Mock(spec=ContainerMetadataFetcher)

--- a/tests/unit/botocore/test_exceptions.py
+++ b/tests/unit/botocore/test_exceptions.py
@@ -49,8 +49,7 @@ def test_retry_info_added_when_present():
     error_msg = str(exceptions.ClientError(response, 'operation'))
     if '(reached max retries: 3)' not in error_msg:
         raise AssertionError(
-            "retry information not inject into error "
-            "message: %s" % error_msg
+            "retry information not inject into error " f"message: {error_msg}"
         )
 
 
@@ -68,7 +67,7 @@ def test_retry_info_not_added_if_retry_attempts_not_present():
         raise AssertionError(
             "Retry information should not be in exception "
             "message when retry attempts not in response "
-            "metadata: %s" % error_msg
+            f"metadata: {error_msg}"
         )
 
 
@@ -85,7 +84,7 @@ def test_can_handle_when_response_missing_error_key():
     if 'An error occurred (Unknown)' not in str(e):
         raise AssertionError(
             "Error code should default to 'Unknown' "
-            "when missing error response, instead got: %s" % str(e)
+            f"when missing error response, instead got: {str(e)}"
         )
 
 

--- a/tests/unit/botocore/test_handlers.py
+++ b/tests/unit/botocore/test_handlers.py
@@ -744,7 +744,7 @@ class TestHandlers(BaseSessionTest):
         request = AWSRequest()
         url = 'https://machinelearning.us-east-1.amazonaws.com'
         new_endpoint = 'https://my-custom-endpoint.amazonaws.com'
-        data = '{"PredictEndpoint":"%s"}' % new_endpoint
+        data = f'{{"PredictEndpoint":"{new_endpoint}"}}'
         request.data = data.encode('utf-8')
         request.url = url
         handlers.switch_host_with_param(request, 'PredictEndpoint')
@@ -799,7 +799,7 @@ class TestHandlers(BaseSessionTest):
             arn = 'arn:aws:s3:us-west-2:123456789012:accesspoint:endpoint'
             handlers.validate_bucket_name({'Bucket': arn})
         except ParamValidationError:
-            self.fail('The s3 arn: %s should pass validation' % arn)
+            self.fail(f'The s3 arn: {arn} should pass validation')
 
     def test_validation_is_s3_outpost_arn(self):
         try:
@@ -809,7 +809,7 @@ class TestHandlers(BaseSessionTest):
             )
             handlers.validate_bucket_name({'Bucket': arn})
         except ParamValidationError:
-            self.fail('The s3 arn: %s should pass validation' % arn)
+            self.fail(f'The s3 arn: {arn} should pass validation')
 
     def test_validation_is_global_s3_bucket_arn(self):
         with self.assertRaises(ParamValidationError):
@@ -1242,7 +1242,7 @@ class TestSSEMD5(BaseMD5Test):
             'UploadPart',
             'UploadPartCopy',
         ):
-            event = 'before-parameter-build.s3.%s' % op
+            event = f'before-parameter-build.s3.{op}'
             params = {
                 'SSECustomerKey': b'bar',
                 'SSECustomerAlgorithm': 'AES256',
@@ -1264,7 +1264,7 @@ class TestSSEMD5(BaseMD5Test):
 
     def test_copy_source_sse_params(self):
         for op in ['CopyObject', 'UploadPartCopy']:
-            event = 'before-parameter-build.s3.%s' % op
+            event = f'before-parameter-build.s3.{op}'
             params = {
                 'CopySourceSSECustomerKey': b'bar',
                 'CopySourceSSECustomerAlgorithm': 'AES256',

--- a/tests/unit/botocore/test_hooks.py
+++ b/tests/unit/botocore/test_hooks.py
@@ -162,7 +162,7 @@ class TestWildcardHandlers(unittest.TestCase):
         self.emitter.emit(event)
         after = len(self.hook_calls)
         if not after > starting:
-            self.fail("Handler was not called for event: %s" % event)
+            self.fail(f"Handler was not called for event: {event}")
         self.assertEqual(self.hook_calls[-1]['event_name'], event)
 
     def assert_hook_is_not_called_given_event(self, event):
@@ -172,8 +172,7 @@ class TestWildcardHandlers(unittest.TestCase):
         if not after == starting:
             self.fail(
                 "Handler was called for event but was not "
-                "suppose to be called: %s, last_event: %s"
-                % (event, self.hook_calls[-1])
+                f"suppose to be called: {event}, last_event: {self.hook_calls[-1]}"
             )
 
     def test_one_level_wildcard_handler(self):

--- a/tests/unit/botocore/test_http_session.py
+++ b/tests/unit/botocore/test_http_session.py
@@ -506,7 +506,7 @@ class TestURLLib3Session(unittest.TestCase):
         proxies = {'https': 'http://proxy.com', 'http': 'http://proxy2.com'}
         session = URLLib3Session(proxies=proxies)
         for proxy, proxy_url in proxies.items():
-            self.request.url = '%s://example.com/' % proxy
+            self.request.url = f'{proxy}://example.com/'
             session.send(self.request.prepare())
 
         session.close()

--- a/tests/unit/botocore/test_protocols.py
+++ b/tests/unit/botocore/test_protocols.py
@@ -155,7 +155,7 @@ def test_input_compliance(json_description, case, basename):
     try:
         protocol_serializer = PROTOCOL_SERIALIZERS[protocol_type]
     except KeyError:
-        raise RuntimeError("Unknown protocol: %s" % protocol_type)
+        raise RuntimeError(f"Unknown protocol: {protocol_type}")
     serializer = protocol_serializer()
     serializer.MAP_TYPE = OrderedDict
     operation_model = OperationModel(case['given'], model)
@@ -175,7 +175,7 @@ def _assert_request_body_is_bytes(body):
     if not isinstance(body, bytes):
         raise AssertionError(
             "Expected body to be serialized as type "
-            "bytes(), instead got: %s" % type(body)
+            f"bytes(), instead got: {type(body)}"
         )
 
 
@@ -259,10 +259,9 @@ def test_output_compliance(json_description, case, basename):
         parsed = _fixup_parsed_result(parsed)
     except Exception as e:
         msg = (
-            "\nFailed to run test  : %s\n"
-            "Protocol            : %s\n"
-            "Description         : %s (%s:%s)\n"
-            % (
+            "\nFailed to run test  : {}\n"
+            "Protocol            : {}\n"
+            "Description         : {} ({}:{})\n".format(
                 e,
                 model.metadata['protocol'],
                 case['description'],
@@ -381,14 +380,13 @@ def _output_failure_message(
 ):
     j = _try_json_dump
     error_message = (
-        "\nDescription           : %s (%s:%s)\n"
-        "Protocol:             : %s\n"
-        "Given                 : %s\n"
-        "Response              : %s\n"
-        "Expected serialization: %s\n"
-        "Actual serialization  : %s\n"
-        "Assertion message     : %s\n"
-        % (
+        "\nDescription           : {} ({}:{})\n"
+        "Protocol:             : {}\n"
+        "Given                 : {}\n"
+        "Response              : {}\n"
+        "Expected serialization: {}\n"
+        "Actual serialization  : {}\n"
+        "Assertion message     : {}\n".format(
             case['description'],
             case['suite_id'],
             case['test_id'],
@@ -406,14 +404,13 @@ def _output_failure_message(
 def _input_failure_message(protocol_type, case, actual_request, error):
     j = _try_json_dump
     error_message = (
-        "\nDescription           : %s (%s:%s)\n"
-        "Protocol:             : %s\n"
-        "Given                 : %s\n"
-        "Params                : %s\n"
-        "Expected serialization: %s\n"
-        "Actual serialization  : %s\n"
-        "Assertion message     : %s\n"
-        % (
+        "\nDescription           : {} ({}:{})\n"
+        "Protocol:             : {}\n"
+        "Given                 : {}\n"
+        "Params                : {}\n"
+        "Expected serialization: {}\n"
+        "Actual serialization  : {}\n"
+        "Assertion message     : {}\n".format(
             case['description'],
             case['suite_id'],
             case['test_id'],
@@ -442,17 +439,9 @@ def assert_equal(first, second, prefix):
         assert first == second
     except Exception:
         try:
-            better = "%s (actual != expected)\n%s !=\n%s" % (
-                prefix,
-                json.dumps(first, indent=2),
-                json.dumps(second, indent=2),
-            )
+            better = f"{prefix} (actual != expected)\n{json.dumps(first, indent=2)} !=\n{json.dumps(second, indent=2)}"
         except (ValueError, TypeError):
-            better = "%s (actual != expected)\n%s !=\n%s" % (
-                prefix,
-                first,
-                second,
-            )
+            better = f"{prefix} (actual != expected)\n{first} !=\n{second}"
         raise AssertionError(better)
 
 
@@ -468,9 +457,9 @@ def _serialize_request_description(request_dict):
             # test runner we need to handle the case where the url_path
             # already has query params.
             if '?' not in request_dict['url_path']:
-                request_dict['url_path'] += '?%s' % encoded
+                request_dict['url_path'] += f'?{encoded}'
             else:
-                request_dict['url_path'] += '&%s' % encoded
+                request_dict['url_path'] += f'&{encoded}'
 
 
 def _assert_requests_equal(actual, expected, protocol):

--- a/tests/unit/botocore/test_signers.py
+++ b/tests/unit/botocore/test_signers.py
@@ -995,7 +995,7 @@ class TestGenerateUrl(unittest.TestCase):
             self.assertTrue(
                 kwargs.get('context', {}).get('is_presign_request'),
                 'The context did not have is_presign_request set to True for '
-                'the following kwargs emitted: %s' % kwargs,
+                f'the following kwargs emitted: {kwargs}',
             )
 
     def test_context_param_from_event_handler_sent_to_endpoint_resolver(self):

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -2302,9 +2302,9 @@ class TestS3EndpointSetter(unittest.TestCase):
         if bucket:
             url += bucket
         if key:
-            url += '/%s' % key
+            url += f'/{key}'
         if querystring:
-            url += '?%s' % querystring
+            url += f'?{querystring}'
         return AWSRequest(method='GET', headers={}, url=url)
 
     def get_s3_outpost_request(self, **s3_request_kwargs):
@@ -2371,65 +2371,37 @@ class TestS3EndpointSetter(unittest.TestCase):
     def test_outpost_endpoint(self):
         request = self.get_s3_outpost_request()
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.%s.s3-outposts.%s.amazonaws.com/' % (
-            self.accesspoint_name,
-            self.account,
-            self.outpost_name,
-            self.region_name,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.{self.outpost_name}.s3-outposts.{self.region_name}.amazonaws.com/'
         self.assertEqual(request.url, expected_url)
 
     def test_outpost_endpoint_preserves_key_in_path(self):
         request = self.get_s3_outpost_request(key=self.key)
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.%s.s3-outposts.%s.amazonaws.com/%s' % (
-            self.accesspoint_name,
-            self.account,
-            self.outpost_name,
-            self.region_name,
-            self.key,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.{self.outpost_name}.s3-outposts.{self.region_name}.amazonaws.com/{self.key}'
         self.assertEqual(request.url, expected_url)
 
     def test_accesspoint_endpoint(self):
         request = self.get_s3_accesspoint_request()
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.s3-accesspoint.%s.amazonaws.com/' % (
-            self.accesspoint_name,
-            self.account,
-            self.region_name,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.s3-accesspoint.{self.region_name}.amazonaws.com/'
         self.assertEqual(request.url, expected_url)
 
     def test_accesspoint_preserves_key_in_path(self):
         request = self.get_s3_accesspoint_request(key=self.key)
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.s3-accesspoint.%s.amazonaws.com/%s' % (
-            self.accesspoint_name,
-            self.account,
-            self.region_name,
-            self.key,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.s3-accesspoint.{self.region_name}.amazonaws.com/{self.key}'
         self.assertEqual(request.url, expected_url)
 
     def test_accesspoint_preserves_scheme(self):
         request = self.get_s3_accesspoint_request(scheme='http://')
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'http://%s-%s.s3-accesspoint.%s.amazonaws.com/' % (
-            self.accesspoint_name,
-            self.account,
-            self.region_name,
-        )
+        expected_url = f'http://{self.accesspoint_name}-{self.account}.s3-accesspoint.{self.region_name}.amazonaws.com/'
         self.assertEqual(request.url, expected_url)
 
     def test_accesspoint_preserves_query_string(self):
         request = self.get_s3_accesspoint_request(querystring='acl')
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.s3-accesspoint.%s.amazonaws.com/?acl' % (
-            self.accesspoint_name,
-            self.account,
-            self.region_name,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.s3-accesspoint.{self.region_name}.amazonaws.com/?acl'
         self.assertEqual(request.url, expected_url)
 
     def test_uses_resolved_dns_suffix(self):
@@ -2438,11 +2410,7 @@ class TestS3EndpointSetter(unittest.TestCase):
         }
         request = self.get_s3_accesspoint_request()
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.s3-accesspoint.%s.mysuffix.com/' % (
-            self.accesspoint_name,
-            self.account,
-            self.region_name,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.s3-accesspoint.{self.region_name}.mysuffix.com/'
         self.assertEqual(request.url, expected_url)
 
     def test_uses_region_of_client_if_use_arn_disabled(self):
@@ -2452,11 +2420,7 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         request = self.get_s3_accesspoint_request()
         self.call_set_endpoint(self.endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.s3-accesspoint.%s.amazonaws.com/' % (
-            self.accesspoint_name,
-            self.account,
-            client_region,
-        )
+        expected_url = f'https://{self.accesspoint_name}-{self.account}.s3-accesspoint.{client_region}.amazonaws.com/'
         self.assertEqual(request.url, expected_url)
 
     def test_accesspoint_supports_custom_endpoint(self):
@@ -2465,9 +2429,8 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         request = self.get_s3_accesspoint_request()
         self.call_set_endpoint(endpoint_setter, request=request)
-        expected_url = 'https://%s-%s.custom.com/' % (
-            self.accesspoint_name,
-            self.account,
+        expected_url = (
+            f'https://{self.accesspoint_name}-{self.account}.custom.com/'
         )
         self.assertEqual(request.url, expected_url)
 
@@ -2497,9 +2460,8 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         request = self.get_s3_request(self.bucket, self.key)
         self.call_set_endpoint(endpoint_setter, request)
-        expected_url = 'https://%s.s3.us-west-2.amazonaws.com/%s' % (
-            self.bucket,
-            self.key,
+        expected_url = (
+            f'https://{self.bucket}.s3.us-west-2.amazonaws.com/{self.key}'
         )
         self.assertEqual(request.url, expected_url)
 
@@ -2509,9 +2471,8 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         request = self.get_s3_request(self.bucket, self.key)
         self.call_set_endpoint(endpoint_setter, request)
-        expected_url = 'https://%s.s3.us-west-2.amazonaws.com/%s' % (
-            self.bucket,
-            self.key,
+        expected_url = (
+            f'https://{self.bucket}.s3.us-west-2.amazonaws.com/{self.key}'
         )
         self.assertEqual(request.url, expected_url)
 
@@ -2521,9 +2482,8 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         request = self.get_s3_request(self.bucket, self.key)
         self.call_set_endpoint(endpoint_setter, request)
-        expected_url = 'https://s3.us-west-2.amazonaws.com/%s/%s' % (
-            self.bucket,
-            self.key,
+        expected_url = (
+            f'https://s3.us-west-2.amazonaws.com/{self.bucket}/{self.key}'
         )
         self.assertEqual(request.url, expected_url)
 
@@ -2533,9 +2493,8 @@ class TestS3EndpointSetter(unittest.TestCase):
         )
         request = self.get_s3_request(self.bucket, self.key)
         self.call_set_endpoint(endpoint_setter, request)
-        expected_url = 'https://%s.s3-accelerate.amazonaws.com/%s' % (
-            self.bucket,
-            self.key,
+        expected_url = (
+            f'https://{self.bucket}.s3-accelerate.amazonaws.com/{self.key}'
         )
         self.assertEqual(request.url, expected_url)
 

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -217,5 +217,5 @@ class TestYaml(BaseYAMLTest):
         ]
         for bool_as_string in bools_as_strings:
             self.assertEqual(
-                yaml_dump(bool_as_string), "'%s'\n" % bool_as_string
+                yaml_dump(bool_as_string), f"'{bool_as_string}'\n"
             )

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -49,7 +49,7 @@ from . import get_private_key_path, get_public_key_path
 START_DATE = parser.parse('20140810T000000Z')
 END_DATE = parser.parse('20150810T000000Z')
 TEST_ACCOUNT_ID = '123456789012'
-TEST_TRAIL_ARN = 'arn:aws:cloudtrail:us-east-1:%s:trail/foo' % TEST_ACCOUNT_ID
+TEST_TRAIL_ARN = f'arn:aws:cloudtrail:us-east-1:{TEST_ACCOUNT_ID}:trail/foo'
 VALID_TEST_KEY = (
     'MIIBCgKCAQEAn11L2YZ9h7onug2ILi1MWyHiMRsTQjfWE+pHVRLk1QjfW'
     'hirG+lpOa8NrwQ/r7Ah5bNL6HepznOU9XTDSfmmnP97mqyc7z/upfZdS/'
@@ -238,7 +238,7 @@ class TestValidation(unittest.TestCase):
     def test_ensures_cloudtrail_arns_are_valid_when_missing_resource(self):
         try:
             assert_cloudtrail_arn_is_valid(
-                'arn:aws:cloudtrail:us-east-1:%s:foo' % TEST_ACCOUNT_ID
+                f'arn:aws:cloudtrail:us-east-1:{TEST_ACCOUNT_ID}:foo'
             )
             self.fail('Should have failed')
         except ParamValidationError as e:
@@ -246,7 +246,7 @@ class TestValidation(unittest.TestCase):
 
     def test_allows_valid_arns(self):
         assert_cloudtrail_arn_is_valid(
-            'arn:aws:cloudtrail:us-east-1:%s:trail/foo' % TEST_ACCOUNT_ID
+            f'arn:aws:cloudtrail:us-east-1:{TEST_ACCOUNT_ID}:trail/foo'
         )
 
     def test_normalizes_date_timezones(self):
@@ -452,7 +452,7 @@ class TestSha256RSADigestValidator(unittest.TestCase):
             get_private_key_path(), get_public_key_path()
         )
         sha256_hash = hashlib.sha256(self._inflated_digest)
-        string_to_sign = "%s\n%s/%s\n%s\n%s" % (
+        string_to_sign = "{}\n{}/{}\n{}\n{}".format(
             self._digest_data['digestEndTime'],
             self._digest_data['digestS3Bucket'],
             self._digest_data['digestS3Object'],
@@ -767,8 +767,8 @@ class TestDigestTraverser(unittest.TestCase):
         self.assertEqual(1, len(calls))
         self.assertEqual(
             (
-                'Digest file\ts3://1/%s\tINVALID: public key not '
-                'found in region %s for fingerprint abc' % (key_name, region)
+                f'Digest file\ts3://1/{key_name}\tINVALID: public key not '
+                f'found in region {region} for fingerprint abc'
             ),
             calls[0]['message'],
         )
@@ -835,7 +835,7 @@ class TestDigestTraverser(unittest.TestCase):
         self.assertIsNone(next(digest_iter, None))
         self.assertEqual(1, len(collected))
         self.assertEqual(
-            'Digest file\ts3://1/%s\tINVALID: invalid format' % key_name,
+            f'Digest file\ts3://1/{key_name}\tINVALID: invalid format',
             collected[0]['message'],
         )
 
@@ -1036,7 +1036,7 @@ class TestDigestTraverser(unittest.TestCase):
         digest_iter = traverser.traverse(start_date, end_date)
         next(digest_iter, None)
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: ' % end_timestamp,
+            f'Digest file\ts3://1/{end_timestamp}\tINVALID: ',
             calls[0]['message'],
         )
 

--- a/tests/unit/customizations/codedeploy/test_push.py
+++ b/tests/unit/customizations/codedeploy/test_push.py
@@ -177,8 +177,8 @@ class TestPush(unittest.TestCase):
         self.push._push(self.args)
         output = stdout_mock.getvalue().strip()
         expected_revision_output = (
-            '--s3-location bucket={0},key={1},'
-            'bundleType=zip,eTag={2},version={3}'.format(
+            '--s3-location bucket={},key={},'
+            'bundleType=zip,eTag={},version={}'.format(
                 self.bucket,
                 self.key,
                 self.eTag.replace('"', ""),

--- a/tests/unit/customizations/configservice/test_subscribe.py
+++ b/tests/unit/customizations/configservice/test_subscribe.py
@@ -144,7 +144,7 @@ class TestSNSTopicHelper(unittest.TestCase):
         with mock.patch('sys.stdout', StringIO()) as mock_stdout:
             self.helper.prepare_topic(name)
             self.assertIn(
-                'Using existing SNS topic: %s' % name, mock_stdout.getvalue()
+                f'Using existing SNS topic: {name}', mock_stdout.getvalue()
             )
 
 

--- a/tests/unit/customizations/configure/test_writer.py
+++ b/tests/unit/customizations/configure/test_writer.py
@@ -41,9 +41,9 @@ class TestConfigFileWriter(unittest.TestCase):
             self.fail(
                 "Config file contents do not match.\n"
                 "Expected contents:\n"
-                "%s\n\n"
+                f"{updated_config_contents}\n\n"
                 "Actual Contents:\n"
-                "%s\n" % (updated_config_contents, new_contents)
+                f"{new_contents}\n"
             )
 
     def test_update_single_existing_value(self):

--- a/tests/unit/customizations/datapipeline/test_arg_serialize.py
+++ b/tests/unit/customizations/datapipeline/test_arg_serialize.py
@@ -41,7 +41,7 @@ class TestPutPipelineDefinition(BaseAWSCommandParamsTest):
             f.flush()
             cmdline = self.prefix
             cmdline += ' --pipeline-id name'
-            cmdline += ' --pipeline-definition file://%s' % f.name
+            cmdline += f' --pipeline-definition file://{f.name}'
             result = {
                 'pipelineId': 'name',
                 'pipelineObjects': [

--- a/tests/unit/customizations/dlm/test_create_default_role.py
+++ b/tests/unit/customizations/dlm/test_create_default_role.py
@@ -28,14 +28,8 @@ from awscli.testutils import BaseAWSCommandParamsTest, mock, unittest
 
 class TestCreateDefaultRole(BaseAWSCommandParamsTest):
     prefix = 'dlm create-default-role'
-    LIFECYCLE_DEFAULT_MANAGED_POLICY_ARN = (
-        "arn:aws:iam::aws:policy/service-role/%s"
-        % (LIFECYCLE_DEFAULT_MANAGED_POLICY_NAME)
-    )
-    LIFECYCLE_DEFAULT_MANAGED_POLICY_AMI_ARN = (
-        "arn:aws:iam::aws:policy/service-role/%s"
-        % (LIFECYCLE_DEFAULT_MANAGED_POLICY_NAME_AMI)
-    )
+    LIFECYCLE_DEFAULT_MANAGED_POLICY_ARN = f"arn:aws:iam::aws:policy/service-role/{LIFECYCLE_DEFAULT_MANAGED_POLICY_NAME}"
+    LIFECYCLE_DEFAULT_MANAGED_POLICY_AMI_ARN = f"arn:aws:iam::aws:policy/service-role/{LIFECYCLE_DEFAULT_MANAGED_POLICY_NAME_AMI}"
 
     # Call to attach policy to role
     def assert_attached_policy_to_role(
@@ -148,7 +142,7 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
         role_exists_patch.return_value = False
 
         self.run_cmd(
-            self.prefix + " --resource-type=%s" % (RESOURCE_TYPE_SNAPSHOT),
+            self.prefix + f" --resource-type={RESOURCE_TYPE_SNAPSHOT}",
             expected_rc=0,
         )
         self.assertEqual(len(self.operations_called), 5)
@@ -211,7 +205,7 @@ class TestCreateDefaultRole(BaseAWSCommandParamsTest):
         role_exists_patch.return_value = False
 
         self.run_cmd(
-            self.prefix + " --resource-type=%s" % (RESOURCE_TYPE_IMAGE),
+            self.prefix + f" --resource-type={RESOURCE_TYPE_IMAGE}",
             expected_rc=0,
         )
         self.assertEqual(len(self.operations_called), 5)

--- a/tests/unit/customizations/dynamodb/test_lexer.py
+++ b/tests/unit/customizations/dynamodb/test_lexer.py
@@ -155,7 +155,7 @@ class LexTester:
         try:
             list(self.lexer.tokenize(expression))
             raise AssertionError(
-                'LexerError not raised for expression: %s' % expression
+                f'LexerError not raised for expression: {expression}'
             )
         except LexerError as e:
             assert error_part in str(e)

--- a/tests/unit/customizations/emr/__init__.py
+++ b/tests/unit/customizations/emr/__init__.py
@@ -42,6 +42,6 @@ class EMRBaseAWSCommandParamsTest(BaseAWSCommandParamsTest):
         self, cmd, exception_class_name, error_msg_kwargs={}, rc=255
     ):
         exception_class = getattr(exceptions, exception_class_name)
-        error_msg = "\n%s\n" % exception_class.fmt.format(**error_msg_kwargs)
+        error_msg = f"\n{exception_class.fmt.format(**error_msg_kwargs)}\n"
         result = self.run_cmd(cmd, rc)
         self.assertEqual(error_msg, result[1])

--- a/tests/unit/customizations/emr/test_config.py
+++ b/tests/unit/customizations/emr/test_config.py
@@ -11,10 +11,7 @@ INSTANCE_GROUPS_ARG = (
     'InstanceCount=1,InstanceType=m1.large '
 )
 
-CREATE_CLUSTER_CMD = (
-    "emr create-cluster --ami-version 3.1.0 --instance-groups %s"
-    % INSTANCE_GROUPS_ARG
-)
+CREATE_CLUSTER_CMD = f"emr create-cluster --ami-version 3.1.0 --instance-groups {INSTANCE_GROUPS_ARG}"
 
 DEFAULT_CONFIGS = {
     'service_role': 'my_default_emr_role',
@@ -41,10 +38,10 @@ BAD_CONFIGS = {
 TEST_CLUSTER_ID = "j-227H3PFKLBOBP"
 TEST_SRC_PATH = "/home/my_src"
 
-SSH_CMD = 'emr ssh --cluster-id %s' % TEST_CLUSTER_ID
-SOCKS_CMD = 'emr socks --cluster-id %s' % TEST_CLUSTER_ID
-GET_CMD = 'emr get --cluster-id %s --src %s' % (TEST_CLUSTER_ID, TEST_SRC_PATH)
-PUT_CMD = 'emr put --cluster-id %s --src %s' % (TEST_CLUSTER_ID, TEST_SRC_PATH)
+SSH_CMD = f'emr ssh --cluster-id {TEST_CLUSTER_ID}'
+SOCKS_CMD = f'emr socks --cluster-id {TEST_CLUSTER_ID}'
+GET_CMD = f'emr get --cluster-id {TEST_CLUSTER_ID} --src {TEST_SRC_PATH}'
+PUT_CMD = f'emr put --cluster-id {TEST_CLUSTER_ID} --src {TEST_SRC_PATH}'
 
 CREATE_DEFAULT_ROLES_CMD = 'emr create-default-roles'
 
@@ -91,10 +88,12 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
     def test_with_bad_boolean_value(self):
         self.set_configs(BAD_BOOLEAN_VALUE_CONFIGS)
         cmd = CREATE_CLUSTER_CMD
-        expect_error_msg = "\n%s\n" % InvalidBooleanConfigError.fmt.format(
-            config_value='False1',
-            config_key='enable_debugging',
-            profile_var_name='default',
+        expect_error_msg = "\n{}\n".format(
+            InvalidBooleanConfigError.fmt.format(
+                config_value='False1',
+                config_key='enable_debugging',
+                profile_var_name='default',
+            )
         )
         result = self.run_cmd(cmd, 252)
         self.assertEqual(expect_error_msg, result[1])

--- a/tests/unit/customizations/emr/test_emrfs_utils.py
+++ b/tests/unit/customizations/emr/test_emrfs_utils.py
@@ -322,7 +322,7 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
         data_path = os.path.join(
             os.path.dirname(__file__), 'input_emr_fs.json'
         )
-        emrfs_option_value = 'file://%s' % data_path
+        emrfs_option_value = f'file://{data_path}'
         expected_emrfs_ba_key_values = [
             'fs.s3.consistent=true',
             'fs.s3.consistent.retryCount=10',
@@ -467,11 +467,7 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             DEFAULT_CONFIGURATIONS, separators=(',', ':')
         )
 
-        cmd = "%s --release-label emr-4.0 --emrfs %s --configurations %s" % (
-            DEFAULT_CMD,
-            emrfs_option_value,
-            configurations,
-        )
+        cmd = f"{DEFAULT_CMD} --release-label emr-4.0 --emrfs {emrfs_option_value} --configurations {configurations}"
 
         expected_emrfs_properties = {'someProperty': 'someValue'}
 
@@ -497,11 +493,7 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
 
         configurations_json = json.dumps(configurations, separators=(',', ':'))
 
-        cmd = "%s --release-label emr-4.0 --emrfs %s --configurations %s" % (
-            DEFAULT_CMD,
-            emrfs_option_value,
-            configurations_json,
-        )
+        cmd = f"{DEFAULT_CMD} --release-label emr-4.0 --emrfs {emrfs_option_value} --configurations {configurations_json}"
 
         result = copy.deepcopy(DEFAULT_RESULT)
         result['ReleaseLabel'] = 'emr-4.0'
@@ -516,10 +508,7 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
         error_msg_kwargs,
         rc=255,
     ):
-        cmd = "%s --ami-version 3.4 --emrfs %s" % (
-            DEFAULT_CMD,
-            emrfs_option_value,
-        )
+        cmd = f"{DEFAULT_CMD} --ami-version 3.4 --emrfs {emrfs_option_value}"
         self.assert_error_msg(
             cmd,
             exception_class_name=exception_class_name,
@@ -527,10 +516,7 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             rc=rc,
         )
 
-        cmd = "%s --release-label emr-4.0 --emrfs %s" % (
-            DEFAULT_CMD,
-            emrfs_option_value,
-        )
+        cmd = f"{DEFAULT_CMD} --release-label emr-4.0 --emrfs {emrfs_option_value}"
         self.assert_error_msg(
             cmd,
             exception_class_name=exception_class_name,
@@ -546,9 +532,8 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
         provider_location=None,
     ):
         if expected_emrfs_ba_key_values is not None:
-            cmd = "%s --ami-version 3.4 --emrfs %s" % (
-                DEFAULT_CMD,
-                emrfs_option_value,
+            cmd = (
+                f"{DEFAULT_CMD} --ami-version 3.4 --emrfs {emrfs_option_value}"
             )
             result = copy.deepcopy(DEFAULT_RESULT)
             result['BootstrapActions'] = (
@@ -566,10 +551,7 @@ class TestEmrfsUtils(BaseAWSCommandParamsTest):
             self.assert_params_for_cmd(cmd, result)
 
         if expected_emrfs_properties is not None:
-            cmd = "%s --release-label emr-4.0 --emrfs %s" % (
-                DEFAULT_CMD,
-                emrfs_option_value,
-            )
+            cmd = f"{DEFAULT_CMD} --release-label emr-4.0 --emrfs {emrfs_option_value}"
             result = copy.deepcopy(DEFAULT_RESULT)
             emrfs_configuration = copy.deepcopy(EMPTY_EMRFS_CONFIGURATION)
             emrfs_configuration['Properties'] = expected_emrfs_properties

--- a/tests/unit/customizations/emrcontainers/test_update_assume_role_policy.py
+++ b/tests/unit/customizations/emrcontainers/test_update_assume_role_policy.py
@@ -59,9 +59,8 @@ class TestUpdateAssumeRolePolicy(BaseAWSCommandParamsTest):
         super(TestUpdateAssumeRolePolicy, self).setUp()
 
         self.command = (
-            'emr-containers update-role-trust-policy --cluster-name=%s '
-            '--namespace=%s --role-name=%s'
-            % (self.cluster_name, self.namespace, self.role_name)
+            f'emr-containers update-role-trust-policy --cluster-name={self.cluster_name} '
+            f'--namespace={self.namespace} --role-name={self.role_name}'
         )
         self.policy_document = {
             "Version": "2012-10-17",

--- a/tests/unit/customizations/gamelift/test_uploadbuild.py
+++ b/tests/unit/customizations/gamelift/test_uploadbuild.py
@@ -168,9 +168,8 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
-                'Fail to upload %s. '
-                'The build root directory is empty or does not exist.\n'
-                % (self.build_root),
+                f'Fail to upload {self.build_root}. '
+                'The build root directory is empty or does not exist.\n',
             )
 
     def test_error_message_when_directory_is_not_provided(self):
@@ -187,9 +186,10 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
-                'Fail to upload %s. '
-                'The build root directory is empty or does not exist.\n'
-                % (''),
+                'Fail to upload {}. '
+                'The build root directory is empty or does not exist.\n'.format(
+                    ''
+                ),
             )
 
     def test_error_message_when_directory_does_not_exist(self):
@@ -208,9 +208,8 @@ class TestGetGameSessionLogCommand(unittest.TestCase):
             self.cmd(self.args, self.global_args)
             self.assertEqual(
                 mock_stderr.getvalue(),
-                'Fail to upload %s. '
-                'The build root directory is empty or does not exist.\n'
-                % (dir_not_exist),
+                f'Fail to upload {dir_not_exist}. '
+                'The build root directory is empty or does not exist.\n',
             )
 
     def test_temporary_file_does_exist_when_fails(self):

--- a/tests/unit/customizations/history/test_list.py
+++ b/tests/unit/customizations/history/test_list.py
@@ -72,7 +72,7 @@ class TestTextFormatter(unittest.TestCase):
                 }
             ]
         )
-        expected_output = 'foo       %s s3 ls     0\n' % self.formatted_time
+        expected_output = f'foo       {self.formatted_time} s3 ls     0\n'
         actual_output = ensure_text_type(self.output_stream.getvalue())
         self.assertEqual(expected_output, actual_output)
 
@@ -94,8 +94,9 @@ class TestTextFormatter(unittest.TestCase):
             ]
         )
         expected_output = (
-            'foo       %s s3 ls     0\n' 'bar       %s s3 cp     1\n'
-        ) % (self.formatted_time, self.formatted_time)
+            f'foo       {self.formatted_time} s3 ls     0\n'
+            f'bar       {self.formatted_time} s3 cp     1\n'
+        )
         actual_output = ensure_text_type(self.output_stream.getvalue())
         self.assertEqual(expected_output, actual_output)
 
@@ -115,7 +116,7 @@ class TestTextFormatter(unittest.TestCase):
                 }
             ]
         )
-        expected_output = 'foo       %s s3 aaa... 0\n' % self.formatted_time
+        expected_output = f'foo       {self.formatted_time} s3 aaa... 0\n'
         actual_output = ensure_text_type(self.output_stream.getvalue())
         self.assertEqual(expected_output, actual_output)
 

--- a/tests/unit/customizations/s3/test_filegenerator.py
+++ b/tests/unit/customizations/s3/test_filegenerator.py
@@ -265,7 +265,7 @@ class TestThrowsWarning(unittest.TestCase):
         warning_message = file_gen.result_queue.get()
         self.assertEqual(
             warning_message.message,
-            ("warning: Skipping file %s. File does not exist." % filename),
+            (f"warning: Skipping file {filename}. File does not exist."),
         )
 
     def test_no_read_access(self):
@@ -281,8 +281,8 @@ class TestThrowsWarning(unittest.TestCase):
         self.assertEqual(
             warning_message.message,
             (
-                "warning: Skipping file %s. File/Directory is "
-                "not readable." % full_path
+                f"warning: Skipping file {full_path}. File/Directory is "
+                "not readable."
             ),
         )
 
@@ -299,9 +299,9 @@ class TestThrowsWarning(unittest.TestCase):
         self.assertEqual(
             warning_message.message,
             (
-                "warning: Skipping file %s. File is character "
+                f"warning: Skipping file {file_path}. File is character "
                 "special device, block special device, FIFO, or "
-                "socket." % file_path
+                "socket."
             ),
         )
 
@@ -500,9 +500,9 @@ class TestListFilesLocally(unittest.TestCase):
                 "a\u0300",
                 "a\u0300-1",
                 "a\u03001",
-                "a\u0300a%sa" % os.path.sep,
-                "a\u0300a%sz" % os.path.sep,
-                "a\u0300a%s\u00e6" % os.path.sep,
+                f"a\u0300a{os.path.sep}a",
+                f"a\u0300a{os.path.sep}z",
+                f"a\u0300a{os.path.sep}\u00e6",
                 "z",
                 "\u00e6",
             ]

--- a/tests/unit/customizations/s3/test_subscribers.py
+++ b/tests/unit/customizations/s3/test_subscribers.py
@@ -221,7 +221,7 @@ class TestDirectoryCreatorSubscriber(BaseTestWithFileCreator):
                 self.fail(
                     'on_queued should not have raised an exception related '
                     'to directory creation especially if one already existed '
-                    'but got %s' % e
+                    f'but got {e}'
                 )
 
 

--- a/tests/unit/customizations/test_codecommit.py
+++ b/tests/unit/customizations/test_codecommit.py
@@ -106,7 +106,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_TRAILING_NEWLINE))
@@ -114,7 +114,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH_BLANK_LINE))
@@ -122,7 +122,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
@@ -134,7 +134,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(VPC_1_PROTOCOL_HOST_PATH))
@@ -144,7 +144,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(VPC_2_PROTOCOL_HOST_PATH))
@@ -156,7 +156,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(FIPS_VPC_1_PROTOCOL_HOST_PATH))
@@ -168,7 +168,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(FIPS_VPC_2_PROTOCOL_HOST_PATH))
@@ -180,7 +180,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(NO_REGION_PROTOCOL_HOST_PATH))
@@ -188,7 +188,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command = CodeCommitGetCommand(self.session)
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
-        self.assertRegex(output, 'username={0}\npassword=.+'.format('access'))
+        self.assertRegex(output, 'username={}\npassword=.+'.format('access'))
 
     @mock.patch('sys.stdout', new_callable=MOCK_STDOUT_CLASS)
     @mock.patch('sys.stdin', StringIO(NON_AWS_PROTOCOL_HOST_PATH))
@@ -212,7 +212,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
         self.get_command._run_main(self.args, self.globals)
         output = stdout_mock.getvalue().strip()
         self.assertRegex(
-            output, 'username={0}%{1}\npassword=.+'.format('access', 'token')
+            output, 'username={}%{}\npassword=.+'.format('access', 'token')
         )
 
     @mock.patch('sys.stdout', MOCK_STDOUT_CLASS())

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -951,7 +951,7 @@ class TestOpsWorksRegisterEc2(TestOpsWorksBase):
         except Exception as e:
             self.fail(
                 'Register should work with bytes response from urlopen.read. '
-                'Got exception: %s' % e
+                f'Got exception: {e}'
             )
 
     def test_retrieve_stack_ec2(self):

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -85,7 +85,7 @@ class TestListUsers(BaseAWSCommandParamsTest):
     def test_jmespath_json_response(self):
         jmespath_query = 'Users[*].UserName'
         output = self.run_cmd(
-            'iam list-users --query %s' % jmespath_query, expected_rc=0
+            f'iam list-users --query {jmespath_query}', expected_rc=0
         )[0]
         parsed_output = json.loads(output)
         self.assertEqual(parsed_output, ['testuser-50', 'testuser-51'])
@@ -96,7 +96,7 @@ class TestListUsers(BaseAWSCommandParamsTest):
         # evalutes to 0.
         jmespath_query = '`0`'
         output = self.run_cmd(
-            'iam list-users --query %s' % jmespath_query, expected_rc=0
+            f'iam list-users --query {jmespath_query}', expected_rc=0
         )[0]
         self.assertEqual(output, '0\n')
 

--- a/tests/unit/output/test_text_output.py
+++ b/tests/unit/output/test_text_output.py
@@ -150,6 +150,5 @@ class TestDescribeChangesets(BaseAWSCommandParamsTest):
             self.assertEqual(
                 count,
                 actual_count,
-                "%s was found in the output %s times. Expected %s."
-                % (key, actual_count, count),
+                f"{key} was found in the output {actual_count} times. Expected {count}.",
             )

--- a/tests/unit/output/test_yaml_output.py
+++ b/tests/unit/output/test_yaml_output.py
@@ -88,7 +88,7 @@ class TestYAMLOutput(BaseAWSCommandParamsTest):
     def test_jmespath_yaml_response(self):
         jmespath_query = 'Users[*].UserName'
         stdout, _, _ = self.run_cmd(
-            'iam list-users --output yaml --query %s' % jmespath_query,
+            f'iam list-users --output yaml --query {jmespath_query}',
             expected_rc=0,
         )
         parsed_output = self.yaml.load(stdout)
@@ -153,7 +153,7 @@ class TestYAMLOutput(BaseAWSCommandParamsTest):
     def test_print_string_literal(self):
         jmespath_query = 'Users[0].UserName'
         stdout, _, _ = self.run_cmd(
-            'iam list-users --output yaml --query %s' % jmespath_query,
+            f'iam list-users --output yaml --query {jmespath_query}',
             expected_rc=0,
         )
         self.assertEqual(stdout, '"testuser-50"\n')

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -102,7 +102,7 @@ class TestBotocoreCRTRequestSerializer(unittest.TestCase):
         self.files = FileCreator()
         self.filename = self.files.create_file('myfile', 'my content')
         self.expected_path = "/" + self.bucket + "/" + self.key
-        self.expected_host = "s3.%s.amazonaws.com" % (self.region)
+        self.expected_host = f"s3.{self.region}.amazonaws.com"
 
     def tearDown(self):
         self.files.remove_all()

--- a/tests/unit/s3transfer/test_manager.py
+++ b/tests/unit/s3transfer/test_manager.py
@@ -133,7 +133,7 @@ class TestTransferCoordinatorController(unittest.TestCase):
         try:
             self.coordinator_controller.wait()
         except FutureResultException as e:
-            self.fail('%s should not have been raised.' % e)
+            self.fail(f'{e} should not have been raised.')
 
     def test_wait_can_be_interrupted(self):
         inject_interrupt_coordinator = TransferCoordinatorWithInterrupt()

--- a/tests/unit/s3transfer/test_subscribers.py
+++ b/tests/unit/s3transfer/test_subscribers.py
@@ -55,7 +55,7 @@ class TestSubscribers(unittest.TestCase):
         except Exception as e:
             self.fail(
                 'Should be able to call base class subscriber method. '
-                'instead got: %s' % e
+                f'instead got: {e}'
             )
 
     def test_subclass_can_have_and_call_additional_methods(self):

--- a/tests/unit/s3transfer/test_upload.py
+++ b/tests/unit/s3transfer/test_upload.py
@@ -50,7 +50,7 @@ class InterruptionError(Exception):
 class OSUtilsExceptionOnFileSize(OSUtils):
     def get_file_size(self, filename):
         raise AssertionError(
-            "The file %s should not have been stated" % filename
+            f"The file {filename} should not have been stated"
         )
 
 

--- a/tests/unit/s3transfer/test_utils.py
+++ b/tests/unit/s3transfer/test_utils.py
@@ -282,7 +282,7 @@ class TestOSUtils(BaseUtilsTest):
         try:
             OSUtils().remove_file(non_existent_file)
         except OSError as e:
-            self.fail('OSError should have been caught: %s' % e)
+            self.fail(f'OSError should have been caught: {e}')
 
     def test_remove_file_proxies_remove_file(self):
         OSUtils().remove_file(self.filename)
@@ -306,7 +306,7 @@ class TestOSUtils(BaseUtilsTest):
         filename = 'myfile'
         self.assertIsNotNone(
             re.match(
-                r'%s\.[0-9A-Fa-f]{8}$' % filename,
+                rf'{filename}\.[0-9A-Fa-f]{{8}}$',
                 OSUtils().get_temp_filename(filename),
             )
         )

--- a/tests/unit/test_alias.py
+++ b/tests/unit/test_alias.py
@@ -36,7 +36,7 @@ class FakeParsedArgs:
         self.__dict__.update(kwargs)
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, self.__dict__)
+        return f'{self.__class__.__name__}({self.__dict__})'
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -80,7 +80,7 @@ class TestURIParams(BaseArgProcessTest):
             )
             f.write(json_argument)
             f.flush()
-            result = self.uri_param('event-name', p, 'file://%s' % f.name)
+            result = self.uri_param('event-name', p, f'file://{f.name}')
         self.assertEqual(result, json_argument)
 
 

--- a/tests/unit/test_arguments.py
+++ b/tests/unit/test_arguments.py
@@ -72,7 +72,7 @@ class TestCLIArgument(unittest.TestCase):
         argument = self.create_argument()
         params = {}
         argument.add_to_params(params, 'value')
-        expected_event_name = 'process-cli-arg.%s.%s' % (
+        expected_event_name = 'process-cli-arg.{}.{}'.format(
             self.service_name,
             'sample-operation',
         )

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -571,7 +571,7 @@ class TestTopicListerDocumentEventHandler(TestTopicDocumentEventHandlerBase):
     def test_title(self):
         self.doc_handler.doc_title(self.cmd)
         title_contents = self.cmd.doc.getvalue().decode('utf-8')
-        self.assertIn('.. _cli:aws help %s:' % self.cmd.name, title_contents)
+        self.assertIn(f'.. _cli:aws help {self.cmd.name}:', title_contents)
         self.assertIn('AWS CLI Topic Guide', title_contents)
 
     def test_description(self):
@@ -585,12 +585,11 @@ class TestTopicListerDocumentEventHandler(TestTopicDocumentEventHandlerBase):
         ref_output = [
             '-------\nGeneral\n-------',
             (
-                '* topic-name-1: %s\n'
-                '* topic-name-3: %s\n'
-                % (self.descriptions[0], self.descriptions[2])
+                f'* topic-name-1: {self.descriptions[0]}\n'
+                f'* topic-name-3: {self.descriptions[2]}\n'
             ),
             '--\nS3\n--',
-            '* topic-name-2: %s\n' % self.descriptions[1],
+            f'* topic-name-2: {self.descriptions[1]}\n',
         ]
 
         self.doc_handler.doc_subitems_start(self.cmd)
@@ -606,14 +605,12 @@ class TestTopicListerDocumentEventHandler(TestTopicDocumentEventHandlerBase):
         ref_output = [
             '-------\nGeneral\n-------',
             (
-                '* :ref:`topic-name-1 <cli:aws help topic-name-1>`: %s\n'
-                '* :ref:`topic-name-3 <cli:aws help topic-name-3>`: %s\n'
-                % (self.descriptions[0], self.descriptions[2])
+                f'* :ref:`topic-name-1 <cli:aws help topic-name-1>`: {self.descriptions[0]}\n'
+                f'* :ref:`topic-name-3 <cli:aws help topic-name-3>`: {self.descriptions[2]}\n'
             ),
             '--\nS3\n--',
             (
-                '* :ref:`topic-name-2 <cli:aws help topic-name-2>`: %s\n'
-                % self.descriptions[1]
+                f'* :ref:`topic-name-2 <cli:aws help topic-name-2>`: {self.descriptions[1]}\n'
             ),
         ]
 
@@ -666,7 +663,7 @@ class TestTopicDocumentEventHandler(TestTopicDocumentEventHandlerBase):
     def test_title(self):
         self.doc_handler.doc_title(self.cmd)
         title_contents = self.cmd.doc.getvalue().decode('utf-8')
-        self.assertIn('.. _cli:aws help %s:' % self.name, title_contents)
+        self.assertIn(f'.. _cli:aws help {self.name}:', title_contents)
         self.assertIn(self.title, title_contents)
 
     def test_description(self):

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -55,8 +55,7 @@ class TestSchemaTransformer(unittest.TestCase):
         actual = transformer.transform(schema)
         if actual != transforms_to:
             self.fail(
-                "Transform failed.\n\nExpected:\n%s\n\nActual:\n%s\n"
-                % (pprint.pformat(transforms_to), pprint.pformat(actual))
+                f"Transform failed.\n\nExpected:\n{pprint.pformat(transforms_to)}\n\nActual:\n{pprint.pformat(actual)}\n"
             )
 
     def test_transforms_list_of_single_string(self):

--- a/tests/unit/test_topictags.py
+++ b/tests/unit/test_topictags.py
@@ -505,7 +505,7 @@ class TestTopicDBScan(TestTopicTagDB):
         for i in range(5):
             topic_name = topic_base + '-' + str(i)
             tags = [
-                ':description: This is about %s' % topic_name,
+                f':description: This is about {topic_name}',
                 ':title: Title',
                 ':category: Foo',
                 ':related topic: Bar',
@@ -513,7 +513,7 @@ class TestTopicDBScan(TestTopicTagDB):
             ]
 
             reference_tag_dict[topic_name] = {
-                'description': ['This is about %s' % topic_name],
+                'description': [f'This is about {topic_name}'],
                 'title': ['Title'],
                 'category': ['Foo'],
                 'related topic': ['Bar'],

--- a/tests/utils/botocore/__init__.py
+++ b/tests/utils/botocore/__init__.py
@@ -123,7 +123,7 @@ def temporary_file(mode):
 
     """
     temporary_directory = tempfile.mkdtemp()
-    basename = 'tmpfile-%s-%s' % (int(time.time()), random.randint(1, 1000))
+    basename = f'tmpfile-{int(time.time())}-{random.randint(1, 1000)}'
     full_filename = os.path.join(temporary_directory, basename)
     open(full_filename, 'w').close()
     try:
@@ -282,7 +282,7 @@ class ClientDriver:
         self.send_cmd(*cmd)
         result = self._popen.stdout.readline().strip()
         if result != b'OK':
-            raise RuntimeError("Error from command '%s': %s" % (cmd, result))
+            raise RuntimeError(f"Error from command '{cmd}': {result}")
 
 
 # This is added to this file because it's used in both
@@ -525,7 +525,9 @@ class ConsistencyWaiter:
 
     def _fail_message(self, attempts, successes):
         format_args = (attempts, successes)
-        return 'Failed after %s attempts, only had %s successes' % format_args
+        return 'Failed after {} attempts, only had {} successes'.format(
+            *format_args
+        )
 
 
 class StubbedSession(botocore.session.Session):

--- a/tests/utils/s3transfer/__init__.py
+++ b/tests/utils/s3transfer/__init__.py
@@ -66,13 +66,12 @@ def is_serial_implementation():
 
 def assert_files_equal(first, second):
     if os.path.getsize(first) != os.path.getsize(second):
-        raise AssertionError("Files are not equal: %s, %s" % (first, second))
+        raise AssertionError(f"Files are not equal: {first}, {second}")
     first_md5 = md5_checksum(first)
     second_md5 = md5_checksum(second)
     if first_md5 != second_md5:
         raise AssertionError(
-            "Files are not equal: %s(md5=%s) != %s(md5=%s)"
-            % (first, first_md5, second, second_md5)
+            f"Files are not equal: {first}(md5={first_md5}) != {second}(md5={second_md5})"
         )
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Run `ruff check --select UP030,UP031,UP032 --unsafe-fixes --fix` to update use of f-strings. `ruff format` also run after.

- UP030: https://docs.astral.sh/ruff/rules/format-literals/
- UP031: https://docs.astral.sh/ruff/rules/printf-string-formatting/
- UP032: https://docs.astral.sh/ruff/rules/f-string/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
