### PR TITLE
remove the very last import of "six"

### DIFF
--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -23,11 +23,10 @@ import re
 import shlex
 import signal
 import urllib.parse as urlparse
+from collections import OrderedDict
 from configparser import RawConfigParser
 from urllib.error import URLError
 from urllib.request import urlopen
-
-from botocore.compat import six, OrderedDict
 
 import sys
 import zipfile


### PR DESCRIPTION
Hi,

Here is as scalled down redo of #9286

> We'd be open to accepting a PR that specifically removes the six import from awscli.compat,
> but that's likely the extent of the changes we'd want at this time.
