### PR TITLE
Update create-datastore.rst

### DIFF
--- a/awscli/examples/medical-imaging/create-datastore.rst
+++ b/awscli/examples/medical-imaging/create-datastore.rst
@@ -1,6 +1,6 @@
 **To create a data store**
 
-The following ``create-datastore`` code example creates a data store with the name ``my-datastore``. When you create a datastore without specifying a ``—lossless-storage-format``, AWS HealthImaging defaults to HTJ2K (High Throughput JPEG 2000). ::
+The following ``create-datastore`` code example creates a data store with the name ``my-datastore``. When you create a datastore without specifying a ``--lossless-storage-format``, AWS HealthImaging defaults to HTJ2K (High Throughput JPEG 2000). ::
 
     aws medical-imaging create-datastore \
         --datastore-name "my-datastore"


### PR DESCRIPTION
Added info for JPEG 2000 lossless datastore

*Issue #, if available:* The create datastore CLI needs to include JPEG 2000 lossless info


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
