### PR TITLE
Have eks update-kubeconfig use --profile for get-token rather than the AWS_PROFILE env var

### DIFF
--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -356,9 +356,9 @@ class EKSClient(object):
             ])
 
         if self._session.profile:
-            generated_user["user"]["exec"]["env"] = [OrderedDict([
-                ("name", "AWS_PROFILE"),
-                ("value", self._session.profile)
-            ])]
+            generated_user["user"]["exec"]["args"].extend([
+                "--profile",
+                self._session.profile
+            ])
 
         return generated_user


### PR DESCRIPTION
We've run into the situation where we need the `aws eks update-kubeconfig --profile ....` CLI switch to translate into `aws eks get-token --profile` rather than setting the `AWS_PROFILE` environment variable. We have some situations where our users have both the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars set, as well as some profiles configured in `~/.aws/config`. The issue right now is when they use `aws eks update-kubeconfig --profile my-profile-in-config .....` it's generating a kubeconfig user entry where the eks token is generated using the `AWS_PROFILE=my-profile-in-config` environment variable. This causes the kubernetes context to not work in this situation, because when the token generation call is made, the cli will pick the keys in the environment over the `AWS_PROFILE` environment variable, and not use the profile that was used to get the cluster details from the command line. It seems safe enough to me to default to the method that is most likely to use the profile when it was determined a profile was used in the `update-kubeconfig` call.

### Reproducing our issue
- Have an environment with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars set while also having a functioning profile in `~/.aws/credentials` or `~/.aws/config` using a different user/role.
- `aws eks update-kubeconfig --profile {using-profile-set}`
- Without this change `kubectl auth whoami` will not use a token from the profile, but will stop as the order of precedence will use the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars over `AWS_PROFILE`.
