### PR TITLE
Exclude hidden files from example folder during test file collection

### DIFF
--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -84,10 +84,10 @@ def _get_all_doc_examples():
     for root, _, filenames in os.walk(EXAMPLES_DIR):
         for filename in filenames:
             full_path = os.path.join(root, filename)
-            if not filename.endswith('.rst'):
-                if filename.startswith('.'):
-                    # Ignore hidden files as it starts with "."
-                    continue
+            if filename.startswith('.'):
+                # Ignore hidden files as it starts with "."
+                continue
+            if not filename.endswith('.rst'):                
                 other_doc_examples.append(full_path)
                 continue
             rst_doc_examples.append(full_path)

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -85,6 +85,10 @@ def _get_all_doc_examples():
         for filename in filenames:
             full_path = os.path.join(root, filename)
             if not filename.endswith('.rst'):
+                #new changes
+                if filename.startswith('.'):
+                    # Ignore hidden files
+                    continue
                 other_doc_examples.append(full_path)
                 continue
             rst_doc_examples.append(full_path)

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -85,9 +85,8 @@ def _get_all_doc_examples():
         for filename in filenames:
             full_path = os.path.join(root, filename)
             if not filename.endswith('.rst'):
-                #new changes
                 if filename.startswith('.'):
-                    # Ignore hidden files
+                    # Ignore hidden files as it starts with "."
                     continue
                 other_doc_examples.append(full_path)
                 continue


### PR DESCRIPTION

*Description of changes:*
Tests are failing for the users who use the Mac Finder that may create hidden system files such as `.DS_Store` or `._command-name.rst` in the directory. Thus, when the test suite is run, it fails because it encounters a file in the examples folder that is not a `.rst `or `.txt`.
_Resolution_
Since hidden files starts with `.`, considering this fact,  system-generated files like `.DS_Store` and other hidden files like `.command-name.rst` are ignored.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
