### PR TITLE
Implement v2-debug checks for customizations, s3, and environment variables

### DIFF
--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -24,6 +24,7 @@ from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 
 from awscli.customizations.commands import BasicCommand
 from awscli.compat import get_stdout_text_writer
+from awscli.customizations.utils import uni_print
 from awscli.utils import create_nested_client, write_exception
 
 LOG = logging.getLogger(__name__)
@@ -321,12 +322,13 @@ class DeployCommand(BasicCommand):
                            parsed_args.execute_changeset, parsed_args.role_arn,
                            parsed_args.notification_arns, s3_uploader,
                            tags, parsed_args.fail_on_empty_changeset,
-                           parsed_args.disable_rollback)
+                           parsed_args.disable_rollback, parsed_args.v2_debug)
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
                notification_arns, s3_uploader, tags,
-               fail_on_empty_changeset=True, disable_rollback=False):
+               fail_on_empty_changeset=True, disable_rollback=False,
+               v2_debug=False):
         try:
             result = deployer.create_and_wait_for_changeset(
                 stack_name=stack_name,
@@ -339,10 +341,18 @@ class DeployCommand(BasicCommand):
                 tags=tags
             )
         except exceptions.ChangeEmptyError as ex:
-            # TODO print the runtime check for cli v2 breakage. technically won't be breaking if --fail-on-empty-changeset is
-            # explicitly provided. but we cannot differentiate between whether fail-on-empty-changeset is true because it's default
-            # or because it's explicitly specified.
             if fail_on_empty_changeset:
+                if v2_debug:
+                    uni_print(
+                        'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, '
+                        'deploying an AWS CloudFormation Template that '
+                        'results in an empty changeset will NOT result in an '
+                        'error. You can add the -–no-fail-on-empty-changeset '
+                        'flag to migrate to v2 behavior and resolve this '
+                        'warning. See https://docs.aws.amazon.com/cli/latest/'
+                        'userguide/cliv2-migration-changes.html'
+                        '#cliv2-migration-cfn.\n'
+                    )
                 raise
             write_exception(ex, outfile=get_stdout_text_writer())
             return 0

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -322,7 +322,7 @@ class DeployCommand(BasicCommand):
                            parsed_args.execute_changeset, parsed_args.role_arn,
                            parsed_args.notification_arns, s3_uploader,
                            tags, parsed_args.fail_on_empty_changeset,
-                           parsed_args.disable_rollback, parsed_args.v2_debug)
+                           parsed_args.disable_rollback, getattr(parsed_globals, 'v2_debug', False))
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -97,18 +97,71 @@ def resolve_cli_connect_timeout(parsed_args, session, **kwargs):
 
 def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
     if parsed_args.v2_debug:
-        url_params = [param for param in remaining_args if param.startswith('http://') or param.startswith('https://')]
+        url_params = [
+            param for param in remaining_args
+            if param.startswith('http://') or param.startswith('https://')
+        ]
+        if 'PYTHONUTF8' in os.environ or 'PYTHONIOENCODING' in os.environ:
+            if 'AWS_CLI_FILE_ENCODING' not in os.environ:
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2. AWS CLI v2 uses AWS_CLI_FILE_ENCODING '
+                    'instead, set this environment variable to resolve this. '
+                    'See https://docs.aws.amazon.com/cli/latest/userguide/'
+                    'cliv2-migration-changes.html'
+                    '#cliv2-migration-encodingenvvar.\n'
+                )
         if parsed_args.command == 'ecr' and remaining_args[0] == 'get-login':
-            uni_print('AWS CLI v2 MIGRATION WARNING: The ecr get-login command has been removed in AWS CLI v2. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-ecr-get-login.\n')
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: The ecr get-login command has '
+                'been removed in AWS CLI v2. See https://docs.aws.amazon.com/'
+                'cli/latest/userguide/cliv2-migration-changes.html'
+                '#cliv2-migration-ecr-get-login.\n'
+            )
         if url_params and session.full_config.get('cli_follow_urlparam', True):
