### PR TITLE
docs(emr): fix example datetime outputs for AWS CLI v2

### DIFF
--- a/awscli/examples/emr/create-security-configuration.rst
+++ b/awscli/examples/emr/create-security-configuration.rst
@@ -27,7 +27,7 @@
 - Output::
 
     {
-    "CreationDateTime": 1474070889.129,
+    "CreationDateTime": "2016-09-17T00:08:09.129+00:00",
     "Name": "MySecurityConfig"
     }
 
@@ -62,7 +62,7 @@
 - Output::
 
     {
-    "CreationDateTime": 1474070889.129,
+    "CreationDateTime": "2016-09-17T00:08:09.129+00:00",
     "Name": "MySecurityConfig"
     }
 
@@ -90,7 +90,7 @@
 - Output::
 
     {
-    "CreationDateTime": 1490225558.982,
+    "CreationDateTime": "2017-03-22T23:32:38.982+00:00",
     "Name": "MySecurityConfig"
     }
 
@@ -120,6 +120,6 @@
 - Output::
 
     {
-    "CreationDateTime": 1490225558.982,
+    "CreationDateTime": "2017-03-22T23:32:38.982+00:00",
     "Name": "MySecurityConfig"
     }

--- a/awscli/examples/emr/describe-cluster.rst
+++ b/awscli/examples/emr/describe-cluster.rst
@@ -10,8 +10,8 @@
 		    "Cluster": {
 		        "Status": {
 		            "Timeline": {
-		                "ReadyDateTime": 1436475075.199, 
-		                "CreationDateTime": 1436474656.563, 
+		                "ReadyDateTime": "2015-07-09T20:51:15.199+00:00", 
+		                "CreationDateTime": "2015-07-09T20:44:16.563+00:00", 
 		            }, 
 		            "State": "WAITING",
 		            "StateChangeReason": {
@@ -38,9 +38,9 @@
 		                "RequestedInstanceCount": 2, 
 		                "Status": {
 		                    "Timeline": {
-		                        "ReadyDateTime": 1436475074.245, 
-		                        "CreationDateTime": 1436474656.564, 
-		                        "EndDateTime": 1436638158.387
+		                        "ReadyDateTime": "2015-07-09T20:51:14.245+00:00", 
+		                        "CreationDateTime": "2015-07-09T20:44:16.564+00:00", 
+		                        "EndDateTime": "2015-07-11T18:09:18.387+00:00"
 		                    }, 
 		                    "State": "RUNNING", 
 		                    "StateChangeReason": {
@@ -59,9 +59,9 @@
 		                "RequestedInstanceCount": 1, 
 		                "Status": {
 		                    "Timeline": {
-		                        "ReadyDateTime": 1436475074.245, 
-		                        "CreationDateTime": 1436474656.564, 
-		                        "EndDateTime": 1436638158.387
+		                        "ReadyDateTime": "2015-07-09T20:51:14.245+00:00", 
+		                        "CreationDateTime": "2015-07-09T20:44:16.564+00:00", 
+		                        "EndDateTime": "2015-07-11T18:09:18.387+00:00"
 		                    }, 
 		                    "State": "RUNNING", 
 		                    "StateChangeReason": {
@@ -107,8 +107,8 @@
             "Cluster": {
                 "Status": {
                     "Timeline": {
-                        "ReadyDateTime": 1487897289.705,
-                        "CreationDateTime": 1487896933.942
+                        "ReadyDateTime": "2017-02-24T00:48:09.705+00:00",
+                        "CreationDateTime": "2017-02-24T00:42:13.942+00:00"
                     },
                     "State": "WAITING",
                     "StateChangeReason": {
@@ -135,8 +135,8 @@
                     {
                         "Status": {
                             "Timeline": {
-                                "ReadyDateTime": 1487897212.74,
-                                "CreationDateTime": 1487896933.948
+                                "ReadyDateTime": "2017-02-24T00:46:52.740+00:00",
+                                "CreationDateTime": "2017-02-24T00:42:13.948+00:00"
                             },
                             "State": "RUNNING",
                             "StateChangeReason": {
@@ -187,8 +187,8 @@
 	        "Cluster": {
 	            "Status": {
 	                "Timeline": {
-	                    "ReadyDateTime": 1399400564.432,
-	                    "CreationDateTime": 1399400268.62
+	                    "ReadyDateTime": "2014-05-06T18:22:44.432+00:00",
+	                    "CreationDateTime": "2014-05-06T18:17:48.620+00:00"
 	                },
 	                "State": "WAITING",
 	                "StateChangeReason": {
@@ -209,8 +209,8 @@
 	                    "RequestedInstanceCount": 1,
 	                    "Status": {
 	                        "Timeline": {
-	                            "ReadyDateTime": 1399400558.848,
-	                            "CreationDateTime": 1399400268.621
+	                            "ReadyDateTime": "2014-05-06T18:22:38.848+00:00",
+	                            "CreationDateTime": "2014-05-06T18:17:48.621+00:00"
 	                        },
 	                        "State": "RUNNING",
 	                        "StateChangeReason": {
@@ -228,8 +228,8 @@
 	                    "RequestedInstanceCount": 2,
 	                    "Status": {
 	                        "Timeline": {
-	                            "ReadyDateTime": 1399400564.439,
-	                            "CreationDateTime": 1399400268.621
+	                            "ReadyDateTime": "2014-05-06T18:22:44.439+00:00",
+	                            "CreationDateTime": "2014-05-06T18:17:48.621+00:00"
 	                        },
 	                        "State": "RUNNING",
 	                        "StateChangeReason": {

--- a/awscli/examples/emr/describe-step.rst
+++ b/awscli/examples/emr/describe-step.rst
@@ -8,9 +8,9 @@ Output::
       "Step": {
           "Status": {
               "Timeline": {
-                  "EndDateTime": 1433200470.481,
-                  "CreationDateTime": 1433199926.597,
-                  "StartDateTime": 1433200404.959
+                  "EndDateTime": "2015-06-01T23:14:30.481+00:00",
+                  "CreationDateTime": "2015-06-01T23:05:26.597+00:00",
+                  "StartDateTime": "2015-06-01T23:13:24.959+00:00"
               },
               "State": "COMPLETED",
               "StateChangeReason": {}

--- a/awscli/examples/emr/list-clusters.rst
+++ b/awscli/examples/emr/list-clusters.rst
@@ -9,8 +9,8 @@ Output::
           {
               "Status": {
                   "Timeline": {
-                      "ReadyDateTime": 1433200405.353,
-                      "CreationDateTime": 1433199926.596
+                      "ReadyDateTime": "2015-06-01T23:13:25.353+00:00",
+                      "CreationDateTime": "2015-06-01T23:05:26.596+00:00"
                   },
                   "State": "WAITING",
                   "StateChangeReason": {

--- a/awscli/examples/emr/list-instance-fleets.rst
+++ b/awscli/examples/emr/list-instance-fleets.rst
@@ -13,8 +13,8 @@ Output::
         {
             "Status": {
                 "Timeline": {
-                    "ReadyDateTime": 1488759094.637,
-                    "CreationDateTime": 1488758719.817
+                    "ReadyDateTime": "2017-03-06T00:11:34.637+00:00",
+                    "CreationDateTime": "2017-03-06T00:05:19.817+00:00"
                 },
                 "State": "RUNNING",
                 "StateChangeReason": {
@@ -43,8 +43,8 @@ Output::
         {
             "Status": {
                 "Timeline": {
-                    "ReadyDateTime": 1488759058.598,
-                    "CreationDateTime": 1488758719.811
+                    "ReadyDateTime": "2017-03-06T00:10:58.598+00:00",
+                    "CreationDateTime": "2017-03-06T00:05:19.811+00:00"
                 },
                 "State": "RUNNING",
                 "StateChangeReason": {

--- a/awscli/examples/emr/list-instances.rst
+++ b/awscli/examples/emr/list-instances.rst
@@ -10,8 +10,8 @@ Output::
            {
               "Status": {
                   "Timeline": {
-                      "ReadyDateTime": 1433200400.03,
-                      "CreationDateTime": 1433199960.152
+                      "ReadyDateTime": "2015-06-01T23:13:20.030+00:00",
+                      "CreationDateTime": "2015-06-01T23:06:00.152+00:00"
                   },
                   "State": "RUNNING",
                   "StateChangeReason": {}
@@ -26,8 +26,8 @@ Output::
           {
               "Status": {
                   "Timeline": {
-                      "ReadyDateTime": 1433200400.031,
-                      "CreationDateTime": 1433199949.102
+                      "ReadyDateTime": "2015-06-01T23:13:20.031+00:00",
+                      "CreationDateTime": "2015-06-01T23:05:49.102+00:00"
                   },
                   "State": "RUNNING",
                   "StateChangeReason": {}
@@ -42,8 +42,8 @@ Output::
           {
               "Status": {
                   "Timeline": {
-                      "ReadyDateTime": 1433200400.031,
-                      "CreationDateTime": 1433199949.102
+                      "ReadyDateTime": "2015-06-01T23:13:20.031+00:00",
+                      "CreationDateTime": "2015-06-01T23:05:49.102+00:00"
                   },
                   "State": "RUNNING",
                   "StateChangeReason": {}
@@ -65,9 +65,9 @@ Output::
             {
                 "Status": {
                     "Timeline": {
-                        "ReadyDateTime": 1487810810.878,
-                        "CreationDateTime": 1487810588.367,
-                        "EndDateTime": 1488022990.924
+                        "ReadyDateTime": "2017-02-23T00:46:50.878+00:00",
+                        "CreationDateTime": "2017-02-23T00:43:08.367+00:00",
+                        "EndDateTime": "2017-02-25T11:43:10.924+00:00"
                     },
                     "State": "TERMINATED",
                     "StateChangeReason": {

--- a/awscli/examples/emr/list-security-configurations.rst
+++ b/awscli/examples/emr/list-security-configurations.rst
@@ -9,11 +9,11 @@ Output::
     {
         "SecurityConfigurations": [
             {
-                "CreationDateTime": 1473889697.417,
+                "CreationDateTime": "2016-09-14T21:48:17.417+00:00",
                 "Name": "MySecurityConfig-1"
             },
             {
-                "CreationDateTime": 1473889697.417,
+                "CreationDateTime": "2016-09-14T21:48:17.417+00:00",
                 "Name": "MySecurityConfig-2"
             }
         ]


### PR DESCRIPTION
Fixes #9827.

The EMR command reference examples currently show Unix epoch timestamps for `*DateTime` fields; AWS CLI v2 renders these as ISO 8601 strings.

This updates the EMR example `.rst` files to use ISO 8601 output across the affected commands:
- create-security-configuration
- describe-cluster
- describe-step
- list-clusters
- list-instance-fleets
- list-instances
- list-security-configurations
