### PR TITLE
Improve User Experience in Linux and Windows

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -450,7 +450,7 @@ class ResultPrinter(BaseResultHandler):
         self._add_progress_if_needed()
 
     def _add_progress_if_needed(self):
-        LOGGER.debug("Remaining Progrss %s",self._has_remaining_progress())
+        LOGGER.debug("Remaining Progrss %s", self._has_remaining_progress())
         if self._has_remaining_progress():
             self._print_progress()
 
@@ -519,11 +519,15 @@ class ResultPrinter(BaseResultHandler):
         return print_statement + ending_char
 
     def _has_remaining_progress(self):
-        LOGGER.debug("Expected Files %s", self._result_recorder.expected_totals_are_final())
+        LOGGER.debug(
+            "Expected Files %s",
+            self._result_recorder.expected_totals_are_final(),
+        )
         if not self._result_recorder.expected_totals_are_final():
             return True
         actual = self._result_recorder.files_transferred
         expected = self._result_recorder.expected_files_transferred
+        LOGGER.debug("Actual %s Expected %s", actual, expected)
         return actual != expected
 
     def _print_to_out_file(self, statement):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -450,7 +450,7 @@ class ResultPrinter(BaseResultHandler):
         self._add_progress_if_needed()
 
     def _add_progress_if_needed(self):
-        LOGGER.debug("Remaining Progrss %s", self._has_remaining_progress())
+        LOGGER.debug("Remaining Progrss %s",self._has_remaining_progress())
         if self._has_remaining_progress():
             self._print_progress()
 
@@ -519,10 +519,7 @@ class ResultPrinter(BaseResultHandler):
         return print_statement + ending_char
 
     def _has_remaining_progress(self):
-        LOGGER.debug(
-            "Expected Files %s",
-            self._result_recorder.expected_totals_are_final(),
-        )
+        LOGGER.debug("Expected Files %s", self._result_recorder.expected_totals_are_final())
         if not self._result_recorder.expected_totals_are_final():
             return True
         actual = self._result_recorder.files_transferred

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -30,6 +30,7 @@ from awscli.customizations.s3.results import (
     ResultPrinter,
     ResultProcessor,
     ResultRecorder,
+    SkipFileResult,
     SuccessResult,
 )
 from awscli.customizations.s3.subscribers import (
@@ -462,10 +463,16 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
         if not self._cli_params.get('no_overwrite'):
             return False
         fileout = self._get_fileout(fileinfo)
+        result_kwargs = {
+            'transfer_type': 'download',
+            'src': fileinfo.src,
+            'dest': fileinfo.dest,
+        }
         if os.path.exists(fileout):
             LOGGER.debug(
                 f"warning: skipping {fileinfo.src} -> {fileinfo.dest}, file exists at destination"
             )
+            self._result_queue.put(SkipFileResult(**result_kwargs))
             return True
         return False
 
@@ -538,11 +545,17 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
 
         bucket, key = find_bucket_key(fileinfo.dest)
         client = fileinfo.source_client
+        result_kwargs = {
+            'transfer_type': 'copy',
+            'src': fileinfo.src,
+            'dest': fileinfo.dest,
+        }
         try:
             client.head_object(Bucket=bucket, Key=key)
             LOGGER.debug(
                 f"warning: skipping {fileinfo.src} -> {fileinfo.dest}, file exists at destination"
             )
+            self._result_queue.put(SkipFileResult(**result_kwargs))
             return True
         except ClientError as e:
             if e.response['Error']['Code'] == '404':


### PR DESCRIPTION

*Description of changes:*
In Current Implementation all the events(Success, Failure, Warning) are handled by result queue. Where every file_transferred is accounted for any of the three events. In case of `--include` and `--exclude`, the files which are supposed to be filtered out are done before initiating the actual transfer hence, they is no issue in those cases.

While in case of `no-overwrite` transfer actually happens so for the files which are skipped a new result queue must be added and those files that are skipped must be properly handled. Here is the example how we can deal with the solution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
