### PR TITLE
Implement linting rules for S3 copies, CloudFormation deploy, and hidden aliases

### DIFF
--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -10,9 +10,9 @@ from awsclilinter import linter
 from awsclilinter.linter import parse
 from awsclilinter.rules import LintFinding, LintRule
 from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
-from awsclilinter.rules.deploy_empty_changeset import DeployEmptyChangeset
+from awsclilinter.rules.default_pager import DefaultPagerRule
+from awsclilinter.rules.deploy_empty_changeset import DeployEmptyChangesetRule
 from awsclilinter.rules.hidden_aliases import create_all_hidden_alias_rules
-from awsclilinter.rules.pagination import PaginationRule
 from awsclilinter.rules.s3_copies import S3CopyRule
 
 # ANSI color codes
@@ -207,9 +207,9 @@ def main():
 
     rules = [
         Base64BinaryFormatRule(),
-        PaginationRule(),
+        DefaultPagerRule(),
         S3CopyRule(),
-        DeployEmptyChangeset(),
+        DeployEmptyChangesetRule(),
         *create_all_hidden_alias_rules(),
     ]
 

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -9,8 +9,11 @@ from ast_grep_py.ast_grep_py import SgRoot
 from awsclilinter import linter
 from awsclilinter.linter import parse
 from awsclilinter.rules import LintFinding, LintRule
-from awsclilinter.rules.base64_rule import Base64BinaryFormatRule
-from awsclilinter.rules.pagination_rule import PaginationRule
+from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
+from awsclilinter.rules.deploy_empty_changeset import DeployEmptyChangeset
+from awsclilinter.rules.hidden_aliases import create_all_hidden_alias_rules
+from awsclilinter.rules.pagination import PaginationRule
+from awsclilinter.rules.s3_copies import S3CopyRule
 
 # ANSI color codes
 RED = "\033[31m"
@@ -76,7 +79,7 @@ def display_finding(finding: LintFinding, index: int, script_content: str):
             print(f"\n{CYAN}{line}{RESET}")
         elif line.startswith("-"):
             # Removed line
-            print(f"{RED}{line}{RESET}", end="")
+            print(f"{RED}{line}{RESET}\n", end="")
         elif line.startswith("+"):
             # Added line
             print(f"{GREEN}{line}{RESET}", end="")
@@ -202,7 +205,13 @@ def main():
 
     script_content = script_path.read_text()
 
-    rules = [Base64BinaryFormatRule(), PaginationRule()]
+    rules = [
+        Base64BinaryFormatRule(),
+        PaginationRule(),
+        S3CopyRule(),
+        DeployEmptyChangeset(),
+        *create_all_hidden_alias_rules(),
+    ]
 
     if args.interactive:
         current_ast = parse(script_content)

--- a/awsclilinter/awsclilinter/rules/binary_params_base64.py
+++ b/awsclilinter/awsclilinter/rules/binary_params_base64.py
@@ -28,7 +28,7 @@ class Base64BinaryFormatRule(LintRule):
         base64_broken_nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {"pattern": "aws $SERVICE $OPERATION $$$ARGS"},
+                {"pattern": "aws $SERVICE $OPERATION"},
                 {"not": {"has": {"kind": "word", "pattern": "--cli-binary-format"}}},
             ]
         )