-            uni_print('AWS CLI v2 MIGRATION WARNING: For input parameters that have a prefix of http:// or https://, AWS CLI v2 will no longer automatically request the content of the URL for the parameter, and the cli_follow_urlparam option has been removed. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-paramfile.\n')
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: For input parameters that have '
+                'a prefix of http:// or https://, AWS CLI v2 will no longer '
+                'automatically request the content of the URL for the '
+                'parameter, and the cli_follow_urlparam option has been '
+                'removed. See https://docs.aws.amazon.com/cli/latest/'
+                'userguide/cliv2-migration-changes.html'
+                '#cliv2-migration-paramfile.\n'
+            )
         for working, obsolete in HIDDEN_ALIASES.items():
             working_split = working.split('.')
             working_service = working_split[0]
             working_cmd = working_split[1]
             working_param = working_split[2]
-            if parsed_args.command == working_service and remaining_args[0] == working_cmd and f"--{working_param}" in remaining_args:
-                uni_print('AWS CLI v2 MIGRATION WARNING: You have entered command arguments that uses at least 1 of 21 hidden aliases that were removed in AWS CLI v2. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-aliases.\n')
+            if (
+                    parsed_args.command == working_service
+                    and remaining_args[0] == working_cmd
+                    and f"--{working_param}" in remaining_args
+            ):
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: You have entered command '
+                    'arguments that uses at least 1 of 21 hidden aliases that '
+                    'were removed in AWS CLI v2. See '
+                    'https://docs.aws.amazon.com/cli/latest/userguide'
+                    '/cliv2-migration-changes.html#cliv2-migration-aliases.\n'
+                )
+        session.register('choose-signer.s3.*', warn_if_sigv2)
+
+def warn_if_sigv2(
+        signing_name,
+        region_name,
+        signature_version,
+        context,
+        **kwargs
+):
+    if context.get('auth_type', None) == 'v2':
+        uni_print(
+            'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 only uses Signature '
+            'v4 to authenticate Amazon S3 requests. Run the command `aws '
+            'configure set s3.signature_version s3v4` to migrate to v4 and '
+            'resolve this.\n'
+        )
 
 def resolve_cli_read_timeout(parsed_args, session, **kwargs):
     arg_name = 'read_timeout'

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1019,7 +1019,7 @@ class CommandArchitecture(object):
 
         return sync_strategies
 
-    def run(self, v2_debug):
+    def run(self, v2_debug=False):
         """
         This function wires together all of the generators and completes
         the command.  First a dictionary is created that is indexed first by

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -775,7 +775,7 @@ class S3TransferCommand(S3Command):
                                   runtime_config)
         cmd.set_clients()
         cmd.create_instructions()
-        return cmd.run(parsed_globals.v2_debug)
+        return cmd.run(getattr(parsed_globals, 'v2_debug', False))
 
     def _build_call_parameters(self, args, command_params):
         """

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -775,7 +775,7 @@ class S3TransferCommand(S3Command):
                                   runtime_config)
         cmd.set_clients()
         cmd.create_instructions()
-        return cmd.run()
+        return cmd.run(parsed_globals.v2_debug)
 
     def _build_call_parameters(self, args, command_params):
         """
@@ -1019,7 +1019,7 @@ class CommandArchitecture(object):
 
         return sync_strategies
 
-    def run(self):
+    def run(self, v2_debug):
         """
         This function wires together all of the generators and completes
         the command.  First a dictionary is created that is indexed first by
