### PR TITLE
Alias socialmessaging command

### DIFF
--- a/awscli/customizations/socialmessaging.py
+++ b/awscli/customizations/socialmessaging.py
@@ -1,0 +1,28 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.utils import make_hidden_command_alias
+
+
+def register_alias_socialmessaging_command(event_emitter):
+    event_emitter.register(
+        'building-command-table.socialmessaging',
+        alias_socialmessaging_command
+    )
+
+
+def alias_socialmessaging_command(command_table, **kwargs):
+    make_hidden_command_alias(
+        command_table,
+        existing_name='delete-whatsapp-message-media',
+        alias_name='delete-whatsapp-media-message',
+    )

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -116,6 +116,7 @@ from awscli.customizations.servicecatalog import (
 from awscli.customizations.sessendemail import register_ses_send_email
 from awscli.customizations.sessionmanager import register_ssm_session
 from awscli.customizations.sms_voice import register_sms_voice_hide
+from awscli.customizations.socialmessaging import register_alias_socialmessaging_command
 from awscli.customizations.streamingoutputarg import add_streaming_output_arg
 from awscli.customizations.toplevelbool import register_bool_params
 from awscli.customizations.translate import (
@@ -210,6 +211,7 @@ def awscli_initialize(event_handlers):
     register_alias_opsworks_cm(event_handlers)
     register_alias_mturk_command(event_handlers)
     register_alias_sagemaker_runtime_command(event_handlers)
+    register_alias_socialmessaging_command(event_handlers)
     register_servicecatalog_commands(event_handlers)
     register_translate_import_terminology(event_handlers)
     register_history_mode(event_handlers)

--- a/tests/functional/socialmessaging/test_alias.py
+++ b/tests/functional/socialmessaging/test_alias.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestAlias(BaseAWSCommandParamsTest):
+    def test_alias(self):
+        # This command was aliased, both should work
+        command_template = ('socialmessaging %s --origination-phone-number-id foo '
+                            '--media-id bar')
+        old_command = command_template % 'delete-whatsapp-media-message'
+        new_command = command_template % 'delete-whatsapp-message-media'
+        self.run_cmd(old_command, expected_rc=0)
+        self.run_cmd(new_command, expected_rc=0)


### PR DESCRIPTION
Due to a human error while customizing the name of a socialmessaging command, we are creating an alias to allow both the old name and the newly corrected name to work.  This generates the correct docs as shown below.  This must be released on the same day as the associated botocore PR.  

![image](https://github.com/user-attachments/assets/838d883e-a6f2-4c69-9463-c4009a3615cb)