### PR TITLE
Input and output for JPEG2K to create-datastore.rst

### DIFF
--- a/awscli/examples/medical-imaging/create-datastore.rst
+++ b/awscli/examples/medical-imaging/create-datastore.rst
@@ -1,9 +1,26 @@
 **To create a data store**
 
-The following ``create-datastore`` code example creates a data store with the name ``my-datastore``. When you create a datastore without specifying a ``--lossless-storage-format``, AWS HealthImaging defaults to HTJ2K (High Throughput JPEG 2000). ::
+The following ``create-datastore`` code example creates a data store with the name ``my-datastore``.
+When you create a datastore without specifying a ``--lossless-storage-format``, AWS HealthImaging defaults to HTJ2K (High Throughput JPEG 2000). ::
 
     aws medical-imaging create-datastore \
         --datastore-name "my-datastore"
+
+Output::
+
+    {
+        "datastoreId": "12345678901234567890123456789012",
+        "datastoreStatus": "CREATING"
+    }
+
+**To create a data store with JPEG 2000 Lossless storage format**
+
+A data store configured with JPEG 2000 Lossless storage format will transcode and persist lossless image frames in JPEG 2000 format. Image frames can then be retrieved in 
+JPEG 2000 Lossless without transcoding. The following ``create-datastore`` code example creates a data store configured for JPEG 2000 Lossless storage format with the name ``my-datastore``. ::
+
+    aws medical-imaging create-datastore \
+        --datastore-name "my-datastore" \
+        --lossless-storage-format JPEG_2000_LOSSLESS
 
 Output::
 


### PR DESCRIPTION
*Description of changes:* Further updates for the create data store CLI section in the dev guide. This includes input for both the default and the specified JPEG2000 image format along with their outputs with the description of the differences indication.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
