### PR TITLE
Comment out temporarily failing test

### DIFF
--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -144,7 +144,7 @@ def test_all_lock_files_are_generated_by_expected_python_version():
         "platforms we need to test are mac and Windows."
     ),
 )
-@pytest.mark.xfail(reason="pip-tools compatibility issue needs to be resolved:,"
+@pytest.mark.xfail(reason="pip-tools compatibility issue needs to be resolved:"
                           " https://github.com/jazzband/pip-tools/issues/2176")
 def test_lock_files_are_up_to_date(tmpdir):
     reqs_dir = tmpdir / "requirements"

--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -133,37 +133,37 @@ def test_all_lock_files_are_generated_by_expected_python_version():
             assert f"Python {CANNONICAL_PYTHON_VERSION}" in content
 
 
-@pytest.mark.skipif(
-    not IS_CANNONICAL_PYTHON_VERSION,
-    reason=SKIP_REASON,
-)
-@pytest.mark.skipif(
-    IS_LINUX,
-    reason=(
-        "The linux lock files are generated on mac. So the only "
-        "platforms we need to test are mac and Windows."
-    ),
-)
-def test_lock_files_are_up_to_date(tmpdir):
-    reqs_dir = tmpdir / "requirements"
-    reqs_dir.mkdir()
-    download_deps_dir = reqs_dir / "download-deps"
-    download_deps_dir.mkdir()
-    command = [
-        sys.executable,
-        REGENERATE_LOCK_FILE_SCRIPT_PATH,
-        "--output-directory",
-        tmpdir,
-    ]
-    result = run(command, cwd=ROOT)
-    assert result.returncode == 0
-
-    lockfile_mapping = {
-        path: path.replace(str(tmpdir), str(ROOT))
-        for path in lockfile_paths(tmpdir)
-    }
-
-    for regenerated_file, original_file in lockfile_mapping.items():
-        assert read_lock_file(regenerated_file) == read_lock_file(
-            original_file
-        )
+# @pytest.mark.skipif(
+#     not IS_CANNONICAL_PYTHON_VERSION,
+#     reason=SKIP_REASON,
+# )
+# @pytest.mark.skipif(
+#     IS_LINUX,
+#     reason=(
+#         "The linux lock files are generated on mac. So the only "
+#         "platforms we need to test are mac and Windows."
+#     ),
+# )
+# def test_lock_files_are_up_to_date(tmpdir):
+#     reqs_dir = tmpdir / "requirements"
+#     reqs_dir.mkdir()
+#     download_deps_dir = reqs_dir / "download-deps"
+#     download_deps_dir.mkdir()
+#     command = [
+#         sys.executable,
+#         REGENERATE_LOCK_FILE_SCRIPT_PATH,
+#         "--output-directory",
+#         tmpdir,
+#     ]
+#     result = run(command, cwd=ROOT)
+#     assert result.returncode == 0
+#
+#     lockfile_mapping = {
+#         path: path.replace(str(tmpdir), str(ROOT))
+#         for path in lockfile_paths(tmpdir)
+#     }
+#
+#     for regenerated_file, original_file in lockfile_mapping.items():
+#         assert read_lock_file(regenerated_file) == read_lock_file(
+#             original_file
+#         )

--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -132,38 +132,38 @@ def test_all_lock_files_are_generated_by_expected_python_version():
             content = f.read()
             assert f"Python {CANNONICAL_PYTHON_VERSION}" in content
 
-# TODO: This test should be re-enabled once pip-tools compatibility issue is resolved.
-# @pytest.mark.skipif(
-#     not IS_CANNONICAL_PYTHON_VERSION,
-#     reason=SKIP_REASON,
-# )
-# @pytest.mark.skipif(
-#     IS_LINUX,
-#     reason=(
-#         "The linux lock files are generated on mac. So the only "
-#         "platforms we need to test are mac and Windows."
-#     ),
-# )
-# def test_lock_files_are_up_to_date(tmpdir):
-#     reqs_dir = tmpdir / "requirements"
-#     reqs_dir.mkdir()
-#     download_deps_dir = reqs_dir / "download-deps"
-#     download_deps_dir.mkdir()
-#     command = [
-#         sys.executable,
-#         REGENERATE_LOCK_FILE_SCRIPT_PATH,
-#         "--output-directory",
-#         tmpdir,
-#     ]
-#     result = run(command, cwd=ROOT)
-#     assert result.returncode == 0
-#
-#     lockfile_mapping = {
-#         path: path.replace(str(tmpdir), str(ROOT))
-#         for path in lockfile_paths(tmpdir)
-#     }
-#
-#     for regenerated_file, original_file in lockfile_mapping.items():
-#         assert read_lock_file(regenerated_file) == read_lock_file(
-#             original_file
-#         )
+@pytest.mark.skipif(
+    not IS_CANNONICAL_PYTHON_VERSION,
+    reason=SKIP_REASON,
+)
+@pytest.mark.skipif(
+    IS_LINUX,
+    reason=(
+        "The linux lock files are generated on mac. So the only "
+        "platforms we need to test are mac and Windows."
+    ),
+)
+@pytest.mark.xfail(reason="pip-tools compatibility issue needs to be resolved")
+def test_lock_files_are_up_to_date(tmpdir):
+    reqs_dir = tmpdir / "requirements"
+    reqs_dir.mkdir()
+    download_deps_dir = reqs_dir / "download-deps"
+    download_deps_dir.mkdir()
+    command = [
+        sys.executable,
+        REGENERATE_LOCK_FILE_SCRIPT_PATH,
+        "--output-directory",
+        tmpdir,
+    ]
+    result = run(command, cwd=ROOT)
+    assert result.returncode == 0
+
+    lockfile_mapping = {
+        path: path.replace(str(tmpdir), str(ROOT))
+        for path in lockfile_paths(tmpdir)
+    }
+
+    for regenerated_file, original_file in lockfile_mapping.items():
+        assert read_lock_file(regenerated_file) == read_lock_file(
+            original_file
+        )

--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -132,6 +132,7 @@ def test_all_lock_files_are_generated_by_expected_python_version():
             content = f.read()
             assert f"Python {CANNONICAL_PYTHON_VERSION}" in content
 
+
 @pytest.mark.skipif(
     not IS_CANNONICAL_PYTHON_VERSION,
     reason=SKIP_REASON,

--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -144,7 +144,8 @@ def test_all_lock_files_are_generated_by_expected_python_version():
         "platforms we need to test are mac and Windows."
     ),
 )
-@pytest.mark.xfail(reason="pip-tools compatibility issue needs to be resolved")
+@pytest.mark.xfail(reason="pip-tools compatibility issue needs to be resolved:,"
+                          " https://github.com/jazzband/pip-tools/issues/2176")
 def test_lock_files_are_up_to_date(tmpdir):
     reqs_dir = tmpdir / "requirements"
     reqs_dir.mkdir()

--- a/tests/backends/build_system/functional/test_lock_files.py
+++ b/tests/backends/build_system/functional/test_lock_files.py
@@ -132,7 +132,7 @@ def test_all_lock_files_are_generated_by_expected_python_version():
             content = f.read()
             assert f"Python {CANNONICAL_PYTHON_VERSION}" in content
 
-
+# TODO: This test should be re-enabled once pip-tools compatibility issue is resolved.
 # @pytest.mark.skipif(
 #     not IS_CANNONICAL_PYTHON_VERSION,
 #     reason=SKIP_REASON,


### PR DESCRIPTION
*Description of changes:* Temporarily marking failing `test_lock_files_are_up_to_date` test as xfail until pip-tools compatibility issue is resolved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
