### PR TITLE
Remove inspector and opsworks smoke tests

### DIFF
--- a/tests/integration/botocore/test_smoke.py
+++ b/tests/integration/botocore/test_smoke.py
@@ -74,13 +74,11 @@ SMOKE_TESTS = {
     # importexport tests are not run.
     #'importexport': {'ListJobs': {}},
     'importexport': {},
-    'inspector': {'DescribeCrossAccountAccessRole': {}},
     'iot': {'DescribeEndpoint': {}},
     'kinesis': {'ListStreams': {}},
     'kms': {'ListKeys': {}},
     'lambda': {'ListFunctions': {}},
     'logs': {'DescribeLogGroups': {}},
-    # 'opsworks': {'DescribeStacks': {}},
     'rds': {'DescribeDBInstances': {}},
     'redshift': {'DescribeClusters': {}},
     'route53': {'ListHostedZones': {}},
@@ -175,7 +173,6 @@ ERROR_TESTS = {
     'kinesis': {'DescribeStream': {'StreamName': 'fake'}},
     'kms': {'GetKeyPolicy': {'KeyId': 'fake', 'PolicyName': 'fake'}},
     'lambda': {'Invoke': {'FunctionName': 'fake'}},
-    # 'opsworks': {'DescribeLayers': {'StackId': 'fake'}},
     'rds': {'DescribeDBInstances': {'DBInstanceIdentifier': 'fake'}},
     'redshift': {'DescribeClusters': {'ClusterIdentifier': 'fake'}},
     'route53': {'GetHostedZone': {'Id': 'fake'}},
@@ -209,7 +206,6 @@ REGION = 'us-east-1'
 REGION_OVERRIDES = {
     'devicefarm': 'us-west-2',
     'efs': 'us-west-2',
-    'inspector': 'us-west-2',
 }
 MAX_RETRIES = 8
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes smoke tests for end of support service opsworks and pending end of support service inspector.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
