### PR TITLE
Fix typo in createcluster.py and emrfsutils.py

### DIFF
--- a/awscli/customizations/emr/createcluster.py
+++ b/awscli/customizations/emr/createcluster.py
@@ -844,7 +844,7 @@ class CreateCluster(Command):
     def _handle_emrfs_parameters(self, cluster, emrfs_args, release_label):
         if release_label:
             self.validate_no_emrfs_configuration(cluster)
-            emrfs_configuration = emrfsutils.build_emrfs_confiuration(
+            emrfs_configuration = emrfsutils.build_emrfs_configuration(
                 emrfs_args
             )
 

--- a/awscli/customizations/emr/emrfsutils.py
+++ b/awscli/customizations/emr/emrfsutils.py
@@ -62,7 +62,7 @@ def build_bootstrap_action_configs(region, emrfs_args):
     return bootstrap_actions
 
 
-def build_emrfs_confiuration(emrfs_args):
+def build_emrfs_configuration(emrfs_args):
     _verify_emrfs_args(emrfs_args)
     emrfs_properties = _build_emrfs_properties(emrfs_args)
 
@@ -77,6 +77,10 @@ def build_emrfs_confiuration(emrfs_args):
     }
 
     return emrfs_configuration
+
+
+# Backwards compatibility alias for the typo in the original function name
+build_emrfs_confiuration = build_emrfs_configuration
 
 
 def _verify_emrfs_args(emrfs_args):


### PR DESCRIPTION
Resolves #6155

*Description of changes:*

- Fix typo: `build_emrfs_confiuration` → `build_emrfs_configuration` in emrfsutils.py
- Add backwards-compatible alias for the old function name (as requested in #6163)
- Update call site in createcluster.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
