### PR TITLE
Update documentation for default retry strategy change

### DIFF
--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -487,13 +487,13 @@ These configuration variables control how the AWS CLI retries requests.
     A string representing the type of retries the AWS CLI will perform.  Value
     values are:
 
-        * ``legacy`` - The pre-existing retry behavior.  This is default value if
-          no retry mode is provided.
         * ``standard`` - A standardized set of retry rules across the AWS SDKs.
           This includes a standard set of errors that are retried as well as
           support for retry quotas, which limit the number of unsuccessful retries
           an SDK can make.  This mode will default the maximum number of attempts
-          to 3 unless a ``max_attempts`` is explicitly provided.
+          to 3 unless a ``max_attempts`` is explicitly provided. This is default
+          value if no retry mode is provided.
+        * ``legacy`` - The pre-existing retry behavior.
         * ``adaptive`` - An experimental retry mode that includes all the
           functionality of ``standard`` mode along with automatic client side
           throttling.  This is a provisional mode that may change behavior in

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -493,12 +493,15 @@ These configuration variables control how the AWS CLI retries requests.
           an SDK can make.  This mode will default the maximum number of attempts
           to 3 unless a ``max_attempts`` is explicitly provided. This is default
           value if no retry mode is provided.
-        * ``legacy`` - The pre-existing retry behavior.
+        * ``legacy`` - The pre-existing retry behavior. This mode will default the
+          maximum number of attempts to 5.
         * ``adaptive`` - An experimental retry mode that includes all the
           functionality of ``standard`` mode along with automatic client side
           throttling.  This is a provisional mode that may change behavior in
           the future.
 
+For more information, see `Available retry modes <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-retries.html#cli-usage-retries-modes>`__
+in the *AWS CLI User Guide*.
 
 Amazon S3
 ---------

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -500,8 +500,8 @@ These configuration variables control how the AWS CLI retries requests.
           throttling.  This is a provisional mode that may change behavior in
           the future.
 
-For more information, see `Available retry modes <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-retries.html#cli-usage-retries-modes>`__
-in the *AWS CLI User Guide*.
+    For more information, see `Available retry modes <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-retries.html#cli-usage-retries-modes>`__
+    in the *AWS CLI User Guide*.
 
 Amazon S3
 ---------


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/boto/botocore/pull/3513/

*Description of changes:*

Updates the configuration options topic guide for retries to indicate the default is changing from `legacy` to `standard`.

The [AWS CLI user guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-retries.html) will be updated separately to reflect the change as well.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
