### PR TITLE
Mark additional tests for model validation for socialmessaging

### DIFF
--- a/tests/functional/botocore/test_socialmessaging.py
+++ b/tests/functional/botocore/test_socialmessaging.py
@@ -32,7 +32,7 @@ def _get_all_xform_operations():
 
 XFORM_OPERATIONS = _get_all_xform_operations()
 
-
+@pytest.mark.validates_models
 @pytest.mark.parametrize("operation, replacement", XFORM_OPERATIONS)
 def test_known_replacements(operation, replacement):
     # Validates that if a replacement shows up in the lowercased version of an


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

Adds `@pytest.mark.validates_models` to an additional test related to model validation for the `socialmessaging` service.

Related commit for `botocore`: https://github.com/boto/botocore/commit/1971a6401d500de7527989040ec88b08c875cd5a

*Testing*

Ran the following to confirm the tests were run with the marker (added the `-v` flag to the test runner):

```
(venv-cliv2) ➜  tests git:(socialmessaging-model-validation) ✗ ../scripts/ci/run-tests ./functional/botocore/test_socialmessaging.py --markers "validates_models" --junit-xml-path test-report.xml 
CDing to /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests
Running pytest --junit-xml=/Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests/test-report.xml -m validates_models --numprocesses=auto --dist=loadfile --maxprocesses=4 -v ./functional/botocore/test_socialmessaging.py...
============================================================== test session starts ===============================================================
platform darwin -- Python 3.13.3, pytest-7.4.0, pluggy-1.6.0 -- /Users/kdaily/workspaces/add-whatsapp-name-validation/venv-cliv2/bin/python3.13
cachedir: .pytest_cache
rootdir: /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli
configfile: pyproject.toml
plugins: xdist-3.1.0, cov-4.1.0
[gw0] darwin Python 3.13.3 cwd: /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests
[gw1] darwin Python 3.13.3 cwd: /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests
[gw2] darwin Python 3.13.3 cwd: /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests
[gw3] darwin Python 3.13.3 cwd: /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests
[gw0] Python 3.13.3 (v3.13.3:6280bb54784, Apr  8 2025, 10:47:54) [Clang 15.0.0 (clang-1500.3.9.4)]
[gw1] Python 3.13.3 (v3.13.3:6280bb54784, Apr  8 2025, 10:47:54) [Clang 15.0.0 (clang-1500.3.9.4)]
[gw2] Python 3.13.3 (v3.13.3:6280bb54784, Apr  8 2025, 10:47:54) [Clang 15.0.0 (clang-1500.3.9.4)]
[gw3] Python 3.13.3 (v3.13.3:6280bb54784, Apr  8 2025, 10:47:54) [Clang 15.0.0 (clang-1500.3.9.4)]
gw0 [18] / gw1 [18] / gw2 [18] / gw3 [18]
scheduling tests via LoadFileScheduling

functional/botocore/test_socialmessaging.py::test_known_replacements[AssociateWhatsAppBusinessAccount-whatsapp] 
[gw0] [  5%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[AssociateWhatsAppBusinessAccount-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[CreateWhatsAppMessageTemplate-whatsapp] 
[gw0] [ 11%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[CreateWhatsAppMessageTemplate-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[CreateWhatsAppMessageTemplateFromLibrary-whatsapp] 
[gw0] [ 16%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[CreateWhatsAppMessageTemplateFromLibrary-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[CreateWhatsAppMessageTemplateMedia-whatsapp] 
[gw0] [ 22%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[CreateWhatsAppMessageTemplateMedia-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[DeleteWhatsAppMessageMedia-whatsapp] 
[gw0] [ 27%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[DeleteWhatsAppMessageMedia-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[DeleteWhatsAppMessageTemplate-whatsapp] 
[gw0] [ 33%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[DeleteWhatsAppMessageTemplate-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[DisassociateWhatsAppBusinessAccount-whatsapp] 
[gw0] [ 38%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[DisassociateWhatsAppBusinessAccount-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[GetLinkedWhatsAppBusinessAccount-whatsapp] 
[gw0] [ 44%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[GetLinkedWhatsAppBusinessAccount-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[GetLinkedWhatsAppBusinessAccountPhoneNumber-whatsapp] 
[gw0] [ 50%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[GetLinkedWhatsAppBusinessAccountPhoneNumber-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[GetWhatsAppMessageMedia-whatsapp] 
[gw0] [ 55%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[GetWhatsAppMessageMedia-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[GetWhatsAppMessageTemplate-whatsapp] 
[gw0] [ 61%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[GetWhatsAppMessageTemplate-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[ListLinkedWhatsAppBusinessAccounts-whatsapp] 
[gw0] [ 66%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[ListLinkedWhatsAppBusinessAccounts-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[ListWhatsAppMessageTemplates-whatsapp] 
[gw0] [ 72%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[ListWhatsAppMessageTemplates-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[ListWhatsAppTemplateLibrary-whatsapp] 
[gw0] [ 77%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[ListWhatsAppTemplateLibrary-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[PostWhatsAppMessageMedia-whatsapp] 
[gw0] [ 83%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[PostWhatsAppMessageMedia-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[PutWhatsAppBusinessAccountEventDestinations-whatsapp] 
[gw0] [ 88%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[PutWhatsAppBusinessAccountEventDestinations-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[SendWhatsAppMessage-whatsapp] 
[gw0] [ 94%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[SendWhatsAppMessage-whatsapp] 
functional/botocore/test_socialmessaging.py::test_known_replacements[UpdateWhatsAppMessageTemplate-whatsapp] 
[gw0] [100%] PASSED functional/botocore/test_socialmessaging.py::test_known_replacements[UpdateWhatsAppMessageTemplate-whatsapp] 

-------------------- generated xml file: /Users/kdaily/workspaces/add-whatsapp-name-validation/aws-cli/tests/test-report.xml ---------------------
=============================================================== 18 passed in 2.52s ===============================================================
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
