### PR TITLE
[v2] Remove PyInstaller LD_LIBRARY_PATH from pager

### DIFF
--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -418,7 +418,6 @@ class OutputStreamFactory:
         if environ is None:
             with original_ld_library_path():
                 self._environ = os.environ.copy()
-            self._environ = os.environ.copy()
         self._default_less_flags = default_less_flags
 
     def get_output_stream(self):

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -64,6 +64,10 @@ class LazyPager:
     def __init__(self, popen, **kwargs):
         self._popen = popen
         self._popen_kwargs = kwargs
+        # When calling out to the system's pager, we want to avoid using
+        # shared libraries bundled with the AWS CLI so that the pager uses
+        # the system's shared libraries.
+        self._popen_kwargs['env'].pop('LD_LIBRARY_PATH', None)
         self._process = None
         self.stdin = LazyStdin(self)
 

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -25,8 +25,8 @@ from botocore.useragent import UserAgentComponent
 from botocore.utils import (
     BadIMDSRequestError,
     IMDSFetcher,
-    resolve_imds_endpoint_mode,
     original_ld_library_path,
+    resolve_imds_endpoint_mode,
 )
 
 from awscli.compat import (
@@ -416,6 +416,9 @@ class OutputStreamFactory:
             self._popen = Popen
         self._environ = environ
         if environ is None:
+            # When calling out to the system's pager, we want to avoid using
+            # shared libraries bundled with the AWS CLI so that the pager uses
+            # the system's shared libraries.
             with original_ld_library_path():
                 self._environ = os.environ.copy()
         self._default_less_flags = default_less_flags


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cli/issues/9433

The AWS CLI calls out to the system's pager, which may share dynamic libraries with the AWS CLI. This can cause issues if an AWS CLI library is incompatible with the system's pager. Although the system owns the pager, because it's executed as a child of the AWS CLI's Python process, it inherits PyInstaller's `LD_LIBRARY_PATH`. This commit fixes the issue by retrieving kwargs for pager popen under the `original_ld_library_path` context manager. The effect is that the system's pager uses the the system's dependencies instead of the AWS CLI's.