### PR TITLE
Fix HTTP 100 Continue parsing to accept optional reason phrase

### DIFF
--- a/awscli/botocore/awsrequest.py
+++ b/awscli/botocore/awsrequest.py
@@ -221,7 +221,7 @@ class AWSConnection:
         parts = maybe_status_line.split(None, 2)
         # Check for HTTP/<version> 100 Continue\r\n
         return (
-            len(parts) >= 3
+            len(parts) >= 2
             and parts[0].startswith(b'HTTP/')
             and parts[1] == b'100'
         )


### PR DESCRIPTION
Merged in Botocore: https://github.com/boto/botocore/pull/3543

Fixes HTTP 100 Continue parsing to accept responses without reason phrases, as allowed by RFC9110. The `_is_100_continue_status()` method currently requires exactly 3 parts (`HTTP/1.1 100 Continue`), which prevents botocore from recognizing valid HTTP 100 responses, causing the client to never see "100 Continue response seen". This breaks compatibility with legitimate HTTP servers that follow the current HTTP specification. The fix changes `len(parts) >= 3` to `len(parts) >= 2` to accept both formats (`HTTP/1.1 100 Continue` or `HTTP/1.1 100`) while maintaining backward compatibility with existing servers.