### PR TITLE
[v2] Implement full object checksum validation for multipart downloads

### DIFF
--- a/awscli/botocore/httpchecksum.py
+++ b/awscli/botocore/httpchecksum.py
@@ -75,6 +75,10 @@ class Crc32Checksum(BaseChecksum):
     def digest(self):
         return self._int_crc32.to_bytes(4, byteorder="big")
 
+    @property
+    def int_crc(self):
+        return self._int_crc32
+
 
 class CrtCrc32Checksum(BaseChecksum):
     # Note: This class is only used if the CRT is available
@@ -87,6 +91,10 @@ class CrtCrc32Checksum(BaseChecksum):
 
     def digest(self):
         return self._int_crc32.to_bytes(4, byteorder="big")
+
+    @property
+    def int_crc(self):
+        return self._int_crc32
 
 
 class CrtCrc32cChecksum(BaseChecksum):
@@ -101,6 +109,10 @@ class CrtCrc32cChecksum(BaseChecksum):
     def digest(self):
         return self._int_crc32c.to_bytes(4, byteorder="big")
 
+    @property
+    def int_crc(self):
+        return self._int_crc32
+
 
 class CrtCrc64NvmeChecksum(BaseChecksum):
     # Note: This class is only used if the CRT is available
@@ -113,6 +125,10 @@ class CrtCrc64NvmeChecksum(BaseChecksum):
 
     def digest(self):
         return self._int_crc64nvme.to_bytes(8, byteorder="big")
+
+    @property
+    def int_crc(self):
+        return self._int_crc32
 
 
 class Sha1Checksum(BaseChecksum):

--- a/awscli/botocore/httpchecksum.py
+++ b/awscli/botocore/httpchecksum.py
@@ -241,6 +241,10 @@ class StreamingChecksumBody(StreamingBody):
         self._checksum = checksum
         self._expected = expected
 
+    @property
+    def checksum(self):
+        return self._checksum
+
     def read(self, amt=None):
         chunk = super().read(amt=amt)
         self._checksum.update(chunk)

--- a/awscli/customizations/s3/filegenerator.py
+++ b/awscli/customizations/s3/filegenerator.py
@@ -389,6 +389,7 @@ class FileGenerator:
         try:
             params = {'Bucket': bucket, 'Key': key}
             params.update(self.request_parameters.get('HeadObject', {}))
+            params["ChecksumMode"] = "ENABLED"
             response = self._client.head_object(**params)
         except ClientError as e:
             # We want to try to give a more helpful error message.

--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -37,6 +37,7 @@ from awscli.customizations.s3.subscribers import (
     DeleteSourceFileSubscriber,
     DeleteSourceObjectSubscriber,
     DirectoryCreatorSubscriber,
+    ProvideChecksumSubscriber,
     ProvideETagSubscriber,
     ProvideLastModifiedTimeSubscriber,
     ProvideSizeSubscriber,
@@ -421,6 +422,9 @@ class DownloadRequestSubmitter(BaseTransferRequestSubmitter):
             subscribers.append(
                 DeleteSourceObjectSubscriber(fileinfo.source_client)
             )
+        subscribers.append(
+            ProvideChecksumSubscriber(fileinfo.associated_response_data)
+        )
 
     def _submit_transfer_request(self, fileinfo, extra_args, subscribers):
         bucket, key = find_bucket_key(fileinfo.src)

--- a/awscli/customizations/s3/subscribers.py
+++ b/awscli/customizations/s3/subscribers.py
@@ -16,6 +16,7 @@ import os
 import time
 
 from botocore.utils import percent_encode_sequence
+from s3transfer.checksums import provide_checksum_to_meta
 from s3transfer.subscribers import BaseSubscriber
 
 from awscli.customizations.s3 import utils
@@ -96,6 +97,26 @@ class ProvideETagSubscriber(BaseSubscriber):
                 'Not providing object ETag. Future: %s does not offer'
                 'the capability to notify the ETag of an object',
                 future,
+            )
+
+
+class ProvideChecksumSubscriber(BaseSubscriber):
+    """
+    A subscriber which provides the object stored checksum and algorithm.
+    """
+
+    def __init__(self, response_data):
+        self.response_data = response_data
+
+    def on_queued(self, future, **kwargs):
+        if hasattr(future.meta, 'provide_stored_checksum') and hasattr(
+            future.meta, 'provide_checksum_algorithm'
+        ):
+            provide_checksum_to_meta(self.response_data, future.meta)
+        else:
+            LOGGER.debug(
+                f"Not providing stored checksum. Future: {future} does not "
+                "offer the capability to notify the checksum of an object",
             )
 
 

--- a/awscli/s3transfer/checksums.py
+++ b/awscli/s3transfer/checksums.py
@@ -18,6 +18,20 @@ subject to abrupt breaking changes. Please do not use them directly.
 from copy import copy
 
 
