### PR TITLE
Add CLI examples for Amazon Macie2 core commands

### DIFF
--- a/awscli/examples/macie2/create-classification-job.rst
+++ b/awscli/examples/macie2/create-classification-job.rst
@@ -1,0 +1,52 @@
+**To create a classification job**
+
+The following ``create-classification-job`` example creates a classification job that analyzes objects in the specified S3 bucket for sensitive data. ::
+
+    aws macie2 create-classification-job \
+        --job-type ONE_TIME \
+        --name "ExampleClassificationJob" \
+        --description "Analyze sensitive data in demo bucket" \
+        --s3-job-definition '{
+            "bucketDefinitions": [
+                {
+                    "accountId": "123456789012",
+                    "buckets": ["amzn-s3-demo-bucket"]
+                }
+            ]
+        }'
+
+Output::
+
+    {
+        "jobArn": "arn:aws:macie2:us-east-1:123456789012:classification-job/42a1c188d7f838f9f0c1234567890",
+        "jobId": "42a1c188d7f838f9f0c1234567890"
+    }
+
+**To create a scheduled classification job**
+
+The following ``create-classification-job`` example creates a classification job that runs weekly to analyze new objects. ::
+
+    aws macie2 create-classification-job \
+        --job-type SCHEDULED \
+        --name "WeeklyClassificationJob" \
+        --description "Weekly scan for sensitive data" \
+        --schedule-frequency '{
+            "weeklySchedule": {
+                "dayOfWeek": "SUNDAY"
+            }
+        }' \
+        --s3-job-definition '{
+            "bucketDefinitions": [
+                {
+                    "accountId": "123456789012",
+                    "buckets": ["amzn-s3-demo-bucket"]
+                }
+            ]
+        }'
+
+Output::
+
+    {
+        "jobArn": "arn:aws:macie2:us-east-1:123456789012:classification-job/52b2c299e8g949g0g1d2345678901",
+        "jobId": "52b2c299e8g949g0g1d2345678901"
+    }

--- a/awscli/examples/macie2/enable-macie.rst
+++ b/awscli/examples/macie2/enable-macie.rst
@@ -1,0 +1,25 @@
+**To enable Amazon Macie**
+
+The following ``enable-macie`` example enables Amazon Macie for the current AWS account and Region. ::
+
+    aws macie2 enable-macie
+
+Output::
+
+    {
+        "status": "ENABLED"
+    }
+
+**To enable Amazon Macie with custom configuration**
+
+The following ``enable-macie`` example enables Amazon Macie with a custom finding publishing frequency and status. ::
+
+    aws macie2 enable-macie \
+        --finding-publishing-frequency FIFTEEN_MINUTES \
+        --status PAUSED
+
+Output::
+
+    {
+        "status": "PAUSED"
+    }

--- a/awscli/examples/macie2/get-findings.rst
+++ b/awscli/examples/macie2/get-findings.rst
@@ -1,0 +1,88 @@
+**To retrieve Amazon Macie findings**
+
+The following ``get-findings`` example retrieves the details of up to 3 findings. ::
+
+    aws macie2 get-findings \
+        --finding-ids "64ed80b084b5b7b985b12345" "64ed80b084b5b7b985b67890" \
+        --sort-criteria attributeName=severity.score,orderBy=DESC
+
+Output::
+
+    {
+        "findings": [
+            {
+                "accountId": "123456789012",
+                "archived": false,
+                "category": "POLICY",
+                "classificationDetails": {
+                    "detailedResultsLocation": "s3://amzn-s3-demo-bucket/sensitive-data/results.json",
+                    "jobArn": "arn:aws:macie2:us-east-1:123456789012:classification-job/42a1c188d7f838f9f0c1234567890",
+                    "result": {
+                        "status": {
+                            "code": "COMPLETE"
+                        }
+                    }
+                },
+                "count": 2,
+                "createdAt": "2023-05-07T20:21:01.656000+00:00",
+                "description": "The S3 bucket is publicly readable.",
+                "id": "64ed80b084b5b7b985b12345",
+                "partition": "aws",
+                "region": "us-east-1",
+                "resourcesAffected": {
+                    "s3Bucket": {
+                        "arn": "arn:aws:s3:::amzn-s3-demo-bucket",
+                        "name": "amzn-s3-demo-bucket",
+                        "owner": {
+                            "displayName": "example-user",
+                            "id": "111122223333"
+                        },
+                        "publicAccess": {
+                            "effectivePermission": "PUBLIC",
+                            "permissionConfiguration": {
+                                "bucketLevelPermissions": {
+                                    "accessControlList": {
+                                        "allowsPublicReadAccess": true,
+                                        "allowsPublicWriteAccess": false
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "severity": {
+                    "description": "High",
+                    "score": 7.4
+                },
+                "title": "Bucket policy allows public read access",
+                "type": "Policy:IAMUser/S3BucketPublicReadAccess",
+                "updatedAt": "2023-05-07T20:21:01.656000+00:00"
+            }
+        ]
+    }
+
+**To retrieve findings with specific criteria**
+
+The following ``get-findings`` example retrieves findings that match specific criteria, such as findings with high severity. ::
+
+    aws macie2 get-findings \
+        --finding-ids "64ed80b084b5b7b985b12345" \
+        --sort-criteria attributeName=createdAt,orderBy=ASC
+
+Output::
+
+    {
+        "findings": [
+            {
+                "accountId": "123456789012",
+                "archived": false,
+                "category": "CLASSIFICATION",
+                "severity": {
+                    "description": "High",
+                    "score": 8.1
+                },
+                "title": "Sensitive data was detected in an S3 object",
+                "type": "SensitiveData:S3Object/Personal"
+            }
+        ]
+    }


### PR DESCRIPTION
Add CLI examples for Amazon Macie2 core commands

## Description
Adds missing CLI examples for Amazon Macie2 security service commands to improve documentation coverage.

## Changes
- Add enable-macie example showing basic enablement and custom configuration options
- Add get-findings example showing security finding retrieval and filtering capabilities
- Add create-classification-job example for one-time and scheduled data classification jobs
- Improves documentation coverage for Amazon Macie2 service from 1 to 4 examples

## Testing
Examples follow existing AWS CLI documentation format and provide realistic use cases for essential Macie2 security workflows including service setup, finding analysis, and data classification.

