### PR TITLE
Add rst files with examples of how to use SNS commands.

### DIFF
--- a/awscli/examples/sns/create-sms-sandbox-phone-number.rst
+++ b/awscli/examples/sns/create-sms-sandbox-phone-number.rst
@@ -1,0 +1,8 @@
+**To add a destination phone number to an Amazon Web Services account in the SMS sandbox**
+
+The following `create-sms-sandbox-phone-number` example adds a destination phone number to your AWS account in the SMS sandbox. ::
+
+    aws sns create-sms-sandbox-phone-number \
+        --phone-number +1555550100
+
+This command produces no output.

--- a/awscli/examples/sns/delete-sms-sandbox-phone-number.rst
+++ b/awscli/examples/sns/delete-sms-sandbox-phone-number.rst
@@ -1,0 +1,8 @@
+**To delete a destination phone number from an AWS account in the SMS sandbox.**
+
+The following `delete-sms-sandbox-phone-number` example deletes a destination phone number from your SMS sandbox. ::
+
+    aws sns delete-sms-sandbox-phone-number \
+        --phone-number +1555550100
+
+This command produces no output.

--- a/awscli/examples/sns/get-data-protection-policy.rst
+++ b/awscli/examples/sns/get-data-protection-policy.rst
@@ -1,0 +1,12 @@
+**To retrieve the data protection policy from an Amazon SNS topic**
+
+The following `get-data-protection-policy` example retrieves the data protection policy from the specified Amazon SNS topic. ::
+
+    aws sns get-data-protection-policy \
+        --resource-arn arn:aws:sns:us-east-1:123456789012:MyTopic
+
+Output::
+
+  {
+    "DataProtectionPolicy": "{\"Name\":\"__example_data_protection_policy\",\"Description\":\"Example data protection policy\",\"Version\":\"2021-06-01\",\"Statement\":[{\"DataDirection\":\"Inbound\",\"Principal\":[\"*\"],\"DataIdentifier\":[\"arn:aws:dataprotection::aws:data-identifier/CreditCardNumber\"],\"Operation\":{\"Audit\":{\"SampleRate\":\"99\",\"FindingsDestination\":{\"CloudWatchLogs\":{\"LogGroup\":\"<example log name>\"},\"Firehose\":{\"DeliveryStream\":\"<example stream name>\"},\"S3\":{\"Bucket\":\"<example bucket name>\"}}}}}]}"
+  }

--- a/awscli/examples/sns/get-sms-sandbox-account-status.rst
+++ b/awscli/examples/sns/get-sms-sandbox-account-status.rst
@@ -1,0 +1,11 @@
+**To retrieve the SMS sandbox status for the calling Amazon Web Services account**
+
+The following `get-sms-sandbox-account-status` example retrieves the SMS sandbox status of your Amazon Web Services account in the current region. ::
+
+    aws sns get-sms-sandbox-account-status
+
+Output::
+
+    {
+        "IsInSandbox": true
+    }

--- a/awscli/examples/sns/list-origination-numbers.rst
+++ b/awscli/examples/sns/list-origination-numbers.rst
@@ -1,0 +1,22 @@
+**To list the calling Amazon Web Services account’s dedicated origination numbers and their metadata**
+
+The following `list-origination-numbers` example lists the dedicated phone numbers associated with your Amazon Web Services account. ::
+
+    aws sns list-origination-numbers
+
+Output::
+
+    {
+        "PhoneNumbers": [
+            {
+                "CreatedAt": "2024-10-01T12:34:56.789Z",
+                "PhoneNumber": "+1555550100",
+                "Status": "ACTIVE",
+                "Iso2CountryCode": "US",
+                "RouteType": "Transactional",
+                "NumberCapabilities": [
+                    "SMS"
+                ]
+            }
+        ]
+    }

--- a/awscli/examples/sns/list-sms-sandbox-phone-numbers.rst
+++ b/awscli/examples/sns/list-sms-sandbox-phone-numbers.rst
@@ -1,0 +1,16 @@
+**To list the calling Amazon Web Services account’s destination phone numbers in the SMS sandbox**
+
+The following `list-sms-sandbox-phone-numbers` example lists the destination phone numbers in the SMS sandbox. ::
+
+    aws sns list-sms-sandbox-phone-numbers
+
+Output::
+
+    {
+        "PhoneNumbers": [
+            {
+                "PhoneNumber": "+1555550100",
+                "Status": "Verified"
+            }
+        ]
+    }

--- a/awscli/examples/sns/publish-batch.rst
+++ b/awscli/examples/sns/publish-batch.rst
@@ -1,0 +1,25 @@
+**To publish up to 10 messages to the specified topic in a single batch**
+
+The following `publish-batch` example publishes multiple messages in a single batch. ::
+
+    aws sns publish-batch \
+        --topic-arn arn:aws:sns:us-east-1:123456789012:MyTopic.fifo \
+        --publish-batch-request-entries '[{"Id": "10001", "Message": "message1"},{"Id": "10002", "Message": "message2"}]'
+
+Output::
+
+    {
+        "Successful": [
+            {
+                "Id": "10001",
+                "MessageId": "123a45b6-7890-12c3-45d6-333322221111",
+                "SequenceNumber": "10000000000000009000"
+            },
+            {
+                "Id": "10002",
+                "MessageId": "ad0a5333-f45c-5d09-8393-087f5d11e3cd",
+                "SequenceNumber": "1000000000000010000"
+            }
+        ],
+        "Failed": []
+    }

--- a/awscli/examples/sns/verify-sms-sandbox-phone-number.rst
+++ b/awscli/examples/sns/verify-sms-sandbox-phone-number.rst
@@ -1,0 +1,9 @@
+**To verify a destination phone number with a one-time password (OTP)**
+
+The following `verify-sms-sandbox-phone-number` example verifies the specified destination phone number using the OTP. ::
+
+    aws sns verify-sms-sandbox-phone-number \
+        --phone-number +1555550100 \
+        --one-time-password 48291
+
+This command produces no output.


### PR DESCRIPTION
*Issue #, if available:*
#10062 (Missing example .rst files for some SNS commands)

*Description of changes:*
The awscli/examples/sns directory contains rst files that contain usage examples for various SNS commands, but there were no rst files corresponding to the commands below, so I would like to add them.

create-sms-sandbox-phone-number
delete-sms-sandbox-phone-number
get-data-protection-policy
get-sms-sandbox-account-status
list-origination-numbers
list-sms-sandbox-phone-numbers
publish-batch
verify-sms-sandbox-phone-number
