### PR TITLE
Add backfill digest file validation for CloudTrail validate-logs

### DIFF
--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -12,24 +12,26 @@
 # language governing permissions and limitations under the License.
 import base64
 import binascii
-import json
 import hashlib
+import json
 import logging
 import re
 import sys
 import zlib
-from zlib import error as ZLibError
 from datetime import timedelta
-from dateutil import tz, parser
+from zlib import error as ZLibError
 
-from pyasn1.error import PyAsn1Error
 import rsa
-
-from awscli.customizations.cloudtrail.utils import get_trail_by_arn, \
-    get_account_id_from_arn
-from awscli.customizations.commands import BasicCommand
 from botocore.exceptions import ClientError
+from dateutil import parser, tz
+from pyasn1.error import PyAsn1Error
+
 from awscli.compat import get_current_datetime
+from awscli.customizations.cloudtrail.utils import (
+    get_account_id_from_arn,
+    get_trail_by_arn,
+)
+from awscli.customizations.commands import BasicCommand
 from awscli.schema import ParameterRequiredError
 from awscli.utils import create_nested_client
 
@@ -53,21 +55,35 @@ def normalize_date(date):
     return date.replace(tzinfo=tz.tzutc())
 
 
+def is_backfill_digest_key(digest_key):
+    """Utility function to determine if a digest key represents a backfill digest file"""
+    return digest_key.endswith('_backfill.json.gz')
+
+
 def extract_digest_key_date(digest_s3_key):
     """Extract the timestamp portion of a manifest file.
 
     Manifest file names take the following form:
     AWSLogs/{account}/CloudTrail-Digest/{region}/{ymd}/{account}_CloudTrail \
     -Digest_{region}_{name}_region_{date}.json.gz
+
+    For backfill files:
+    AWSLogs/{account}/CloudTrail-Digest/{region}/{ymd}/{account}_CloudTrail \
+    -Digest_{region}_{name}_region_{date}_backfill.json.gz
     """
-    return digest_s3_key[-24:-8]
+    if is_backfill_digest_key(digest_s3_key):
+        # Backfill files have _backfill suffix before .json.gz
+        return digest_s3_key[-33:-17]
+    else:
+        # Regular digest files
+        return digest_s3_key[-24:-8]
 
 
 def parse_date(date_string):
     try:
         return parser.parse(date_string)
     except ValueError:
-        raise ValueError('Unable to parse date value: %s' % date_string)
+        raise ValueError(f'Unable to parse date value: {date_string}')
 
 
 def assert_cloudtrail_arn_is_valid(trail_arn):
@@ -76,7 +92,7 @@ def assert_cloudtrail_arn_is_valid(trail_arn):
     ARNs look like: arn:aws:cloudtrail:us-east-1:123456789012:trail/foo"""
     pattern = re.compile(r'arn:.+:cloudtrail:.+:\d{12}:trail/.+')
     if not pattern.match(trail_arn):
-        raise ValueError('Invalid trail ARN provided: %s' % trail_arn)
+        raise ValueError(f'Invalid trail ARN provided: {trail_arn}')
 
 
 def create_digest_traverser(
@@ -132,7 +148,7 @@ def create_digest_traverser(
     if bucket is None:
         # Determine the bucket and prefix based on the trail arn.
         trail_info = get_trail_by_arn(cloudtrail_client, trail_arn)
-        LOG.debug('Loaded trail info: %s', trail_info)
+        LOG.debug(f'Loaded trail info: {trail_info}')
         bucket = trail_info['S3BucketName']
         prefix = trail_info.get('S3KeyPrefix', None)
         is_org_trail = trail_info.get('IsOrganizationTrail')
@@ -140,9 +156,11 @@ def create_digest_traverser(
             if not account_id:
                 raise ParameterRequiredError(
                     "Missing required parameter for organization "
-                    "trail: '--account-id'")
+                    "trail: '--account-id'"
+                )
             organization_id = organization_client.describe_organization()[
-                'Organization']['Id']
+                'Organization'
+            ]['Id']
 
     # Determine the region from the ARN (e.g., arn:aws:cloudtrail:REGION:...)
     trail_region = trail_arn.split(':')[3]
@@ -153,24 +171,31 @@ def create_digest_traverser(
         account_id = get_account_id_from_arn(trail_arn)
 
     digest_provider = DigestProvider(
-        account_id=account_id, trail_name=trail_name,
+        account_id=account_id,
+        trail_name=trail_name,
         s3_client_provider=s3_client_provider,
         trail_source_region=trail_source_region,
         trail_home_region=trail_region,
-        organization_id=organization_id)
+        organization_id=organization_id,
+    )
     return DigestTraverser(
-        digest_provider=digest_provider, starting_bucket=bucket,
-        starting_prefix=prefix, on_invalid=on_invalid, on_gap=on_gap,
+        digest_provider=digest_provider,
+        starting_bucket=bucket,
+        starting_prefix=prefix,
+        on_invalid=on_invalid,
+        on_gap=on_gap,
         on_missing=on_missing,
-        public_key_provider=PublicKeyProvider(cloudtrail_client))
+        public_key_provider=PublicKeyProvider(cloudtrail_client),
+    )
 
 
-class S3ClientProvider(object):
+class S3ClientProvider:
     """Creates Amazon S3 clients and determines the region name of a client.
 
     This class will cache the location constraints of previously requested
     buckets and cache previously created clients for the same region.
     """
+
     def __init__(self, session, get_bucket_location_region='us-east-1'):
         self._session = session
         self._get_bucket_location_region = get_bucket_location_region
@@ -194,7 +219,9 @@ class S3ClientProvider(object):
     def _create_client(self, region_name):
         """Creates an Amazon S3 client for the given region name"""
         if region_name not in self._client_cache:
-            client = create_nested_client(self._session, 's3', region_name=region_name)
+            client = create_nested_client(
+                self._session, 's3', region_name=region_name
+            )
             # Remove the CLI error event that prevents exceptions.
             self._client_cache[region_name] = client
         return self._client_cache[region_name]
@@ -202,27 +229,32 @@ class S3ClientProvider(object):
 
 class DigestError(ValueError):
     """Exception raised when a digest fails to validate"""
+
     pass
 
 
 class DigestSignatureError(DigestError):
     """Exception raised when a digest signature is invalid"""
+
     def __init__(self, bucket, key):
-        message = ('Digest file\ts3://%s/%s\tINVALID: signature verification '
-                   'failed') % (bucket, key)
-        super(DigestSignatureError, self).__init__(message)
+        message = (
+            f'Digest file\ts3://{bucket}/{key}\tINVALID: signature verification '
+            'failed'
+        )
+        super().__init__(message)
 
 
 class InvalidDigestFormat(DigestError):
     """Exception raised when a digest has an invalid format"""
+
     def __init__(self, bucket, key):
-        message = 'Digest file\ts3://%s/%s\tINVALID: invalid format' % (bucket,
-                                                                        key)
-        super(InvalidDigestFormat, self).__init__(message)
+        message = f'Digest file\ts3://{bucket}/{key}\tINVALID: invalid format'
+        super().__init__(message)
 
 
-class PublicKeyProvider(object):
+class PublicKeyProvider:
     """Retrieves public keys from CloudTrail within a date range."""
+
     def __init__(self, cloudtrail_client):
         self._cloudtrail_client = cloudtrail_client
 
@@ -238,13 +270,14 @@ class PublicKeyProvider(object):
             public key, and each value is a dict of public key data.
         """
         public_keys = self._cloudtrail_client.list_public_keys(
-            StartTime=start_date, EndTime=end_date)
+            StartTime=start_date, EndTime=end_date
+        )
         public_keys_in_range = public_keys['PublicKeyList']
-        LOG.debug('Loaded public keys in range: %s', public_keys_in_range)
+        LOG.debug(f'Loaded public keys in range: {public_keys_in_range}')
         return dict((key['Fingerprint'], key) for key in public_keys_in_range)
 
 
-class DigestProvider(object):
+class DigestProvider:
     """
     Retrieves digest keys and digests from Amazon S3.
 
@@ -269,63 +302,128 @@ class DigestProvider(object):
         self.trail_home_region = trail_home_region
         self.trail_source_region = trail_source_region or trail_home_region
         self.organization_id = organization_id
+        self._digest_cache = {}
 
-    def load_digest_keys_in_range(self, bucket, prefix, start_date, end_date):
-        """Returns a list of digest keys in the date range.
+    def load_all_digest_keys_in_range(
+        self, bucket, prefix, start_date, end_date
+    ):
+        """Load all digest keys and separate into standard and backfill lists.
 
-        This method uses a list_objects API call and provides a Marker
-        parameter that is calculated based on the start_date provided.
-        Amazon S3 then returns all keys in the bucket that start after
-        the given key (non-inclusive). We then iterate over the keys
-        until the date extracted from the yielded keys is greater than
-        the given end_date.
+        Performs a single S3 list operation and separates keys into standard
+        and backfill digest lists during iteration for optimal performance.
+
+        :param bucket: S3 bucket name
+        :param prefix: S3 key prefix
+        :param start_date: Start date for digest range
+        :param end_date: End date for digest range
+        :return: Tuple of (standard_digests, backfill_digests) lists
+        :rtype: tuple
         """
-        digests = []
+        standard_digests = []
+        backfill_digests = []
         marker = self._create_digest_key(start_date, prefix)
         s3_digest_files_prefix = self._create_digest_prefix(start_date, prefix)
         client = self._client_provider.get_client(bucket)
         paginator = client.get_paginator('list_objects')
-        page_iterator = paginator.paginate(Bucket=bucket, Marker=marker, Prefix=s3_digest_files_prefix)
+        page_iterator = paginator.paginate(
+            Bucket=bucket, Marker=marker, Prefix=s3_digest_files_prefix
+        )
         key_filter = page_iterator.search('Contents[*].Key')
         # Create a target start end end date
         target_start_date = format_date(normalize_date(start_date))
         # Add one hour to the end_date to get logs that spilled over to next.
         target_end_date = format_date(
-            normalize_date(end_date + timedelta(hours=1)))
+            normalize_date(end_date + timedelta(hours=1))
+        )
         # Ensure digests are from the same trail.
         digest_key_regex = re.compile(self._create_digest_key_regex(prefix))
         for key in key_filter:
-            if key and digest_key_regex.match(key):
-                # Use a lexicographic comparison to know when to stop.
-                extracted_date = extract_digest_key_date(key)
-                if extracted_date > target_end_date:
-                    break
-                # Only append digests after the start date.
-                if extracted_date >= target_start_date:
-                    digests.append(key)
-        return digests
+            if not (key and digest_key_regex.match(key)):
+                continue
+            # Use a lexicographic comparison to know when to stop.
+            extracted_date = extract_digest_key_date(key)
+            if extracted_date > target_end_date:
+                break
+            # Only append digests after the start date.
+            if extracted_date < target_start_date:
+                continue
+            if is_backfill_digest_key(key):
+                backfill_digests.append(key)
+            else:
+                standard_digests.append(key)
+        return standard_digests, backfill_digests
+
+    def load_digest_keys_in_range(
+        self, bucket, prefix, start_date, end_date, is_backfill=False
+    ):
+        """Returns a list of digest keys in the date range.
+
+        This method uses caching to avoid duplicate S3 list operations.
+        On first call, it loads all digest keys and caches them separated
+        by type. Subsequent calls return the appropriate cached list.
+
+        :param bucket: S3 bucket name
+        :param prefix: S3 key prefix
+        :param start_date: Start date for digest range
+        :param end_date: End date for digest range
+        :param is_backfill: Optional filter - True for backfill digests only,
+                           False for standard digests only
+        :return: List of digest keys matching the specified type
+        :rtype: list
+        """
+        cache_key = (bucket, prefix, start_date, end_date)
+
+        if cache_key not in self._digest_cache:
+            standard_digests, backfill_digests = (
+                self.load_all_digest_keys_in_range(
+                    bucket, prefix, start_date, end_date
+                )
+            )
+            self._digest_cache[cache_key] = {
+                'standard': standard_digests,
+                'backfill': backfill_digests,
+            }
+
+        if is_backfill:
+            return self._digest_cache[cache_key]['backfill']
+        else:
+            return self._digest_cache[cache_key]['standard']
 
     def fetch_digest(self, bucket, key):
         """Loads a digest by key from S3.
 
         Returns the JSON decode data and GZIP inflated raw content.
+        For backfill digests, also extracts the backfill-generation-timestamp.
         """
         client = self._client_provider.get_client(bucket)
         result = client.get_object(Bucket=bucket, Key=key)
         try:
-            digest = zlib.decompress(result['Body'].read(),
-                                     zlib.MAX_WBITS | 16)
+            digest = zlib.decompress(
+                result['Body'].read(), zlib.MAX_WBITS | 16
+            )
             digest_data = json.loads(digest.decode())
         except (ValueError, ZLibError):
             # Cannot gzip decode or JSON parse.
             raise InvalidDigestFormat(bucket, key)
         # Add the expected digest signature and algorithm to the dict.
-        if 'signature' not in result['Metadata'] \
-                or 'signature-algorithm' not in result['Metadata']:
+        if (
+            'signature' not in result['Metadata']
+            or 'signature-algorithm' not in result['Metadata']
+        ):
             raise DigestSignatureError(bucket, key)
         digest_data['_signature'] = result['Metadata']['signature']
-        digest_data['_signature_algorithm'] = \
-            result['Metadata']['signature-algorithm']
+        digest_data['_signature_algorithm'] = result['Metadata'][
+            'signature-algorithm'
+        ]
+
+        if is_backfill_digest_key(key):
+            if 'backfill-generation-timestamp' in result['Metadata']:
+                digest_data['_backfill_generation_timestamp'] = result[
+                    'Metadata'
+                ]['backfill-generation-timestamp']
+            else:
+                raise InvalidDigestFormat(bucket, key)
+
         return digest_data, digest
 
     def _create_digest_key(self, start_date, key_prefix):
@@ -340,24 +438,27 @@ class DigestProvider(object):
         """
         # Subtract one minute to ensure the dates are inclusive.
         date = start_date - timedelta(minutes=1)
-        template = 'AWSLogs/'
-        template_params = {
-            'account_id': self.account_id,
-            'date': format_date(date),
-            'ymd': date.strftime('%Y/%m/%d'),
-            'source_region': self.trail_source_region,
-            'home_region': self.trail_home_region,
-            'name': self.trail_name
-        }
+        account_id = self.account_id
+        date_str = format_date(date)
+        ymd = date.strftime('%Y/%m/%d')
+        source_region = self.trail_source_region
+        home_region = self.trail_home_region
+        name = self.trail_name
+
         if self.organization_id:
-            template += '{organization_id}/'
-            template_params['organization_id'] = self.organization_id
-        template += (
-            '{account_id}/CloudTrail-Digest/{source_region}/'
-            '{ymd}/{account_id}_CloudTrail-Digest_{source_region}_{name}_'
-            '{home_region}_{date}.json.gz'
-        )
-        key = template.format(**template_params)
+            organization_id = self.organization_id
+            key = (
+                f'AWSLogs/{organization_id}/{account_id}/CloudTrail-Digest/'
+                f'{source_region}/{ymd}/{account_id}_CloudTrail-Digest_'
+                f'{source_region}_{name}_{home_region}_{date_str}.json.gz'
+            )
+        else:
+            key = (
+                f'AWSLogs/{account_id}/CloudTrail-Digest/{source_region}/'
+                f'{ymd}/{account_id}_CloudTrail-Digest_{source_region}_{name}_'
+                f'{home_region}_{date_str}.json.gz'
+            )
+
         if key_prefix:
             key = key_prefix + '/' + key
         return key
@@ -370,7 +471,7 @@ class DigestProvider(object):
         template = 'AWSLogs/'
         template_params = {
             'account_id': self.account_id,
-            'source_region': self.trail_source_region
+            'source_region': self.trail_source_region,
         }
         if self.organization_id:
             template += '{organization_id}/'
@@ -382,39 +483,56 @@ class DigestProvider(object):
         return prefix
 
     def _create_digest_key_regex(self, key_prefix):
-        """Creates a regular expression used to match against S3 keys"""
-        template = 'AWSLogs/'
-        template_params = {
-            'account_id': re.escape(self.account_id),
-            'source_region': re.escape(self.trail_source_region),
-            'home_region': re.escape(self.trail_home_region),
-            'name': re.escape(self.trail_name)
-        }
+        """Creates a regular expression used to match against S3 keys for both standard and backfill digests"""
+        account_id = re.escape(self.account_id)
+        source_region = re.escape(self.trail_source_region)
+        home_region = re.escape(self.trail_home_region)
+        name = re.escape(self.trail_name)
+
         if self.organization_id:
-            template += '{organization_id}/'
-            template_params['organization_id'] = self.organization_id
-        template += (
-            '{account_id}/CloudTrail\\-Digest/{source_region}/'
-            '\\d+/\\d+/\\d+/{account_id}_CloudTrail\\-Digest_'
-            '{source_region}_{name}_{home_region}_.+\\.json\\.gz'
-        )
-        key = template.format(**template_params)
+            organization_id = self.organization_id
+            key = (
+                f'AWSLogs/{organization_id}/{account_id}/CloudTrail\\-Digest/'
+                f'{source_region}/\\d+/\\d+/\\d+/{account_id}_CloudTrail\\-Digest_'
+                f'{source_region}_{name}_{home_region}_.+(?:_backfill)?\\.json\\.gz'
+            )
+        else:
+            key = (
+                f'AWSLogs/{account_id}/CloudTrail\\-Digest/{source_region}/'
+                f'\\d+/\\d+/\\d+/{account_id}_CloudTrail\\-Digest_'
+                f'{source_region}_{name}_{home_region}_.+(?:_backfill)?\\.json\\.gz'
+            )
+
         if key_prefix:
             key = re.escape(key_prefix) + '/' + key
         return '^' + key + '$'
 
 
-class DigestTraverser(object):
+class DigestTraverser:
     """Retrieves and validates digests within a date range."""
+
     # These keys are required to be present before validating the contents
     # of a digest.
-    required_digest_keys = ['digestPublicKeyFingerprint', 'digestS3Bucket',
-                            'digestS3Object', 'previousDigestSignature',
-                            'digestEndTime', 'digestStartTime']
+    required_digest_keys = [
+        'digestPublicKeyFingerprint',
+        'digestS3Bucket',
+        'digestS3Object',
+        'previousDigestSignature',
+        'digestEndTime',
+        'digestStartTime',
+    ]
 
-    def __init__(self, digest_provider, starting_bucket, starting_prefix,
-                 public_key_provider, digest_validator=None,
-                 on_invalid=None, on_gap=None, on_missing=None):
+    def __init__(
+        self,
+        digest_provider,
+        starting_bucket,
+        starting_prefix,
+        public_key_provider,
+        digest_validator=None,
+        on_invalid=None,
+        on_gap=None,
+        on_missing=None,
+    ):
         """
         :type digest_provider: DigestProvider
         :param digest_provider: DigestProvider object
