### PR TITLE
Add missing SNS example .rst files

### DIFF
--- a/awscli/examples/sns/create-sms-sandbox-phone-number.rst
+++ b/awscli/examples/sns/create-sms-sandbox-phone-number.rst
@@ -1,0 +1,9 @@
+**To create an SMS sandbox destination phone number**
+
+The following ``create-sms-sandbox-phone-number`` example adds a destination phone number to your SMS sandbox. SNS sends a one-time password (OTP) to this number that you must verify before publishing SMS messages to it. ::
+
+    aws sns create-sms-sandbox-phone-number \
+        --phone-number "+12065550100" \
+        --language-code en-US
+
+This command produces no output.

--- a/awscli/examples/sns/delete-sms-sandbox-phone-number.rst
+++ b/awscli/examples/sns/delete-sms-sandbox-phone-number.rst
@@ -1,0 +1,8 @@
+**To delete an SMS sandbox destination phone number**
+
+The following ``delete-sms-sandbox-phone-number`` example removes a phone number from your SMS sandbox. ::
+
+    aws sns delete-sms-sandbox-phone-number \
+        --phone-number "+12065550100"
+
+This command produces no output.

--- a/awscli/examples/sns/get-data-protection-policy.rst
+++ b/awscli/examples/sns/get-data-protection-policy.rst
@@ -1,0 +1,28 @@
+**To get a data protection policy for an SNS topic**
+
+The following ``get-data-protection-policy`` example retrieves the data protection policy attached to the specified SNS topic. ::
+
+    aws sns get-data-protection-policy \
+        --resource-arn arn:aws:sns:us-east-1:123456789012:MyTopic
+
+Output::
+
+    {
+        "Name": "data_protection_policy",
+        "Description": "Example data protection policy",
+        "Version": "2021-06-01",
+        "Statement": [
+            {
+                "DataDirection": "Inbound",
+                "Principal": [
+                    "*"
+                ],
+                "DataIdentifier": [
+                    "arn:aws:dataprotection::aws:data-identifier/CreditCardNumber"
+                ],
+                "Operation": {
+                    "Deny": {}
+                }
+            }
+        ]
+    }

--- a/awscli/examples/sns/get-sms-sandbox-account-status.rst
+++ b/awscli/examples/sns/get-sms-sandbox-account-status.rst
@@ -1,0 +1,11 @@
+**To get your SMS sandbox account status**
+
+The following ``get-sms-sandbox-account-status`` example gets your account's current SMS sandbox status. ::
+
+    aws sns get-sms-sandbox-account-status
+
+Output::
+
+    {
+        "IsInSandbox": true
+    }

--- a/awscli/examples/sns/list-origination-numbers.rst
+++ b/awscli/examples/sns/list-origination-numbers.rst
@@ -1,0 +1,18 @@
+**To list origination numbers**
+
+The following ``list-origination-numbers`` example lists origination numbers associated with your account. ::
+
+    aws sns list-origination-numbers
+
+Output::
+
+    {
+        "PhoneNumbers": [
+            {
+                "CreatedAt": "2022-12-09T18:13:01.0+0000",
+                "PhoneNumber": "+12065550199",
+                "Status": "ACTIVE",
+                "TwoWayChannelArn": "arn:aws:sns:us-east-1:123456789012:my-topic"
+            }
+        ]
+    }

--- a/awscli/examples/sns/list-sms-sandbox-phone-numbers.rst
+++ b/awscli/examples/sns/list-sms-sandbox-phone-numbers.rst
@@ -1,0 +1,16 @@
+**To list SMS sandbox destination phone numbers**
+
+The following ``list-sms-sandbox-phone-numbers`` example lists destination phone numbers in your SMS sandbox. ::
+
+    aws sns list-sms-sandbox-phone-numbers
+
+Output::
+
+    {
+        "PhoneNumbers": [
+            {
+                "PhoneNumber": "+12065550100",
+                "Status": "Verified"
+            }
+        ]
+    }

--- a/awscli/examples/sns/publish-batch.rst
+++ b/awscli/examples/sns/publish-batch.rst
@@ -1,0 +1,23 @@
+**To publish a batch of messages to an SNS topic**
+
+The following ``publish-batch`` example publishes two messages to the specified SNS topic in a single request. ::
+
+    aws sns publish-batch \
+        --topic-arn arn:aws:sns:us-west-2:123456789012:my-topic \
+        --publish-batch-request-entries Id=msg1,Message=hello Id=msg2,Message=world
+
+Output::
+
+    {
+        "Successful": [
+            {
+                "Id": "msg1",
+                "MessageId": "123a45b6-7890-12c3-45d6-111122223333"
+            },
+            {
+                "Id": "msg2",
+                "MessageId": "123a45b6-7890-12c3-45d6-444455556666"
+            }
+        ],
+        "Failed": []
+    }

--- a/awscli/examples/sns/verify-sms-sandbox-phone-number.rst
+++ b/awscli/examples/sns/verify-sms-sandbox-phone-number.rst
@@ -1,0 +1,9 @@
+**To verify an SMS sandbox destination phone number**
+
+The following ``verify-sms-sandbox-phone-number`` example verifies a destination phone number in your SMS sandbox using the one-time password (OTP) received by SMS. ::
+
+    aws sns verify-sms-sandbox-phone-number \
+        --phone-number "+12065550100" \
+        --one-time-password 123456
+
+This command produces no output.


### PR DESCRIPTION
## Summary
- add missing SNS command example files under `awscli/examples/sns`
- include examples for SMS sandbox, data protection policy retrieval, origination number listing, and batch publish

## Testing
- docs/examples only change

Closes #10062