### PR TITLE
[v2] Pin Python versions for sdist action

### DIFF
--- a/.github/workflows/source-dist-tests.yml
+++ b/.github/workflows/source-dist-tests.yml
@@ -13,7 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Pin until we fix sdist test
+        # https://github.com/aws/aws-cli/blob/61523c9604dd1955d220e833da8cc0c13c4609b0/tests/backends/build_system/integration/test_build_system.py#L47
+        python-version: ["3.9", "3.10", "3.11", "3.12.9", "3.13.2"]
         # macOS pinned to 13 due to 14+ defaulting to arm64 hardware
         os: [ubuntu-latest, macOS-13, windows-latest]
     steps:


### PR DESCRIPTION
`tests/backends/build_system/integration/test_build_system.py::TestBuildBackendFailureCases::test_errors_building_venv_without_runtime_deps` is failing on newer versions of Python 3.12 and 3.13 [[example](https://github.com/aws/aws-cli/actions/runs/14478834843/job/40675279266?pr=9444)] because the bundled `pip` versions upgraded `pyproject-hooks` (aka `pep517`) to 1.2.0, changing the propagated error message: https://github.com/pypa/pip/pull/13125

This pins the Python versions for now so we can get clean CI runs. We just need to decide how we want to catch the dependencies error.