### PR TITLE
Deleting all versions of objects

### DIFF
--- a/.changes/next-release/enhancement-s3-34855.json
+++ b/.changes/next-release/enhancement-s3-34855.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "`s3`",
+  "description": "Add all-versions flag with AWS CLI S3 rm command to delete all versions of objects present in a versioned-enabled bucket. fixes `#4070 <https://github.com/aws/aws-cli/issues/4070>`__"
+}

--- a/awscli/customizations/s3/fileinfo.py
+++ b/awscli/customizations/s3/fileinfo.py
@@ -109,3 +109,37 @@ class FileInfo:
         # restored back to S3.
         # 'Restore' looks like: 'ongoing-request="false", expiry-date="..."'
         return 'ongoing-request="false"' in response_data.get('Restore', '')
+
+
+class VersionedFileInfo(FileInfo):
+    def __init__(self, version_id=None, is_delete_marker=False, **kwargs):
+        """
+        This class extends FileInfo to include version information for S3 objects.
+        It is specifically designed for operations that need to work with versioned
+        S3 objects, such as deleting all versions of an object.
+
+        :param version_id: The version ID of the S3 object.
+        :type version_id: string
+        """
+        super().__init__(**kwargs)
+        self.version_id = version_id
+
+    def is_glacier_compatible(self):
+        """
+        Determines glacier compatibility for versioned S3 objects, with special handling for delete operations.
+
+        This method overrides the parent FileInfo.is_glacier_compatible() to provide enhanced
+        compatibility checking for S3 objects stored in glacier storage classes
+        when versioning is enabled on the bucket.
+
+        This method override allows delete operations to proceed on versioned glacier objects.
+        Since delete operations on glacier objects succeed regardless of storage class
+
+        :rtype: bool
+        :returns: True if the operation can proceed on glacier objects (specifically for delete
+                operations on versioned objects), False if the operation would fail due to
+                glacier storage class restrictions
+        """
+        if self.operation_name == 'delete':
+            return True
+        return super().is_glacier_compatible()