@@ -438,7 +556,7 @@ class DigestTraverser(object):
             digest_validator = Sha256RSADigestValidator()
         self._digest_validator = digest_validator
 
-    def traverse(self, start_date, end_date=None):
+    def traverse_digests(self, start_date, end_date=None, is_backfill=False):
         """Creates and returns a generator that yields validated digest data.
 
         Each yielded digest dictionary contains information about the digest
@@ -449,8 +567,10 @@ class DigestTraverser(object):
 
         :type start_date: datetime
         :param start_date: Date to start validating from (inclusive).
-        :type start_date: datetime
+        :type end_date: datetime
         :param end_date: Date to stop validating at (inclusive).
+        :type is_backfill: bool
+        :param is_backfill: Flag indicating whether to process backfill digests only.
         """
         if end_date is None:
             end_date = get_current_datetime()
@@ -458,64 +578,143 @@ class DigestTraverser(object):
         start_date = normalize_date(start_date)
         bucket = self.starting_bucket
         prefix = self.starting_prefix
-        digests = self._load_digests(bucket, prefix, start_date, end_date)
-        public_keys = self._load_public_keys(start_date, end_date)
+
+        digests = self._load_digests(
+            bucket, prefix, start_date, end_date, is_backfill=is_backfill
+        )
+
+        # For regular digests, pre-load public keys. For backfill, start with empty dict
+        public_keys = (
+            {} if is_backfill else self._load_public_keys(start_date, end_date)
+        )
+
+        yield from self._traverse_digest_chain(
+            digests,
+            bucket,
+            prefix,
+            start_date,
+            public_keys,
+            is_backfill=is_backfill,
+        )
+
+    def _traverse_digest_chain(
+        self,
+        digests,
+        bucket,
+        prefix,
+        start_date,
+        public_keys,
+        is_backfill=False,
+    ):
+        """Traverses a single chain of digests
+
+        :param is_backfill: Boolean indicating whether this chain contains backfill digests
+        """
         key, end_date = self._get_last_digest(digests)
         last_start_date = end_date
+
         while key and start_date <= last_start_date:
             try:
                 digest, end_date = self._load_and_validate_digest(
-                    public_keys, bucket, key)
+                    public_keys, bucket, key, is_backfill=is_backfill
+                )
                 last_start_date = normalize_date(
-                    parse_date(digest['digestStartTime']))
+                    parse_date(digest['digestStartTime'])
+                )
                 previous_bucket = digest.get('previousDigestS3Bucket', None)
+                previous_key = digest.get('previousDigestS3Object', None)
                 yield digest
-                if previous_bucket is None:
+                if previous_bucket is None or previous_key is None:
                     # The chain is broken, so find next in digest store.
                     key, end_date = self._find_next_digest(
-                        digests=digests, bucket=bucket, last_key=key,
-                        last_start_date=last_start_date, cb=self._on_gap,
-                        is_cb_conditional=True)
+                        digests=digests,
+                        bucket=bucket,
+                        last_key=key,
+                        last_start_date=last_start_date,
+                        cb=self._on_gap,
+                        is_cb_conditional=True,
+                        is_backfill=is_backfill,
+                    )
                 else:
-                    key = digest['previousDigestS3Object']
+                    key = previous_key
                     if previous_bucket != bucket:
                         bucket = previous_bucket
                         # The bucket changed so reload the digest list.
                         digests = self._load_digests(
-                            bucket, prefix, start_date, end_date)
+                            bucket,
+                            prefix,
+                            start_date,
+                            end_date,
+                            is_backfill=is_backfill,
+                        )
             except ClientError as e:
                 if e.response['Error']['Code'] != 'NoSuchKey':
                     raise e
                 key, end_date = self._find_next_digest(
-                    digests=digests, bucket=bucket, last_key=key,
-                    last_start_date=last_start_date, cb=self._on_missing,
-                    message=str(e))
+                    digests=digests,
+                    bucket=bucket,
+                    last_key=key,
+                    last_start_date=last_start_date,
+                    cb=self._on_missing,
+                    message=str(e),
+                    is_backfill=is_backfill,
+                )
             except DigestError as e:
                 key, end_date = self._find_next_digest(
-                    digests=digests, bucket=bucket, last_key=key,
-                    last_start_date=last_start_date, cb=self._on_invalid,
-                    message=str(e))
+                    digests=digests,
+                    bucket=bucket,
+                    last_key=key,
+                    last_start_date=last_start_date,
+                    cb=self._on_invalid,
+                    message=str(e),
+                    is_backfill=is_backfill,
+                )
             except Exception as e:
                 # Any other unexpected errors.
                 key, end_date = self._find_next_digest(
-                    digests=digests, bucket=bucket, last_key=key,
-                    last_start_date=last_start_date, cb=self._on_invalid,
-                    message='Digest file\ts3://%s/%s\tINVALID: %s'
-                            % (bucket, key, str(e)))
+                    digests=digests,
+                    bucket=bucket,
+                    last_key=key,
+                    last_start_date=last_start_date,
+                    cb=self._on_invalid,
+                    message=f'Digest file\ts3://{bucket}/{key}\tINVALID: {str(e)}',
+                    is_backfill=is_backfill,
+                )
 
-    def _load_digests(self, bucket, prefix, start_date, end_date):
+    def _load_digests(
+        self, bucket, prefix, start_date, end_date, is_backfill=False
+    ):
         return self.digest_provider.load_digest_keys_in_range(
-            bucket=bucket, prefix=prefix,
-            start_date=start_date, end_date=end_date)
+            bucket=bucket,
+            prefix=prefix,
+            start_date=start_date,
+            end_date=end_date,
+            is_backfill=is_backfill,
+        )
 
-    def _find_next_digest(self, digests, bucket, last_key, last_start_date,
-                          cb=None, is_cb_conditional=False, message=None):
+    def _find_next_digest(
+        self,
+        digests,
+        bucket,
+        last_key,
+        last_start_date,
+        cb=None,
+        is_cb_conditional=False,
+        message=None,
+        is_backfill=False,
+    ):
         """Finds the next digest in the bucket and invokes any callback."""
         next_key, next_end_date = self._get_last_digest(digests, last_key)
         if cb and (not is_cb_conditional or next_key):
-            cb(bucket=bucket, next_key=next_key, last_key=last_key,
-               next_end_date=next_end_date, last_start_date=last_start_date,
-               message=message)
+            cb(
+                bucket=bucket,
+                next_key=next_key,
+                last_key=last_key,
+                next_end_date=next_end_date,
+                last_start_date=last_start_date,
+                message=message,
+                is_backfill=is_backfill,
+            )
         return next_key, next_end_date
 
     def _get_last_digest(self, digests, before_key=None):
@@ -530,62 +729,87 @@ class DigestTraverser(object):
         elif before_key is None:
             next_key = digests.pop()
             next_key_date = normalize_date(
-                parse_date(extract_digest_key_date(next_key)))
+                parse_date(extract_digest_key_date(next_key))
+            )
             return next_key, next_key_date
         # find a key before the given key.
         before_key_date = parse_date(extract_digest_key_date(before_key))
         while digests:
             next_key = digests.pop()
             next_key_date = normalize_date(
-                parse_date(extract_digest_key_date(next_key)))
+                parse_date(extract_digest_key_date(next_key))
+            )
             if next_key_date < before_key_date:
-                LOG.debug("Next found key: %s", next_key)
+                LOG.debug(f"Next found key: {next_key}")
                 return next_key, next_key_date
         return None, None
 
-    def _load_and_validate_digest(self, public_keys, bucket, key):
+    def _load_and_validate_digest(
+        self, public_keys, bucket, key, is_backfill=False
+    ):
         """Loads and validates a digest from S3.
 
         :param public_keys: Public key dictionary of fingerprint to dict.
+        :param bucket: S3 bucket name
+        :param key: S3 key for the digest file
+        :param is_backfill: Flag indicating if this is a backfill digest
         :return: Returns a tuple of the digest data as a dict and end_date
         :rtype: tuple
         """
         digest_data, digest = self.digest_provider.fetch_digest(bucket, key)
+
+        # Validate required keys are present
         for required_key in self.required_digest_keys:
             if required_key not in digest_data:
                 raise InvalidDigestFormat(bucket, key)
-        # Ensure the bucket and key are the same as what's expected.
-        if digest_data['digestS3Bucket'] != bucket \
-                or digest_data['digestS3Object'] != key:
+
+        # Ensure the bucket and key are the same as what's expected
+        if (
+            digest_data['digestS3Bucket'] != bucket
+            or digest_data['digestS3Object'] != key
+        ):
             raise DigestError(
-                ('Digest file\ts3://%s/%s\tINVALID: has been moved from its '
-                 'original location') % (bucket, key))
-        # Get the public keys in the given time range.
+                f'Digest file\ts3://{bucket}/{key}\tINVALID: has been moved from its '
+                'original location'
+            )
+
         fingerprint = digest_data['digestPublicKeyFingerprint']
+        if fingerprint not in public_keys and is_backfill:
+            # Backfill-specific logic to fetch public keys
+            backfill_timestamp = normalize_date(
+                parse_date(digest_data['_backfill_generation_timestamp'])
+            )
+            start_time = backfill_timestamp - timedelta(hours=1)
+            end_time = backfill_timestamp + timedelta(hours=1)
+            public_keys.update(self._load_public_keys(start_time, end_time))
+
         if fingerprint not in public_keys:
-            raise DigestError(
-                ('Digest file\ts3://%s/%s\tINVALID: public key not found in '
-                 'region %s for fingerprint %s') %
-                (bucket, key, self.digest_provider.trail_home_region,
-                 fingerprint))
+            error_message = (
+                f'Digest file\ts3://{bucket}/{key}\tINVALID: public key not found in '
+                f'region {self.digest_provider.trail_home_region} for fingerprint {fingerprint}'
+            )
+            raise DigestError(error_message)
+
         public_key_hex = public_keys[fingerprint]['Value']
         self._digest_validator.validate(
-            bucket, key, public_key_hex, digest_data, digest)
+            bucket, key, public_key_hex, digest_data, digest
+        )
+
         end_date = normalize_date(parse_date(digest_data['digestEndTime']))
         return digest_data, end_date
 
     def _load_public_keys(self, start_date, end_date):
         public_keys = self._public_key_provider.get_public_keys(
-            start_date, end_date)
+            start_date, end_date
+        )
         if not public_keys:
             raise RuntimeError(
-                'No public keys found between %s and %s' %
-                (format_display_date(start_date),
-                 format_display_date(end_date)))
+                f'No public keys found between {format_display_date(start_date)} and {format_display_date(end_date)}'
+            )
         return public_keys
 
 
-class Sha256RSADigestValidator(object):
+class Sha256RSADigestValidator:
     """
     Validates SHA256withRSA signed digests.
 
@@ -613,9 +837,9 @@ class Sha256RSADigestValidator(object):
             rsa.verify(to_sign, signature_bytes, public_key)
         except PyAsn1Error:
             raise DigestError(
-                ('Digest file\ts3://%s/%s\tINVALID: Unable to load PKCS #1 key'
-                 ' with fingerprint %s')
-                % (bucket, key, digest_data['digestPublicKeyFingerprint']))
+                f'Digest file\ts3://{bucket}/{key}\tINVALID: Unable to load PKCS #1 key'
+                f' with fingerprint {digest_data["digestPublicKeyFingerprint"]}'
+            )
         except rsa.pkcs1.VerificationError:
             # Note from the Python-RSA docs: Never display the stack trace of
             # a rsa.pkcs1.VerificationError exception. It shows where in the
@@ -628,13 +852,9 @@ class Sha256RSADigestValidator(object):
         if previous_signature is None:
             # The value must be 'null' to match the Java implementation.
             previous_signature = 'null'
-        string_to_sign = "%s\n%s/%s\n%s\n%s" % (
-            digest_data['digestEndTime'],
-            digest_data['digestS3Bucket'],
-            digest_data['digestS3Object'],
-            hashlib.sha256(inflated_digest).hexdigest(),
-            previous_signature)
-        LOG.debug('Digest string to sign: %s', string_to_sign)
+
+        string_to_sign = f"{digest_data['digestEndTime']}\n{digest_data['digestS3Bucket']}/{digest_data['digestS3Object']}\n{hashlib.sha256(inflated_digest).hexdigest()}\n{previous_signature}"
+        LOG.debug(f'Digest string to sign: {string_to_sign}')
         return string_to_sign.encode()
 
 
@@ -642,12 +862,14 @@ class CloudTrailValidateLogs(BasicCommand):
     """
     Validates log digests and log files, optionally saving them to disk.
     """
+
     NAME = 'validate-logs'
     DESCRIPTION = """
     Validates CloudTrail logs for a given period of time.
 
     This command uses the digest files delivered to your S3 bucket to perform
-    the validation.
+    the validation. It supports validation of both digest files and
+    backfill digest files in a single run.
 
     The AWS CLI allows you to detect the following types of changes:
 