@@ -1055,6 +1055,20 @@ class CommandArchitecture(object):
         }
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type]
+
+        if v2_debug:
+            if operation_name == 'copy':
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object '
+                    'properties will be copied from the source in multipart '
+                    'copies between S3 buckets. This may result in extra S3 '
+                    'API calls being made. Breakage may occur if the principal '
+                    'does not have permission to call these extra APIs. This '
+                    'warning cannot be resolved. See '
+                    'https://docs.aws.amazon.com/cli/latest/userguide/'
+                    'cliv2-migration-changes.html'
+                    '#cliv2-migration-s3-copy-metadata\n\n'
+                )
 
         fgen_kwargs = {
             'client': self._source_client, 'operation_name': operation_name,

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -66,15 +66,19 @@ def add_timestamp_parser(session, v2_debug):
         # parser (which parses to a datetime.datetime object) with the
         # identity function which prints the date exactly the same as it comes
         # across the wire.
+        encountered_timestamp = False
         def identity_with_warning(x):
-            uni_print(
-                'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, all timestamp '
-                'response values are returned in the ISO 8601 format. To '
-                'migrate to v2 behavior and resolve this warning, set the '
-                'configuration variable `cli_timestamp_format` to `iso8601`. '
-                'See https://docs.aws.amazon.com/cli/latest/userguide/'
-                'cliv2-migration-changes.html#cliv2-migration-timestamp.\n'
-            )
+            nonlocal encountered_timestamp
+            if not encountered_timestamp:
+                encountered_timestamp = True
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, all timestamp '
+                    'response values are returned in the ISO 8601 format. To '
+                    'migrate to v2 behavior and resolve this warning, set the '
+                    'configuration variable `cli_timestamp_format` to `iso8601`. '
+                    'See https://docs.aws.amazon.com/cli/latest/userguide/'
+                    'cliv2-migration-changes.html#cliv2-migration-timestamp.\n'
+                )
             return identity(x)
 
         timestamp_parser = identity_with_warning if v2_debug else identity

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -120,7 +120,8 @@ class TestDeployCommand(unittest.TestCase):
                     None,
                     fake_tags,
                     True,
-                    True
+                    True,
+                    False
                 )
 
                 self.deploy_command.parse_key_value_arg.assert_has_calls([
@@ -207,7 +208,8 @@ class TestDeployCommand(unittest.TestCase):
                 s3UploaderObject,
                 [{"Key": "tagkey1", "Value": "tagvalue1"}],
                 True,
-                True
+                True,
+                False
             )
 
             s3UploaderMock.assert_called_once_with(mock.ANY,

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -613,6 +613,31 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         output_str = "(dryrun) upload: %s to %s" % (rel_local_file, s3_file)
         self.assertIn(output_str, self.output.getvalue())
 
+    def test_v2_debug_mv(self):
+        s3_file = 's3://' + self.bucket + '/' + 'text1.txt'
+        filters = [['--include', '*']]
+        params = {'dir_op': False, 'quiet': False, 'dryrun': True,
+                  'src': s3_file, 'dest': s3_file, 'filters': filters,
+                  'paths_type': 's3s3', 'region': 'us-east-1',
+                  'endpoint_url': None, 'verify_ssl': None,
+                  'follow_symlinks': True, 'page_size': None,
+                  'is_stream': False, 'source_region': None,
+                  'is_move': True}
+        self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
+                                  "LastModified": "2014-01-09T20:45:49.000Z"}]
+        config = RuntimeConfig().build_config()
+        cmd_arc = CommandArchitecture(self.session, 'mv', params, config)
+        cmd_arc.set_clients()
+        cmd_arc.create_instructions()
+        self.patch_make_request()
+        cmd_arc.run(v2_debug=True)
+        warning_str = 'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object '\
+                      'properties will be copied from the source in multipart '\
+                      'copies between S3 buckets.'
+        output_str = f"(dryrun) move: {s3_file} to {s3_file}"
+        self.assertIn(warning_str, self.output.getvalue())
+        self.assertIn(output_str, self.output.getvalue())
+
 
 class CommandParametersTest(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -14,7 +14,7 @@ from botocore.session import get_session
 from botocore import UNSIGNED
 import os
 
-from awscli.testutils import mock, unittest
+from awscli.testutils import mock, unittest, capture_output
 from awscli.customizations import globalargs
 
 
@@ -185,3 +185,63 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         self.assertEqual(parsed_args.connect_timeout, None)
         self.assertEqual(
             session.get_default_client_config().connect_timeout, None)
+
+    def test_v2_debug_python_utf8_env_var(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        environ = {'PYTHONUTF8': '1'}
+        with mock.patch('os.environ', environ):
+            with capture_output() as output:
+                globalargs.detect_migration_breakage(parsed_args, [], session)
+                self.assertIn(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2.',
+                    output.stdout.getvalue()
+                )
+
+    def test_v2_debug_python_utf8_resolved_env_var(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        environ = {'PYTHONUTF8': '1', 'AWS_CLI_FILE_ENCODING': 'UTF-8'}
+        with mock.patch('os.environ', environ):
+            with capture_output() as output:
+                globalargs.detect_migration_breakage(parsed_args, [], session)
+                self.assertNotIn(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2.',
+                    output.stdout.getvalue()
+                )
+
+    def test_v2_debug_python_io_encoding_env_var(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        environ = {'PYTHONIOENCODING': 'UTF8'}
+        with mock.patch('os.environ', environ):
+            with capture_output() as output:
+                globalargs.detect_migration_breakage(parsed_args, [], session)
+                self.assertIn(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2.',
+                    output.stdout.getvalue()
+                )
+
+    def test_v2_debug_s3_sigv2(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        globalargs.detect_migration_breakage(parsed_args, [], session)
+        with capture_output() as output:
+            session.emit(
+                'choose-signer.s3.*',
+                signing_name='s3',
+                region_name='us-west-2',
+                signature_version='v2',
+                context={'auth_type': 'v2'},
+            )
+        self.assertIn(
+            'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 only uses Signature '
+            'v4 to authenticate Amazon S3 requests.',
+            output.stdout.getvalue()
+        )

--- a/tests/unit/customizations/test_scalarparse.py
+++ b/tests/unit/customizations/test_scalarparse.py
@@ -32,7 +32,7 @@ class TestScalarParse(unittest.TestCase):
         session = mock.Mock()
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'none'}
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         session.get_component.assert_called_with('response_parser_factory')
         factory = session.get_component.return_value
         expected = [mock.call(blob_parser=scalarparse.identity),
@@ -45,7 +45,7 @@ class TestScalarParse(unittest.TestCase):
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'none'}
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.identity)
 
@@ -54,7 +54,7 @@ class TestScalarParse(unittest.TestCase):
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'iso8601'}
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.iso_format)
 
@@ -64,12 +64,12 @@ class TestScalarParse(unittest.TestCase):
                                                   'foobar'}
         session.get_component.return_value
         with self.assertRaises(ValueError):