--- a/awsclilinter/awsclilinter/rules/binary_params_base64.py
+++ b/awsclilinter/awsclilinter/rules/binary_params_base64.py
@@ -25,7 +25,7 @@ class Base64BinaryFormatRule(LintRule):
         """Check for AWS CLI commands missing --cli-binary-format."""
         node = root.root()
         base64_broken_nodes = node.find_all(
-            all=[
+            all=[  # type: ignore[arg-type]
                 {"kind": "command"},
                 {"pattern": "aws $SERVICE $OPERATION $$$ARGS"},
                 {"not": {"has": {"kind": "word", "pattern": "--cli-binary-format"}}},

--- a/awsclilinter/awsclilinter/rules/binary_params_base64.py
+++ b/awsclilinter/awsclilinter/rules/binary_params_base64.py
@@ -18,7 +18,8 @@ class Base64BinaryFormatRule(LintRule):
         return (
             "In AWS CLI v2, an input parameter typed as binary large object (BLOB) expects "
             "the input to be base64-encoded. To retain v1 behavior after upgrading to AWS CLI v2, "
-            "add `--cli-binary-format raw-in-base64-out`."
+            "add `--cli-binary-format raw-in-base64-out`. See https://docs.aws.amazon.com/cli/"
+            "latest/userguide/cliv2-migration-changes.html#cliv2-migration-binaryparam."
         )
 
     def check(self, root: SgRoot) -> List[LintFinding]:

--- a/awsclilinter/awsclilinter/rules/default_pager.py
+++ b/awsclilinter/awsclilinter/rules/default_pager.py
@@ -5,35 +5,37 @@ from ast_grep_py.ast_grep_py import SgRoot
 from awsclilinter.rules import LintFinding, LintRule
 
 
-class PaginationRule(LintRule):
-    """Detects AWS CLI commands missing --no-cli-paginate flag."""
+class DefaultPagerRule(LintRule):
+    """Detects AWS CLI commands missing --no-cli-pager flag."""
 
     @property
     def name(self) -> str:
-        return "pagination-by-default"
+        return "pager-by-default"
 
     @property
     def description(self) -> str:
         return (
-            "AWS CLI v2 uses pagination by default for commands that return large result sets. "
-            "Add --no-cli-paginate to disable pagination and match v1 behavior."
+            "AWS CLI v2 uses the system pager by default for all command output. "
+            "Add --no-cli-pager to disable use of the pager and match v1 behavior. See "
+            "https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html"
+            "#cliv2-migration-output-pager."
         )
 
     def check(self, root: SgRoot) -> List[LintFinding]:
-        """Check for AWS CLI commands missing --no-cli-paginate."""
+        """Check for AWS CLI commands missing --no-cli-pager."""
         node = root.root()
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
                 {"pattern": "aws $SERVICE $OPERATION $$$ARGS"},
-                {"not": {"has": {"kind": "word", "pattern": "--no-cli-paginate"}}},
+                {"not": {"has": {"kind": "word", "pattern": "--no-cli-pager"}}},
             ]
         )
 
         findings = []
         for stmt in nodes:
             original = stmt.text()
-            suggested = original + " --no-cli-paginate"
+            suggested = original + " --no-cli-pager"
             edit = stmt.replace(suggested)
 
             findings.append(

--- a/awsclilinter/awsclilinter/rules/default_pager.py
+++ b/awsclilinter/awsclilinter/rules/default_pager.py
@@ -27,7 +27,7 @@ class DefaultPagerRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {"pattern": "aws $SERVICE $OPERATION $$$ARGS"},
+                {"pattern": "aws $SERVICE $OPERATION"},
                 {"not": {"has": {"kind": "word", "pattern": "--no-cli-pager"}}},
             ]
         )

--- a/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
+++ b/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
@@ -1,0 +1,55 @@
+from typing import List
+
+from ast_grep_py.ast_grep_py import SgRoot
+
+from awsclilinter.rules import LintFinding, LintRule
+
+
+class DeployEmptyChangeset(LintRule):
+    """Detects AWS CLI CloudFormation deploy commands."""
+
+    @property
+    def name(self) -> str:
+        return "deploy-empty-changeset"
+
+    @property
+    def description(self) -> str:
+        return (
+            "In AWS CLI v2, deploying an AWS CloudFormation Template that results in an empty "
+            "changeset will NOT result in an error. You can add the -–fail-on-empty-changeset "
+            "flag to retain v1 behavior in v2. See https://docs.aws.amazon.com/cli/latest/"
+            "userguide/cliv2-migration-changes.html#cliv2-migration-cfn."
+        )
+
+    def check(self, root: SgRoot) -> List[LintFinding]:
+        """Check for AWS CLI CloudFormation deploy commands
+        without the --fail-on-empty-changeset or --no-fail-on-empty-changeset arguments.
+        """
+        node = root.root()
+        nodes = node.find_all(
+            all=[  # type: ignore[arg-type]
+                {"kind": "command"},
+                {"pattern": "aws cloudformation deploy $$$ARGS"},
+                {"not": {"has": {"kind": "word", "pattern": "--fail-on-empty-changeset"}}},
+                {"not": {"has": {"kind": "word", "pattern": "--no-fail-on-empty-changeset"}}},
+            ]
+        )
+
+        findings = []
+        for stmt in nodes:
+            original = stmt.text()
+            suggested = original + " --fail-on-empty-changeset"
+            edit = stmt.replace(suggested)
+
+            findings.append(
+                LintFinding(
+                    line_start=stmt.range().start.line,
+                    line_end=stmt.range().end.line,
+                    edit=edit,
+                    original_text=original,
+                    rule_name=self.name,
+                    description=self.description,
+                )
+            )
+
+        return findings

