### PR TITLE
Implement v2-debug checks for args, config, customizations, s3, and environment variables

### DIFF
--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -697,7 +697,8 @@ class ServiceOperation:
                     '`cli_binary_format` configuration variable to '
                     '`raw-in-base64-out`. See https://docs.aws.amazon.com/cli/'
                     'latest/userguide/cliv2-migration-changes.html#'
-                    'cliv2-migration-binaryparam.\n'
+                    'cliv2-migration-binaryparam.\n',
+                    out_file=sys.stderr
                 )
 
 

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -546,7 +546,7 @@ class ServiceOperation:
             parsed_args, self.arg_table
         )
 
-        self._detect_migration_breakage(
+        self._detect_binary_file_migration_change(
             self._session,
             parsed_args,
             parsed_globals,
@@ -668,7 +668,13 @@ class ServiceOperation:
         parser = ArgTableArgParser(arg_table)
         return parser
 
-    def _detect_migration_breakage(self, session, parsed_args, parsed_globals, arg_table):
+    def _detect_binary_file_migration_change(
+            self,
+            session,
+            parsed_args,
+            parsed_globals,
+            arg_table
+    ):
         if (
                 session.get_scoped_config()
                         .get('cli_binary_format', None) == 'raw-in-base64-out'

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -669,7 +669,10 @@ class ServiceOperation:
         return parser
 
     def _detect_migration_breakage(self, session, parsed_args, parsed_globals, arg_table):
-        if session.get_config_variable('cli_binary_format') == 'raw-in-base64-out':
+        if (
+                session.get_scoped_config()
+                        .get('cli_binary_format', None) == 'raw-in-base64-out'
+        ):
             # if cli_binary_format is set to raw-in-base64-out, then v2 behavior will
             # be the same as v1, so there is no breaking change in this case.
             return

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -529,7 +529,6 @@ class ServiceOperation:
         operation_parser = self._create_operation_parser(self.arg_table)
         self._add_help(operation_parser)
         parsed_args, remaining = operation_parser.parse_known_args(args)
-        # print(f"operation parser parsed args: {parsed_args}")
         if parsed_args.help == 'help':
             op_help = self.create_help_command()
             return op_help(remaining, parsed_globals)
@@ -547,8 +546,12 @@ class ServiceOperation:
             parsed_args, self.arg_table
         )
 
-        self._detect_migration_breakage(self._session, parsed_args, parsed_globals, self.arg_table)
-
+        self._detect_migration_breakage(
+            self._session,
+            parsed_args,
+            parsed_globals,
+            self.arg_table
+        )
         event = f'calling-command.{self._parent_name}.{self._name}'
         override = self._emit_first_non_none_response(
             event,

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -79,8 +79,6 @@ def main():
 def create_clidriver():
     session = botocore.session.Session(EnvironmentVariables)
     _set_user_agent_for_session(session)
-    # TODO check if full config plugins is empty or not. if it's not, we signal the warning for plugin support being provisional
-    # similarly, we check for api_versions config value here.
     load_plugins(
         session.full_config.get('plugins', {}),
         event_hooks=session.get_component('event_emitter'),

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -41,6 +41,7 @@ from awscli.arguments import (
 )
 from awscli.commands import CLICommand
 from awscli.compat import get_stderr_text_writer
+from awscli.customizations.utils import uni_print
 from awscli.formatter import get_formatter
 from awscli.help import (
     OperationHelpCommand,
@@ -528,6 +529,7 @@ class ServiceOperation:
         operation_parser = self._create_operation_parser(self.arg_table)
         self._add_help(operation_parser)
         parsed_args, remaining = operation_parser.parse_known_args(args)
+        # print(f"operation parser parsed args: {parsed_args}")
         if parsed_args.help == 'help':
             op_help = self.create_help_command()
             return op_help(remaining, parsed_globals)
@@ -544,6 +546,8 @@ class ServiceOperation:
         call_parameters = self._build_call_parameters(
             parsed_args, self.arg_table
         )
+
+        self._detect_migration_breakage(self._session, parsed_args, parsed_globals, self.arg_table)
 
         event = f'calling-command.{self._parent_name}.{self._name}'
         override = self._emit_first_non_none_response(
@@ -660,6 +664,35 @@ class ServiceOperation:
     def _create_operation_parser(self, arg_table):
         parser = ArgTableArgParser(arg_table)
         return parser
+
+    def _detect_migration_breakage(self, session, parsed_args, parsed_globals, arg_table):
+        if session.get_config_variable('cli_binary_format') == 'raw-in-base64-out':
+            # if cli_binary_format is set to raw-in-base64-out, then v2 behavior will
+            # be the same as v1, so there is no breaking change in this case.
+            return
+        if parsed_globals.v2_debug:
+            parsed_args_to_check = {
+                arg: getattr(parsed_args, arg)
+                for arg in vars(parsed_args) if getattr(parsed_args, arg)
+            }
+
+            arg_values_to_check = [
+                arg.py_name for arg in arg_table.values()
+                if arg.py_name in parsed_args_to_check
+                   and arg.argument_model.type_name == 'blob'
+                   and parsed_args_to_check[arg.py_name].startswith('file://')
+            ]
+            if arg_values_to_check:
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: When specifying a blob-type '
+                    'parameter starting with `file://`, AWS CLI v2 will assume '
+                    'the content of the file is already base64-encoded. To '
+                    'maintain v1 behavior after upgrading to v2, set the '
+                    '`cli_binary_format` configuration variable to '
+                    '`raw-in-base64-out`. See https://docs.aws.amazon.com/cli/'
+                    'latest/userguide/cliv2-migration-changes.html#'
+                    'cliv2-migration-binaryparam.\n'
+                )
 
 
 class CLIOperationCaller:

--- a/awscli/customizations/cliinputjson.py
+++ b/awscli/customizations/cliinputjson.py
@@ -70,6 +70,10 @@ class CliInputJSONArgument(OverrideRequiredArgsArgument):
             try:
                 # Try to load the JSON string into a python dictionary
                 input_data = json.loads(retrieved_json)
+                self._session.register(
+                    f"get-cli-input-json-data",
+                    lambda **inner_kwargs: input_data
+                )
             except ValueError as e:
                 raise ParamError(
                     self.name, "Invalid JSON: %s\nJSON received: %s"

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -351,7 +351,8 @@ class DeployCommand(BasicCommand):
                         'flag to migrate to v2 behavior and resolve this '
                         'warning. See https://docs.aws.amazon.com/cli/latest/'
                         'userguide/cliv2-migration-changes.html'
-                        '#cliv2-migration-cfn.\n'
+                        '#cliv2-migration-cfn.\n',
+                        out_file=sys.stderr
                     )
                 raise
             write_exception(ex, outfile=get_stdout_text_writer())

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -24,6 +24,7 @@ from awscli.customizations.cloudformation.yamlhelper import yaml_parse
 
 from awscli.customizations.commands import BasicCommand
 from awscli.compat import get_stdout_text_writer
+from awscli.customizations.utils import uni_print
 from awscli.utils import create_nested_client, write_exception
 
 LOG = logging.getLogger(__name__)
@@ -321,12 +322,13 @@ class DeployCommand(BasicCommand):
                            parsed_args.execute_changeset, parsed_args.role_arn,
                            parsed_args.notification_arns, s3_uploader,
                            tags, parsed_args.fail_on_empty_changeset,
-                           parsed_args.disable_rollback)
+                           parsed_args.disable_rollback, parsed_args.v2_debug)
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,
                notification_arns, s3_uploader, tags,
-               fail_on_empty_changeset=True, disable_rollback=False):
+               fail_on_empty_changeset=True, disable_rollback=False,
+               v2_debug=False):
         try:
             result = deployer.create_and_wait_for_changeset(
                 stack_name=stack_name,
@@ -339,10 +341,18 @@ class DeployCommand(BasicCommand):
                 tags=tags
             )
         except exceptions.ChangeEmptyError as ex:
-            # TODO print the runtime check for cli v2 breakage. technically won't be breaking if --fail-on-empty-changeset is
-            # explicitly provided. but we cannot differentiate between whether fail-on-empty-changeset is true because it's default
-            # or because it's explicitly specified.
             if fail_on_empty_changeset:
+                if v2_debug:
+                    uni_print(
+                        'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, '
+                        'deploying an AWS CloudFormation Template that '
+                        'results in an empty changeset will NOT result in an '
+                        'error. You can add the -–no-fail-on-empty-changeset '
+                        'flag to migrate to v2 behavior and resolve this '
+                        'warning. See https://docs.aws.amazon.com/cli/latest/'
+                        'userguide/cliv2-migration-changes.html'
+                        '#cliv2-migration-cfn.\n'
+                    )
                 raise
             write_exception(ex, outfile=get_stdout_text_writer())
             return 0

--- a/awscli/customizations/cloudformation/deploy.py
+++ b/awscli/customizations/cloudformation/deploy.py
@@ -322,7 +322,7 @@ class DeployCommand(BasicCommand):
                            parsed_args.execute_changeset, parsed_args.role_arn,
                            parsed_args.notification_arns, s3_uploader,
                            tags, parsed_args.fail_on_empty_changeset,
-                           parsed_args.disable_rollback, parsed_args.v2_debug)
+                           parsed_args.disable_rollback, getattr(parsed_globals, 'v2_debug', False))
 
     def deploy(self, deployer, stack_name, template_str,
                parameters, capabilities, execute_changeset, role_arn,

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -102,6 +102,7 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
             if param.startswith('http://') or param.startswith('https://')
         ]
         region = parsed_args.region or session.get_config_variable('region')
