### PR TITLE
Fix support for multiple linting rules with auto-fix mode

### DIFF
--- a/awsclilinter/README.md
+++ b/awsclilinter/README.md
@@ -42,25 +42,25 @@ If you want to run `awsclilinter` from source, see the [Installing development v
 ### Dry-run mode (default)
 Display issues without modifying the script:
 ```bash
-upgrade-aws-cli --script upload_s3_files.sh
+migrate-aws-cli --script upload_s3_files.sh
 ```
 
 ### Fix mode
 Automatically update the input script:
 ```bash
-upgrade-aws-cli --script upload_s3_files.sh --fix
+migrate-aws-cli --script upload_s3_files.sh --fix
 ```
 
 ### Output mode
 Create a new fixed script without modifying the original:
 ```bash
-upgrade-aws-cli --script upload_s3_files.sh --output upload_s3_files_v2.sh
+migrate-aws-cli --script upload_s3_files.sh --output upload_s3_files_v2.sh
 ```
 
 ### Interactive mode
 Review and accept/reject each change individually:
 ```bash
-upgrade-aws-cli --script upload_s3_files.sh --interactive --output upload_s3_files_v2.sh
+migrate-aws-cli --script upload_s3_files.sh --interactive --output upload_s3_files_v2.sh
 ```
 
 In interactive mode, you can:
@@ -95,7 +95,7 @@ source .venv/bin/activate
 
 ### Running the CLI
 ```bash
-upgrade-aws-cli --script <script.sh>
+migrate-aws-cli --script <script.sh>
 ```
 
 ### Running tests

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple
 from ast_grep_py.ast_grep_py import SgRoot
 
 from awsclilinter import linter
+from awsclilinter import __version__
 from awsclilinter.linter import parse
 from awsclilinter.rules import LintFinding, LintRule
 from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
@@ -324,6 +325,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Lint and upgrade bash scripts from AWS CLI v1 to v2"
     )
+    parser.add_argument("-v", "--version", action="version", version=f"%(prog)s {__version__}")
     parser.add_argument("--script", required=True, help="Path to the bash script to lint")
     parser.add_argument(
         "--fix", action="store_true", help="Apply fixes to the script (modifies in place)"

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -212,10 +212,10 @@ def dry_run_mode(
     for line_num, line in enumerate(diff):
         if line_num == 0:
             # First line is always '--- '
-            print(f"{line}a/{script_path}")
+            print(f"{line}{script_path}")
         elif line_num == 1:
             # Second line is always '+++ '
-            print(f"{line}b/{script_path}")
+            print(f"{line}{script_path}")
         elif line.startswith("@"):
             # Context control line.
             print(f"\n{_color_text(line, CYAN)}")

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -110,9 +110,9 @@ def display_finding(finding: LintFinding, index: int, script_content: str):
                 print(f"{line}")
 
         warning_msg = color_text(
-            f'⚠️  This issue requires manual intervention. '
-            f'Suggested action: {finding.suggested_manual_fix}',
-            YELLOW
+            f"⚠️  This issue requires manual intervention. "
+            f"Suggested action: {finding.suggested_manual_fix}",
+            YELLOW,
         )
         print(f"\n{warning_msg}")
 
@@ -165,7 +165,7 @@ def auto_fix_mode(
     # If there were findings that need manual review, display them last.
     if non_auto_fixable:
         warning_header = color_text(
-            f'⚠️  {len(non_auto_fixable)} issue(s) require manual review:', YELLOW
+            f"⚠️  {len(non_auto_fixable)} issue(s) require manual review:", YELLOW
         )
         print(f"\n{warning_header}\n")
         for i, (finding, _) in enumerate(non_auto_fixable, 1):

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -10,6 +10,7 @@ from awsclilinter import linter
 from awsclilinter.linter import parse
 from awsclilinter.rules import LintFinding, LintRule
 from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
+from awsclilinter.rules.cli_input_json import CLIInputJSONRule
 from awsclilinter.rules.default_pager import DefaultPagerRule
 from awsclilinter.rules.deploy_empty_changeset import DeployEmptyChangesetRule
 from awsclilinter.rules.ecr_get_login import EcrGetLoginRule
@@ -361,6 +362,7 @@ def main():
         *create_all_hidden_alias_rules(),
         # Rules that do not automatically generate fixes go last
         EcrGetLoginRule(),
+        CLIInputJSONRule(),
     ]
 
     if args.interactive:

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -27,6 +27,13 @@ RESET = "\033[0m"
 CONTEXT_SIZE = 3
 
 
+def color_text(text, color_code):
+    """Colorize text for terminal output only if a TTY is available."""
+    if sys.stdout.isatty():
+        return f"{color_code}{text}{RESET}"
+    return text
+
+
 def prompt_user_choice_interactive_mode(auto_fixable: bool = True) -> str:
     """Get user input for interactive mode."""
     while True:
@@ -71,13 +78,14 @@ def display_finding(finding: LintFinding, index: int, script_content: str):
                 continue
             elif line_num == 2:
                 # The 3rd line is the context control line.
-                print(f"\n{CYAN}{line}{RESET}")
+                print("\n")
+                print(color_text(line, CYAN))
             elif line.startswith("-"):
                 # Removed line
-                print(f"{RED}{line}{RESET}")
+                print(color_text(line, RED))
             elif line.startswith("+"):
                 # Added line
-                print(f"{GREEN}{line}{RESET}")
+                print(color_text(line, GREEN))
             else:
                 # Context (unchanged) lines always start with whitespace.
                 print(line)
@@ -89,20 +97,23 @@ def display_finding(finding: LintFinding, index: int, script_content: str):
         context_start = max(0, start_line - CONTEXT_SIZE)
         context_end = min(len(src_lines), end_line + CONTEXT_SIZE + 1)
 
-        print(f"\n[{index}] {finding.rule_name} {YELLOW}[MANUAL REVIEW REQUIRED]{RESET}")
-        print(f"{finding.description}")
+        print(f"\n[{index}] {finding.rule_name} {color_text("[MANUAL REVIEW REQUIRED]", YELLOW)}")
+        print(f"{finding.description}\n")
 
-        print(f"\n{CYAN}Lines {context_start + 1}-{context_end + 1}{RESET}")
+        print(color_text(f"Lines {context_start + 1}-{context_end + 1}", CYAN))
         for i in range(context_start, context_end):
             line = src_lines[i]
             if start_line <= i <= end_line:
-                print(f"{YELLOW}{line}{RESET}")
+                print(f"{color_text(line, YELLOW)}")
             else:
                 print(f"{line}")
 
         print(
-            f"\n{YELLOW}⚠️  This issue requires manual intervention. "
-            f"Suggested action: {finding.suggested_manual_fix}{RESET}"
+            f"\n{color_text(
+                f'⚠️  This issue requires manual intervention. '
+                f'Suggested action: {finding.suggested_manual_fix}', 
+                YELLOW
+            )}"
         )
 
 
