### PR TITLE
Provide ETag to transfer manager

### DIFF
--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -94,7 +94,7 @@ class FileDecodingError(Exception):
 class FileStat(object):
     def __init__(self, src, dest=None, compare_key=None, size=None,
                  last_update=None, src_type=None, dest_type=None,
-                 operation_name=None, response_data=None):
+                 operation_name=None, response_data=None, etag=None):
         self.src = src
         self.dest = dest
         self.compare_key = compare_key
@@ -104,6 +104,7 @@ class FileStat(object):
         self.dest_type = dest_type
         self.operation_name = operation_name
         self.response_data = response_data
+        self.etag = etag
 
 
 class FileGenerator(object):
@@ -152,6 +153,7 @@ class FileGenerator(object):
         src_type = file_stat_kwargs['src_type']
         file_stat_kwargs['size'] = extra_information['Size']
         file_stat_kwargs['last_update'] = extra_information['LastModified']
+        file_stat_kwargs['etag'] = extra_information.get('ETag')
 
         # S3 objects require the response data retrieved from HeadObject
         # and ListObject
@@ -366,4 +368,5 @@ class FileGenerator(object):
         response['Size'] = int(response.pop('ContentLength'))
         last_update = parse(response['LastModified'])
         response['LastModified'] = last_update.astimezone(tzlocal())
+        response['ETag'] = response.pop('ETag', None)
         return s3_path, response

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -42,7 +42,7 @@ class FileInfo(object):
                  last_update=None, src_type=None, dest_type=None,
                  operation_name=None, client=None, parameters=None,
                  source_client=None, is_stream=False,
-                 associated_response_data=None):
+                 associated_response_data=None, etag=None):
         self.src = src
         self.src_type = src_type
         self.operation_name = operation_name
@@ -59,6 +59,7 @@ class FileInfo(object):
         self.source_client = source_client
         self.is_stream = is_stream
         self.associated_response_data = associated_response_data
