### PR TITLE
[v2] Validate multipart downloads using object ETags

### DIFF
--- a/.changes/next-release/bugfix-s3transfer-31636.json
+++ b/.changes/next-release/bugfix-s3transfer-31636.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "s3transfer",
+  "description": "Validate ETag of stored object during multipart downloads"
+}

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -108,6 +108,7 @@ class FileStat:
         dest_type=None,
         operation_name=None,
         response_data=None,
+        etag=None,
     ):
         self.src = src
         self.dest = dest
@@ -118,6 +119,7 @@ class FileStat:
         self.dest_type = dest_type
         self.operation_name = operation_name
         self.response_data = response_data
+        self.etag = etag
 
 
 class FileGenerator:
@@ -177,6 +179,7 @@ class FileGenerator:
         src_type = file_stat_kwargs['src_type']
         file_stat_kwargs['size'] = extra_information['Size']
         file_stat_kwargs['last_update'] = extra_information['LastModified']
+        file_stat_kwargs['etag'] = extra_information.get('ETag')
 
         # S3 objects require the response data retrieved from HeadObject
         # and ListObject
@@ -401,4 +404,5 @@ class FileGenerator:
         response['Size'] = int(response.pop('ContentLength'))
         last_update = parse(response['LastModified'])
         response['LastModified'] = last_update.astimezone(tzlocal())
+        response['ETag'] = response.pop('ETag', None)
         return s3_path, response

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -54,6 +54,7 @@ class FileInfo:
         source_client=None,
         is_stream=False,
         associated_response_data=None,
+        etag=None,
     ):
         self.src = src
         self.src_type = src_type
@@ -71,6 +72,7 @@ class FileInfo:
         self.source_client = source_client
         self.is_stream = is_stream
         self.associated_response_data = associated_response_data
+        self.etag = etag
 
     def is_glacier_compatible(self):
         """Determines if a file info object is glacier compatible

--- a/awscli/customizations/s3/fileinfobuilder.py
+++ b/awscli/customizations/s3/fileinfobuilder.py
@@ -47,6 +47,7 @@ class FileInfoBuilder:
         file_info_attr['parameters'] = self._parameters
         file_info_attr['is_stream'] = self._is_stream
         file_info_attr['associated_response_data'] = file_base.response_data
+        file_info_attr['etag'] = file_base.etag
 
         # This is a bit quirky. The below conditional hinges on the --delete
         # flag being set, which only occurs during a sync command. The source

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -37,6 +37,7 @@ from awscli.customizations.s3.subscribers import (
     DeleteSourceFileSubscriber,
     DeleteSourceObjectSubscriber,
     DirectoryCreatorSubscriber,
+    ProvideETagSubscriber,
     ProvideLastModifiedTimeSubscriber,
     ProvideSizeSubscriber,
     ProvideUploadContentTypeSubscriber,
@@ -243,6 +244,7 @@ class BaseTransferRequestSubmitter:
         subscribers = []
         result_subscriber_kwargs = self._get_result_subscriber_kwargs(fileinfo)
         self._add_provide_size_subscriber(subscribers, fileinfo)
+        subscribers.append(ProvideETagSubscriber(fileinfo.etag))
         subscribers.append(QueuedResultSubscriber(**result_subscriber_kwargs))
         self._add_additional_subscribers(subscribers, fileinfo)
         subscribers.extend(

--- a/awscli/customizations/s3/subscribers.py
+++ b/awscli/customizations/s3/subscribers.py
@@ -78,6 +78,27 @@ class ProvideSizeSubscriber(BaseSubscriber):
             )
 
 
+class ProvideETagSubscriber(BaseSubscriber):
+    """
+    A subscriber which provides the object ETag before it's queued.
+    """
+
+    def __init__(self, etag):
+        self.etag = etag
+
+    def on_queued(self, future, **kwargs):
+        # The CRT transfer client does not support providing an expected
+        # ETag of an object. So only provide it if it is available.
+        if hasattr(future.meta, 'provide_object_etag'):
+            future.meta.provide_object_etag(self.etag)
+        else:
+            LOGGER.debug(
+                'Not providing object ETag. Future: %s does not offer'
+                'the capability to notify the ETag of an object',
+                future,
+            )
+
+
 class DeleteSourceSubscriber(OnDoneFilteredSubscriber):
     """A subscriber which deletes the source of the transfer."""
 

--- a/awscli/s3transfer/download.py
+++ b/awscli/s3transfer/download.py
@@ -14,8 +14,9 @@ import heapq
 import logging
 import threading
 
+from botocore.exceptions import ClientError
 from s3transfer.compat import seekable
-from s3transfer.exceptions import RetriesExceededError
+from s3transfer.exceptions import RetriesExceededError, S3DownloadFailedError
 from s3transfer.futures import IN_MEMORY_DOWNLOAD_TAG
 from s3transfer.tasks import SubmissionTask, Task
 from s3transfer.utils import (
@@ -346,14 +347,18 @@ class DownloadSubmissionTask(SubmissionTask):
         :param bandwidth_limiter: The bandwidth limiter to use when
             downloading streams
         """
