### PR TITLE
Fix printing bugs when using no-overwrite flag

### DIFF
--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -457,24 +457,16 @@ class ResultPrinter(BaseResultHandler):
         if self._has_remaining_progress():
             self._print_progress()
         else:
-            LOGGER.debug(f"No progress remaining, length: {self._progress_length}")
             self._clear_progress_if_no_more_expected_transfers(ending_char='\r')
 
     def _print_progress(self, **kwargs):
-        # Get all of the statistics in the correct form.
-
-        # For downloads, we know how many are skipped in advanced due to listing directory.
-        # so expected already takes into account the skips
-
-        # For uploads, we only know after the transfer, so expected does not take into account the skips
-
+        # Get all the statistics in the correct form.
         remaining_files = self._get_expected_total(
             str(
                 self._result_recorder.expected_files_transferred
                 - (self._result_recorder.files_transferred + self._result_recorder.files_skipped)
             )
         )
-        LOGGER.debug(f"expected files transferred={self._result_recorder.expected_files_transferred}, files_transferred={self._result_recorder.files_transferred}, files_skipped={self._result_recorder.files_skipped}")
 
         # Create the display statement.
         if self._result_recorder.expected_bytes_transferred > 0:
@@ -537,7 +529,6 @@ class ResultPrinter(BaseResultHandler):
             return True
         actual = self._result_recorder.files_transferred + self._result_recorder.files_skipped
         expected = self._result_recorder.expected_files_transferred
-        LOGGER.debug(f"Result recorder expected totals not final. Actual={actual}, expected={expected}")
         return actual != expected
 
     def _print_to_out_file(self, statement):
@@ -549,7 +540,6 @@ class ResultPrinter(BaseResultHandler):
     def _clear_progress_if_no_more_expected_transfers(self, ending_char='\n', **kwargs):
         if self._progress_length and not self._has_remaining_progress():
             uni_print(self._adjust_statement_padding('', ending_char=ending_char), self._out_file)
-            LOGGER.debug("Cleared progress;")
 
 
 class NoProgressResultPrinter(ResultPrinter):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -390,10 +390,7 @@ class ResultPrinter(BaseResultHandler):
         pass
 
     def _print_skip(self, **kwargs):
-        # First, try to print nothing but call redisplay progress for consistency
-        # if that doesn't work, can try printing all spaces with carriage return line ending
-
-        # specify False for reset progress length since this result printer doesnt print newline
+        # Don't reset progress length since this result printer doesn't print a newline
         self._redisplay_progress(reset_progress_length=False)
 
     def _print_dry_run(self, result, **kwargs):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -453,7 +453,8 @@ class ResultPrinter(BaseResultHandler):
         # Reset to zero because done statements are printed with new lines
         # meaning there are no carriage returns to take into account when
         # printing the next line.
-        self._progress_length = 0
+        if reset_progress_length:
+            self._progress_length = 0
         self._add_progress_if_needed()
 
     def _add_progress_if_needed(self):

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -311,7 +311,6 @@ class ResultRecorder(BaseResultHandler):
 
     def _record_skipped_file_result(self, result, **kwargs):
         self.files_skipped += 1
-        # self.files_transferred += 1
 
     def _record_warning_result(self, **kwargs):
         self.files_warned += 1
@@ -466,12 +465,19 @@ class ResultPrinter(BaseResultHandler):
 
     def _print_progress(self, **kwargs):
         # Get all of the statistics in the correct form.
+
+        # For downloads, we know how many are skipped in advanced due to listing directory.
+        # so expected already takes into account the skips
+
+        # For uploads, we only know after the transfer, so expected does not take into account the skips
+
         remaining_files = self._get_expected_total(
             str(
                 self._result_recorder.expected_files_transferred
-                - self._result_recorder.files_transferred
+                - (self._result_recorder.files_transferred + self._result_recorder.files_skipped)
             )
         )
+        LOGGER.debug(f"expected files transferred={self._result_recorder.expected_files_transferred}, files_transferred={self._result_recorder.files_transferred}, files_skipped={self._result_recorder.files_skipped}")
 
         # Create the display statement.
         if self._result_recorder.expected_bytes_transferred > 0:

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -462,6 +462,7 @@ class ResultPrinter(BaseResultHandler):
             self._print_progress()
         else:
             LOGGER.debug(f"No progress remaining, length: {self._progress_length}")
+            self._clear_progress_if_no_more_expected_transfers(ending_char='\r')
 
     def _print_progress(self, **kwargs):
         # Get all of the statistics in the correct form.
@@ -542,9 +543,9 @@ class ResultPrinter(BaseResultHandler):
     def _print_to_error_file(self, statement):
         uni_print(statement, self._error_file)
 
-    def _clear_progress_if_no_more_expected_transfers(self, **kwargs):
+    def _clear_progress_if_no_more_expected_transfers(self, ending_char='\n', **kwargs):
         if self._progress_length and not self._has_remaining_progress():