@@ -688,38 +910,71 @@ class CloudTrailValidateLogs(BasicCommand):
     """
 
     ARG_TABLE = [
-        {'name': 'trail-arn', 'required': True, 'cli_type_name': 'string',
-         'help_text': 'Specifies the ARN of the trail to be validated'},
-        {'name': 'start-time', 'required': True, 'cli_type_name': 'string',
-         'help_text': ('Specifies that log files delivered on or after the '
-                       'specified UTC timestamp value will be validated. '
-                       'Example: "2015-01-08T05:21:42Z".')},
-        {'name': 'end-time', 'cli_type_name': 'string',
-         'help_text': ('Optionally specifies that log files delivered on or '
-                       'before the specified UTC timestamp value will be '
-                       'validated. The default value is the current time. '
-                       'Example: "2015-01-08T12:31:41Z".')},
-        {'name': 's3-bucket', 'cli_type_name': 'string',
-         'help_text': ('Optionally specifies the S3 bucket where the digest '
-                       'files are stored. If a bucket name is not specified, '
-                       'the CLI will retrieve it by calling describe_trails')},
-        {'name': 's3-prefix', 'cli_type_name': 'string',
-         'help_text': ('Optionally specifies the optional S3 prefix where the '
-                       'digest files are stored. If not specified, the CLI '
-                       'will determine the prefix automatically by calling '
-                       'describe_trails.')},
-        {'name': 'account-id', 'cli_type_name': 'string',
-         'help_text': ('Optionally specifies the account for validating logs. '
-                       'This parameter is needed for organization trails '
-                       'for validating logs for specific account inside an '
-                       'organization')},
-        {'name': 'verbose', 'cli_type_name': 'boolean',
-         'action': 'store_true',
-         'help_text': 'Display verbose log validation information'}
+        {
+            'name': 'trail-arn',
+            'required': True,
+            'cli_type_name': 'string',
+            'help_text': 'Specifies the ARN of the trail to be validated',
+        },
+        {
+            'name': 'start-time',
+            'required': True,
+            'cli_type_name': 'string',
+            'help_text': (
+                'Specifies that log files delivered on or after the '
+                'specified UTC timestamp value will be validated. '
+                'Example: "2015-01-08T05:21:42Z".'
+            ),
+        },
+        {
+            'name': 'end-time',
+            'cli_type_name': 'string',
+            'help_text': (
+                'Optionally specifies that log files delivered on or '
+                'before the specified UTC timestamp value will be '
+                'validated. The default value is the current time. '
+                'Example: "2015-01-08T12:31:41Z".'
+            ),
+        },
+        {
+            'name': 's3-bucket',
+            'cli_type_name': 'string',
+            'help_text': (
+                'Optionally specifies the S3 bucket where the digest '
+                'files are stored. If a bucket name is not specified, '
+                'the CLI will retrieve it by calling describe_trails'
+            ),
+        },
+        {
+            'name': 's3-prefix',
+            'cli_type_name': 'string',
+            'help_text': (
+                'Optionally specifies the optional S3 prefix where the '
+                'digest files are stored. If not specified, the CLI '
+                'will determine the prefix automatically by calling '
+                'describe_trails.'
+            ),
+        },
+        {
+            'name': 'account-id',
+            'cli_type_name': 'string',
+            'help_text': (
+                'Optionally specifies the account for validating logs. '
+                'This parameter is needed for organization trails '
+                'for validating logs for specific account inside an '
+                'organization'
+            ),
+        },
+        {
+            'name': 'verbose',
+            'cli_type_name': 'boolean',
+            'action': 'store_true',
+            'help_text': 'Display verbose log validation information',
+        },
     ]
 
     def __init__(self, session):
-        super(CloudTrailValidateLogs, self).__init__(session)
+        super().__init__(session)
         self.trail_arn = None
         self.is_verbose = False
         self.start_time = None
@@ -732,6 +987,8 @@ class CloudTrailValidateLogs(BasicCommand):
         self._source_region = None
         self._valid_digests = 0
         self._invalid_digests = 0
+        self._valid_backfill_digests = 0
+        self._invalid_backfill_digests = 0
         self._valid_logs = 0
         self._invalid_logs = 0
         self._is_last_status_double_space = True
@@ -742,7 +999,10 @@ class CloudTrailValidateLogs(BasicCommand):
         self.handle_args(args)
         self.setup_services(parsed_globals)
         self._call()
-        if self._invalid_digests > 0 or self._invalid_logs > 0:
+        total_invalid_digests = (
+            self._invalid_digests + self._invalid_backfill_digests
+        )
+        if total_invalid_digests > 0 or self._invalid_logs > 0:
             return 1
         return 0
 
@@ -758,74 +1018,112 @@ class CloudTrailValidateLogs(BasicCommand):
         else:
             self.end_time = normalize_date(get_current_datetime())
         if self.start_time > self.end_time:
-            raise ValueError(('Invalid time range specified: start-time must '
-                              'occur before end-time'))
-        # Found start time always defaults to the given start time. This value
-        # may change if the earliest found digest is after the given start
-        # time. Note that the summary output report of what date ranges were
-        # actually found is only shown if a valid digest is encountered,
-        # thereby setting self._found_end_time to a value.
-        self._found_start_time = self.start_time
+            raise ValueError(
+                'Invalid time range specified: start-time must '
+                'occur before end-time'
+            )
 
     def setup_services(self, parsed_globals):
         self._source_region = parsed_globals.region
         # Use the the same region as the region of the CLI to get locations.
         self.s3_client_provider = S3ClientProvider(
-            self._session, self._source_region)
-        client_args = {'region_name': parsed_globals.region,
-                       'verify': parsed_globals.verify_ssl}
+            self._session, self._source_region
+        )
+        client_args = {
+            'region_name': parsed_globals.region,
+            'verify': parsed_globals.verify_ssl,
+        }
         self.organization_client = create_nested_client(
-            self._session, 'organizations', **client_args)
+            self._session, 'organizations', **client_args
+        )
 
         if parsed_globals.endpoint_url is not None:
             client_args['endpoint_url'] = parsed_globals.endpoint_url
         self.cloudtrail_client = create_nested_client(
-            self._session, 'cloudtrail', **client_args)
+            self._session, 'cloudtrail', **client_args
+        )
 
     def _call(self):
         traverser = create_digest_traverser(
-            trail_arn=self.trail_arn, cloudtrail_client=self.cloudtrail_client,
+            trail_arn=self.trail_arn,
+            cloudtrail_client=self.cloudtrail_client,
             organization_client=self.organization_client,
             trail_source_region=self._source_region,
-            s3_client_provider=self.s3_client_provider, bucket=self.s3_bucket,
-            prefix=self.s3_prefix, on_missing=self._on_missing_digest,
-            on_invalid=self._on_invalid_digest, on_gap=self._on_digest_gap,
-            account_id=self.account_id)
+            s3_client_provider=self.s3_client_provider,
+            bucket=self.s3_bucket,
+            prefix=self.s3_prefix,
+            on_missing=self._on_missing_digest,
+            on_invalid=self._on_invalid_digest,
+            on_gap=self._on_digest_gap,
+            account_id=self.account_id,
+        )
         self._write_startup_text()
-        digests = traverser.traverse(self.start_time, self.end_time)
+
+        digests = traverser.traverse_digests(
+            self.start_time, self.end_time, is_backfill=False
+        )
         for digest in digests:
             # Only valid digests are yielded and only valid digests can adjust
             # the found times that are reported in the CLI output summary.
             self._track_found_times(digest)
+
             self._valid_digests += 1
+
             self._write_status(
-                'Digest file\ts3://%s/%s\tvalid'
-                % (digest['digestS3Bucket'], digest['digestS3Object']))
+                f'Digest file\ts3://{digest["digestS3Bucket"]}/{digest["digestS3Object"]}\tvalid'
+            )
+
             if not digest['logFiles']:
                 continue
             for log in digest['logFiles']:
                 self._download_log(log)
+
+        backfill_digests = traverser.traverse_digests(
+            self.start_time, self.end_time, is_backfill=True
+        )
+        for digest in backfill_digests:
+            # Only valid digests are yielded and only valid digests can adjust
+            # the found times that are reported in the CLI output summary.
+            self._track_found_times(digest)
+
+            self._valid_backfill_digests += 1
+
+            self._write_status(
+                f'(backfill) Digest file\ts3://{digest["digestS3Bucket"]}/{digest["digestS3Object"]}\tvalid'
+            )
+
+            if not digest['logFiles']:
+                continue
+            for log in digest['logFiles']:
+                self._download_log(log)
+
         self._write_summary_text()
 
     def _track_found_times(self, digest):
         # Track the earliest found start time, but do not use a date before
         # the user supplied start date.
         digest_start_time = parse_date(digest['digestStartTime'])
-        if digest_start_time > self.start_time:
-            self._found_start_time = digest_start_time
-        # Only use the last found end time if it is less than the
-        # user supplied end time (or the current date).
-        if not self._found_end_time:
-            digest_end_time = parse_date(digest['digestEndTime'])
-            self._found_end_time = min(digest_end_time, self.end_time)
+        earliest_start_time = max(digest_start_time, self.start_time)
+        if (
+            not self._found_start_time
+            or earliest_start_time < self._found_start_time
+        ):
+            self._found_start_time = earliest_start_time
+        # Track the latest found end time from all digest types, but do not exceed
+        # the user supplied end time (or the current date).
+        digest_end_time = parse_date(digest['digestEndTime'])
+        latest_end_time = min(digest_end_time, self.end_time)
+        if not self._found_end_time or latest_end_time > self._found_end_time:
+            self._found_end_time = latest_end_time
 
     def _download_log(self, log):
-        """ Download a log, decompress, and compare SHA256 checksums"""
+        """Download a log, decompress, and compare SHA256 checksums"""
         try:
             # Create a client that can work with this bucket.
             client = self.s3_client_provider.get_client(log['s3Bucket'])
             response = client.get_object(
-                Bucket=log['s3Bucket'], Key=log['s3Object'])
+                Bucket=log['s3Bucket'], Key=log['s3Object']
+            )
             gzip_inflater = zlib.decompressobj(zlib.MAX_WBITS | 16)
             rolling_hash = hashlib.sha256()
             for chunk in iter(lambda: response['Body'].read(2048), b""):
@@ -839,8 +1137,9 @@ class CloudTrailValidateLogs(BasicCommand):
                 self._on_log_invalid(log)
             else:
                 self._valid_logs += 1
-                self._write_status(('Log file\ts3://%s/%s\tvalid'
-                                    % (log['s3Bucket'], log['s3Object'])))
+                self._write_status(
+                    f'Log file\ts3://{log["s3Bucket"]}/{log["s3Object"]}\tvalid'
+                )
         except ClientError as e:
             if e.response['Error']['Code'] != 'NoSuchKey':
                 raise
@@ -851,76 +1150,105 @@ class CloudTrailValidateLogs(BasicCommand):
     def _write_status(self, message, is_error=False):
         if is_error:
             if self._is_last_status_double_space:
-                sys.stderr.write("%s\n\n" % message)
+                sys.stderr.write(f"{message}\n\n")
             else:
-                sys.stderr.write("\n%s\n\n" % message)
+                sys.stderr.write(f"\n{message}\n\n")
             self._is_last_status_double_space = True
         elif self.is_verbose:
             self._is_last_status_double_space = False
-            sys.stdout.write("%s\n" % message)
+            sys.stdout.write(f"{message}\n")
 
     def _write_startup_text(self):
         sys.stdout.write(
-            'Validating log files for trail %s between %s and %s\n\n'
-            % (self.trail_arn, format_display_date(self.start_time),
-               format_display_date(self.end_time)))
+            f'Validating log files for trail {self.trail_arn} between {format_display_date(self.start_time)} and {format_display_date(self.end_time)}\n\n'
+        )
 
     def _write_summary_text(self):
         if not self._is_last_status_double_space:
             sys.stdout.write('\n')
-        sys.stdout.write('Results requested for %s to %s\n'
-                         % (format_display_date(self.start_time),
-                            format_display_date(self.end_time)))
-        if not self._valid_digests and not self._invalid_digests:
+        sys.stdout.write(
+            f'Results requested for {format_display_date(self.start_time)} to {format_display_date(self.end_time)}\n'
+        )
+
+        total_valid_digests = (
+            self._valid_digests + self._valid_backfill_digests
+        )
+        total_invalid_digests = (
+            self._invalid_digests + self._invalid_backfill_digests
+        )
+
+        if not total_valid_digests and not total_invalid_digests:
             sys.stdout.write('No digests found\n')
             return
         if not self._found_start_time or not self._found_end_time:
             sys.stdout.write('No valid digests found in range\n')
         else:
-            sys.stdout.write('Results found for %s to %s:\n'
-                             % (format_display_date(self._found_start_time),
-                                format_display_date(self._found_end_time)))
+            sys.stdout.write(
+                f'Results found for {format_display_date(self._found_start_time)} to {format_display_date(self._found_end_time)}:\n'
+            )
+
         self._write_ratio(self._valid_digests, self._invalid_digests, 'digest')
+        self._write_ratio(
+            self._valid_backfill_digests,
+            self._invalid_backfill_digests,
+            'backfill digest',
+        )
         self._write_ratio(self._valid_logs, self._invalid_logs, 'log')
+
         sys.stdout.write('\n')
 
     def _write_ratio(self, valid, invalid, name):
         total = valid + invalid
         if total > 0:
-            sys.stdout.write('\n%d/%d %s files valid' % (valid, total, name))
+            sys.stdout.write(f'\n{valid}/{total} {name} files valid')
             if invalid > 0:
-                sys.stdout.write(', %d/%d %s files INVALID' % (invalid, total,
-                                                               name))
+                sys.stdout.write(f', {invalid}/{total} {name} files INVALID')
 
-    def _on_missing_digest(self, bucket, last_key, **kwargs):
-        self._invalid_digests += 1
-        self._write_status('Digest file\ts3://%s/%s\tINVALID: not found'
-                           % (bucket, last_key), True)
-
-    def _on_digest_gap(self, **kwargs):
+    def _on_missing_digest(
+        self, bucket, last_key, is_backfill=False, **kwargs
+    ):
+        if is_backfill:
+            self._invalid_backfill_digests += 1
+        else:
+            self._invalid_digests += 1
+        digest_type = '(backfill) ' if is_backfill else ''
         self._write_status(
-            'No log files were delivered by CloudTrail between %s and %s'
-            % (format_display_date(kwargs['next_end_date']),
-               format_display_date(kwargs['last_start_date'])), True)
+            f'{digest_type}Digest file\ts3://{bucket}/{last_key}\tINVALID: not found',
+            True,
+        )
 
-    def _on_invalid_digest(self, message, **kwargs):
-        self._invalid_digests += 1
-        self._write_status(message, True)
+    def _on_digest_gap(self, is_backfill=False, **kwargs):
+        log_type = '(backfill) ' if is_backfill else ''
+        self._write_status(
+            f'{log_type}No log files were delivered by CloudTrail between {format_display_date(kwargs["next_end_date"])} and {format_display_date(kwargs["last_start_date"])}',
+            True,
+        )
+
+    def _on_invalid_digest(self, message, is_backfill=False, **kwargs):
+        if is_backfill:
+            self._invalid_backfill_digests += 1
+        else:
+            self._invalid_digests += 1
+        digest_type = '(backfill) ' if is_backfill else ''
+        self._write_status(f'{digest_type}{message}', True)
 
     def _on_invalid_log_format(self, log_data):
         self._invalid_logs += 1
         self._write_status(
-            ('Log file\ts3://%s/%s\tINVALID: invalid format'
-             % (log_data['s3Bucket'], log_data['s3Object'])), True)
+            f'Log file\ts3://{log_data["s3Bucket"]}/{log_data["s3Object"]}\tINVALID: invalid format',
+            True,
+        )
 
     def _on_log_invalid(self, log_data):
         self._invalid_logs += 1
         self._write_status(
-            "Log file\ts3://%s/%s\tINVALID: hash value doesn't match"
-            % (log_data['s3Bucket'], log_data['s3Object']), True)
+            f"Log file\ts3://{log_data['s3Bucket']}/{log_data['s3Object']}\tINVALID: hash value doesn't match",
+            True,
+        )
 
     def _on_missing_log(self, log_data):
         self._invalid_logs += 1
         self._write_status(
-            'Log file\ts3://%s/%s\tINVALID: not found'
-            % (log_data['s3Bucket'], log_data['s3Object']), True)
+            f'Log file\ts3://{log_data["s3Bucket"]}/{log_data["s3Object"]}\tINVALID: not found',
+            True,
+        )

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -11,18 +11,33 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import gzip
+import json
 
 from botocore.exceptions import ClientError
-from tests.unit.customizations.cloudtrail.test_validation import \
-    create_scenario, TEST_TRAIL_ARN, START_DATE, END_DATE, VALID_TEST_KEY, \
-    DigestProvider, MockDigestProvider, TEST_ACCOUNT_ID
-from awscli.testutils import mock, BaseAWSCommandParamsTest
-from awscli.customizations.cloudtrail.validation import DigestTraverser, \
-    DATE_FORMAT, format_display_date, S3ClientProvider
-from awscli.compat import BytesIO
 from botocore.handlers import parse_get_bucket_location
 
-RETRIEVER_FUNCTION = 'awscli.customizations.cloudtrail.validation.create_digest_traverser'
+from awscli.compat import BytesIO
+from awscli.customizations.cloudtrail.validation import (
+    DATE_FORMAT,
+    DigestTraverser,
+    S3ClientProvider,
+    format_display_date,
+)
+from awscli.testutils import BaseAWSCommandParamsTest, mock
+from tests.unit.customizations.cloudtrail.test_validation import (
+    END_DATE,
+    START_DATE,
+    TEST_ACCOUNT_ID,
+    TEST_TRAIL_ARN,
+    VALID_TEST_KEY,
+    DigestProvider,
+    MockDigestProvider,
+    create_scenario,
+)
+
+RETRIEVER_FUNCTION = (
+    'awscli.customizations.cloudtrail.validation.create_digest_traverser'
+)
 START_TIME_ARG = START_DATE.strftime(DATE_FORMAT)
 END_TIME_ARG = END_DATE.strftime(DATE_FORMAT)
 
@@ -35,145 +50,248 @@ def _gz_compress(data):
     return out.getvalue()
 
 
-def _setup_mock_traverser(mock_create_digest_traverser, key_provider,
-                          digest_provider, validator):
-    def mock_create(trail_arn, cloudtrail_client, s3_client_provider,
-                    organization_client, trail_source_region,
-                    bucket, prefix, on_missing, on_invalid, on_gap,
-                    account_id):
+def _setup_mock_traverser(
+    mock_create_digest_traverser, key_provider, digest_provider, validator
+):
+    def mock_create(
+        trail_arn,
+        cloudtrail_client,
+        s3_client_provider,
+        organization_client,
+        trail_source_region,
+        bucket,
+        prefix,
+        on_missing,
+        on_invalid,
+        on_gap,
+        account_id,
+    ):
         bucket = bucket or '1'
         return DigestTraverser(
-            digest_provider=digest_provider, starting_bucket=bucket,
-            starting_prefix=prefix, public_key_provider=key_provider,
-            digest_validator=validator, on_invalid=on_invalid, on_gap=on_gap,
-            on_missing=on_missing)
+            digest_provider=digest_provider,
+            starting_bucket=bucket,
+            starting_prefix=prefix,
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_invalid=on_invalid,
+            on_gap=on_gap,
+            on_missing=on_missing,
+        )
 
     mock_create_digest_traverser.side_effect = mock_create
 
 
 class BaseCloudTrailCommandTest(BaseAWSCommandParamsTest):
     def setUp(self):
-        super(BaseCloudTrailCommandTest, self).setUp()
+        super().setUp()
         # We need to remove this handler to ensure that we can mock out the
         # get_bucket_location operation.
-        self.driver.session.unregister('after-call.s3.GetBucketLocation',
-                                       parse_get_bucket_location)
+        self.driver.session.unregister(
+            'after-call.s3.GetBucketLocation', parse_get_bucket_location
+        )
         self._logs = [
-            {'hashValue': '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
-             'oldestEventTime': '2015-08-16T22:36:54Z',
-             's3Object': 'key1',
-             'hashAlgorithm': 'SHA-256',
-             's3Bucket': '1',
-             'newestEventTime': '2015-08-16T22:36:54Z',
-             '_raw_value': '{}'},
-            {'hashValue': '7a38bf81f383f69433ad6e900d35b3e2385593f76a7b7ab5d4355b8ba41ee24b',
-             'oldestEventTime': '2015-08-16T22:54:56Z',
-             's3Object': 'key2',
-             'hashAlgorithm': 'SHA-256',
-             's3Bucket': '1',
-             'newestEventTime': '2015-08-16T22:55:49Z',
-             '_raw_value': '{"foo":"bar"}'},
-            {'hashValue': '5b1070294963f40cb5b3c7a05d3fbaf7ffe4e5d226632026e39cfeb32d349c0c',
-             'oldestEventTime': '2015-08-16T21:54:59Z',
-             's3Object': 'key3',
-             'hashAlgorithm': 'SHA-256',
-             's3Bucket': '1',
-             'newestEventTime': '2015-08-16T21:54:59Z',
-             '_raw_value': '{"baz":"qux"}'}
+            {
+                'hashValue': '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
+                'oldestEventTime': '2015-08-16T22:36:54Z',
+                's3Object': 'key1',
+                'hashAlgorithm': 'SHA-256',
+                's3Bucket': '1',
+                'newestEventTime': '2015-08-16T22:36:54Z',
+                '_raw_value': '{}',
+            },
+            {
+                'hashValue': '7a38bf81f383f69433ad6e900d35b3e2385593f76a7b7ab5d4355b8ba41ee24b',
+                'oldestEventTime': '2015-08-16T22:54:56Z',
+                's3Object': 'key2',
+                'hashAlgorithm': 'SHA-256',
+                's3Bucket': '1',
+                'newestEventTime': '2015-08-16T22:55:49Z',
+                '_raw_value': '{"foo":"bar"}',
+            },
+            {
+                'hashValue': '5b1070294963f40cb5b3c7a05d3fbaf7ffe4e5d226632026e39cfeb32d349c0c',
+                'oldestEventTime': '2015-08-16T21:54:59Z',
+                's3Object': 'key3',
+                'hashAlgorithm': 'SHA-256',
+                's3Bucket': '1',
+                'newestEventTime': '2015-08-16T21:54:59Z',
+                '_raw_value': '{"baz":"qux"}',
+            },
         ]
 
 
 class TestCloudTrailCommand(BaseCloudTrailCommandTest):
     def setUp(self):
-        super(TestCloudTrailCommand, self).setUp()
+        super().setUp()
         self._traverser_patch = mock.patch(RETRIEVER_FUNCTION)
         self._mock_traverser = self._traverser_patch.start()
 
     def tearDown(self):
-        super(TestCloudTrailCommand, self).tearDown()
+        super().tearDown()
         self._traverser_patch.stop()
 
     def test_verbose_output_shows_happy_case(self):
         self.parsed_responses = [
             {'LocationConstraint': 'us-east-1'},
-            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))}
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
         ]
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link'], [[], [self._logs[0]]])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            ['gap', 'link'], [[], [self._logs[0]]]
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time %s "
-             "--region us-east-1 --verbose")
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 0)
-        self.assertIn('Digest file\ts3://1/%s\tvalid'
-                      % digest_provider.digests[0], stdout)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
+            "--region us-east-1 --verbose",
+            0,
+        )
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[0]}\tvalid',
+            stdout,
+        )
+        self.assertIn('2/2 digest files valid', stdout)
+        self.assertIn('2/2 backfill digest files valid', stdout)
+        self.assertIn('2/2 log files valid', stdout)
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[1]}\tvalid',
+            stdout,
+        )
+        self.assertIn('Log file\ts3://1/key1\tvalid', stdout)
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[0]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[1]}\tvalid',
+            stdout,
+        )
+        self.assertIn('Log file\ts3://1/key1\tvalid', stdout)
 
     def test_verbose_output_shows_valid_digests(self):
-        key_provider, digest_provider, validator = create_scenario(
-            ['gap'], [])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+        key_provider, digest_provider, validator = create_scenario(['gap'], [])
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s --verbose"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 0)
-        self.assertIn('Digest file\ts3://1/%s\tvalid'
-                      % digest_provider.digests[0], stdout)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            0,
+        )
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[0]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[0]}\tvalid',
+            stdout,
+        )
+        self.assertIn('1/1 digest files valid', stdout)
+        self.assertIn('1/1 backfill digest files valid', stdout)
 
     def test_warns_when_digest_deleted(self):
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'missing', 'link', 'missing'], [])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            ['gap', 'missing', 'link', 'missing'], []
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s --verbose"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
-        self.assertIn('Digest file\ts3://1/%s\tINVALID: not found'
-                      % digest_provider.digests[1], stderr)
-        self.assertIn('Digest file\ts3://1/%s\tINVALID: not found'
-                      % digest_provider.digests[3], stderr)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            1,
+        )
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[1]}\tINVALID: not found',
+            stderr,
+        )
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[3]}\tINVALID: not found',
+            stderr,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[1]}\tINVALID: not found',
+            stderr,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[3]}\tINVALID: not found',
+            stderr,
+        )
+        self.assertIn(
+            '2/4 digest files valid, 2/4 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '2/4 backfill digest files valid, 2/4 backfill digest files INVALID',
+            stdout,
+        )
 
     def test_warns_when_no_digests_in_gap(self):
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'gap'], [])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            ['gap', 'gap'], []
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time '%s'"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 0)
-        self.assertIn(('No log files were delivered by CloudTrail between '
-                       '2014-08-10T00:00:00Z and 2014-08-10T01:00:00Z'), stderr)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}'",
+            0,
+        )
+        self.assertIn(
+            (
+                'No log files were delivered by CloudTrail between '
+                '2014-08-10T00:00:00Z and 2014-08-10T01:00:00Z'
+            ),
+            stderr,
+        )
 
     def test_warns_when_digest_invalid(self):
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'invalid', 'link'], [])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            ['gap', 'invalid', 'link'], []
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
+            1,
+        )
         self.assertIn('invalid error', stderr)
         self.assertIn(
-            'Results requested for %s to ' % format_display_date(START_DATE),
-            stdout)
-        self.assertIn('2/3 digest files valid, 1/3 digest files INVALID',
-                      stdout)
+            f'Results requested for {format_display_date(START_DATE)} to ',
+            stdout,
+        )
+        self.assertIn(
+            '2/3 digest files valid, 1/3 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '2/3 backfill digest files valid, 1/3 backfill digest files INVALID',
+            stdout,
+        )
 
     def test_shows_successful_summary(self):
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link'], [])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            ['gap', 'link'], []
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time %s "
-             "--end-time %s --verbose")
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG), 0)
-        self.assertIn(('Results requested for 2014-08-10T00:00:00Z to '
-                       '2015-08-10T00:00:00Z'), stdout)
-        self.assertIn('2/2 digest files valid', stdout)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
+            f"--end-time {END_TIME_ARG} --verbose",
+            0,
+        )
         self.assertIn(
-            'Results found for 2014-08-10T01:00:00Z to 2014-08-10T02:30:00Z',
-            stdout)
+            (
+                'Results requested for 2014-08-10T00:00:00Z to '
+                '2015-08-10T00:00:00Z'
+            ),
+            stdout,
+        )
+        self.assertIn('2/2 digest files valid', stdout)
+        self.assertIn('2/2 backfill digest files valid', stdout)
+        self.assertIn(
+            'Results found for 2014-08-10T00:00:00Z to 2014-08-10T02:30:00Z',
+            stdout,
+        )
 
     def test_warns_when_no_digests_after_start_date(self):
         key_provider = mock.Mock()
@@ -181,15 +299,18 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         digest_provider = mock.Mock()
         digest_provider.load_digest_keys_in_range.return_value = []
         validator = mock.Mock()
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ('cloudtrail validate-logs --trail-arn %s --start-time %s '
-             '--end-time %s') % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG),
-            0)
-        self.assertIn('Results requested for %s to %s\nNo digests found'
-                      % (format_display_date(START_DATE),
-                         format_display_date(END_DATE)), stdout)
+            f'cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} '
+            f'--end-time {END_TIME_ARG}',
+            0,
+        )
+        self.assertIn(
+            f'Results requested for {format_display_date(START_DATE)} to {format_display_date(END_DATE)}\nNo digests found',
+            stdout,
+        )
 
     def test_warns_when_no_digests_found_in_range(self):
         key_provider = mock.Mock()
@@ -197,155 +318,501 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         digest_provider = mock.Mock()
         digest_provider.load_digest_keys_in_range.return_value = []
         validator = mock.Mock()
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time '%s' "
-             "--end-time '%s'")
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG), 0)
-        self.assertIn('Results requested for %s to %s\nNo digests found'
-                      % (format_display_date(START_DATE),
-                         format_display_date(END_DATE)), stdout)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}' "
+            f"--end-time '{END_TIME_ARG}'",
+            0,
+        )
+        self.assertIn(
+            f'Results requested for {format_display_date(START_DATE)} to {format_display_date(END_DATE)}\nNo digests found',
+            stdout,
+        )
 
     def test_warns_when_no_valid_digests_found_in_range(self):
         key_provider, digest_provider, validator = create_scenario(
-            ['invalid'], [])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            ['invalid'], []
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time '%s' "
-             "--end-time '%s'")
-            % (TEST_TRAIL_ARN, START_TIME_ARG, END_TIME_ARG), 1)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}' "
+            f"--end-time '{END_TIME_ARG}'",
+            1,
+        )
         self.assertIn(
-            'Results requested for %s to %s\nNo valid digests found in range'
-            % (format_display_date(START_DATE),
-               format_display_date(END_DATE)), stdout)
+            f'Results requested for {format_display_date(START_DATE)} to {format_display_date(END_DATE)}\nNo valid digests found in range',
+            stdout,
+        )
+        self.assertIn('(backfill) invalid error', stderr)
+        self.assertIn('invalid error', stderr)
+        self.assertIn(
+            '0/1 digest files valid, 1/1 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '0/1 backfill digest files valid, 1/1 backfill digest files INVALID',
+            stdout,
+        )
 
     def test_fails_and_warns_when_log_hash_is_invalid(self):
         key_provider, digest_provider, validator = create_scenario(
-            ['gap'], [[self._logs[0]]])
+            ['gap'], [[self._logs[0]]]
+        )
         self.parsed_responses = [
             {'LocationConstraint': ''},
-            {'Body': BytesIO(_gz_compress('does not match'))}
+            {'Body': BytesIO(_gz_compress('does not match'))},
+            {'Body': BytesIO(_gz_compress('does not match'))},
         ]
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time "
-             "--region us-east-1 '%s'") % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --region us-east-1",
+            1,
+        )
         self.assertIn(
-            'Log file\ts3://1/key1\tINVALID: hash value doesn\'t match', stderr)
+            'Log file\ts3://1/key1\tINVALID: hash value doesn\'t match', stderr
+        )
+        self.assertIn('1/1 digest files valid', stdout)
+        self.assertIn('1/1 backfill digest files valid', stdout)
+        self.assertIn('0/2 log files valid, 2/2 log files INVALID', stdout)
 
     def test_validates_valid_log_files(self):
         key_provider, digest_provider, validator = create_scenario(
             ['gap', 'link', 'link'],
-            [[self._logs[2]], [], [self._logs[0], self._logs[1]]])
+            [[self._logs[2]], [], [self._logs[0], self._logs[1]]],
+        )
         self.parsed_responses = [
             {'LocationConstraint': ''},
             {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
             {'Body': BytesIO(_gz_compress(self._logs[1]['_raw_value']))},
             {'Body': BytesIO(_gz_compress(self._logs[2]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[1]['_raw_value']))},
+            {'Body': BytesIO(_gz_compress(self._logs[2]['_raw_value']))},
         ]
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s --verbose"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 0)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            0,
+        )
         self.assertIn('s3://1/key1', stdout)
         self.assertIn('s3://1/key2', stdout)
         self.assertIn('s3://1/key3', stdout)
+        self.assertIn('Log file\ts3://1/key1\tvalid', stdout)
+        self.assertIn('Log file\ts3://1/key2\tvalid', stdout)
+        self.assertIn('Log file\ts3://1/key3\tvalid', stdout)
+        self.assertIn('3/3 digest files valid', stdout)
+        self.assertIn('3/3 backfill digest files valid', stdout)
+        self.assertIn('6/6 log files valid', stdout)
 
     def test_ensures_start_time_before_end_time(self):
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time 2015-01-01 "
-             "--end-time 2014-01-01"), 255)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time 2015-01-01 "
+            "--end-time 2014-01-01",
+            255,
+        )
         self.assertIn('start-time must occur before end-time', stderr)
 
     def test_fails_when_digest_not_from_same_location_as_json_contents(self):
-        key_name = END_TIME_ARG + '.json.gz'
-        digest = {'digestPublicKeyFingerprint': 'a',
-                  'digestS3Bucket': 'not_same',
-                  'digestS3Object': key_name,
-                  'previousDigestSignature': '...',
-                  'digestStartTime': '...',
-                  'digestEndTime': '...'}
-        digest_provider = mock.Mock()
-        digest_provider.load_digest_keys_in_range.return_value = [key_name]
-        digest_provider.fetch_digest.return_value = (digest, key_name)
-        _setup_mock_traverser(self._mock_traverser, mock.Mock(),
-                              digest_provider, mock.Mock())
+        key_provider, digest_provider, validator = create_scenario(['gap'], [])
+
+        # Use the actual digest keys from the provider
+        key_name = digest_provider.digests[0]
+        backfill_key_name = digest_provider.backfill_digests[0]
+        digest = {
+            'digestPublicKeyFingerprint': 'a',
+            'digestS3Bucket': 'not_same',
+            'digestS3Object': key_name,
+            'previousDigestSignature': '...',
+            'digestStartTime': '...',
+            'digestEndTime': '...',
+        }
+        backfill_digest = {
+            'digestPublicKeyFingerprint': 'a',
+            'digestS3Bucket': 'not_same',
+            'digestS3Object': backfill_key_name,
+            'previousDigestSignature': '...',
+            'digestStartTime': '...',
+            'digestEndTime': '...',
+        }
+
+        def mock_fetch(bucket, key):
+            if '_backfill' in key:
+                return (backfill_digest, json.dumps(backfill_digest).encode())
+            return (digest, json.dumps(digest).encode())
+
+        digest_provider.fetch_digest = mock_fetch
+
+        _setup_mock_traverser(
+            self._mock_traverser, mock.Mock(), digest_provider, mock.Mock()
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
+            1,
+        )
         self.assertIn(
-            ('Digest file\ts3://1/%s\tINVALID: has been moved from its '
-             'original location' % key_name), stderr)
+            f'Digest file\ts3://1/{key_name}\tINVALID: has been moved from its '
+            'original location',
+            stderr,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{backfill_key_name}\tINVALID: has been moved from its '
+            'original location',
+            stderr,
+        )
+        self.assertIn(
+            '0/1 digest files valid, 1/1 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '0/1 backfill digest files valid, 1/1 backfill digest files INVALID',
+            stdout,
+        )
 
     def test_fails_when_digest_is_missing_keys_before_validation(self):
-        digest = {}
-        digest_provider = mock.Mock()
-        key_name = END_TIME_ARG + '.json.gz'
-        digest_provider.load_digest_keys_in_range.return_value = [key_name]
-        digest_provider.fetch_digest.return_value = (digest, key_name)
-        _setup_mock_traverser(self._mock_traverser, mock.Mock(),
-                              digest_provider, mock.Mock())
+        key_provider, digest_provider, validator = create_scenario(['gap'], [])
+
+        def mock_fetch(bucket, key):
+            return ({}, b'{}')
+
+        digest_provider.fetch_digest = mock_fetch
+
+        _setup_mock_traverser(
+            self._mock_traverser, mock.Mock(), digest_provider, mock.Mock()
+        )
         stdout, stderr, rc = self.run_cmd(
-            "cloudtrail validate-logs --trail-arn %s --start-time %s"
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
+            1,
+        )
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: invalid format' % key_name,
-            stderr)
+            f'Digest file\ts3://1/{digest_provider.digests[0]}\tINVALID: invalid format',
+            stderr,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[0]}\tINVALID: invalid format',
+            stderr,
+        )
+        self.assertIn(
+            '0/1 digest files valid, 1/1 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '0/1 backfill digest files valid, 1/1 backfill digest files INVALID',
+            stdout,
+        )
 
     def test_fails_when_digest_metadata_is_missing(self):
         key = MockDigestProvider([]).get_key_at_position(1)
+        backfill_key = MockDigestProvider([]).get_key_at_position(
+            1, is_backfill=True
+        )
         self.parsed_responses = [
             {'LocationConstraint': ''},
-            {'Contents': [{'Key': key}]},
-            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value'])),
-             'Metadata': {}},
+            {'Contents': [{'Key': key}, {'Key': backfill_key}]},
+            {
+                'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value'])),
+                'Metadata': {},
+            },
+            {
+                'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value'])),
+                'Metadata': {},
+            },
         ]
         s3_client_provider = S3ClientProvider(self.driver.session, 'us-east-1')
         digest_provider = DigestProvider(
-            s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1')
+            s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1'
+        )
         key_provider = mock.Mock()
         key_provider.get_public_keys.return_value = {
             'a': {'Value': VALID_TEST_KEY}
         }
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, mock.Mock())
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, mock.Mock()
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time %s "
-             "--region us-east-1") % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
+            "--region us-east-1",
+            1,
+        )
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: signature verification failed'
-            % key, stderr)
+            f'Digest file\ts3://1/{key}\tINVALID: signature verification failed',
+            stderr,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{backfill_key}\tINVALID: signature verification failed',
+            stderr,
+        )
+        self.assertIn(
+            '0/1 digest files valid, 1/1 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '0/1 backfill digest files valid, 1/1 backfill digest files INVALID',
+            stdout,
+        )
 
     def test_follows_trails_when_bucket_changes(self):
         self.parsed_responses = [
             {'LocationConstraint': 'us-east-1'},
             {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
-            {'LocationConstraint': 'us-west-2'},
-            {'LocationConstraint': 'eu-west-1'}
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
         ]
         key_provider, digest_provider, validator = create_scenario(
             ['gap', 'bucket_change', 'link', 'bucket_change', 'link'],
-            [[], [self._logs[0]], [], [], []])
-        _setup_mock_traverser(self._mock_traverser, key_provider,
-                              digest_provider, validator)
+            [[], [self._logs[0]], [], [], []],
+        )
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
         stdout, stderr, rc = self.run_cmd(
-            ("cloudtrail validate-logs --trail-arn %s --start-time %s "
-             "--region us-east-1 --verbose")
-            % (TEST_TRAIL_ARN, START_TIME_ARG), 0)
-        self.assertIn('Digest file\ts3://3/%s\tvalid'
-                      % digest_provider.digests[0], stdout)
-        self.assertIn('Digest file\ts3://2/%s\tvalid'
-                      % digest_provider.digests[1], stdout)
-        self.assertIn('Digest file\ts3://2/%s\tvalid'
-                      % digest_provider.digests[2], stdout)
-        self.assertIn('Digest file\ts3://1/%s\tvalid'
-                      % digest_provider.digests[3], stdout)
-        self.assertIn('Digest file\ts3://1/%s\tvalid'
-                      % digest_provider.digests[4], stdout)
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} "
+            "--region us-east-1 --verbose",
+            0,
+        )
+        self.assertIn(
+            f'Digest file\ts3://3/{digest_provider.digests[0]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'Digest file\ts3://2/{digest_provider.digests[1]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'Digest file\ts3://2/{digest_provider.digests[2]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[3]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'Digest file\ts3://1/{digest_provider.digests[4]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://3/{digest_provider.backfill_digests[0]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://2/{digest_provider.backfill_digests[1]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://2/{digest_provider.backfill_digests[2]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[3]}\tvalid',
+            stdout,
+        )
+        self.assertIn(
+            f'(backfill) Digest file\ts3://1/{digest_provider.backfill_digests[4]}\tvalid',
+            stdout,
+        )
+        self.assertIn('Log file\ts3://1/key1\tvalid', stdout)
+        self.assertIn('Log file\ts3://1/key1\tvalid', stdout)
+        self.assertIn('5/5 digest files valid', stdout)
+        self.assertIn('5/5 backfill digest files valid', stdout)
+        self.assertIn('2/2 log files valid', stdout)
+
+    def test_validates_standard_digests_only(self):
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link'], [[], [self._logs[0]]]
+        )
+        original_load = digest_provider.load_digest_keys_in_range
+
+        def mock_load_keys(
+            bucket, prefix, start_date, end_date, is_backfill=False
+        ):
+            if is_backfill:
+                return []
+            return original_load(
+                bucket, prefix, start_date, end_date, is_backfill=False
+            )
+
+        digest_provider.load_digest_keys_in_range = mock_load_keys
+
+        self.parsed_responses = [
+            {'LocationConstraint': 'us-east-1'},
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
+        ]
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            0,
+        )
+        self.assertIn('2/2 digest files valid', stdout)
+        self.assertIn('1/1 log files valid', stdout)
+        self.assertNotIn('(backfill)', stdout)
+        self.assertIn(
+            'Results found for 2014-08-10T00:00:00Z to 2014-08-10T02:30:00Z',
+            stdout,
+        )
+
+    def test_validates_backfill_digests_only(self):
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link'], [[], [self._logs[0]]]
+        )
+        original_load = digest_provider.load_digest_keys_in_range
+
+        def mock_load_keys(
+            bucket, prefix, start_date, end_date, is_backfill=False
+        ):
+            if not is_backfill:
+                return []
+            return original_load(
+                bucket, prefix, start_date, end_date, is_backfill=True
+            )
+
+        digest_provider.load_digest_keys_in_range = mock_load_keys
+
+        self.parsed_responses = [
+            {'LocationConstraint': 'us-east-1'},
+            {'Body': BytesIO(_gz_compress(self._logs[0]['_raw_value']))},
+        ]
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            0,
+        )
+        self.assertIn('(backfill) Digest file\ts3://1/', stdout)
+        self.assertIn('Log file\ts3://1/key1\tvalid', stdout)
+        self.assertIn('2/2 backfill digest files valid', stdout)
+        self.assertIn('1/1 log files valid', stdout)
+        self.assertIn(
+            'Results found for 2014-08-10T00:00:00Z to 2014-08-10T02:30:00Z',
+            stdout,
+        )
+
+    def _setup_mixed_period_providers(
+        self, standard_actions, backfill_actions, logs=None
+    ):
+        """Helper method to set up mixed period test scenarios with proper key alignment."""
+        key_provider, digest_provider, validator = create_scenario(
+            standard_actions, logs or []
+        )
+        key_provider_bf, digest_provider_bf, _ = create_scenario(
+            backfill_actions, logs or []
+        )
+
+        combined_keys = {}
+        combined_keys.update(key_provider.get_public_keys.return_value)
+        combined_keys.update(key_provider_bf.get_public_keys.return_value)
+        key_provider.get_public_keys.return_value = combined_keys
+
+        original_load = digest_provider.load_digest_keys_in_range
+        original_load_bf = digest_provider_bf.load_digest_keys_in_range
+        original_fetch = digest_provider.fetch_digest
+        original_fetch_bf = digest_provider_bf.fetch_digest
+
+        def mock_load_keys(
+            bucket, prefix, start_date, end_date, is_backfill=False
+        ):
+            if is_backfill:
+                return original_load_bf(
+                    bucket, prefix, start_date, end_date, is_backfill=True
+                )
+            return original_load(
+                bucket, prefix, start_date, end_date, is_backfill=False
+            )
+
+        def mock_fetch(bucket, key):
+            if '_backfill' in key:
+                return original_fetch_bf(bucket, key)
+            return original_fetch(bucket, key)
+
+        digest_provider.load_digest_keys_in_range = mock_load_keys
+        digest_provider.fetch_digest = mock_fetch
+
+        return key_provider, digest_provider, validator
+
+    def test_validates_mixed_digests_standard_smaller_period(self):
+        """Test validation when standard digests have smaller time period than backfill digests."""
+        key_provider, digest_provider, validator = (
+            self._setup_mixed_period_providers(
+                ['gap'], ['gap', 'link', 'link'], [[]] * 4
+            )
+        )
+
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            0,
+        )
+        self.assertIn('1/1 digest files valid', stdout)
+        self.assertIn('3/3 backfill digest files valid', stdout)
+        self.assertIn(
+            'Results found for 2014-08-10T00:00:00Z to 2014-08-10T03:30:00Z',
+            stdout,
+        )
+
+    def test_validates_mixed_digests_backfill_smaller_period(self):
+        key_provider, digest_provider, validator = (
+            self._setup_mixed_period_providers(
+                ['gap', 'link', 'link'], ['gap'], [[], [], [], []]
+            )
+        )
+
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG} --verbose",
+            0,
+        )
+        self.assertIn('3/3 digest files valid', stdout)
+        self.assertIn('1/1 backfill digest files valid', stdout)
+        self.assertIn(
+            'Results found for 2014-08-10T00:00:00Z to 2014-08-10T03:30:00Z',
+            stdout,
+        )
+
+    def test_fails_when_digest_public_key_not_found(self):
+        key_provider, digest_provider, validator = create_scenario(['gap'], [])
+        key_provider.get_public_keys.return_value = {
+            'wrong_fp': {'Fingerprint': 'wrong_fp', 'Value': 'wrong_key'}
+        }
+
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time {START_TIME_ARG}",
+            1,
+        )
+        error_lines = stderr.split('\n')
+        standard_errors = [
+            line
+            for line in error_lines
+            if 'public key not found' in line and '(backfill)' not in line
+        ]
+        backfill_errors = [
+            line
+            for line in error_lines
+            if 'public key not found' in line and '(backfill)' in line
+        ]
+
+        self.assertEqual(1, len(standard_errors))
+        self.assertEqual(1, len(backfill_errors))
+        self.assertIn('public key not found', standard_errors[0])
+        self.assertIn('public key not found', backfill_errors[0])
+
+        self.assertIn(
+            '0/1 digest files valid, 1/1 digest files INVALID', stdout
+        )
+        self.assertIn(
+            '0/1 backfill digest files valid, 1/1 backfill digest files INVALID',
+            stdout,
+        )
 
 
 class TestCloudTrailCommandWithMissingLogs(BaseCloudTrailCommandTest):
@@ -353,19 +820,34 @@ class TestCloudTrailCommandWithMissingLogs(BaseCloudTrailCommandTest):
     behavior of BaseAWSCommandParamsTest. Instead of returning responses from
     a queue, we want to raise a ClientError.
     """