+        s3_config = session.get_config_variable('s3')
         if 'PYTHONUTF8' in os.environ or 'PYTHONIOENCODING' in os.environ:
             if 'AWS_CLI_FILE_ENCODING' not in os.environ:
                 uni_print(
@@ -114,8 +115,8 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                     '#cliv2-migration-encodingenvvar.\n'
                 )
         if (
-                session.get_config_variable('s3')
-                        .get(
+                s3_config is not None and s3_config
+                    .get(
                             'us_east_1_regional_endpoint',
                             'legacy'
                         ) == 'legacy' and region in ('us-east-1', None)

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -183,8 +183,8 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
 
 def warn_if_east_configured_global_endpoint(request, operation_name, **kwargs):
     # The regional us-east-1 endpoint is used in certain cases (e.g.
-    # FIPS/Dual-Stack is enabled). Rather than duplicating this logic from botocore,
-    # we check the endpoint URL directly.
+    # FIPS/Dual-Stack is enabled). Rather than duplicating this logic
+    # from botocore, we check the endpoint URL directly.
     if 's3.amazonaws.com' in request.url:
         uni_print(
             'AWS CLI v2 MIGRATION WARNING: When you configure AWS CLI v2 '

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -112,7 +112,8 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                     'instead, set this environment variable to resolve this. '
                     'See https://docs.aws.amazon.com/cli/latest/userguide/'
                     'cliv2-migration-changes.html'
-                    '#cliv2-migration-encodingenvvar.\n'
+                    '#cliv2-migration-encodingenvvar.\n',
+                    out_file=sys.stderr
                 )
         if (
                 s3_config is not None and s3_config
@@ -133,7 +134,8 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                 'behavior and resolve this warning, remove the `api_versions` '
                 'setting in the configuration file. See '
                 'https://docs.aws.amazon.com/cli/latest/userguide/'
-                'cliv2-migration-changes.html#cliv2-migration-api-versions.\n'
+                'cliv2-migration-changes.html#cliv2-migration-api-versions.\n',
+                out_file = sys.stderr
             )
         if session.full_config.get('plugins', {}):
             uni_print(
@@ -143,14 +145,16 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                 'functionality of your plugins for each upgrade. See '
                 'https://docs.aws.amazon.com/cli/latest/userguide/'
                 'cliv2-migration-changes.html#'
-                'cliv2-migration-profile-plugins\n'
+                'cliv2-migration-profile-plugins\n',
+                out_file=sys.stderr
             )
         if parsed_args.command == 'ecr' and remaining_args[0] == 'get-login':
             uni_print(
                 'AWS CLI v2 MIGRATION WARNING: The ecr get-login command has '
                 'been removed in AWS CLI v2. See https://docs.aws.amazon.com/'
                 'cli/latest/userguide/cliv2-migration-changes.html'
-                '#cliv2-migration-ecr-get-login.\n'
+                '#cliv2-migration-ecr-get-login.\n',
+                out_file=sys.stderr
             )
         if url_params and session.full_config.get('cli_follow_urlparam', True):
             uni_print(
@@ -160,7 +164,8 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                 'parameter, and the cli_follow_urlparam option has been '
                 'removed. See https://docs.aws.amazon.com/cli/latest/'
                 'userguide/cliv2-migration-changes.html'
-                '#cliv2-migration-paramfile.\n'
+                '#cliv2-migration-paramfile.\n',
+                out_file=sys.stderr
             )
         for working, obsolete in HIDDEN_ALIASES.items():
             working_split = working.split('.')
@@ -177,7 +182,8 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                     'arguments that uses at least 1 of 21 hidden aliases that '
                     'were removed in AWS CLI v2. See '
                     'https://docs.aws.amazon.com/cli/latest/userguide'
-                    '/cliv2-migration-changes.html#cliv2-migration-aliases.\n'
+                    '/cliv2-migration-changes.html#cliv2-migration-aliases.\n',
+                    out_file=sys.stderr
                 )
         session.register('choose-signer.s3.*', warn_if_sigv2)
 
@@ -193,7 +199,8 @@ def warn_if_east_configured_global_endpoint(request, operation_name, **kwargs):
             'the global endpoint on v2, configure the region to be '
             '`aws-global`. See https://docs.aws.amazon.com/cli/latest/'
             'userguide/cliv2-migration-changes.html'
-            '#cliv2-migration-s3-regional-endpoint.\n'
+            '#cliv2-migration-s3-regional-endpoint.\n',
+            out_file=sys.stderr
         )
 
 def warn_if_sigv2(
@@ -208,7 +215,8 @@ def warn_if_sigv2(
             'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 only uses Signature '
             'v4 to authenticate Amazon S3 requests. Run the command `aws '
             'configure set s3.signature_version s3v4` to migrate to v4 and '
-            'resolve this.\n'
+            'resolve this.\n',
+            out_file=sys.stderr
         )
 
 def resolve_cli_read_timeout(parsed_args, session, **kwargs):

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -96,96 +96,97 @@ def resolve_cli_connect_timeout(parsed_args, session, **kwargs):
     _resolve_timeout(session, parsed_args, arg_name)
 
 def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
-    if parsed_args.v2_debug:
-        url_params = [
-            param for param in remaining_args
-            if param.startswith('http://') or param.startswith('https://')
-        ]
-        region = parsed_args.region or session.get_config_variable('region')
-        s3_config = session.get_config_variable('s3')
-        if 'PYTHONUTF8' in os.environ or 'PYTHONIOENCODING' in os.environ:
-            if 'AWS_CLI_FILE_ENCODING' not in os.environ:
-                uni_print(
-                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
-                    'PYTHONIOENCODING environment variables are unsupported '
-                    'in AWS CLI v2. AWS CLI v2 uses AWS_CLI_FILE_ENCODING '
-                    'instead, set this environment variable to resolve this. '
-                    'See https://docs.aws.amazon.com/cli/latest/userguide/'
-                    'cliv2-migration-changes.html'
-                    '#cliv2-migration-encodingenvvar.\n',
-                    out_file=sys.stderr
-                )
+    if not parsed_args.v2_debug:
+        return
+    url_params = [
+        param for param in remaining_args
+        if param.startswith('http://') or param.startswith('https://')
+    ]
+    region = parsed_args.region or session.get_config_variable('region')
+    s3_config = session.get_config_variable('s3')
+    if 'PYTHONUTF8' in os.environ or 'PYTHONIOENCODING' in os.environ:
+        if 'AWS_CLI_FILE_ENCODING' not in os.environ:
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                'PYTHONIOENCODING environment variables are unsupported '
+                'in AWS CLI v2. AWS CLI v2 uses AWS_CLI_FILE_ENCODING '
+                'instead, set this environment variable to resolve this. '
+                'See https://docs.aws.amazon.com/cli/latest/userguide/'
+                'cliv2-migration-changes.html'
+                '#cliv2-migration-encodingenvvar.\n',
+                out_file=sys.stderr
+            )
+    if (
+            s3_config is not None and s3_config
+                .get(
+                        'us_east_1_regional_endpoint',
+                        'legacy'
+                    ) == 'legacy' and region in ('us-east-1', None)
+    ):
+        session.register(
+            'request-created.s3.*',
+            warn_if_east_configured_global_endpoint
+        )
+    if session.get_config_variable('api_versions'):
+        uni_print(
+            'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support '
+            'calling earlier versions of AWS service APIs via the '
+            '`api_versions` configuration file setting. To migrate to v2 '
+            'behavior and resolve this warning, remove the `api_versions` '
+            'setting in the configuration file. See '
+            'https://docs.aws.amazon.com/cli/latest/userguide/'
+            'cliv2-migration-changes.html#cliv2-migration-api-versions.\n',
+            out_file = sys.stderr
+        )
+    if session.full_config.get('plugins', {}):
+        uni_print(
+            'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, plugin support '
+            'is provisional. If you rely on plugins, be sure to lock into '
+            'a particular version of the AWS CLI and test the '
+            'functionality of your plugins for each upgrade. See '
+            'https://docs.aws.amazon.com/cli/latest/userguide/'
+            'cliv2-migration-changes.html#'
+            'cliv2-migration-profile-plugins\n',
+            out_file=sys.stderr
+        )
+    if parsed_args.command == 'ecr' and remaining_args[0] == 'get-login':
+        uni_print(
+            'AWS CLI v2 MIGRATION WARNING: The ecr get-login command has '
+            'been removed in AWS CLI v2. See https://docs.aws.amazon.com/'
+            'cli/latest/userguide/cliv2-migration-changes.html'
+            '#cliv2-migration-ecr-get-login.\n',
+            out_file=sys.stderr
+        )
+    if url_params and session.full_config.get('cli_follow_urlparam', True):
+        uni_print(
+            'AWS CLI v2 MIGRATION WARNING: For input parameters that have '
+            'a prefix of http:// or https://, AWS CLI v2 will no longer '
+            'automatically request the content of the URL for the '
+            'parameter, and the cli_follow_urlparam option has been '
+            'removed. See https://docs.aws.amazon.com/cli/latest/'
+            'userguide/cliv2-migration-changes.html'
+            '#cliv2-migration-paramfile.\n',
+            out_file=sys.stderr
+        )
+    for working, obsolete in HIDDEN_ALIASES.items():
+        working_split = working.split('.')
+        working_service = working_split[0]
+        working_cmd = working_split[1]
+        working_param = working_split[2]
         if (
-                s3_config is not None and s3_config
-                    .get(
-                            'us_east_1_regional_endpoint',
-                            'legacy'
-                        ) == 'legacy' and region in ('us-east-1', None)
+                parsed_args.command == working_service
+                and remaining_args[0] == working_cmd
+                and f"--{working_param}" in remaining_args
         ):