--- a/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
+++ b/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
@@ -29,7 +29,7 @@ class DeployEmptyChangesetRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {"pattern": "aws cloudformation deploy $$$ARGS"},
+                {"pattern": "aws cloudformation deploy"},
                 {"not": {"has": {"kind": "word", "pattern": "--fail-on-empty-changeset"}}},
                 {"not": {"has": {"kind": "word", "pattern": "--no-fail-on-empty-changeset"}}},
             ]

--- a/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
+++ b/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
@@ -5,7 +5,7 @@ from ast_grep_py.ast_grep_py import SgRoot
 from awsclilinter.rules import LintFinding, LintRule
 
 
-class DeployEmptyChangeset(LintRule):
+class DeployEmptyChangesetRule(LintRule):
     """Detects AWS CLI CloudFormation deploy commands."""
 
     @property

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -163,7 +163,7 @@ class HiddenAliasRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {"pattern": f"aws {self._service} {self._operation} $$$ARGS"},
+                {"pattern": f"aws {self._service} {self._operation}"},
                 {"has": {"kind": "word", "pattern": f"--{self._hidden_alias}"}},
             ]
         )

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -1,0 +1,203 @@
+from typing import List
+
+from ast_grep_py.ast_grep_py import SgRoot
+
+from awsclilinter.rules import LintFinding, LintRule
+
+_HIDDEN_ALIASES = [
+    {
+        "service": "cognito-identity",
+        "operation": "create-identity-pool",
+        "alternative": "open-id-connect-provider-arns",
+        "alias": "open-id-connect-provider-ar-ns",
+    },
+    {
+        "service": "storagegateway",
+        "operation": "describe-tapes",
+        "alternative": "tape-arns",
+        "alias": "tape-ar-ns",
+    },
+    {
+        "service": "storagegateway",
+        "operation": "describe-tape-archives",
+        "alternative": "tape-arns",
+        "alias": "tape-ar-ns",
+    },
+    {
+        "service": "storagegateway",
+        "operation": "describe-vtl-devices",
+        "alternative": "vtl-device-arns",
+        "alias": "vtl-device-ar-ns",
+    },
+    {
+        "service": "storagegateway",
+        "operation": "describe-cached-iscsi-volumes",
+        "alternative": "volume-arns",
+        "alias": "volume-ar-ns",
+    },
+    {
+        "service": "storagegateway",
+        "operation": "describe-stored-iscsi-volumes",
+        "alternative": "volume-arns",
+        "alias": "volume-ar-ns",
+    },
+    {
+        "service": "route53domains",
+        "operation": "view-billing",
+        "alternative": "start-time",
+        "alias": "start",
+    },
+    {
+        "service": "deploy",
+        "operation": "create-deployment-group",
+        "alternative": "ec2-tag-set",
+        "alias": "ec-2-tag-set",
+    },
+    {
+        "service": "deploy",
+        "operation": "list-application-revisions",
+        "alternative": "s3-bucket",
+        "alias": "s-3-bucket",
+    },
+    {
+        "service": "deploy",
+        "operation": "list-application-revisions",
+        "alternative": "s3-key-prefix",
+        "alias": "s-3-key-prefix",
+    },
+    {
+        "service": "deploy",
+        "operation": "update-deployment-group",
+        "alternative": "ec2-tag-set",
+        "alias": "ec-2-tag-set",
+    },
+    {
+        "service": "iam",
+        "operation": "enable-mfa-device",
+        "alternative": "authentication-code1",
+        "alias": "authentication-code-1",
+    },
+    {
+        "service": "iam",
+        "operation": "enable-mfa-device",
+        "alternative": "authentication-code2",
+        "alias": "authentication-code-2",
+    },
+    {
+        "service": "iam",
+        "operation": "resync-mfa-device",
+        "alternative": "authentication-code1",
+        "alias": "authentication-code-1",
+    },
+    {
+        "service": "iam",
+        "operation": "resync-mfa-device",
+        "alternative": "authentication-code2",
+        "alias": "authentication-code-2",
+    },
+    {
+        "service": "importexport",
+        "operation": "get-shipping-label",
+        "alternative": "street1",
+        "alias": "street-1",
+    },
+    {
+        "service": "importexport",
+        "operation": "get-shipping-label",
+        "alternative": "street2",
+        "alias": "street-2",
+    },
+    {
+        "service": "importexport",
+        "operation": "get-shipping-label",
+        "alternative": "street3",
+        "alias": "street-3",
+    },
+    {
+        "service": "lambda",
+        "operation": "publish-version",
+        "alternative": "code-sha256",
+        "alias": "code-sha-256",
+    },
+    {
+        "service": "lightsail",
+        "operation": "import-key-pair",
+        "alternative": "public-key-base64",
+        "alias": "public-key-base-64",
+    },
+    {
+        "service": "opsworks",
+        "operation": "register-volume",
+        "alternative": "ec2-volume-id",
+        "alias": "ec-2-volume-id",
+    },
+]
+
+
+class HiddenAliasRule(LintRule):
+    """Detects AWS CLI commands using hidden aliases."""
+
+    def __init__(self, alias: str, alternative: str, service: str, operation: str):
+        self._hidden_alias = alias
+        self._alternative = alternative
+        self._service = service
+        self._operation = operation
+
+    @property
+    def name(self) -> str:
+        return f"hidden-alias-{self._hidden_alias}"
+
+    @property
+    def description(self) -> str:
+        return (
+            f"In AWS CLI v2, the hidden alias {self._hidden_alias} was removed."
+            "You must replace usage of the obsolete alias with the corresponding "
+            f"working parameter: {self._alternative}. See "
+            "https://docs.aws.amazon.com/cli/latest/userguide"
+            "/cliv2-migration-changes.html#cliv2-migration-aliases."
+        )
+
+    def check(self, root: SgRoot) -> List[LintFinding]:
+        """Check for AWS CLI commands using hidden aliases."""
+        node = root.root()
+        nodes = node.find_all(
+            all=[  # type: ignore[arg-type]
+                {"kind": "command"},
+                {"pattern": f"aws {self._service} {self._operation} $$$ARGS"},
+                {"has": {"kind": "word", "pattern": f"--{self._hidden_alias}"}},
+            ]
+        )
+
+        findings = []
+        for stmt in nodes:
+            original = stmt.text()
+            suggested = original + f" --{self._alternative}"
+            edit = stmt.replace(suggested)
+
+            findings.append(
+                LintFinding(
+                    line_start=stmt.range().start.line,
+                    line_end=stmt.range().end.line,
+                    edit=edit,
+                    original_text=original,
+                    rule_name=self.name,
+                    description=self.description,
+                )
+            )
+
+        return findings
+
+
+def create_all_hidden_alias_rules() -> List[HiddenAliasRule]:
+    """Create and return a list of all hidden alias rules: one for each hidden alias
+    removed in AWS CLI v2.
+    """
+    return [
+        HiddenAliasRule(
+            alias=hidden_alias_def["alias"],
+            alternative=hidden_alias_def["alternative"],
+            service=hidden_alias_def["service"],
+            operation=hidden_alias_def["operation"],
+        )
+        for hidden_alias_def in _HIDDEN_ALIASES
+    ]

