### PR TITLE
Update JSON formatter to encode bytes as Base64 strings.

### DIFF
--- a/.changes/next-release/bugfix-Formatter-25003.json
+++ b/.changes/next-release/bugfix-Formatter-25003.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "Formatter",
+  "description": "Update JSON formatter to encode raw bytes as UTF-8."
+}

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import base64
 import contextlib
 import csv
 import datetime
@@ -185,11 +186,14 @@ def operation_uses_document_types(operation_model):
 
 
 def json_encoder(obj):
-    """JSON encoder that formats datetimes as ISO8601 format."""
+    """JSON encoder that formats datetimes as ISO8601 format
+    and encodes bytes to UTF-8 Base64 string."""
     if isinstance(obj, datetime.datetime):
         return obj.isoformat()
+    elif isinstance(obj, bytes):
+        return base64.b64encode(obj).decode("utf-8")
     else:
-        return obj
+        raise TypeError('Encountered unrecognized type in JSON encoder.')
 
 
 @contextlib.contextmanager

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -11,6 +11,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import base64
+
+import sys
+
+import contextlib
+
+import io
+
 from botocore.compat import json
 import platform
 from awscli.formatter import JSONFormatter
@@ -127,3 +135,26 @@ class TestFormattersHandleClosedPipes(unittest.TestCase):
         # we still should have called the flush() on the
         # stream.
         fake_closed_stream.flush.assert_called_with()
+
+
+class TestBinaryData(unittest.TestCase):
+    def test_binary_data_gets_base64_encoded(self):
+        args = mock.Mock(query=None)
+        raw_bytes = b'foo'
+        response = {'BinaryValue': raw_bytes}
+        stdout_b = io.BytesIO()
+        stdout = io.TextIOWrapper(stdout_b, newline='\n')
+        formatter = JSONFormatter(args)
+
+        with contextlib.redirect_stdout(stdout):
+            formatter('command-name', response, sys.stdout)
+            stdout.flush()
+
+        assert (
+                stdout_b.getvalue()
+                == (
+                    '{\n'
+                    f'    "BinaryValue": "{base64.b64encode(raw_bytes).decode("utf-8")}"\n'
+                    '}\n'
+                ).encode()
+        )

--- a/tests/unit/output/test_json_output.py
+++ b/tests/unit/output/test_json_output.py
@@ -12,13 +12,9 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import base64
-
-import sys
-
 import contextlib
-
 import io
-
+import sys
 from botocore.compat import json
 import platform
 from awscli.formatter import JSONFormatter
@@ -151,10 +147,10 @@ class TestBinaryData(unittest.TestCase):
             stdout.flush()
 
         assert (
-                stdout_b.getvalue()
-                == (
-                    '{\n'
-                    f'    "BinaryValue": "{base64.b64encode(raw_bytes).decode("utf-8")}"\n'
-                    '}\n'
-                ).encode()
+            stdout_b.getvalue()
+            == (
+                '{\n'
+                f'    "BinaryValue": "{base64.b64encode(raw_bytes).decode("utf-8")}"\n'
+                '}\n'
+            ).encode()
         )


### PR DESCRIPTION
v1 port of #9424 

# Description of changes

- Modifies JSON formatter so that it serializes bytes into a UTF-8 Base64 string.
- Add a regression unit test to verify that binary data in the response gets base-64 encoded.

# Description of tests

- Call a service operation using the CBOR protocol and receive a response containing a member with raw bytes. Prior to this change, error code 255 is observed and the full response is not printed. After the change, the output is fully printed, and it matches the output seen when using the JSON protocol on the same operation.
- Ran and passed all test suites and CI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
