### PR TITLE
CI: Only run stale actions for upstream

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   handle-stale-discussions:
+    if: ${{ github.event.repository.fork == false || github.event_name != 'schedule' }}
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   cleanup:
+    if: github.event.repository.fork == false
     permissions:
       issues: write
       contents: read


### PR DESCRIPTION
*Description of changes:*

For forks with GitHub Actions enabled, there's no need to run the scheduled stale ones.

Let's disable them for forks.

See also https://hugovk.dev/blog/2023/til-how-to-disable-cron-for-github-forks/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