-            session.register(
-                'request-created.s3.*',
-                warn_if_east_configured_global_endpoint
-            )
-        if session.get_config_variable('api_versions'):
             uni_print(
-                'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support '
-                'calling earlier versions of AWS service APIs via the '
-                '`api_versions` configuration file setting. To migrate to v2 '
-                'behavior and resolve this warning, remove the `api_versions` '
-                'setting in the configuration file. See '
-                'https://docs.aws.amazon.com/cli/latest/userguide/'
-                'cliv2-migration-changes.html#cliv2-migration-api-versions.\n',
-                out_file = sys.stderr
-            )
-        if session.full_config.get('plugins', {}):
-            uni_print(
-                'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, plugin support '
-                'is provisional. If you rely on plugins, be sure to lock into '
-                'a particular version of the AWS CLI and test the '
-                'functionality of your plugins for each upgrade. See '
-                'https://docs.aws.amazon.com/cli/latest/userguide/'
-                'cliv2-migration-changes.html#'
-                'cliv2-migration-profile-plugins\n',
+                'AWS CLI v2 MIGRATION WARNING: You have entered command '
+                'arguments that uses at least 1 of 21 hidden aliases that '
+                'were removed in AWS CLI v2. See '
+                'https://docs.aws.amazon.com/cli/latest/userguide'
+                '/cliv2-migration-changes.html#cliv2-migration-aliases.\n',
                 out_file=sys.stderr
             )