-            uni_print(self._adjust_statement_padding(''), self._out_file)
+            uni_print(self._adjust_statement_padding('', ending_char=ending_char), self._out_file)
             LOGGER.debug("Cleared progress;")
 
 

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -393,7 +393,9 @@ class ResultPrinter(BaseResultHandler):
     def _print_skip(self, **kwargs):
         # First, try to print nothing but call redisplay progress for consistency
         # if that doesn't work, can try printing all spaces with carriage return line ending
-        self._redisplay_progress()
+
+        # specify False for reset progress length since this result printer doesnt print newline
+        self._redisplay_progress(reset_progress_length=False)
 
     def _print_dry_run(self, result, **kwargs):
         statement = self.DRY_RUN_FORMAT.format(
@@ -447,7 +449,7 @@ class ResultPrinter(BaseResultHandler):
             src=result.src, dest=result.dest
         )
 
-    def _redisplay_progress(self):
+    def _redisplay_progress(self, reset_progress_length=True):
         # Reset to zero because done statements are printed with new lines
         # meaning there are no carriage returns to take into account when
         # printing the next line.

--- a/awscli/customizations/s3/results.py
+++ b/awscli/customizations/s3/results.py
@@ -460,6 +460,8 @@ class ResultPrinter(BaseResultHandler):
     def _add_progress_if_needed(self):
         if self._has_remaining_progress():
             self._print_progress()
+        else:
+            LOGGER.debug(f"No progress remaining, length: {self._progress_length}")
 
     def _print_progress(self, **kwargs):
         # Get all of the statistics in the correct form.
@@ -529,8 +531,9 @@ class ResultPrinter(BaseResultHandler):
     def _has_remaining_progress(self):
         if not self._result_recorder.expected_totals_are_final():
             return True
-        actual = self._result_recorder.files_transferred
+        actual = self._result_recorder.files_transferred + self._result_recorder.files_skipped
         expected = self._result_recorder.expected_files_transferred
+        LOGGER.debug(f"Result recorder expected totals not final. Actual={actual}, expected={expected}")
         return actual != expected
 
     def _print_to_out_file(self, statement):

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -462,16 +462,10 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
         if not self._cli_params.get('no_overwrite'):
             return False
         fileout = self._get_fileout(fileinfo)
-        result_kwargs = {
-            'transfer_type': 'download',
-            'src': fileinfo.src,
-            'dest': fileinfo.dest,
-        }
         if os.path.exists(fileout):
             LOGGER.debug(
                 f"warning: skipping {fileinfo.src} -> {fileinfo.dest}, file exists at destination"
             )
-            self._result_queue.put(SkipFileResult(**result_kwargs))
             return True
         return False
 

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -538,17 +538,11 @@ class CopyRequestSubmitter(BaseTransferRequestSubmitter):
 
         bucket, key = find_bucket_key(fileinfo.dest)
         client = fileinfo.source_client
-        result_kwargs = {
-            'transfer_type': 'copy',
-            'src': fileinfo.src,
-            'dest': fileinfo.dest,
-        }
         try:
             client.head_object(Bucket=bucket, Key=key)
             LOGGER.debug(
                 f"warning: skipping {fileinfo.src} -> {fileinfo.dest}, file exists at destination"
             )
-            self._result_queue.put(SkipFileResult(**result_kwargs))
             return True
         except ClientError as e:
             if e.response['Error']['Code'] == '404':

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -30,7 +30,7 @@ from awscli.customizations.s3.results import (
     ResultPrinter,
     ResultProcessor,
     ResultRecorder,
-    SuccessResult, SkipFileResult,
+    SuccessResult,
 )
 from awscli.customizations.s3.subscribers import (
     CopyPropsSubscriberFactory,

--- a/tests/unit/customizations/s3/test_results.py
+++ b/tests/unit/customizations/s3/test_results.py
@@ -10,8 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from s3transfer.exceptions import CancelledError, FatalError
 from botocore.exceptions import HTTPClientError
+from s3transfer.exceptions import CancelledError, FatalError
 
 from awscli.compat import StringIO, queue
 from awscli.customizations.s3.results import (


### PR DESCRIPTION
*Description of changes:*

* Fixed bug when using `--no-overwrite` parameter where the last character printed to CLI would be a carriage return (`\r`), which would cause incompatibility with some terminal program (e.g. Windows Powershell).
  * Keep track of files skipped for determining whether there is progress remaining in `ResultPrinter`.
  * Update files remaining progress to take into account files skipped.
  * Add support for results that do not print newlines (e.g. new `SkipFileResult`).
  * Modify result handling in `ResultPrinter` so that they can opt-out of resetting `progress_length` to 0. Useful for result handlers that do not print newlines (e.g. new `SkipFileResult`).

*Description of tests:*

* Manually tested changes on Windows Powershell, with uploads, bucket-to-bucket copies, and downloads. Verified the bug is fixed in all three cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
