### PR TITLE
Add SHA256 fallback if MD5 isn't available on the system

### DIFF
--- a/tests/unit/customizations/test_s3uploader.py
+++ b/tests/unit/customizations/test_s3uploader.py
@@ -304,6 +304,27 @@ class TestS3Uploader(unittest.TestCase):
         finally:
             shutil.rmtree(tempdir)
 
+    @mock.patch("awscli.customizations.s3uploader.get_md5")
+    def test_file_checksum_fips_fallback(self, get_md5_mock):
+        num_chars = 4096*5
+        data = ''.join(random.choice(string.ascii_uppercase)
+                       for _ in range(num_chars)).encode('utf-8')
+        checksum = hashlib.sha256(usedforsecurity=False)
+        checksum.update(data)
+        expected_checksum = checksum.hexdigest()
+
+        tempdir = tempfile.mkdtemp()
+        get_md5_mock.side_effect = botocore.exceptions.MD5UnavailableError()
+        try:
+            filename = os.path.join(tempdir, 'tempfile')
+            with open(filename, 'wb') as f:
+                f.write(data)
+
+            actual_checksum = self.s3uploader.file_checksum(filename)
+            self.assertEqual(expected_checksum, actual_checksum)
+        finally:
+            shutil.rmtree(tempdir)
+
     def test_make_url(self):
         path = "Hello/how/are/you"
         expected = "s3://{0}/{1}".format(self.bucket_name, path)


### PR DESCRIPTION
*Description of changes:*
This PR will move our usage of md5 to enable the usedforsecurity flag set to false since these checksumming functions are only intended to create a deterministic path. If MD5 is still not available on the system, we'll attempt to use a FIPS compliant algorithm (SHA256 in this case) to derive an alternative path.

Path names should stay deterministic on similarly configured systems but customers uploading from both FIPS compliant and non-compliant environments to the same bucket may see some redundant uploads for the same template. Risk of this should be low given compliance requirements. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