+        self.etag = etag
 
     def is_glacier_compatible(self):
         """Determines if a file info object is glacier compatible

--- a/awscli/customizations/s3/fileinfobuilder.py
+++ b/awscli/customizations/s3/fileinfobuilder.py
@@ -45,6 +45,7 @@ class FileInfoBuilder(object):
         file_info_attr['parameters'] = self._parameters
         file_info_attr['is_stream'] = self._is_stream
         file_info_attr['associated_response_data'] = file_base.response_data
+        file_info_attr['etag'] = file_base.etag
 
         # This is a bit quirky. The below conditional hinges on the --delete
         # flag being set, which only occurs during a sync command. The source

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -39,6 +39,7 @@ from awscli.customizations.s3.results import CommandResultRecorder
 from awscli.customizations.s3.utils import RequestParamsMapper
 from awscli.customizations.s3.utils import StdoutBytesWriter
 from awscli.customizations.s3.utils import ProvideSizeSubscriber
+from awscli.customizations.s3.utils import ProvideETagSubscriber
 from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideCopyContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideLastModifiedTimeSubscriber
@@ -395,6 +396,7 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
 
     def _add_additional_subscribers(self, subscribers, fileinfo):
         subscribers.append(ProvideSizeSubscriber(fileinfo.size))
+        subscribers.append(ProvideETagSubscriber(fileinfo.etag))
         subscribers.append(DirectoryCreatorSubscriber())
         subscribers.append(ProvideLastModifiedTimeSubscriber(
             fileinfo.last_update, self._result_queue))

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -649,6 +649,17 @@ class ProvideSizeSubscriber(BaseSubscriber):
         future.meta.provide_transfer_size(self.size)
 
 
+class ProvideETagSubscriber(BaseSubscriber):
+    """
+    A subscriber which provides the object ETag before it's queued.
+    """
+    def __init__(self, etag):
+        self.etag = etag
+
+    def on_queued(self, future, **kwargs):
+        future.meta.provide_object_etag(self.etag)
+
+
 # TODO: Eventually port this down to the BaseSubscriber or a new subscriber
 # class in s3transfer. The functionality is very convenient but may need
 # some further design decisions to make it a feature in s3transfer.

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -33,7 +33,8 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
     def head_object_response(self, **override_kwargs):
         response = {
             'ContentLength': 100,
-            'LastModified': '00:00:00Z'
+            'LastModified': '00:00:00Z',
+            'ETag': '"foo-1"'
         }
         response.update(override_kwargs)
         return response
@@ -45,7 +46,8 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
                 {
                     'Key': key,
                     'LastModified': '00:00:00Z',
-                    'Size': 100
+                    'Size': 100,
+                    'ETag': '"foo-1"',
                 }
             )
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -177,7 +177,11 @@ class TestCPCommand(BaseCPCommandTest):
 
     def test_operations_used_in_download_file(self):
         self.parsed_responses = [
-            {"ContentLength": "100", "LastModified": "00:00:00Z"},
+            {
+                "ContentLength": "100",
+                "LastModified": "00:00:00Z",
+                "ETag": '"foo-1"'
+            },
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
         ]
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix,
@@ -305,7 +309,11 @@ class TestCPCommand(BaseCPCommandTest):
         full_path = self.files.create_file('foo.txt', '')
         cmdline = '%s s3://bucket/key.txt %s' % (self.prefix, full_path)
         self.parsed_responses = [
-            {"ContentLength": "100", "LastModified": "00:00:00Z"},
+            {
+                "ContentLength": "100",
+                "LastModified": "00:00:00Z",
+                "ETag": '"foo-1"'
+            },
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')}
         ]
         with mock.patch('os.utime') as mock_utime:
@@ -317,10 +325,13 @@ class TestCPCommand(BaseCPCommandTest):
         self.parsed_responses = [
             {
                 'Contents': [
-                    {'Key': 'foo/bar.txt', 'ContentLength': '100',
-                     'LastModified': '00:00:00Z',
-                     'StorageClass': 'GLACIER',
-                     'Size': 100},
+                    {
+                        'Key': 'foo/bar.txt', 'ContentLength': '100',
+                        'LastModified': '00:00:00Z',
+                        'StorageClass': 'GLACIER',
+                        'Size': 100,
+                        'ETag': '"foo-1"',
+                     },
                 ],
                 'CommonPrefixes': []
             },
@@ -1046,10 +1057,14 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
                     'mybucket', 'mykey', RequestPayer='requester'),
                 self.get_object_request(
                     'mybucket', 'mykey', Range=mock.ANY,
-                    RequestPayer='requester'),
+                    RequestPayer='requester',
+                    IfMatch='"foo-1"',
+                ),
                 self.get_object_request(
                     'mybucket', 'mykey', Range=mock.ANY,
-                    RequestPayer='requester'),
+                    RequestPayer='requester',
+                    IfMatch='"foo-1"',
+                ),
             ]
         )
 

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -81,7 +81,11 @@ class TestMvCommand(BaseS3TransferCommandTest):
 
         self.parsed_responses = [
             # Response for HeadObject
-            {"ContentLength": 100, "LastModified": "00:00:00Z"},
+            {
+                "ContentLength": 100,
+                "LastModified": "00:00:00Z",
+                "ETag": '"foo-1"',
+            },
             # Response for GetObject
             {'ETag': '"foo-1"', 'Body': BytesIO(b'foo')},
             # Response for DeleteObject

--- a/tests/functional/s3/test_sync_command.py
+++ b/tests/functional/s3/test_sync_command.py
@@ -63,7 +63,8 @@ class TestSyncCommand(BaseS3TransferCommandTest):
         self.parsed_responses = [
             {"CommonPrefixes": [], "Contents": [
                 {"Key": key, "Size": 3,
-                 "LastModified": "2014-01-09T20:45:49.000Z"}]},
+                 "LastModified": "2014-01-09T20:45:49.000Z",
+                 "ETag": '"c8afdb36c52cf4727836669019e69222-"',}]},
             {'ETag': '"c8afdb36c52cf4727836669019e69222-"',
              'Body': BytesIO(b'foo')}
         ]
@@ -79,7 +80,7 @@ class TestSyncCommand(BaseS3TransferCommandTest):
                     {'Key': 'foo/bar.txt', 'ContentLength': '100',
                      'LastModified': '00:00:00Z',
                      'StorageClass': 'GLACIER',
-                     'Size': 100},
+                     'Size': 100, 'ETag': '"foo-1"',},
                 ],
                 'CommonPrefixes': []
             },

--- a/tests/unit/customizations/s3/test_fileinfobuilder.py
+++ b/tests/unit/customizations/s3/test_fileinfobuilder.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import mock 
+from awscli.testutils import mock
 from awscli.testutils import unittest
 from awscli.customizations.s3.filegenerator import FileStat
 from awscli.customizations.s3.fileinfo import FileInfo
@@ -27,7 +27,8 @@ class TestFileInfoBuilder(unittest.TestCase):
                           size='size', last_update='last_update',
                           src_type='src_type', dest_type='dest_type',
                           operation_name='operation_name',
-                          response_data='associated_response_data')]
+                          response_data='associated_response_data',
+                          etag='etag',)]
         file_infos = info_setter.call(files)
         for file_info in file_infos:
             attributes = file_info.__dict__.keys()

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -46,6 +46,7 @@ from awscli.customizations.s3.utils import NonSeekableStream
 from awscli.customizations.s3.utils import StdoutBytesWriter
 from awscli.customizations.s3.utils import WarningResult
 from awscli.customizations.s3.utils import ProvideSizeSubscriber
+from awscli.customizations.s3.utils import ProvideETagSubscriber
 from awscli.customizations.s3.utils import ProvideUploadContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideCopyContentTypeSubscriber
 from awscli.customizations.s3.utils import ProvideLastModifiedTimeSubscriber
@@ -442,6 +443,7 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         # Make sure the subscriber applied are of the correct type and order
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             DirectoryCreatorSubscriber,
             ProvideLastModifiedTimeSubscriber,
             DownloadResultSubscriber
@@ -579,6 +581,7 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
         self.transfer_request_submitter.submit(fileinfo)
         ref_subscribers = [
             ProvideSizeSubscriber,
+            ProvideETagSubscriber,
             DirectoryCreatorSubscriber,
             ProvideLastModifiedTimeSubscriber,
             DeleteSourceObjectSubscriber,

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -35,7 +35,7 @@ from awscli.customizations.s3.utils import (
     StablePriorityQueue, BucketLister, get_file_stat, AppendFilter,
     create_warning, human_readable_size, human_readable_to_bytes,
     set_file_utime, SetFileUtimeError, RequestParamsMapper, StdoutBytesWriter,
-    ProvideSizeSubscriber, OnDoneFilteredSubscriber,
+    ProvideSizeSubscriber, ProvideETagSubscriber, OnDoneFilteredSubscriber,
     ProvideUploadContentTypeSubscriber, ProvideCopyContentTypeSubscriber,
     ProvideLastModifiedTimeSubscriber, DirectoryCreatorSubscriber,
     DeleteSourceObjectSubscriber, DeleteSourceFileSubscriber,
@@ -792,6 +792,19 @@ class TestProvideSizeSubscriber(unittest.TestCase):
         subscriber = ProvideSizeSubscriber(10)
         subscriber.on_queued(self.transfer_future)
         self.assertEqual(self.transfer_meta.size, 10)
+
+
+class TestProvideEtagSubscriber:
+    def test_etag_set(self):
+        transfer_meta = TransferMeta()
+        transfer_future = mock.Mock(spec=TransferFuture)
+        transfer_future.meta = transfer_meta
+        etag = 'myetag'
+
+        transfer_meta.provide_object_etag('oldetag')
+        subscriber = ProvideETagSubscriber(etag)
+        subscriber.on_queued(transfer_future)
+        assert transfer_meta.etag == etag
 
 
 class OnDoneFilteredRecordingSubscriber(OnDoneFilteredSubscriber):


### PR DESCRIPTION
Companion PR to https://github.com/boto/s3transfer/pull/345

The S3 transfer manager will call HeadObject during a download if object size and ETag are not provided. To avoid a double HeadObject, this PR updates the high level S3 library to provide the ETag when it makes its own initial HeadObject request.