### PR TITLE
Fix failing EMR customization unit test

### DIFF
--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -235,7 +235,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
             'ActionOnFailure=TERMINATE_CLUSTER,'
             'LogUri="TestLogUri",'
             'EncryptionKeyArn="TestEncryptionKeyArn",'
-            'Properties=k1=v1\,k2=v2\,k3'
+            'Properties=k1=v1\\,k2=v2\\,k3'
         )
         expected_result = {
             'JobFlowId': 'j-ABC',


### PR DESCRIPTION
*Description of changes:*

* Update unit test to escape backslash characters in a unit test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
