### PR TITLE
Fix validates models record property

### DIFF
--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -41,7 +41,7 @@ def test_no_event_stream_unless_allowed(record_property):
                         # Store the service and operation in
                         # PyTest custom properties
                         record_property(
-                            'aws_service', model.service_model.service_id
+                            'aws_service', str(model.service_model.service_id)
                         )
                         record_property('aws_operation', model.name)
                         supported_commands = '\n'.join(_ALLOWED_COMMANDS)

--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -16,7 +16,7 @@ from botocore.model import OperationModel
 from awscli.clidriver import create_clidriver
 
 # Excluded commands must be registered in awscli/customizations/removals.py
-_ALLOWED_COMMANDS = []
+_ALLOWED_COMMANDS = ['s3api select-object-content']
 
 
 @pytest.mark.validates_models

--- a/tests/functional/test_no_event_streams.py
+++ b/tests/functional/test_no_event_streams.py
@@ -16,7 +16,7 @@ from botocore.model import OperationModel
 from awscli.clidriver import create_clidriver
 
 # Excluded commands must be registered in awscli/customizations/removals.py
-_ALLOWED_COMMANDS = ['s3api select-object-content']
+_ALLOWED_COMMANDS = []
 
 
 @pytest.mark.validates_models
@@ -41,7 +41,7 @@ def test_no_event_stream_unless_allowed(record_property):
                         # Store the service and operation in
                         # PyTest custom properties
                         record_property(
-                            'aws_service', str(model.service_model.service_id)
+                            'aws_service', model.service_model.service_name
                         )
                         record_property('aws_operation', model.name)
                         supported_commands = '\n'.join(_ALLOWED_COMMANDS)

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -69,7 +69,7 @@ def test_no_shadowed_builtins(
                     # Store the service and operation in
                     # PyTest custom properties
                     record_property(
-                        'aws_service', str(model.service_model.service_id)
+                        'aws_service', model.service_model.service_name
                     )
                     record_property('aws_operation', model.name)
                 # Then we are shadowing or prefixing a top level argument

--- a/tests/functional/test_shadowing.py
+++ b/tests/functional/test_shadowing.py
@@ -69,7 +69,7 @@ def test_no_shadowed_builtins(
                     # Store the service and operation in
                     # PyTest custom properties
                     record_property(
-                        'aws_service', model.service_model.service_id
+                        'aws_service', str(model.service_model.service_id)
                     )
                     record_property('aws_operation', model.name)
                 # Then we are shadowing or prefixing a top level argument


### PR DESCRIPTION
*Description of changes:*

* Switch use of `service_id` in `validates-models` tests to use of `service_name`. The use of `service_id` would cause a serialization error since PyTest does not know how to serialize/deserialize it.

*Description of tests:*

* Forced the `test_no_event_stream_unless_allowed` test to call `record_property` with `service_name`, and verified that PyTest does not raise any internal errors.
* Successfully ran all CI and test suites.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
