### PR TITLE
[v2] Reduce invalid choice output

### DIFF
--- a/awscli/argparser.py
+++ b/awscli/argparser.py
@@ -65,10 +65,6 @@ class CommandAction(argparse.Action):
 class CLIArgParser(argparse.ArgumentParser):
     Formatter = argparse.RawTextHelpFormatter
 
-    # When displaying invalid choice error messages,
-    # this controls how many options to show per line.
-    ChoicesPerLine = 2
-
     def _check_value(self, action, value):
         """
         It's probably not a great idea to override a "hidden" method
@@ -77,15 +73,10 @@ class CLIArgParser(argparse.ArgumentParser):
         """
         # converted value must be one of the choices (if specified)
         if action.choices is not None and value not in action.choices:
-            msg = ['Invalid choice, valid choices are:\n']
-            for i in range(len(action.choices))[:: self.ChoicesPerLine]:
-                current = []
-                for choice in action.choices[i : i + self.ChoicesPerLine]:
-                    current.append('%-40s' % choice)
-                msg.append(' | '.join(current))
+            msg = [f"Found invalid choice '{value}'\n"]
             possible = get_close_matches(value, action.choices, cutoff=0.8)
             if possible:
-                extra = ['\n\nInvalid choice: %r, maybe you meant:\n' % value]
+                extra = ['Maybe you meant:\n']
                 for word in possible:
                     extra.append('  * %s' % word)
                 msg.extend(extra)
@@ -126,8 +117,8 @@ class CLIArgParser(argparse.ArgumentParser):
         should raise an exception.
         """
         usage_message = self.format_usage()
-        error_message = f'{self.prog}: error: {message}\n'
-        raise ArgParseException(f'{usage_message}\n{error_message}')
+        error_message = f'{self.prog}: error: {message}'
+        raise ArgParseException(f'{error_message}\n\n{usage_message}')
 
 
 class MainArgParser(CLIArgParser):

--- a/tests/functional/docs/test_help_output.py
+++ b/tests/functional/docs/test_help_output.py
@@ -217,7 +217,7 @@ class TestRemoveDeprecatedCommands(BaseAWSHelpOutputTest):
         self.assertEqual(cr, 252)
         # We should see an error message complaining about
         # an invalid choice because the operation has been removed.
-        self.assertIn('argument operation: Invalid choice', stderr.getvalue())
+        self.assertIn('argument operation: Found invalid choice', stderr.getvalue())
 
     def test_ses_deprecated_commands(self):
         self.driver.main(['ses', 'help'])

--- a/tests/functional/ec2instanceconnect/test_ssh.py
+++ b/tests/functional/ec2instanceconnect/test_ssh.py
@@ -886,7 +886,7 @@ class TestSSHCommand:
                     "test",
                 ],
                 252,
-                "argument --connection-type: Invalid choice, valid choices are:",
+                "argument --connection-type: Found invalid choice 'test'",
                 id='Failure: Customer must provide connection-type when IP defined',
             ),
             pytest.param(

--- a/tests/functional/kinesis/test_remove_operations.py
+++ b/tests/functional/kinesis/test_remove_operations.py
@@ -15,5 +15,5 @@ from tests import CLIRunner
 
 def test_subscribe_to_shard_removed():
     result = CLIRunner().run(['kinesis', 'subscribe-to-shard', 'help'])
-    expected_error = 'argument operation: Invalid choice, valid choices are:'
+    expected_error = "argument operation: Found invalid choice 'subscribe-to-shard'"
     assert expected_error in result.stderr

--- a/tests/functional/lex/test_remove_operations.py
+++ b/tests/functional/lex/test_remove_operations.py
@@ -15,5 +15,5 @@ from tests import CLIRunner
 
 def test_start_conversation_removed():
     result = CLIRunner().run(['lexv2-runtime', 'start-conversation', 'help'])
-    expected_error = 'argument operation: Invalid choice, valid choices are:'
+    expected_error = "argument operation: Found invalid choice 'start-conversation'"
     assert expected_error in result.stderr

--- a/tests/functional/servicecatalog/test_generate_createproduct.py
+++ b/tests/functional/servicecatalog/test_generate_createproduct.py
@@ -198,7 +198,7 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             self.cmd_line,
             expected_rc=252,
-            stderr_contains='--product-type: Invalid choice',
+            stderr_contains='--product-type: Found invalid choice',
         )
 
     def test_generate_product_invalid_provisioning_artifact_type(self):
@@ -208,5 +208,5 @@ class TestGenerateProduct(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             self.cmd_line,
             expected_rc=252,
-            stderr_contains='--provisioning-artifact-type: Invalid choice',
+            stderr_contains='--provisioning-artifact-type: Found invalid choice',
         )

--- a/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
+++ b/tests/functional/servicecatalog/test_generate_createprovisioningartifact.py
@@ -105,7 +105,7 @@ class TestGenerateProvisioningArtifact(BaseAWSCommandParamsTest):
         self.assert_params_for_cmd(
             self.cmd_line,
             expected_rc=252,
-            stderr_contains='--provisioning-artifact-type: Invalid choice',
+            stderr_contains='--provisioning-artifact-type: Found invalid choice',
         )
 
     def test_generate_provisioning_artifact_missing_file_path(self):

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -493,10 +493,10 @@ class TestCliDriverHooks(unittest.TestCase):
         )
         self.assertEqual(rc, 252)
         # Tell the user what went wrong.
-        self.assertIn("Invalid choice: 'list-objecst'", self.stderr.getvalue())
+        self.assertIn("Found invalid choice 'list-objecst'", self.stderr.getvalue())
         # Offer the user a suggestion.
         self.assertIn(
-            "maybe you meant:\n\n  * list-objects", self.stderr.getvalue()
+            "Maybe you meant:\n\n  * list-objects", self.stderr.getvalue()
         )
 
 


### PR DESCRIPTION
Currently, if a user supplies an invalid choice in a command, the error output contains all possible values (eg all service commands). This output is noisy, especially for developers who use screen readers. This PR reduces noise by removing all possible suggestions, keeping only suggestions that are similar to the supplied invalid choice.

Example:
```
> aws s3api hello-world

aws: error: argument operation: Found invalid choice 'hello-world'


usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
```

Example with suggestion:
```
> aws s3api get-objeck

aws: error: argument operation: Found invalid choice 'get-objeck'

Maybe you meant:

  * get-object

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
```