### PR TITLE
Fix invalid escape sequence in EMR test

### DIFF
--- a/tests/unit/customizations/emr/test_add_steps.py
+++ b/tests/unit/customizations/emr/test_add_steps.py
@@ -235,7 +235,7 @@ class TestAddSteps(BaseAWSCommandParamsTest):
             'ActionOnFailure=TERMINATE_CLUSTER,'
             'LogUri="TestLogUri",'
             'EncryptionKeyArn="TestEncryptionKeyArn",'
-            'Properties=k1=v1\,k2=v2\,k3'
+            'Properties=k1=v1\\,k2=v2\\,k3'
         )
         expected_result = {
             'JobFlowId': 'j-ABC',


### PR DESCRIPTION
*Notes:*

* v1 port of #9865, which fixed a test error. We do not see this error in v1, because v2 is specifically configured to treat `DeprecationWarning`s as errors, which is not the case for v1. This PR is still worth creating to resolve the warning in v1.

*Description of changes:*

* v1 port of https://github.com/aws/aws-cli/pull/9865



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