@@ -153,7 +164,11 @@ def auto_fix_mode(
 
     # If there were findings that need manual review, display them last.
     if non_auto_fixable:
-        print(f"\n{YELLOW}⚠️  {len(non_auto_fixable)} issue(s) require manual review:{RESET}\n")
+        print(
+            f"\n{color_text(
+                f'⚠️  {len(non_auto_fixable)} issue(s) require manual review:', YELLOW
+            )}\n"
+        )
         for i, (finding, _) in enumerate(non_auto_fixable, 1):
             display_finding(finding, i, script_content)
 

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -78,8 +78,7 @@ def _display_finding(finding: LintFinding, index: int, script_content: str):
                 continue
             elif line_num == 2:
                 # The 3rd line is the context control line.
-                print("\n")
-                print(_color_text(line, CYAN))
+                print(f"\n{_color_text(line, CYAN)}")
             elif line.startswith("-"):
                 # Removed line
                 print(_color_text(line, RED))

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -97,7 +97,8 @@ def display_finding(finding: LintFinding, index: int, script_content: str):
         context_start = max(0, start_line - CONTEXT_SIZE)
         context_end = min(len(src_lines), end_line + CONTEXT_SIZE + 1)
 
-        print(f"\n[{index}] {finding.rule_name} {color_text("[MANUAL REVIEW REQUIRED]", YELLOW)}")
+        manual_tag = color_text("[MANUAL REVIEW REQUIRED]", YELLOW)
+        print(f"\n[{index}] {finding.rule_name} {manual_tag}")
         print(f"{finding.description}\n")
 
         print(color_text(f"Lines {context_start + 1}-{context_end + 1}", CYAN))
@@ -108,13 +109,12 @@ def display_finding(finding: LintFinding, index: int, script_content: str):
             else:
                 print(f"{line}")
 
-        print(
-            f"\n{color_text(
-                f'⚠️  This issue requires manual intervention. '
-                f'Suggested action: {finding.suggested_manual_fix}', 
-                YELLOW
-            )}"
+        warning_msg = color_text(
+            f'⚠️  This issue requires manual intervention. '
+            f'Suggested action: {finding.suggested_manual_fix}',
+            YELLOW
         )
