### PR TITLE
Move datetime.datetime.utcnow usage to consolidated function

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -13,6 +13,7 @@
 
 import collections.abc as collections_abc
 import contextlib
+import datetime
 import io
 import locale
 import os
@@ -502,3 +503,13 @@ except ImportError:
         if _id:
             id = _id
         return distname, version, id
+
+
+def get_current_datetime(remove_tzinfo=True):
+    # TODO: Consolidate to botocore.compat.get_current_datetime
+    # after it's had time to bake to avoid import errors with
+    # mismatched versions.
+    datetime_now = datetime.datetime.now(datetime.timezone.utc)
+    if remove_tzinfo:
+        datetime_now = datetime_now.replace(tzinfo=None)
+    return datetime_now

--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -17,10 +17,10 @@ import logging
 import botocore
 import collections
 
+from awscli.compat import get_current_datetime
 from awscli.customizations.cloudformation import exceptions
 from awscli.customizations.cloudformation.artifact_exporter import mktempfile, parse_s3_url
 
-from datetime import datetime
 
 LOG = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class Deployer(object):
         :return:
         """
 
-        now = datetime.utcnow().isoformat()
+        now = get_current_datetime().isoformat()
         description = "Created by AWS CLI at {0} UTC".format(now)
 
         # Each changeset will get a unique name based on time

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -19,7 +19,7 @@ import re
 import sys
 import zlib
 from zlib import error as ZLibError
-from datetime import datetime, timedelta
+from datetime import timedelta
 from dateutil import tz, parser
 
 from pyasn1.error import PyAsn1Error
@@ -29,6 +29,7 @@ from awscli.customizations.cloudtrail.utils import get_trail_by_arn, \
     get_account_id_from_arn
 from awscli.customizations.commands import BasicCommand
 from botocore.exceptions import ClientError
+from awscli.compat import get_current_datetime
 from awscli.schema import ParameterRequiredError
 from awscli.utils import create_nested_client
 
@@ -432,7 +433,7 @@ class DigestTraverser(object):
         :param end_date: Date to stop validating at (inclusive).
         """
         if end_date is None:
-            end_date = datetime.utcnow()
+            end_date = get_current_datetime()
         end_date = normalize_date(end_date)
         start_date = normalize_date(start_date)
         bucket = self.starting_bucket
@@ -735,7 +736,7 @@ class CloudTrailValidateLogs(BasicCommand):
         if args.end_time:
             self.end_time = normalize_date(parse_date(args.end_time))
         else:
-            self.end_time = normalize_date(datetime.utcnow())
+            self.end_time = normalize_date(get_current_datetime())
         if self.start_time > self.end_time:
             raise ValueError(('Invalid time range specified: start-time must '
                               'occur before end-time'))

--- a/awscli/customizations/codecommit.py
+++ b/awscli/customizations/codecommit.py
@@ -16,13 +16,12 @@ import re
 import sys
 import logging
 import fileinput
-import datetime
 
 from botocore.auth import SigV4Auth
 from botocore.awsrequest import AWSRequest
 from botocore.compat import urlsplit
 from awscli.customizations.commands import BasicCommand
-from awscli.compat import NonTranslatedStdout
+from awscli.compat import NonTranslatedStdout, get_current_datetime
 
 logger = logging.getLogger('botocore.credentials')
 
@@ -150,7 +149,7 @@ class CodeCommitGetCommand(BasicCommand):
         request = AWSRequest()
         request.url = url_to_sign
         request.method = 'GIT'
-        now = datetime.datetime.utcnow()
+        now = get_current_datetime()
         request.context['timestamp'] = now.strftime('%Y%m%dT%H%M%S')
         split = urlsplit(request.url)
         # we don't want to include the port number in the signature

--- a/awscli/customizations/codedeploy/push.py
+++ b/awscli/customizations/codedeploy/push.py
@@ -16,13 +16,12 @@ import sys
 import zipfile
 import tempfile
 import contextlib
-from datetime import datetime
 
 from botocore.exceptions import ClientError
 
 from awscli.customizations.codedeploy.utils import validate_s3_location
 from awscli.customizations.commands import BasicCommand
-from awscli.compat import BytesIO, ZIP_COMPRESSION_MODE
+from awscli.compat import BytesIO, ZIP_COMPRESSION_MODE, get_current_datetime
 from awscli.utils import create_nested_client
 
 ONE_MB = 1 << 20
