### PR TITLE
Fix grammar in get-vpc-attachment example

### DIFF
--- a/awscli/examples/networkmanager/get-vpc-attachment.rst
+++ b/awscli/examples/networkmanager/get-vpc-attachment.rst
@@ -1,4 +1,4 @@
-**To get an a VPC attachment**
+**To get a VPC attachment**
 
 The following ``get-vpc-attachment`` example returns information about a VPC attachment. ::
 


### PR DESCRIPTION
**Changes:**
- Corrected "To get an a VPC attachment" to "To get a VPC attachment" in https://docs.aws.amazon.com/cli/latest/reference/networkmanager/get-vpc-attachment.html 

**File modified:**
- awscli/examples/networkmanager/get-vpc-attachment.rst

From a customer feedback: V2071738585 (Internal Tracking Only)