+def provide_checksum_to_meta(response, transfer_meta):
+    stored_checksum = None
+    checksum_algorithm = None
+    checksum_type = response.get("ChecksumType")
+    if checksum_type and checksum_type == "FULL_OBJECT":
+        for crc_checksum in _CRC_CHECKSUM_TO_COMBINE_FUNCTION.keys():
+            if checksum_value := response.get(crc_checksum):
+                stored_checksum = checksum_value
+                checksum_algorithm = crc_checksum
+                break
+    transfer_meta.provide_checksum_algorithm(checksum_algorithm)
+    transfer_meta.provide_stored_checksum(stored_checksum)
+
+
 def combine_crc32(crc1, crc2, len2):
     """Combine two CRC32 values.
 

--- a/awscli/s3transfer/checksums.py
+++ b/awscli/s3transfer/checksums.py
@@ -20,6 +20,7 @@ from copy import copy
 from functools import cached_property
 
 from botocore.httpchecksum import CrtCrc32Checksum
+from s3transfer.exceptions import S3ValidationError
 
 
 class PartStreamingChecksumBody:
@@ -34,6 +35,10 @@ class PartStreamingChecksumBody:
         # it's updating (eg `botocore.httpchecksum.StreamingChecksumBody`),
         # reuse its calculated value.
         self._reuse_checksum = hasattr(self._stream, 'checksum')
+
+    @property
+    def checksum(self):
+        return self._checksum
 
     def read(self, *args, **kwargs):
         value = self._stream.read(*args, **kwargs)
@@ -106,7 +111,7 @@ class FullObjectChecksum:
 
     def validate(self):
         if self.calculated_checksum != self._stored_checksum:
-            raise ValueError(
+            raise S3ValidationError(
                 f"Calculated checksum {self.calculated_checksum} does not match "
                 f"stored checksum {self._stored_checksum}"
             )

--- a/awscli/s3transfer/checksums.py
+++ b/awscli/s3transfer/checksums.py
@@ -15,7 +15,95 @@ NOTE: All classes and functions in this module are considered private and are
 subject to abrupt breaking changes. Please do not use them directly.
 """
 
+import base64
 from copy import copy
+from functools import cached_property
+
+from botocore.httpchecksum import CrtCrc32cChecksum
+
+
+class PartStreamingChecksumBody:
+    def __init__(self, stream, starting_index, full_object_checksum):
+        self._stream = stream
+        self._starting_index = starting_index
+        self._checksum = CRC_CHECKSUM_CLS[
+            full_object_checksum.checksum_algorithm
+        ]()
+        self._full_object_checksum = full_object_checksum
+        # If the underlying stream already has a checksum object
+        # it's updating (eg `botocore.httpchecksum.StreamingChecksumBody`),
+        # reuse its calculated value.
+        self._reuse_checksum = hasattr(self._stream, 'checksum')
+
+    def read(self, *args, **kwargs):
+        value = self._stream.read(*args, **kwargs)
+        if not self._reuse_checksum:
+            self._checksum.update(value)
+        if not value:
+            self._set_part_checksum()
+        return value
+
+    def _set_part_checksum(self):
+        if not self._reuse_checksum:
+            value = self._checksum.int_crc
+        else:
+            value = self._stream.checksum.int_crc
+        self._full_object_checksum.set_part_checksum(
+            self._starting_index,
+            value,
+        )
+
+
+class FullObjectChecksum:
+    def __init__(self, checksum_algorithm, content_length):
+        self.checksum_algorithm = checksum_algorithm
+        self._content_length = content_length
+        self._combine_function = _CRC_CHECKSUM_TO_COMBINE_FUNCTION[
+            self.checksum_algorithm
+        ]
+        self._stored_checksum = None
+        self._part_checksums = None
+        self._calculated_checksum = None
+
+    @cached_property
+    def calculated_checksum(self):
+        if self._calculated_checksum is None:
+            self._combine_part_checksums()
+        return self._calculated_checksum
+
+    def set_stored_checksum(self, stored_checksum):
+        self._stored_checksum = stored_checksum
+
+    def set_part_checksum(self, offset, checksum):
+        if self._part_checksums is None:
+            self._part_checksums = {}
+        self._part_checksums[offset] = checksum
+
+    def _combine_part_checksums(self):
+        if self._part_checksums is None:
+            return
+        sorted_keys = sorted(self._part_checksums.keys())
+        combined = self._part_checksums[sorted_keys[0]]
+        for i, offset in enumerate(sorted_keys[1:]):
+            part_checksum = self._part_checksums[offset]
+            if i + 1 == len(sorted_keys) - 1:
+                next_offset = self._content_length
+            else:
+                next_offset = sorted_keys[i + 2]
+            offset_len = next_offset - offset
+            combined = self._combine_function(
+                combined, part_checksum, offset_len
+            )
+        self._calculated_checksum = base64.b64encode(
+            combined.to_bytes(4, byteorder='big')
+        ).decode('ascii')
+
+    def validate(self):
+        if self.calculated_checksum != self._stored_checksum:
+            raise ValueError(
+                f"Calculated checksum {self.calculated_checksum} does not match "
+                f"stored checksum {self._stored_checksum}"
+            )
 
 
 def provide_checksum_to_meta(response, transfer_meta):
@@ -105,4 +193,9 @@ def combine_crc32(crc1, crc2, len2):
 
 _CRC_CHECKSUM_TO_COMBINE_FUNCTION = {
     "ChecksumCRC32": combine_crc32,
+}
+
+
+CRC_CHECKSUM_CLS = {
+    "ChecksumCRC32": CrtCrc32Checksum,
 }

