### PR TITLE
Add create_nested_client method

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -48,7 +48,7 @@ from awscli.help import (
     ServiceHelpCommand,
 )
 from awscli.plugin import load_plugins
-from awscli.utils import emit_top_level_args_parsed_event, write_exception
+from awscli.utils import emit_top_level_args_parsed_event, write_exception, create_nested_client
 from botocore import __version__ as botocore_version
 from botocore import xform_name
 
@@ -692,7 +692,8 @@ class CLIOperationCaller:
             value is returned.
 
         """
-        client = self._session.create_client(
+        client = create_nested_client(
+            self._session,
             service_name,
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -24,7 +24,7 @@ from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 
 from awscli.customizations.commands import BasicCommand
 from awscli.compat import get_stdout_text_writer
-from awscli.utils import write_exception
+from awscli.utils import create_nested_client, write_exception
 
 LOG = logging.getLogger(__name__)
 
@@ -267,8 +267,8 @@ class DeployCommand(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         cloudformation_client = \
-            self._session.create_client(
-                    'cloudformation', region_name=parsed_globals.region,
+            create_nested_client(
+                    self._session, 'cloudformation', region_name=parsed_globals.region,
                     endpoint_url=parsed_globals.endpoint_url,
                     verify=parsed_globals.verify_ssl)
 
@@ -300,7 +300,8 @@ class DeployCommand(BasicCommand):
 
         bucket = parsed_args.s3_bucket
         if bucket:
-            s3_client = self._session.create_client(
+            s3_client = create_nested_client(
+                self._session,
                 "s3",
                 config=Config(signature_version='s3v4'),
                 region_name=parsed_globals.region,

--- a/awscli/customizations/cloudformation/package.py
+++ b/awscli/customizations/cloudformation/package.py
@@ -24,6 +24,7 @@ from awscli.customizations.cloudformation.yamlhelper import yaml_dump
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.s3uploader import S3Uploader
+from awscli.utils import create_nested_client
 
 LOG = logging.getLogger(__name__)
 
@@ -124,8 +125,8 @@ class PackageCommand(BasicCommand):
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
-        s3_client = self._session.create_client(
-            "s3",
+        s3_client = create_nested_client(
+            self._session, "s3",
             config=Config(signature_version='s3v4'),
             region_name=parsed_globals.region,
             verify=parsed_globals.verify_ssl)

--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -21,6 +21,7 @@ from botocore.signers import CloudFrontSigner
 from awscli.arguments import CustomArgument
 from awscli.customizations.utils import validate_mutually_exclusive_handler
 from awscli.customizations.commands import BasicCommand
+from awscli.utils import create_nested_client
 
 
 def register(event_handler):
@@ -172,7 +173,8 @@ class UpdateDefaultRootObject(CreateDefaultRootObject):
 
     def add_to_params(self, parameters, value):
         if value is not None:
-            client = self.context['session'].create_client(
+            client = create_nested_client(
+                self.context['session'],
                 'cloudfront',
                 region_name=self.context['parsed_args'].region,
                 endpoint_url=self.context['parsed_args'].endpoint_url,

--- a/awscli/customizations/cloudtrail/subscribe.py
+++ b/awscli/customizations/cloudtrail/subscribe.py
@@ -17,8 +17,8 @@ import sys
 from .utils import get_account_id
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import s3_bucket_exists
+from awscli.utils import create_nested_client
 from botocore.exceptions import ClientError
-
 
 LOG = logging.getLogger(__name__)
 S3_POLICY_TEMPLATE = 'policy/S3/AWSCloudTrail-S3BucketPolicy-2014-12-17.json'
@@ -80,16 +80,16 @@ class CloudTrailSubscribe(BasicCommand):
 
         # Initialize services
         LOG.debug('Initializing S3, SNS and CloudTrail...')
-        self.sts = self._session.create_client('sts', **client_args)
-        self.s3 = self._session.create_client('s3', **client_args)
-        self.sns = self._session.create_client('sns', **client_args)
+        self.sts = create_nested_client(self._session, 'sts', **client_args)
+        self.s3 = create_nested_client(self._session, 's3', **client_args)
+        self.sns = create_nested_client(self._session, 'sns', **client_args)
         self.region_name = self.s3.meta.region_name
 
         # If the endpoint is specified, it is designated for the cloudtrail
         # service. Not all of the other services will use it.
         if parsed_globals.endpoint_url is not None:
             client_args['endpoint_url'] = parsed_globals.endpoint_url
-        self.cloudtrail = self._session.create_client('cloudtrail', **client_args)
+        self.cloudtrail = create_nested_client(self._session, 'cloudtrail', **client_args)
 
     def _call(self, options, parsed_globals):
         """

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -30,7 +30,7 @@ from awscli.customizations.cloudtrail.utils import get_trail_by_arn, \
 from awscli.customizations.commands import BasicCommand
 from botocore.exceptions import ClientError
 from awscli.schema import ParameterRequiredError
