### PR TITLE
docs: include valid values for S3 checksum options

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -456,7 +456,7 @@ CHECKSUM_MODE = {
         'name': 'checksum-mode', 'choices': ['ENABLED'],
         'help_text': (
             'To retrieve the checksum, this mode must be enabled. If the object has a '
-            'checksum, it will be verified. Valid value: ENABLED.'
+            'checksum, it will be verified. ENABLED is the only valid value.'
         )
 }
 
@@ -464,7 +464,7 @@ CHECKSUM_ALGORITHM = {
         'name': 'checksum-algorithm', 'choices': ['CRC64NVME', 'CRC32', 'SHA256', 'SHA1', 'CRC32C'],
         'help_text': (
             'Indicates the algorithm used to create the checksum for the object. '
-            'Valid choices are: CRC64NVME | CRC32 | SHA256 | SHA1 | CRC32C. Defaults to \'CRC64NVME\'.'
+            'Valid values: CRC64NVME | CRC32 | SHA256 | SHA1 | CRC32C. Defaults to \'CRC64NVME\'.'
         )
 }
 


### PR DESCRIPTION
Adds valid enum values to help text for --checksum-mode and --checksum-algorithm so generated documentation includes them.

Fixes #10025

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
