### PR TITLE
Add 'wire' as a valid value for cli_timestamp_format.

### DIFF
--- a/.changes/next-release/enhancement-timestamps-52310.json
+++ b/.changes/next-release/enhancement-timestamps-52310.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "timestamps",
-  "description": "Add `wire` as a valid value for `cli_timestamp_format`."
+  "description": "Add ``wire`` as a valid value for ``cli_timestamp_format``."
 }

--- a/.changes/next-release/enhancement-timestamps-52310.json
+++ b/.changes/next-release/enhancement-timestamps-52310.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "timestamps",
+  "description": "Add `wire` as a valid value for `cli_timestamp_format`."
+}

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -71,7 +71,7 @@ def add_timestamp_parser(session):
         timestamp_parser = iso_format
     else:
         raise ValueError('Unknown cli_timestamp_format value: %s, valid values'
-                         ' are "wire" or "iso8601"' % timestamp_format)
+                         ' are "none", "wire" or "iso8601"' % timestamp_format)
     factory.set_parser_defaults(timestamp_parser=timestamp_parser)
 
 

--- a/awscli/customizations/scalarparse.py
+++ b/awscli/customizations/scalarparse.py
@@ -49,7 +49,7 @@ def add_timestamp_parser(session):
     try:
         timestamp_format = session.get_scoped_config().get(
             'cli_timestamp_format',
-            'none')
+            'wire')
     except ProfileNotFound:
         # If a --profile is provided that does not exist, loading
         # a value from get_scoped_config will crash the CLI.
@@ -57,9 +57,11 @@ def add_timestamp_parser(session):
         # the session-initialized event, which happens before a
         # profile can be created, even if the command would have
         # successfully created a profile. Instead of crashing here
-        # on a ProfileNotFound the CLI should just use 'none'.
-        timestamp_format = 'none'
-    if timestamp_format == 'none':
+        # on a ProfileNotFound the CLI should just use 'wire'.
+        timestamp_format = 'wire'
+    # We also support 'none' for backwards compatibility reasons, though we
+    # document 'wire' instead.
+    if timestamp_format == 'wire' or timestamp_format == 'none':
         # For backwards compatibility reasons, we replace botocore's timestamp
         # parser (which parses to a datetime.datetime object) with the
         # identity function which prints the date exactly the same as it comes
@@ -69,7 +71,7 @@ def add_timestamp_parser(session):
         timestamp_parser = iso_format
     else:
         raise ValueError('Unknown cli_timestamp_format value: %s, valid values'
-                         ' are "none" or "iso8601"' % timestamp_format)
+                         ' are "wire" or "iso8601"' % timestamp_format)
     factory.set_parser_defaults(timestamp_parser=timestamp_parser)
 
 

--- a/awscli/topics/config-vars.rst
+++ b/awscli/topics/config-vars.rst
@@ -98,7 +98,7 @@ The valid values of the ``output`` configuration variable are:
 ``cli_timestamp_format`` controls the format of timestamps displayed by the AWS CLI.
 The valid values of the ``cli_timestamp_format`` configuration variable are:
 
-* none - Display the timestamp exactly as received from the HTTP response.
+* wire - Display the timestamp exactly as received from the HTTP response.
 * iso8601 - Reformat timestamp using iso8601 in the UTC timezone.
 
 ``cli_follow_urlparam`` controls whether or not the CLI will attempt to follow

--- a/tests/unit/customizations/test_scalarparse.py
+++ b/tests/unit/customizations/test_scalarparse.py
@@ -49,6 +49,15 @@ class TestScalarParse(unittest.TestCase):
         factory.set_parser_defaults.assert_called_with(
             timestamp_parser=scalarparse.identity)
 
+    def test_choose_wire_timestamp_formatter(self):
+        session = mock.Mock(spec=Session)
+        session.get_scoped_config.return_value = {'cli_timestamp_format':
+                                                  'wire'}
+        factory = session.get_component.return_value
+        scalarparse.add_scalar_parsers(session)
+        factory.set_parser_defaults.assert_called_with(
+            timestamp_parser=scalarparse.identity)
+
     def test_choose_iso_timestamp_formatter(self):
         session = mock.Mock(spec=Session)
         session.get_scoped_config.return_value = {'cli_timestamp_format':


### PR DESCRIPTION
*Description of changes:*

* Added `wire` as a valid value for `cli_timestamp_format` configuration setting, to align with our [published documentation](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html#cli-config-cli_timestamp_format).

*Description of tests:*

* Added a unit test that tests setting the config value to `wire`. Verified all unit and functional tests pass locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