+        print(f"\n{warning_msg}")
 
 
 def auto_fix_mode(
@@ -164,11 +164,10 @@ def auto_fix_mode(
 
     # If there were findings that need manual review, display them last.
     if non_auto_fixable:
-        print(
-            f"\n{color_text(
-                f'⚠️  {len(non_auto_fixable)} issue(s) require manual review:', YELLOW
-            )}\n"
+        warning_header = color_text(
+            f'⚠️  {len(non_auto_fixable)} issue(s) require manual review:', YELLOW
         )
+        print(f"\n{warning_header}\n")
         for i, (finding, _) in enumerate(non_auto_fixable, 1):
             display_finding(finding, i, script_content)
 

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -6,8 +6,7 @@ from typing import List, Optional, Tuple
 
 from ast_grep_py.ast_grep_py import SgRoot
 
-from awsclilinter import linter
-from awsclilinter import __version__
+from awsclilinter import __version__, linter
 from awsclilinter.linter import parse
 from awsclilinter.rules import LintFinding, LintRule
 from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
@@ -118,7 +117,7 @@ def _display_finding(finding: LintFinding, index: int, script_content: str):
         print(f"\n{warning_msg}")
 
 
-def _lint_and_fix_script(
+def _lint_and_generate_updated_script(
     rules: List[LintRule],
     script_ast: SgRoot,
 ) -> tuple[SgRoot, int, list[tuple[LintFinding, LintRule]]]:
@@ -161,7 +160,7 @@ def auto_fix_mode(
         script_content: Current script represented as an AST.
         output_path: The path to write the updated script if any findings were detected.
     """
-    current_ast, num_auto_fixable_findings, non_auto_fixable = _lint_and_fix_script(
+    current_ast, num_auto_fixable_findings, non_auto_fixable = _lint_and_generate_updated_script(
         rules, parse(script_content)
     )
 
@@ -195,7 +194,7 @@ def dry_run_mode(
         script_content: The input script.
         script_path: Path to the script being linted.
     """
-    current_ast, num_auto_fixable_findings, non_auto_fixable = _lint_and_fix_script(
+    current_ast, num_auto_fixable_findings, non_auto_fixable = _lint_and_generate_updated_script(
         rules, parse(script_content)
     )
 

--- a/awsclilinter/awsclilinter/cli.py
+++ b/awsclilinter/awsclilinter/cli.py
@@ -2,10 +2,9 @@ import argparse
 import difflib
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple, Any
+from typing import List, Optional, Tuple
 
-from ast_grep_py import SgRoot
-from ast_grep_py.ast_grep_py import SgRoot, SgNode
+from ast_grep_py.ast_grep_py import SgRoot
 
 from awsclilinter import linter
 from awsclilinter.linter import parse
@@ -162,8 +161,7 @@ def auto_fix_mode(
         output_path: The path to write the updated script if any findings were detected.
     """
     current_ast, num_auto_fixable_findings, non_auto_fixable = _lint_and_fix_script(
-        rules,
-        parse(script_content)
+        rules, parse(script_content)
     )
 
     if num_auto_fixable_findings:
@@ -184,9 +182,9 @@ def auto_fix_mode(
 
 
 def dry_run_mode(
-        rules: List[LintRule],
-        script_content: str,
-        script_path: Path,
+    rules: List[LintRule],
+    script_content: str,
+    script_path: Path,
 ):
     """Handler for dry-run mode. Lints the input script based on the input rules list and
     prints the diff to stdout.
@@ -197,8 +195,7 @@ def dry_run_mode(
         script_path: Path to the script being linted.
     """
     current_ast, num_auto_fixable_findings, non_auto_fixable = _lint_and_fix_script(
-        rules,
-        parse(script_content)
+        rules, parse(script_content)
     )
 
     if not num_auto_fixable_findings and not non_auto_fixable:

--- a/awsclilinter/awsclilinter/rules/binary_params_base64.py
+++ b/awsclilinter/awsclilinter/rules/binary_params_base64.py
@@ -48,7 +48,10 @@ class Base64BinaryFormatRule(LintRule):
                                         "regex": "\\A--cli-binary-format\\z",
                                     },
                                 },
-                                {"kind": "raw_string", "regex": "--cli-binary-format"},
+                                {
+                                    "kind": "raw_string",
+                                    "regex": "--cli-binary-format",
+                                },
                             ]
                         }
                     }

--- a/awsclilinter/awsclilinter/rules/binary_params_base64.py
+++ b/awsclilinter/awsclilinter/rules/binary_params_base64.py
@@ -40,17 +40,10 @@ class Base64BinaryFormatRule(LintRule):
                                     "kind": "word",
                                     "pattern": "--cli-binary-format",
                                 },
-                                {
-                                    "kind": "string",
-                                    "has": {
-                                        "kind": "string_content",
-                                        "nthChild": 1,
-                                        "regex": "\\A--cli-binary-format\\z",
-                                    },
-                                },
+                                {"kind": "string", "pattern": '"--cli-binary-format"'},
                                 {
                                     "kind": "raw_string",
-                                    "regex": "--cli-binary-format",
+                                    "pattern": "'--cli-binary-format'",
                                 },
                             ]
                         }

--- a/awsclilinter/awsclilinter/rules/binary_params_base64.py
+++ b/awsclilinter/awsclilinter/rules/binary_params_base64.py
@@ -45,13 +45,10 @@ class Base64BinaryFormatRule(LintRule):
                                     "has": {
                                         "kind": "string_content",
                                         "nthChild": 1,
-                                        "regex": "\\A--cli-binary-format\\z"
-                                    }
+                                        "regex": "\\A--cli-binary-format\\z",
+                                    },
                                 },
-                                {
-                                    "kind": "raw_string",
-                                    "regex": "\\A--cli-binary-format\\z"
-                                },
+                                {"kind": "raw_string", "regex": "--cli-binary-format"},
                             ]
                         }
                     }

--- a/awsclilinter/awsclilinter/rules/cli_input_json.py
+++ b/awsclilinter/awsclilinter/rules/cli_input_json.py
@@ -1,0 +1,81 @@
+from typing import List
+
+from ast_grep_py.ast_grep_py import SgRoot
+
+from awsclilinter.rules import LintFinding, LintRule
+from awsclilinter.rules.utils import has_aws_command_any_kind
+
+
+class CLIInputJSONRule(LintRule):
+    """Detects AWS CLI commands that use the `--cli-input-json` parameter."""
+
+    _SUGGESTED_MANUAL_FIX = (
+        "If pagination-related parameters are present in the JSON file specified with "
+        "`--cli-input-json`, remove the pagination parameters from the JSON file "
+        "to retain v1 behavior. Alternatively, migrate to v2 behavior by moving the pagination "
+        "parameters from the JSON file onto the command as separate command line parameters. "
+        "See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html"
+        "#cliv2-migration-skeleton-paging.\n"
+    )
+
+    @property
+    def name(self) -> str:
+        return "cli-input-json"
+
+    @property
+    def description(self) -> str:
+        return (
+            "In AWS CLI v2, specifying pagination parameters via `--cli-input-json` "
+            "will turn off automatic pagination. See https://docs.aws.amazon.com/cli/"
+            "latest/userguide/cliv2-migration-changes.html#cliv2-migration-skeleton-paging.\n"
+        )
+
+    def check(self, root: SgRoot) -> List[LintFinding]:
+        """Check for AWS CLI commands that use `--cli-input-json`."""
+        # TODO Add tests for this rule, and test (especially this rule).
+        node = root.root()
+        nodes = node.find_all(
+            all=[  # type: ignore[arg-type]
+                {"kind": "command"},
+                has_aws_command_any_kind(),
+                # Has the --cli-input-json parameter (unquoted, double-quoted, or single-quoted).
+                {
+                    "has": {
+                        "any": [
+                            {
+                                "kind": "word",
+                                "pattern": "--cli-input-json",
+                            },
+                            {
+                                "kind": "string",
+                                "has": {
+                                    "kind": "string_content",
+                                    "nthChild": 1,
+                                    "regex": "\\A--cli-input-json\\z"
+                                }
+                            },
+                            {
+                                "kind": "raw_string",
+                                "regex": "\\A--cli-input-json\\z"
+                            },
+                        ]
+                    }
+                },
+            ]
+        )
+
+        findings = []
+        for stmt in nodes:
+            findings.append(
+                LintFinding(
+                    line_start=stmt.range().start.line,
+                    line_end=stmt.range().end.line,
+                    edit=None,
+                    original_text=stmt.text(),
+                    suggested_manual_fix=self._SUGGESTED_MANUAL_FIX,
+                    rule_name=self.name,
+                    description=self.description,
+                )
+            )
+
+        return findings

--- a/awsclilinter/awsclilinter/rules/cli_input_json.py
+++ b/awsclilinter/awsclilinter/rules/cli_input_json.py
@@ -47,15 +47,11 @@ class CLIInputJSONRule(LintRule):
                             },
                             {
                                 "kind": "string",
-                                "has": {
-                                    "kind": "string_content",
-                                    "nthChild": 1,
-                                    "regex": "\\A--cli-input-json\\z",
-                                },
+                                "pattern": '"--cli-input-json"',
                             },
                             {
                                 "kind": "raw_string",
-                                "regex": "--cli-input-json",
+                                "pattern": "'--cli-input-json'",
                             },
                         ]
                     }

--- a/awsclilinter/awsclilinter/rules/cli_input_json.py
+++ b/awsclilinter/awsclilinter/rules/cli_input_json.py
@@ -10,10 +10,10 @@ class CLIInputJSONRule(LintRule):
     """Detects AWS CLI commands that use the `--cli-input-json` parameter."""
 
     _SUGGESTED_MANUAL_FIX = (
-        "If pagination-related parameters are present in the JSON file specified with "
-        "`--cli-input-json`, remove the pagination parameters from the JSON file "
+        "If pagination-related parameters are present in the input JSON specified with "
+        "`--cli-input-json`, remove the pagination parameters from the input JSON "
         "to retain v1 behavior. Alternatively, migrate to v2 behavior by moving the pagination "
-        "parameters from the JSON file onto the command as separate command line parameters. "
+        "parameters from the input JSON onto the command as separate command line parameters. "
         "See https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration-changes.html"
         "#cliv2-migration-skeleton-paging.\n"
     )
@@ -32,7 +32,6 @@ class CLIInputJSONRule(LintRule):
 
     def check(self, root: SgRoot) -> List[LintFinding]:
         """Check for AWS CLI commands that use `--cli-input-json`."""
-        # TODO Add tests for this rule, and test (especially this rule).
         node = root.root()
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
@@ -51,13 +50,10 @@ class CLIInputJSONRule(LintRule):
                                 "has": {
                                     "kind": "string_content",
                                     "nthChild": 1,
-                                    "regex": "\\A--cli-input-json\\z"
-                                }
+                                    "regex": "\\A--cli-input-json\\z",
+                                },
                             },
-                            {
-                                "kind": "raw_string",
-                                "regex": "\\A--cli-input-json\\z"
-                            },
+                            {"kind": "raw_string", "regex": "--cli-input-json"},
                         ]
                     }
                 },

--- a/awsclilinter/awsclilinter/rules/cli_input_json.py
+++ b/awsclilinter/awsclilinter/rules/cli_input_json.py
@@ -53,7 +53,10 @@ class CLIInputJSONRule(LintRule):
                                     "regex": "\\A--cli-input-json\\z",
                                 },
                             },
-                            {"kind": "raw_string", "regex": "--cli-input-json"},
+                            {
+                                "kind": "raw_string",
+                                "regex": "--cli-input-json",
+                            },
                         ]
                     }
                 },

--- a/awsclilinter/awsclilinter/rules/default_pager.py
+++ b/awsclilinter/awsclilinter/rules/default_pager.py
@@ -47,7 +47,10 @@ class DefaultPagerRule(LintRule):
                                         "regex": "\\A--no-cli-pager\\z",
                                     },
                                 },
-                                {"kind": "raw_string", "regex": "--no-cli-pager"},
+                                {
+                                    "kind": "raw_string",
+                                    "regex": "--no-cli-pager",
+                                },
                             ]
                         }
                     }

--- a/awsclilinter/awsclilinter/rules/default_pager.py
+++ b/awsclilinter/awsclilinter/rules/default_pager.py
@@ -41,15 +41,11 @@ class DefaultPagerRule(LintRule):
                                 },
                                 {
                                     "kind": "string",
-                                    "has": {
-                                        "kind": "string_content",
-                                        "nthChild": 1,
-                                        "regex": "\\A--no-cli-pager\\z",
-                                    },
+                                    "pattern": '"--no-cli-pager"',
                                 },
                                 {
                                     "kind": "raw_string",
-                                    "regex": "--no-cli-pager",
+                                    "pattern": "'--no-cli-pager'",
                                 },
                             ]
                         }

--- a/awsclilinter/awsclilinter/rules/default_pager.py
+++ b/awsclilinter/awsclilinter/rules/default_pager.py
@@ -44,13 +44,10 @@ class DefaultPagerRule(LintRule):
                                     "has": {
                                         "kind": "string_content",
                                         "nthChild": 1,
-                                        "regex": "\\A--no-cli-pager\\z"
-                                    }
+                                        "regex": "\\A--no-cli-pager\\z",
+                                    },
                                 },
-                                {
-                                    "kind": "raw_string",
-                                    "regex": "\\A--no-cli-pager\\z"
-                                },
+                                {"kind": "raw_string", "regex": "--no-cli-pager"},
                             ]
                         }
                     }

--- a/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
+++ b/awsclilinter/awsclilinter/rules/deploy_empty_changeset.py
@@ -3,6 +3,7 @@ from typing import List
 from ast_grep_py.ast_grep_py import SgRoot
 
 from awsclilinter.rules import LintFinding, LintRule
+from awsclilinter.rules.utils import has_aws_command_any_kind
 
 
 class DeployEmptyChangesetRule(LintRule):
@@ -16,7 +17,7 @@ class DeployEmptyChangesetRule(LintRule):
     def description(self) -> str:
         return (
             "In AWS CLI v2, deploying an AWS CloudFormation Template that results in an empty "
-            "changeset will NOT result in an error. You can add the -–fail-on-empty-changeset "
+            "changeset will NOT result in an error. You can add the --fail-on-empty-changeset "
             "flag to retain v1 behavior in v2. See https://docs.aws.amazon.com/cli/latest/"
             "userguide/cliv2-migration-changes.html#cliv2-migration-cfn."
         )
@@ -29,15 +30,7 @@ class DeployEmptyChangesetRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {
-                    "has": {
-                        "kind": "command_name",
-                        "has": {
-                            "kind": "word",
-                            "pattern": "aws",
-                        },
-                    }
-                },
+                has_aws_command_any_kind(),
                 {
                     "has": {
                         "kind": "word",

--- a/awsclilinter/awsclilinter/rules/ecr_get_login.py
+++ b/awsclilinter/awsclilinter/rules/ecr_get_login.py
@@ -3,6 +3,7 @@ from typing import List
 from ast_grep_py.ast_grep_py import SgRoot
 
 from awsclilinter.rules import LintFinding, LintRule
+from awsclilinter.rules.utils import has_aws_command_any_kind
 
 
 class EcrGetLoginRule(LintRule):
@@ -33,15 +34,7 @@ class EcrGetLoginRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {
-                    "has": {
-                        "kind": "command_name",
-                        "has": {
-                            "kind": "word",
-                            "pattern": "aws",
-                        },
-                    }
-                },
+                has_aws_command_any_kind(),
                 {
                     "has": {
                         "kind": "word",

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -3,6 +3,7 @@ from typing import List
 from ast_grep_py.ast_grep_py import SgRoot
 
 from awsclilinter.rules import LintFinding, LintRule
+from awsclilinter.rules.utils import has_aws_command_any_kind
 
 _HIDDEN_ALIASES = [
     {
@@ -181,15 +182,7 @@ class HiddenAliasRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {
-                    "has": {
-                        "kind": "command_name",
-                        "has": {
-                            "kind": "word",
-                            "pattern": "aws",
-                        },
-                    }
-                },
+                has_aws_command_any_kind(),
                 {
                     "has": {
                         "kind": "word",
@@ -202,7 +195,29 @@ class HiddenAliasRule(LintRule):
                         "pattern": self._operation,
                     }
                 },
-                {"has": {"kind": "word", "pattern": f"--{self._hidden_alias}"}},
+                # Has the hidden alias parameter (unquoted, double-quoted, or single-quoted).
+                {
+                    "has": {
+                        "any": [
+                            {
+                                "kind": "word",
+                                "pattern": f"--{self._hidden_alias}",
+                            },
+                            {
+                                "kind": "string",
+                                "has": {
+                                    "kind": "string_content",
+                                    "nthChild": 1,
+                                    "regex": f"\\A--{self._hidden_alias}\\z"
+                                }
+                            },
+                            {
+                                "kind": "raw_string",
+                                "regex": f"\\A--{self._hidden_alias}\\z"
+                            },
+                        ]
+                    }
+                },
             ]
         )
 

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -211,10 +211,7 @@ class HiddenAliasRule(LintRule):
                                     "regex": f"\\A--{self._hidden_alias}\\z",
                                 },
                             },
-                            {
-                                "kind": "raw_string",
-                                "regex": f"--{self._hidden_alias}"
-                            },
+                            {"kind": "raw_string", "regex": f"--{self._hidden_alias}"},
                         ]
                     }
                 },

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -208,13 +208,10 @@ class HiddenAliasRule(LintRule):
                                 "has": {
                                     "kind": "string_content",
                                     "nthChild": 1,
-                                    "regex": f"\\A--{self._hidden_alias}\\z"
-                                }
+                                    "regex": f"\\A--{self._hidden_alias}\\z",
+                                },
                             },
-                            {
-                                "kind": "raw_string",
-                                "regex": f"\\A--{self._hidden_alias}\\z"
-                            },
+                            {"kind": "raw_string", "regex": f"--{self._hidden_alias}"},
                         ]
                     }
                 },

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -211,7 +211,10 @@ class HiddenAliasRule(LintRule):
                                     "regex": f"\\A--{self._hidden_alias}\\z",
                                 },
                             },
-                            {"kind": "raw_string", "regex": f"--{self._hidden_alias}"},
+                            {
+                                "kind": "raw_string",
+                                "regex": f"--{self._hidden_alias}"
+                            },
                         ]
                     }
                 },

--- a/awsclilinter/awsclilinter/rules/hidden_aliases.py
+++ b/awsclilinter/awsclilinter/rules/hidden_aliases.py
@@ -205,13 +205,9 @@ class HiddenAliasRule(LintRule):
                             },
                             {
                                 "kind": "string",
-                                "has": {
-                                    "kind": "string_content",
-                                    "nthChild": 1,
-                                    "regex": f"\\A--{self._hidden_alias}\\z",
-                                },
+                                "pattern": f'"--{self._hidden_alias}"',
                             },
-                            {"kind": "raw_string", "regex": f"--{self._hidden_alias}"},
+                            {"kind": "raw_string", "pattern": f"'--{self._hidden_alias}'"},
                         ]
                     }
                 },

--- a/awsclilinter/awsclilinter/rules/s3_copies.py
+++ b/awsclilinter/awsclilinter/rules/s3_copies.py
@@ -32,7 +32,7 @@ class S3CopyRule(LintRule):
                     # Occurs after raw-string S3 bucket (e.g. 's3://bucket').
                     {
                         "kind": "raw_string",
-                        "regex": "s3://",
+                        "regex": "'s3://[^']+'",
                     },
                     # Occurs after concatenated S3 bucket (e.g. s3://$S3_BUCKET_NAME).
                     {
@@ -53,7 +53,7 @@ class S3CopyRule(LintRule):
                                 },
                                 {
                                     "kind": "raw_string",
-                                    "regex": "s3://",
+                                    "regex": "'s3://[^']+'",
                                 },
                             ]
                         },
@@ -134,7 +134,7 @@ class S3CopyRule(LintRule):
                             # raw-string S3 bucket (e.g. 's3://bucket').
                             {
                                 "kind": "raw_string",
-                                "regex": "s3://",
+                                "regex": "'s3://[^']+'",
                                 **self._follows_s3_bucket_any_kind(),
                             },
                             # Has an S3 bucket followed by a
@@ -157,7 +157,7 @@ class S3CopyRule(LintRule):
                                         },
                                         {
                                             "kind": "raw_string",
-                                            "regex": "s3://",
+                                            "regex": "'s3://[^']+'",
                                         },
                                     ]
                                 },

--- a/awsclilinter/awsclilinter/rules/s3_copies.py
+++ b/awsclilinter/awsclilinter/rules/s3_copies.py
@@ -3,6 +3,7 @@ from typing import List
 from ast_grep_py.ast_grep_py import SgRoot
 
 from awsclilinter.rules import LintFinding, LintRule
+from awsclilinter.rules.utils import has_aws_command_any_kind
 
 
 class S3CopyRule(LintRule):
@@ -82,15 +83,7 @@ class S3CopyRule(LintRule):
         nodes = node.find_all(
             all=[  # type: ignore[arg-type]
                 {"kind": "command"},
-                {
-                    "has": {
-                        "kind": "command_name",
-                        "has": {
-                            "kind": "word",
-                            "pattern": "aws",
-                        },
-                    }
-                },
+                has_aws_command_any_kind(),
                 {
                     "has": {
                         "kind": "word",

--- a/awsclilinter/awsclilinter/rules/s3_copies.py
+++ b/awsclilinter/awsclilinter/rules/s3_copies.py
@@ -32,7 +32,7 @@ class S3CopyRule(LintRule):
                     # Occurs after raw-string S3 bucket (e.g. 's3://bucket').
                     {
                         "kind": "raw_string",
-                        "regex": "\\As3://",
+                        "regex": "s3://",
                     },
                     # Occurs after concatenated S3 bucket (e.g. s3://$S3_BUCKET_NAME).
                     {
@@ -53,7 +53,7 @@ class S3CopyRule(LintRule):
                                 },
                                 {
                                     "kind": "raw_string",
-                                    "regex": "\\As3://",
+                                    "regex": "s3://",
                                 },
                             ]
                         },
@@ -134,7 +134,7 @@ class S3CopyRule(LintRule):
                             # raw-string S3 bucket (e.g. 's3://bucket').
                             {
                                 "kind": "raw_string",
-                                "regex": "\\As3://",
+                                "regex": "s3://",
                                 **self._follows_s3_bucket_any_kind(),
                             },
                             # Has an S3 bucket followed by a
@@ -157,7 +157,7 @@ class S3CopyRule(LintRule):
                                         },
                                         {
                                             "kind": "raw_string",
-                                            "regex": "\\As3://",
+                                            "regex": "s3://",
                                         },
                                     ]
                                 },

--- a/awsclilinter/awsclilinter/rules/utils.py
+++ b/awsclilinter/awsclilinter/rules/utils.py
@@ -1,7 +1,7 @@
 def has_aws_command_any_kind():
     return {
         "has": {
-           "kind": "command_name",
+            "kind": "command_name",
             "has": {
                 "any": [
                     {
@@ -10,17 +10,10 @@ def has_aws_command_any_kind():
                     },
                     {
                         "kind": "string",
-                        "has": {
-                            "kind": "string_content",
-                            "nthChild": 1,
-                            "regex": "\\Aaws\\z"
-                        }
+                        "has": {"kind": "string_content", "nthChild": 1, "regex": "\\Aaws\\z"},
                     },
-                    {
-                        "kind": "raw_string",
-                        "regex": "\\Aaws\\z"
-                    },
+                    {"kind": "raw_string", "regex": "aws"},
                 ]
-            }
+            },
         }
     }

--- a/awsclilinter/awsclilinter/rules/utils.py
+++ b/awsclilinter/awsclilinter/rules/utils.py
@@ -1,0 +1,26 @@
+def has_aws_command_any_kind():
+    return {
+        "has": {
+           "kind": "command_name",
+            "has": {
+                "any": [
+                    {
+                        "kind": "word",
+                        "pattern": "aws",
+                    },
+                    {
+                        "kind": "string",
+                        "has": {
+                            "kind": "string_content",
+                            "nthChild": 1,
+                            "regex": "\\Aaws\\z"
+                        }
+                    },
+                    {
+                        "kind": "raw_string",
+                        "regex": "\\Aaws\\z"
+                    },
+                ]
+            }
+        }
+    }

--- a/awsclilinter/awsclilinter/rules/utils.py
+++ b/awsclilinter/awsclilinter/rules/utils.py
@@ -10,9 +10,9 @@ def has_aws_command_any_kind():
                     },
                     {
                         "kind": "string",
-                        "has": {"kind": "string_content", "nthChild": 1, "regex": "\\Aaws\\z"},
+                        "pattern": '"aws"',
                     },
-                    {"kind": "raw_string", "regex": "aws"},
+                    {"kind": "raw_string", "pattern": "'aws'"},
                 ]
             },
         }

--- a/awsclilinter/examples/upload_s3_files.sh
+++ b/awsclilinter/examples/upload_s3_files.sh
@@ -4,7 +4,7 @@
 TEMPLATE_FILE="$1"
 BUCKET="$2"
 
-aws secretsmanager put-secret-value --secret-id secret1213 \
+'aws' secretsmanager put-secret-value --secret-id secret1213 \
   --secret-binary file://data.json
 
 if

--- a/awsclilinter/pyproject.toml
+++ b/awsclilinter/pyproject.toml
@@ -41,7 +41,7 @@ Documentation = "https://github.com/aws/aws-cli"
 "Source Code" = "https://github.com/aws/aws-cli"
 
 [project.scripts]
-upgrade-aws-cli = "awsclilinter.cli:main"
+migrate-aws-cli = "awsclilinter.cli:main"
 
 [tool.ruff]
 line-length = 100

--- a/awsclilinter/pyproject.toml
+++ b/awsclilinter/pyproject.toml
@@ -62,3 +62,9 @@ python_functions = ["test_*"]
 
 [tool.setuptools]
 packages = ["awsclilinter"]
+
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true

--- a/awsclilinter/pyproject.toml
+++ b/awsclilinter/pyproject.toml
@@ -60,8 +60,9 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 
-[tool.setuptools]
-packages = ["awsclilinter"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["awsclilinter*"]
 
 [[tool.uv.index]]
 name = "testpypi"

--- a/awsclilinter/tests/test_cli.py
+++ b/awsclilinter/tests/test_cli.py
@@ -352,3 +352,21 @@ class TestCLI:
 
                 # Should have saved and exited
                 assert output_file.exists()
+
+    def test_version_flag(self, capsys):
+        """Test --version flag displays version and exits."""
+        with patch("sys.argv", ["migrate-aws-cli", "--version"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            captured = capsys.readouterr()
+            assert "migrate-aws-cli" in captured.out
+
+    def test_version_flag_short(self, capsys):
+        """Test -v flag displays version and exits."""
+        with patch("sys.argv", ["migrate-aws-cli", "-v"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            captured = capsys.readouterr()
+            assert "migrate-aws-cli" in captured.out

--- a/awsclilinter/tests/test_cli.py
+++ b/awsclilinter/tests/test_cli.py
@@ -10,7 +10,7 @@ class TestCLI:
 
     def test_script_not_found(self, capsys):
         """Test error when script file doesn't exist."""
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", "nonexistent.sh"]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", "nonexistent.sh"]):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
@@ -18,7 +18,7 @@ class TestCLI:
     def test_fix_and_output_conflict(self, capsys):
         """Test error when both --fix and --output are provided."""
         with patch(
-            "sys.argv", ["upgrade-aws-cli", "--script", "test.sh", "--fix", "--output", "out.sh"]
+            "sys.argv", ["migrate-aws-cli", "--script", "test.sh", "--fix", "--output", "out.sh"]
         ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
@@ -27,7 +27,7 @@ class TestCLI:
     def test_fix_and_interactive_conflict(self, capsys):
         """Test error when both --fix and --interactive are provided."""
         with patch(
-            "sys.argv", ["upgrade-aws-cli", "--script", "test.sh", "--fix", "--interactive"]
+            "sys.argv", ["migrate-aws-cli", "--script", "test.sh", "--fix", "--interactive"]
         ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
@@ -38,7 +38,7 @@ class TestCLI:
         script_file = tmp_path / "test.sh"
         script_file.write_text("echo 'hello world'")
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file)]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file)]):
             main()
             captured = capsys.readouterr()
             assert "No issues found" in captured.out
@@ -50,7 +50,7 @@ class TestCLI:
             "aws secretsmanager put-secret-value --secret-id secret1213 --secret-binary file://data.json"
         )
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file)]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file)]):
             main()
             captured = capsys.readouterr()
             assert "Found" in captured.out
