### PR TITLE
[v2] Validate multipart download content ranges

### DIFF
--- a/.changes/next-release/feature-download-58503.json
+++ b/.changes/next-release/feature-download-58503.json
@@ -1,0 +1,5 @@
+{
+  "type": "feature",
+  "category": "s3 download",
+  "description": "Validate requested range matches content range in response for multipart downloads"
+}

--- a/awscli/s3transfer/exceptions.py
+++ b/awscli/s3transfer/exceptions.py
@@ -39,3 +39,7 @@ class FatalError(CancelledError):
     """A CancelledError raised from an error in the TransferManager"""
 
     pass
+
+
+class S3ValidationError(Exception):
+    pass


### PR DESCRIPTION
Add runtime validation to ensure that the fetched content ranges match the requested ranges for multipart downloads.