### PR TITLE
Fix EC2 example's invalid quotes

### DIFF
--- a/awscli/examples/ec2/authorize-security-group-ingress.rst
+++ b/awscli/examples/ec2/authorize-security-group-ingress.rst
@@ -63,7 +63,7 @@ The following ``authorize-security-group-ingress`` example uses the ``ip-permiss
 
     aws ec2 authorize-security-group-ingress \
         --group-id sg-1234567890abcdef0 \
-        --ip-permissions 'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=172.31.0.0/16}]' IpProtocol=icmp,FromPort=-1,ToPort=-1,IpRanges=[{CidrIp=172.31.0.0/16}]'
+        --ip-permissions 'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=172.31.0.0/16}]' 'IpProtocol=icmp,FromPort=-1,ToPort=-1,IpRanges=[{CidrIp=172.31.0.0/16}]'
 
 Output::
 

--- a/awscli/examples/ec2/authorize-security-group-ingress.rst
+++ b/awscli/examples/ec2/authorize-security-group-ingress.rst
@@ -63,7 +63,7 @@ The following ``authorize-security-group-ingress`` example uses the ``ip-permiss
 
     aws ec2 authorize-security-group-ingress \
         --group-id sg-1234567890abcdef0 \
-        --ip-permissions 'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=172.31.0.0/16}]" "IpProtocol=icmp,FromPort=-1,ToPort=-1,IpRanges=[{CidrIp=172.31.0.0/16}]'
+        --ip-permissions 'IpProtocol=tcp,FromPort=3389,ToPort=3389,IpRanges=[{CidrIp=172.31.0.0/16}]' IpProtocol=icmp,FromPort=-1,ToPort=-1,IpRanges=[{CidrIp=172.31.0.0/16}]'
 
 Output::
 


### PR DESCRIPTION
*Description of issues*

* V2065878664

*Description of changes:*

* Fix invalid quotes in an EC2 CLI command example.

*Description of tests:*

* Tested the command in the example in AWS CLI v2 to verify it passes client-side parameter validation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
