### PR TITLE
Adding No overwrite for copy operation

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -23,7 +23,6 @@ from awscli.compat import ensure_text_type, queue
 from awscli.customizations.s3.subscribers import OnDoneFilteredSubscriber
 from awscli.customizations.s3.utils import (
     WarningResult,
-    create_warning,
     human_readable_size,
 )
 from awscli.customizations.utils import uni_print

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -13,6 +13,7 @@
 import logging
 import os
 
+from botocore.exceptions import ClientError
 from s3transfer.manager import TransferManager
 
 from awscli.compat import get_binary_stdin
@@ -481,7 +482,46 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
         )
 
     def _get_warning_handlers(self):
-        return [self._warn_glacier]
+        return [
+            self._warn_glacier,
+            self._warn_if_zero_byte_file_exists_with_no_overwrite,
+        ]
+
+    def _warn_if_zero_byte_file_exists_with_no_overwrite(self, fileinfo):
+        """
+        Warning handler to skip zero-byte files when no_overwrite is set and file exists.
+
+        This method handles the transfer of zero-byte objects when the no-overwrite parameter is specified.
+        To prevent overwrite, it uses head_object to verify if the object exists at the destination:
+        If the object is present at destination: skip the file (return True)
+        If the object is not present at destination: allow transfer (return False)
+
+        :type fileinfo: FileInfo
+        :param fileinfo: The FileInfo object containing transfer details
+
+        :rtype: bool
+        :return: True if file should be skipped, False if transfer should proceed
+        """
+        if not self._cli_params.get('no_overwrite') or (
+            getattr(fileinfo, 'size') and fileinfo.size > 0
+        ):
+            return False
+
+        bucket, key = find_bucket_key(fileinfo.dest)
+        client = fileinfo.source_client
+        try:
+            client.head_object(Bucket=bucket, Key=key)
+            LOGGER.debug(
+                "Warning: Skipping file %s as it already exists on %s",
+                fileinfo.src,
+                fileinfo.dest,
+            )
+            return True
+        except ClientError as e:
+            if e.response['Error']['Code'] == '404':
+                return False
+            else:
+                raise
 
     def _format_src_dest(self, fileinfo):
         src = self._format_s3_path(fileinfo.src)

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -521,6 +521,7 @@ class RequestParamsMapper:
         )
         cls._set_request_payer_param(request_params, cli_params)
         cls._set_checksum_algorithm_param(request_params, cli_params)
+        cls._set_no_overwrite_param(request_params, cli_params)
 
     @classmethod
     def map_head_object_params(cls, request_params, cli_params):

--- a/awscli/s3transfer/manager.py
+++ b/awscli/s3transfer/manager.py
@@ -188,6 +188,7 @@ class TransferManager:
         'SSEKMSEncryptionContext',
         'Tagging',
         'WebsiteRedirectLocation',
+        'IfNoneMatch',
     ]
 
     ALLOWED_UPLOAD_ARGS = (
@@ -195,7 +196,6 @@ class TransferManager:
         + [
             'ChecksumType',
             'MpuObjectSize',
-            'IfNoneMatch',
         ]
         + FULL_OBJECT_CHECKSUM_ARGS
     )

--- a/tests/functional/s3/__init__.py
+++ b/tests/functional/s3/__init__.py
@@ -257,6 +257,16 @@ class BaseS3TransferCommandTest(BaseAWSCommandParamsTest):
             self.complete_mpu_response(),
         ]
 
+    def precondition_failed_error_response(self, condition='If-None-Match'):
+        return {
+            'Error': {
+                'Code': 'PreconditionFailed',
+                'Message': 'At least one of the pre-conditions you '
+                'specified did not hold',
+                'Condition': condition,
+            }
+        }
+
 
 class BaseS3CLIRunnerTest(unittest.TestCase):
     def setUp(self):

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -335,7 +335,6 @@ class TestCPCommand(BaseCPCommandTest):
         # Create a large file that will trigger multipart upload
         full_path = self.files.create_file('foo.txt', 'a' * 10 * (1024**2))
         cmdline = f'{self.prefix} {full_path} s3://bucket --no-overwrite'
