### PR TITLE
[v2] Update sdist fail case

### DIFF
--- a/tests/backends/build_system/integration/test_build_system.py
+++ b/tests/backends/build_system/integration/test_build_system.py
@@ -14,7 +14,6 @@ import os
 import subprocess
 
 import pytest
-from pep517 import BackendUnavailable
 
 from tests.backends.build_system.integration import (
     BaseArtifactTest,

--- a/tests/backends/build_system/integration/test_build_system.py
+++ b/tests/backends/build_system/integration/test_build_system.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 
 import pytest
+from pep517 import BackendUnavailable
 
 from tests.backends.build_system.integration import (
     BaseArtifactTest,
@@ -48,7 +49,13 @@ class TestBuildBackendFailureCases:
         with pytest.raises(subprocess.CalledProcessError) as e:
             workspace.call_build_system("system-sandbox", download_deps=False)
         error_text = e.value.stdout.decode()
-        assert "No module named 'flit_core'" in error_text
+        possible_messages = [
+            "No module named 'flit_core'",
+            # Recent versions of pyproject-hooks started consuming
+            # ImportError messages and replacing it.
+            "Cannot import 'pep517'",
+        ]
+        assert any([msg in error_text for msg in possible_messages])
 
 
 class TestInstall(BaseArtifactTest):


### PR DESCRIPTION
`tests/backends/build_system/integration/test_build_system.py::TestBuildBackendFailureCases::test_errors_building_venv_without_runtime_deps` is failing on newer versions of Python [[example](https://github.com/aws/aws-cli/actions/runs/14478834843/job/40675279266?pr=9444)] because the bundled `pip` versions upgraded `pyproject-hooks` (aka `pep517`) to 1.2.0, changing the propagated error message: https://github.com/pypa/pip/pull/13125