@@ -63,7 +63,7 @@ class TestCLI:
             "aws secretsmanager put-secret-value --secret-id secret1213 --secret-binary file://data.json"
         )
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file), "--fix"]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file), "--fix"]):
             main()
             fixed_content = script_file.read_text()
             # 1 command, 2 rules = 2 flags added
@@ -81,7 +81,7 @@ class TestCLI:
             "--deployment-group-name mygroup --ec-2-tag-set file://tags.json"
         )
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file), "--fix"]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file), "--fix"]):
             main()
             captured = capsys.readouterr()
 
@@ -106,7 +106,7 @@ class TestCLI:
 
         with patch(
             "sys.argv",
-            ["upgrade-aws-cli", "--script", str(script_file), "--output", str(output_file)],
+            ["migrate-aws-cli", "--script", str(script_file), "--output", str(output_file)],
         ):
             main()
             assert output_file.exists()
@@ -128,7 +128,7 @@ class TestCLI:
         with patch(
             "sys.argv",
             [
-                "upgrade-aws-cli",
+                "migrate-aws-cli",
                 "--script",
                 str(script_file),
                 "--interactive",
@@ -150,7 +150,7 @@ class TestCLI:
         original = "aws secretsmanager put-secret-value --secret-id secret1213 --secret-binary file://data.json"
         script_file.write_text(original)
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file), "--interactive"]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file), "--interactive"]):
             with patch("builtins.input", return_value="n"):
                 main()
                 captured = capsys.readouterr()
