### PR TITLE
Fix CancelledError retry loops to enable immediate S3 upload cancellation

### DIFF
--- a/.changes/next-release/bugfix-s3-89705.json
+++ b/.changes/next-release/bugfix-s3-89705.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``s3``",
+  "description": "Fix CancelledError retry loops to enable immediate S3 upload cancellation"
+}

--- a/awscli/botocore/httpsession.py
+++ b/awscli/botocore/httpsession.py
@@ -28,6 +28,8 @@ from urllib3.util.ssl_ import (
 )
 from urllib3.util.url import parse_url
 
+from concurrent.futures import CancelledError
+
 try:
     from urllib3.util.ssl_ import OP_NO_TICKET, PROTOCOL_TLS_CLIENT
 except ImportError:
@@ -497,6 +499,8 @@ class URLLib3Session:
             raise ConnectionClosedError(
                 error=e, request=request, endpoint_url=request.url
             )
+        except CancelledError:
+            raise
         except Exception as e:
             message = 'Exception received when sending urllib3 HTTP request'
             logger.debug(message, exc_info=True)

--- a/tests/unit/botocore/test_http_session.py
+++ b/tests/unit/botocore/test_http_session.py
@@ -18,6 +18,7 @@ from botocore.httpsession import (
     mask_proxy_url,
 )
 from urllib3.exceptions import NewConnectionError, ProtocolError, ProxyError
+from concurrent.futures import CancelledError
 
 from tests import mock, unittest
 
@@ -462,6 +463,12 @@ class TestURLLib3Session(unittest.TestCase):
         error = ProtocolError(None)
         with pytest.raises(ConnectionClosedError):
             self.make_request_with_error(error)
+
+    def test_catches_cancelled_error(self):
+        self.connection.urlopen.side_effect = CancelledError()
+        session = URLLib3Session()
+        with pytest.raises(CancelledError):
+            session.send(self.request.prepare())
 
     def test_catches_proxy_error(self):
         self.connection.urlopen.side_effect = ProxyError('test', None)


### PR DESCRIPTION
Copy from Botocore: https://github.com/boto/botocore/pull/3552 

This fix ensures that Ctrl-C and other cancellation signals immediately stop S3 uploads by preventing CancelledError retry loops in the HTTP session, allowing users to terminate operations promptly instead of waiting through lengthy retry cycles. Adding a specific exception handler for CancelledError in httpsession.py that re-raises the error unchanged before it reaches the generic handler. This prevents the cancellation signal from being misclassified as a retryable HTTP error.