### PR TITLE
[v2] Add extra utilities to Docker image

### DIFF
--- a/.changes/next-release/enhancement-Dockerfile-38945.json
+++ b/.changes/next-release/enhancement-Dockerfile-38945.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "Dockerfile",
+  "description": "Include ``findutils`` and ``jq`` in Docker image"
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf update -y \
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf update -y \
-  && dnf install -y less groff \
+  && dnf install -y less groff findutils \
   && dnf clean all
 COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=installer /aws-cli-bin/ /usr/local/bin/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf update -y \
 
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 RUN dnf update -y \
-  && dnf install -y less groff findutils \
+  && dnf install -y less groff findutils jq \
   && dnf clean all
 COPY --from=installer /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=installer /aws-cli-bin/ /usr/local/bin/


### PR DESCRIPTION
Addresses feedback received from upgrading base Docker image to Amazon Linux 2023: https://github.com/aws/aws-cli/issues/9586. This should make migration a bit easier for users.

While `jq` was never pre-installed on Amazon Linux 2 or AWS CLI v2 Docker image, we decided to include it moving forward by popular demand: https://github.com/aws/aws-cli/issues/5227