### PR TITLE
Update README.rst to list 3.13.x as supported.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ The aws-cli package works on Python versions:
 -  3.10.x and greater
 -  3.11.x and greater
 -  3.12.x and greater
+-  3.13.x and greater
 
 Notices
 ~~~~~~~


### PR DESCRIPTION
*Description of changes:*

* Updates README to list Python 3.13.x as a supported version. 3.13 support was added in #9566.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
