### PR TITLE
[v2] Fix HTTP 100 Continue parsing to accept optional reason phrase

### DIFF
--- a/awscli/botocore/awsrequest.py
+++ b/awscli/botocore/awsrequest.py
@@ -219,9 +219,9 @@ class AWSConnection:
 
     def _is_100_continue_status(self, maybe_status_line):
         parts = maybe_status_line.split(None, 2)
-        # Check for HTTP/<version> 100 Continue\r\n
+        # Check for HTTP/<version> 100 Continue\r\n or HTTP/<version> 100\r\n
         return (
-            len(parts) >= 3
+            len(parts) >= 2
             and parts[0].startswith(b'HTTP/')
             and parts[1] == b'100'
         )


### PR DESCRIPTION
*Issue #, if available:*
aws-cli: N/A
botocore: https://github.com/boto/botocore/issues/3455
Fixed in botocore 1.40.21

*Description of changes:*
Fix 100-continue behaviour with servers that do not send the optional reason phrase on 100-continue responses.
See https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1

AWS CLI v1 regularly updates boto / botocore, the newest version includes the fix.
AWS CLI v2 seems to have a copy of some old version of boto / botocore that needs a separate fix.

--------------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
