### PR TITLE
Add changelog entry for OpenSSL 1.1.1ze Linux Installers Upgrade

### DIFF
--- a/.changes/next-release/enhancement-openssl-35914.json
+++ b/.changes/next-release/enhancement-openssl-35914.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``openssl``",
+  "description": "Update bundled OpenSSL version to 1.1.1ze for Linux installers"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This openssl version update to 1.1.1ze is only applicable to official Linux executables for the AWS CLI v2.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
