### PR TITLE
added support for AWS temp creds being set with AWS configure, added aws MFA-login

### DIFF
--- a/.changes/next-release/configure-tempcreds.json
+++ b/.changes/next-release/configure-tempcreds.json
@@ -1,12 +1,11 @@
-[]
 {
   "type": "enhancement",
-  "category": "``Configure``",
-  "description": "Added Support for AWS temp creds with AWS configure, e.g. CLI will ask for aws_session_token if the access key id is temporary"
+  "category": "``configure``",
+  "description": "Added support for temporary credentials with ``aws configure``. The CLI will prompt for an ``aws_session_token`` if the provided access key ID is temporary."
 },
 {
   "type": "enhancement",
-  "category": "``Configure``",
-  "description": "Added new sub-command to aws confugre, `mfa-login`, which is an interactive wrapper for the aws sts get-session-token command"
+  "category": "``configure``",
+  "description": "Added the new ``aws configure mfa-login` command, which creates a profile with temporary credentials corresponding to an IAM user with an MFA code."
 },
 ]

--- a/.changes/next-release/configure-tempcreds.json
+++ b/.changes/next-release/configure-tempcreds.json
@@ -1,6 +1,12 @@
-
+[]
 {
   "type": "enhancement",
   "category": "``Configure``",
   "description": "Added Support for AWS temp creds with AWS configure, e.g. CLI will ask for aws_session_token if the access key id is temporary"
-}
+},
+{
+  "type": "enhancement",
+  "category": "``Configure``",
+  "description": "Added new sub-command to aws confugre, `mfa-login`, which is an interactive wrapper for the aws sts get-session-token command"
+},
+]

--- a/.changes/next-release/configure-tempcreds.json
+++ b/.changes/next-release/configure-tempcreds.json
@@ -1,0 +1,6 @@
+
+{
+  "type": "enhancement",
+  "category": "``Configure``",
+  "description": "Added Support for AWS temp creds with AWS configure, e.g. CLI will ask for aws_session_token if the access key id is temporary"
+}

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 import logging
 import os
+import sys
 
 from botocore.exceptions import ProfileNotFound
 
@@ -25,6 +26,7 @@ from awscli.customizations.configure.get import ConfigureGetCommand
 from awscli.customizations.configure.importer import ConfigureImportCommand
 from awscli.customizations.configure.list import ConfigureListCommand
 from awscli.customizations.configure.listprofiles import ListProfilesCommand
