### PR TITLE
Lower CBOR in priority order

### DIFF
--- a/awscli/botocore/args.py
+++ b/awscli/botocore/args.py
@@ -47,10 +47,10 @@ VALID_RESPONSE_CHECKSUM_VALIDATION_CONFIG = (
 )
 
 PRIORITY_ORDERED_SUPPORTED_PROTOCOLS = (
-    'smithy-rpc-v2-cbor',
     'json',
     'rest-json',
     'rest-xml',
+    'smithy-rpc-v2-cbor',
     'query',
     'ec2',
 )


### PR DESCRIPTION
port of https://github.com/boto/botocore/pull/3471

Copy/paste of the description from that PR:


> Internal guidance has now been updated to encourage us to use a priority order that makes the most sense for our customers instead of a standardized priority list.
> 
> I've updated the list based to reflect the proper priority for CBOR based on the following points:
> 
> -   CBOR is slower than JSON and Rest-JSON, so it should be lower priority
> -  We have not done extensive performance testing on XML based services, of which there are only a few. If any XML service wants to add CBOR as a priority protocol, we should do the testing at that point. Until then it makes sense to keep it a higher priority and err on the side of caution
> -  CBOR is faster than query/EC2
> 
> There are no services currently using CBOR a protocol, so no customers will be impacted by this change so long as it is merged before the first one is released.