-
+from awscli.utils import create_nested_client
 
 LOG = logging.getLogger(__name__)
 DATE_FORMAT = '%Y%m%dT%H%M%SZ'
@@ -193,7 +193,7 @@ class S3ClientProvider(object):
     def _create_client(self, region_name):
         """Creates an Amazon S3 client for the given region name"""
         if region_name not in self._client_cache:
-            client = self._session.create_client('s3', region_name)
+            client = create_nested_client(self._session, 's3', region_name=region_name)
             # Remove the CLI error event that prevents exceptions.
             self._client_cache[region_name] = client
         return self._client_cache[region_name]
@@ -753,13 +753,13 @@ class CloudTrailValidateLogs(BasicCommand):
             self._session, self._source_region)
         client_args = {'region_name': parsed_globals.region,
                        'verify': parsed_globals.verify_ssl}
-        self.organization_client = self._session.create_client(
-            'organizations', **client_args)
+        self.organization_client = create_nested_client(
+            self._session, 'organizations', **client_args)
 
         if parsed_globals.endpoint_url is not None:
             client_args['endpoint_url'] = parsed_globals.endpoint_url
-        self.cloudtrail_client = self._session.create_client(
-            'cloudtrail', **client_args)
+        self.cloudtrail_client = create_nested_client(
+            self._session, 'cloudtrail', **client_args)
 
     def _call(self):
         traverser = create_digest_traverser(

--- a/awscli/customizations/codedeploy/deregister.py
+++ b/awscli/customizations/codedeploy/deregister.py
@@ -18,6 +18,7 @@ from botocore.exceptions import ClientError
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.codedeploy.utils import \
     validate_region, validate_instance_name, INSTANCE_NAME_ARG
+from awscli.utils import create_nested_client
 
 
 class Deregister(BasicCommand):
@@ -48,13 +49,15 @@ class Deregister(BasicCommand):
         validate_region(params, parsed_globals)
         validate_instance_name(params)
 
-        self.codedeploy = self._session.create_client(
+        self.codedeploy = create_nested_client(
+            self._session,
             'codedeploy',
             region_name=params.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
-        self.iam = self._session.create_client(
+        self.iam = create_nested_client(
+            self._session,
             'iam',
             region_name=params.region
         )

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -23,7 +23,7 @@ from botocore.exceptions import ClientError
 from awscli.customizations.codedeploy.utils import validate_s3_location
 from awscli.customizations.commands import BasicCommand
 from awscli.compat import BytesIO, ZIP_COMPRESSION_MODE
-
+from awscli.utils import create_nested_client
 
 ONE_MB = 1 << 20
 MULTIPART_LIMIT = 6 * ONE_MB
@@ -107,13 +107,15 @@ class Push(BasicCommand):
 
     def _run_main(self, parsed_args, parsed_globals):
         self._validate_args(parsed_args)
-        self.codedeploy = self._session.create_client(
+        self.codedeploy = create_nested_client(
+            self._session,
             'codedeploy',
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
-        self.s3 = self._session.create_client(
+        self.s3 = create_nested_client(
+            self._session,
             's3',
             region_name=parsed_globals.region
         )

--- a/awscli/customizations/codedeploy/register.py
+++ b/awscli/customizations/codedeploy/register.py
@@ -18,6 +18,7 @@ from awscli.customizations.codedeploy.systems import DEFAULT_CONFIG_FILE
 from awscli.customizations.codedeploy.utils import \
     validate_region, validate_instance_name, validate_tags, \
     validate_iam_user_arn, INSTANCE_NAME_ARG, IAM_USER_ARN_ARG
+from awscli.utils import create_nested_client
 
 
 class Register(BasicCommand):
@@ -73,13 +74,15 @@ class Register(BasicCommand):
         validate_tags(params)
         validate_iam_user_arn(params)
 
-        self.codedeploy = self._session.create_client(
+        self.codedeploy = create_nested_client(
+            self._session,
             'codedeploy',
             region_name=params.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
-        self.iam = self._session.create_client(
+        self.iam = create_nested_client(
+            self._session,
             'iam',
             region_name=params.region
         )

--- a/awscli/customizations/codedeploy/systems.py
+++ b/awscli/customizations/codedeploy/systems.py
@@ -14,6 +14,7 @@
 import ctypes
 import os
 import subprocess
+from awscli.utils import create_nested_client
 
 DEFAULT_CONFIG_FILE = 'codedeploy.onpremises.yml'
 
@@ -26,7 +27,8 @@ class System:
 
     def __init__(self, params):
         self.session = params.session
-        self.s3 = self.session.create_client(
+        self.s3 = create_nested_client(
+            self.session,
             's3',
             region_name=params.region
         )

--- a/awscli/customizations/configservice/getstatus.py
+++ b/awscli/customizations/configservice/getstatus.py
@@ -13,7 +13,7 @@
 import sys
 
 from awscli.customizations.commands import BasicCommand
-
+from awscli.utils import create_nested_client
 
 def register_get_status(cli):
     cli.register('building-command-table.configservice', add_get_status)
@@ -44,8 +44,8 @@ class GetStatusCommand(BasicCommand):
             'region_name': parsed_globals.region,
             'endpoint_url': parsed_globals.endpoint_url
         }
-        self._config_client = self._session.create_client('config',
-                                                          **client_args)
+        self._config_client = create_nested_client(self._session, 'config',
+                                           **client_args)
 
     def _check_configuration_recorders(self):
         status = self._config_client.describe_configuration_recorder_status()

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -22,7 +22,7 @@ from awscli.customizations.datapipeline.createdefaultroles \
     import CreateDefaultRoles
 from awscli.customizations.datapipeline.listrunsformatter \
     import ListRunsFormatter
-
+from awscli.utils import create_nested_client
 
 DEFINITION_HELP_TEXT = """\
 The JSON pipeline definition.  If the pipeline definition
@@ -361,7 +361,9 @@ class ListRunsCommand(BasicCommand):
     def _set_client(self, parsed_globals):
         # This is called from _run_main and is used to ensure that we have
         # a service/endpoint object to work with.
-        self.client = self._session.create_client(
+        from awscli.utils import create_nested_client
+        self.client = create_nested_client(
+            self._session,
             'datapipeline',
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,

--- a/awscli/customizations/datapipeline/createdefaultroles.py
+++ b/awscli/customizations/datapipeline/createdefaultroles.py
@@ -25,6 +25,8 @@ from awscli.customizations.datapipeline.constants \
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.datapipeline.translator \
     import display_response, dict_to_string, get_region
+from awscli.utils import create_nested_client
+
 from botocore.exceptions import ClientError
 
 LOG = logging.getLogger(__name__)
@@ -69,8 +71,8 @@ class CreateDefaultRoles(BasicCommand):
         """Call to run the commands"""
         self._region = get_region(self._session, parsed_globals)
         self._endpoint_url = parsed_globals.endpoint_url
-        self._iam_client = self._session.create_client(
-            'iam', 
+        self._iam_client = create_nested_client(
+            self._session, 'iam', 
             region_name=self._region, 
             endpoint_url=self._endpoint_url,
             verify=parsed_globals.verify_ssl

--- a/awscli/customizations/dlm/createdefaultrole.py
+++ b/awscli/customizations/dlm/createdefaultrole.py
@@ -23,6 +23,7 @@ from awscli.customizations.dlm.constants \
     POLICY_ARN_PATTERN, \
     RESOURCE_TYPE_SNAPSHOT, \
     RESOURCE_TYPE_IMAGE
+from awscli.utils import create_nested_client
 
 LOG = logging.getLogger(__name__)
 
@@ -98,8 +99,9 @@ class CreateDefaultRole(BasicCommand):
         self._region = get_region(self._session, parsed_globals)
         self._endpoint_url = parsed_args.iam_endpoint
         self._resource_type = parsed_args.resource_type
-        self._iam_client = IAM(self._session.create_client(
-            'iam',
+        from awscli.utils import create_nested_client
+        self._iam_client = IAM(create_nested_client(
+            self._session, 'iam',
             region_name=self._region,
             endpoint_url=self._endpoint_url,
             verify=parsed_globals.verify_ssl

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -21,6 +21,7 @@ from botocore.signers import RequestSigner
 from botocore.model import ServiceId
 
 from awscli.formatter import get_formatter
+from awscli.utils import create_nested_client
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import uni_print
 from awscli.customizations.utils import validate_mutually_exclusive
@@ -247,12 +248,12 @@ class STSClientFactory(object):
             client_kwargs['aws_access_key_id'] = creds['AccessKeyId']
             client_kwargs['aws_secret_access_key'] = creds['SecretAccessKey']
             client_kwargs['aws_session_token'] = creds['SessionToken']
-        sts = self._session.create_client('sts', **client_kwargs)
+        sts = create_nested_client(self._session, 'sts', **client_kwargs)
         self._register_k8s_aws_id_handlers(sts)
         return sts
 
     def _get_role_credentials(self, region_name, role_arn):
-        sts = self._session.create_client('sts', region_name)
+        sts = create_nested_client(self._session, 'sts', region_name=region_name)
         return sts.assume_role(
             RoleArn=role_arn, RoleSessionName='EKSGetTokenAuth'
         )['Credentials']

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -26,6 +26,7 @@ from awscli.customizations.eks.kubeconfig import (Kubeconfig,
                                                   KubeconfigValidator,
                                                   KubeconfigAppender)
 from awscli.customizations.eks.ordered_yaml import ordered_yaml_dump
+from awscli.utils import create_nested_client
 
 LOG = logging.getLogger(__name__)
 
@@ -270,7 +271,7 @@ class EKSClient(object):
 
         # Handle role assumption if needed
         if getattr(self._parsed_args, 'assume_role_arn', None):
-            sts_client = self._session.create_client('sts')
+            sts_client = create_nested_client(self._session, 'sts')
             credentials = sts_client.assume_role(
                 RoleArn=self._parsed_args.assume_role_arn,
                 RoleSessionName='EKSDescribeClusterSession'
@@ -282,7 +283,7 @@ class EKSClient(object):
                 "aws_session_token": credentials["SessionToken"],
             })
 
-        client = self._session.create_client("eks", **client_kwargs)
+        client = create_nested_client(self._session, "eks", **client_kwargs)
         full_description = client.describe_cluster(name=self._cluster_name)
         cluster = full_description.get("cluster")
 

--- a/awscli/customizations/gamelift/getlog.py
+++ b/awscli/customizations/gamelift/getlog.py
@@ -15,6 +15,7 @@ from functools import partial
 
 from awscli.compat import urlopen
 from awscli.customizations.commands import BasicCommand
+from awscli.utils import create_nested_client
 
 
 class GetGameSessionLogCommand(BasicCommand):
@@ -28,8 +29,8 @@ class GetGameSessionLogCommand(BasicCommand):
     ]
 
     def _run_main(self, args, parsed_globals):
-        client = self._session.create_client(
-            'gamelift', region_name=parsed_globals.region,
+        client = create_nested_client(
+            self._session, 'gamelift', region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )

--- a/awscli/customizations/gamelift/uploadbuild.py
+++ b/awscli/customizations/gamelift/uploadbuild.py
@@ -21,6 +21,7 @@ from s3transfer import S3Transfer
 
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.s3.utils import human_readable_size
+from awscli.utils import create_nested_client
 
 
 class UploadBuildCommand(BasicCommand):
@@ -43,8 +44,8 @@ class UploadBuildCommand(BasicCommand):
     ]
 
     def _run_main(self, args, parsed_globals):
-        gamelift_client = self._session.create_client(
-            'gamelift', region_name=parsed_globals.region,
+        gamelift_client = create_nested_client(
+            self._session, 'gamelift', region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl
         )
@@ -81,8 +82,9 @@ class UploadBuildCommand(BasicCommand):
         access_key = upload_credentials['AccessKeyId']
         secret_key = upload_credentials['SecretAccessKey']
         session_token = upload_credentials['SessionToken']
-        s3_client = self._session.create_client(
-            's3', aws_access_key_id=access_key,
+        s3_client = create_nested_client(
+            self._session, 's3', 
+            aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
             aws_session_token=session_token,
             region_name=parsed_globals.region,

--- a/awscli/customizations/logs/startlivetail.py
+++ b/awscli/customizations/logs/startlivetail.py
@@ -19,7 +19,7 @@ import time
 
 from awscli.compat import get_stdout_text_writer
 from awscli.customizations.commands import BasicCommand
-from awscli.utils import is_a_tty
+from awscli.utils import is_a_tty, create_nested_client
 
 
 DESCRIPTION = (
@@ -240,8 +240,8 @@ class StartLiveTailCommand(BasicCommand):
         self._output = get_stdout_text_writer()
 
     def _get_client(self, parsed_globals):
-        return self._session.create_client(
-            "logs",
+        return create_nested_client(
+            self._session, "logs",
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl,

--- a/awscli/customizations/rds.py
+++ b/awscli/customizations/rds.py
@@ -29,6 +29,7 @@ from awscli.clidriver import CLIOperationCaller
 from awscli.customizations import utils
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import uni_print
+from awscli.utils import create_nested_client
 
 
 def register_rds_modify_split(cli):
@@ -95,7 +96,8 @@ class GenerateDBAuthTokenCommand(BasicCommand):
     ]
 
     def _run_main(self, parsed_args, parsed_globals):
-        rds = self._session.create_client(
+        rds = create_nested_client(
+            self._session,
             'rds',
             region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,

--- a/awscli/customizations/utils.py
+++ b/awscli/customizations/utils.py
@@ -18,6 +18,7 @@ import copy
 import sys
 
 from botocore.exceptions import ClientError
+from awscli.utils import create_nested_client
 
 
 def rename_argument(argument_table, existing_name, new_name):
@@ -172,7 +173,7 @@ def create_client_from_parsed_globals(session, service_name, parsed_globals,
         client_args['verify'] = parsed_globals.verify_ssl
     if overrides:
         client_args.update(overrides)
-    return session.create_client(service_name, **client_args)
+    return create_nested_client(session, service_name, **client_args)
 
 
 def uni_print(statement, out_file=None):

--- a/awscli/customizations/waiters.py
+++ b/awscli/customizations/waiters.py
@@ -16,6 +16,7 @@ from botocore.exceptions import DataNotFoundError
 from awscli.clidriver import ServiceOperation
 from awscli.customizations.commands import BasicCommand, BasicHelp, \
     BasicDocHandler
+from awscli.utils import create_nested_client
 
 
 def register_add_waiters(cli):
@@ -200,8 +201,8 @@ class WaiterCaller(object):
         self._waiter_name = waiter_name
 
     def invoke(self, service_name, operation_name, parameters, parsed_globals):
-        client = self._session.create_client(
-            service_name, region_name=parsed_globals.region,
+        client = create_nested_client(
+            self._session, service_name, region_name=parsed_globals.region,
             endpoint_url=parsed_globals.endpoint_url,
             verify=parsed_globals.verify_ssl)
         waiter = client.get_waiter(xform_name(self._waiter_name))

--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -43,6 +43,7 @@ from botocore.exceptions import ClientError, WaiterError
 
 import awscli.clidriver
 from awscli.compat import BytesIO, StringIO
+from awscli.utils import create_nested_client
 
 _LOADER = botocore.loaders.Loader()
 INTEG_LOG = logging.getLogger('awscli.tests.integration')
@@ -143,7 +144,7 @@ def create_bucket(session, name=None, region=None):
     """
     if not region:
         region = 'us-west-2'
-    client = session.create_client('s3', region_name=region)
+    client = create_nested_client(session, 's3', region_name=region)
     if name:
         bucket_name = name
     else:
@@ -172,7 +173,7 @@ def create_dir_bucket(session, name=None, location=None):
     if not location:
         location = ('us-west-2', 'usw2-az1')
     region, az = location
-    client = session.create_client('s3', region_name=region)
+    client = create_nested_client(session, 's3', region_name=region)
     if name:
         bucket_name = name
     else:
@@ -778,7 +779,7 @@ class BaseS3CLICommand(unittest.TestCase):
         self.session = botocore.session.get_session()
         self.regions = {}
         self.region = 'us-west-2'
-        self.client = self.session.create_client('s3', region_name=self.region)
+        self.client = create_nested_client(self.session, 's3', region_name=self.region)
         self.extra_setup()
 
     def extra_setup(self):
@@ -799,7 +800,7 @@ class BaseS3CLICommand(unittest.TestCase):
 
     def create_client_for_bucket(self, bucket_name):
         region = self.regions.get(bucket_name, self.region)
-        client = self.session.create_client('s3', region_name=region)
+        client = create_nested_client(self.session, 's3', region_name=region)
         return client
 
     def assert_key_contents_equal(self, bucket, key, expected_contents):

--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -311,3 +311,17 @@ class ShapeRecordingVisitor(BaseShapeVisitor):
 
     def visit_shape(self, shape):
         self.visited.append(shape)
+
+# NOTE: The following interfaces are considered private and are subject
+# to abrupt breaking changes. Please do not use them directly.
+
+try:
+    from botocore.utils import create_nested_client as create_client
+except ImportError:
+
+    def create_client(session, service_name, **kwargs):
+        return session.create_client(service_name, **kwargs)
+
+
+def create_nested_client(session, service_name, **kwargs):
+    return create_client(session, service_name, **kwargs)

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -917,7 +917,7 @@ class TestS3ClientProvider(BaseAWSCommandParamsTest):
         created_client = provider.get_client('foo')
         self.assertEqual(s3_client, created_client)
         create_client_calls = session.create_client.call_args_list
-        self.assertEqual(create_client_calls, [mock.call('s3', 'us-east-1')])
+        self.assertEqual(create_client_calls, [mock.call('s3', region_name='us-east-1')])
         self.assertEqual(1, s3_client.get_bucket_location.call_count)
 
     def test_creates_clients_for_buckets_outside_us_east_1(self):
@@ -931,8 +931,8 @@ class TestS3ClientProvider(BaseAWSCommandParamsTest):
         self.assertEqual(s3_client, created_client)
         create_client_calls = session.create_client.call_args_list
         self.assertEqual(create_client_calls, [
-            mock.call('s3', 'us-west-1'),
-            mock.call('s3', 'us-west-2')
+            mock.call('s3', region_name='us-west-1'),
+            mock.call('s3', region_name='us-west-2')
         ])
         self.assertEqual(1, s3_client.get_bucket_location.call_count)
 


### PR DESCRIPTION
Adds a nested client method for creating clients from within non-boto3 products. This is part of a new experimental plugins interface that we are intending to touch as little surface area as possible to start with; this will cause clients created internally from within s3transfer to not make use of the experimental interface.