### PR TITLE
Fix PEP-765 violation: return in finally block

### DIFF
--- a/awscli/customizations/s3/s3handler.py
+++ b/awscli/customizations/s3/s3handler.py
@@ -561,9 +561,10 @@ class LocalDeleteRequestSubmitter(BaseTransferRequestSubmitter):
         except Exception as e:
             self._result_queue.put(
                 FailureResult(exception=e, **result_kwargs))
-        finally:
-            # Return True to indicate that the transfer was submitted
-            return True
+        # Return True to indicate that the transfer was submitted.
+        # This is returned regardless of success or failure since
+        # the transfer request was submitted and results were queued.
+        return True
 
     def _format_src_dest(self, fileinfo):
         return self._format_local_path(fileinfo.src), None


### PR DESCRIPTION
## Summary

This PR fixes the PEP-765 violation reported in #9985 by moving the `return True` statement outside of the `finally` block in `LocalDeleteRequestSubmitter._submit_transfer_request()`.

### Problem

Python 3.14 (per [PEP-765](https://peps.python.org/pep-0765/)) emits a `SyntaxWarning` for `return`, `break`, or `continue` statements directly within `finally` blocks. The current code has:

```python
finally:
    # Return True to indicate that the transfer was submitted
    return True
```

### Solution

Move the `return True` after the `try-except` block. This preserves the exact same behavior (always returning `True` regardless of success or failure) while avoiding the warning.

### Behavior Verification

- The function always returns `True` to indicate the transfer was submitted
- Success: queues `QueuedResult` and `SuccessResult`, then returns `True`
- Failure: queues `QueuedResult` and `FailureResult`, then returns `True`

Both existing tests (`test_submit` and `test_submit_with_exception`) verify this behavior and pass.

## Test Plan

- [x] All 5 existing `TestLocalDeleteRequestSubmitter` tests pass
- [x] Verified no `SyntaxWarning` when importing the module
- [x] Verified the AST check finds no remaining PEP-765 violations in `awscli/`

```bash
$ python -m pytest tests/unit/customizations/s3/test_s3handler.py::TestLocalDeleteRequestSubmitter -v
# 5 passed
```

Fixes #9985
