### PR TITLE
Add SHA256 fallback if MD5 isn't available on the system

### DIFF
--- a/.changes/next-release/enhancement-cloudformation-37336.json
+++ b/.changes/next-release/enhancement-cloudformation-37336.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``cloudformation``",
+  "description": "High-level Cloudformation commands such as ``deploy`` and ``package`` will now fallback to SHA256 for checksumming if MD5 isn't present on the host"
+}

--- a/awscli/customizations/s3uploader.py
+++ b/awscli/customizations/s3uploader.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import hashlib
 import logging
 import os
 import sys
@@ -19,12 +18,23 @@ import threading
 
 import botocore
 import botocore.exceptions
+from botocore.compat import get_md5
 from s3transfer.manager import TransferManager
 from s3transfer.subscribers import BaseSubscriber
 
 from awscli.compat import collections_abc
 
 LOG = logging.getLogger(__name__)
+
+
+def _get_checksum():
+    hashlib_params = {"usedforsecurity": False}
+    try:
+        checksum = get_md5(**hashlib_params)
+    except botocore.exceptions.MD5UnavailableError:
+        import hashlib
+        checksum = hashlib.sha256(**hashlib_params)
+    return checksum
 
 
 class NoSuchBucketError(Exception):
@@ -134,7 +144,7 @@ class S3Uploader:
 
     def upload_with_dedup(self, file_name, extension=None):
         """
-        Makes and returns name of the S3 object based on the file's MD5 sum
+        Makes and returns name of the S3 object based on the file's checksum
 
         :param file_name: file to upload
         :param extension: String of file extension to append to the object
@@ -146,8 +156,8 @@ class S3Uploader:
         # and re-upload only if necessary. So the template points to same file
         # in multiple places, this will upload only once
 
-        filemd5 = self.file_checksum(file_name)
-        remote_path = filemd5
+        file_checksum = self.file_checksum(file_name)
+        remote_path = file_checksum
         if extension:
             remote_path = remote_path + "." + extension
 
@@ -175,7 +185,7 @@ class S3Uploader:
 
     def file_checksum(self, file_name):
         with open(file_name, "rb") as file_handle:
-            md5 = hashlib.md5()
+            checksum = _get_checksum()
             # Read file in chunks of 4096 bytes
             block_size = 4096
 
@@ -185,13 +195,13 @@ class S3Uploader:
 
             buf = file_handle.read(block_size)
             while len(buf) > 0:
-                md5.update(buf)
+                checksum.update(buf)
                 buf = file_handle.read(block_size)
 
             # Restore file cursor's position
             file_handle.seek(curpos)
 
-            return md5.hexdigest()
+            return checksum.hexdigest()
 
     def to_path_style_s3_url(self, key, version=None):
         """

--- a/awscli/examples/cloudformation/_package_description.rst
+++ b/awscli/examples/cloudformation/_package_description.rst
@@ -49,8 +49,8 @@ current working directory. The exception is ``AWS::ApiGateway::RestApi``;
 if you don't specify a ``BodyS3Location``, this command will not upload an artifact to S3.
 
 Before the command uploads artifacts, it checks if the artifacts are already
-present in the S3 bucket to prevent unnecessary uploads. The command uses MD5
-checksums to compare files. If the values match, the command doesn't upload the
-artifacts. Use the ``--force-upload flag`` to skip this check and always upload the
-artifacts.
+present in the S3 bucket to prevent unnecessary uploads. If the values match, the
+command doesn't upload the artifacts. Use the ``--force-upload flag`` to skip this
+check and always upload the artifacts. The command uses MD5 checksums to compare
+files by default. If MD5 is not available in the environment, a SHA256 checksum is used.
 


### PR DESCRIPTION
*Description of changes:*
This PR will move our usage of md5 to enable the usedforsecurity flag set to false since these checksumming functions are only intended to create a deterministic path. If MD5 is still not available on the system, we'll attempt to use a FIPS compliant algorithm (SHA256 in this case) to derive an alternative path.

Path names should stay deterministic on similarly configured systems but customers uploading from both FIPS compliant and non-compliant environments to the same bucket may see some redundant uploads for the same template. Risk of this should be low given compliance requirements.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
