### PR TITLE
Document valid values for s3 cp checksum options

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -455,12 +455,13 @@ VALIDATE_SAME_S3_PATHS = {
 CHECKSUM_MODE = {
         'name': 'checksum-mode', 'choices': ['ENABLED'],
         'help_text': 'To retrieve the checksum, this mode must be enabled. If the object has a '
-                     'checksum, it will be verified.'
+                     'checksum, it will be verified. Valid value: ENABLED.'
 }
 
 CHECKSUM_ALGORITHM = {
         'name': 'checksum-algorithm', 'choices': ['CRC64NVME', 'CRC32', 'SHA256', 'SHA1', 'CRC32C'],
-        'help_text': 'Indicates the algorithm used to create the checksum for the object.'
+        'help_text': 'Indicates the algorithm used to create the checksum for the object. '
+                     'Valid values: CRC64NVME, CRC32, SHA256, SHA1, CRC32C.'
 }
 
 BUCKET_NAME_PREFIX = {


### PR DESCRIPTION
## Summary
- update `aws s3 cp` option help text to explicitly list valid values for:
  - `--checksum-mode`
  - `--checksum-algorithm`
- keeps existing behavior unchanged and only clarifies docs output

## Testing
- help text/docs-only change

Closes #10025