### PR TITLE
Fix incorrect socialmessaging command

### DIFF
--- a/.changes/next-release/bugfix-socialmessaging-6243.json
+++ b/.changes/next-release/bugfix-socialmessaging-6243.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "socialmessaging",
+  "description": "Fixes incorrect customization for renaming a socialmessaging command"
+}

--- a/.changes/next-release/bugfix-socialmessaging-6243.json
+++ b/.changes/next-release/bugfix-socialmessaging-6243.json
@@ -1,5 +1,5 @@
 {
   "type": "bugfix",
   "category": "socialmessaging",
-  "description": "Fixes incorrect customization for renaming a socialmessaging command"
+  "description": "Renames the incorrectly named delete-whatsapp-media-message command to the correct name of delete-whatsapp-message-media"
 }

--- a/awscli/botocore/__init__.py
+++ b/awscli/botocore/__init__.py
@@ -61,8 +61,8 @@ _xform_cache = {
         'AssociateWhatsAppBusinessAccount',
         '-',
     ): 'associate-whatsapp-business-account',
-    ('DeleteWhatsAppMessageMedia', '_'): 'delete_whatsapp_media_message',
-    ('DeleteWhatsAppMessageMedia', '-'): 'delete-whatsapp-media-message',
+    ('DeleteWhatsAppMessageMedia', '_'): 'delete_whatsapp_message_media',
+    ('DeleteWhatsAppMessageMedia', '-'): 'delete-whatsapp-message-media',
     (
         'DisassociateWhatsAppBusinessAccount',
         '_',

--- a/tests/unit/botocore/test_utils.py
+++ b/tests/unit/botocore/test_utils.py
@@ -295,7 +295,7 @@ class TestTransformName(unittest.TestCase):
         )
         self.assertEqual(
             xform_name('DeleteWhatsAppMessageMedia', '-'),
-            'delete-whatsapp-media-message',
+            'delete-whatsapp-message-media',
         )
         self.assertEqual(
             xform_name('DisassociateWhatsAppBusinessAccount', '-'),


### PR DESCRIPTION
This PR fixes a relatively new command that had a human error due to manually renaming it to preserve branding.  All customers currently using this command are aware of this breaking change.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
