### PR TITLE
Add prefix to CloudTrail S3 digest file listing

### DIFF
--- a/.changes/next-release/enhancement-cloudtrail-89408.json
+++ b/.changes/next-release/enhancement-cloudtrail-89408.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "cloudtrail",
+  "description": "Fixed performance issue in cloudtrail validate-logs command by scoping S3 digest file listing to the trail's region instead of processing digest files from all regions."
+}

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -595,15 +595,16 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
         mock_search = mock_paginate.return_value.search
         mock_search.return_value = []
         provider = self._get_mock_provider(s3_client)
-        provider.load_digest_keys_in_range('1', 'prefix', START_DATE, END_DATE)
-        marker = (
-            'prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1/'
-            '2014/08/09/{account}_CloudTrail-Digest_us-east-1_foo_'
-            'us-east-1_20140809T235900Z.json.gz'
-        )
+        provider.load_digest_keys_in_range(
+            '1', 'prefix', START_DATE, END_DATE)
+        marker = ('prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1/'
+                  '2014/08/09/{account}_CloudTrail-Digest_us-east-1_foo_'
+                  'us-east-1_20140809T235900Z.json.gz')
+        prefix = 'prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1'
         mock_paginate.assert_called_once_with(
-            Bucket='1', Marker=marker.format(account=TEST_ACCOUNT_ID)
-        )
+            Bucket='1',
+            Marker=marker.format(account=TEST_ACCOUNT_ID),
+            Prefix=prefix.format(account=TEST_ACCOUNT_ID))
 
     def test_calls_list_objects_correctly_org_trails(self):
         s3_client = mock.Mock()
@@ -627,13 +628,61 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
             '2014/08/09/{member_account}_CloudTrail-Digest_us-east-1_foo_'
             'us-east-1_20140809T235900Z.json.gz'
         )
+        prefix = (
+            'prefix/AWSLogs/{organization_id}/{member_account}/'
+            'CloudTrail-Digest/us-east-1'
+        )
         mock_paginate.assert_called_once_with(
             Bucket='1',
             Marker=marker.format(
                 member_account=TEST_ORGANIZATION_ACCOUNT_ID,
-                organization_id=TEST_ORGANIZATION_ID,
+                organization_id=TEST_ORGANIZATION_ID
             ),
+            Prefix=prefix.format(
+                member_account=TEST_ORGANIZATION_ACCOUNT_ID,
+                organization_id=TEST_ORGANIZATION_ID
+            )
         )
+
+    def test_create_digest_prefix_without_key_prefix(self):
+        mock_s3_client_provider = mock.Mock()
+        provider = DigestProvider(
+            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1')
+        prefix = provider._create_digest_prefix(START_DATE, None)
+        expected = 'AWSLogs/{account}/CloudTrail-Digest/us-east-1'.format(
+            account=TEST_ACCOUNT_ID)
+        self.assertEqual(expected, prefix)
+
+    def test_create_digest_prefix_with_key_prefix(self):
+        mock_s3_client_provider = mock.Mock()
+        provider = DigestProvider(
+            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1')
+        prefix = provider._create_digest_prefix(START_DATE, 'my-prefix')
+        expected = 'my-prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1'.format(
+            account=TEST_ACCOUNT_ID)
+        self.assertEqual(expected, prefix)
+
+    def test_create_digest_prefix_org_trail(self):
+        mock_s3_client_provider = mock.Mock()
+        provider = DigestProvider(
+            mock_s3_client_provider, TEST_ORGANIZATION_ACCOUNT_ID,
+            'foo', 'us-east-1', 'us-east-1', TEST_ORGANIZATION_ID)
+        prefix = provider._create_digest_prefix(START_DATE, None)
+        expected = 'AWSLogs/{org}/{account}/CloudTrail-Digest/us-east-1'.format(
+            org=TEST_ORGANIZATION_ID,
+            account=TEST_ORGANIZATION_ACCOUNT_ID)
+        self.assertEqual(expected, prefix)
+
+    def test_create_digest_prefix_org_trail_with_key_prefix(self):
+        mock_s3_client_provider = mock.Mock()
+        provider = DigestProvider(
+            mock_s3_client_provider, TEST_ORGANIZATION_ACCOUNT_ID,
+            'foo', 'us-east-1', 'us-east-1', TEST_ORGANIZATION_ID)
+        prefix = provider._create_digest_prefix(START_DATE, 'custom-prefix')
+        expected = 'custom-prefix/AWSLogs/{org}/{account}/CloudTrail-Digest/us-east-1'.format(
+            org=TEST_ORGANIZATION_ID,
+            account=TEST_ORGANIZATION_ACCOUNT_ID)
+        self.assertEqual(expected, prefix)
 
     def test_ensures_digest_has_proper_metadata(self):
         out = BytesIO()


### PR DESCRIPTION
*Description of changes:*

Scope S3 list_objects call to trail's region by adding prefix parameter. This prevents processing digest files from all regions and improves validate-logs command performance when validating logs near current time.

Add _create_digest_prefix method to generate region-specific prefix for both regular and organizational trails. Update existing tests and add new test coverage for prefix generation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
