### PR TITLE
Add html meta description to service and operation pages

### DIFF
--- a/awscli/bcdoc/docevents.py
+++ b/awscli/bcdoc/docevents.py
@@ -13,6 +13,7 @@
 
 
 DOC_EVENTS = {
+    'doc-meta-description': '.%s',
     'doc-breadcrumbs': '.%s',
     'doc-title': '.%s',
     'doc-description': '.%s',
@@ -38,6 +39,8 @@ DOC_EVENTS = {
 def generate_events(session, help_command):
     # Now generate the documentation events
     session.emit('doc-breadcrumbs.%s' % help_command.event_class,
+                 help_command=help_command)
+    session.emit('doc-meta-description.%s' % help_command.event_class,
                  help_command=help_command)
     session.emit('doc-title.%s' % help_command.event_class,
                  help_command=help_command)

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -17,7 +17,7 @@ import re
 from botocore.model import StringShape
 from botocore.utils import is_json_value_header
 
-from awscli import SCALAR_TYPES
+from awscli import SCALAR_TYPES, __version__ as AWS_CLI_VERSION
 from awscli.argprocess import ParamShorthandDocGen
 from awscli.bcdoc.docevents import DOC_EVENTS
 from awscli.topictags import TopicTagDB
@@ -114,7 +114,8 @@ class CLIDocumentEventHandler:
                 full_cmd_list.append(cmd)
                 full_cmd_name = ' '.join(full_cmd_list)
                 doc.write(f':ref:`{cmd} <cli:{full_cmd_name}>`')
-            doc.write(' ]')
+            doc.writeln(' ]')
+            doc.writeln('')
 
     def doc_title(self, help_command, **kwargs):
         doc = help_command.doc
@@ -222,6 +223,9 @@ class CLIDocumentEventHandler:
             label=f'cli:{related_item}', text=related_item
         )
         doc.write('\n')
+
+    def doc_meta_description(self, help_command, **kwargs):
+        pass
 
     def _document_enums(self, model, doc):
         """Documents top-level parameter enums"""
@@ -401,6 +405,13 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
             doc.style.tocitem(command_name, file_name=f"{command_name}/index")
         else:
             doc.style.tocitem(command_name)
+
+    def doc_meta_description(self, help_command, **kwargs):
+        doc = help_command.doc
+        reference = help_command.event_class.replace('.', ' ')
+        doc.writeln(".. meta::")
+        doc.writeln(f"   :description: Learn about the AWS CLI {AWS_CLI_VERSION} {reference} commands.")
+        doc.writeln("")
 
 
 class OperationDocumentEventHandler(CLIDocumentEventHandler):
@@ -618,6 +629,12 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             for member_name, member_shape in output_shape.members.items():
                 self._doc_member(doc, member_name, member_shape, stack=[])
 
+    def doc_meta_description(self, help_command, **kwargs):
+        doc = help_command.doc
+        reference = help_command.event_class.replace('.', ' ')
+        doc.writeln(".. meta::")
+        doc.writeln(f"   :description: Use the AWS CLI {AWS_CLI_VERSION} to run the {reference} command.")
+        doc.writeln("")
 
 class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     DESCRIPTION = (


### PR DESCRIPTION
*Issue #, if available:*

NA

*Description of changes:*

To all top level service documentation and individual operation pages, add an HTML meta directive.

This also adds in some extra newlines to account for new reStructuredText directives that would have not been spaced properly and then rendered directly as text.

The `doc_meta_description` is added to the main `CLIDocumentEventHandler` so that child classes that inherit it that are not for service or operations do not add the directive to the RST files (like topics or CLI configuration).

Added a test for a service and operation page to assert some of the expected text is included in the document.

### RST file before

```
[ :ref:`aws <cli:aws>` . :ref:`bedrock-agentcore <cli:aws bedrock-agentcore>` ]

.. _cli:aws bedrock-agentcore batch-create-memory-records:


***************************
batch-create-memory-records
***************************
```

### RST file after

```
[ :ref:`aws <cli:aws>` . :ref:`bedrock-agentcore <cli:aws bedrock-agentcore>` ]

.. meta::
   :description: Use the AWS CLI 1.42.59 to run the bedrock-agentcore batch-create-memory-records command.


.. _cli:aws bedrock-agentcore batch-create-memory-records:


***************************
batch-create-memory-records
***************************```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
