### PR TITLE
Need a --force flag in Example 3 update-image-set-metadata.rst

### DIFF
--- a/awscli/examples/medical-imaging/update-image-set-metadata.rst
+++ b/awscli/examples/medical-imaging/update-image-set-metadata.rst
@@ -69,7 +69,8 @@ The following ``update-image-set-metadata`` example removes an instance from ima
         --image-set-id ea92b0d8838c72a3f25d00d13616f87e \
         --latest-version-id 1 \
         --cli-binary-format raw-in-base64-out \
-        --update-image-set-metadata-updates file://metadata-updates.json
+        --update-image-set-metadata-updates file://metadata-updates.json \
+        --force
 
 Contents of ``metadata-updates.json`` ::
 


### PR DESCRIPTION
During testing for customer-facing metrics, found a gap in current documentation for instance removal from imageset Ref in example 3. The correct command needs --force flag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
