### PR TITLE
Fix handling of SSE-C keys when copying unencrypted to encrypted objects or objects with different keys

### DIFF
--- a/.changes/next-release/bugfix-s3-83199.json
+++ b/.changes/next-release/bugfix-s3-83199.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Fix handling of SSE-C keys when copying unencrypted to encrypted objects or objects with different encryption keys"
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1481,16 +1481,18 @@ class CommandArchitecture:
         # SSE-C key and algorithm. Note the reverse FileGenerator does
         # not need any of these because it is used only for sync operations
         # which only use ListObjects which does not require HeadObject.
-        RequestParamsMapper.map_head_object_params(
-            request_parameters['HeadObject'], self.parameters
-        )
         if paths_type == 's3s3':
+            head_params = self.parameters.copy()
+            head_params['sse_c'] = self.parameters.get('sse_c_copy_source')
+            head_params['sse_c_key'] = self.parameters.get(
+                'sse_c_copy_source_key'
+            )
             RequestParamsMapper.map_head_object_params(
-                request_parameters['HeadObject'],
-                {
-                    'sse_c': self.parameters.get('sse_c_copy_source'),
-                    'sse_c_key': self.parameters.get('sse_c_copy_source_key'),
-                },
+                request_parameters['HeadObject'], head_params
+            )
+        else:
+            RequestParamsMapper.map_head_object_params(
+                request_parameters['HeadObject'], self.parameters
             )
 
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -757,6 +757,102 @@ class TestCPCommand(BaseCPCommandTest):
         }
         self.assertDictEqual(self.operations_called[1][1], expected_args)
 
+    def test_s3s3_cp_with_destination_sse_c(self):
+        """S3->S3 copy with an unencrypted source and encrypted destination"""
+        self.parsed_responses = [
+            {
+                "AcceptRanges": "bytes",
+                "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
+                "ContentLength": 4,
+                "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
+                "Metadata": {},
+                "ContentType": "binary/octet-stream",
+            },
+            {
+                "AcceptRanges": "bytes",
+                "Metadata": {},
+                "ContentType": "binary/octet-stream",
+                "ContentLength": 4,
+                "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
+                "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
+                "Body": BytesIO(b'foo\n'),
+            },
+            {},
+        ]
+        cmdline = (
+            '%s s3://bucket-one/key.txt s3://bucket/key.txt '
+            '--sse-c --sse-c-key foo' % self.prefix
+        )
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        expected_head_args = {
+            'Bucket': 'bucket-one',
+            'Key': 'key.txt',
+            # don't expect to see SSE-c params for the source
+        }
+        self.assertDictEqual(self.operations_called[0][1], expected_head_args)
+
+        self.assertEqual(self.operations_called[1][0].name, 'CopyObject')
+        expected_copy_args = {
+            'Key': 'key.txt',
+            'Bucket': 'bucket',
+            'CopySource': {'Bucket': 'bucket-one', 'Key': 'key.txt'},
+            'SSECustomerAlgorithm': 'AES256',
+            'SSECustomerKey': 'foo',
+        }
+        self.assertDictEqual(self.operations_called[1][1], expected_copy_args)
+
+    def test_s3s3_cp_with_different_sse_c_keys(self):
+        """S3->S3 copy with different SSE-C keys for source and destination"""
+        self.parsed_responses = [
+            {
+                "AcceptRanges": "bytes",
+                "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
+                "ContentLength": 4,
+                "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
+                "Metadata": {},
+                "ContentType": "binary/octet-stream",
+            },
+            {
+                "AcceptRanges": "bytes",
+                "Metadata": {},
+                "ContentType": "binary/octet-stream",
+                "ContentLength": 4,
+                "ETag": '"d3b07384d113edec49eaa6238ad5ff00"',
+                "LastModified": "Tue, 12 Jul 2016 21:26:07 GMT",
+                "Body": BytesIO(b'foo\n'),
+            },
+            {},
+        ]
+        cmdline = (
+            '%s s3://bucket-one/key.txt s3://bucket/key.txt '
+            '--sse-c-copy-source --sse-c-copy-source-key foo --sse-c --sse-c-key bar'
+            % self.prefix
+        )
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        expected_head_args = {
+            'Bucket': 'bucket-one',
+            'Key': 'key.txt',
+            'SSECustomerAlgorithm': 'AES256',
+            'SSECustomerKey': 'foo',
+        }
+        self.assertDictEqual(self.operations_called[0][1], expected_head_args)
+
+        self.assertEqual(self.operations_called[1][0].name, 'CopyObject')
+        expected_copy_args = {
+            'Key': 'key.txt',
+            'Bucket': 'bucket',
+            'CopySource': {'Bucket': 'bucket-one', 'Key': 'key.txt'},
+            'SSECustomerAlgorithm': 'AES256',
+            'SSECustomerKey': 'bar',
+            'CopySourceSSECustomerAlgorithm': 'AES256',
+            'CopySourceSSECustomerKey': 'foo',
+        }
+        self.assertDictEqual(self.operations_called[1][1], expected_copy_args)
+
     # Note ideally the kms sse with a key id would be integration tests
     # However, you cannot delete kms keys so there would be no way to clean
     # up the tests


### PR DESCRIPTION
*Issue #, if available:* #6012, and supersedes #8345

*Description of changes:* When copying a file that originates in S3, the high level `aws s3` commands make a `HeadObject` call for the file that is being copied. 

When using [server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html), callers can specify the key for the source object(s) `--sse-c-copy-source`/`--sse-c-copy-source-key` and/or the destination object (`--sse-c`/`--sse-c-key`). 

The CLI is incorrectly handling this for S3 -> S3 copies, by applying destination key to the copy source object.
1. Copying an unencrypted object to an encrypted one: `aws s3 cp s3://$bucket/file.txt s3://$bucket/ssec-copy-c.txt --sse-c AES256 --sse-c-key $key_1`
2. Copying an object with different encryption keys: `aws s3 cp s3://$bucket/ssec.txt s3://$bucket/ssec-copy-diff-key.txt --sse-c-copy-source AES256 --sse-c-copy-source-key $key_1 --sse-c AES256 --sse-c-key $key_2`

*Arguably Incorrect Behavior, Leaving for Backwards Compatibility*

I think we're arguably handling S3 -> local copies as well. `aws s3 cp s3://$bucket/ssec.txt decrypt.txt --sse-c AES256 --sse-c-key $key_1` works, but I can see a case for applying `--sse-c-copy-source`/`--sse-c-copy-source-key` to the object that's originating to S3. But I'm preserving this behavior for backwards compatibility, the updated logic only runs for S3 -> S3 copies.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
