### PR TITLE
Clarify SSO to only suggest a different device when using `--use-device-code

### DIFF
--- a/.changes/next-release/enhancement-sso-54764.json
+++ b/.changes/next-release/enhancement-sso-54764.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``sso``",
+  "description": "Clarify ``aws sso login`` to only suggest a different device when using ``--use-device-code``."
+}

--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -179,13 +179,21 @@ class OpenBrowserHandler(BaseAuthorizationhandler):
     def __call__(
         self, userCode, verificationUri, verificationUriComplete, **kwargs
     ):
-        opening_msg = (
-            f'Attempting to automatically open the SSO authorization page in '
-            f'your default browser.\nIf the browser does not open or you wish '
-            f'to use a different device to authorize this request, open the '
-            f'following URL:\n'
-            f'\n{verificationUri}\n'
-        )
+        if userCode: # only the device code flow supports different devices
+            opening_msg = (
+                f'Attempting to automatically open the SSO authorization page '
+                f'in your default browser.\nIf the browser does not open or '
+                f'you wish to use a different device to authorize this '
+                f'request, open the following URL:\n'
+                f'\n{verificationUri}\n'
+            )
+        else:
+            opening_msg = (
+                f'Attempting to automatically open the SSO authorization page '
+                f'in your default browser.\nIf the browser does not open, open '
+                f'the following URL:\n'
+                f'\n{verificationUri}\n'
+            )
 
         user_code_msg = f'\nThen enter the code:\n\n{userCode}\n'
         uni_print(opening_msg, self._outfile)


### PR DESCRIPTION
*Issue #, if available:* P250288278

*Description of changes:* From the internal ticket, when we added the auth code + PKCE flow, I reused the `opening_msg` which includes _"...you wish to use a different device..."_.

This is misleading for auth code flow, since you must use the same device to handle the callback.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
