### PR TITLE
ci: Skip new internal build for fork-origin PRs

### DIFF
--- a/.github/workflows/pull-request-build.yml
+++ b/.github/workflows/pull-request-build.yml
@@ -18,7 +18,8 @@ env:
 
 jobs:
   aws-cli-v2-pr-build:
-    if: github.event.pull_request.draft == false
+    # Don't run on drafts or for fork-orign PRs, since they won't have access
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Skips the new internal build trigger introduced by #9918 for fork-origin PRs, since it won't be successful. The maintainers will continue to either kick off these builds manually or else move the PR to a branch in the main repo once ready. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
