### PR TITLE
Loosen test assertion that relies on static models

### DIFF
--- a/tests/functional/autocomplete/test_completer.py
+++ b/tests/functional/autocomplete/test_completer.py
@@ -163,15 +163,10 @@ class TestShorthandCompleter(unittest.TestCase):
             self.assertTrue(
                 all(
                     [
-                        suggest in expected_suggestions
-                        for suggest in displayed_suggestions
+                        suggest in displayed_suggestions
+                        for suggest in expected_suggestions
                     ]
                 ),
-                command_line,
-            )
-            self.assertEqual(
-                len(expected_suggestions),
-                len(displayed_suggestions),
                 command_line,
             )
 


### PR DESCRIPTION
Updates an assertion that relies on models not growing; if one of the models that uses `assert_command_generates_suggestions` were to grow, this test would begin failing.  This updates the assertion to ensure that the expected suggestions are present, but it allows new suggestions to be added as well.

An alternative to this PR would be overwriting the models in this test to be a frozen snapshot in time.  