### PR TITLE
[v2] Use AssertionError instead of unittest.TestCase.fail for S3 memory assertion integration tests

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1554,7 +1554,7 @@ class TestMemoryUtilization(BaseS3IntegrationTest):
                     peak_memory / 1024.0 / 1024.0,
                 )
             )
-            self.fail(failure_message)
+            raise AssertionError(failure_message)
 
     def test_transfer_single_large_file(self, files, shared_bucket):
         # 40MB will force a multipart upload.

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1544,17 +1544,12 @@ class TestMemoryUtilization(BaseS3IntegrationTest):
 
     def assert_max_memory_used(self, process, max_mem_allowed, full_command):
         peak_memory = max(process.memory_usage)
-        if peak_memory > max_mem_allowed:
-            failure_message = (
-                'Exceeded max memory allowed (%s MB) for command '
-                '"%s": %s MB'
-                % (
-                    self.max_mem_allowed / 1024.0 / 1024.0,
-                    full_command,
-                    peak_memory / 1024.0 / 1024.0,
-                )
-            )
-            raise AssertionError(failure_message)
+
+        assert peak_memory <= max_mem_allowed, (
+            "Exceeded max memory allowed "
+            f"({max_mem_allowed / 1024.0 / 1024.0} MB) for command "
+            f'"{full_command}": {peak_memory / 1024.0 / 1024.0} MB'
+        )
 
     def test_transfer_single_large_file(self, files, shared_bucket):
         # 40MB will force a multipart upload.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Integration tests were ported from CLI v1, but some were altered to not inherit from a `unittest.TestCase`, so it does not have a fail method. Tests using the `assert_max_memory_used` will fail incorrectly and not print the failure message. This change makes the test raise an `AssertionError` with the existing failure message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
