### PR TITLE
Remove the markdown hyperlink from the Migration Tool GitHub template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/migration-tool.yml
+++ b/.github/ISSUE_TEMPLATE/migration-tool.yml
@@ -1,6 +1,6 @@
 ---
 name: "AWS CLI v1-to-v2 Migration Tool Issue"
-description: Report an issue or get support with the AWS CLI v1-to-v2 Migration Tool. Please see our [documentation](https://github.com/aws/aws-cli/tree/v1v2-migration-tool?tab=readme-ov-file#usage).
+description: Report an issue or get support with the AWS CLI v1-to-v2 Migration Tool. Please see our documentation at https://github.com/aws/aws-cli/tree/v1v2-migration-tool?tab=readme-ov-file#usage.
 title: "(short issue description)"
 labels: [v1-to-v2-migration-tool, needs-triage]
 assignees: []

--- a/.github/ISSUE_TEMPLATE/migration-tool.yml
+++ b/.github/ISSUE_TEMPLATE/migration-tool.yml
@@ -1,10 +1,14 @@
 ---
 name: "AWS CLI v1-to-v2 Migration Tool Issue"
-description: Report an issue or get support with the AWS CLI v1-to-v2 Migration Tool. Please see our documentation at https://github.com/aws/aws-cli/tree/v1v2-migration-tool?tab=readme-ov-file#usage.
+description: Report an issue or get support with the AWS CLI v1-to-v2 Migration Tool.
 title: "(short issue description)"
 labels: [v1-to-v2-migration-tool, needs-triage]
 assignees: []
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please see the [documentation](https://github.com/aws/aws-cli/tree/v1v2-migration-tool?tab=readme-ov-file#usage).
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/migration-tool.yml
+++ b/.github/ISSUE_TEMPLATE/migration-tool.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please see the [documentation](https://github.com/aws/aws-cli/tree/v1v2-migration-tool?tab=readme-ov-file#usage).
+        Please see the [documentation](https://github.com/aws/aws-cli/tree/v1v2-migration-tool?tab=readme-ov-file#usage) before creating an issue.
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
*Description of changes:*

* Remove the broken markdown hyperlink from the GitHub template for the migration tool.

*Description of tests:*

* Verified the preview of the template looks correct in my fork: https://github.com/aemous/aws-cli/blob/migration-tool-issue-template/.github/ISSUE_TEMPLATE/migration-tool.yml.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
