### PR TITLE
Delete flaky integ test

### DIFF
--- a/tests/integration/botocore/test_smoke.py
+++ b/tests/integration/botocore/test_smoke.py
@@ -89,7 +89,6 @@ SMOKE_TESTS = {
     'sns': {'ListTopics': {}},
     'sqs': {'ListQueues': {}},
     'ssm': {'ListDocuments': {}},
-    'storagegateway': {'ListGateways': {}},
     # sts tests would normally go here, but
     # there aren't any calls you can make when
     # using session credentials so we don't run any


### PR DESCRIPTION
Port of https://github.com/boto/botocore/pull/3569/files, which deletes a flaky integ test that doesn't add any valuable assertions.  