### PR TITLE
Add ruff warning for new colorama usage

### DIFF
--- a/awscli/customizations/ecs/expressgateway/color_utils.py
+++ b/awscli/customizations/ecs/expressgateway/color_utils.py
@@ -13,7 +13,7 @@
 
 """Color utilities for ECS Express Gateway Service monitoring."""
 
-from colorama import Fore, Style, init
+from colorama import Fore, Style, init  # noqa
 
 # Status symbols
 CHECK_MARK = '✓'

--- a/awscli/customizations/history/show.py
+++ b/awscli/customizations/history/show.py
@@ -157,7 +157,7 @@ class DetailedFormatter(Formatter):
         self._colorize = colorize
         self._value_pformatter = SectionValuePrettyFormatter()
         if self._colorize:
-            colorama.init(**COLORAMA_KWARGS)
+            colorama.init(**COLORAMA_KWARGS)  # noqa
 
     def _display(self, event_record):
         section_definition = self._SECTIONS.get(event_record['event_type'])

--- a/awscli/customizations/logs/startlivetail.py
+++ b/awscli/customizations/logs/startlivetail.py
@@ -543,7 +543,7 @@ class InteractivePrinter(BaseLiveTailPrinter):
         self._is_sampled = False
         self._keywords_to_highlight = keywords_to_highlight
         self._format = OutputFormat.JSON
-        colorama.init(autoreset=True, strip=False)
+        colorama.init(autoreset=True, strip=False)  # noqa
 
     @property
     def log_events_displayed(self):

--- a/awscli/customizations/logs/tail.py
+++ b/awscli/customizations/logs/tail.py
@@ -33,7 +33,7 @@ class BaseLogEventsFormatter:
         self._output = output
         self._colorize = colorize
         if self._colorize:
-            colorama.init(autoreset=True, strip=False)
+            colorama.init(autoreset=True, strip=False)  # noqa
 
     def display_log_event(self, log_event):
         raise NotImplementedError('display_log_event()')

--- a/awscli/table.py
+++ b/awscli/table.py
@@ -175,7 +175,7 @@ class Styler:
 
 class ColorizedStyler(Styler):
     def __init__(self):
-        colorama.init(**COLORAMA_KWARGS)
+        colorama.init(**COLORAMA_KWARGS)  # noqa
 
     def style_title(self, text):
         # Originally bold + underline

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,3 +192,6 @@ line-ending = "auto"
 
 docstring-code-format = false
 docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"colorama.init".msg = "Ensure you call colorama.init() only when invoking a command that uses it, and not on import. See https://github.com/aws/aws-cli/issues/9864"


### PR DESCRIPTION
*Issue #, if available:* Follow-up to #9864

*Description of changes:* Adds a warning via ruff to new `colorama.init()` calls to help avoid an issue like #9864.

We do intend to ultimately `noqa` these, but this warning will guide developers to lazy initialization.

Example with a `noqa` addition removed:
```
➜ uvx ruff check --select TID251
TID251 `colorama.init` is banned: Ensure you call colorama.init() only when invoking a command that uses it, and not on import. See https://github.com/aws/aws-cli/issues/9864
   --> awscli/customizations/history/show.py:160:13
    |
158 |         self._value_pformatter = SectionValuePrettyFormatter()
159 |         if self._colorize:
160 |             colorama.init(**COLORAMA_KWARGS)
    |             ^^^^^^^^^^^^^
161 |
162 |     def _display(self, event_record):
    |

Found 1 error.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