+from awscli.customizations.configure.mfalogin import ConfigureMFALoginCommand
 from awscli.customizations.configure.set import ConfigureSetCommand
 from awscli.customizations.configure.sso import (
     ConfigureSSOCommand,
@@ -88,6 +90,7 @@ class ConfigureCommand(BasicCommand):
         {'name': 'list-profiles', 'command_class': ListProfilesCommand},
         {'name': 'sso', 'command_class': ConfigureSSOCommand},
         {'name': 'sso-session', 'command_class': ConfigureSSOSessionCommand},
+        {'name': 'mfa-login', 'command_class': ConfigureMFALoginCommand},
         {
             'name': 'export-credentials',
             'command_class': ConfigureExportCredentialsCommand,
@@ -114,6 +117,16 @@ class ConfigureCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         # Called when invoked with no args "aws configure"
+        # Check if there are any remaining unparsed arguments that might be invalid subcommands
+        if hasattr(parsed_args, 'remaining') and parsed_args.remaining:
+            sys.stderr.write(
+                f"Invalid subcommand: {' '.join(parsed_args.remaining)}\n"
+            )
+            sys.stderr.write(
+                "Valid subcommands are: list, get, set, add-model, import, list-profiles, sso, sso-session, mfa-login, export-credentials\n"
+            )
+            return 1
+
         new_values = {}
         # This is the config from the config file scoped to a specific
         # profile.

--- a/awscli/customizations/configure/mfalogin.py
+++ b/awscli/customizations/configure/mfalogin.py
@@ -113,7 +113,7 @@ class ConfigureMFALoginCommand(BasicCommand):
 
     def _generate_profile_name_from_mfa(self, mfa_serial):
         """Generate a deterministic profile name from MFA serial/ARN."""
-        if mfa_serial.startswith('arn:aws:iam::'):
+        if isinstance(mfa_serial, str) and mfa_serial.startswith('arn:aws:iam::'):
             # Parse ARN: arn:aws:iam::123456789012:mfa/device-name
             parts = mfa_serial.split(':')
             account_id = parts[4]
@@ -158,8 +158,6 @@ class ConfigureMFALoginCommand(BasicCommand):
         except ClientError as e:
             sys.stderr.write(f"An error occurred: {e}\n")
             return None
-
-
 
     def _resolve_mfa_serial(self, parsed_args, source_config):
         """Resolve MFA serial from args, config, or prompt."""

--- a/awscli/customizations/configure/mfalogin.py
+++ b/awscli/customizations/configure/mfalogin.py
@@ -165,7 +165,7 @@ class ConfigureMFALoginCommand(BasicCommand):
 
     def _write_temporary_credentials(self, temp_credentials, target_profile):
         """Write temporary credentials to the credentials file."""
-        credentials_file = os.path.expanduser('~/.aws/credentials')
+        credentials_file = os.path.expanduser(self._session.get_config_variable('credentials_file'))
 
         credential_values = {
             '__section__': target_profile,

--- a/awscli/customizations/configure/mfalogin.py
+++ b/awscli/customizations/configure/mfalogin.py
@@ -51,35 +51,15 @@ class ConfigureMFALoginCommand(BasicCommand):
     """Configures MFA login for AWS CLI by creating temporary credentials."""
 
     NAME = 'mfa-login'
-    DESCRIPTION = (
-        'Sets up temporary credentials for MFA authentication. '
-        'This command creates a new profile with temporary credentials '
-        'obtained using the AWS STS get-session-token API.'
+    DESCRIPTION = BasicCommand.FROM_FILE(
+        'configure', 'mfa-login', '_description.rst'
     )
     SYNOPSIS = (
         'aws configure mfa-login [--profile profile-name] '
         '[--update-profile profile-to-update] [--duration-seconds seconds] '
         '[--serial-number mfa-serial-number]'
     )
-    EXAMPLES = (
-        'To create a new profile with temporary credentials::\n'
-        '\n'
-        '    $ aws configure mfa-login\n'
-        '    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user\n'
-        '    MFA token code: 123456\n'
-        '    Profile to update [session-12345]:\n'
-        '\n'
-        'To update an existing profile with temporary credentials::\n'
-        '\n'
-        '    $ aws configure mfa-login --profile myprofile --update-profile mytemp\n'
-        '    MFA token code: 123456\n'
-        '\n'
-        'To specify the MFA device serial number or ARN directly::\n'
-        '\n'
-        '    $ aws configure mfa-login --serial-number arn:aws:iam::123456789012:mfa/user\n'
-        '    MFA token code: 123456\n'
-        '    Profile to update [session-12345]:\n'
-    )
+    EXAMPLES = BasicCommand.FROM_FILE('configure', 'mfa-login', '_examples.rst')
     ARG_TABLE = [
         {
             'name': 'profile',
@@ -102,11 +82,12 @@ class ConfigureMFALoginCommand(BasicCommand):
             'name': 'duration-seconds',
             'help_text': (
                 'The duration, in seconds, that the credentials should remain valid. '
-                'Default is 43200 seconds (12 hours).'
+                'Minimum is 900 seconds (15 minutes), maximum is 129600 seconds (36 hours).'
             ),
             'action': 'store',
             'required': False,
             'cli_type_name': 'integer',
+            'default': 43200,
         },
         {
             'name': 'serial-number',
@@ -220,9 +201,7 @@ class ConfigureMFALoginCommand(BasicCommand):
         source_profile = parsed_globals.profile or 'default'
 
         # Get duration seconds
-        duration_seconds = (
-            parsed_args.duration_seconds or 43200
-        )  # Default 12 hours
+        duration_seconds = parsed_args.duration_seconds
 
         # Create a new session with the specified profile
         try:

--- a/awscli/customizations/configure/mfalogin.py
+++ b/awscli/customizations/configure/mfalogin.py
@@ -259,7 +259,7 @@ class ConfigureMFALoginCommand(BasicCommand):
                 'None', 'mfa_serial', 'MFA serial number or ARN'
             )
             if not mfa_serial:
-                sys.stderr.write("MFA serial number or ARN is required\n")
+                sys.stderr.write("MFA serial number or MFA device ARN is required\n")
                 return 1
 
         # Get MFA token code

--- a/awscli/customizations/configure/mfalogin.py
+++ b/awscli/customizations/configure/mfalogin.py
@@ -154,10 +154,9 @@ class ConfigureMFALoginCommand(BasicCommand):
                 target_profile = self._generate_profile_name_from_mfa(mfa_serial)
             else:
                 target_profile = "session-temp"
-            if sys.stdin.isatty():
-                target_profile = self._prompter.get_value(
-                    target_profile, 'Profile to update'
-                )
+            target_profile = self._prompter.get_value(
+                target_profile, 'Profile to update'
+            )
         return target_profile
 
     def _run_main(self, parsed_args, parsed_globals):
@@ -187,8 +186,8 @@ class ConfigureMFALoginCommand(BasicCommand):
             # Get credentials
             credentials = session.get_credentials()
             if credentials is None:
-                # If no credentials found and using default profile and running interactively, prompt for them
-                if source_profile == 'default' and sys.stdin.isatty():
+                # If no credentials found and using default profile, prompt for them
+                if source_profile == 'default':
                     return self._handle_missing_default_profile(
                         parsed_args, duration_seconds
                     )
@@ -200,8 +199,8 @@ class ConfigureMFALoginCommand(BasicCommand):
 
             source_config = session.get_scoped_config()
         except ProfileNotFound:
-            # If default profile not found and running interactively, prompt for credentials
-            if source_profile == 'default' and sys.stdin.isatty():
+            # If default profile not found, prompt for credentials
+            if source_profile == 'default':
                 return self._handle_missing_default_profile(
                     parsed_args, duration_seconds
                 )
@@ -221,26 +220,18 @@ class ConfigureMFALoginCommand(BasicCommand):
             'mfa_serial'
         )
         if not mfa_serial:
-            if sys.stdin.isatty():
-                mfa_serial = self._prompter.get_credential_value(
-                    'None', 'mfa_serial', 'MFA serial number or ARN'
-                )
-                if not mfa_serial:
-                    sys.stderr.write("MFA serial number or ARN is required\n")
-                    return 1
-            else:
+            mfa_serial = self._prompter.get_credential_value(
+                'None', 'mfa_serial', 'MFA serial number or ARN'
+            )
+            if not mfa_serial:
                 sys.stderr.write("MFA serial number or ARN is required\n")
                 return 1
 
         # Get MFA token code
-        if sys.stdin.isatty():
-            token_code = self._prompter.get_credential_value(
-                'None', 'mfa_token', 'MFA token code'
-            )
-            if not token_code:
-                sys.stderr.write("MFA token code is required\n")
-                return 1
-        else:
+        token_code = self._prompter.get_credential_value(
+            'None', 'mfa_token', 'MFA token code'
+        )
+        if not token_code:
             sys.stderr.write("MFA token code is required\n")
             return 1
 

--- a/awscli/examples/configure/mfa-login.rst
+++ b/awscli/examples/configure/mfa-login.rst
@@ -1,0 +1,49 @@
+**To create a new profile with temporary MFA credentials**
+
+The following ``mfa-login`` command creates a new profile with temporary credentials obtained using MFA authentication. ::
+
+    aws configure mfa-login
+
+Output::
+
+    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user
+    MFA token code: 123456
+    Profile to update [session-12345]:
+    Temporary credentials written to profile 'session-12345'
+    Credentials will expire at 2023-05-19 18:06:10 UTC
+    To use these credentials, specify --profile session-12345 when running AWS CLI commands
+
+**To create credentials when no default profile exists**
+
+If you don't have a default profile configured, the ``mfa-login`` command will prompt you for your AWS credentials first. ::
+
+    aws configure mfa-login
+
+Output::
+
+    No default profile found. Please provide your AWS credentials:
+    AWS Access Key ID: AKIAIOSFODNN7EXAMPLE
+    AWS Secret Access Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user
+    MFA token code: 123456
+    Profile to update [session-12345]:
+    Temporary credentials written to profile 'session-12345'
+    Credentials will expire at 2023-05-19 18:06:10 UTC
+    To use these credentials, specify --profile session-12345 when running AWS CLI commands
+
+**To update an existing profile with temporary MFA credentials**
+
+The following ``mfa-login`` command updates an existing profile with temporary credentials obtained using MFA authentication. ::
+
+    aws configure mfa-login --profile myprofile --update-profile mytemp
+
+Output::
+
+    MFA token code: 123456
+    Temporary credentials written to profile 'mytemp'
+    Credentials will expire at 2023-05-19 18:06:10 UTC
+    To use these credentials, specify --profile mytemp when running AWS CLI commands
+
+**Note:** This command currently supports only hardware or software based one-time password (OTP) authenticators. Passkeys and U2F devices are not currently supported.
+
+For more information, see `Using Multi-Factor Authentication (MFA) in AWS <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html>`__ in the *AWS IAM User Guide*.

--- a/awscli/examples/configure/mfa-login.rst
+++ b/awscli/examples/configure/mfa-login.rst
@@ -6,12 +6,12 @@ The following ``mfa-login`` command creates a new profile with temporary credent
 
 Output::
 
-    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user
+    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/MFADeviceName
     MFA token code: 123456
-    Profile to update [session-12345]:
-    Temporary credentials written to profile 'session-12345'
+    Profile to update [session-MFADeviceName]:
+    Temporary credentials written to profile 'session-MFADeviceName'
     Credentials will expire at 2023-05-19 18:06:10 UTC
-    To use these credentials, specify --profile session-12345 when running AWS CLI commands
+    To use these credentials, specify --profile session-MFADeviceName when running AWS CLI commands
 
 **To create credentials when no default profile exists**
 
@@ -24,26 +24,26 @@ Output::
     No default profile found. Please provide your AWS credentials:
     AWS Access Key ID: AKIAIOSFODNN7EXAMPLE
     AWS Secret Access Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user
+    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/MFADeviceName
     MFA token code: 123456
-    Profile to update [session-12345]:
-    Temporary credentials written to profile 'session-12345'
+    Profile to update [session-MFADeviceName]:
+    Temporary credentials written to profile 'session-MFADeviceName'
     Credentials will expire at 2023-05-19 18:06:10 UTC
-    To use these credentials, specify --profile session-12345 when running AWS CLI commands
+    To use these credentials, specify --profile session-MFADeviceName when running AWS CLI commands
 
 **To update an existing profile with temporary MFA credentials**
 
 The following ``mfa-login`` command updates an existing profile with temporary credentials obtained using MFA authentication. ::
 
-    aws configure mfa-login --profile myprofile --update-profile mytemp
+    aws configure mfa-login --profile myprofile --update-profile mfaprofile
 
 Output::
 
     MFA token code: 123456
-    Temporary credentials written to profile 'mytemp'
+    Temporary credentials written to profile 'mfaprofile'
     Credentials will expire at 2023-05-19 18:06:10 UTC
-    To use these credentials, specify --profile mytemp when running AWS CLI commands
+    To use these credentials, specify --profile mfaprofile when running AWS CLI commands
 
-**Note:** This command currently supports only hardware or software based one-time password (OTP) authenticators. Passkeys and U2F devices are not currently supported.
+**Note:** This command currently supports only hardware or software based one-time password (OTP) authenticators. Passkeys and U2F devices are not currently supported with this command.
 
 For more information, see `Using Multi-Factor Authentication (MFA) in AWS <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html>`__ in the *AWS IAM User Guide*.

--- a/awscli/examples/configure/mfa-login/_description.rst
+++ b/awscli/examples/configure/mfa-login/_description.rst
@@ -1,0 +1,3 @@
+This command gets temporary AWS security credentials for use with the AWS CLI and SDK, and places them in an AWS profile. It will use a long-lived IAM user access key, and the MFA code from either a virtual TOTP MFA device, or a hardware OTP authenticator to call STS get-session-token to get the temporary credentials. If no default profile exists, the command will prompt you to provide your AWS credentials first.
+
+Note: This command currently supports only hardware or software based one-time password (OTP) authenticators. Passkeys and U2F devices are not currently supported.

--- a/awscli/examples/configure/mfa-login/_examples.rst
+++ b/awscli/examples/configure/mfa-login/_examples.rst
@@ -1,0 +1,47 @@
+**To create a new profile with temporary MFA credentials**
+
+The following ``mfa-login`` command creates a new profile with temporary credentials obtained using MFA authentication. ::
+
+    aws configure mfa-login
+
+Output::
+
+    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user
+    MFA token code: 123456
+    Profile to update [session-12345]:
+    Temporary credentials written to profile 'session-12345'
+    Credentials will expire at 2023-05-19 18:06:10 UTC
+    To use these credentials, specify --profile session-12345 when running AWS CLI commands
+
+**To update an existing profile with temporary MFA credentials**
+
+The following ``mfa-login`` command updates an existing profile with temporary credentials obtained using MFA authentication. ::
+
+    aws configure mfa-login --profile myprofile --update-profile mytemp
+
+Output::
+
+    MFA token code: 123456
+    Temporary credentials written to profile 'mytemp'
+    Credentials will expire at 2023-05-19 18:06:10 UTC
+    To use these credentials, specify --profile mytemp when running AWS CLI commands
+
+**To create credentials when no default profile exists**
+
+If you don't have a default profile configured, the ``mfa-login`` command will prompt you for your AWS credentials first. ::
+
+    aws configure mfa-login
+
+Output::
+
+    No default profile found. Please provide your AWS credentials:
+    AWS Access Key ID: AKIAIOSFODNN7EXAMPLE
+    AWS Secret Access Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    MFA serial number or ARN: arn:aws:iam::123456789012:mfa/user
+    MFA token code: 123456
+    Profile to update [session-12345]:
+    Temporary credentials written to profile 'session-12345'
+    Credentials will expire at 2023-05-19 18:06:10 UTC
+    To use these credentials, specify --profile session-12345 when running AWS CLI commands
+
+**Note:** This command currently supports only hardware or software based one-time password (OTP) authenticators. Passkeys and U2F devices are not currently supported.

--- a/tests/unit/customizations/configure/test_mfalogin.py
+++ b/tests/unit/customizations/configure/test_mfalogin.py
@@ -376,7 +376,7 @@ class TestConfigureMFALoginCommand(unittest.TestCase):
                 'os.path.expanduser', return_value='/tmp/credentials'
             ):
                 with mock.patch('sys.stdout'):
-                    rc = self.command._handle_missing_default_profile(
+                    rc = self.command._handle_interactive_prompting(
                         self.parsed_args, 43200
                     )
 
@@ -400,7 +400,7 @@ class TestConfigureMFALoginCommand(unittest.TestCase):
         )
 
         with mock.patch('sys.stderr') as mock_stderr:
-            rc = self.command._handle_missing_default_profile(
+            rc = self.command._handle_interactive_prompting(
                 self.parsed_args, 43200
             )
 
@@ -417,7 +417,7 @@ class TestConfigureMFALoginCommand(unittest.TestCase):
         ]
 
         with mock.patch('sys.stderr') as mock_stderr:
-            rc = self.command._handle_missing_default_profile(
+            rc = self.command._handle_interactive_prompting(
                 self.parsed_args, 43200
             )
 
@@ -469,7 +469,7 @@ class TestConfigureMFALoginCommand(unittest.TestCase):
 
         with mock.patch('botocore.session.Session', return_value=mock_session):
             with mock.patch('sys.stderr') as mock_stderr:
-                rc = self.command._handle_missing_default_profile(
+                rc = self.command._handle_interactive_prompting(
                     self.parsed_args, 43200
                 )
 
@@ -529,7 +529,7 @@ class TestConfigureMFALoginCommand(unittest.TestCase):
         self.prompter.get_credential_value.return_value = ''  # Empty string
 
         with mock.patch('sys.stderr') as mock_stderr:
-            rc = self.command._handle_missing_default_profile(
+            rc = self.command._handle_interactive_prompting(
                 self.parsed_args, 43200
             )
 

--- a/tests/unit/customizations/configure/test_mfalogin.py
+++ b/tests/unit/customizations/configure/test_mfalogin.py
@@ -1,0 +1,539 @@
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import datetime
+import os
+from unittest import mock
+
+import botocore.session
+from botocore.exceptions import ClientError, ProfileNotFound
+
+from awscli.customizations.configure.mfalogin import (
+    ConfigureMFALoginCommand,
+    InteractiveMFAPrompter,
+)
+from awscli.testutils import unittest
+
+
+class TestInteractiveMFAPrompter(unittest.TestCase):
+    def test_get_value_with_response(self):
+        prompter = InteractiveMFAPrompter()
+        # Mock the entire compat_input function, not just the return value
+        with mock.patch(
+            'awscli.customizations.configure.mfalogin.compat_input'
+        ) as mock_input:
+            mock_input.return_value = 'response'
+            self.assertEqual(
+                prompter.get_value('current', 'prompt'), 'response'
+            )
+
+    def test_get_value_with_no_response(self):
+        prompter = InteractiveMFAPrompter()
+        # Mock the entire compat_input function, not just the return value
+        with mock.patch(
+            'awscli.customizations.configure.mfalogin.compat_input'
+        ) as mock_input:
+            mock_input.return_value = ''
+            self.assertEqual(
+                prompter.get_value('current', 'prompt'), 'current'
+            )
+
+
+class TestConfigureMFALoginCommand(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock()
+        self.session.get_scoped_config.return_value = {}
+        self.session.get_credentials.return_value = mock.Mock()
+        # Add available_profiles to the session mock
+        self.session.available_profiles = ['default', 'test']
+        self.prompter = mock.Mock()
+        self.config_writer = mock.Mock()
+        self.command = ConfigureMFALoginCommand(
+            self.session,
+            prompter=self.prompter,
+            config_writer=self.config_writer,
+        )
+        self.parsed_args = mock.Mock()
+        self.parsed_args.profile = None
+        self.parsed_args.update_profile = None
+        self.parsed_args.duration_seconds = None
+        self.parsed_args.serial_number = None
+        self.parsed_globals = mock.Mock()
+        # Set profile in parsed_globals
+        self.parsed_globals.profile = 'default'
+
+    def test_no_credentials_found(self):
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = None
+        mock_session.available_profiles = ['default']
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch(
+                'sys.stdin.isatty', return_value=False
+            ):  # Non-interactive
+                with mock.patch('sys.stderr') as mock_stderr:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+                    self.assertEqual(rc, 1)
+                    mock_stderr.write.assert_called_with(
+                        "Unable to locate credentials for profile default\n"
+                    )
+
+    def test_profile_not_found(self):
+        # Set profile to a non-existent profile
+        self.parsed_globals.profile = 'nonexistent'
+
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.available_profiles = ['default', 'test']
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch('sys.stderr') as mock_stderr:
+                rc = self.command._run_main(
+                    self.parsed_args, self.parsed_globals
+                )
+                self.assertEqual(rc, 1)
+                mock_stderr.write.assert_called_with(
+                    "The profile (nonexistent) could not be found. \n"
+                )
+
+    def test_no_mfa_serial_provided(self):
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {}
+        mock_session.available_profiles = ['default']
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch('sys.stdin.isatty', return_value=True):
+                self.prompter.get_value.return_value = 'None'
+                with mock.patch('sys.stderr') as mock_stderr:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+                    self.assertEqual(rc, 1)
+                    mock_stderr.write.assert_called_with(
+                        "MFA serial number or ARN is required\n"
+                    )
+
+    def test_no_token_code_provided(self):
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {}
+        mock_session.available_profiles = ['default']
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch('sys.stdin.isatty', return_value=True):
+                self.prompter.get_value.side_effect = [
+                    'arn:aws:iam::123456789012:mfa/user',
+                    'None',
+                ]
+                with mock.patch('sys.stderr') as mock_stderr:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+                    self.assertEqual(rc, 1)
+                    mock_stderr.write.assert_called_with(
+                        "MFA token code is required\n"
+                    )
+
+    def test_sts_client_error(self):
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {}
+        mock_session.available_profiles = ['default']
+
+        sts_client = mock.Mock()
+        sts_client.get_session_token.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'InvalidClientTokenId',
+                    'Message': 'Test error',
+                }
+            },
+            'GetSessionToken',
+        )
+        mock_session.create_client.return_value = sts_client
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            self.prompter.get_value.side_effect = [
+                'arn:aws:iam::123456789012:mfa/user',
+                '123456',
+                'session-test',
+            ]
+
+            with mock.patch('sys.stderr') as mock_stderr:
+                rc = self.command._run_main(
+                    self.parsed_args, self.parsed_globals
+                )
+                self.assertEqual(rc, 1)
+                mock_stderr.write.assert_called_with(
+                    mock.ANY
+                )  # Just check it was called
+
+    def test_successful_mfa_login(self):
+        # Setup
+        self.prompter.get_value.side_effect = [
+            'arn:aws:iam::123456789012:mfa/user',
+            '123456',
+            'session-test',
+        ]
+
+        expiration = datetime.datetime(2023, 5, 19, 18, 6, 10)
+        sts_response = {
+            'Credentials': {
+                'AccessKeyId': 'ASIAIOSFODNN7EXAMPLE',
+                'SecretAccessKey': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
+                'SessionToken': 'AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE',
+                'Expiration': expiration,
+            }
+        }
+
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {}
+        mock_session.available_profiles = ['default']
+
+        sts_client = mock.Mock()
+        sts_client.get_session_token.return_value = sts_response
+        mock_session.create_client.return_value = sts_client
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch('sys.stdin.isatty', return_value=True):
+                with mock.patch(
+                    'os.path.expanduser', return_value='/tmp/credentials'
+                ):
+                    with mock.patch('sys.stdout'):
+                        rc = self.command._run_main(
+                            self.parsed_args, self.parsed_globals
+                        )
+
+        # Verify
+        self.assertEqual(rc, 0)
+
+        # Check STS was called correctly
+        sts_client.get_session_token.assert_called_with(
+            DurationSeconds=43200,
+            SerialNumber='arn:aws:iam::123456789012:mfa/user',
+            TokenCode='123456',
+        )
+
+        # Check config writer was called correctly
+        expected_values = {
+            '__section__': 'session-test',
+            'aws_access_key_id': 'ASIAIOSFODNN7EXAMPLE',
+            'aws_secret_access_key': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
+            'aws_session_token': 'AQoEXAMPLEH4aoAH0gNCAPyJxz4BlCFFxWNE1OPTgk5TthT+FvwqnKwRcOIfrRh3c/LTo6UDdyJwOOvEVPvLXCrrrUtdnniCEXAMPLE/IvU1dYUg2RVAJBanLiHb4IgRmpRV3zrkuWJOgQs8IZZaIv2BXIa2R4OlgkBN9bkUDNCJiBeb/AXlzBBko7b15fjrBs2+cTQtpZ3CYWFXG8C5zqx37wnOE49mRl/+OtkIKGO7fAE',
+            '#expiration': f"# Credentials expire at: {expiration.strftime('%Y-%m-%d %H:%M:%S UTC')}",
+        }
+
+        self.config_writer.update_config.assert_called_with(
+            expected_values, '/tmp/credentials'
+        )
+
+    def test_serial_number_from_parameter(self):
+        # Setup - use serial number from parameter
+        self.parsed_args.serial_number = (
+            'arn:aws:iam::123456789012:mfa/user-param'
+        )
+
+        # Mock botocore.session.Session
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {
+            'mfa_serial': 'arn:aws:iam::123456789012:mfa/user-config'
+        }
+        mock_session.available_profiles = ['default']
+
+        sts_client = mock.Mock()
+        expiration = datetime.datetime(2023, 5, 19, 18, 6, 10)
+        sts_response = {
+            'Credentials': {
+                'AccessKeyId': 'ASIAIOSFODNN7EXAMPLE',
+                'SecretAccessKey': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
+                'SessionToken': 'SESSION_TOKEN',
+                'Expiration': expiration,
+            }
+        }
+        sts_client.get_session_token.return_value = sts_response
+        mock_session.create_client.return_value = sts_client
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch('sys.stdin.isatty', return_value=True):
+                self.prompter.get_value.side_effect = [
+                    '123456',
+                    'session-test',
+                ]
+                with mock.patch(
+                    'os.path.expanduser', return_value='/tmp/credentials'
+                ):
+                    with mock.patch('sys.stdout'):
+                        rc = self.command._run_main(
+                            self.parsed_args, self.parsed_globals
+                        )
+
+        # Verify
+        self.assertEqual(rc, 0)
+
+        # Check that the parameter value was used instead of the config value
+        sts_client.get_session_token.assert_called_with(
+            DurationSeconds=43200,
+            SerialNumber='arn:aws:iam::123456789012:mfa/user-param',
+            TokenCode='123456',
+        )
+
+    def test_missing_default_profile_interactive(self):
+        """Test prompting for credentials when no default profile exists in interactive mode."""
+        self.parsed_globals.profile = None  # Use default profile
+
+        # Mock botocore.session.Session to raise ProfileNotFound
+        with mock.patch('botocore.session.Session') as mock_session_class:
+            mock_session_class.side_effect = ProfileNotFound(profile='default')
+
+            # Mock sys.stdin.isatty to return True (interactive)
+            with mock.patch('sys.stdin.isatty', return_value=True):
+                # Mock the _handle_missing_default_profile method
+                with mock.patch.object(
+                    self.command,
+                    '_handle_missing_default_profile',
+                    return_value=0,
+                ) as mock_handle:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+
+                    self.assertEqual(rc, 0)
+                    mock_handle.assert_called_once_with(
+                        self.parsed_args, 43200
+                    )
+
+    def test_missing_default_profile_non_interactive(self):
+        """Test error when no default profile exists in non-interactive mode."""
+        self.parsed_globals.profile = None  # Use default profile
+
+        # Mock botocore.session.Session to raise ProfileNotFound
+        with mock.patch('botocore.session.Session') as mock_session_class:
+            mock_session_class.side_effect = ProfileNotFound(profile='default')
+
+            # Mock sys.stdin.isatty to return False (non-interactive)
+            with mock.patch('sys.stdin.isatty', return_value=False):
+                with mock.patch('sys.stderr') as mock_stderr:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+
+                    self.assertEqual(rc, 1)
+                    mock_stderr.write.assert_called_with(
+                        "The profile (default) could not be found. \n"
+                    )
+
+    def test_handle_missing_default_profile_success(self):
+        """Test successful credential prompting and MFA login when no default profile exists."""
+        # Setup mock responses for prompting
+        self.prompter.get_credential_value.side_effect = [
+            'AKIAIOSFODNN7EXAMPLE',  # access key
+            'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',  # secret key
+        ]
+        self.prompter.get_value.side_effect = [
+            'arn:aws:iam::123456789012:mfa/user',  # MFA serial
+            '123456',  # MFA token
+            'session-test',  # profile name
+        ]
+
+        # Mock STS response
+        expiration = datetime.datetime(2023, 5, 19, 18, 6, 10)
+        sts_response = {
+            'Credentials': {
+                'AccessKeyId': 'ASIAIOSFODNN7EXAMPLE',
+                'SecretAccessKey': 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
+                'SessionToken': 'SESSION_TOKEN',
+                'Expiration': expiration,
+            }
+        }
+
+        # Mock botocore session and STS client
+        mock_session = mock.Mock()
+        sts_client = mock.Mock()
+        sts_client.get_session_token.return_value = sts_response
+        mock_session.create_client.return_value = sts_client
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch(
+                'os.path.expanduser', return_value='/tmp/credentials'
+            ):
+                with mock.patch('sys.stdout'):
+                    rc = self.command._handle_missing_default_profile(
+                        self.parsed_args, 43200
+                    )
+
+        # Verify success
+        self.assertEqual(rc, 0)
+
+        # Verify STS call
+        sts_client.get_session_token.assert_called_with(
+            DurationSeconds=43200,
+            SerialNumber='arn:aws:iam::123456789012:mfa/user',
+            TokenCode='123456',
+        )
+
+        # Verify only the session profile was written
+        self.assertEqual(self.config_writer.update_config.call_count, 1)
+
+    def test_handle_missing_default_profile_missing_access_key(self):
+        """Test error when access key is not provided."""
+        self.prompter.get_credential_value.return_value = (
+            None  # No access key provided
+        )
+
+        with mock.patch('sys.stderr') as mock_stderr:
+            rc = self.command._handle_missing_default_profile(
+                self.parsed_args, 43200
+            )
+
+            self.assertEqual(rc, 1)
+            mock_stderr.write.assert_called_with(
+                "AWS Access Key ID is required\n"
+            )
+
+    def test_handle_missing_default_profile_missing_secret_key(self):
+        """Test error when secret key is not provided."""
+        self.prompter.get_credential_value.side_effect = [
+            'AKIAIOSFODNN7EXAMPLE',  # access key provided
+            None,  # secret key not provided
+        ]
+
+        with mock.patch('sys.stderr') as mock_stderr:
+            rc = self.command._handle_missing_default_profile(
+                self.parsed_args, 43200
+            )
+
+            self.assertEqual(rc, 1)
+            mock_stderr.write.assert_called_with(
+                "AWS Secret Access Key is required\n"
+            )
+
+    def test_credential_value_prompting_clean_display(self):
+        """Test that credential prompting doesn't show default values."""
+        prompter = InteractiveMFAPrompter()
+        with mock.patch(
+            'awscli.customizations.configure.mfalogin.compat_input'
+        ) as mock_input:
+            mock_input.return_value = 'test-value'
+            result = prompter.get_credential_value(
+                'None', 'aws_access_key_id', 'AWS Access Key ID'
+            )
+
+            # Verify the prompt doesn't show [None] or any default value
+            mock_input.assert_called_with('AWS Access Key ID: ')
+            self.assertEqual(result, 'test-value')
+
+    def test_handle_missing_default_profile_sts_error(self):
+        """Test STS error handling in missing default profile scenario."""
+        self.prompter.get_credential_value.side_effect = [
+            'AKIAIOSFODNN7EXAMPLE',  # access key
+            'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',  # secret key
+        ]
+        self.prompter.get_value.side_effect = [
+            'arn:aws:iam::123456789012:mfa/user',  # MFA serial
+            '123456',  # MFA token
+            'session-test',  # profile name
+        ]
+
+        # Mock STS client to raise an error
+        mock_session = mock.Mock()
+        sts_client = mock.Mock()
+        sts_client.get_session_token.side_effect = ClientError(
+            {
+                'Error': {
+                    'Code': 'InvalidClientTokenId',
+                    'Message': 'Invalid credentials',
+                }
+            },
+            'GetSessionToken',
+        )
+        mock_session.create_client.return_value = sts_client
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch('sys.stderr') as mock_stderr:
+                rc = self.command._handle_missing_default_profile(
+                    self.parsed_args, 43200
+                )
+
+                self.assertEqual(rc, 1)
+                # Verify error message was written
+                mock_stderr.write.assert_called()
+                self.assertIn(
+                    'An error occurred', str(mock_stderr.write.call_args)
+                )
+
+    def test_non_interactive_missing_mfa_serial(self):
+        """Test non-interactive mode when MFA serial is missing."""
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {}  # No mfa_serial in config
+        mock_session.available_profiles = ['default']
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch(
+                'sys.stdin.isatty', return_value=False
+            ):  # Non-interactive
+                with mock.patch('sys.stderr') as mock_stderr:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+
+                    self.assertEqual(rc, 1)
+                    mock_stderr.write.assert_called_with(
+                        "MFA serial number or ARN is required\n"
+                    )
+
+    def test_non_interactive_missing_token_code(self):
+        """Test non-interactive mode when token code would be prompted."""
+        mock_session = mock.Mock()
+        mock_session.get_credentials.return_value = mock.Mock()
+        mock_session.get_scoped_config.return_value = {
+            'mfa_serial': 'arn:aws:iam::123456789012:mfa/user'
+        }
+        mock_session.available_profiles = ['default']
+
+        with mock.patch('botocore.session.Session', return_value=mock_session):
+            with mock.patch(
+                'sys.stdin.isatty', return_value=False
+            ):  # Non-interactive
+                with mock.patch('sys.stderr') as mock_stderr:
+                    rc = self.command._run_main(
+                        self.parsed_args, self.parsed_globals
+                    )
+
+                    self.assertEqual(rc, 1)
+                    mock_stderr.write.assert_called_with(
+                        "MFA token code is required\n"
+                    )
+
+    def test_empty_credential_input_handling(self):
+        """Test handling of empty credential inputs."""
+        self.prompter.get_credential_value.return_value = ''  # Empty string
+
+        with mock.patch('sys.stderr') as mock_stderr:
+            rc = self.command._handle_missing_default_profile(
+                self.parsed_args, 43200
+            )
+
+            self.assertEqual(rc, 1)
+            mock_stderr.write.assert_called_with(
+                "AWS Access Key ID is required\n"
+            )


### PR DESCRIPTION
*Issue #, if available:*
N/A, find me on slack

*Description of changes:*
Per our discussion

*Added aws configure mfa-login sub command, which takes the user interactively through starting an MFA session for an IAM user
*Added support for temporary AWS security credentials with aws configure

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