-
         # Set up responses for multipart upload
         self.parsed_responses = [
             {'UploadId': 'foo'},  # CreateMultipartUpload response
@@ -396,6 +395,160 @@ class TestCPCommand(BaseCPCommandTest):
         )
         # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
         self.assertEqual(self.operations_called[3][1]['IfNoneMatch'], '*')
+
+    def test_no_overwrite_flag_on_copy_when_small_object_does_not_exist_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket/key1.txt --no-overwrite'
+        # Set up responses for multipart copy (since no-overwrite always uses multipart)
+        self.parsed_responses = [
+            self.head_object_response(),  # HeadObject to get source metadata
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response
+            {},  # CompleteMultipartUpload response
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 4)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(
+            self.operations_called[1][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[2][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[3][0].name, 'CompleteMultipartUpload'
+        )
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[3][1]['IfNoneMatch'], '*')
+
+    def test_no_overwrite_flag_on_copy_when_small_object_exists_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket/key.txt --no-overwrite'
+        # Set up responses for multipart copy (since no-overwrite always uses multipart)
+        self.parsed_responses = [
+            self.head_object_response(),  # HeadObject to get source metadata
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response
+            self.precondition_failed_error_response(),  # CompleteMultipartUpload
+            {},  # AbortMultipartUpload response
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 5)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(
+            self.operations_called[1][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[2][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[3][0].name, 'CompleteMultipartUpload'
+        )
+        self.assertEqual(
+            self.operations_called[4][0].name, 'AbortMultipartUpload'
+        )
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[3][1]['IfNoneMatch'], '*')
+
+    def test_no_overwrite_flag_on_copy_when_zero_size_object_exists_at_destination(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/file.txt s3://bucket2/file.txt --no-overwrite'
+        self.parsed_responses = [
+            self.head_object_response(
+                ContentLength=0
+            ),  # Source object (zero size)
+            self.head_object_response(),  # Checking the object at destination
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'HeadObject')
+
+    def test_no_overwrite_flag_on_copy_when_zero_size_object_not_exists_at_destination(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/file.txt s3://bucket2/file1.txt --no-overwrite'
+        self.parsed_responses = [
+            self.head_object_response(
+                ContentLength=0
+            ),  # Source object (zero size)
+            {
+                'Error': {'Code': '404', 'Message': 'Not Found'}
+            },  # At destination object does not exists
+            self.copy_object_response(),  # Copy Request when object does not exists
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 3)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[2][0].name, 'CopyObject')
+
+    def test_no_overwrite_flag_on_copy_when_large_object_exists_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket/key.txt --no-overwrite'
+        # Set up responses for multipart copy with large object
+        self.parsed_responses = [
+            self.head_object_response(
+                ContentLength=10 * (1024**2)
+            ),  # HeadObject with large content
+            self.get_object_tagging_response({}),  # GetObjectTagging response
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response part 1
+            self.upload_part_copy_response(),  # UploadPartCopy response part 2
+            self.precondition_failed_error_response(),  # CompleteMultipartUpload fails with PreconditionFailed
+            {},  # AbortMultipartUpload response
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 7)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObjectTagging')
+        self.assertEqual(
+            self.operations_called[2][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[3][0].name, 'UploadPartCopy')
+        self.assertEqual(self.operations_called[4][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[5][0].name, 'CompleteMultipartUpload'
+        )
+        self.assertEqual(
+            self.operations_called[6][0].name, 'AbortMultipartUpload'
+        )
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[5][1]['IfNoneMatch'], '*')
+
+    def test_no_overwrite_flag_on_copy_when_large_object_does_not_exist_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket/key1.txt --no-overwrite'
+        # Set up responses for multipart copy with large object
+        self.parsed_responses = [
+            self.head_object_response(
+                ContentLength=10 * (1024**2)
+            ),  # HeadObject with large content
+            self.get_object_tagging_response({}),  # GetObjectTagging response
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response part 1
+            self.upload_part_copy_response(),  # UploadPartCopy response part 2
+            {},  # CompleteMultipartUpload response
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 6)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObjectTagging')
+        self.assertEqual(
+            self.operations_called[2][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[3][0].name, 'UploadPartCopy')
+        self.assertEqual(self.operations_called[4][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[5][0].name, 'CompleteMultipartUpload'
+        )
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[5][1]['IfNoneMatch'], '*')
 
     def test_dryrun_download(self):
         self.parsed_responses = [self.head_object_response()]

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -422,6 +422,159 @@ class TestMvCommand(BaseS3TransferCommandTest):
         # Verify source file was not deleted (failed move operation due to PreconditionFailed)
         self.assertTrue(os.path.exists(full_path))
 
+    def test_mv_no_overwrite_flag_on_copy_when_small_object_does_not_exist_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket2/key1.txt --no-overwrite'
+        # Set up responses for multipart copy (since no-overwrite always uses multipart)
+        self.parsed_responses = [
+            self.head_object_response(),  # HeadObject to get source metadata
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response
+            {},  # CompleteMultipartUpload response
+            self.delete_object_response(),  # DeleteObject (for move operation)
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart copy operations were called
+        self.assertEqual(len(self.operations_called), 5)
+        self.assertEqual(len(self.operations_called), 5)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(
+            self.operations_called[1][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[2][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[3][0].name, 'CompleteMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[4][0].name, 'DeleteObject')
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[3][1]['IfNoneMatch'], '*')
+
+    def test_mv_no_overwrite_flag_on_copy_when_small_object_exists_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key.txt s3://bucket2/key.txt --no-overwrite'
+        # Set up responses for multipart copy (since no-overwrite always uses multipart)
+        self.parsed_responses = [
+            self.head_object_response(),  # HeadObject to get source metadata
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response
+            self.precondition_failed_error_response(),  # CompleteMultipartUpload response
+            {},  # AbortMultipart
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Set up the response to simulate a PreconditionFailed error
+        self.http_response.status_code = 412
+        # Verify all multipart copy operations were called
+        self.assertEqual(len(self.operations_called), 5)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(
+            self.operations_called[1][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[2][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[3][0].name, 'CompleteMultipartUpload'
+        )
+        self.assertEqual(
+            self.operations_called[4][0].name, 'AbortMultipartUpload'
+        )
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[3][1]['IfNoneMatch'], '*')
+
+    def test_no_overwrite_flag_on_copy_when_zero_size_object_exists_at_destination(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/file.txt s3://bucket2/file.txt --no-overwrite'
+        self.parsed_responses = [
+            self.head_object_response(
+                ContentLength=0
+            ),  # Source object (zero size)
+            self.head_object_response(),  # Checking the object at destination
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 2)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'HeadObject')
+
+    def test_no_overwrite_flag_on_copy_when_zero_size_object_not_exists_at_destination(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/file.txt s3://bucket2/file1.txt --no-overwrite'
+        self.parsed_responses = [
+            self.head_object_response(
+                ContentLength=0
+            ),  # Source object (zero size)
+            {
+                'Error': {'Code': '404', 'Message': 'Not Found'}
+            },  # At destination object does not exists
+            self.copy_object_response(),  # Copy Request when object does not exists
+            self.delete_object_response(),  # Delete Request for move object
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        self.assertEqual(len(self.operations_called), 4)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[2][0].name, 'CopyObject')
+        self.assertEqual(self.operations_called[3][0].name, 'DeleteObject')
+
+    def test_mv_no_overwrite_flag_when_large_object_exists_on_target(self):
+        cmdline = f'{self.prefix} s3://bucket1/key1.txt s3://bucket/key1.txt --no-overwrite'
+        self.parsed_responses = [
+            self.head_object_response(ContentLength=10 * (1024**2)),
+            self.get_object_tagging_response({}),  # GetObjectTagging response
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response part 1
+            self.upload_part_copy_response(),  # UploadPartCopy response part 2
+            self.precondition_failed_error_response(),  # CompleteMultipartUpload fails with PreconditionFailed
+            {},  # AbortMultipartUpload response
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 7)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObjectTagging')
+        self.assertEqual(
+            self.operations_called[2][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[3][0].name, 'UploadPartCopy')
+        self.assertEqual(self.operations_called[4][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[5][0].name, 'CompleteMultipartUpload'
+        )
+        self.assertEqual(
+            self.operations_called[6][0].name, 'AbortMultipartUpload'
+        )
+        # Verify the IfNoneMatch condition was set in the CompleteMultipartUpload request
+        self.assertEqual(self.operations_called[5][1]['IfNoneMatch'], '*')
+
+    def test_mv_no_overwrite_flag_when_large_object_does_not_exist_on_target(
+        self,
+    ):
+        cmdline = f'{self.prefix} s3://bucket1/key1.txt s3://bucket/key.txt --no-overwrite'
+        self.parsed_responses = [
+            self.head_object_response(ContentLength=10 * (1024**2)),
+            self.get_object_tagging_response({}),  # GetObjectTagging response
+            self.create_mpu_response('foo'),  # CreateMultipartUpload response
+            self.upload_part_copy_response(),  # UploadPartCopy response part 1
+            self.upload_part_copy_response(),  # UploadPartCopy response part 2
+            {},  # CompleteMultipartUpload response
+            self.delete_object_response(),  # DeleteObject (for move operation)
+        ]
+        self.run_cmd(cmdline, expected_rc=0)
+        # Verify all multipart operations were called
+        self.assertEqual(len(self.operations_called), 7)
+        self.assertEqual(self.operations_called[0][0].name, 'HeadObject')
+        self.assertEqual(self.operations_called[1][0].name, 'GetObjectTagging')
+        self.assertEqual(
+            self.operations_called[2][0].name, 'CreateMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[3][0].name, 'UploadPartCopy')
+        self.assertEqual(self.operations_called[4][0].name, 'UploadPartCopy')
+        self.assertEqual(
+            self.operations_called[5][0].name, 'CompleteMultipartUpload'
+        )
+        self.assertEqual(self.operations_called[6][0].name, 'DeleteObject')
+
 
 class TestMvWithCRTClient(BaseCRTTransferClientTest):
     def test_upload_move_using_crt_client(self):

--- a/tests/functional/s3transfer/test_copy.py
+++ b/tests/functional/s3transfer/test_copy.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from botocore.exceptions import ClientError
 from botocore.stub import Stubber
+from s3transfer.copies import CopySubmissionTask
 from s3transfer.manager import TransferConfig, TransferManager
 from s3transfer.utils import MIN_UPLOAD_CHUNKSIZE
 
@@ -275,7 +276,12 @@ class TestNonMultipartCopy(BaseCopyTest):
 
     def test_allowed_copy_params_are_valid(self):
         op_model = self.client.meta.service_model.operation_model('CopyObject')
-        for allowed_upload_arg in self._manager.ALLOWED_COPY_ARGS:
+        allowed_copy_arg = [
+            arg
+            for arg in self._manager.ALLOWED_COPY_ARGS
+            if arg not in CopySubmissionTask.COPY_OBJECT_ARGS_BLOCKLIST
+        ]
+        for allowed_upload_arg in allowed_copy_arg:
             self.assertIn(allowed_upload_arg, op_model.input_shape.members)
 
     def test_copy_with_tagging(self):
@@ -698,5 +704,218 @@ class TestMultipartCopy(BaseCopyTest):
         future = self.manager.copy(
             self.copy_source, self.bucket, self.key, extra_args
         )
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_copy_with_no_overwrite_flag_when_small_object_exists_at_target(
+        self,
+    ):
+        # Set up IfNoneMatch in extra_args
+        self.extra_args['IfNoneMatch'] = '*'
+        # Setting up the size of object
+        small_content_size = 5
+        self.content = b'0' * small_content_size
+        # Add head object response with small content size
+        head_response = self.create_stubbed_responses()[0]
+        head_response['service_response'] = {
+            'ContentLength': small_content_size
+        }
+        self.stubber.add_response(**head_response)
+        # Should use multipart upload
+        # Add create_multipart_upload response
+        self.stubber.add_response(
+            'create_multipart_upload',
+            service_response={'UploadId': self.multipart_id},
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+            },
+        )
+        # Add upload_part_copy response
+        self.stubber.add_response(
+            'upload_part_copy',
+            {'CopyPartResult': {'ETag': 'etag-1'}},
+            {
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.multipart_id,
+                'PartNumber': 1,
+                'CopySourceRange': f'bytes=0-{small_content_size-1}',
+            },
+        )
+        # Mock a PreconditionFailed error for complete_multipart_upload
+        self.stubber.add_client_error(
+            method='complete_multipart_upload',
+            service_error_code='PreconditionFailed',
+            service_message='The condition specified in the conditional header(s) was not met',
+            http_status_code=412,
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+                'MultipartUpload': {
+                    'Parts': [{'ETag': 'etag-1', 'PartNumber': 1}]
+                },
+                'IfNoneMatch': '*',
+            },
+        )
+        # Add abort_multipart_upload response
+        self.stubber.add_response(
+            'abort_multipart_upload',
+            service_response={},
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+            },
+        )
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = self.extra_args
+        future = self.manager.copy(**call_kwargs)
+        with self.assertRaises(ClientError) as context:
+            future.result()
+        self.assertEqual(
+            context.exception.response['Error']['Code'], 'PreconditionFailed'
+        )
+        self.stubber.assert_no_pending_responses()
+
+    def test_copy_with_no_overwrite_flag_when_small_object_not_exists_at_target(
+        self,
+    ):
+        # Set up IfNoneMatch in extra_args
+        self.extra_args['IfNoneMatch'] = '*'
+        # Setting up the size of object
+        small_content_size = 5
+        self.content = b'0' * small_content_size
+        # Add head object response with small content size
+        head_response = self.create_stubbed_responses()[0]
+        head_response['service_response'] = {
+            'ContentLength': small_content_size
+        }
+        self.stubber.add_response(**head_response)
+        # Should use multipart copy
+        # Add create_multipart_upload response
+        self.stubber.add_response(
+            'create_multipart_upload',
+            service_response={'UploadId': self.multipart_id},
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+            },
+        )
+        # Add upload_part_copy response
+        self.stubber.add_response(
+            'upload_part_copy',
+            {'CopyPartResult': {'ETag': 'etag-1'}},
+            {
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'CopySource': self.copy_source,
+                'UploadId': self.multipart_id,
+                'PartNumber': 1,
+                'CopySourceRange': f'bytes=0-{small_content_size-1}',
+            },
+        )
+        self.stubber.add_response(
+            'complete_multipart_upload',
+            service_response={},
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+                'MultipartUpload': {
+                    'Parts': [{'ETag': 'etag-1', 'PartNumber': 1}]
+                },
+                'IfNoneMatch': '*',
+            },
+        )
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = self.extra_args
+        future = self.manager.copy(**call_kwargs)
+        future.result()
+        self.stubber.assert_no_pending_responses()
+
+    def test_copy_with_no_overwrite_flag_when_large_object_exists_at_target(
+        self,
+    ):
+        # Set up IfNoneMatch in extra_args
+        self.extra_args['IfNoneMatch'] = '*'
+        # Add head object response
+        self.add_get_head_response_with_default_expected_params()
+        # Should use multipart upload
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_copy_responses_with_default_expected_params()
+        # Mock a PreconditionFailed error for complete_multipart_upload
+        self.stubber.add_client_error(
+            method='complete_multipart_upload',
+            service_error_code='PreconditionFailed',
+            service_message='The condition specified in the conditional header(s) was not met',
+            http_status_code=412,
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+                'MultipartUpload': {
+                    'Parts': [
+                        {'ETag': 'etag-1', 'PartNumber': 1},
+                        {'ETag': 'etag-2', 'PartNumber': 2},
+                        {'ETag': 'etag-3', 'PartNumber': 3},
+                    ]
+                },
+                'IfNoneMatch': '*',
+            },
+        )
+        # Add abort_multipart_upload response
+        self.stubber.add_response(
+            'abort_multipart_upload',
+            service_response={},
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+            },
+        )
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = self.extra_args
+        future = self.manager.copy(**call_kwargs)
+        with self.assertRaises(ClientError) as context:
+            future.result()
+        self.assertEqual(
+            context.exception.response['Error']['Code'], 'PreconditionFailed'
+        )
+        self.stubber.assert_no_pending_responses()
+
+    def test_copy_with_no_overwrite_flag_when_large_object_not_exists_at_target(
+        self,
+    ):
+        # Set up IfNoneMatch in extra_args
+        self.extra_args['IfNoneMatch'] = '*'
+        # Add head object response
+        self.add_get_head_response_with_default_expected_params()
+        # Should use multipart upload
+        self.add_create_multipart_response_with_default_expected_params()
+        self.add_upload_part_copy_responses_with_default_expected_params()
+        # Add successful complete_multipart_upload response
+        self.stubber.add_response(
+            'complete_multipart_upload',
+            service_response={},
+            expected_params={
+                'Bucket': self.bucket,
+                'Key': self.key,
+                'UploadId': self.multipart_id,
+                'MultipartUpload': {
+                    'Parts': [
+                        {'ETag': 'etag-1', 'PartNumber': 1},
+                        {'ETag': 'etag-2', 'PartNumber': 2},
+                        {'ETag': 'etag-3', 'PartNumber': 3},
+                    ]
+                },
+                'IfNoneMatch': '*',
+            },
+        )
+        call_kwargs = self.create_call_kwargs()
+        call_kwargs['extra_args'] = self.extra_args
+        future = self.manager.copy(**call_kwargs)
         future.result()
         self.stubber.assert_no_pending_responses()

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -872,6 +872,18 @@ class TestRequestParamsMapperNoOverwrite(unittest.TestCase):
         RequestParamsMapper.map_put_object_params(request_params, cli_params)
         self.assertNotIn('IfNoneMatch', request_params)
 
+    def test_map_copy_object_params_with_no_overwrite(self):
+        request_params = {}
+        cli_params = {'no_overwrite': True}
+        RequestParamsMapper.map_copy_object_params(request_params, cli_params)
+        self.assertEqual(request_params['IfNoneMatch'], '*')
+
+    def test_map_copy_object_params_without_no_overwrite(self):
+        request_params = {}
+        cli_params = {}
+        RequestParamsMapper.map_copy_object_params(request_params, cli_params)
+        self.assertNotIn('IfNoneMatch', request_params)
+
 
 class TestS3PathResolver:
     _BASE_ACCESSPOINT_ARN = (


### PR DESCRIPTION
*Issue :*  Github Issue #2874 

*Description of changes:*

Customers requested to prevent overwriting of objects. This is done by providing `no-overwrite` header using `ifNoneMatch` with Etags  to transfer objects that are not present on the bucket. However, retrieval of etags is difficult hence during copy operation always perform multipart copy since it follows multipart upload approach which indeed supports `ifNoneMatch` header without Etags. The `no-overwrite` header works well with other `cp` command headers. Customer can be implemented using `aws s3 cp <source> <destination> --no-overwrite` which allows successful transfers when object with the same name is not present on the destination. However, if the user tries to transfer the object which is already present at the target bucket using command line, a `warning` about skipping the file will be generated and that object is not allowed to transfer to S3 bucket.

_Testing_:
 Functional testing is performed to validate the object copy process. This included both scenarios copying an object when object with same key is already present in the bucket as well as those when the object with same key is not present on bucket. These tests were conducted for both object having size less than multipart threshold and one with greater than multipart threshold