@@ -169,7 +169,7 @@ class TestCLI:
         with patch(
             "sys.argv",
             [
-                "upgrade-aws-cli",
+                "migrate-aws-cli",
                 "--script",
                 str(script_file),
                 "--interactive",
@@ -197,7 +197,7 @@ class TestCLI:
         with patch(
             "sys.argv",
             [
-                "upgrade-aws-cli",
+                "migrate-aws-cli",
                 "--script",
                 str(script_file),
                 "--interactive",
@@ -224,7 +224,7 @@ class TestCLI:
         with patch(
             "sys.argv",
             [
-                "upgrade-aws-cli",
+                "migrate-aws-cli",
                 "--script",
                 str(script_file),
                 "--interactive",
@@ -244,7 +244,7 @@ class TestCLI:
         script_file = tmp_path / "test.sh"
         script_file.write_text("aws ecr get-login --region us-west-2")
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file)]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file)]):
             main()
             captured = capsys.readouterr()
             assert "MANUAL REVIEW REQUIRED" in captured.out
@@ -259,7 +259,7 @@ class TestCLI:
             "aws ecr get-login --region us-west-2"
         )
 
-        with patch("sys.argv", ["upgrade-aws-cli", "--script", str(script_file), "--fix"]):
+        with patch("sys.argv", ["migrate-aws-cli", "--script", str(script_file), "--fix"]):
             main()
             captured = capsys.readouterr()
 
