### PR TITLE
Update pip-tools to 7.5.3

### DIFF
--- a/requirements-dev-lock.txt
+++ b/requirements-dev-lock.txt
@@ -143,13 +143,14 @@ packaging==24.1 \
     #   pyproject-api
     #   pytest
     #   tox
+    #   wheel
 pefile==2023.2.7 \
     --hash=sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc \
     --hash=sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6
     # via -r requirements-build-win.txt
-pip-tools==7.5.2 \
-    --hash=sha256:2d64d72da6a044da1110257d333960563d7a4743637e8617dd2610ae7b82d60f \
-    --hash=sha256:2fe16db727bbe5bf28765aeb581e792e61be51fc275545ef6725374ad720a1ce
+pip-tools==7.5.3 \
+    --hash=sha256:3aac0c473240ae90db7213c033401f345b05197293ccbdd2704e52e7a783785e \
+    --hash=sha256:8fa364779ebc010cbfe17cb9de404457ac733e100840423f28f6955de7742d41
     # via -r requirements-test.txt
 platformdirs==4.4.0 \
     --hash=sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85 \

--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -100,9 +100,10 @@ packaging==24.1 \
     #   -r requirements-test.txt
     #   build
     #   pytest
-pip-tools==7.5.2 \
-    --hash=sha256:2d64d72da6a044da1110257d333960563d7a4743637e8617dd2610ae7b82d60f \
-    --hash=sha256:2fe16db727bbe5bf28765aeb581e792e61be51fc275545ef6725374ad720a1ce
+    #   wheel
+pip-tools==7.5.3 \
+    --hash=sha256:3aac0c473240ae90db7213c033401f345b05197293ccbdd2704e52e7a783785e \
+    --hash=sha256:8fa364779ebc010cbfe17cb9de404457ac733e100840423f28f6955de7742d41
     # via -r requirements-test.txt
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,5 +8,5 @@ pytest==7.4.0
 coverage==7.0.1
 pytest-cov==4.1.0
 pytest-xdist==3.1.0
-pip-tools==7.5.2
+pip-tools==7.5.3
 packaging==24.1


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Update pip-tools to https://github.com/jazzband/pip-tools/releases/tag/v7.5.3, which fixes compatibility with pip 26.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