-            scalarparse.add_scalar_parsers(session)
+            scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
 
     def test_choose_timestamp_parser_profile_not_found(self):
         session = mock.Mock(spec=Session)
         session.get_scoped_config.side_effect = ProfileNotFound(profile='foo')
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.identity)


### PR DESCRIPTION
*Description of changes:*

* Implemented runtime checks for the following breaking changes via `--v2-debug`:
  * Usage of `PYTHONUTF8` and `PYTHONIOENCODING` env vars unsupported in v2.
  * S3 copies executed under `aws s3` namespace may call additional APIs for multipart S3 copies 
  * Signer used for S3 request is Sigv2 (I expect it's very rare for customers to be using sigv2 and run into this)
  * [!] `aws cloudformation deploy` will not fail on empty changesets.
  * Timestamps in responses will be formatted in ISO 8601.
* Line-length formatting of other `--v2-debug` code.
* Added tests to cover some added functionality

*Description of tests:*

* Ran and passed all new tests.
* Manually tested the file encoding checker by supplying  `PYTHONUTF8`:
```
$ PYTHONUTF8=1 python3 -m awscli s3 ls --v2-debug
AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and PYTHONIOENCODING environment variables are unsupported in AWS CLI v2. AWS CLI v2 uses AWS_CLI_FILE_ENCODING instead, set this environment variable to resolve this. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-encodingenvvar.

An error occurred (ExpiredToken) when calling the ListBuckets operation: The provided token has expired.
```
* Manually tested the s3 copies checker via `aws s3 cp`:
```
$ python3 -m awscli s3 cp s3://BUCKET1/file1 s3://BUCKET2 --v2-debug
AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object properties will be copied from the source in multipart copies between S3 buckets. This may result in extra S3 API calls being made. Breakage may occur if the principal does not have permission to call these extra APIs. This warning cannot be resolved. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-s3-copy-metadata

copy: s3://BUCKET1/file1 to s3://BUCKET2
```
* Manually tested the timestamps checker via `aws s3 ls`:
```
AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, all timestamp response values are returned in the ISO 8601 format. To migrate to v2 behavior and resolve this warning, set the configuration variable `cli_timestamp_format` to `iso8601`. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-timestamp.
[...]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
