### PR TITLE
Update README to suggest requirements-dev-lock.txt for CLI Dev Version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -371,11 +371,11 @@ The latest changes to the CLI are in the ``v2`` branch on github.  This is
 to make sure you ``git checkout v2``.
 
 If you just want to install a snapshot of the latest development version of
-the CLI, you can use the ``requirements-dev.txt`` file included in this repo.
+the CLI, you can use the ``requirements-dev-lock.txt`` file included in this repo.
 This file points to the development version of our dependencies::
 
     $ cd <path_to_awscli> && git checkout v2
-    $ pip install -r requirements-dev.txt
+    $ pip install -r requirements-dev-lock.txt
     $ pip install -e .
 
 Verify that the AWS CLI is correctly installed. Note that the word ``source`` should appear in the output::


### PR DESCRIPTION
*Description of changes:*

* Updated README to suggest using `requirements-dev-lock.txt` instead of `requirements-dev.txt` in installing AWS CLI Dev Version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
