### PR TITLE
Only run stale actions for upstream for v2

### DIFF
--- a/.github/workflows/handle-stale-discussions.yml
+++ b/.github/workflows/handle-stale-discussions.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   handle-stale-discussions:
+    if: ${{ github.event.repository.fork == false || github.event_name != 'schedule' }}
     name: Handle stale discussions
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   cleanup:
+    if: github.event.repository.fork == false
     permissions:
       issues: write
       contents: read


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Ports #9464 to `v2`. This shouldn't matter yet since `v2` isn't the default branch. But keeping these in sync while we're here since `v2` may become the default branch in the future once V1 hits end of support.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