--- a/awscli/s3transfer/checksums.py
+++ b/awscli/s3transfer/checksums.py
@@ -1,0 +1,94 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+# http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""
+NOTE: All classes and functions in this module are considered private and are
+subject to abrupt breaking changes. Please do not use them directly.
+"""
+
+from copy import copy
+
+
+def combine_crc32(crc1, crc2, len2):
+    """Combine two CRC32 values.
+
+    :type crc1: int
+    :param crc1: Current CRC32 integer value.
+
+    :type crc2: int
+    :param crc2: Second CRC32 integer value to combine.
+
+    :type len2: int
+    :param len2: Length of data that produced `crc2`.
+
+    :rtype: int
+    :returns: Combined CRC32 integer value.
+    """
+    _GF2_DIM = 32
+    _CRC32_POLY = 0xEDB88320
+    _MASK_32BIT = 0xFFFFFFFF
+
+    def _gf2_matrix_times(mat, vec):
+        res = 0
+        idx = 0
+        while vec != 0:
+            if vec & 1:
+                res ^= mat[idx]
+            vec >>= 1
+            idx += 1
+        return res
+
+    def _gf2_matrix_square(square, mat):
+        res = copy(square)
+        for n in range(_GF2_DIM):
+            d = mat[n]
+            res[n] = _gf2_matrix_times(mat, d)
+        return res
+
+    even = [0] * _GF2_DIM
+    odd = [0] * _GF2_DIM
+
+    if len2 <= 0:
+        return crc1
+
+    odd[0] = _CRC32_POLY
+    row = 1
+    for i in range(1, _GF2_DIM):
+        odd[i] = row
+        row <<= 1
+
+    even = _gf2_matrix_square(even, odd)
+    odd = _gf2_matrix_square(odd, even)
+
+    while True:
+        even = _gf2_matrix_square(even, odd)
+        if len2 & 1:
+            crc1 = _gf2_matrix_times(even, crc1)
+        len2 >>= 1
+
+        if len2 == 0:
+            break
+
+        odd = _gf2_matrix_square(odd, even)
+        if len2 & 1:
+            crc1 = _gf2_matrix_times(odd, crc1)
+        len2 >>= 1
+
+        if len2 == 0:
+            break
+
+    return (crc1 ^ crc2) & _MASK_32BIT
+
+
+_CRC_CHECKSUM_TO_COMBINE_FUNCTION = {
+    "ChecksumCRC32": combine_crc32,
+}

--- a/awscli/s3transfer/download.py
+++ b/awscli/s3transfer/download.py
@@ -576,6 +576,7 @@ class DownloadSubmissionTask(SubmissionTask):
         if full_object_checksum is None:
             task = CompleteDownloadNOOPTask(
                 transfer_coordinator=self._transfer_coordinator,
+                is_final=False,
             )
         else:
             task = download_manager.get_validate_checksum_task(

--- a/awscli/s3transfer/futures.py
+++ b/awscli/s3transfer/futures.py
@@ -176,6 +176,7 @@ class TransferMeta(BaseTransferMeta):
             return None
         return self._checksum_algorithm
 
+    @property
     def checksum_is_provided(self):
         return (
             self._stored_checksum is not self._UNPROVIDED

--- a/awscli/s3transfer/futures.py
+++ b/awscli/s3transfer/futures.py
@@ -166,18 +166,21 @@ class TransferMeta(BaseTransferMeta):
 
     @property
     def stored_checksum(self):
+        """Stored full object checksum value, if any"""
         if self._stored_checksum is self._UNPROVIDED:
             return None
         return self._stored_checksum
 
     @property
     def checksum_algorithm(self):
+        """Algorithm used to compute stored full object checksum, if any"""
         if self._checksum_algorithm is self._UNPROVIDED:
             return None
         return self._checksum_algorithm
 
     @property
     def checksum_is_provided(self):
+        """Boolean used to check if checksum properties have been provided"""
         return (
             self._stored_checksum is not self._UNPROVIDED
             and self._checksum_algorithm is not self._UNPROVIDED
@@ -202,9 +205,21 @@ class TransferMeta(BaseTransferMeta):
         self._etag = etag
 
     def provide_stored_checksum(self, stored_checksum):
+        """A method to provide the stored checksum of a transfer request
+
+        By providing this value with `checksum_algorithm`, the TransferManager
+        will validate multipart downloads by calculating the
+        full object checksum and comparing it to the stored checksum.
+        """
         self._stored_checksum = stored_checksum
 
     def provide_checksum_algorithm(self, checksum_algorithm):
+        """A method to provide the checksum algorithm of a transfer request
+
+        By providing this value with `stored_checksum`, the TransferManager
+        will validate multipart downloads by calculating the
+        full object checksum and comparing it to the stored checksum.
+        """
         self._checksum_algorithm = checksum_algorithm
 
 

--- a/awscli/s3transfer/futures.py
+++ b/awscli/s3transfer/futures.py
@@ -122,12 +122,22 @@ class TransferFuture(BaseTransferFuture):
 class TransferMeta(BaseTransferMeta):
     """Holds metadata about the TransferFuture"""
 
+    _UNPROVIDED = object()
+
     def __init__(self, call_args=None, transfer_id=None):
         self._call_args = call_args
         self._transfer_id = transfer_id
         self._size = None
         self._user_context = {}
         self._etag = None
+
+        # These values are provided via initial HeadObject requests
+        # when downloading objects. But they're not guaranteed to be
+        # in the response, in which case `None` values will be provided.
+        # A sentinel value is set as the default so we can disambiguate
+        # between "no value provided yet" and "explicit `None` value provided".
+        self._stored_checksum = self._UNPROVIDED
+        self._checksum_algorithm = self._UNPROVIDED
 
     @property
     def call_args(self):
@@ -154,6 +164,24 @@ class TransferMeta(BaseTransferMeta):
         """The etag of the stored object for validating multipart downloads"""
         return self._etag
 
+    @property
+    def stored_checksum(self):
+        if self._stored_checksum is self._UNPROVIDED:
+            return None
+        return self._stored_checksum
+
+    @property
+    def checksum_algorithm(self):
+        if self._checksum_algorithm is self._UNPROVIDED:
+            return None
+        return self._checksum_algorithm
+
+    def checksum_is_provided(self):
+        return (
+            self._stored_checksum is not self._UNPROVIDED
+            and self._checksum_algorithm is not self._UNPROVIDED
+        )
+
     def provide_transfer_size(self, size):
         """A method to provide the size of a transfer request
 
