### PR TITLE
[Documentation] Warning against the use of S3 Global Endpoint (s3.amazonaws.com) as endpoint-url

### DIFF
--- a/awscli/topics/s3-config.rst
+++ b/awscli/topics/s3-config.rst
@@ -18,7 +18,7 @@ for performance reasons or to account for the specific environment where these
 .. note::
    S3 commands have an option to use a custom endpoint using ``--endpoint-url``.
    This overrides the default endpoint the command will use.
-   Use caution when configuring this parameter as it can cause S3 unintended behavior including S3 redirect issues.
+   Use caution when configuring this parameter as it can cause unintended behavior including S3 redirect issues.
    See `Service-specific endpoints <https://docs.aws.amazon.com/sdkref/latest/guide/feature-ss-endpoints.html>`_ page in the *AWS SDK reference guide* for more information.
 
 Configuration Values


### PR DESCRIPTION
## Summary
Adds documentation improvements to [S3 configuration documentation](https://docs.aws.amazon.com/cli/latest/topic/s3-config.html) (in the AWS CLI) for the --endpoint-url parameter:

1. Warning against S3 Global endpoint: Advises users to avoid using `https://s3.amazonaws.com` or `http://s3.amazonaws.com` as the --endpoint-url parameter value, as it can cause PermanentRedirect errors and configuration confusion.

2. General endpoint_url guidance: Adds a note explaining the --endpoint-url parameter usage, including caution about S3 unintended behavior such as S3 redirect issues. References the AWS SDK reference guide for additional endpoint configuration information.

## Testing
• [x] Documentation builds successfully with make html
• [x] Warning and note display correctly in generated docs



<img width="1049" height="1150" alt="Screenshot 2025-11-28 at 9 40 03 AM" src="https://github.com/user-attachments/assets/c3ea28a5-3de4-42ba-8b1a-5b46d9e5daf2" />



Addresses #9479