### PR TITLE
Bugfix within shorthand example generation for map-type parameters in documentation

### DIFF
--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -437,7 +437,7 @@ class ParamShorthandDocGen(ParamShorthand):
     """Documentation generator for param shorthand syntax."""
 
     _DONT_DOC = object()
-    _MAX_STACK = 4
+    _MAX_STACK = 3
 
     def supports_shorthand(self, argument_model):
         """Checks if a CLI argument supports shorthand syntax."""

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -539,7 +539,11 @@ class ParamShorthandDocGen(ParamShorthand):
 
     def _map_docs(self, argument_model, stack):
         k = argument_model.key
-        value_docs = self._shorthand_docs(argument_model.value, stack)
+        stack.append(argument_model.value.name)
+        try:
+            value_docs = self._shorthand_docs(argument_model.value, stack)
+        finally:
+            stack.pop()
         start = 'KeyName1=%s,KeyName2=%s' % (value_docs, value_docs)
         if k.enum and not stack:
             start += '\n\nWhere valid key names are:\n'

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -437,7 +437,7 @@ class ParamShorthandDocGen(ParamShorthand):
     """Documentation generator for param shorthand syntax."""
 
     _DONT_DOC = object()
-    _MAX_STACK = 3
+    _MAX_STACK = 4
 
     def supports_shorthand(self, argument_model):
         """Checks if a CLI argument supports shorthand syntax."""

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -857,7 +857,12 @@ class TestDocGen(BaseArgProcessTest):
                                 'C': {
                                     'type': 'structure',
                                     'members': {
-                                        'D': {'type': 'string'},
+                                        'D': {
+                                            'type': 'structure',
+                                            'members': {
+                                                'E': {'type': 'string'},
+                                            },
+                                        }
                                     },
                                 }
                             },

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -857,12 +857,7 @@ class TestDocGen(BaseArgProcessTest):
                                 'C': {
                                     'type': 'structure',
                                     'members': {
-                                        'D': {
-                                            'type': 'structure',
-                                            'members': {
-                                                'E': {'type': 'string'},
-                                            },
-                                        }
+                                        'D': {'type': 'string'},
                                     },
                                 }
                             },

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -869,6 +869,24 @@ class TestDocGen(BaseArgProcessTest):
         generated_example = self.get_generated_example_for(argument)
         self.assertEqual(generated_example, '')
 
+    def test_structure_within_map(self):
+        argument = self.create_argument(
+            {
+                'A': {
+                    'type': 'map',
+                    'key': {'type': 'string'},
+                    'value': {
+                        'type': 'structure',
+                        'members': {
+                            'B': {'type': 'string'},
+                        },
+                    },
+                },
+            }
+        )
+        generated_example = self.get_generated_example_for(argument)
+        self.assertEqual('A={KeyName1={B=string},KeyName2={B=string}}', generated_example)
+
 
 class TestUnpackJSONParams(BaseArgProcessTest):
     def setUp(self):


### PR DESCRIPTION
*Related Issues:*

* https://github.com/aws/aws-cli/issues/3637 - [sqs send-message](https://github.com/aws/aws-cli/pull/7286)
* https://github.com/aws/aws-cli/issues/5129 - [sns publish](https://github.com/aws/aws-cli/pull/7286)
* https://github.com/aws/aws-cli/issues/7433 - [iot update-event-configurations](https://github.com/aws/aws-cli/pull/7286)
* V1046315945

*Description of changes:*

* When parameter-type is `map`, and the value is a structure or list, include curly-braces or square-brackets around the value. This change is consistent with how structures are handled.
* Increased the max stack size from `3` to `4`. This threshold controls which parameters receive a generated shorthand example. Without this increase, 61 shorthand examples would have been removed from the docs. As a consequence of this increase, 38 shorthand examples will be added to the docs (see *Description of Impact* below).

*Description of tests:*

* Added a new test to verify the behavior of the new code. Ran and passed all tests with a build-and-validate workflow execution.
* Generated a diff of the docs with and without this change. Verified the changes look as expected. Fed the diff to an LLM and prompted it to summarize the diff in human-readable text-only format. I've attached the summaries for in *Description of Impact* below.
* Verified the updated shorthand syntax examples are correctly rendered in the man pages on Mac OS building from source.

*Notes:*

This PR supersedes https://github.com/aws/aws-cli/pull/7286, which did not increase the max stack size to 4, and would have caused 61 shorthand examples for being removed.

*Description of impact:*

Two files attaches below describe the full set of docs changes that will be caused by this change:

* **shorthand_diff_4stack_unique_summary.txt** Describes 38 added shorthand syntax examples that reach a max depth of 4.
* **shorthand_diff_4stack_summary.txt** Describes 127 updated shorthand examples for a parameter type of `map`.

[shorthand_diff_4stack_unique_summary.txt](https://github.com/user-attachments/files/24597405/shorthand_diff_4stack_unique_summary.txt)
[shorthand_diff_4stack_summary.txt](https://github.com/user-attachments/files/24597406/shorthand_diff_4stack_summary.txt)
