### PR TITLE
Add monitoring configuration to emr create-cluster

### DIFF
--- a/awscli/customizations/emr/argumentschema.py
+++ b/awscli/customizations/emr/argumentschema.py
@@ -868,3 +868,47 @@ AUTO_TERMINATION_POLICY_SCHEMA = {
         }
     },
 }
+
+MONITORING_CONFIGURATION_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "CloudWatchLogConfiguration": {
+            "type": "object",
+            "description": "CloudWatch log configuration settings and metadata that specify settings like log files to monitor and where to send them.",
+            "properties": {
+                "Enabled": {
+                    "type": "boolean",
+                    "description": "Specifies if CloudWatch logging is enabled.",
+                    "required": True
+                },
+                "LogGroupName": {
+                    "type": "string",
+                    "description": "The name of the CloudWatch log group where logs are published."
+                },
+                "LogStreamNamePrefix": {
+                    "type": "string",
+                    "description": "The prefix of the log stream name."
+                },
+                "EncryptionKeyArn": {
+                    "type": "string",
+                    "description": "The ARN of the encryption key used to encrypt the logs."
+                },
+                "LogTypes": {
+                    "type": "map",
+                    "key": {
+                        "type": "string",
+                        "description": "Log type category"
+                    },
+                    "value": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "File names (STDOUT or STDERR) for the log type"
+                    },
+                    "description": "A map of log types to file names for publishing logs to the standard output or standard error streams for CloudWatch. Valid log types include STEP_LOGS, SPARK_DRIVER, and SPARK_EXECUTOR. Valid file names for each type include STDOUT and STDERR."
+                }
+            }
+        }
+    }
+}

--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -214,6 +214,11 @@ class CreateCluster(Command):
             'help_text': helptext.AUTO_TERMINATION_POLICY,
         },
         {
+            'name': 'monitoring-configuration',
+            'schema': argumentschema.MONITORING_CONFIGURATION_SCHEMA,
+            'help_text': helptext.MONITORING_CONFIGURATION,
+        },
+        {
             'name': 'extended-support',
             'action': 'store_true',
             'group_name': 'extended-support',
@@ -552,6 +557,13 @@ class CreateCluster(Command):
                 params,
                 'AutoTerminationPolicy',
                 parsed_args.auto_termination_policy,
+            )
+
+        if parsed_args.monitoring_configuration is not None:
+            emrutils.apply_dict(
+                params,
+                'MonitoringConfiguration',
+                parsed_args.monitoring_configuration,
             )
 
         self._validate_required_applications(parsed_args)

--- a/awscli/customizations/emr/helptext.py
+++ b/awscli/customizations/emr/helptext.py
@@ -570,3 +570,13 @@ UNHEALTHY_NODE_REPLACEMENT = (
 )
 
 EXTENDED_SUPPORT = '<p>Reserved.</p> '
+
+MONITORING_CONFIGURATION = (
+    '<p>Monitoring configuration for an Amazon EMR cluster. '
+    'The configuration specifies CloudWatch logging settings for the cluster. '
+    'You can configure the CloudWatchLogConfiguration which includes '
+    'the Enabled flag (required), LogGroupName, LogStreamNamePrefix, '
+    'EncryptionKeyArn, and LogTypes. The LogTypes parameter is a map '
+    'of log type categories (e.g., "STEP_LOGS", "SPARK_DRIVER", '
+    '"SPARK_EXECUTOR") to a list of file names (e.g., "STDOUT", "STDERR").</p>'
+)

--- a/tests/unit/customizations/emr/test_create_cluster_release_label.py
+++ b/tests/unit/customizations/emr/test_create_cluster_release_label.py
@@ -1828,6 +1828,39 @@ class TestCreateCluster(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(cmd, result)
 
+    def test_create_cluster_with_monitoring_configuration(self):
+        cmd = (
+            self.prefix
+            + '--release-label emr-5.34.0 '
+            + '--monitoring-configuration '
+            + 'CloudWatchLogConfiguration={Enabled=true,LogGroupName=MyLogGroup,'
+            + 'LogStreamNamePrefix=MyPrefix,EncryptionKeyArn=arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012,'
+            + 'LogTypes={STEP_LOGS=[STDOUT,STDERR],SPARK_DRIVER=[STDOUT],SPARK_EXECUTOR=[STDERR]}} '
+            + '--instance-groups '
+            + DEFAULT_INSTANCE_GROUPS_ARG
+        )
+        result = {
+            'Name': DEFAULT_CLUSTER_NAME,
+            'Instances': DEFAULT_INSTANCES,
+            'ReleaseLabel': 'emr-5.34.0',
+            'VisibleToAllUsers': True,
+            'Tags': [],
+            'MonitoringConfiguration': {
+                'CloudWatchLogConfiguration': {
+                    'Enabled': True,
+                    'LogGroupName': 'MyLogGroup',
+                    'LogStreamNamePrefix': 'MyPrefix',
+                    'EncryptionKeyArn': 'arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012',
+                    'LogTypes': {
+                        'STEP_LOGS': ['STDOUT', 'STDERR'],
+                        'SPARK_DRIVER': ['STDOUT'],
+                        'SPARK_EXECUTOR': ['STDERR'],
+                    },
+                },
+            },
+        }
+        self.assert_params_for_cmd(cmd, result)
+
     def test_create_cluster_with_log_encryption_kms_key_id(self):
         test_log_uri = 's3://test/logs'
         test_log_encryption_kms_key_id = 'valid_kms_key'


### PR DESCRIPTION
## Note: This is a cherry-pick of [#9891](https://github.com/aws/aws-cli/pull/9891) to the v2 branch.

## Description
Add support for the `--monitoring-configuration` parameter to the `emr create-cluster` command, enabling users to configure CloudWatch logging for EMR clusters through the CLI.

## Motivation
This change exposes an existing EMR API feature (`MonitoringConfiguration`) through the AWS CLI, allowing users to configure cluster-level CloudWatch logging without needing to use the AWS SDK or Console.

## Changes
- Added `MONITORING_CONFIGURATION_SCHEMA` to `argumentschema.py`
- Added `MONITORING_CONFIGURATION` help text to `helptext.py`
- Integrated `--monitoring-configuration` parameter in `createcluster.py`
- Added unit test `test_create_cluster_with_monitoring_configuration`

## Testing
- Unit tests pass locally
- Test validates parameter parsing and API call structure
- No changes to botocore or service models required

## Example Usage
```bash
aws emr create-cluster \
  --release-label emr-7.11.0 \
  --instance-groups InstanceGroupType=MASTER,InstanceType=m5.xlarge,InstanceCount=1 \
  --monitoring-configuration '{
    "CloudWatchLogConfiguration": {
        "Enabled": true,
        "LogGroupName": "MyLogGroup",
        "LogStreamNamePrefix": "MyPrefix",
        "EncryptionKeyArn": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012",
        "LogTypes": {
            "STEP_LOGS": ["STDOUT", "STDERR"],
            "SPARK_DRIVER": ["STDOUT"],
            "SPARK_EXECUTOR": ["STDERR"]
        }
    }
}'