+        response = client.head_object(
+            Bucket=transfer_future.meta.call_args.bucket,
+            Key=transfer_future.meta.call_args.key,
+            **transfer_future.meta.call_args.extra_args,
+        )
+        # Provide an etag to ensure a stored object is not modified
+        # during a multipart download.
+        transfer_future.meta.provide_object_etag(response.get('ETag'))
+
         if transfer_future.meta.size is None:
             # If a size was not provided figure out the size for the
             # user.
-            response = client.head_object(
-                Bucket=transfer_future.meta.call_args.bucket,
-                Key=transfer_future.meta.call_args.key,
-                **transfer_future.meta.call_args.extra_args,
-            )
             transfer_future.meta.provide_transfer_size(
                 response['ContentLength']
             )
@@ -479,9 +484,12 @@ class DownloadSubmissionTask(SubmissionTask):
                 part_size, i, num_parts
             )
 
-            # Inject the Range parameter to the parameters to be passed in
-            # as extra args
-            extra_args = {'Range': range_parameter}
+            # Inject extra parameters to be passed in as extra args
+            extra_args = {
+                'Range': range_parameter,
+            }
+            if transfer_future.meta.etag is not None:
+                extra_args['IfMatch'] = transfer_future.meta.etag
             extra_args.update(call_args.extra_args)
             finalize_download_invoker.increment()
             # Submit the ranged downloads
@@ -593,6 +601,15 @@ class GetObjectTask(Task):
                     else:
                         return
                 return
