### PR TITLE
[v2] Fix start-live-tail tests

### DIFF
--- a/awscli/customizations/logs/startlivetail.py
+++ b/awscli/customizations/logs/startlivetail.py
@@ -620,6 +620,7 @@ class InteractiveUI(BaseLiveTailUI):
         log_events,
         session_metadata: LiveTailSessionMetadata,
         app_output=None,
+        app_input=None,
     ) -> None:
         self._log_events = log_events
         self._session_metadata = session_metadata
@@ -633,9 +634,9 @@ class InteractiveUI(BaseLiveTailUI):
             self._session_metadata,
             self._keywords_to_highlight,
         )
-        self._create_ui(app_output)
+        self._create_ui(app_output, app_input)
 
-    def _create_ui(self, app_output):
+    def _create_ui(self, app_output, app_input):
         prompt_buffer = Buffer()
         self._prompt_buffer_control = BufferControl(prompt_buffer)
         prompt_buffer_window = Window(self._prompt_buffer_control)
@@ -677,6 +678,7 @@ class InteractiveUI(BaseLiveTailUI):
             key_bindings=self._key_bindings,
             refresh_interval=1,
             output=app_output,
+            input=app_input,
         )
 
     @property

--- a/tests/unit/customizations/logs/test_startlivetail.py
+++ b/tests/unit/customizations/logs/test_startlivetail.py
@@ -17,6 +17,7 @@ from prompt_toolkit.application import Application
 from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.key_binding import KeyPressEvent
 from prompt_toolkit.output import DummyOutput
+from prompt_toolkit.input import create_pipe_input
 
 from awscli.compat import StringIO
 from awscli.customizations.logs.startlivetail import (
@@ -607,7 +608,8 @@ class InteractiveUITest(unittest.IsolatedAsyncioTestCase):
         self.log_events = []
         self.session_metadata = LiveTailSessionMetadata()
         self.ui = InteractiveUI(
-            self.log_events, self.session_metadata, app_output=DummyOutput()
+            self.log_events, self.session_metadata, app_output=DummyOutput(),
+            app_input=create_pipe_input()
         )
 
     def test_update_toolbar(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This fix addresses failures encountered on some systems when running the startlivetail unit tests through the AWS CLI test runner script at `scripts/ci/run-tests`. This change adds an optional `app_input` parameter so that the test can be run with `create_pipe_input()` to replace the input for unit testing.

According to prompt toolkit documentation:

> During the creation of a prompt_toolkit Application, we can specify
> what input and output device to be used. By default, these are output
> objects that correspond with sys.stdin and sys.stdout. In unit tests
> however, we want to replace these.
> - For the input, we want a “pipe input”. This is an input device,
> in which we can programmatically send some input. It can be created
> with create_pipe_input(), and that return either a PosixPipeInput or a
> Win32PipeInput depending on the platform.

Reference: https://python-prompt-toolkit.readthedocs.io/en/stable/pages/advanced_topics/unit_testing.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
