### PR TITLE
Fix ecs monitor-express-gateway-service timeout behavior

### DIFF
--- a/.changes/next-release/bugfix-ecs-31001.json
+++ b/.changes/next-release/bugfix-ecs-31001.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``ecs``",
+  "description": "Fixes timeout behavior of the ``ecs monitor-express-gateway-service`` command."
+}

--- a/awscli/customizations/ecs/expressgateway/color_utils.py
+++ b/awscli/customizations/ecs/expressgateway/color_utils.py
@@ -24,7 +24,7 @@ class ColorUtils:
 
     def __init__(self):
         # Initialize colorama
-        init(autoreset=True, strip=False)
+        init(autoreset=False, strip=False)
 
     def make_green(self, text, use_color=True):
         if not use_color:

--- a/awscli/customizations/ecs/monitorexpressgatewayservice.py
+++ b/awscli/customizations/ecs/monitorexpressgatewayservice.py
@@ -238,6 +238,7 @@ class ECSExpressGatewayServiceWatcher:
             while True:
                 current_time = time.time()
                 if current_time - self.start_time > self.timeout_minutes * 60:
+                    self.display.app.exit()
                     break
                 try:
                     loop = asyncio.get_event_loop()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This fixes an issue where the command would not properly exit the interactive display upon timeout. Once properly exiting on timeout, Colorama would fall into an infinite loop due to its autoreset behavior.

I have manually validated this behavior for now as automated testing of the interactive display is proving difficult.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