@@ -132,7 +131,7 @@ class Push(BasicCommand):
         if not parsed_args.description:
             parsed_args.description = (
                 'Uploaded by AWS CLI {0} UTC'.format(
-                    datetime.utcnow().isoformat()
+                    get_current_datetime().isoformat()
                 )
             )
 

--- a/awscli/customizations/datapipeline/__init__.py
+++ b/awscli/customizations/datapipeline/__init__.py
@@ -12,10 +12,11 @@
 # language governing permissions and limitations under the License.
 
 import json
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from awscli.formatter import get_formatter
 from awscli.arguments import CustomArgument
+from awscli.compat import get_current_datetime
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.datapipeline import translator
 from awscli.customizations.datapipeline.createdefaultroles \
@@ -184,7 +185,7 @@ class QueryArgBuilder(object):
     """
     def __init__(self, current_time=None):
         if current_time is None:
-            current_time = datetime.utcnow()
+            current_time = get_current_datetime()
         self.current_time = current_time
 
     def build_query(self, parsed_args):

--- a/awscli/customizations/ec2/bundleinstance.py
+++ b/awscli/customizations/ec2/bundleinstance.py
@@ -18,6 +18,7 @@ import base64
 import datetime
 
 from awscli.arguments import CustomArgument
+from awscli.compat import get_current_datetime
 
 logger = logging.getLogger('ec2bundleinstance')
 
@@ -117,7 +118,7 @@ def _generate_policy(params):
     # Called if there is no policy supplied by the user.
     # Creates a policy that provides access for 24 hours.
     delta = datetime.timedelta(hours=24)
-    expires = datetime.datetime.utcnow() + delta
+    expires = get_current_datetime() + delta
     expires_iso = expires.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     policy = POLICY.format(expires=expires_iso,
                            bucket=params['Bucket'],

--- a/awscli/customizations/eks/get_token.py
+++ b/awscli/customizations/eks/get_token.py
@@ -16,12 +16,13 @@ import json
 import os
 import sys
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from botocore.signers import RequestSigner
 from botocore.model import ServiceId
 
 from awscli.formatter import get_formatter
 from awscli.utils import create_nested_client
+from awscli.compat import get_current_datetime
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import uni_print
 from awscli.customizations.utils import validate_mutually_exclusive
@@ -107,7 +108,7 @@ class GetTokenCommand(BasicCommand):
     ]
 
     def get_expiration_time(self):
-        token_expiration = datetime.utcnow() + timedelta(
+        token_expiration = get_current_datetime() + timedelta(
             minutes=TOKEN_EXPIRATION_MINS
         )
         return token_expiration.strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/awscli/customizations/opsworks.py
+++ b/awscli/customizations/opsworks.py
@@ -24,7 +24,7 @@ import textwrap
 
 from botocore.exceptions import ClientError
 
-from awscli.compat import urlopen, ensure_text_type
+from awscli.compat import get_current_datetime, urlopen, ensure_text_type
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.utils import create_client_from_parsed_globals
 
@@ -505,7 +505,7 @@ class OpsWorksRegister(BasicCommand):
             "Resource": arn,
         }
         if timeout is not None:
-            valid_until = datetime.datetime.utcnow() + timeout
+            valid_until = get_current_datetime() + timeout
             statement["Condition"] = {
                 "DateLessThan": {
                     "aws:CurrentTime":

--- a/tests/functional/ec2/test_bundle_instance.py
+++ b/tests/functional/ec2/test_bundle_instance.py
@@ -31,7 +31,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
 
     def setUp(self):
         super(TestBundleInstance, self).setUp()
-        # This mocks out datetime.datetime.utcnow() so that it always
+        # This mocks out datetime.datetime.now() so that it always
         # returns the same datetime object.  This is because this value
         # is embedded into the policy file that is generated and we
         # don't what the policy or its signature to change each time
@@ -41,7 +41,7 @@ class TestBundleInstance(BaseAWSCommandParamsTest):
             mock.Mock(wraps=datetime.datetime)
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(2013, 8, 9)
+        mocked_datetime.now.return_value = datetime.datetime(2013, 8, 9)
 
     def tearDown(self):
         super(TestBundleInstance, self).tearDown()

--- a/tests/functional/rds/test_generate_db_auth_token.py
+++ b/tests/functional/rds/test_generate_db_auth_token.py
@@ -51,7 +51,7 @@ class TestGenerateDBAuthToken(BaseAWSCommandParamsTest):
         clock = datetime.datetime(2016, 11, 7, 17, 39, 33, tzinfo=tzutc())
 
         with mock.patch('datetime.datetime') as dt:
-            dt.utcnow.return_value = clock
+            dt.now.return_value = clock
             stdout, _, _ = self.run_cmd(command, expected_rc=0)
 
         expected = (

--- a/tests/functional/s3/test_presign_command.py
+++ b/tests/functional/s3/test_presign_command.py
@@ -17,7 +17,7 @@ from awscli.testutils import BaseAWSCommandParamsTest, mock, temporary_file
 from awscli.testutils import create_clidriver
 
 
-# Values used to fix time.time() and datetime.datetime.utcnow()
+# Values used to fix time.time() and datetime.datetime.now()
 # so we know the exact values of the signatures generated.
 FROZEN_TIMESTAMP = 1471305652
 DEFAULT_EXPIRES = 3600
@@ -75,7 +75,7 @@ class TestPresignCommand(BaseAWSCommandParamsTest):
     def get_presigned_url_for_cmd(self, cmdline):
         with mock.patch('time.time', FROZEN_TIME):
             with mock.patch('datetime.datetime') as d:
-                d.utcnow = FROZEN_DATETIME
+                d.now = FROZEN_DATETIME
                 stdout = self.assert_params_for_cmd(cmdline, None)[0].strip()
                 return stdout
 

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -59,7 +59,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
@@ -74,7 +74,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_fips_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()
@@ -89,7 +89,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
     @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
     def test_integration_vpc_using_cli_driver(self, dt_mock, stdout_mock):
-        dt_mock.utcnow.return_value = datetime(2010, 10, 8)
+        dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
         rc = driver.main('codecommit credential-helper get'.split())
         output = stdout_mock.getvalue().strip()

--- a/tests/integration/customizations/test_codecommit.py
+++ b/tests/integration/customizations/test_codecommit.py
@@ -16,6 +16,7 @@ import os
 
 from datetime import datetime
 
+import awscli.compat
 from awscli.compat import StringIO
 from botocore.session import Session
 from botocore.credentials import Credentials
@@ -57,7 +58,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
 
     @mock.patch('sys.stdin', StringIO(PROTOCOL_HOST_PATH))
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
-    @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
+    @mock.patch.object(awscli.compat.datetime, 'datetime', wraps=datetime)
     def test_integration_using_cli_driver(self, dt_mock, stdout_mock):
         dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
@@ -72,7 +73,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
 
     @mock.patch('sys.stdin', StringIO(FIPS_PROTOCOL_HOST_PATH))
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
-    @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
+    @mock.patch.object(awscli.compat.datetime, 'datetime', wraps=datetime)
     def test_integration_fips_using_cli_driver(self, dt_mock, stdout_mock):
         dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()
@@ -87,7 +88,7 @@ class TestCodeCommitCredentialHelper(unittest.TestCase):
 
     @mock.patch('sys.stdin', StringIO(VPC_PROTOCOL_HOST_PATH))
     @mock.patch('sys.stdout', new_callable=StringIOWithFileNo)
-    @mock.patch.object(awscli.customizations.codecommit.datetime, 'datetime')
+    @mock.patch.object(awscli.compat.datetime, 'datetime', wraps=datetime)
     def test_integration_vpc_using_cli_driver(self, dt_mock, stdout_mock):
         dt_mock.now.return_value = datetime(2010, 10, 8)
         driver = create_clidriver()

--- a/tests/unit/customizations/test_opsworks.py
+++ b/tests/unit/customizations/test_opsworks.py
@@ -32,7 +32,7 @@ class TestOpsWorksBase(unittest.TestCase):
             mock.Mock(wraps=datetime.datetime)
         )
         mocked_datetime = self.datetime_patcher.start()
-        mocked_datetime.utcnow.return_value = datetime.datetime(
+        mocked_datetime.now.return_value = datetime.datetime(
             2013, 8, 9, 23, 42)
 
     def tearDown(self):


### PR DESCRIPTION
*Description of changes:*
This PR moves our use of datetime.utcnow() to datetime.now() to avoid deprecation warnings in Python 3.12+. It's accompanied by similar changes in botocore which this PR is reliant on for testing.

We're currently duplicating the `get_current_datetime` function in the CLI v1 code base to avoid import issues when paired with an incorrect version of Botocore. In a future release, we can consolidate the two to using `botocore.compat`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