@@ -171,6 +199,12 @@ class TransferMeta(BaseTransferMeta):
         the etag as the value to GetObject requests.
         """
         self._etag = etag
+
+    def provide_stored_checksum(self, stored_checksum):
+        self._stored_checksum = stored_checksum
+
+    def provide_checksum_algorithm(self, checksum_algorithm):
+        self._checksum_algorithm = checksum_algorithm
 
 
 class TransferCoordinator:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -93,6 +93,7 @@ from tests.utils.s3transfer import (
     RecordingSubscriber,
     FileSizeProvider,
     ETagProvider,
+    ChecksumProvider,
     RecordingOSUtils,
     RecordingExecutor,
     TransferCoordinatorWithInterrupt,

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -308,6 +308,7 @@ class TestCPCommand(BaseCPCommandTest):
                     {
                         'Bucket': 'bucket',
                         'Key': 'key.txt',
+                        'ChecksumMode': 'ENABLED',
                     },
                 )
             ]
@@ -349,6 +350,7 @@ class TestCPCommand(BaseCPCommandTest):
                     {
                         'Bucket': 'bucket',
                         'Key': 'key.txt',
+                        'ChecksumMode': 'ENABLED',
                     },
                 )
             ]
@@ -1305,7 +1307,10 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         self.assert_operations_called(
             [
                 self.head_object_request(
-                    'mybucket', 'mykey', RequestPayer='requester'
+                    'mybucket',
+                    'mykey',
+                    RequestPayer='requester',
+                    **{'ChecksumMode': "ENABLED"},
                 ),
                 self.get_object_request(
                     'mybucket', 'mykey', RequestPayer='requester'
@@ -1328,7 +1333,10 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         self.assert_operations_called(
             [
                 self.head_object_request(
-                    'mybucket', 'mykey', RequestPayer='requester'
+                    'mybucket',
+                    'mykey',
+                    RequestPayer='requester',
+                    **{'ChecksumMode': "ENABLED"},
                 ),
                 self.get_object_request(
                     'mybucket',
@@ -1380,7 +1388,10 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         self.assert_operations_called(
             [
                 self.head_object_request(
-                    'sourcebucket', 'sourcekey', RequestPayer='requester'
+                    'sourcebucket',
+                    'sourcekey',
+                    RequestPayer='requester',
+                    **{'ChecksumMode': "ENABLED"},
                 ),
                 self.copy_object_request(
                     'sourcebucket',
@@ -1409,7 +1420,10 @@ class TestCpCommandWithRequesterPayer(BaseCPCommandTest):
         self.assert_operations_called(
             [
                 self.head_object_request(
-                    'sourcebucket', 'sourcekey', RequestPayer='requester'
+                    'sourcebucket',
+                    'sourcekey',
+                    RequestPayer='requester',
+                    **{'ChecksumMode': "ENABLED"},
                 ),
                 self.create_mpu_request(
                     'mybucket', 'mykey', RequestPayer='requester'
@@ -1576,7 +1590,11 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [
-                self.head_object_request(self.accesspoint_arn, 'mykey'),
+                self.head_object_request(
+                    self.accesspoint_arn,
+                    'mykey',
+                    **{'ChecksumMode': "ENABLED"},
+                ),
                 self.get_object_request(self.accesspoint_arn, 'mykey'),
             ]
         )
@@ -1610,7 +1628,11 @@ class TestAccesspointCPCommand(BaseCPCommandTest):
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [
-                self.head_object_request(self.accesspoint_arn, 'mykey'),
+                self.head_object_request(
+                    self.accesspoint_arn,
+                    'mykey',
+                    **{'ChecksumMode': "ENABLED"},
+                ),
                 self.copy_object_request(
                     self.accesspoint_arn,
                     'mykey',

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -51,6 +51,7 @@ class TestMvCommand(BaseS3TransferCommandTest):
                     {
                         'Bucket': 'bucket',
                         'Key': 'key.txt',
+                        'ChecksumMode': 'ENABLED',
                     },
                 )
             ]
@@ -144,6 +145,7 @@ class TestMvCommand(BaseS3TransferCommandTest):
                         'Bucket': 'mybucket',
                         'Key': 'mykey',
                         'RequestPayer': 'requester',
+                        'ChecksumMode': 'ENABLED',
                     },
                 ),
                 (
@@ -179,7 +181,10 @@ class TestMvCommand(BaseS3TransferCommandTest):
         self.assert_operations_called(
             [
                 self.head_object_request(
-                    'sourcebucket', 'sourcekey', RequestPayer='requester'
+                    'sourcebucket',
+                    'sourcekey',
+                    RequestPayer='requester',
+                    **{'ChecksumMode': 'ENABLED'},
                 ),
                 self.copy_object_request(
                     'sourcebucket',
@@ -216,7 +221,9 @@ class TestMvCommand(BaseS3TransferCommandTest):
         self.run_cmd(cmdline, expected_rc=0)
         self.assert_operations_called(
             [
-                self.head_object_request('sourcebucket', 'sourcekey'),
+                self.head_object_request(
+                    'sourcebucket', 'sourcekey', **{'ChecksumMode': 'ENABLED'}
+                ),
                 self.get_object_tagging_request('sourcebucket', 'sourcekey'),
                 self.create_mpu_request('bucket', 'key', Metadata=metadata),
                 self.upload_part_copy_request(
@@ -269,7 +276,9 @@ class TestMvCommand(BaseS3TransferCommandTest):
         self.run_cmd(cmdline, expected_rc=1)
         self.assert_operations_called(
             [
-                self.head_object_request('sourcebucket', 'sourcekey'),
+                self.head_object_request(
+                    'sourcebucket', 'sourcekey', **{'ChecksumMode': 'ENABLED'}
+                ),
                 self.get_object_tagging_request('sourcebucket', 'sourcekey'),
                 self.create_mpu_request('bucket', 'key', Metadata=metadata),
                 self.upload_part_copy_request(

--- a/tests/functional/s3transfer/test_download.py
+++ b/tests/functional/s3transfer/test_download.py
@@ -60,6 +60,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         # Create a stream to read from
         self.content = b'my content'
         self.stream = BytesIO(self.content)
+        self.checksum_crc32 = "AUwfuQ=="
 
     def tearDown(self):
         super().tearDown()
@@ -106,10 +107,12 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         # that the stream is done.
         return [{'bytes_transferred': 10}]
 
-    def add_head_object_response(self, expected_params=None):
+    def add_head_object_response(self, expected_params=None, extras=None):
         head_response = self.create_stubbed_responses()[0]
         if expected_params:
             head_response['expected_params'] = expected_params
+        if extras:
+            head_response['service_response'].update(extras)
         self.stubber.add_response(**head_response)
 
     def add_successful_get_object_responses(
@@ -383,7 +386,9 @@ class TestNonRangedDownload(BaseDownloadTest):
             'Key': self.key,
             'RequestPayer': 'requester',
         }
-        self.add_head_object_response(expected_params)
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'}
+        )
         self.add_successful_get_object_responses(expected_params)
         future = self.manager.download(
             self.bucket, self.key, self.filename, self.extra_args
@@ -395,13 +400,13 @@ class TestNonRangedDownload(BaseDownloadTest):
             self.assertEqual(self.content, f.read())
 
     def test_download_with_checksum_enabled(self):
-        self.extra_args['ChecksumMode'] = 'ENABLED'
         expected_params = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'ChecksumMode': 'ENABLED',
         }
-        self.add_head_object_response(expected_params)
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'}
+        )
         self.add_successful_get_object_responses(expected_params)
         future = self.manager.download(
             self.bucket, self.key, self.filename, self.extra_args
@@ -518,7 +523,9 @@ class TestRangedDownload(BaseDownloadTest):
         }
         expected_ranges = ['bytes=0-3', 'bytes=4-7', 'bytes=8-']
         stubbed_ranges = ['bytes 0-3/10', 'bytes 4-7/10', 'bytes 8-9/10']
-        self.add_head_object_response(expected_params)
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'}
+        )
         self.add_successful_get_object_responses(
             {**expected_params, 'IfMatch': self.etag},
             expected_ranges,
@@ -535,14 +542,14 @@ class TestRangedDownload(BaseDownloadTest):
             self.assertEqual(self.content, f.read())
 
     def test_download_with_checksum_enabled(self):
-        self.extra_args['ChecksumMode'] = 'ENABLED'
         expected_params = {
             'Bucket': self.bucket,
             'Key': self.key,
-            'ChecksumMode': 'ENABLED',
         }
         expected_ranges = ['bytes=0-3', 'bytes=4-7', 'bytes=8-']
-        self.add_head_object_response(expected_params)
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'}
+        )
         self.add_successful_get_object_responses(
             {**expected_params, 'IfMatch': self.etag}, expected_ranges
         )
@@ -564,7 +571,9 @@ class TestRangedDownload(BaseDownloadTest):
         expected_ranges = ['bytes=0-3', 'bytes=4-7', 'bytes=8-']
         # Note that the final retrieved range should be `bytes 8-9/10`.
         stubbed_ranges = ['bytes 0-3/10', 'bytes 4-7/10', 'bytes 7-8/10']
-        self.add_head_object_response(expected_params)
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'}
+        )
         self.add_successful_get_object_responses(
             {**expected_params, 'IfMatch': self.etag},
             expected_ranges,
@@ -584,7 +593,9 @@ class TestRangedDownload(BaseDownloadTest):
             'Key': self.key,
         }
         expected_ranges = ['bytes=0-3', 'bytes=4-7']
-        self.add_head_object_response(expected_params)
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'}
+        )
 
         # Add successful GetObject responses for the first 2 requests.
         for i, stubbed_response in enumerate(
@@ -630,7 +641,7 @@ class TestRangedDownload(BaseDownloadTest):
             'service_response': {
                 'ContentLength': len(self.content),
             },
-            'expected_params': expected_params,
+            'expected_params': expected_params | {'ChecksumMode': 'ENABLED'},
         }
         self.stubber.add_response(**head_object_response)
 
@@ -647,3 +658,63 @@ class TestRangedDownload(BaseDownloadTest):
         # Ensure that the contents are correct
         with open(self.filename, 'rb') as f:
             self.assertEqual(self.content, f.read())
+
+    def test_download_full_object_checksum_validation(self):
+        self.extra_args['RequestPayer'] = 'requester'
+        expected_params = {
+            'Bucket': self.bucket,
+            'Key': self.key,
+            'RequestPayer': 'requester',
+        }
+        expected_ranges = ['bytes=0-3', 'bytes=4-7', 'bytes=8-']
+        stubbed_ranges = ['bytes 0-3/10', 'bytes 4-7/10', 'bytes 8-9/10']
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'},
+            {
+                "ChecksumCRC32": self.checksum_crc32,
+                "ChecksumType": "FULL_OBJECT",
+            },
+        )
+        self.add_successful_get_object_responses(
+            {**expected_params, 'IfMatch': self.etag},
+            expected_ranges,
+            [{"ContentRange": r} for r in stubbed_ranges],
+        )
+
+        future = self.manager.download(
+            self.bucket, self.key, self.filename, self.extra_args
+        )
+        future.result()
+
+        # Ensure that the contents are correct
+        with open(self.filename, 'rb') as f:
+            self.assertEqual(self.content, f.read())
+
+    def test_download_full_object_checksum_validation_mismatch_raises(self):
+        self.extra_args['RequestPayer'] = 'requester'
+        expected_params = {
+            'Bucket': self.bucket,
+            'Key': self.key,
+            'RequestPayer': 'requester',
+        }
+        expected_ranges = ['bytes=0-3', 'bytes=4-7', 'bytes=8-']
+        stubbed_ranges = ['bytes 0-3/10', 'bytes 4-7/10', 'bytes 8-9/10']
+        self.add_head_object_response(
+            expected_params | {'ChecksumMode': 'ENABLED'},
+            {"ChecksumCRC32": "badchecksum", "ChecksumType": "FULL_OBJECT"},
+        )
+        self.add_successful_get_object_responses(
+            {**expected_params, 'IfMatch': self.etag},
+            expected_ranges,
+            [{"ContentRange": r} for r in stubbed_ranges],
+        )
+
+        future = self.manager.download(
+            self.bucket, self.key, self.filename, self.extra_args
+        )
+        with self.assertRaises(S3ValidationError) as e:
+            future.result()
+        self.assertIn('does not match stored checksum', str(e.exception))
+
+        # Ensure no data is written to disk.
+        self.assertFalse(os.path.exists(self.filename))

--- a/tests/functional/s3transfer/test_download.py
+++ b/tests/functional/s3transfer/test_download.py
@@ -29,6 +29,7 @@ from s3transfer.manager import TransferConfig, TransferManager
 
 from tests import (
     BaseGeneralInterfaceTest,
+    ChecksumProvider,
     ETagProvider,
     FileSizeProvider,
     NonSeekableWriter,
@@ -311,6 +312,7 @@ class BaseDownloadTest(BaseGeneralInterfaceTest):
         call_kwargs['subscribers'] = [
             FileSizeProvider(len(self.content)),
             ETagProvider(self.etag),
+            ChecksumProvider({}),
         ]
 
         future = self.manager.download(**call_kwargs)

--- a/tests/unit/customizations/s3/test_s3handler.py
+++ b/tests/unit/customizations/s3/test_s3handler.py
@@ -43,6 +43,7 @@ from awscli.customizations.s3.subscribers import (
     DeleteSourceFileSubscriber,
     DeleteSourceObjectSubscriber,
     DirectoryCreatorSubscriber,
+    ProvideChecksumSubscriber,
     ProvideETagSubscriber,
     ProvideLastModifiedTimeSubscriber,
     ProvideSizeSubscriber,
@@ -524,6 +525,7 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
             QueuedResultSubscriber,
             DirectoryCreatorSubscriber,
             ProvideLastModifiedTimeSubscriber,
+            ProvideChecksumSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
         ]
@@ -670,6 +672,7 @@ class TestDownloadRequestSubmitter(BaseTransferRequestSubmitterTest):
             DirectoryCreatorSubscriber,
             ProvideLastModifiedTimeSubscriber,
             DeleteSourceObjectSubscriber,
+            ProvideChecksumSubscriber,
             ProgressResultSubscriber,
             DoneResultSubscriber,
         ]

--- a/tests/unit/s3transfer/test_checksums.py
+++ b/tests/unit/s3transfer/test_checksums.py
@@ -1,0 +1,155 @@
+from io import BytesIO
+
+import pytest
+from botocore.httpchecksum import CrtCrc32Checksum
+from s3transfer.checksums import (
+    FullObjectChecksum,
+    PartStreamingChecksumBody,
+    provide_checksum_to_meta,
+)
+from s3transfer.exceptions import S3ValidationError
+
+from tests import mock
+
+
+def read_from_stream(stream):
+    data = b""
+    val = stream.read()
+    while val:
+        data += val
+        val = stream.read()
+    return data
+
+
+@pytest.fixture
+def stream():
+    return BytesIO(b'hello world')
+
+
+@pytest.fixture
+def mock_full_object_checksum():
+    mock_full_object_checksum = mock.MagicMock(FullObjectChecksum)
+    mock_full_object_checksum.checksum_algorithm = 'ChecksumCRC32'
+    return mock_full_object_checksum
+
+
+@pytest.fixture
+def part_streaming_checksum_body(stream, mock_full_object_checksum):
+    return PartStreamingChecksumBody(stream, 0, mock_full_object_checksum)
+
+
+class TestPartStreamingChecksumBody:
+    def test_basic_read(self, part_streaming_checksum_body):
+        read_data = read_from_stream(part_streaming_checksum_body)
+        assert read_data == b'hello world'
+
+    def test_sets_part_checksum(
+        self, stream, mock_full_object_checksum, part_streaming_checksum_body
+    ):
+        read_from_stream(part_streaming_checksum_body)
+        mock_full_object_checksum.set_part_checksum.assert_called_with(
+            0, 222957957
+        )
+
+    def test_reuses_checksum(self, stream, mock_full_object_checksum):
+        mock_checksum = mock.MagicMock(CrtCrc32Checksum)
+        mock_checksum.int_crc = 111111111
+        stream.checksum = mock_checksum
+
+        part_streaming_checksum_body = PartStreamingChecksumBody(
+            stream, 0, mock_full_object_checksum
+        )
+        read_from_stream(part_streaming_checksum_body)
+        mock_full_object_checksum.set_part_checksum.assert_called_with(
+            0, 111111111
+        )
+
+
+class TestFullObjectChecksum:
+    def generate_part_checksum_bodies(self, n, full_object_checksum):
+        parts = []
+        for i in range(n):
+            parts.append(
+                PartStreamingChecksumBody(
+                    BytesIO(f"Part{i}".encode()),
+                    i * 5,
+                    full_object_checksum,
+                )
+            )
+        return parts
+
+    @pytest.mark.parametrize(
+        "n_parts,expected", [(2, "Fd9B+g=="), (10, "eywYgg==")]
+    )
+    def test_calculated_checksum(self, n_parts, expected):
+        full_object_checksum = FullObjectChecksum("ChecksumCRC32", 5 * n_parts)
+        parts = self.generate_part_checksum_bodies(
+            n_parts, full_object_checksum
+        )
+        for part in parts:
+            read_from_stream(part)
+        assert full_object_checksum.calculated_checksum == expected
+
+    def test_checksum_mismatch_raises(self):
+        n_parts = 10
+        full_object_checksum = FullObjectChecksum("ChecksumCRC32", 5 * n_parts)
+        parts = self.generate_part_checksum_bodies(
+            n_parts, full_object_checksum
+        )
+        for part in parts:
+            read_from_stream(part)
+        full_object_checksum.set_stored_checksum('foobar')
+        with pytest.raises(S3ValidationError) as exc_info:
+            full_object_checksum.validate()
+        assert "does not match stored checksum" in str(exc_info.value)
+
+    @pytest.mark.parametrize("content_length", [0, 49, 51])
+    def test_wrong_content_length_raises(self, content_length):
+        n_parts = 10
+        # Note that total content length should be `50`.
+        full_object_checksum = FullObjectChecksum(
+            "ChecksumCRC32", content_length
+        )
+        parts = self.generate_part_checksum_bodies(
+            n_parts, full_object_checksum
+        )
+        for part in parts:
+            read_from_stream(part)
+        full_object_checksum.set_stored_checksum("eywYgg==")
+        with pytest.raises(S3ValidationError) as exc_info:
+            full_object_checksum.validate()
+        assert "does not match stored checksum" in str(exc_info.value)
+
+
+class TestProvideChecksumToMeta:
+    def test_provides_checksum_to_meta(self):
+        response = {
+            "ChecksumType": "FULL_OBJECT",
+            "ChecksumCRC32": "foobar",
+        }
+        mock_transfer_meta = mock.Mock()
+        provide_checksum_to_meta(response, mock_transfer_meta)
+        mock_transfer_meta.provide_checksum_algorithm.assert_called_with(
+            "ChecksumCRC32"
+        )
+        mock_transfer_meta.provide_stored_checksum.assert_called_with("foobar")
+
+    def test_provides_none_if_composite(self):
+        response = {
+            "ChecksumType": "COMPOSITE",
+            "ChecksumCRC32": "foobar",
+        }
+        mock_transfer_meta = mock.Mock()
+        provide_checksum_to_meta(response, mock_transfer_meta)
+        mock_transfer_meta.provide_checksum_algorithm.assert_called_with(None)
+        mock_transfer_meta.provide_stored_checksum.assert_called_with(None)
+
+    def test_provides_none_if_not_crc(self):
+        response = {
+            "ChecksumType": "FULL_OBJECT",
+            "ChecksumFooBar": "foobar",
+        }
+        mock_transfer_meta = mock.Mock()
+        provide_checksum_to_meta(response, mock_transfer_meta)
+        mock_transfer_meta.provide_checksum_algorithm.assert_called_with(None)
+        mock_transfer_meta.provide_stored_checksum.assert_called_with(None)

--- a/tests/unit/s3transfer/test_futures.py
+++ b/tests/unit/s3transfer/test_futures.py
@@ -169,6 +169,27 @@ class TestTransferMeta(unittest.TestCase):
         self.transfer_meta.user_context['foo'] = 'bar'
         self.assertEqual(self.transfer_meta.user_context, {'foo': 'bar'})
 
+    def test_checksum(self):
+        self.transfer_meta.provide_stored_checksum('foo')
+        self.transfer_meta.provide_checksum_algorithm('bar')
+        self.assertEqual(self.transfer_meta.stored_checksum, 'foo')
+        self.assertEqual(self.transfer_meta.checksum_algorithm, 'bar')
+        self.assertTrue(self.transfer_meta.checksum_is_provided)
+
+    def test_checksum_not_provided(self):
+        self.assertFalse(self.transfer_meta.checksum_is_provided)
+        transfer_meta_with_checksum = TransferMeta()
+        transfer_meta_with_checksum.provide_stored_checksum('foo')
+        self.assertFalse(transfer_meta_with_checksum.checksum_is_provided)
+        transfer_meta_with_algorithm = TransferMeta()
+        transfer_meta_with_algorithm.provide_checksum_algorithm('bar')
+        self.assertFalse(transfer_meta_with_algorithm.checksum_is_provided)
+
+    def test_checksum_provided_none(self):
+        self.transfer_meta.provide_stored_checksum(None)
+        self.transfer_meta.provide_checksum_algorithm(None)
+        self.assertTrue(self.transfer_meta.checksum_is_provided)
+
 
 class TestTransferCoordinator(unittest.TestCase):
     def setUp(self):

--- a/tests/utils/s3transfer/__init__.py
+++ b/tests/utils/s3transfer/__init__.py
@@ -23,6 +23,7 @@ from unittest import mock  # noqa: F401
 
 import botocore.session
 from botocore.stub import Stubber
+from s3transfer.checksums import provide_checksum_to_meta
 from s3transfer.futures import (
     IN_MEMORY_DOWNLOAD_TAG,
     IN_MEMORY_UPLOAD_TAG,
@@ -160,6 +161,14 @@ class ETagProvider:
 
     def on_queued(self, future, **kwargs):
         future.meta.provide_object_etag(self.etag)
+
+
+class ChecksumProvider:
+    def __init__(self, response_data):
+        self.response_data = response_data
+
+    def on_queued(self, future, **kwargs):
+        provide_checksum_to_meta(self.response_data, future.meta)
 
 
 class FileCreator:


### PR DESCRIPTION
This PR implements full object checksum validation for multipart downloads when using the high-level `s3` command.

Currently, checksum validation is only done at the low-level S3 client level via Botocore. This current validation only happens when either the object is retrieved in a single GET request, or if the requested range of an object happens to fall in the same boundary as the part size (if the object was uploaded via MPU).

At a high-level:
1. Each download task calls an initial `HeadObject` (existing behavior), where it retrieves the stored checksum value and algorithm, if in the response.
2. If there's a stored checksum and the checksum type is `FULL_OBJECT` and the checksum algorithm is CRC-based, then it provides the checksum value and algorithm to the future meta.
3. If a multipart download is required and the checksum properties are provided to the future meta, then it'll create a `FullObjectChecksum` object that's responsible for storing part checksums and then later combining them to a full object checksum and validation.
4. As parts are being downloaded, the response streams are wrapped by `PartStreamingChecksumBody`. This class calculates the checksum for each part, unless the underlying stream is already calculating the checksum in which case the underlying stream's checksum is reused.
5. Once all part download tasks are completed, a final validation task is invoked. `FullObjectChecksum` combines all part-level checksums and then validates the calculated checksum against the stored checksum.

Note that `s3transfer.checksums.combine_crc32` will only be added to the S3Transfer library, not in AWS CLI v2's vended library because AWS CLI v2 can just use CRT's future bindings. It's included in this PR for now so reviewers can play around with it.

**To manually test:**
Upload an object with CRC32 with a single PUT request:
```
aws s3api put-object --body myobject --bucket mybucket --key mykey --checksum-algorithm CRC32
```

Ensure checksum type is `FULL_OBJECT` and has CRC32 checksum value:
```
aws s3api head-object --bucket mybucket --key mykey --checksum-mode ENABLED
{
    "AcceptRanges": "bytes",
    "LastModified": "2025-09-15T14:13:18+00:00",
    "ContentLength": 39542919,
    "ChecksumCRC32": "mychecksum",
    "ChecksumType": "FULL_OBJECT",
    "ETag": "\"myetag"",
    "ContentType": "application/octet-stream",
    "ServerSideEncryption": "AES256",
    "Metadata": {}
}
```

Download object using multipart ranged GETs:
```
aws s3 cp s3://mybucket/mykey /tmp/ --debug
```

In the debug logs you should see something like:
```
s3transfer.checksums - DEBUG - Successfully validated stored checksum mychecksum against calculated checksum mychecksum
```