+
     def test_fails_and_warns_when_log_is_deleted(self):
         # Override the default request patching because we need to
         # raise a ClientError exception.
         key_provider, digest_provider, validator = create_scenario(
-            ['gap'], [[self._logs[0]]])
+            ['gap'], [[self._logs[0]]]
+        )
         with mock.patch(RETRIEVER_FUNCTION) as mock_create_digest_traverser:
-            _setup_mock_traverser(mock_create_digest_traverser,
-                                  key_provider, digest_provider, validator)
+            _setup_mock_traverser(
+                mock_create_digest_traverser,
+                key_provider,
+                digest_provider,
+                validator,
+            )
             stdout, stderr, rc = self.run_cmd(
-                "cloudtrail validate-logs --trail-arn %s --start-time '%s'"
-                % (TEST_TRAIL_ARN, START_TIME_ARG), 1)
+                f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} --start-time '{START_TIME_ARG}'",
+                1,
+            )
             self.assertIn(
-                'Log file\ts3://1/key1\tINVALID: not found\n\n', stderr)
+                'Log file\ts3://1/key1\tINVALID: not found\n\n', stderr
+            )
+            self.assertIn(
+                'Log file\ts3://1/key1\tINVALID: not found\n\n',
+                stderr,
+            )
+            self.assertIn('1/1 digest files valid', stdout)
+            self.assertIn('1/1 backfill digest files valid', stdout)
+            self.assertIn('0/2 log files valid, 2/2 log files INVALID', stdout)
 
     def patch_make_request(self):
         """Override the default request patching because we need to
@@ -374,5 +856,5 @@ class TestCloudTrailCommandWithMissingLogs(BaseCloudTrailCommandTest):
         self.make_request_is_patched = True
         make_request_patch = self.make_request_patch.start()
         make_request_patch.side_effect = ClientError(
-            {'Error': {'Code': 'NoSuchKey', 'Message': 'foo'}},
-            'GetObject')
+            {'Error': {'Code': 'NoSuchKey', 'Message': 'foo'}}, 'GetObject'
+        )

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -10,41 +10,54 @@
 # distributed on an 'AS IS' BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import binascii
 import base64
+import binascii
+import gzip
 import hashlib
 import json
-import gzip
+from argparse import Namespace
 from datetime import datetime, timedelta
-from dateutil import parser, tz
 
 import rsa
-from argparse import Namespace
-
-from awscli.testutils import BaseAWSCommandParamsTest
-from awscli.customizations.cloudtrail.validation import DigestError, \
-    extract_digest_key_date, normalize_date, format_date, DigestProvider, \
-    DigestTraverser, create_digest_traverser, PublicKeyProvider, \
-    Sha256RSADigestValidator, DATE_FORMAT, CloudTrailValidateLogs, \
-    parse_date, assert_cloudtrail_arn_is_valid, DigestSignatureError, \
-    InvalidDigestFormat, S3ClientProvider
-from awscli.compat import BytesIO
 from botocore.exceptions import ClientError
-from awscli.testutils import mock, unittest
-from awscli.schema import ParameterRequiredError
+from dateutil import parser, tz
 
+from awscli.compat import BytesIO
+from awscli.customizations.cloudtrail.validation import (
+    DATE_FORMAT,
+    CloudTrailValidateLogs,
+    DigestError,
+    DigestProvider,
+    DigestSignatureError,
+    DigestTraverser,
+    InvalidDigestFormat,
+    PublicKeyProvider,
+    S3ClientProvider,
+    Sha256RSADigestValidator,
+    assert_cloudtrail_arn_is_valid,
+    create_digest_traverser,
+    extract_digest_key_date,
+    format_date,
+    is_backfill_digest_key,
+    normalize_date,
+    parse_date,
+)
+from awscli.schema import ParameterRequiredError
+from awscli.testutils import BaseAWSCommandParamsTest, mock, unittest
 
 START_DATE = parser.parse('20140810T000000Z')
 END_DATE = parser.parse('20150810T000000Z')
 TEST_ACCOUNT_ID = '123456789012'
-TEST_TRAIL_ARN = 'arn:aws:cloudtrail:us-east-1:%s:trail/foo' % TEST_ACCOUNT_ID
-VALID_TEST_KEY = ('MIIBCgKCAQEAn11L2YZ9h7onug2ILi1MWyHiMRsTQjfWE+pHVRLk1QjfW'
-                  'hirG+lpOa8NrwQ/r7Ah5bNL6HepznOU9XTDSfmmnP97mqyc7z/upfZdS/'
-                  'AHhYcGaz7n6Wc/RRBU6VmiPCrAUojuSk6/GjvA8iOPFsYDuBtviXarvuL'
-                  'PlrT9kAd4Lb+rFfR5peEgBEkhlzc5HuWO7S0y+KunqxX6jQBnXGMtxmPB'
-                  'PP0FylgWGNdFtks/4YSKcgqwH0YDcawP9GGGDAeCIqPWIXDLG1jOjRRzW'
-                  'fCmD0iJUkz8vTsn4hq/5ZxRFE7UBAUiVcGbdnDdvVfhF9C3dQiDq3k7ad'
-                  'QIziLT0cShgQIDAQAB')
+TEST_TRAIL_ARN = f'arn:aws:cloudtrail:us-east-1:{TEST_ACCOUNT_ID}:trail/foo'
+VALID_TEST_KEY = (
+    'MIIBCgKCAQEAn11L2YZ9h7onug2ILi1MWyHiMRsTQjfWE+pHVRLk1QjfW'
+    'hirG+lpOa8NrwQ/r7Ah5bNL6HepznOU9XTDSfmmnP97mqyc7z/upfZdS/'
+    'AHhYcGaz7n6Wc/RRBU6VmiPCrAUojuSk6/GjvA8iOPFsYDuBtviXarvuL'
+    'PlrT9kAd4Lb+rFfR5peEgBEkhlzc5HuWO7S0y+KunqxX6jQBnXGMtxmPB'
+    'PP0FylgWGNdFtks/4YSKcgqwH0YDcawP9GGGDAeCIqPWIXDLG1jOjRRzW'
+    'fCmD0iJUkz8vTsn4hq/5ZxRFE7UBAUiVcGbdnDdvVfhF9C3dQiDq3k7ad'
+    'QIziLT0cShgQIDAQAB'
+)
 TEST_ORGANIZATION_ACCOUNT_ID = '987654321098'
 TEST_ORGANIZATION_ID = 'o-12345'
 
@@ -53,8 +66,7 @@ def create_mock_key_provider(key_list):
     """Creates a mock key provider that yields keys for each in key_list"""
     public_keys = {}
     for k in key_list:
-        public_keys[k] = {'Fingerprint': k,
-                          'Value': 'ffaa00'}
+        public_keys[k] = {'Fingerprint': k, 'Value': 'ffaa00'}
     key_provider = mock.Mock()
     key_provider.get_public_keys.return_value = public_keys
     return key_provider
@@ -93,42 +105,64 @@ def collecting_callback():
     return cb, calls
 
 
-class MockDigestProvider(object):
+class MockDigestProvider:
     def __init__(self, actions, logs=None):
         self.logs = logs or []
         self.actions = actions
         self.calls = {'fetch_digest': [], 'load_digest_keys_in_range': []}
         self.digests = []
+        self.backfill_digests = []
+        self.trail_home_region = 'us-east-1'
         for i in range(len(self.actions)):
             self.digests.append(self.get_key_at_position(i))
+            self.backfill_digests.append(
+                self.get_key_at_position(i, is_backfill=True)
+            )
 
-    def get_key_at_position(self, position):
+    def get_key_at_position(self, position, is_backfill=False):
+        """Get digest key at position, generating backfill keys if needed."""
         dt = START_DATE + timedelta(hours=position)
-        key = ('AWSLogs/{account}/CloudTrail-Digest/us-east-1/{ymd}/{account}_'
-               'CloudTrail-Digest_us-east-1_foo_us-east-1_{date}.json.gz')
-        return key.format(
-            account=TEST_ACCOUNT_ID,
-            ymd=dt.strftime('%Y/%m/%d'),
-            date=dt.strftime(DATE_FORMAT))
+
+        if is_backfill:
+            key = (
+                f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/{dt.strftime("%Y/%m/%d")}/'
+                f'{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_{dt.strftime(DATE_FORMAT)}_backfill.json.gz'
+            )
+        else:
+            key = (
+                f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/{dt.strftime("%Y/%m/%d")}/'
+                f'{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_{dt.strftime(DATE_FORMAT)}.json.gz'
+            )
+        return key
 
     @staticmethod
-    def create_digest(fingerprint, start_date, key, bucket, next_key=None,
-                      next_bucket=None, logs=None):
+    def create_digest(
+        fingerprint,
+        start_date,
+        key,
+        bucket,
+        next_key=None,
+        next_bucket=None,
+        logs=None,
+    ):
         digest_end_date = start_date + timedelta(hours=1, minutes=30)
-        return {'digestPublicKeyFingerprint': fingerprint,
-                'digestEndTime': digest_end_date.strftime(DATE_FORMAT),
-                'digestStartTime': start_date.strftime(DATE_FORMAT),
-                'previousDigestS3Bucket': next_bucket,
-                'previousDigestS3Object': next_key,
-                'digestS3Bucket': bucket,
-                'digestS3Object': key,
-                'awsAccountId': TEST_ACCOUNT_ID,
-                'previousDigestSignature': 'abcd',
-                'logFiles': logs or []}
+        return {
+            'digestPublicKeyFingerprint': fingerprint,
+            'digestEndTime': digest_end_date.strftime(DATE_FORMAT),
+            'digestStartTime': start_date.strftime(DATE_FORMAT),
+            'previousDigestS3Bucket': next_bucket,
+            'previousDigestS3Object': next_key,
+            'digestS3Bucket': bucket,
+            'digestS3Object': key,
+            'awsAccountId': TEST_ACCOUNT_ID,
+            'previousDigestSignature': 'abcd',
+            'logFiles': logs or [],
+        }
 
     @staticmethod
-    def create_link(key, next_key, next_bucket, position, action, logs,
-                    bucket):
+    def create_link(
+        key, next_key, next_bucket, position, action, logs, bucket
+    ):
         """Creates a link in a digest chain for testing."""
         digest_logs = []
         if len(logs) > position:
@@ -137,37 +171,71 @@ class MockDigestProvider(object):
         # gap actions have no previous link.
         if action == 'gap':
             digest = MockDigestProvider.create_digest(
-                key=key, bucket=bucket, fingerprint=str(position),
-                start_date=end_date, logs=digest_logs)
+                key=key,
+                bucket=bucket,
+                fingerprint=str(position),
+                start_date=end_date,
+                logs=digest_logs,
+            )
         else:
             digest = MockDigestProvider.create_digest(
-                key=key, bucket=bucket, fingerprint=str(position),
-                start_date=end_date, next_bucket=next_bucket, next_key=next_key,
-                logs=digest_logs)
-            # Mark the digest as invalid if specified in the action.
+                key=key,
+                bucket=bucket,
+                fingerprint=str(position),
+                start_date=end_date,
+                next_bucket=next_bucket,
+                next_key=next_key,
+                logs=digest_logs,
+            )
             if action == 'invalid':
                 digest['_invalid'] = True
+
+        digest['_signature'] = 'mock_signature'
+        digest['_signature_algorithm'] = 'SHA256'
+
+        if is_backfill_digest_key(key):
+            digest['_backfill_generation_timestamp'] = '2025-09-01T00:00:00Z'
+
         return digest, json.dumps(digest)
 
-    def load_digest_keys_in_range(self, bucket, prefix, start_date, end_date):
+    def load_digest_keys_in_range(
+        self, bucket, prefix, start_date, end_date, is_backfill=False
+    ):
         self.calls['load_digest_keys_in_range'].append(locals())
+        if is_backfill:
+            return list(self.backfill_digests)
         return list(self.digests)
 
     def fetch_digest(self, bucket, key):
         self.calls['fetch_digest'].append(key)
-        position = self.digests.index(key)
+        position = (
+            self.backfill_digests.index(key)
+            if is_backfill_digest_key(key)
+            else self.digests.index(key)
+        )
         action = self.actions[position]
         # Simulate a digest missing from S3
         if action == 'missing':
             raise ClientError(
-                {'Error': {'Code': 'NoSuchKey', 'Message': 'foo'}},
-                'GetObject')
-        next_key = self.get_key_at_position(position - 1)
+                {'Error': {'Code': 'NoSuchKey', 'Message': 'foo'}}, 'GetObject'
+            )
+
+        next_key = self.get_key_at_position(
+            position - 1, is_backfill_digest_key(key)
+        )
         next_bucket = int(bucket)
         if action == 'bucket_change':
             next_bucket += 1
-        return self.create_link(key, next_key, str(next_bucket), position,
-                                action, self.logs, bucket)
+
+        return self.create_link(
+            key,
+            next_key,
+            str(next_bucket),
+            position,
+            action,
+            self.logs,
+            bucket,
+        )
 
 
 class TestValidation(unittest.TestCase):
@@ -196,14 +264,16 @@ class TestValidation(unittest.TestCase):
     def test_ensures_cloudtrail_arns_are_valid_when_missing_resource(self):
         try:
             assert_cloudtrail_arn_is_valid(
-                'arn:aws:cloudtrail:us-east-1:%s:foo' % TEST_ACCOUNT_ID)
+                f'arn:aws:cloudtrail:us-east-1:{TEST_ACCOUNT_ID}:foo'
+            )
             self.fail('Should have failed')
         except ValueError as e:
             self.assertIn('Invalid trail ARN provided', str(e))
 
     def test_allows_valid_arns(self):
         assert_cloudtrail_arn_is_valid(
-            'arn:aws:cloudtrail:us-east-1:%s:trail/foo' % TEST_ACCOUNT_ID)
+            f'arn:aws:cloudtrail:us-east-1:{TEST_ACCOUNT_ID}:trail/foo'
+        )
 
     def test_normalizes_date_timezones(self):
         date = datetime(2015, 8, 21, tzinfo=tz.tzlocal())
@@ -211,19 +281,69 @@ class TestValidation(unittest.TestCase):
         self.assertEqual(tz.tzutc(), normalized.tzinfo)
 
     def test_extracts_dates_from_digest_keys(self):
-        arn = ('AWSLogs/{account}/CloudTrail-Digest/us-east-1/2015/08/'
-               '16/{account}_CloudTrail-Digest_us-east-1_foo_us-east-1_'
-               '20150816T230550Z.json.gz').format(account=TEST_ACCOUNT_ID)
+        arn = (
+            f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/2015/08/'
+            f'16/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_'
+            '20150816T230550Z.json.gz'
+        )
         self.assertEqual('20150816T230550Z', extract_digest_key_date(arn))
+
+    def test_is_backfill_digest_key_identifies_standard_digest(self):
+        standard_key = (
+            f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/2015/08/'
+            f'16/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_'
+            '20150816T230550Z.json.gz'
+        )
+        self.assertFalse(is_backfill_digest_key(standard_key))
+
+    def test_is_backfill_digest_key_identifies_backfill_digest(self):
+        backfill_key = (
+            f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/2015/08/'
+            f'16/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_'
+            '20150816T230550Z_backfill.json.gz'
+        )
+        self.assertTrue(is_backfill_digest_key(backfill_key))
+
+    def test_is_backfill_digest_key_handles_edge_cases(self):
+        # Test with different file extensions
+        self.assertFalse(is_backfill_digest_key('file.txt'))
+        self.assertFalse(is_backfill_digest_key('file_backfill.txt'))
+        self.assertFalse(is_backfill_digest_key('file.json.gz'))
+
+        # Test with backfill in middle of filename
+        self.assertFalse(is_backfill_digest_key('file_backfill_other.json.gz'))
+
+    def test_extracts_dates_from_backfill_digest_keys(self):
+        backfill_key = (
+            f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/2015/08/'
+            f'16/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_'
+            '20150816T230550Z_backfill.json.gz'
+        )
+        self.assertEqual(
+            '20150816T230550Z', extract_digest_key_date(backfill_key)
+        )
+
+    def test_extracts_dates_from_standard_digest_keys(self):
+        standard_key = (
+            f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/2015/08/'
+            f'16/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_us-east-1_'
+            '20150816T230550Z.json.gz'
+        )
+        self.assertEqual(
+            '20150816T230550Z', extract_digest_key_date(standard_key)
+        )
 
     def test_creates_traverser(self):
         mock_s3_provider = mock.Mock()
         traverser = create_digest_traverser(
-            trail_arn=TEST_TRAIL_ARN, cloudtrail_client=mock.Mock(),
+            trail_arn=TEST_TRAIL_ARN,
+            cloudtrail_client=mock.Mock(),
             organization_client=mock.Mock(),
             trail_source_region='us-east-1',
             s3_client_provider=mock_s3_provider,
-            bucket='bucket', prefix='prefix')
+            bucket='bucket',
+            prefix='prefix',
+        )
         self.assertEqual('bucket', traverser.starting_bucket)
         self.assertEqual('prefix', traverser.starting_prefix)
         digest_provider = traverser.digest_provider
@@ -233,32 +353,43 @@ class TestValidation(unittest.TestCase):
     def test_creates_traverser_account_id(self):
         mock_s3_provider = mock.Mock()
         traverser = create_digest_traverser(
-            trail_arn=TEST_TRAIL_ARN, cloudtrail_client=mock.Mock(),
+            trail_arn=TEST_TRAIL_ARN,
+            cloudtrail_client=mock.Mock(),
             organization_client=mock.Mock(),
             trail_source_region='us-east-1',
             s3_client_provider=mock_s3_provider,
-            bucket='bucket', prefix='prefix',
-            account_id=TEST_ORGANIZATION_ACCOUNT_ID)
+            bucket='bucket',
+            prefix='prefix',
+            account_id=TEST_ORGANIZATION_ACCOUNT_ID,
+        )
         self.assertEqual('bucket', traverser.starting_bucket)
         self.assertEqual('prefix', traverser.starting_prefix)
         digest_provider = traverser.digest_provider
         self.assertEqual('us-east-1', digest_provider.trail_home_region)
         self.assertEqual('foo', digest_provider.trail_name)
         self.assertEqual(
-            TEST_ORGANIZATION_ACCOUNT_ID, digest_provider.account_id)
+            TEST_ORGANIZATION_ACCOUNT_ID, digest_provider.account_id
+        )
 
     def test_creates_traverser_and_gets_trail_by_arn(self):
         cloudtrail_client = mock.Mock()
-        cloudtrail_client.describe_trails.return_value = {'trailList': [
-            {'TrailARN': TEST_TRAIL_ARN,
-             'S3BucketName': 'bucket', 'S3KeyPrefix': 'prefix',
-             'IsOrganizationTrail': False}
-        ]}
+        cloudtrail_client.describe_trails.return_value = {
+            'trailList': [
+                {
+                    'TrailARN': TEST_TRAIL_ARN,
+                    'S3BucketName': 'bucket',
+                    'S3KeyPrefix': 'prefix',
+                    'IsOrganizationTrail': False,
+                }
+            ]
+        }
         traverser = create_digest_traverser(
-            trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+            trail_arn=TEST_TRAIL_ARN,
+            trail_source_region='us-east-1',
             cloudtrail_client=cloudtrail_client,
             organization_client=mock.Mock(),
-            s3_client_provider=mock.Mock())
+            s3_client_provider=mock.Mock(),
+        )
         self.assertEqual('bucket', traverser.starting_bucket)
         self.assertEqual('prefix', traverser.starting_prefix)
         digest_provider = traverser.digest_provider
@@ -268,15 +399,22 @@ class TestValidation(unittest.TestCase):
 
     def test_create_traverser_organizational_trail_not_launched(self):
         cloudtrail_client = mock.Mock()
-        cloudtrail_client.describe_trails.return_value = {'trailList': [
-            {'TrailARN': TEST_TRAIL_ARN,
-             'S3BucketName': 'bucket', 'S3KeyPrefix': 'prefix'}
-        ]}
+        cloudtrail_client.describe_trails.return_value = {
+            'trailList': [
+                {
+                    'TrailARN': TEST_TRAIL_ARN,
+                    'S3BucketName': 'bucket',
+                    'S3KeyPrefix': 'prefix',
+                }
+            ]
+        }
         traverser = create_digest_traverser(
-            trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+            trail_arn=TEST_TRAIL_ARN,
+            trail_source_region='us-east-1',
             cloudtrail_client=cloudtrail_client,
             organization_client=mock.Mock(),
-            s3_client_provider=mock.Mock())
+            s3_client_provider=mock.Mock(),
+        )
         self.assertEqual('bucket', traverser.starting_bucket)
         self.assertEqual('prefix', traverser.starting_prefix)
         digest_provider = traverser.digest_provider
@@ -287,11 +425,13 @@ class TestValidation(unittest.TestCase):
     def test_creates_traverser_and_gets_trail_by_arn_s3_bucket_specified(self):
         cloudtrail_client = mock.Mock()
         traverser = create_digest_traverser(
-            trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+            trail_arn=TEST_TRAIL_ARN,
+            trail_source_region='us-east-1',
             cloudtrail_client=cloudtrail_client,
             organization_client=mock.Mock(),
             s3_client_provider=mock.Mock(),
-            bucket="bucket")
+            bucket="bucket",
+        )
         self.assertEqual('bucket', traverser.starting_bucket)
         digest_provider = traverser.digest_provider
         self.assertEqual('us-east-1', digest_provider.trail_home_region)
@@ -300,11 +440,16 @@ class TestValidation(unittest.TestCase):
 
     def test_creates_traverser_and_gets_organization_id(self):
         cloudtrail_client = mock.Mock()
-        cloudtrail_client.describe_trails.return_value = {'trailList': [
-            {'TrailARN': TEST_TRAIL_ARN,
-             'S3BucketName': 'bucket', 'S3KeyPrefix': 'prefix',
-             'IsOrganizationTrail': True}
-        ]}
+        cloudtrail_client.describe_trails.return_value = {
+            'trailList': [
+                {
+                    'TrailARN': TEST_TRAIL_ARN,
+                    'S3BucketName': 'bucket',
+                    'S3KeyPrefix': 'prefix',
+                    'IsOrganizationTrail': True,
+                }
+            ]
+        }
         organization_client = mock.Mock()
         organization_client.describe_organization.return_value = {
             "Organization": {
@@ -313,10 +458,13 @@ class TestValidation(unittest.TestCase):
             }
         }
         traverser = create_digest_traverser(
-            trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+            trail_arn=TEST_TRAIL_ARN,
+            trail_source_region='us-east-1',
             cloudtrail_client=cloudtrail_client,
             organization_client=organization_client,
-            s3_client_provider=mock.Mock(), account_id=TEST_ACCOUNT_ID)
+            s3_client_provider=mock.Mock(),
+            account_id=TEST_ACCOUNT_ID,
+        )
         self.assertEqual('bucket', traverser.starting_bucket)
         self.assertEqual('prefix', traverser.starting_prefix)
         digest_provider = traverser.digest_provider
@@ -326,11 +474,16 @@ class TestValidation(unittest.TestCase):
 
     def test_creates_traverser_organization_trail_missing_account_id(self):
         cloudtrail_client = mock.Mock()
-        cloudtrail_client.describe_trails.return_value = {'trailList': [
-            {'TrailARN': TEST_TRAIL_ARN,
-             'S3BucketName': 'bucket', 'S3KeyPrefix': 'prefix',
-             'IsOrganizationTrail': True}
-        ]}
+        cloudtrail_client.describe_trails.return_value = {
+            'trailList': [
+                {
+                    'TrailARN': TEST_TRAIL_ARN,
+                    'S3BucketName': 'bucket',
+                    'S3KeyPrefix': 'prefix',
+                    'IsOrganizationTrail': True,
+                }
+            ]
+        }
         organization_client = mock.Mock()
         organization_client.describe_organization.return_value = {
             "Organization": {
@@ -340,81 +493,96 @@ class TestValidation(unittest.TestCase):
         }
         with self.assertRaises(ParameterRequiredError):
             create_digest_traverser(
-                trail_arn=TEST_TRAIL_ARN, trail_source_region='us-east-1',
+                trail_arn=TEST_TRAIL_ARN,
+                trail_source_region='us-east-1',
                 cloudtrail_client=cloudtrail_client,
                 organization_client=organization_client,
-                s3_client_provider=mock.Mock())
+                s3_client_provider=mock.Mock(),
+            )
 
 
 class TestPublicKeyProvider(unittest.TestCase):
     def test_returns_public_key_in_range(self):
         cloudtrail_client = mock.Mock()
-        cloudtrail_client.list_public_keys.return_value = {'PublicKeyList': [
-            {'Fingerprint': 'a', 'OtherData': 'a', 'Value': 'a'},
-            {'Fingerprint': 'b', 'OtherData': 'b', 'Value': 'b'},
-            {'Fingerprint': 'c', 'OtherData': 'c', 'Value': 'c'},
-        ]}
+        cloudtrail_client.list_public_keys.return_value = {
+            'PublicKeyList': [
+                {'Fingerprint': 'a', 'OtherData': 'a', 'Value': 'a'},
+                {'Fingerprint': 'b', 'OtherData': 'b', 'Value': 'b'},
+                {'Fingerprint': 'c', 'OtherData': 'c', 'Value': 'c'},
+            ]
+        }
         provider = PublicKeyProvider(cloudtrail_client)
         start_date = START_DATE
         end_date = start_date + timedelta(days=2)
         keys = provider.get_public_keys(start_date, end_date)
-        self.assertEqual({
-            'a': {'Fingerprint': 'a', 'OtherData': 'a', 'Value': 'a'},
-            'b': {'Fingerprint': 'b', 'OtherData': 'b', 'Value': 'b'},
-            'c': {'Fingerprint': 'c', 'OtherData': 'c', 'Value': 'c'},
-        }, keys)
+        self.assertEqual(
+            {
+                'a': {'Fingerprint': 'a', 'OtherData': 'a', 'Value': 'a'},
+                'b': {'Fingerprint': 'b', 'OtherData': 'b', 'Value': 'b'},
+                'c': {'Fingerprint': 'c', 'OtherData': 'c', 'Value': 'c'},
+            },
+            keys,
+        )
         cloudtrail_client.list_public_keys.assert_has_calls(
-            [mock.call(EndTime=end_date, StartTime=start_date)])
+            [mock.call(EndTime=end_date, StartTime=start_date)]
+        )
 
 
 class TestSha256RSADigestValidator(unittest.TestCase):
     def setUp(self):
-        self._digest_data = {'digestStartTime': 'baz',
-                             'digestEndTime': 'foo',
-                             'awsAccountId': 'account',
-                             'digestPublicKeyFingerprint': 'abc',
-                             'digestS3Bucket': 'bucket',
-                             'digestS3Object': 'object',
-                             'previousDigestSignature': 'xyz'}
+        self._digest_data = {
+            'digestStartTime': 'baz',
+            'digestEndTime': 'foo',
+            'awsAccountId': 'account',
+            'digestPublicKeyFingerprint': 'abc',
+            'digestS3Bucket': 'bucket',
+            'digestS3Object': 'object',
+            'previousDigestSignature': 'xyz',
+        }
         self._inflated_digest = json.dumps(self._digest_data).encode()
         self._digest_data['_signature'] = 'aeff'
 
     def test_validates_digests(self):
         (public_key, private_key) = rsa.newkeys(512)
         sha256_hash = hashlib.sha256(self._inflated_digest)
-        string_to_sign = "%s\n%s/%s\n%s\n%s" % (
-            self._digest_data['digestEndTime'],
-            self._digest_data['digestS3Bucket'],
-            self._digest_data['digestS3Object'],
-            sha256_hash.hexdigest(),
-            self._digest_data['previousDigestSignature'])
+        string_to_sign = f"{self._digest_data['digestEndTime']}\n{self._digest_data['digestS3Bucket']}/{self._digest_data['digestS3Object']}\n{sha256_hash.hexdigest()}\n{self._digest_data['previousDigestSignature']}"
         signature = rsa.sign(string_to_sign.encode(), private_key, 'SHA-256')
         self._digest_data['_signature'] = binascii.hexlify(signature)
         validator = Sha256RSADigestValidator()
         public_key_b64 = base64.b64encode(public_key.save_pkcs1(format='DER'))
-        validator.validate('b', 'k', public_key_b64, self._digest_data,
-                           self._inflated_digest)
+        validator.validate(
+            'b', 'k', public_key_b64, self._digest_data, self._inflated_digest
+        )
 
     def test_does_not_expose_underlying_key_decoding_error(self):
         validator = Sha256RSADigestValidator()
         try:
-            validator.validate(
-                'b', 'k', 'YQo=', self._digest_data, 'invalid'.encode())
+            validator.validate('b', 'k', 'YQo=', self._digest_data, b'invalid')
             self.fail('Should have failed')
         except DigestError as e:
-            self.assertEqual(('Digest file\ts3://b/k\tINVALID: Unable to load '
-                              'PKCS #1 key with fingerprint abc'), str(e))
+            self.assertEqual(
+                (
+                    'Digest file\ts3://b/k\tINVALID: Unable to load '
+                    'PKCS #1 key with fingerprint abc'
+                ),
+                str(e),
+            )
 
     def test_does_not_expose_underlying_validation_error(self):
         validator = Sha256RSADigestValidator()
         try:
             validator.validate(
-                'b', 'k', VALID_TEST_KEY, self._digest_data,
-                'invalid'.encode())
+                'b', 'k', VALID_TEST_KEY, self._digest_data, b'invalid'
+            )
             self.fail('Should have failed')
         except DigestSignatureError as e:
-            self.assertEqual(('Digest file\ts3://b/k\tINVALID: signature '
-                              'verification failed'), str(e))
+            self.assertEqual(
+                (
+                    'Digest file\ts3://b/k\tINVALID: signature '
+                    'verification failed'
+                ),
+                str(e),
+            )
 
     def test_properly_signs_when_no_previous_signature(self):
         validator = Sha256RSADigestValidator()
@@ -422,28 +590,33 @@ class TestSha256RSADigestValidator(unittest.TestCase):
             'digestEndTime': 'a',
             'digestS3Bucket': 'b',
             'digestS3Object': 'c',
-            'previousDigestSignature': None}
-        signed = validator._create_string_to_sign(digest_data, 'abc'.encode())
+            'previousDigestSignature': None,
+        }
+        signed = validator._create_string_to_sign(digest_data, b'abc')
         self.assertEqual(
-            ('a\nb/c\nba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff6'
-             '1f20015ad\nnull').encode(), signed)
+            (
+                b'a\nb/c\nba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff6'
+                b'1f20015ad\nnull'
+            ),
+            signed,
+        )
 
 
 class TestDigestProvider(BaseAWSCommandParamsTest):
     def _fake_key(self, date):
         parsed = parser.parse(date)
-        return ('prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1/{year}/'
-                '{month}/{day}/{account}_CloudTrail-Digest_us-east-1_foo_'
-                'us-east-1_{date}.json.gz').format(date=date, year=parsed.year,
-                                                   month=parsed.month,
-                                                   account=TEST_ACCOUNT_ID,
-                                                   day=parsed.day)
+        return (
+            f'prefix/AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/{parsed.year}/'
+            f'{parsed.month}/{parsed.day}/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_'
+            f'us-east-1_{date}.json.gz'
+        )
 
     def _get_mock_provider(self, s3_client):
         mock_s3_client_provider = mock.Mock()
         mock_s3_client_provider.get_client.return_value = s3_client
         return DigestProvider(
-            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1')
+            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1'
+        )
 
     def test_initializes_public_properties(self):
         client = mock.Mock()
@@ -454,34 +627,44 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
 
     def test_returns_digests_in_range(self):
         s3_client = self.driver.session.create_client('s3')
-        keys = [self._fake_key(format_date(START_DATE - timedelta(days=1))),
-                self._fake_key(format_date(START_DATE + timedelta(days=1))),
-                self._fake_key(format_date(START_DATE + timedelta(days=2))),
-                self._fake_key(format_date(START_DATE + timedelta(days=3))),
-                self._fake_key(format_date(END_DATE + timedelta(hours=1))),
-                self._fake_key(format_date(END_DATE + timedelta(days=1)))]
+        keys = [
+            self._fake_key(format_date(START_DATE - timedelta(days=1))),
+            self._fake_key(format_date(START_DATE + timedelta(days=1))),
+            self._fake_key(format_date(START_DATE + timedelta(days=2))),
+            self._fake_key(format_date(START_DATE + timedelta(days=3))),
+            self._fake_key(format_date(END_DATE + timedelta(hours=1))),
+            self._fake_key(format_date(END_DATE + timedelta(days=1))),
+        ]
         # Create a key that looks similar but for a different trail.
         bad_name = keys[3].replace('foo', 'baz')
         # Create a key that looks similar but is from a different trail source
         # region (e.g., CloudTrail-Digest/us-west-2).
         bad_region = keys[3].replace(
-            'CloudTrail-Digest/us-east-1', 'CloudTrail-Digest/us-west-2')
+            'CloudTrail-Digest/us-east-1', 'CloudTrail-Digest/us-west-2'
+        )
         bad_region = bad_region.replace(
-            'CloudTrail-Digest_us-east-1', 'CloudTrail-Digest_us-west-2')
+            'CloudTrail-Digest_us-east-1', 'CloudTrail-Digest_us-west-2'
+        )
         self.parsed_responses = [
-            {"Contents": [{"Key": keys[0]},        # skip (date <)
-                          {"Key": keys[1]},
-                          {"Key": keys[2]},
-                          {"Key": 'foo/baz/bar'},  # skip (regex (bogus))
-                          {"Key": bad_name},       # skip (regex (trail name))
-                          {"Key": bad_region},     # skip (regex (source))
-                          {"Key": keys[3]},
-                          {"Key": keys[4]},        # hour is +1, but keep
-                          {"Key": keys[5]}]}]      # skip (date >)
+            {
+                "Contents": [
+                    {"Key": keys[0]},  # skip (date <)
+                    {"Key": keys[1]},
+                    {"Key": keys[2]},
+                    {"Key": 'foo/baz/bar'},  # skip (regex (bogus))
+                    {"Key": bad_name},  # skip (regex (trail name))
+                    {"Key": bad_region},  # skip (regex (source))
+                    {"Key": keys[3]},
+                    {"Key": keys[4]},  # hour is +1, but keep
+                    {"Key": keys[5]},  # skip (date >)
+                ]
+            }
+        ]
         self.patch_make_request()
         provider = self._get_mock_provider(s3_client)
         digests = provider.load_digest_keys_in_range(
-            'foo', 'prefix', START_DATE, END_DATE)
+            'foo', 'prefix', START_DATE, END_DATE
+        )
         self.assertNotIn(bad_name, digests)
         self.assertNotIn(bad_region, digests)
         self.assertEqual(keys[1], digests[0])
@@ -495,16 +678,18 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
         mock_search = mock_paginate.return_value.search
         mock_search.return_value = []
         provider = self._get_mock_provider(s3_client)
-        provider.load_digest_keys_in_range(
-            '1', 'prefix', START_DATE, END_DATE)
-        marker = ('prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1/'
-                  '2014/08/09/{account}_CloudTrail-Digest_us-east-1_foo_'
-                  'us-east-1_20140809T235900Z.json.gz')
+        provider.load_digest_keys_in_range('1', 'prefix', START_DATE, END_DATE)
+        marker = (
+            'prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1/'
+            '2014/08/09/{account}_CloudTrail-Digest_us-east-1_foo_'
+            'us-east-1_20140809T235900Z.json.gz'
+        )
         prefix = 'prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1'
         mock_paginate.assert_called_once_with(
             Bucket='1',
             Marker=marker.format(account=TEST_ACCOUNT_ID),
-            Prefix=prefix.format(account=TEST_ACCOUNT_ID))
+            Prefix=prefix.format(account=TEST_ACCOUNT_ID),
+        )
 
     def test_calls_list_objects_correctly_org_trails(self):
         s3_client = mock.Mock()
@@ -514,11 +699,14 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
         mock_search.return_value = []
         mock_s3_client_provider.get_client.return_value = s3_client
         provider = DigestProvider(
-            mock_s3_client_provider, TEST_ORGANIZATION_ACCOUNT_ID,
-            'foo', 'us-east-1', 'us-east-1',
-            TEST_ORGANIZATION_ID)
-        provider.load_digest_keys_in_range(
-            '1', 'prefix', START_DATE, END_DATE)
+            mock_s3_client_provider,
+            TEST_ORGANIZATION_ACCOUNT_ID,
+            'foo',
+            'us-east-1',
+            'us-east-1',
+            TEST_ORGANIZATION_ID,
+        )
+        provider.load_digest_keys_in_range('1', 'prefix', START_DATE, END_DATE)
         marker = (
             'prefix/AWSLogs/{organization_id}/{member_account}/'
             'CloudTrail-Digest/us-east-1/'
@@ -533,64 +721,73 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
             Bucket='1',
             Marker=marker.format(
                 member_account=TEST_ORGANIZATION_ACCOUNT_ID,
-                organization_id=TEST_ORGANIZATION_ID
+                organization_id=TEST_ORGANIZATION_ID,
             ),
             Prefix=prefix.format(
                 member_account=TEST_ORGANIZATION_ACCOUNT_ID,
-                organization_id=TEST_ORGANIZATION_ID
-            )
+                organization_id=TEST_ORGANIZATION_ID,
+            ),
         )
 
     def test_create_digest_prefix_without_key_prefix(self):
         mock_s3_client_provider = mock.Mock()
         provider = DigestProvider(
-            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1')
+            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1'
+        )
         prefix = provider._create_digest_prefix(START_DATE, None)
-        expected = 'AWSLogs/{account}/CloudTrail-Digest/us-east-1'.format(
-            account=TEST_ACCOUNT_ID)
+        expected = f'AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1'
         self.assertEqual(expected, prefix)
 
     def test_create_digest_prefix_with_key_prefix(self):
         mock_s3_client_provider = mock.Mock()
         provider = DigestProvider(
-            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1')
+            mock_s3_client_provider, TEST_ACCOUNT_ID, 'foo', 'us-east-1'
+        )
         prefix = provider._create_digest_prefix(START_DATE, 'my-prefix')
-        expected = 'my-prefix/AWSLogs/{account}/CloudTrail-Digest/us-east-1'.format(
-            account=TEST_ACCOUNT_ID)
+        expected = (
+            f'my-prefix/AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1'
+        )
         self.assertEqual(expected, prefix)
 
     def test_create_digest_prefix_org_trail(self):
         mock_s3_client_provider = mock.Mock()
         provider = DigestProvider(
-            mock_s3_client_provider, TEST_ORGANIZATION_ACCOUNT_ID,
-            'foo', 'us-east-1', 'us-east-1', TEST_ORGANIZATION_ID)
+            mock_s3_client_provider,
+            TEST_ORGANIZATION_ACCOUNT_ID,
+            'foo',
+            'us-east-1',
+            'us-east-1',
+            TEST_ORGANIZATION_ID,
+        )
         prefix = provider._create_digest_prefix(START_DATE, None)
-        expected = 'AWSLogs/{org}/{account}/CloudTrail-Digest/us-east-1'.format(
-            org=TEST_ORGANIZATION_ID,
-            account=TEST_ORGANIZATION_ACCOUNT_ID)
+        expected = f'AWSLogs/{TEST_ORGANIZATION_ID}/{TEST_ORGANIZATION_ACCOUNT_ID}/CloudTrail-Digest/us-east-1'
         self.assertEqual(expected, prefix)
 
     def test_create_digest_prefix_org_trail_with_key_prefix(self):
         mock_s3_client_provider = mock.Mock()
         provider = DigestProvider(
-            mock_s3_client_provider, TEST_ORGANIZATION_ACCOUNT_ID,
-            'foo', 'us-east-1', 'us-east-1', TEST_ORGANIZATION_ID)
+            mock_s3_client_provider,
+            TEST_ORGANIZATION_ACCOUNT_ID,
+            'foo',
+            'us-east-1',
+            'us-east-1',
+            TEST_ORGANIZATION_ID,
+        )
         prefix = provider._create_digest_prefix(START_DATE, 'custom-prefix')
-        expected = 'custom-prefix/AWSLogs/{org}/{account}/CloudTrail-Digest/us-east-1'.format(
-            org=TEST_ORGANIZATION_ID,
-            account=TEST_ORGANIZATION_ACCOUNT_ID)
+        expected = f'custom-prefix/AWSLogs/{TEST_ORGANIZATION_ID}/{TEST_ORGANIZATION_ACCOUNT_ID}/CloudTrail-Digest/us-east-1'
         self.assertEqual(expected, prefix)
 
     def test_ensures_digest_has_proper_metadata(self):
         out = BytesIO()
         f = gzip.GzipFile(fileobj=out, mode="wb")
-        f.write('{"foo":"bar"}'.encode())
+        f.write(b'{"foo":"bar"}')
         f.close()
         gzipped_data = out.getvalue()
         s3_client = mock.Mock()
         s3_client.get_object.return_value = {
             'Body': BytesIO(gzipped_data),
-            'Metadata': {}}
+            'Metadata': {},
+        }
         provider = self._get_mock_provider(s3_client)
         with self.assertRaises(DigestSignatureError):
             provider.fetch_digest('bucket', 'key')
@@ -598,8 +795,9 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
     def test_ensures_digest_can_be_gzip_inflated(self):
         s3_client = mock.Mock()
         s3_client.get_object.return_value = {
-            'Body': BytesIO('foo'.encode()),
-            'Metadata': {}}
+            'Body': BytesIO(b'foo'),
+            'Metadata': {},
+        }
         provider = self._get_mock_provider(s3_client)
         with self.assertRaises(InvalidDigestFormat):
             provider.fetch_digest('bucket', 'key')
@@ -614,7 +812,8 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
         s3_client = mock.Mock()
         s3_client.get_object.return_value = {
             'Body': BytesIO(gzipped_data),
-            'Metadata': {'signature': 'abc', 'signature-algorithm': 'SHA256'}}
+            'Metadata': {'signature': 'abc', 'signature-algorithm': 'SHA256'},
+        }
         provider = self._get_mock_provider(s3_client)
         with self.assertRaises(InvalidDigestFormat):
             provider.fetch_digest('bucket', 'key')
@@ -629,20 +828,153 @@ class TestDigestProvider(BaseAWSCommandParamsTest):
         s3_client = mock.Mock()
         s3_client.get_object.return_value = {
             'Body': BytesIO(gzipped_data),
-            'Metadata': {'signature': 'abc', 'signature-algorithm': 'SHA256'}}
+            'Metadata': {'signature': 'abc', 'signature-algorithm': 'SHA256'},
+        }
         provider = self._get_mock_provider(s3_client)
         result = provider.fetch_digest('bucket', 'key')
-        self.assertEqual({'foo': 'bar', '_signature': 'abc',
-                          '_signature_algorithm': 'SHA256'}, result[0])
+        self.assertEqual(
+            {
+                'foo': 'bar',
+                '_signature': 'abc',
+                '_signature_algorithm': 'SHA256',
+            },
+            result[0],
+        )
         self.assertEqual(json_str.encode(), result[1])
+
+    def _fake_backfill_key(self, date):
+        parsed = parser.parse(date)
+        return (
+            f'prefix/AWSLogs/{TEST_ACCOUNT_ID}/CloudTrail-Digest/us-east-1/{parsed.year}/'
+            f'{parsed.month}/{parsed.day}/{TEST_ACCOUNT_ID}_CloudTrail-Digest_us-east-1_foo_'
+            f'us-east-1_{date}_backfill.json.gz'
+        )
+
+    def test_load_all_digest_keys_in_range_separates_standard_and_backfill(
+        self,
+    ):
+        s3_client = self.driver.session.create_client('s3')
+        standard_keys = [
+            self._fake_key(format_date(START_DATE + timedelta(days=1))),
+            self._fake_key(format_date(START_DATE + timedelta(days=2))),
+        ]
+        backfill_keys = [
+            self._fake_backfill_key(
+                format_date(START_DATE + timedelta(days=1))
+            ),
+            self._fake_backfill_key(
+                format_date(START_DATE + timedelta(days=2))
+            ),
+        ]
+
+        self.parsed_responses = [
+            {
+                "Contents": [
+                    {"Key": standard_keys[0]},
+                    {"Key": backfill_keys[0]},
+                    {"Key": standard_keys[1]},
+                    {"Key": backfill_keys[1]},
+                ]
+            }
+        ]
+        self.patch_make_request()
+        provider = self._get_mock_provider(s3_client)
+
+        standard_digests, backfill_digests = (
+            provider.load_all_digest_keys_in_range(
+                'foo', 'prefix', START_DATE, END_DATE
+            )
+        )
+
+        self.assertEqual(standard_keys, standard_digests)
+        self.assertEqual(backfill_keys, backfill_digests)
+
+    def test_load_digest_keys_in_range_uses_cache(self):
+        s3_client = mock.Mock()
+        mock_paginate = s3_client.get_paginator.return_value.paginate
+        mock_search = mock_paginate.return_value.search
+        mock_search.return_value = []
+        provider = self._get_mock_provider(s3_client)
+
+        provider.load_digest_keys_in_range(
+            'bucket', 'prefix', START_DATE, END_DATE, is_backfill=False
+        )
+        self.assertEqual(1, mock_paginate.call_count)
+
+        provider.load_digest_keys_in_range(
+            'bucket', 'prefix', START_DATE, END_DATE, is_backfill=True
+        )
+        self.assertEqual(1, mock_paginate.call_count)
+
+        provider.load_digest_keys_in_range(
+            'bucket', 'prefix', START_DATE, START_DATE, is_backfill=False
+        )
+        self.assertEqual(2, mock_paginate.call_count)
+
+    def test_fetches_backfill_digests_with_metadata(self):
+        json_str = '{"foo":"bar"}'
+        out = BytesIO()
+        f = gzip.GzipFile(fileobj=out, mode="wb")
+        f.write(json_str.encode())
+        f.close()
+        gzipped_data = out.getvalue()
+        s3_client = mock.Mock()
+        s3_client.get_object.return_value = {
+            'Body': BytesIO(gzipped_data),
+            'Metadata': {
+                'signature': 'abc',
+                'signature-algorithm': 'SHA256',
+                'backfill-generation-timestamp': '2025-09-01T00:00:00Z',
+            },
+        }
+        provider = self._get_mock_provider(s3_client)
+        backfill_key = self._fake_backfill_key(format_date(START_DATE))
+
+        result = provider.fetch_digest('bucket', backfill_key)
+
+        self.assertEqual(
+            {
+                'foo': 'bar',
+                '_signature': 'abc',
+                '_signature_algorithm': 'SHA256',
+                '_backfill_generation_timestamp': '2025-09-01T00:00:00Z',
+            },
+            result[0],
+        )
+        self.assertEqual(json_str.encode(), result[1])
+
+    def test_ensures_backfill_digest_has_proper_metadata(self):
+        json_str = '{"foo":"bar"}'
+        out = BytesIO()
+        f = gzip.GzipFile(fileobj=out, mode="wb")
+        f.write(json_str.encode())
+        f.close()
+        gzipped_data = out.getvalue()
+        s3_client = mock.Mock()
+        s3_client.get_object.return_value = {
+            'Body': BytesIO(gzipped_data),
+            'Metadata': {
+                'signature': 'abc',
+                'signature-algorithm': 'SHA256',
+                # Missing backfill-generation-timestamp
+            },
+        }
+        provider = self._get_mock_provider(s3_client)
+        backfill_key = self._fake_backfill_key(format_date(START_DATE))
+
+        with self.assertRaises(InvalidDigestFormat):
+            provider.fetch_digest('bucket', backfill_key)
 
 
 class TestDigestTraverser(unittest.TestCase):
     def test_initializes_with_default_validator(self):
         provider = mock.Mock()
         traverser = DigestTraverser(
-            digest_provider=provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=mock.Mock())
+            digest_provider=provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=mock.Mock(),
+        )
         self.assertEqual('1', traverser.starting_bucket)
         self.assertEqual('baz', traverser.starting_prefix)
         self.assertEqual(provider, traverser.digest_provider)
@@ -654,13 +986,15 @@ class TestDigestTraverser(unittest.TestCase):
         key_provider = mock.Mock()
         key_provider.get_public_keys.return_value = []
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider)
-        digest_iter = traverser.traverse(start_date, end_date)
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+        )
+        digest_iter = traverser.traverse_digests(start_date, end_date)
         with self.assertRaises(RuntimeError):
             next(digest_iter)
-        key_provider.get_public_keys.assert_called_with(
-            start_date, end_date)
+        key_provider.get_public_keys.assert_called_with(start_date, end_date)
 
     def test_ensures_public_key_is_found(self):
         start_date = START_DATE
@@ -671,97 +1005,121 @@ class TestDigestTraverser(unittest.TestCase):
         digest_provider.trail_home_region = region
         digest_provider.load_digest_keys_in_range.return_value = [key_name]
         digest_provider.fetch_digest.return_value = (
-            {'digestEndTime': 'foo',
-             'digestStartTime': 'foo',
-             'awsAccountId': 'account',
-             'digestPublicKeyFingerprint': 'abc',
-             'digestS3Bucket': '1',
-             'digestS3Object': key_name,
-             'previousDigestSignature': 'xyz'},
-            'abc'
+            {
+                'digestEndTime': 'foo',
+                'digestStartTime': 'foo',
+                'awsAccountId': 'account',
+                'digestPublicKeyFingerprint': 'abc',
+                'digestS3Bucket': '1',
+                'digestS3Object': key_name,
+                'previousDigestSignature': 'xyz',
+            },
+            'abc',
         )
         key_provider = mock.Mock()
         key_provider.get_public_keys.return_value = [{'Fingerprint': 'a'}]
         on_invalid, calls = collecting_callback()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            on_invalid=on_invalid)
-        digest_iter = traverser.traverse(start_date, end_date)
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            on_invalid=on_invalid,
+        )
+        digest_iter = traverser.traverse_digests(start_date, end_date)
         with self.assertRaises(StopIteration):
             next(digest_iter)
         self.assertEqual(1, len(calls))
         self.assertEqual(
-            ('Digest file\ts3://1/%s\tINVALID: public key not '
-             'found in region %s for fingerprint abc' % (key_name, region)),
-            calls[0]['message'])
+            f'Digest file\ts3://1/{key_name}\tINVALID: public key not '
+            f'found in region {region} for fingerprint abc',
+            calls[0]['message'],
+        )
 
     def test_invokes_digest_validator(self):
         start_date = START_DATE
         end_date = END_DATE
         key_name = end_date.strftime(DATE_FORMAT) + '.json.gz'
-        digest = {'digestPublicKeyFingerprint': 'a',
-                  'digestS3Bucket': '1',
-                  'digestS3Object': key_name,
-                  'previousDigestSignature': '...',
-                  'digestStartTime': (end_date - timedelta(hours=1)).strftime(
-                      DATE_FORMAT),
-                  'digestEndTime': end_date.strftime(DATE_FORMAT)}
+        digest = {
+            'digestPublicKeyFingerprint': 'a',
+            'digestS3Bucket': '1',
+            'digestS3Object': key_name,
+            'previousDigestSignature': '...',
+            'digestStartTime': (end_date - timedelta(hours=1)).strftime(
+                DATE_FORMAT
+            ),
+            'digestEndTime': end_date.strftime(DATE_FORMAT),
+        }
         digest_provider = mock.Mock()
-        digest_provider.load_digest_keys_in_range.return_value = [
-            key_name]
+        digest_provider.load_digest_keys_in_range.return_value = [key_name]
         digest_provider.fetch_digest.return_value = (digest, key_name)
         key_provider = mock.Mock()
         public_keys = {'a': {'Fingerprint': 'a', 'Value': 'a'}}
         key_provider.get_public_keys.return_value = public_keys
         digest_validator = mock.Mock()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=digest_validator)
-        digest_iter = traverser.traverse(start_date, end_date)
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=digest_validator,
+        )
+        digest_iter = traverser.traverse_digests(start_date, end_date)
         self.assertEqual(digest, next(digest_iter))
         digest_validator.validate.assert_called_with(
-            '1', key_name, public_keys['a']['Value'], digest, key_name)
+            '1', key_name, public_keys['a']['Value'], digest, key_name
+        )
 
     def test_ensures_digest_from_same_location_as_json_contents(self):
         start_date = START_DATE
         end_date = END_DATE
         callback, collected = collecting_callback()
         key_name = end_date.strftime(DATE_FORMAT) + '.json.gz'
-        digest = {'digestPublicKeyFingerprint': 'a',
-                  'digestS3Bucket': 'not_same',
-                  'digestS3Object': key_name,
-                  'digestEndTime': end_date.strftime(DATE_FORMAT)}
+        digest = {
+            'digestPublicKeyFingerprint': 'a',
+            'digestS3Bucket': 'not_same',
+            'digestS3Object': key_name,
+            'digestEndTime': end_date.strftime(DATE_FORMAT),
+        }
         digest_provider = mock.Mock()
         digest_provider.load_digest_keys_in_range.return_value = [key_name]
         digest_provider.fetch_digest.return_value = (digest, key_name)
         key_provider = mock.Mock()
         digest_validator = mock.Mock()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=digest_validator, on_invalid=callback)
-        digest_iter = traverser.traverse(start_date, end_date)
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=digest_validator,
+            on_invalid=callback,
+        )
+        digest_iter = traverser.traverse_digests(start_date, end_date)
         self.assertIsNone(next(digest_iter, None))
         self.assertEqual(1, len(collected))
         self.assertEqual(
-            'Digest file\ts3://1/%s\tINVALID: invalid format' % key_name,
-            collected[0]['message'])
+            f'Digest file\ts3://1/{key_name}\tINVALID: invalid format',
+            collected[0]['message'],
+        )
 
     def test_loads_digests_in_range(self):
         start_date = START_DATE
         end_date = START_DATE + timedelta(hours=5)
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link', 'link', 'link'])
+            ['gap', 'link', 'link', 'link']
+        )
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=validator)
-        collected = list(traverser.traverse(start_date, end_date))
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+        )
+        collected = list(traverser.traverse_digests(start_date, end_date))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(
-            1, len(digest_provider.calls['load_digest_keys_in_range']))
+            1, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
         self.assertEqual(4, len(digest_provider.calls['fetch_digest']))
         self.assertEqual(4, len(collected))
 
@@ -769,13 +1127,18 @@ class TestDigestTraverser(unittest.TestCase):
         start_date = START_DATE
         end_date = END_DATE
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link', 'missing', 'link'])
+            ['gap', 'link', 'missing', 'link']
+        )
         on_missing, missing_calls = collecting_callback()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=validator, on_missing=on_missing)
-        collected = list(traverser.traverse(start_date, end_date))
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_missing=on_missing,
+        )
+        collected = list(traverser.traverse_digests(start_date, end_date))
         self.assertEqual(3, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(1, len(missing_calls))
@@ -783,27 +1146,35 @@ class TestDigestTraverser(unittest.TestCase):
         self.assertIn('bucket', missing_calls[0])
         self.assertIn('next_end_date', missing_calls[0])
         # Ensure the keys were provided in the correct order.
-        self.assertEqual(digest_provider.digests[1],
-                         missing_calls[0]['next_key'])
-        self.assertEqual(digest_provider.digests[2],
-                         missing_calls[0]['last_key'])
+        self.assertEqual(
+            digest_provider.digests[1], missing_calls[0]['next_key']
+        )
+        self.assertEqual(
+            digest_provider.digests[2], missing_calls[0]['last_key']
+        )
         # Ensure the provider was called correctly
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(
-            1, len(digest_provider.calls['load_digest_keys_in_range']))
+            1, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
         self.assertEqual(4, len(digest_provider.calls['fetch_digest']))
 
     def test_invokes_cb_and_continues_when_invalid(self):
         start_date = START_DATE
         end_date = END_DATE
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link', 'invalid', 'link', 'invalid'])
+            ['gap', 'link', 'invalid', 'link', 'invalid']
+        )
         on_invalid, invalid_calls = collecting_callback()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=validator, on_invalid=on_invalid)
-        collected = list(traverser.traverse(start_date, end_date))
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_invalid=on_invalid,
+        )
+        collected = list(traverser.traverse_digests(start_date, end_date))
         self.assertEqual(3, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(2, len(invalid_calls))
@@ -811,31 +1182,41 @@ class TestDigestTraverser(unittest.TestCase):
         self.assertIn('bucket', invalid_calls[0])
         self.assertIn('next_end_date', invalid_calls[0])
         # Ensure the keys were provided in the correct order.
-        self.assertEqual(digest_provider.digests[4],
-                         invalid_calls[0]['last_key'])
-        self.assertEqual(digest_provider.digests[3],
-                         invalid_calls[0]['next_key'])
-        self.assertEqual(digest_provider.digests[2],
-                         invalid_calls[1]['last_key'])
-        self.assertEqual(digest_provider.digests[1],
-                         invalid_calls[1]['next_key'])
+        self.assertEqual(
+            digest_provider.digests[4], invalid_calls[0]['last_key']
+        )
+        self.assertEqual(
+            digest_provider.digests[3], invalid_calls[0]['next_key']
+        )
+        self.assertEqual(
+            digest_provider.digests[2], invalid_calls[1]['last_key']
+        )
+        self.assertEqual(
+            digest_provider.digests[1], invalid_calls[1]['next_key']
+        )
         # Ensure the provider was called correctly
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(
-            1, len(digest_provider.calls['load_digest_keys_in_range']))
+            1, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
         self.assertEqual(5, len(digest_provider.calls['fetch_digest']))
 
     def test_invokes_cb_and_continues_when_gap(self):
         start_date = START_DATE
         end_date = END_DATE
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link', 'gap', 'gap'])
+            ['gap', 'link', 'gap', 'gap']
+        )
         on_gap, gap_calls = collecting_callback()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=validator, on_gap=on_gap)
-        collected = list(traverser.traverse(start_date, end_date))
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_gap=on_gap,
+        )
+        collected = list(traverser.traverse_digests(start_date, end_date))
         self.assertEqual(4, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(2, len(gap_calls))
@@ -853,43 +1234,54 @@ class TestDigestTraverser(unittest.TestCase):
         # Ensure the provider was called correctly
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(
-            1, len(digest_provider.calls['load_digest_keys_in_range']))
+            1, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
         self.assertEqual(4, len(digest_provider.calls['fetch_digest']))
 
     def test_reloads_objects_on_bucket_change(self):
         start_date = START_DATE
         end_date = END_DATE
         key_provider, digest_provider, validator = create_scenario(
-            ['gap', 'link', 'bucket_change', 'link'])
+            ['gap', 'link', 'bucket_change', 'link']
+        )
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=validator)
-        collected = list(traverser.traverse(start_date, end_date))
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+        )
+        collected = list(traverser.traverse_digests(start_date, end_date))
         self.assertEqual(4, len(collected))
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         # Ensure the provider was called correctly
         self.assertEqual(1, key_provider.get_public_keys.call_count)
         self.assertEqual(
-            2, len(digest_provider.calls['load_digest_keys_in_range']))
-        self.assertEqual(['1', '1', '2', '2'],
-                         [c['digestS3Bucket'] for c in collected])
+            2, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
+        self.assertEqual(
+            ['1', '1', '2', '2'], [c['digestS3Bucket'] for c in collected]
+        )
 
     def test_does_not_hard_fail_on_invalid_signature(self):
         start_date = START_DATE
         end_date = END_DATE
         end_timestamp = end_date.strftime(DATE_FORMAT) + '.json.gz'
-        digest = {'digestPublicKeyFingerprint': 'a',
-                  'digestS3Bucket': '1',
-                  'digestS3Object': end_timestamp,
-                  'previousDigestSignature': '...',
-                  'digestStartTime': (end_date - timedelta(hours=1)).strftime(
-                      DATE_FORMAT),
-                  'digestEndTime': end_timestamp,
-                  '_signature': '123'}
+        digest = {
+            'digestPublicKeyFingerprint': 'a',
+            'digestS3Bucket': '1',
+            'digestS3Object': end_timestamp,
+            'previousDigestSignature': '...',
+            'digestStartTime': (end_date - timedelta(hours=1)).strftime(
+                DATE_FORMAT
+            ),
+            'digestEndTime': end_timestamp,
+            '_signature': '123',
+        }
         digest_provider = mock.Mock()
         digest_provider.load_digest_keys_in_range.return_value = [
-            end_timestamp]
+            end_timestamp
+        ]
         digest_provider.fetch_digest.return_value = (digest, end_timestamp)
         key_provider = mock.Mock()
         public_keys = {'a': {'Fingerprint': 'a', 'Value': 'a'}}
@@ -897,37 +1289,251 @@ class TestDigestTraverser(unittest.TestCase):
         digest_validator = Sha256RSADigestValidator()
         on_invalid, calls = collecting_callback()
         traverser = DigestTraverser(
-            digest_provider=digest_provider, starting_bucket='1',
-            starting_prefix='baz', public_key_provider=key_provider,
-            digest_validator=digest_validator, on_invalid=on_invalid)
-        digest_iter = traverser.traverse(start_date, end_date)
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=digest_validator,
+            on_invalid=on_invalid,
+        )
+        digest_iter = traverser.traverse_digests(start_date, end_date)
         next(digest_iter, None)
         self.assertIn(
-            'Digest file\ts3://1/%s\tINVALID: ' % end_timestamp,
-            calls[0]['message'])
+            f'Digest file\ts3://1/{end_timestamp}\tINVALID: ',
+            calls[0]['message'],
+        )
+
+    def test_traverse_backfill_digests_basic(self):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=4)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'link', 'link']
+        )
+
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+        )
+
+        collected = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(4, len(collected))
+        self.assertEqual(1, key_provider.get_public_keys.call_count)
+        self.assertEqual(
+            1, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
+        self.assertEqual(4, len(digest_provider.calls['fetch_digest']))
+
+    def test_traverse_backfill_digests_with_missing(self):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=4)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'missing', 'link']
+        )
+
+        on_missing, missing_calls = collecting_callback()
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_missing=on_missing,
+        )
+
+        collected = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(3, len(collected))
+        self.assertEqual(1, key_provider.get_public_keys.call_count)
+        self.assertEqual(1, len(missing_calls))
+        self.assertIn('bucket', missing_calls[0])
+        self.assertIn('next_end_date', missing_calls[0])
+
+    def test_traverse_backfill_digests_with_invalid(self):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=5)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'invalid', 'link', 'invalid']
+        )
+
+        on_invalid, invalid_calls = collecting_callback()
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_invalid=on_invalid,
+        )
+
+        collected = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(3, len(collected))
+        self.assertEqual(1, key_provider.get_public_keys.call_count)
+        self.assertEqual(2, len(invalid_calls))
+
+    def test_traverse_backfill_digests_with_gaps(self):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=4)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'gap', 'gap']
+        )
+
+        on_gap, gap_calls = collecting_callback()
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+            on_gap=on_gap,
+        )
+
+        collected = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(4, len(collected))
+        self.assertEqual(1, key_provider.get_public_keys.call_count)
+        self.assertEqual(2, len(gap_calls))
+        for gap_call in gap_calls:
+            self.assertIn('bucket', gap_call)
+            self.assertIn('next_key', gap_call)
+
+    def test_traverse_backfill_digests_bucket_change(self):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=4)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'bucket_change', 'link']
+        )
+
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+        )
+
+        collected = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(4, len(collected))
+        self.assertEqual(1, key_provider.get_public_keys.call_count)
+        self.assertEqual(
+            2, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
+        self.assertEqual(
+            ['1', '1', '2', '2'], [c['digestS3Bucket'] for c in collected]
+        )
+
+    def test_traverse_mixed_standard_and_backfill_digests(self):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=3)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'link']
+        )
+
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+        )
+
+        standard_digests = list(
+            traverser.traverse_digests(start_date, end_date)
+        )
+        backfill_digests = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(3, len(standard_digests))
+        self.assertEqual(3, len(backfill_digests))
+        self.assertEqual(2, key_provider.get_public_keys.call_count)
+        self.assertEqual(
+            2, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
+        self.assertEqual(6, len(digest_provider.calls['fetch_digest']))
+
+    def test_traverse_backfill_digests_cache_miss_triggers_multiple_api_calls(
+        self,
+    ):
+        start_date = START_DATE
+        end_date = START_DATE + timedelta(hours=3)
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap', 'link', 'link']
+        )
+
+        call_count = 0
+
+        def mock_get_public_keys(start_date, end_date):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return {'2': {'Fingerprint': '2', 'Value': 'ffaa02'}}
+            elif call_count == 2:
+                return {'1': {'Fingerprint': '1', 'Value': 'ffaa01'}}
+            else:
+                return {'0': {'Fingerprint': '0', 'Value': 'ffaa00'}}
+
+        key_provider.get_public_keys.side_effect = mock_get_public_keys
+
+        traverser = DigestTraverser(
+            digest_provider=digest_provider,
+            starting_bucket='1',
+            starting_prefix='baz',
+            public_key_provider=key_provider,
+            digest_validator=validator,
+        )
+
+        collected = list(
+            traverser.traverse_digests(start_date, end_date, True)
+        )
+
+        self.assertEqual(3, len(collected))
+        self.assertEqual(3, key_provider.get_public_keys.call_count)
+        self.assertEqual(
+            1, len(digest_provider.calls['load_digest_keys_in_range'])
+        )
+        self.assertEqual(3, len(digest_provider.calls['fetch_digest']))
 
 
 class TestCloudTrailCommand(BaseAWSCommandParamsTest):
     def test_s3_client_created_lazily(self):
         session = mock.Mock()
         command = CloudTrailValidateLogs(session)
-        parsed_globals = mock.Mock(region=None, verify_ssl=None, endpoint_url=None)
+        parsed_globals = mock.Mock(
+            region=None, verify_ssl=None, endpoint_url=None
+        )
         command.setup_services(parsed_globals)
         create_client_calls = session.create_client.call_args_list
         self.assertEqual(
             create_client_calls,
             [
                 mock.call('organizations', verify=None, region_name=None),
-                mock.call('cloudtrail', verify=None, region_name=None)
-            ]
+                mock.call('cloudtrail', verify=None, region_name=None),
+            ],
         )
 
     def test_endpoint_url_is_used_for_cloudtrail(self):
         endpoint_url = 'https://mycloudtrail.aws.amazon.com/'
         session = mock.Mock()
         command = CloudTrailValidateLogs(session)
-        parsed_globals = mock.Mock(region='foo', verify_ssl=None,
-                              endpoint_url=endpoint_url)
+        parsed_globals = mock.Mock(
+            region='foo', verify_ssl=None, endpoint_url=endpoint_url
+        )
         command.setup_services(parsed_globals)
         create_client_calls = session.create_client.call_args_list
         self.assertEqual(
@@ -935,18 +1541,28 @@ class TestCloudTrailCommand(BaseAWSCommandParamsTest):
             [
                 mock.call('organizations', verify=None, region_name='foo'),
                 # Here we should inject the endpoint_url only for cloudtrail.
-                mock.call('cloudtrail', verify=None, region_name='foo',
-                     endpoint_url=endpoint_url)
-            ]
+                mock.call(
+                    'cloudtrail',
+                    verify=None,
+                    region_name='foo',
+                    endpoint_url=endpoint_url,
+                ),
+            ],
         )
 
     def test_initializes_args(self):
         session = mock.Mock()
         command = CloudTrailValidateLogs(session)
         start_date = START_DATE.strftime(DATE_FORMAT)
-        args = Namespace(trail_arn='abc', verbose=True,
-                         start_time=start_date, s3_bucket='bucket',
-                         s3_prefix='prefix', end_time=None, account_id=None)
+        args = Namespace(
+            trail_arn='abc',
+            verbose=True,
+            start_time=start_date,
+            s3_bucket='bucket',
+            s3_prefix='prefix',
+            end_time=None,
+            account_id=None,
+        )
         command.handle_args(args)
         self.assertEqual('abc', command.trail_arn)
         self.assertEqual(True, command.is_verbose)
@@ -967,7 +1583,9 @@ class TestS3ClientProvider(BaseAWSCommandParamsTest):
         created_client = provider.get_client('foo')
         self.assertEqual(s3_client, created_client)
         create_client_calls = session.create_client.call_args_list
-        self.assertEqual(create_client_calls, [mock.call('s3', region_name='us-east-1')])
+        self.assertEqual(
+            create_client_calls, [mock.call('s3', region_name='us-east-1')]
+        )
         self.assertEqual(1, s3_client.get_bucket_location.call_count)
 
     def test_creates_clients_for_buckets_outside_us_east_1(self):
@@ -975,15 +1593,19 @@ class TestS3ClientProvider(BaseAWSCommandParamsTest):
         s3_client = mock.Mock()
         session.create_client.return_value = s3_client
         s3_client.get_bucket_location.return_value = {
-            'LocationConstraint': 'us-west-2'}
+            'LocationConstraint': 'us-west-2'
+        }
         provider = S3ClientProvider(session, 'us-west-1')
         created_client = provider.get_client('foo')
         self.assertEqual(s3_client, created_client)
         create_client_calls = session.create_client.call_args_list
-        self.assertEqual(create_client_calls, [
-            mock.call('s3', region_name='us-west-1'),
-            mock.call('s3', region_name='us-west-2')
-        ])
+        self.assertEqual(
+            create_client_calls,
+            [
+                mock.call('s3', region_name='us-west-1'),
+                mock.call('s3', region_name='us-west-2'),
+            ],
+        )
         self.assertEqual(1, s3_client.get_bucket_location.call_count)
 
     def test_caches_previously_loaded_bucket_regions(self):
@@ -1020,4 +1642,4 @@ class TestS3ClientProvider(BaseAWSCommandParamsTest):
         session.create_client.return_value = s3_client
         s3_client.get_bucket_location.return_value = {'LocationConstraint': ''}
         provider = S3ClientProvider(session)
-        client = provider.get_client('foo')
+        provider.get_client('foo')


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Update CloudTrail validate-logs cli to support backfill digest validation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
