### PR TITLE
Retroactively add imagebuilder changelog entry to 1.40.38

### DIFF
--- a/.changes/1.40.38.json
+++ b/.changes/1.40.38.json
@@ -10,6 +10,11 @@
     "type": "api-change"
   },
   {
+    "category": "``imagebuilder``",
+    "description": "Added paginators for ``imagebuilder``.",
+    "type": "api-change"
+  },
+  {
     "category": "``logs``",
     "description": "Added CloudWatch Logs Transformer support for converting CloudTrail, VPC Flow, EKS Audit, AWS WAF and Route53 Resolver logs to OCSF v1.1 format.",
     "type": "api-change"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ CHANGELOG
 
 * api-change:``aiops``: This is the initial SDK release for Amazon AI Operations (AIOps). AIOps is a generative AI-powered assistant that helps you respond to incidents in your system by scanning your system's telemetry and quickly surface suggestions that might be related to your issue.
 * api-change:``autoscaling``: Add IncludeInstances parameter to DescribeAutoScalingGroups API
+* api-change:``imagebuilder``: Added paginators for ``imagebuilder``.
 * api-change:``logs``: Added CloudWatch Logs Transformer support for converting CloudTrail, VPC Flow, EKS Audit, AWS WAF and Route53 Resolver logs to OCSF v1.1 format.
 * api-change:``s3``: Added support for renaming objects within the same bucket using the new RenameObject API.
 * api-change:``sagemaker``: Add support for p6-b200 instance type for SageMaker Hyperpod


### PR DESCRIPTION
*Description of changes:*

* Added missing imagebuilder changelog entry for a change that was introduced in 1.40.38.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
