### PR TITLE
Add exec-profile arguments to eks update-kubeconfig

### DIFF
--- a/.changes/next-release/enhancement-eks-73766.json
+++ b/.changes/next-release/enhancement-eks-73766.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "eks",
+  "description": "Add exec-profile argument to update-kubeconfig command. Fixes `#9759 <https://github.com/aws/aws-cli/issues/9759>`__"
+}

--- a/awscli/customizations/eks/update_kubeconfig.py
+++ b/awscli/customizations/eks/update_kubeconfig.py
@@ -106,6 +106,14 @@ class UpdateKubeconfigCommand(BasicCommand):
             'required': False
         },
         {
+            'name': 'exec-profile',
+            'help_text': ("Profile to use when getting the access token "
+                          "or assuming the role specified in --role-arn. "
+                          "This overrides the current session profile, which "
+                          "will otherwise be used."),
+            'required': False
+        },
+        {
             'name': 'assume-role-arn',
             'help_text': ('To assume a role for retrieving cluster information, '
                          'specify an IAM role ARN with this option. '
@@ -356,10 +364,10 @@ class EKSClient(object):
                 self._parsed_args.role_arn
             ])
 
-        if self._session.profile:
+        if self._session.profile or getattr(self._parsed_args, 'exec_profile', None):
             generated_user["user"]["exec"]["env"] = [OrderedDict([
                 ("name", "AWS_PROFILE"),
-                ("value", self._session.profile)
+                ("value", getattr(self._parsed_args, 'exec_profile', None) or self._session.profile)
             ])]
 
         return generated_user

--- a/tests/unit/customizations/eks/test_update_kubeconfig.py
+++ b/tests/unit/customizations/eks/test_update_kubeconfig.py
@@ -308,6 +308,22 @@ class TestEKSClient(unittest.TestCase):
         )
         self._session.create_client.assert_called_once_with("eks")
 
+    def test_exec_profile(self):
+        self._session.profile = "session-profile"
+        self._client = EKSClient(self._session, parsed_args=Namespace(cluster_name="ExampleCluster", role_arn=None, exec_profile="exec-profile"))
+        self._correct_user_entry["user"]["exec"]["env"] = [
+            OrderedDict([
+                ("name", "AWS_PROFILE"),
+                ("value", "exec-profile")
+            ])
+        ]
+        self.assertEqual(self._client.get_user_entry(),
+                         self._correct_user_entry)
+        self._mock_client.describe_cluster.assert_called_once_with(
+            name="ExampleCluster"
+        )
+        self._session.create_client.assert_called_once_with("eks")
+
     def test_create_user_with_alias(self):
         self._correct_user_entry["name"] = "alias"
         self.assertEqual(self._client.get_user_entry(user_alias="alias"),


### PR DESCRIPTION
*Issue #, if available:*
#9759

*Description of changes:*
Adds `--exec-profile` argument to `eks update-kubeconfig`. When set, this profile will be set as `AWS_PROFILE` within the generated kubeconfig. This allows for using one profile (the session profile) to _generate_ the config, without requiring that same profile for connecting to the cluster or for assuming the `--role-arn`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

I was unable to find any documentation on how to set up this repository for local development, so I'm not sure that my added unit test actually passes. We shall see what the CI says.