@@ -289,7 +289,7 @@ class TestCLI:
         with patch(
             "sys.argv",
             [
-                "upgrade-aws-cli",
+                "migrate-aws-cli",
                 "--script",
                 str(script_file),
                 "--interactive",
@@ -329,7 +329,7 @@ class TestCLI:
         with patch(
             "sys.argv",
             [
-                "upgrade-aws-cli",
+                "migrate-aws-cli",
                 "--script",
                 str(script_file),
                 "--interactive",

--- a/awsclilinter/tests/test_rules.py
+++ b/awsclilinter/tests/test_rules.py
@@ -1,6 +1,7 @@
 from ast_grep_py import SgRoot
 
 from awsclilinter.rules.binary_params_base64 import Base64BinaryFormatRule
+from awsclilinter.rules.cli_input_json import CLIInputJSONRule
 from awsclilinter.rules.default_pager import DefaultPagerRule
 from awsclilinter.rules.deploy_empty_changeset import DeployEmptyChangesetRule
 from awsclilinter.rules.ecr_get_login import EcrGetLoginRule
@@ -297,6 +298,78 @@ class TestEcrGetLoginRule:
         script = "aws ecr get-login\naws ecr get-login --region us-east-1"
         root = SgRoot(script, "bash")
         rule = EcrGetLoginRule()
+        findings = rule.check(root)
+
+        assert len(findings) == 2
+        for finding in findings:
+            assert finding.edit is None
+            assert finding.suggested_manual_fix is not None
+            assert finding.auto_fixable is False
+
+
+class TestCLIInputJSONRule:
+    """Test cases for CLIInputJSONRule (manual review only)."""
+
+    def test_rule_properties(self):
+        """Test rule description and auto_fixable property."""
+        rule = CLIInputJSONRule()
+        assert "cli-input-json" in rule.description
+        assert "pagination" in rule.description
+
+    def test_detects_cli_input_json(self):
+        """Test detection of the `--cli-input-json` parameter."""
+        script = "aws ec2 describe-instances --cli-input-json file://input.json"
+        root = SgRoot(script, "bash")
+        rule = CLIInputJSONRule()
+        findings = rule.check(root)
+
+        assert len(findings) == 1
+        assert findings[0].edit is None
+        assert findings[0].suggested_manual_fix is not None
+        assert "pagination" in findings[0].suggested_manual_fix
+        assert findings[0].auto_fixable is False
+
+    def test_detects_cli_input_json_double_quoted(self):
+        """Test detection of the `--cli-input-json` parameter with double quotes."""
+        script = 'aws s3api list-objects "--cli-input-json" file://input.json'
+        root = SgRoot(script, "bash")
+        rule = CLIInputJSONRule()
+        findings = rule.check(root)
+
+        assert len(findings) == 1
+        assert findings[0].edit is None
+        assert findings[0].suggested_manual_fix is not None
+        assert findings[0].auto_fixable is False
+
+    def test_detects_cli_input_json_single_quoted(self):
+        """Test detection of the `--cli-input-json` parameter with single quotes."""
+        script = "aws dynamodb query '--cli-input-json' file://query.json"
+        root = SgRoot(script, "bash")
+        rule = CLIInputJSONRule()
+        findings = rule.check(root)
+
+        assert len(findings) == 1
+        assert findings[0].edit is None
+        assert findings[0].suggested_manual_fix is not None
+        assert findings[0].auto_fixable is False
+
+    def test_no_detection_without_cli_input_json(self):
+        """Test no detection when the `--cli-input-json` parameter is not present."""
+        script = "aws ec2 describe-instances --region us-west-2"
+        root = SgRoot(script, "bash")
+        rule = CLIInputJSONRule()
+        findings = rule.check(root)
+
+        assert len(findings) == 0
+
+    def test_detects_multiple_cli_input_json(self):
+        """Test detection of multiple commands with --cli-input-json."""
+        script = (
+            "aws ec2 describe-instances --cli-input-json file://input.json\n"
+            "aws s3api list-buckets --cli-input-json file://buckets.json"
+        )
+        root = SgRoot(script, "bash")
+        rule = CLIInputJSONRule()
         findings = rule.check(root)
 
         assert len(findings) == 2

--- a/awsclilinter/tests/test_rules.py
+++ b/awsclilinter/tests/test_rules.py
@@ -236,9 +236,13 @@ class TestHiddenAliasRule:
 
     def test_fix_replaces_hidden_alias(self):
         """Test detection of public-key-base-64 alias in lightsail."""
-        script = "aws lightsail import-key-pair --key-pair-name mykey --public-key-base-64 c3NoLXJzYQ=="
+        script = (
+            "aws lightsail import-key-pair --key-pair-name mykey --public-key-base-64 c3NoLXJzYQ=="
+        )
         root = SgRoot(script, "bash")
-        rule = HiddenAliasRule("public-key-base-64", "public-key-base64", "lightsail", "import-key-pair")
+        rule = HiddenAliasRule(
+            "public-key-base-64", "public-key-base64", "lightsail", "import-key-pair"
+        )
         findings = rule.check(root)
 
         assert len(findings) == 1

--- a/awsclilinter/tests/test_rules.py
+++ b/awsclilinter/tests/test_rules.py
@@ -190,6 +190,15 @@ class TestS3CopyRule:
 
         assert len(findings) == 0
 
+    def test_no_detection_non_s3_paths(self):
+        """Test no detection for paths that don't start with s3://."""
+        script = "aws s3 cp 'as3://test-bucket1' 'as3://test-bucket2'"
+        root = SgRoot(script, "bash")
+        rule = S3CopyRule()
+        findings = rule.check(root)
+
+        assert len(findings) == 0
+
 
 class TestHiddenAliasRule:
     """Test cases for HiddenAliasRule."""


### PR DESCRIPTION
*Description of changes:*

* Fix bug with auto-fix mode where multiple findings detected in a single command would cause conflicts/script-corruption.
* Added a regression test to detect the auto-fix bug's failure mode.
* Updated dry-run mode to show the full-file diff instead of per-finding diff, based on previous reviewer feedback.
* Added new `CLIInputJSONRule` to detect AWS CLI commands that use the `--cli-input-json` parameter. These commands are flagged for manual review.
* Improved detection capabilities across linting rules to account for double and single-quoted command names. 
  * For example, `"aws" ecr get-login` is now detected by the `EcrGetLoginRule`; this was previously not true.
* Fixed bug where raw-string detections (i.e. single-quoted tokens) were not being detected.
* Modified use of ANSI color codes so that they are only used when the linter is being run in a TTY. This fixes compatibility with piping the application output.
* Fix compatibility issues with older versions of Python (<3.12).
* Added tests to cover new/updated functionality.

*Description of tests:*

* Ran and passed all automated tests.
* Manually tested linter in all major modes (dry-run, auto-fix, and interactive).
* Manually tested linter against Python version 3.9.
* Manually tested the linter with Unix file piping.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
