### PR TITLE
Add CLI examples for translate-text and list-languages commands

### DIFF
--- a/awscli/examples/translate/list-languages.rst
+++ b/awscli/examples/translate/list-languages.rst
@@ -1,0 +1,62 @@
+**To list supported languages**
+
+The following ``list-languages`` example lists all languages supported by Amazon Translate. ::
+
+    aws translate list-languages
+
+Output::
+
+    {
+        "Languages": [
+            {
+                "LanguageName": "Afrikaans",
+                "LanguageCode": "af"
+            },
+            {
+                "LanguageName": "Albanian",
+                "LanguageCode": "sq"
+            },
+            {
+                "LanguageName": "Amharic",
+                "LanguageCode": "am"
+            },
+            {
+                "LanguageName": "Arabic",
+                "LanguageCode": "ar"
+            },
+            {
+                "LanguageName": "Armenian",
+                "LanguageCode": "hy"
+            },
+            {
+                "LanguageName": "Azerbaijani",
+                "LanguageCode": "az"
+            }
+        ]
+    }
+
+**To list languages with a specific display language**
+
+The following ``list-languages`` example lists supported languages with names displayed in German. ::
+
+    aws translate list-languages \
+        --display-language-code de
+
+Output::
+
+    {
+        "Languages": [
+            {
+                "LanguageName": "Afrikaans",
+                "LanguageCode": "af"
+            },
+            {
+                "LanguageName": "Albanisch",
+                "LanguageCode": "sq"
+            },
+            {
+                "LanguageName": "Amharisch",
+                "LanguageCode": "am"
+            }
+        ]
+    }

--- a/awscli/examples/translate/translate-text.rst
+++ b/awscli/examples/translate/translate-text.rst
@@ -1,0 +1,33 @@
+**To translate text from one language to another**
+
+The following ``translate-text`` example translates the text "Hello, world!" from English to Spanish. ::
+
+    aws translate translate-text \
+        --source-language-code en \
+        --target-language-code es \
+        --text "Hello, world!"
+
+Output::
+
+    {
+        "TranslatedText": "¡Hola, mundo!",
+        "SourceLanguageCode": "en",
+        "TargetLanguageCode": "es"
+    }
+
+**To translate text with auto-detection of source language**
+
+The following ``translate-text`` example translates text without specifying the source language, allowing Amazon Translate to automatically detect it. ::
+
+    aws translate translate-text \
+        --source-language-code auto \
+        --target-language-code fr \
+        --text "Good morning"
+
+Output::
+
+    {
+        "TranslatedText": "Bonjour",
+        "SourceLanguageCode": "en",
+        "TargetLanguageCode": "fr"
+    }


### PR DESCRIPTION
## Description
Adds missing CLI examples for AWS Translate service commands to improve documentation coverage.

## Changes
- Add translate-text example showing basic translation and auto-detection of source language
- Add list-languages example showing supported languages listing with optional display language
- Improves documentation coverage for AWS Translate service from 1 to 3 examples

## Testing
Examples follow existing AWS CLI documentation format and provide realistic use cases for common translation workflows including basic text translation and language discovery.

