### PR TITLE
Add CLI examples for Amazon Managed Grafana workspace operations

### DIFF
--- a/awscli/examples/grafana/create-workspace.rst
+++ b/awscli/examples/grafana/create-workspace.rst
@@ -1,0 +1,55 @@
+**To create a Grafana workspace**
+
+The following ``create-workspace`` example creates a new Amazon Managed Grafana workspace with basic configuration. ::
+
+    aws grafana create-workspace \
+        --workspace-name "MyGrafanaWorkspace" \
+        --workspace-description "Development team monitoring workspace" \
+        --account-access-type CURRENT_ACCOUNT \
+        --authentication-providers AWS_SSO \
+        --permission-type SERVICE_MANAGED
+
+Output::
+
+    {
+        "workspace": {
+            "id": "g-1234567890",
+            "name": "MyGrafanaWorkspace",
+            "description": "Development team monitoring workspace",
+            "endpoint": "https://g-1234567890.grafana-workspace.us-east-1.amazonaws.com",
+            "status": "CREATING",
+            "created": "2023-05-07T20:21:01.656000+00:00",
+            "modified": "2023-05-07T20:21:01.656000+00:00",
+            "accountAccessType": "CURRENT_ACCOUNT",
+            "authenticationProviders": ["AWS_SSO"],
+            "permissionType": "SERVICE_MANAGED",
+            "grafanaVersion": "9.4"
+        }
+    }
+
+**To create a workspace with custom data sources**
+
+The following ``create-workspace`` example creates a Grafana workspace with specific data sources enabled. ::
+
+    aws grafana create-workspace \
+        --workspace-name "ProductionMonitoring" \
+        --workspace-description "Production monitoring and alerting" \
+        --account-access-type CURRENT_ACCOUNT \
+        --authentication-providers AWS_SSO \
+        --permission-type SERVICE_MANAGED \
+        --workspace-data-sources CLOUDWATCH PROMETHEUS XRAY \
+        --workspace-notification-destinations SNS
+
+Output::
+
+    {
+        "workspace": {
+            "id": "g-0987654321",
+            "name": "ProductionMonitoring",
+            "description": "Production monitoring and alerting",
+            "endpoint": "https://g-0987654321.grafana-workspace.us-east-1.amazonaws.com",
+            "status": "CREATING",
+            "dataSources": ["CLOUDWATCH", "PROMETHEUS", "XRAY"],
+            "notificationDestinations": ["SNS"]
+        }
+    }

--- a/awscli/examples/grafana/describe-workspace.rst
+++ b/awscli/examples/grafana/describe-workspace.rst
@@ -1,0 +1,28 @@
+**To describe a Grafana workspace**
+
+The following ``describe-workspace`` example retrieves detailed information about a specific Grafana workspace. ::
+
+    aws grafana describe-workspace \
+        --workspace-id g-1234567890
+
+Output::
+
+    {
+        "workspace": {
+            "id": "g-1234567890",
+            "name": "MyGrafanaWorkspace",
+            "description": "Development team monitoring workspace",
+            "endpoint": "https://g-1234567890.grafana-workspace.us-east-1.amazonaws.com",
+            "status": "ACTIVE",
+            "created": "2023-05-07T20:21:01.656000+00:00",
+            "modified": "2023-05-07T20:25:15.123000+00:00",
+            "accountAccessType": "CURRENT_ACCOUNT",
+            "authenticationProviders": ["AWS_SSO"],
+            "permissionType": "SERVICE_MANAGED",
+            "grafanaVersion": "9.4",
+            "dataSources": ["CLOUDWATCH"],
+            "organizationRoleName": "ADMIN",
+            "stackSetName": "grafana-workspace-stack",
+            "workspaceRoleArn": "arn:aws:iam::123456789012:role/service-role/AmazonGrafanaServiceRole-g1234567890"
+        }
+    }

--- a/awscli/examples/grafana/update-workspace.rst
+++ b/awscli/examples/grafana/update-workspace.rst
@@ -1,0 +1,43 @@
+**To update a Grafana workspace**
+
+The following ``update-workspace`` example updates the name and description of an existing Grafana workspace. ::
+
+    aws grafana update-workspace \
+        --workspace-id g-1234567890 \
+        --workspace-name "UpdatedGrafanaWorkspace" \
+        --workspace-description "Updated development team monitoring workspace"
+
+Output::
+
+    {
+        "workspace": {
+            "id": "g-1234567890",
+            "name": "UpdatedGrafanaWorkspace",
+            "description": "Updated development team monitoring workspace",
+            "endpoint": "https://g-1234567890.grafana-workspace.us-east-1.amazonaws.com",
+            "status": "UPDATING",
+            "modified": "2023-05-07T21:30:45.789000+00:00"
+        }
+    }
+
+**To update workspace data sources**
+
+The following ``update-workspace`` example adds additional data sources to an existing workspace. ::
+
+    aws grafana update-workspace \
+        --workspace-id g-1234567890 \
+        --workspace-data-sources CLOUDWATCH PROMETHEUS TIMESTREAM \
+        --workspace-notification-destinations SNS SES
+
+Output::
+
+    {
+        "workspace": {
+            "id": "g-1234567890",
+            "name": "UpdatedGrafanaWorkspace",
+            "status": "UPDATING",
+            "dataSources": ["CLOUDWATCH", "PROMETHEUS", "TIMESTREAM"],
+            "notificationDestinations": ["SNS", "SES"],
+            "modified": "2023-05-07T21:35:12.456000+00:00"
+        }
+    }


### PR DESCRIPTION
## Description
Adds missing CLI examples for Amazon Managed Grafana service commands to improve documentation coverage.

## Changes
- Add create-workspace example showing basic and advanced workspace creation with data sources
- Add describe-workspace example for retrieving detailed workspace information and configuration
- Add update-workspace example for modifying workspace settings and data source configurations
- Improves documentation coverage for Amazon Managed Grafana service from 1 to 4 examples

## Testing
Examples follow existing AWS CLI documentation format and provide realistic use cases for essential Grafana workspace management including creation, inspection, and configuration updates.