-        if parsed_args.command == 'ecr' and remaining_args[0] == 'get-login':
-            uni_print(
-                'AWS CLI v2 MIGRATION WARNING: The ecr get-login command has '
-                'been removed in AWS CLI v2. See https://docs.aws.amazon.com/'
-                'cli/latest/userguide/cliv2-migration-changes.html'
-                '#cliv2-migration-ecr-get-login.\n',
-                out_file=sys.stderr
-            )
-        if url_params and session.full_config.get('cli_follow_urlparam', True):
-            uni_print(
-                'AWS CLI v2 MIGRATION WARNING: For input parameters that have '
-                'a prefix of http:// or https://, AWS CLI v2 will no longer '
-                'automatically request the content of the URL for the '
-                'parameter, and the cli_follow_urlparam option has been '
-                'removed. See https://docs.aws.amazon.com/cli/latest/'
-                'userguide/cliv2-migration-changes.html'
-                '#cliv2-migration-paramfile.\n',
-                out_file=sys.stderr
-            )
-        for working, obsolete in HIDDEN_ALIASES.items():
-            working_split = working.split('.')
-            working_service = working_split[0]
-            working_cmd = working_split[1]
-            working_param = working_split[2]
-            if (
-                    parsed_args.command == working_service
-                    and remaining_args[0] == working_cmd
-                    and f"--{working_param}" in remaining_args
-            ):
-                uni_print(
-                    'AWS CLI v2 MIGRATION WARNING: You have entered command '
-                    'arguments that uses at least 1 of 21 hidden aliases that '
-                    'were removed in AWS CLI v2. See '
-                    'https://docs.aws.amazon.com/cli/latest/userguide'
-                    '/cliv2-migration-changes.html#cliv2-migration-aliases.\n',
-                    out_file=sys.stderr
-                )
-        session.register('choose-signer.s3.*', warn_if_sigv2)
+    session.register('choose-signer.s3.*', warn_if_sigv2)
 
 def warn_if_east_configured_global_endpoint(request, operation_name, **kwargs):
     # The regional us-east-1 endpoint is used in certain cases (e.g.

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -97,18 +97,71 @@ def resolve_cli_connect_timeout(parsed_args, session, **kwargs):
 
 def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
     if parsed_args.v2_debug:
-        url_params = [param for param in remaining_args if param.startswith('http://') or param.startswith('https://')]
+        url_params = [
+            param for param in remaining_args
+            if param.startswith('http://') or param.startswith('https://')
+        ]
+        if 'PYTHONUTF8' in os.environ or 'PYTHONIOENCODING' in os.environ:
+            if 'AWS_CLI_FILE_ENCODING' not in os.environ:
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2. AWS CLI v2 uses AWS_CLI_FILE_ENCODING '
+                    'instead, set this environment variable to resolve this. '
+                    'See https://docs.aws.amazon.com/cli/latest/userguide/'
+                    'cliv2-migration-changes.html'
+                    '#cliv2-migration-encodingenvvar.\n'
+                )
         if parsed_args.command == 'ecr' and remaining_args[0] == 'get-login':
-            uni_print('AWS CLI v2 MIGRATION WARNING: The ecr get-login command has been removed in AWS CLI v2. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-ecr-get-login.\n')
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: The ecr get-login command has '
+                'been removed in AWS CLI v2. See https://docs.aws.amazon.com/'
+                'cli/latest/userguide/cliv2-migration-changes.html'
+                '#cliv2-migration-ecr-get-login.\n'
+            )
         if url_params and session.full_config.get('cli_follow_urlparam', True):
-            uni_print('AWS CLI v2 MIGRATION WARNING: For input parameters that have a prefix of http:// or https://, AWS CLI v2 will no longer automatically request the content of the URL for the parameter, and the cli_follow_urlparam option has been removed. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-paramfile.\n')
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: For input parameters that have '
+                'a prefix of http:// or https://, AWS CLI v2 will no longer '
+                'automatically request the content of the URL for the '
+                'parameter, and the cli_follow_urlparam option has been '
+                'removed. See https://docs.aws.amazon.com/cli/latest/'
+                'userguide/cliv2-migration-changes.html'
+                '#cliv2-migration-paramfile.\n'
+            )
         for working, obsolete in HIDDEN_ALIASES.items():
             working_split = working.split('.')
             working_service = working_split[0]
             working_cmd = working_split[1]
             working_param = working_split[2]
-            if parsed_args.command == working_service and remaining_args[0] == working_cmd and f"--{working_param}" in remaining_args:
-                uni_print('AWS CLI v2 MIGRATION WARNING: You have entered command arguments that uses at least 1 of 21 hidden aliases that were removed in AWS CLI v2. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-aliases.\n')
+            if (
+                    parsed_args.command == working_service
+                    and remaining_args[0] == working_cmd
+                    and f"--{working_param}" in remaining_args
+            ):
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: You have entered command '
+                    'arguments that uses at least 1 of 21 hidden aliases that '
+                    'were removed in AWS CLI v2. See '
+                    'https://docs.aws.amazon.com/cli/latest/userguide'
+                    '/cliv2-migration-changes.html#cliv2-migration-aliases.\n'
+                )
+        session.register('choose-signer.s3.*', warn_if_sigv2)
+
+def warn_if_sigv2(
+        signing_name,
+        region_name,
+        signature_version,
+        context,
+        **kwargs
+):
+    if context.get('auth_type', None) == 'v2':
+        uni_print(
+            'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 only uses Signature '
+            'v4 to authenticate Amazon S3 requests. Run the command `aws '
+            'configure set s3.signature_version s3v4` to migrate to v4 and '
+            'resolve this.\n'
+        )
 
 def resolve_cli_read_timeout(parsed_args, session, **kwargs):
     arg_name = 'read_timeout'

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -101,6 +101,7 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
             param for param in remaining_args
             if param.startswith('http://') or param.startswith('https://')
         ]
+        region = parsed_args.region or session.get_config_variable('region')
         if 'PYTHONUTF8' in os.environ or 'PYTHONIOENCODING' in os.environ:
             if 'AWS_CLI_FILE_ENCODING' not in os.environ:
                 uni_print(
@@ -112,6 +113,22 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                     'cliv2-migration-changes.html'
                     '#cliv2-migration-encodingenvvar.\n'
                 )
+        if (
+                session.get_config_variable('s3')
+                        .get(
+                            'us_east_1_regional_endpoint',
+                            'legacy'
+                        ) == 'legacy' and region in ('us-east-1', None)
+        ):
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: When you configure AWS CLI v2 '
+                'to use the `us-east-1` region, it uses the true regional '
+                'endpoint rather than the global endpoint. To continue using '
+                'the global endpoint on v2, configure the region to be '
+                '`aws-global`. See https://docs.aws.amazon.com/cli/latest/'
+                'userguide/cliv2-migration-changes.html'
+                '#cliv2-migration-s3-regional-endpoint.\n'
+            )
         if session.get_config_variable('api_versions'):
             uni_print(
                 'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support '

--- a/awscli/customizations/globalargs.py
+++ b/awscli/customizations/globalargs.py
@@ -112,6 +112,26 @@ def detect_migration_breakage(parsed_args, remaining_args, session, **kwargs):
                     'cliv2-migration-changes.html'
                     '#cliv2-migration-encodingenvvar.\n'
                 )
