### PR TITLE
[v2] Exclude hidden files from example folder during test file collection 

### DIFF
--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -90,6 +90,9 @@ def _get_all_doc_examples():
     for root, _, filenames in os.walk(EXAMPLES_DIR):
         for filename in filenames:
             full_path = os.path.join(root, filename)
+            if filename.startswith('.'):
+                #Ignore hidden files as it starts with "."
+                continue
             if not filename.endswith('.rst'):
                 other_doc_examples.append(full_path)
                 continue


### PR DESCRIPTION
This is the port of CLI v1 of [https://github.com/aws/aws-cli/pull/9530](https://github.com/aws/aws-cli/pull/9530)

Description of changes:
Tests cases were failing for the users who use Mac Finder that creates hidden system files such as .DS_Store or ._command-name.rst in the directory. Thus, when the test suite is running, it fails because it encounters a unwanted files in the examples folder that has not a .rst or .txt extension.

Resolution
System-generated files like .DS_Store and other hidden files like .command-name.rst are starting with . followed by the file name, hence while gathering all the files having extension other than .rst file, the files starting with . were ignored, making the test suite free from hidden files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

