### PR TITLE
Update Dockerfile to use Amazon Linux 2023 instead of Amazon Linux 2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM public.ecr.aws/amazonlinux/amazonlinux:2 as installer
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as installer
 ARG EXE_FILENAME=awscli-exe-linux-x86_64.zip
 COPY $EXE_FILENAME .
 RUN yum update -y \
-  && yum install -y unzip \
+  && dnf install -y unzip \
   && unzip $EXE_FILENAME \
   # The --bin-dir is specified so that we can copy the
   # entire bin directory from the installer stage into
@@ -11,10 +11,10 @@ RUN yum update -y \
   # may be present in /usr/local/bin of the installer stage.
   && ./aws/install --bin-dir /aws-cli-bin/
 
-FROM public.ecr.aws/amazonlinux/amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN yum update -y \
-  && yum install -y less groff \
-  && yum clean all
+  && dnf install -y less groff \
+  && dnf clean all
 COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=installer /aws-cli-bin/ /usr/local/bin/
 WORKDIR /aws


### PR DESCRIPTION
*Issue #, if available:*
Fixes #9508

*Description of changes:*
Updates the `Dockerfile` to use Amazon Linux 2023

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
