### PR TITLE
Add maintenance mode announcement to readme, API ref, and bundled installer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,17 @@ Jump to:
 -  `Getting Help <#getting-help>`__
 -  `More Resources <#more-resources>`__
 
+
+Entering Maintenance Mode on July 15, 2026
+------------------------------------------
+
+We `announced <https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/>`__
+the upcoming **end-of-support for the AWS CLI v1**. We recommend
+that you migrate to
+`AWS CLI v2 <https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html>`__.
+For dates, additional details, and information on how to migrate,
+please refer to the linked announcement.
+
 Getting Started
 ---------------
 

--- a/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
+++ b/doc/source/guzzle_sphinx_theme/guzzle_sphinx_theme/layout.html
@@ -94,10 +94,7 @@
                     <p>
                         <h3 style="margin-top: 0px;">Note:</h3>
                         You are viewing the documentation for an older major version of the AWS CLI (version 1).
-                    </p>
-                    <p>
-                        AWS CLI version 2, the latest major version of AWS CLI, is now stable and recommended for general use.
-                        {% if pagename in deprecated_commands %}
+                         {% if pagename in deprecated_commands %}
                             {% if deprecated_commands[pagename] %}
                                 This command is deprecated in AWS CLI version 2, use
                                 <a href="https://docs.aws.amazon.com/cli/latest/{{ deprecated_commands[pagename][0] }}.html">{{ deprecated_commands[pagename][1] }}</a> instead.
@@ -108,6 +105,10 @@
                             To view this page for the AWS CLI version 2, click
                             <a href="https://docs.aws.amazon.com/cli/latest/{{ pagename }}.html">here</a>.
                         {% endif %}
+                    </p>
+                    <p>
+                        We <a href="https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/">announced</a> the upcoming end-of-support for the AWS CLI v1.
+                        For dates, additional details, and information on how to migrate, please refer to the linked announcement.
                         For more information see the AWS CLI version 2
                         <a href="https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html">installation instructions</a>
                         and

--- a/scripts/install
+++ b/scripts/install
@@ -236,9 +236,12 @@ def main():
             print("You can now run: %s --version" % opts.bin_location)
         else:
             print("You can now run: %s --version" % real_location)
-        print('\nNote: AWS CLI version 2, the latest major version '
-              'of the AWS CLI, is now stable and recommended for general '
-              'use. For more information, see the AWS CLI version 2 '
+        print('\nNote: We announced the end-of-support for the AWS CLI v1: '
+              'https://aws.amazon.com/blogs/developer/'
+              'cli-v1-maintenance-mode-announcement/',
+              '\nFor dates, additional details, and information on how to '
+              'migrate, please refer to the linked announcement.',
+              '\nWe recommend that you migrate to AWS CLI v2, see the',
               'installation instructions at: https://docs.aws.amazon.com/cli/'
               'latest/userguide/install-cliv2.html')
     finally:


### PR DESCRIPTION
*Description of changes:* We announced that CLI v1 will enter maintenance mode on July 15, 2026, and reach end-of-support on July 15, 2027 via https://aws.amazon.com/blogs/developer/cli-v1-maintenance-mode-announcement/ on January 15, 2026.

This PR adds that link:
* To the banner in the API ref
* To the README
* To the post-installation message for the bundled installers.


API ref after generation:
<img width="735" height="263" alt="image" src="https://github.com/user-attachments/assets/516bfac5-770f-4cbd-9de2-b87c6022143f" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