--- a/awscli/s3transfer/constants.py
+++ b/awscli/s3transfer/constants.py
@@ -36,3 +36,4 @@ FULL_OBJECT_CHECKSUM_ARGS = [
 
 USER_AGENT = f's3transfer/{s3transfer.__version__}'
 PROCESS_USER_AGENT = f'{USER_AGENT} processpool'
+MAX_BATCH_SIZE = 1000

--- a/awscli/s3transfer/delete.py
+++ b/awscli/s3transfer/delete.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from s3transfer.tasks import SubmissionTask, Task
 
 
@@ -69,3 +70,78 @@ class DeleteObjectTask(Task):
 
         """
         client.delete_object(Bucket=bucket, Key=key, **extra_args)
+
+
+class BatchDeleteSubmissionTask(SubmissionTask):
+    """Task for submitting tasks to execute batch deletion of S3 objects"""
+
+    def _submit(self, client, request_executor, transfer_future, **kwargs):
+        """
+        :param client: The client associated with the transfer manager
+
+        :type config: s3transfer.manager.TransferConfig
+        :param config: The transfer config associated with the transfer
+            manager
+
+        :type osutil: s3transfer.utils.OSUtil
+        :param osutil: The os utility associated to the transfer manager
+
+        :type request_executor: s3transfer.futures.BoundedExecutor
+        :param request_executor: The request executor associated with the
+            transfer manager
+
+        :type transfer_future: s3transfer.futures.TransferFuture
+        :param transfer_future: The transfer future associated with the
+            transfer request that tasks are being submitted for
+        """
+        call_args = transfer_future.meta.call_args
+
+        # Extract the objects to delete from the call_args
+        bucket = call_args.bucket
+        objects = call_args.objects
+        extra_args = call_args.extra_args or {}
+
+        self._transfer_coordinator.submit(
+            request_executor,
+            BatchDeleteObjectsTask(
+                transfer_coordinator=self._transfer_coordinator,
+                main_kwargs={
+                    'client': client,
+                    'bucket': bucket,
+                    'objects': objects,
+                    'extra_args': extra_args,
+                },
+                is_final=True,
+            ),
+        )
+
+
+class BatchDeleteObjectsTask(Task):
+    def _main(self, client, bucket, objects, extra_args):
+        """
+        Delete multiple objects in a single API call
+
+        :param client: The S3 client to use when calling DeleteObjects
+
+        :type bucket: str
+        :param bucket: The name of the bucket.
+
+        :type objects: list
+        :param objects: The list of objects to delete.
+
+        :type extra_args: dict
+        :param extra_args: Extra arguments to pass to the DeleteObjects call.
+        """
+        # Create a copy of extra_args to avoid modifying the original
+        extra_args_copy = extra_args.copy()
+
+        # Create the request body
+        delete_request = {
+            'Objects': objects,
+            'Quiet': False,
+        }
+
+        response = client.delete_objects(
+            Bucket=bucket, Delete=delete_request, **extra_args_copy
+        )
+        return response

--- a/tests/functional/s3transfer/test_delete.py
+++ b/tests/functional/s3transfer/test_delete.py
@@ -74,3 +74,76 @@ class TestDeleteObject(BaseGeneralInterfaceTest):
         )
         with self.assertRaisesRegex(ValueError, 'methods do not support'):
             self.manager.delete(s3_object_lambda_arn, self.key)
+
+
+class TestBatchDelete(BaseGeneralInterfaceTest):
+    __test__ = True
+
+    def setUp(self):
+        super().setUp()
+        self.bucket = 'mybucket'
+        self.key = 'mykey'
+        self.objects = [
+            {'Key': self.key, 'VersionId': 'version1'},
+            {'Key': self.key, 'VersionId': 'deletemarker1'},
+        ]
+        self.manager = TransferManager(self.client)
+
+    @property
+    def method(self):
+        """The transfer manager method to invoke i.e. upload()"""
+        return self.manager.batch_delete
+
+    def create_call_kwargs(self):
+        """The kwargs to be passed to the transfer manager method"""
+        return {
+            'bucket': self.bucket,
+            'objects': self.objects,
+        }
+
+    def create_invalid_extra_args(self):
+        return {
+            'BadKwargs': True,
+        }
+
+    def create_stubbed_responses(self):
+        """A list of stubbed responses that will cause the request to succeed
+
+        The elements of this list is a dictionary that will be used as key
+        word arguments to botocore.Stubber.add_response(). For example::
+
+            [{'method': 'delete_objects', 'service_response': {}}]
+        """
+        return [
+            {
+                'method': 'delete_objects',
+                'service_response': {},
+                'expected_params': {
+                    'Bucket': self.bucket,
+                    'Delete': {'Objects': self.objects, 'Quiet': False},
+                },
+            }
+        ]
+
+    def create_expected_progress_callback_info(self):
+        return []
+
+    def test_known_allowed_args_in_input_shape(self):
+        op_model = self.client.meta.service_model.operation_model(
+            'DeleteObjects'
+        )
+        allowed_delete_objects_args = [
+            arg
+            for arg in self.manager.ALLOWED_DELETE_ARGS
+            if arg != 'VersionId'
+        ]
+        for allowed_arg in allowed_delete_objects_args:
+            self.assertIn(allowed_arg, op_model.input_shape.members)
+
+    def test_raise_exception_on_s3_object_lambda_resource(self):
+        s3_object_lambda_arn = (
+            'arn:aws:s3-object-lambda:us-west-2:123456789012:'
+            'accesspoint:my-accesspoint'
+        )
+        with self.assertRaisesRegex(ValueError, 'methods do not support'):
+            self.manager.batch_delete(s3_object_lambda_arn, self.key)

--- a/tests/integration/s3transfer/test_delete.py
+++ b/tests/integration/s3transfer/test_delete.py
@@ -26,3 +26,22 @@ class TestDeleteObject(BaseTransferManagerIntegTest):
         future.result()
 
         self.assertTrue(self.object_not_exists(key_name))
+
+
+class TestBatchDeleteObject(BaseTransferManagerIntegTest):
+    def test_can_delete_versioned_objects(self):
+        key_name = 'mykey'
+        self.client.put_object(
+            Bucket=self.bucket_name, Key=key_name, Body=b'hello world'
+        )
+        response = self.client.list_object_versions(Bucket=self.bucket_name)
+        version_id = response['Versions'][0]['VersionId']
+        objects = [{'Key': key_name, 'VersionId': version_id}]
+        transfer_manager = self.create_transfer_manager()
+        future = transfer_manager.batch_delete(
+            bucket=self.bucket_name, objects=objects
+        )
+
+        future.result()
+
+        self.assertTrue(self.object_not_exists(key_name))


### PR DESCRIPTION
*Issue* :https://github.com/aws/aws-cli/issues/4070

Description of changes:
Added a flag for deleting all versions of an object present in a versioned-enable bucket. For dealing with versions, a `list-object-versions` api is called to get the `version ids` as well as `delete markers` of the objects. Once the object and their version ids are retrieved, then a batch of objects with their version id is created which is passed to `delete-objects` api for deletion. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
