### PR TITLE
Add Changelog entry for openSSL 1.1.1zd

### DIFF
--- a/.changes/next-release/enhancement-openssl-17952.json
+++ b/.changes/next-release/enhancement-openssl-17952.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "openssl",
+  "description": "Update bundled OpenSSL version to 1.1.1zd for Linux installers"
+}


### PR DESCRIPTION
*Issue #, if available:* CLI-7303

*Description of changes:* This openssl version update to 1.1.1zd is only applicable to official Linux executables for the AWS CLI v2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