--- a/awsclilinter/awsclilinter/rules/pagination.py
+++ b/awsclilinter/awsclilinter/rules/pagination.py
@@ -10,7 +10,7 @@ class PaginationRule(LintRule):
 
     @property
     def name(self) -> str:
-        return "no-cli-paginate"
+        return "pagination-by-default"
 
     @property
     def description(self) -> str:
@@ -23,7 +23,7 @@ class PaginationRule(LintRule):
         """Check for AWS CLI commands missing --no-cli-paginate."""
         node = root.root()
         nodes = node.find_all(
-            all=[
+            all=[  # type: ignore[arg-type]
                 {"kind": "command"},
                 {"pattern": "aws $SERVICE $OPERATION $$$ARGS"},
                 {"not": {"has": {"kind": "word", "pattern": "--no-cli-paginate"}}},

--- a/awsclilinter/awsclilinter/rules/s3_copies.py
+++ b/awsclilinter/awsclilinter/rules/s3_copies.py
@@ -31,9 +31,9 @@ class S3CopyRule(LintRule):
                 {"kind": "command"},
                 {
                     "any": [
-                        {"pattern": "aws s3 cp $$$ARGS"},
-                        {"pattern": "aws s3 mv $$$ARGS"},
-                        {"pattern": "aws s3 sync $$$ARGS"},
+                        {"pattern": "aws s3 cp"},
+                        {"pattern": "aws s3 mv"},
+                        {"pattern": "aws s3 sync"},
                     ]
                 },
                 {"has": {"kind": "word", "regex": "\\As3://"}},

--- a/awsclilinter/awsclilinter/rules/s3_copies.py
+++ b/awsclilinter/awsclilinter/rules/s3_copies.py
@@ -1,0 +1,68 @@
+from typing import List
+
+from ast_grep_py.ast_grep_py import SgRoot
+
+from awsclilinter.rules import LintFinding, LintRule
+
+
+class S3CopyRule(LintRule):
+    """Detects AWS CLI high-level s3 cp/mv/sync bucket-to-bucket commands."""
+
+    @property
+    def name(self) -> str:
+        return "s3-copy"
+
+    @property
+    def description(self) -> str:
+        return (
+            "In AWS CLI v2, object properties will be copied from the source in multipart "
+            "copies between S3 buckets. If a copy is or becomes multipart after upgrading to "
+            "AWS CLI v2, extra API calls will be made. See https://docs.aws.amazon.com/cli/latest/"
+            "userguide/cliv2-migration-changes.html#cliv2-migration-s3-copy-metadata."
+        )
+
+    def check(self, root: SgRoot) -> List[LintFinding]:
+        """Check for AWS CLI s3 cp/mv/sync bucket-to-bucket
+        commands without --copy-props argument.
+        """
+        node = root.root()
+        nodes = node.find_all(
+            all=[  # type: ignore[arg-type]
+                {"kind": "command"},
+                {
+                    "any": [
+                        {"pattern": "aws s3 cp $$$ARGS"},
+                        {"pattern": "aws s3 mv $$$ARGS"},
+                        {"pattern": "aws s3 sync $$$ARGS"},
+                    ]
+                },
+                {"has": {"kind": "word", "regex": "\\As3://"}},
+                {
+                    "has": {
+                        "kind": "word",
+                        "regex": "\\As3://",
+                        "follows": {"stopBy": "end", "kind": "word", "regex": "\\As3://"},
+                    }
+                },
+                {"not": {"has": {"kind": "word", "pattern": "--copy-props"}}},
+            ]
+        )
+
+        findings = []
+        for stmt in nodes:
+            original = stmt.text()
+            suggested = original + " --copy-props none"
+            edit = stmt.replace(suggested)
+
+            findings.append(
+                LintFinding(
+                    line_start=stmt.range().start.line,
+                    line_end=stmt.range().end.line,
+                    edit=edit,
+                    original_text=original,
+                    rule_name=self.name,
+                    description=self.description,
+                )
+            )
+
+        return findings

--- a/awsclilinter/tests/test_cli.py
+++ b/awsclilinter/tests/test_cli.py
@@ -68,7 +68,7 @@ class TestCLI:
             fixed_content = script_file.read_text()
             # 1 command, 2 rules = 2 flags added
             assert "--cli-binary-format" in fixed_content
-            assert "--no-cli-paginate" in fixed_content
+            assert "--no-cli-pager" in fixed_content
 
     def test_output_mode(self, tmp_path):
         """Test output mode creates new file."""
@@ -87,7 +87,7 @@ class TestCLI:
             content = output_file.read_text()
             # 1 command, 2 rules = 2 flags added
             assert "--cli-binary-format" in content
-            assert "--no-cli-paginate" in content
+            assert "--no-cli-pager" in content
 
     def test_interactive_mode_accept_all(self, tmp_path):
         """Test interactive mode with 'y' to accept all changes."""
@@ -116,7 +116,7 @@ class TestCLI:
                 print(fixed_content)
                 # 2 commands, 2 rules = 4 findings, so 2 of each flag
                 assert fixed_content.count("--cli-binary-format") == 2
-                assert fixed_content.count("--no-cli-paginate") == 2
+                assert fixed_content.count("--no-cli-pager") == 2
 
     def test_interactive_mode_reject_all(self, tmp_path, capsys):
         """Test interactive mode with 'n' to reject all changes."""
@@ -156,7 +156,7 @@ class TestCLI:
                 fixed_content = output_file.read_text()
                 # 2 commands, 2 rules = 4 findings, so 2 of each flag
                 assert fixed_content.count("--cli-binary-format") == 2
-                assert fixed_content.count("--no-cli-paginate") == 2
+                assert fixed_content.count("--no-cli-pager") == 2
 
     def test_interactive_mode_save_and_exit(self, tmp_path):
         """Test interactive mode with 's' to save and exit."""

--- a/awsclilinter/tests/test_linter.py
+++ b/awsclilinter/tests/test_linter.py
@@ -1,5 +1,5 @@
 from awsclilinter import linter
-from awsclilinter.rules.base64_rule import Base64BinaryFormatRule
+from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
 
 
 class TestLinter:

--- a/awsclilinter/tests/test_rules.py
+++ b/awsclilinter/tests/test_rules.py
@@ -1,6 +1,6 @@
 from ast_grep_py import SgRoot
 
-from awsclilinter.rules.base64_rule import Base64BinaryFormatRule
+from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
 
 
 class TestBase64BinaryFormatRule:

--- a/awsclilinter/tests/test_rules.py
+++ b/awsclilinter/tests/test_rules.py
@@ -104,7 +104,9 @@ class TestDeployEmptyChangesetRule:
 
     def test_no_detection_with_no_fail_flag(self):
         """Test no detection when --no-fail-on-empty-changeset is present."""
-        script = "aws cloudformation deploy --template-file template.yaml --no-fail-on-empty-changeset"
+        script = (
+            "aws cloudformation deploy --template-file template.yaml --no-fail-on-empty-changeset"
+        )
         root = SgRoot(script, "bash")
         rule = DeployEmptyChangesetRule()
         findings = rule.check(root)
@@ -172,7 +174,9 @@ class TestHiddenAliasRule:
 
     def test_rule_properties(self):
         """Test rule description."""
-        rule = HiddenAliasRule("authentication-code-1", "authentication-code1", "iam", "enable-mfa-device")
+        rule = HiddenAliasRule(
+            "authentication-code-1", "authentication-code1", "iam", "enable-mfa-device"
+        )
         assert "authentication-code-1" in rule.description
         assert "authentication-code1" in rule.description
 
@@ -180,7 +184,9 @@ class TestHiddenAliasRule:
         """Test detection of hidden alias usage."""
         script = "aws iam enable-mfa-device --user-name Bob --authentication-code-1 123456"
         root = SgRoot(script, "bash")
-        rule = HiddenAliasRule("authentication-code-1", "authentication-code1", "iam", "enable-mfa-device")
+        rule = HiddenAliasRule(
+            "authentication-code-1", "authentication-code1", "iam", "enable-mfa-device"
+        )
         findings = rule.check(root)
 
         assert len(findings) == 1
@@ -190,7 +196,9 @@ class TestHiddenAliasRule:
         """Test no detection when correct parameter is used."""
         script = "aws iam enable-mfa-device --user-name Bob --authentication-code1 123456"
         root = SgRoot(script, "bash")
-        rule = HiddenAliasRule("authentication-code-1", "authentication-code1", "iam", "enable-mfa-device")
+        rule = HiddenAliasRule(
+            "authentication-code-1", "authentication-code1", "iam", "enable-mfa-device"
+        )
         findings = rule.check(root)
 
         assert len(findings) == 0


### PR DESCRIPTION
*Description of changes:*

* Added 23 more linting rules to the linter with auto-fix behavior:
  * High-level s3 copies. Adds `--copy-props none` to the command.
  * CloudFormation deploy commands that rely on default behavior for empty changesets. Adds `--fail-on-empty-changeset` to the command.
  * Use of hidden aliases. Replaces the hidden alias with the original modeled parameter.
* Update pagination linting rule to be based on `--no-cli-pager` flag. ([details](https://github.com/aws/aws-cli/pull/9859#issuecomment-3607395374))
* Add new tests to test new behavior added in this PR, and updated existing tests based on updates to existing functionality.

*Description of tests:*

* Ran and passed all tests.
* Manually tested different modes on example scripts, verifying the new linting rules are working as exected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
