### PR TITLE
fix Incomplete URL substring sanitization Unvalidated Redirects and BXSS

### DIFF
--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -95,9 +95,11 @@ class CodeCommitGetCommand(BasicCommand):
 
     def _run_main(self, args, parsed_globals):
         git_parameters = self.read_git_parameters()
-        if ('amazon.com' in git_parameters['host'] or
-                'amazonaws.com' in git_parameters['host'] or
-                args.ignore_host_check):
+        from urllib.parse import urlparse
+        host = urlparse(git_parameters['host']).hostname
+        if (host and (host.endswith('amazon.com') or
+                      host.endswith('amazonaws.com') or
+                      args.ignore_host_check)):
             theUrl = self.extract_url(git_parameters)
             region = self.extract_region(git_parameters, parsed_globals)
             signature = self.sign_request(region, theUrl)


### PR DESCRIPTION
https://github.com/aws/aws-cli/blob/f38990ec8dc5900f17e647764cf3c7d09ac7b249/awscli/customizations/codecommit.py#L99-L99

fix the problem need to parse the URL and check the host value correctly. Instead of checking if "amazonaws.com" is a substring of the host, we should use the `urlparse` function to extract the hostname and then check if it ends with "amazonaws.com". This ensures that the check is accurate and not prone to bypasses.

1. Import the `urlparse` function from the `urllib.parse` module.
2. Parse the URL to extract the hostname.
3. Check if the hostname ends with "amazonaws.com".


Sanitizing untrusted URLs is a common technique for preventing attacks such as request forgeries and malicious redirections. Usually, this is done by checking that the host of a URL is in a set of allowed hosts. However, treating the URL as a string and checking if one of the allowed hosts is a substring of the URL is very prone to errors. Malicious URLs can bypass such security checks by embedding one of the allowed hosts in an unexpected location. Even if the substring check is not used in a security-critical context, the incomplete check may still cause undesirable behaviors when the check succeeds accidentally.

## POC
The following code checks that a URL redirection will reach the `evil-redacted.com` domain.
```py
from flask import Flask, request, redirect
from urllib.parse import urlparse

app = Flask(__name__)

# Not safe, as "evil-example.net/evil.com" would be accepted

@app.route('/some/path/bad1')
def unsafe1(request):
    target = request.args.get('target', '')
    if "example.com" in target:
        return redirect(target)

# Not safe, as "benign-looking-prefix-evil.com" would be accepted

@app.route('/some/path/bad2')
def unsafe2(request):
    target = request.args.get('target', '')
    if target.endswith("example.com"):
        return redirect(target)



#Simplest and safest approach is to use an allowlist

@app.route('/some/path/good1')
def safe1(request):
    allowlist = [
        "example.com/home",
        "example.com/login",
    ]
    target = request.args.get('target', '')
    if target in allowlist:
        return redirect(target)

#More complex example allowing sub-domains.

@app.route('/some/path/good2')
def safe2(request):
    target = request.args.get('target', '')
    host = urlparse(target).hostname
    #Note the '.' preceding example.com
    if host and host.endswith(".example.com"):
        return redirect(target)
```
The first two examples show unsafe checks that are easily bypassed. In `unsafe1` the attacker can simply add `evil.com` anywhere in the url, for the vulnerable `http://<aws-host>/evil.com`. In `safe2`, `urlparse` is used to parse the URL, then the hostname is checked to make sure it ends with `<aws-host>.evil.com`.

## References
[SSRF](https://www.owasp.org/index.php/Server_Side_Request_Forgery)
[XSS Unvalidated Redirects and Forwards Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)
[CWE-20](https://cwe.mitre.org/data/definitions/20.html)


