### PR TITLE
Silence session-manager-plugin check

### DIFF
--- a/awscli/customizations/ecs/executecommand.py
+++ b/awscli/customizations/ecs/executecommand.py
@@ -13,7 +13,7 @@
 import errno
 import json
 import logging
-from subprocess import check_call
+from subprocess import check_call, DEVNULL
 
 from awscli.clidriver import CLIOperationCaller, ServiceOperation
 from awscli.compat import ignore_user_entered_signals
@@ -75,7 +75,7 @@ class ExecuteCommandCaller(CLIOperationCaller):
             # before calling execute-command to ensure that
             # session-manager-plugin is installed
             # before execute-command-command is made
-            check_call(["session-manager-plugin"])
+            check_call(["session-manager-plugin"], stdout=DEVNULL)
             client = self._session.create_client(
                 service_name,
                 region_name=parsed_globals.region,


### PR DESCRIPTION
*Issue:*

Same as #6653. Every time you run `aws ecs execute-command` there is an annoying message from `session-manager-plugin`:

```console
$ aws ecs execute-command --cluster … --interactive --command /bin/sh

The Session Manager plugin was installed successfully. Use the AWS CLI to start a session.

…
```

*Description of changes:*

Send the output of `session-manager-plugin` to /dev/null when its presence is checked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
