### PR TITLE
Bugfix within shorthand example generation for map-type parameters in documentation

### DIFF
--- a/.changes/next-release/bugfix-documentation-51673.json
+++ b/.changes/next-release/bugfix-documentation-51673.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "documentation",
+  "description": "Fixed shorthand example generation in documentation."
+}

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -536,7 +536,11 @@ class ParamShorthandDocGen(ParamShorthand):
 
     def _map_docs(self, argument_model, stack):
         k = argument_model.key
-        value_docs = self._shorthand_docs(argument_model.value, stack)
+        stack.append(argument_model.value.name)
+        try:
+            value_docs = self._shorthand_docs(argument_model.value, stack)
+        finally:
+            stack.pop()
         start = 'KeyName1=%s,KeyName2=%s' % (value_docs, value_docs)
         if k.enum and not stack:
             start += '\n\nWhere valid key names are:\n'

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -803,6 +803,24 @@ class TestDocGen(BaseArgProcessTest):
         generated_example = self.get_generated_example_for(argument)
         self.assertEqual(generated_example, '')
 
+    def test_structure_within_map(self):
+        argument = self.create_argument(
+            {
+                'A': {
+                    'type': 'map',
+                    'key': {'type': 'string'},
+                    'value': {
+                        'type': 'structure',
+                        'members': {
+                            'B': {'type': 'string'},
+                        },
+                    },
+                },
+            }
+        )
+        generated_example = self.get_generated_example_for(argument)
+        self.assertEqual('A={KeyName1={B=string},KeyName2={B=string}}', generated_example)
+
 
 class TestUnpackJSONParams(BaseArgProcessTest):
     def setUp(self):


### PR DESCRIPTION
*Description of changes:*

* v1 port of https://github.com/aws/aws-cli/pull/9982

*Description of tests:*

* Verified man pages are successfully updated with the fix via `sqs send-message` `message-attributes` paramater.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