+        if session.get_config_variable('api_versions'):
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support '
+                'calling earlier versions of AWS service APIs via the '
+                '`api_versions` configuration file setting. To migrate to v2 '
+                'behavior and resolve this warning, remove the `api_versions` '
+                'setting in the configuration file. See '
+                'https://docs.aws.amazon.com/cli/latest/userguide/'
+                'cliv2-migration-changes.html#cliv2-migration-api-versions.\n'
+            )
+        if session.full_config.get('plugins', {}):
+            uni_print(
+                'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, plugin support '
+                'is provisional. If you rely on plugins, be sure to lock into '
+                'a particular version of the AWS CLI and test the '
+                'functionality of your plugins for each upgrade. See '
+                'https://docs.aws.amazon.com/cli/latest/userguide/'
+                'cliv2-migration-changes.html#'
+                'cliv2-migration-profile-plugins\n'
+            )
         if parsed_args.command == 'ecr' and remaining_args[0] == 'get-login':
             uni_print(
                 'AWS CLI v2 MIGRATION WARNING: The ecr get-login command has '

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -296,7 +296,8 @@ def check_should_enable_pagination_call_parameters(
                 'turned off. This is not the case in v1. See '
                 'https://docs.aws.amazon.com/cli/latest/userguide/'
                 'cliv2-migration-changes.html'
-                '#cliv2-migration-skeleton-paging.\n'
+                '#cliv2-migration-skeleton-paging.\n',
+                out_file=sys.stderr
             )
 
 

--- a/awscli/customizations/paginate.py
+++ b/awscli/customizations/paginate.py
@@ -290,7 +290,13 @@ def check_should_enable_pagination_call_parameters(
         ]
         if pagination_params_in_input_tokens:
             uni_print(
-                'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, if you specify pagination parameters by using a file with the `--cli-input-json` parameter, automatic pagination will be turned off. This is not the case in v1. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-skeleton-paging.\n'
+                'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, if you specify '
+                'pagination parameters by using a file with the '
+                '`--cli-input-json` parameter, automatic pagination will be '
+                'turned off. This is not the case in v1. See '
+                'https://docs.aws.amazon.com/cli/latest/userguide/'
+                'cliv2-migration-changes.html'
+                '#cliv2-migration-skeleton-paging.\n'
             )
 
 

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1019,7 +1019,7 @@ class CommandArchitecture(object):
 
         return sync_strategies
 
-    def run(self, v2_debug):
+    def run(self, v2_debug=False):
         """
         This function wires together all of the generators and completes
         the command.  First a dictionary is created that is indexed first by

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -775,7 +775,7 @@ class S3TransferCommand(S3Command):
                                   runtime_config)
         cmd.set_clients()
         cmd.create_instructions()
-        return cmd.run(parsed_globals.v2_debug)
+        return cmd.run(getattr(parsed_globals, 'v2_debug', False))
 
     def _build_call_parameters(self, args, command_params):
         """

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -767,6 +767,7 @@ class S3TransferCommand(S3Command):
         cmd_params.add_verify_ssl(parsed_globals)
         cmd_params.add_page_size(parsed_args)
         cmd_params.add_paths(parsed_args.paths)
+        cmd_params.add_v2_debug(parsed_globals)
 
         runtime_config = transferconfig.RuntimeConfig().build_config(
             **self._session.get_scoped_config().get('s3', {}))
@@ -775,7 +776,7 @@ class S3TransferCommand(S3Command):
                                   runtime_config)
         cmd.set_clients()
         cmd.create_instructions()
-        return cmd.run(getattr(parsed_globals, 'v2_debug', False))
+        return cmd.run()
 
     def _build_call_parameters(self, args, command_params):
         """
@@ -1019,7 +1020,7 @@ class CommandArchitecture(object):
 
         return sync_strategies
 
-    def run(self, v2_debug=False):
+    def run(self):
         """
         This function wires together all of the generators and completes
         the command.  First a dictionary is created that is indexed first by
@@ -1056,7 +1057,7 @@ class CommandArchitecture(object):
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type]
 
-        if v2_debug:
+        if self.parameters['v2_debug']:
             if operation_name == 'copy':
                 uni_print(
                     'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object '
@@ -1461,6 +1462,9 @@ class CommandParameters(object):
 
     def add_page_size(self, parsed_args):
         self.parameters['page_size'] = getattr(parsed_args, 'page_size', None)
+
+    def add_v2_debug(self, parsed_globals):
+        self.parameters['v2_debug'] = parsed_globals.v2_debug
 
     def _validate_sse_c_args(self):
         self._validate_sse_c_arg()

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -775,7 +775,7 @@ class S3TransferCommand(S3Command):
                                   runtime_config)
         cmd.set_clients()
         cmd.create_instructions()
-        return cmd.run()
+        return cmd.run(parsed_globals.v2_debug)
 
     def _build_call_parameters(self, args, command_params):
         """
@@ -1019,7 +1019,7 @@ class CommandArchitecture(object):
 
         return sync_strategies
 
-    def run(self):
+    def run(self, v2_debug):
         """
         This function wires together all of the generators and completes
         the command.  First a dictionary is created that is indexed first by
@@ -1055,6 +1055,20 @@ class CommandArchitecture(object):
         }
         result_queue = queue.Queue()
         operation_name = cmd_translation[paths_type]