+            except ClientError as e:
+                error_code = e.response.get('Error', {}).get('Code')
+                if error_code == "PreconditionFailed":
+                    raise S3DownloadFailedError(
+                        f'Contents of stored object "{key}" in bucket '
+                        f'"{bucket}" did not match expected ETag.'
+                    )
+                else:
+                    raise
             except S3_RETRYABLE_DOWNLOAD_ERRORS as e:
                 logger.debug(
                     "Retrying exception caught (%s), "

--- a/awscli/s3transfer/download.py
+++ b/awscli/s3transfer/download.py
@@ -349,7 +349,7 @@ class DownloadSubmissionTask(SubmissionTask):
         """
         if (
             transfer_future.meta.size is None
-            and transfer_future.meta.etag is None
+            or transfer_future.meta.etag is None
         ):
             response = client.head_object(
                 Bucket=transfer_future.meta.call_args.bucket,

--- a/awscli/s3transfer/exceptions.py
+++ b/awscli/s3transfer/exceptions.py
@@ -23,6 +23,10 @@ class S3UploadFailedError(Exception):
     pass
 
 
+class S3DownloadFailedError(Exception):
+    pass
+
+
 class InvalidSubscriberMethodError(Exception):
     pass
 

--- a/awscli/s3transfer/futures.py
+++ b/awscli/s3transfer/futures.py
@@ -127,6 +127,7 @@ class TransferMeta(BaseTransferMeta):
         self._transfer_id = transfer_id
         self._size = None
         self._user_context = {}
+        self._etag = None
 
     @property
     def call_args(self):
@@ -148,6 +149,11 @@ class TransferMeta(BaseTransferMeta):
         """A dictionary that requesters can store data in"""
         return self._user_context
 
+    @property
+    def etag(self):
+        """The etag of the stored object for validating multipart downloads"""
+        return self._etag
+
     def provide_transfer_size(self, size):
         """A method to provide the size of a transfer request
 
@@ -156,6 +162,15 @@ class TransferMeta(BaseTransferMeta):
         transfer.
         """
         self._size = size
+
+    def provide_object_etag(self, etag):
+        """A method to provide the etag of a transfer request
+
+        By providing this value, the TransferManager will validate
+        multipart downloads by supplying an IfMatch parameter with
+        the etag as the value to GetObject requests.
+        """
+        self._etag = etag
 
 
 class TransferCoordinator:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -92,6 +92,7 @@ from tests.utils.s3transfer import (
     StreamWithError,
     RecordingSubscriber,
     FileSizeProvider,
+    ETagProvider,
     RecordingOSUtils,
     RecordingExecutor,
     TransferCoordinatorWithInterrupt,

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -70,14 +70,23 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
         )
 
     def head_object_response(self, **override_kwargs):
-        response = {'ContentLength': 100, 'LastModified': '00:00:00Z'}
+        response = {
+            'ContentLength': 100,
+            'LastModified': '00:00:00Z',
+            'ETag': '"foo-1"',
+        }
         response.update(override_kwargs)
         return response
 
     def list_objects_response(self, keys, **override_kwargs):
         contents = []
         for key in keys:
-            content = {'Key': key, 'LastModified': '00:00:00Z', 'Size': 100}
+            content = {
+                'Key': key,
+                'LastModified': '00:00:00Z',
+                'Size': 100,
+                'ETag': '"foo-1"',
+            }
             if override_kwargs:
                 content.update(override_kwargs)
             contents.append(content)

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -261,7 +261,11 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_operations_used_in_download_file(self):
         self.parsed_responses = [
-            {"ContentLength": "100", "LastModified": "00:00:00Z"},
+            {
+                "ContentLength": "100",
+                "LastModified": "00:00:00Z",
+                'ETag': '"foo-1"',
+            },
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
         cmdline = '%s s3://bucket/key.txt %s' % (
@@ -468,7 +472,11 @@ class TestCPCommand(BaseCPCommandTest):
         full_path = self.files.create_file('foo.txt', '')
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)
         self.parsed_responses = [
-            {"ContentLength": "100", "LastModified": "00:00:00Z"},
+            {
+                "ContentLength": "100",
+                "LastModified": "00:00:00Z",
+                "ETag": '"foo-1"',
+            },
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
         with mock.patch('os.utime') as mock_utime:
@@ -486,6 +494,7 @@ class TestCPCommand(BaseCPCommandTest):
                         'LastModified': '00:00:00Z',
                         'StorageClass': 'GLACIER',
                         'Size': 100,
+                        'ETag': '"foo-1"',
                     },
                 ],
                 'CommonPrefixes': [],
@@ -1326,12 +1335,14 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
                     'mykey',
                     Range=mock.ANY,
                     RequestPayer='requester',
+                    IfMatch='"foo-1"',
                 ),
                 self.get_object_request(
                     'mybucket',
                     'mykey',
                     Range=mock.ANY,
                     RequestPayer='requester',
+                    IfMatch='"foo-1"',
                 ),
             ]
         )

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -124,7 +124,11 @@ class TestMvCommand(BaseS3TransferCommandTest):
 
         self.parsed_responses = [
             # Response for HeadObject
-            {"ContentLength": 100, "LastModified": "00:00:00Z"},
+            {
+                "ContentLength": 100,
+                "LastModified": "00:00:00Z",
+                "ETag": '"foo-1"',
+            },
             # Response for GetObject
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
             # Response for DeleteObject

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -77,6 +77,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
                         "Key": key,
                         "Size": 3,
                         "LastModified": "2014-01-09T20:45:49.000Z",
+                        "ETag": '"c8afdb36c52cf4727836669019e69222-"',
                     }
                 ],
             },
@@ -125,6 +126,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
                         'LastModified': '00:00:00Z',
                         'StorageClass': 'GLACIER',
                         'Size': 100,
+                        'ETag': '"foo-1"',
                     },
                 ],
                 'CommonPrefixes': [],

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -35,6 +35,7 @@ class TestFileInfoBuilder(unittest.TestCase):
                 dest_type='dest_type',
                 operation_name='operation_name',
                 response_data='associated_response_data',
+                etag='etag',
             )
         ]
         file_infos = info_setter.call(files)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -43,6 +43,7 @@ from awscli.customizations.s3.subscribers import (
     DeleteSourceFileSubscriber,
     DeleteSourceObjectSubscriber,
     DirectoryCreatorSubscriber,
+    ProvideETagSubscriber,
     ProvideLastModifiedTimeSubscriber,
     ProvideSizeSubscriber,
     ProvideUploadContentTypeSubscriber,
@@ -344,6 +345,7 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProvideUploadContentTypeSubscriber,
             ProgressResultSubscriber,
@@ -381,6 +383,7 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         )
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
@@ -400,6 +403,7 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         upload_call_kwargs = self.transfer_manager.upload.call_args[1]
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
@@ -455,6 +459,7 @@ class TestUploadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter.submit(fileinfo)
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProvideUploadContentTypeSubscriber,
             DeleteSourceFileSubscriber,
@@ -515,6 +520,7 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             DirectoryCreatorSubscriber,
             ProvideLastModifiedTimeSubscriber,
@@ -659,6 +665,7 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter.submit(fileinfo)
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             DirectoryCreatorSubscriber,
             ProvideLastModifiedTimeSubscriber,
@@ -712,6 +719,7 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             SetMetadataDirectivePropsSubscriber,
             SetTagsSubscriber,
@@ -752,6 +760,7 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         )
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             SetMetadataDirectivePropsSubscriber,
             SetTagsSubscriber,
@@ -775,6 +784,7 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         copy_call_kwargs = self.transfer_manager.copy.call_args[1]
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
@@ -900,6 +910,7 @@ class TestCopyRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter.submit(fileinfo)
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             SetMetadataDirectivePropsSubscriber,
             SetTagsSubscriber,
@@ -947,6 +958,7 @@ class TestUploadStreamRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.assertEqual(upload_call_kwargs['extra_args'], {})
 
         ref_subscribers = [
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
@@ -967,6 +979,7 @@ class TestUploadStreamRequestSubmitter(BaseTransferRequestSubmitterTest):
 
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
@@ -1036,6 +1049,7 @@ class TestDownloadStreamRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.assertEqual(download_call_kwargs['extra_args'], {})
 
         ref_subscribers = [
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
@@ -1109,6 +1123,7 @@ class TestDeleteRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.assertEqual(delete_call_kwargs['extra_args'], {})
 
         ref_subscribers = [
+            ProvideETagSubscriber,
             QueuedResultSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,

--- a/tests/unit/s3transfer/test_download.py
+++ b/tests/unit/s3transfer/test_download.py
@@ -396,7 +396,8 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
 
         self.bucket = 'mybucket'
         self.key = 'mykey'
-        self.extra_args = {}
+        self.etag = 'myetag'
+        self.extra_args = {'IfMatch': self.etag}
         self.subscribers = []
 
         # Create a stream to read from
@@ -453,7 +454,11 @@ class TestDownloadSubmissionTask(BaseSubmissionTaskTest):
 
     def add_head_object_response(self):
         self.stubber.add_response(
-            'head_object', {'ContentLength': len(self.content)}
+            'head_object',
+            {
+                'ContentLength': len(self.content),
+                'ETag': self.etag,
+            },
         )
 
     def add_get_responses(self):

--- a/tests/utils/s3transfer/__init__.py
+++ b/tests/utils/s3transfer/__init__.py
@@ -154,6 +154,14 @@ class FileSizeProvider:
         future.meta.provide_transfer_size(self.file_size)
 
 
+class ETagProvider:
+    def __init__(self, etag):
+        self.etag = etag
+
+    def on_queued(self, future, **kwargs):
+        future.meta.provide_object_etag(self.etag)
+
+
 class FileCreator:
     def __init__(self):
         self.rootdir = tempfile.mkdtemp()


### PR DESCRIPTION
Ports https://github.com/boto/s3transfer/pull/345 and https://github.com/aws/aws-cli/pull/9494

This PR adds an ETag check from the initial HEAD response to confirm object parts are downloaded from the same version. If the object ETag is modified during the multi-part download, the download will fail.