### PR TITLE
[v2] Add html meta description to service and operation pages

### DIFF
--- a/awscli/bcdoc/docevents.py
+++ b/awscli/bcdoc/docevents.py
@@ -13,6 +13,7 @@
 
 
 DOC_EVENTS = {
+    'doc-meta-description': '.%s',
     'doc-breadcrumbs': '.%s',
     'doc-title': '.%s',
     'doc-description': '.%s',
@@ -40,6 +41,10 @@ def generate_events(session, help_command):
     session.emit(
         'doc-breadcrumbs.%s' % help_command.event_class,
         help_command=help_command,
+    )
+    session.emit(
+        'doc-meta-description.%s' % help_command.event_class,
+        help_command=help_command
     )
     session.emit(
         'doc-title.%s' % help_command.event_class, help_command=help_command

--- a/awscli/clidocs.py
+++ b/awscli/clidocs.py
@@ -18,7 +18,7 @@ from botocore import xform_name
 from botocore.model import StringShape
 from botocore.utils import is_json_value_header
 
-from awscli import SCALAR_TYPES
+from awscli import SCALAR_TYPES, __version__ as AWS_CLI_VERSION
 from awscli.argprocess import ParamShorthandDocGen
 from awscli.bcdoc.docevents import DOC_EVENTS
 from awscli.topictags import TopicTagDB
@@ -115,7 +115,8 @@ class CLIDocumentEventHandler:
                 full_cmd_list.append(cmd)
                 full_cmd_name = ' '.join(full_cmd_list)
                 doc.write(f':ref:`{cmd} <cli:{full_cmd_name}>`')
-            doc.write(' ]')
+            doc.writeln(' ]')
+            doc.writeln('')
 
     def doc_title(self, help_command, **kwargs):
         doc = help_command.doc
@@ -236,6 +237,9 @@ class CLIDocumentEventHandler:
             label=f'cli:{related_item}', text=related_item
         )
         doc.write('\n')
+
+    def doc_meta_description(self, help_command, **kwargs):
+        pass
 
     def _document_enums(self, model, doc):
         """Documents top-level parameter enums"""
@@ -476,6 +480,13 @@ class ServiceDocumentEventHandler(CLIDocumentEventHandler):
         else:
             doc.style.tocitem(command_name)
 
+    def doc_meta_description(self, help_command, **kwargs):
+        doc = help_command.doc
+        reference = help_command.event_class.replace('.', ' ')
+        doc.writeln(".. meta::")
+        doc.writeln(f"   :description: Learn about the AWS CLI {AWS_CLI_VERSION} {reference} commands.")
+        doc.writeln("")
+
 
 class OperationDocumentEventHandler(CLIDocumentEventHandler):
     AWS_DOC_BASE = 'https://docs.aws.amazon.com/goto/WebAPI'
@@ -683,6 +694,12 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             for member_name, member_shape in output_shape.members.items():
                 self._doc_member(doc, member_name, member_shape, stack=[])
 
+    def doc_meta_description(self, help_command, **kwargs):
+        doc = help_command.doc
+        reference = help_command.event_class.replace('.', ' ')
+        doc.writeln(".. meta::")
+        doc.writeln(f"   :description: Use the AWS CLI {AWS_CLI_VERSION} to run the {reference} command.")
+        doc.writeln("")
 
 class TopicListerDocumentEventHandler(CLIDocumentEventHandler):
     DESCRIPTION = (

--- a/tests/unit/test_clidocs.py
+++ b/tests/unit/test_clidocs.py
@@ -28,6 +28,7 @@ from awscli.clidocs import (
     CLIDocumentEventHandler,
     GlobalOptionsDocumenter,
     OperationDocumentEventHandler,
+    ServiceDocumentEventHandler,
     TopicDocumentEventHandler,
     TopicListerDocumentEventHandler,
 )
@@ -220,7 +221,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler = CLIDocumentEventHandler(help_cmd)
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
-            help_cmd.doc.getvalue().decode('utf-8'), '[ :ref:`aws <cli:aws>` ]'
+            help_cmd.doc.getvalue().decode('utf-8'), '[ :ref:`aws <cli:aws>` ]\n\n'
         )
 
     def test_breadcrumbs_service_command_html(self):
@@ -236,7 +237,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler = CLIDocumentEventHandler(help_cmd)
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
-            help_cmd.doc.getvalue().decode('utf-8'), '[ :ref:`aws <cli:aws>` ]'
+            help_cmd.doc.getvalue().decode('utf-8'), '[ :ref:`aws <cli:aws>` ]\n\n'
         )
 
     def test_breadcrumbs_operation_command_html(self):
@@ -253,7 +254,7 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         doc_handler.doc_breadcrumbs(help_cmd)
         self.assertEqual(
             help_cmd.doc.getvalue().decode('utf-8'),
-            '[ :ref:`aws <cli:aws>` . :ref:`ec2 <cli:aws ec2>` ]',
+            '[ :ref:`aws <cli:aws>` . :ref:`ec2 <cli:aws ec2>` ]\n\n'
         )
 
     def test_breadcrumbs_wait_command_html(self):
@@ -272,8 +273,8 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
             help_cmd.doc.getvalue().decode('utf-8'),
             (
                 '[ :ref:`aws <cli:aws>` . :ref:`s3api <cli:aws s3api>`'
-                ' . :ref:`wait <cli:aws s3api wait>` ]'
-            ),
+                ' . :ref:`wait <cli:aws s3api wait>` ]\n\n'
+            )
         )
 
     def test_documents_json_header_shape(self):
@@ -542,6 +543,32 @@ class TestCLIDocumentEventHandler(unittest.TestCase):
         self.assertIn('min: ``0``', rendered)
         self.assertIn('max: ``10``', rendered)
         self.assertIn('pattern: ``.*``', rendered)
+
+    def test_meta_description_operation_command_html(self):
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, 'ec2.run-instances'
+        )
+        help_cmd.doc.target = 'html'
+        doc_handler = OperationDocumentEventHandler(help_cmd)
+        doc_handler.doc_meta_description(help_cmd)
+
+        meta_description = help_cmd.doc.getvalue().decode('utf-8')
+        self.assertIn(".. meta::\n   :description: ", meta_description)
+        self.assertIn('to run the ec2 run-instances command', meta_description)
+
+    def test_meta_description_service_html(self):
+        help_cmd = ServiceHelpCommand(
+            self.session, self.obj, self.command_table, self.arg_table,
+            self.name, 'ec2'
+        )
+        help_cmd.doc.target = 'html'
+        doc_handler = ServiceDocumentEventHandler(help_cmd)
+        doc_handler.doc_meta_description(help_cmd)
+
+        meta_description = help_cmd.doc.getvalue().decode('utf-8')
+        self.assertIn(".. meta::\n   :description: Learn about the AWS CLI ", meta_description)
+        self.assertIn(' ec2 commands', meta_description)
 
 
 class TestTopicDocumentEventHandlerBase(unittest.TestCase):


### PR DESCRIPTION
*Issue #, if available:*

Port of #9824 to v2.

*Description of changes:*

This adds an html meta description only to service and operation pages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
