### PR TITLE
Update CloudTrail validate-logs for full key query range

### DIFF
--- a/.changes/next-release/bugfix-cloudtrail-2781.json
+++ b/.changes/next-release/bugfix-cloudtrail-2781.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "cloudtrail",
+  "description": "Fixed edge case in validate-logs where digest validation could fail with \"public key not found\" when the end time lands near a key rotation boundary"
+}

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -585,7 +585,11 @@ class DigestTraverser:
 
         # For regular digests, pre-load public keys. For backfill, start with empty dict
         public_keys = (
-            {} if is_backfill else self._load_public_keys(start_date, end_date)
+            {}
+            if is_backfill
+            else self._load_public_keys(
+                start_date, end_date + timedelta(hours=2)
+            )
         )
 
         yield from self._traverse_digest_chain(

--- a/tests/unit/customizations/cloudtrail/test_validation.py
+++ b/tests/unit/customizations/cloudtrail/test_validation.py
@@ -994,7 +994,9 @@ class TestDigestTraverser(unittest.TestCase):
         digest_iter = traverser.traverse_digests(start_date, end_date)
         with self.assertRaises(RuntimeError):
             next(digest_iter)
-        key_provider.get_public_keys.assert_called_with(start_date, end_date)
+        key_provider.get_public_keys.assert_called_with(
+            start_date, end_date + timedelta(hours=2)
+        )
 
     def test_ensures_public_key_is_found(self):
         start_date = START_DATE


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
There exists an edge case in the CloudTrail validate-logs command where the script fails to query all CloudTrail public keys to validate the digest signature. It can happen when the command end time lands right after the rotation instant. Fix is to add a two hour buffer period.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