+
+        if v2_debug:
+            if operation_name == 'copy':
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object '
+                    'properties will be copied from the source in multipart '
+                    'copies between S3 buckets. This may result in extra S3 '
+                    'API calls being made. Breakage may occur if the principal '
+                    'does not have permission to call these extra APIs. This '
+                    'warning cannot be resolved. See '
+                    'https://docs.aws.amazon.com/cli/latest/userguide/'
+                    'cliv2-migration-changes.html'
+                    '#cliv2-migration-s3-copy-metadata\n\n'
+                )
 
         fgen_kwargs = {
             'client': self._source_client, 'operation_name': operation_name,

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1067,7 +1067,8 @@ class CommandArchitecture(object):
                     'warning cannot be resolved. See '
                     'https://docs.aws.amazon.com/cli/latest/userguide/'
                     'cliv2-migration-changes.html'
-                    '#cliv2-migration-s3-copy-metadata\n\n'
+                    '#cliv2-migration-s3-copy-metadata\n\n',
+                    out_file=sys.stderr
                 )
 
         fgen_kwargs = {

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -66,15 +66,19 @@ def add_timestamp_parser(session, v2_debug):
         # parser (which parses to a datetime.datetime object) with the
         # identity function which prints the date exactly the same as it comes
         # across the wire.
+        encountered_timestamp = False
         def identity_with_warning(x):
-            uni_print(
-                'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, all timestamp '
-                'response values are returned in the ISO 8601 format. To '
-                'migrate to v2 behavior and resolve this warning, set the '
-                'configuration variable `cli_timestamp_format` to `iso8601`. '
-                'See https://docs.aws.amazon.com/cli/latest/userguide/'
-                'cliv2-migration-changes.html#cliv2-migration-timestamp.\n'
-            )
+            nonlocal encountered_timestamp
+            if not encountered_timestamp:
+                encountered_timestamp = True
+                uni_print(
+                    'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, all timestamp '
+                    'response values are returned in the ISO 8601 format. To '
+                    'migrate to v2 behavior and resolve this warning, set the '
+                    'configuration variable `cli_timestamp_format` to `iso8601`. '
+                    'See https://docs.aws.amazon.com/cli/latest/userguide/'
+                    'cliv2-migration-changes.html#cliv2-migration-timestamp.\n'
+                )
             return identity(x)
 
         timestamp_parser = identity_with_warning if v2_debug else identity

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -27,6 +27,8 @@ There's nothing currently done for timestamps, but this will change
 in the future.
 
 """
+import sys
+
 from botocore.utils import parse_timestamp
 from botocore.exceptions import ProfileNotFound
 
@@ -77,7 +79,8 @@ def add_timestamp_parser(session, v2_debug):
                     'migrate to v2 behavior and resolve this warning, set the '
                     'configuration variable `cli_timestamp_format` to `iso8601`. '
                     'See https://docs.aws.amazon.com/cli/latest/userguide/'
-                    'cliv2-migration-changes.html#cliv2-migration-timestamp.\n'
+                    'cliv2-migration-changes.html#cliv2-migration-timestamp.\n',
+                    out_file=sys.stderr
                 )
             return identity(x)
 

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -70,6 +70,9 @@ def add_timestamp_parser(session, v2_debug):
         # across the wire.
         encountered_timestamp = False
         def identity_with_warning(x):
+            # To prevent printing the same warning for each timestamp in the
+            # response, we utilize a reference to a nonlocal variable to track
+            # if we have already printed the warning.
             nonlocal encountered_timestamp
             if not encountered_timestamp:
                 encountered_timestamp = True

--- a/tests/functional/test_api_versions.py
+++ b/tests/functional/test_api_versions.py
@@ -52,7 +52,7 @@ class TestAPIVersions(BaseAWSCommandParamsTest):
 
     def test_v2_debug_migration_warning(self):
         cmdline = 'ec2 describe-instances --v2-debug'
-        stdout, _, _ = self.run_cmd(cmdline)
+        _, stderr, _ = self.run_cmd(cmdline)
         # Make sure that the correct api version is used for the client
         # by checking the version that was sent in the request.
         self.assertEqual(self.last_params['Version'], self.api_version)
@@ -62,6 +62,6 @@ class TestAPIVersions(BaseAWSCommandParamsTest):
             'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support '
             'calling earlier versions of AWS service APIs via the '
             '`api_versions` configuration file setting.',
-            stdout
+            stderr
         )
 

--- a/tests/functional/test_api_versions.py
+++ b/tests/functional/test_api_versions.py
@@ -10,7 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from awscli.testutils import create_clidriver
+from awscli.testutils import create_clidriver, capture_output
 from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
 
 
@@ -49,3 +49,19 @@ class TestAPIVersions(BaseAWSCommandParamsTest):
         cmdline = 'ec2 describe-nat-gateways'
         _, stderr, _ = self.run_cmd(cmdline, expected_rc=2)
         self.assertIn("Invalid choice: 'describe-nat-gateways'", stderr)
+
+    def test_v2_debug_migration_warning(self):
+        cmdline = 'ec2 describe-instances --v2-debug'
+        stdout, _, _ = self.run_cmd(cmdline)
+        # Make sure that the correct api version is used for the client
+        # by checking the version that was sent in the request.
+        self.assertEqual(self.last_params['Version'], self.api_version)
+        # Make sure that the migration warning is printed since the user
+        # specified --v2-debug
+        self.assertIn(
+            'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support '
+            'calling earlier versions of AWS service APIs via the '
+            '`api_versions` configuration file setting.',
+            stdout
+        )
+

--- a/tests/unit/customizations/cloudformation/test_deploy.py
+++ b/tests/unit/customizations/cloudformation/test_deploy.py
@@ -120,7 +120,8 @@ class TestDeployCommand(unittest.TestCase):
                     None,
                     fake_tags,
                     True,
-                    True
+                    True,
+                    False
                 )
 
                 self.deploy_command.parse_key_value_arg.assert_has_calls([
@@ -207,7 +208,8 @@ class TestDeployCommand(unittest.TestCase):
                 s3UploaderObject,
                 [{"Key": "tagkey1", "Value": "tagvalue1"}],
                 True,
-                True
+                True,
+                False
             )
 
             s3UploaderMock.assert_called_once_with(mock.ANY,

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -636,7 +636,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                       'copies between S3 buckets.'
         output_str = f"(dryrun) move: {s3_file} to {s3_file}"
         self.assertIn(warning_str, self.err_output.getvalue())
-        self.assertIn(output_str, self.err_output.getvalue())
+        self.assertIn(output_str, self.output.getvalue())
 
 
 class CommandParametersTest(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -635,8 +635,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                       'properties will be copied from the source in multipart '\
                       'copies between S3 buckets.'
         output_str = f"(dryrun) move: {s3_file} to {s3_file}"
-        self.assertIn(warning_str, self.output.getvalue())
-        self.assertIn(output_str, self.output.getvalue())
+        self.assertIn(warning_str, self.err_output.getvalue())
+        self.assertIn(output_str, self.err_output.getvalue())
 
 
 class CommandParametersTest(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -613,6 +613,31 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         output_str = "(dryrun) upload: %s to %s" % (rel_local_file, s3_file)
         self.assertIn(output_str, self.output.getvalue())
 
+    def test_v2_debug_mv(self):
+        s3_file = 's3://' + self.bucket + '/' + 'text1.txt'
+        filters = [['--include', '*']]
+        params = {'dir_op': False, 'quiet': False, 'dryrun': True,
+                  'src': s3_file, 'dest': s3_file, 'filters': filters,
+                  'paths_type': 's3s3', 'region': 'us-east-1',
+                  'endpoint_url': None, 'verify_ssl': None,
+                  'follow_symlinks': True, 'page_size': None,
+                  'is_stream': False, 'source_region': None,
+                  'is_move': True}
+        self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
+                                  "LastModified": "2014-01-09T20:45:49.000Z"}]
+        config = RuntimeConfig().build_config()
+        cmd_arc = CommandArchitecture(self.session, 'mv', params, config)
+        cmd_arc.set_clients()
+        cmd_arc.create_instructions()
+        self.patch_make_request()
+        cmd_arc.run(v2_debug=True)
+        warning_str = 'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object '\
+                      'properties will be copied from the source in multipart '\
+                      'copies between S3 buckets.'
+        output_str = f"(dryrun) move: {s3_file} to {s3_file}"
+        self.assertIn(warning_str, self.output.getvalue())
+        self.assertIn(output_str, self.output.getvalue())
+
 
 class CommandParametersTest(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -450,7 +450,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None, 'metadata': None}
+                  'is_stream': False, 'source_region': None, 'metadata': None,
+                  'v2_debug': False}
         config = RuntimeConfig().build_config()
         cmd_arc = CommandArchitecture(self.session, 'cp', params, config)
         cmd_arc.set_clients()
@@ -470,7 +471,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None, 'metadata': None}
+                  'is_stream': False, 'source_region': None, 'metadata': None,
+                  'v2_debug': False}
         self.http_response.status_code = 400
         self.parsed_responses = [{'Error': {
                                   'Code': 'BucketNotExists',
@@ -501,7 +503,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 's3local', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None}
+                  'is_stream': False, 'source_region': None, 'v2_debug': False}
         self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
                                   "LastModified": "2014-01-09T20:45:49.000Z"}]
         config = RuntimeConfig().build_config()
@@ -524,7 +526,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 's3s3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None}
+                  'is_stream': False, 'source_region': None, 'v2_debug': False}
         self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
                                   "LastModified": "2014-01-09T20:45:49.000Z"}]
         config = RuntimeConfig().build_config()
@@ -548,7 +550,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
                   'is_stream': False, 'source_region': None,
-                  'is_move': True}
+                  'is_move': True, 'v2_debug': False}
         self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
                                   "LastModified": "2014-01-09T20:45:49.000Z"}]
         config = RuntimeConfig().build_config()
@@ -571,7 +573,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 's3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': None}
+                  'is_stream': False, 'source_region': None,
+                  'v2_debug': False}
         self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
                                   "LastModified": "2014-01-09T20:45:49.000Z"}]
         config = RuntimeConfig().build_config()
@@ -598,7 +601,8 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'paths_type': 'locals3', 'region': 'us-east-1',
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
-                  'is_stream': False, 'source_region': 'us-west-2'}
+                  'is_stream': False, 'source_region': 'us-west-2',
+                  'v2_debug': False}
         self.parsed_responses = [
             {"CommonPrefixes": [], "Contents": [
                 {"Key": "text1.txt", "Size": 100,
@@ -622,7 +626,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
                   'endpoint_url': None, 'verify_ssl': None,
                   'follow_symlinks': True, 'page_size': None,
                   'is_stream': False, 'source_region': None,
-                  'is_move': True}
+                  'is_move': True, 'v2_debug': True}
         self.parsed_responses = [{"ETag": "abcd", "ContentLength": 100,
                                   "LastModified": "2014-01-09T20:45:49.000Z"}]
         config = RuntimeConfig().build_config()
@@ -630,7 +634,7 @@ class CommandArchitectureTest(BaseAWSCommandParamsTest):
         cmd_arc.set_clients()
         cmd_arc.create_instructions()
         self.patch_make_request()
-        cmd_arc.run(v2_debug=True)
+        cmd_arc.run()
         warning_str = 'AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object '\
                       'properties will be copied from the source in multipart '\
                       'copies between S3 buckets.'

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -14,7 +14,7 @@ from botocore.session import get_session
 from botocore import UNSIGNED
 import os
 
-from awscli.testutils import mock, unittest
+from awscli.testutils import mock, unittest, capture_output
 from awscli.customizations import globalargs
 
 
@@ -185,3 +185,63 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         self.assertEqual(parsed_args.connect_timeout, None)
         self.assertEqual(
             session.get_default_client_config().connect_timeout, None)
+
+    def test_v2_debug_python_utf8_env_var(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        environ = {'PYTHONUTF8': '1'}
+        with mock.patch('os.environ', environ):
+            with capture_output() as output:
+                globalargs.detect_migration_breakage(parsed_args, [], session)
+                self.assertIn(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2.',
+                    output.stdout.getvalue()
+                )
+
+    def test_v2_debug_python_utf8_resolved_env_var(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        environ = {'PYTHONUTF8': '1', 'AWS_CLI_FILE_ENCODING': 'UTF-8'}
+        with mock.patch('os.environ', environ):
+            with capture_output() as output:
+                globalargs.detect_migration_breakage(parsed_args, [], session)
+                self.assertNotIn(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2.',
+                    output.stdout.getvalue()
+                )
+
+    def test_v2_debug_python_io_encoding_env_var(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        environ = {'PYTHONIOENCODING': 'UTF8'}
+        with mock.patch('os.environ', environ):
+            with capture_output() as output:
+                globalargs.detect_migration_breakage(parsed_args, [], session)
+                self.assertIn(
+                    'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
+                    'PYTHONIOENCODING environment variables are unsupported '
+                    'in AWS CLI v2.',
+                    output.stdout.getvalue()
+                )
+
+    def test_v2_debug_s3_sigv2(self):
+        parsed_args = FakeParsedArgs(v2_debug=True)
+        session = get_session()
+        globalargs.detect_migration_breakage(parsed_args, [], session)
+        with capture_output() as output:
+            session.emit(
+                'choose-signer.s3.*',
+                signing_name='s3',
+                region_name='us-west-2',
+                signature_version='v2',
+                context={'auth_type': 'v2'},
+            )
+        self.assertIn(
+            'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 only uses Signature '
+            'v4 to authenticate Amazon S3 requests.',
+            output.stdout.getvalue()
+        )

--- a/tests/unit/customizations/test_globalargs.py
+++ b/tests/unit/customizations/test_globalargs.py
@@ -197,7 +197,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
                     'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
                     'PYTHONIOENCODING environment variables are unsupported '
                     'in AWS CLI v2.',
-                    output.stdout.getvalue()
+                    output.stderr.getvalue()
                 )
 
     def test_v2_debug_python_utf8_resolved_env_var(self):
@@ -211,7 +211,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
                     'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
                     'PYTHONIOENCODING environment variables are unsupported '
                     'in AWS CLI v2.',
-                    output.stdout.getvalue()
+                    output.stderr.getvalue()
                 )
 
     def test_v2_debug_python_io_encoding_env_var(self):
@@ -225,7 +225,7 @@ class TestGlobalArgsCustomization(unittest.TestCase):
                     'AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and '
                     'PYTHONIOENCODING environment variables are unsupported '
                     'in AWS CLI v2.',
-                    output.stdout.getvalue()
+                    output.stderr.getvalue()
                 )
 
     def test_v2_debug_s3_sigv2(self):
@@ -243,5 +243,5 @@ class TestGlobalArgsCustomization(unittest.TestCase):
         self.assertIn(
             'AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 only uses Signature '
             'v4 to authenticate Amazon S3 requests.',
-            output.stdout.getvalue()
+            output.stderr.getvalue()
         )

--- a/tests/unit/customizations/test_paginate.py
+++ b/tests/unit/customizations/test_paginate.py
@@ -232,7 +232,7 @@ class TestShouldEnablePagination(TestPaginateBase):
         # user specified --bar 10
         self.assertFalse(self.parsed_globals.paginate)
 
-    def test_should_not_enable_pagination_call_parameters(self):
+    def test_v2_debug_call_parameters(self):
         # Here the user has specified a manual pagination argument,
         # via CLI Input JSON and specified v2-debug, so a
         # migration warning should printed.
@@ -254,7 +254,7 @@ class TestShouldEnablePagination(TestPaginateBase):
                 'pagination parameters by using a file with the '
                 '`--cli-input-json` parameter, automatic pagination will be '
                 'turned off.',
-                output.stdout.getvalue()
+                output.stderr.getvalue()
             )
 
     def test_should_enable_pagination_with_no_args(self):

--- a/tests/unit/customizations/test_scalarparse.py
+++ b/tests/unit/customizations/test_scalarparse.py
@@ -32,7 +32,7 @@ class TestScalarParse(unittest.TestCase):
         session = mock.Mock()
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'none'}
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         session.get_component.assert_called_with('response_parser_factory')
         factory = session.get_component.return_value
         expected = [mock.call(blob_parser=scalarparse.identity),
@@ -45,7 +45,7 @@ class TestScalarParse(unittest.TestCase):
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'none'}
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.identity)
 
@@ -54,7 +54,7 @@ class TestScalarParse(unittest.TestCase):
         session.get_scoped_config.return_value = {'cli_timestamp_format':
                                                   'iso8601'}
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.iso_format)
 
@@ -64,12 +64,12 @@ class TestScalarParse(unittest.TestCase):
                                                   'foobar'}
         session.get_component.return_value
         with self.assertRaises(ValueError):
-            scalarparse.add_scalar_parsers(session)
+            scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
 
     def test_choose_timestamp_parser_profile_not_found(self):
         session = mock.Mock(spec=Session)
         session.get_scoped_config.side_effect = ProfileNotFound(profile='foo')
         factory = session.get_component.return_value
-        scalarparse.add_scalar_parsers(session)
+        scalarparse.add_scalar_parsers(session, mock.Mock(v2_debug=False))
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.identity)

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -104,7 +104,8 @@ GET_DATA = {
 GET_VARIABLE = {
     'provider': 'aws',
     'output': 'json',
-    'api_versions': {}
+    'api_versions': {},
+    'cli_binary_format': 'raw-in-base64-out',
 }
 
 

--- a/tests/unit/test_clidriver.py
+++ b/tests/unit/test_clidriver.py
@@ -237,6 +237,9 @@ class FakeSession(object):
             return GET_VARIABLE[name]
         return self.session_vars[name]
 
+    def get_scoped_config(self):
+        return GET_VARIABLE
+
     def get_service_model(self, name, api_version=None):
         return botocore.model.ServiceModel(
             MINI_SERVICE, service_name='s3')


### PR DESCRIPTION
*Description of changes:*

* Implemented runtime checks for the following breaking changes via `--v2-debug`:
  * Usage of `PYTHONUTF8` and `PYTHONIOENCODING` env vars unsupported in v2.
  * S3 copies executed under `aws s3` namespace may call additional APIs for multipart S3 copies 
  * Signer used for S3 request is Sigv2 (I expect it's very rare for customers to be using sigv2 and run into this)
  * [!] `aws cloudformation deploy` will not fail on empty changesets.
  * Timestamps in responses will be formatted in ISO 8601.
  * Usage of `file://` with blob-type parameters.
  * `us-east-1` will use the regional endpoint in v2 rather than global.
  * Usage of `api_versions` in config will not be supported in v2.
  * Support for `[plugins]` will be provisional in v2.
  * Pagination params used in `--cli-input-json` will disable automatic paging in v2.
* Line-length formatting of other `--v2-debug` code.
* Added tests to cover some added functionality

*Description of tests:*

* Ran and passed all new tests.
* Manually tested the file encoding checker by supplying  `PYTHONUTF8`:
```
$ PYTHONUTF8=1 python3 -m awscli s3 ls --v2-debug
AWS CLI v2 MIGRATION WARNING: The PYTHONUTF8 and PYTHONIOENCODING environment variables are unsupported in AWS CLI v2. AWS CLI v2 uses AWS_CLI_FILE_ENCODING instead, set this environment variable to resolve this. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-encodingenvvar.

An error occurred (ExpiredToken) when calling the ListBuckets operation: The provided token has expired.
```
* Manually tested the s3 copies checker via `aws s3 cp`:
```
$ python3 -m awscli s3 cp s3://BUCKET1/file1 s3://BUCKET2 --v2-debug
AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, object properties will be copied from the source in multipart copies between S3 buckets. This may result in extra S3 API calls being made. Breakage may occur if the principal does not have permission to call these extra APIs. This warning cannot be resolved. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-s3-copy-metadata

copy: s3://BUCKET1/file1 to s3://BUCKET2
```
* Manually tested the timestamps checker via `aws s3 ls`:
```
AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, all timestamp response values are returned in the ISO 8601 format. To migrate to v2 behavior and resolve this warning, set the configuration variable `cli_timestamp_format` to `iso8601`. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-timestamp.
[...]
```
* Manually tested specifying pagination params through `--cli-input-json`:
```
 $ aws s3api list-buckets --v2-debug --cli-input-json file://pagination-params.json 
AWS CLI v2 MIGRATION WARNING: In AWS CLI v2, if you specify pagination parameters by using a file with the `--cli-input-json` parameter, automatic pagination will be turned off. This is not the case in v1. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-skeleton-paging.
[...]
```
* Manually tested specifying `api_versions` in config file:
```
api_versions =
    ec2 = 2016-11-15
    s3 = 2006-03-01
```
```
$ aws s3 ls --v2-debug
AWS CLI v2 MIGRATION WARNING: The AWS CLI v2 does not support calling earlier versions of AWS service APIs via the `api_versions` configuration file setting. To migrate to v2 behavior and resolve this warning, remove the `api_versions` setting in the configuration file. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-api-versions.
```
* Manually tested using `file://` for a blob-type parameter:

```
$ python3 -m awscli secretsmanager update-secret --secret-id SECRET-NAME --secret-binary file://BINARY-SECRET.json --v2-debug
AWS CLI v2 MIGRATION WARNING: When specifying a blob-type parameter starting with `file://`, AWS CLI v2 will assume the content of the file is already base64-encoded. To maintain v1 behavior after upgrading to v2, set the `cli_binary_format` configuration variable to `raw-in-base64-out`. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-binaryparam.
{
    "ARN": "ARN",
    "Name": "SECRET-NAME",
    "VersionId": "VERSION-ID"
}
```

After setting  `cli_binary_format` to `raw-in-base64-out`, I've verified that the warning above was not printed.

* Manually tested configuring region to `us-east-1` and executing an S3 command:

```
$ python3 -m awscli s3 ls --v2-debug 
AWS CLI v2 MIGRATION WARNING: When you configure AWS CLI v2 to use the `us-east-1` region, it uses the true regional endpoint rather than the global endpoint. To continue using the global endpoint on v2, configure the region to be `aws-global`. See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html#cliv2-migration-s3-regional-endpoint.
```

After setting `region` to `aws-global`, I've verified that the warning above was not printed.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
