### PR TITLE
[v2] Improve example validation and corrections

### DIFF
--- a/awscli/examples/apigatewayv2/put-routing-rule.rst
+++ b/awscli/examples/apigatewayv2/put-routing-rule.rst
@@ -3,7 +3,7 @@
 The following ``put-routing-rule`` example updates the priority of a routing rule. ::
 
     aws apigatewayv2 put-routing-rule \
-        --routing-rule-id 'abc123' \
+        --routing-rule-id 'aaa111' \
         --domain-name 'regional.example.com' \
         --priority 150 \
         --conditions '[ \

--- a/awscli/examples/apigatewayv2/put-routing-rule.rst
+++ b/awscli/examples/apigatewayv2/put-routing-rule.rst
@@ -3,6 +3,7 @@
 The following ``put-routing-rule`` example updates the priority of a routing rule. ::
 
     aws apigatewayv2 put-routing-rule \
+        --routing-rule-id 'abc123' \
         --domain-name 'regional.example.com' \
         --priority 150 \
         --conditions '[ \

--- a/awscli/examples/application-autoscaling/put-scaling-policy.rst
+++ b/awscli/examples/application-autoscaling/put-scaling-policy.rst
@@ -42,7 +42,7 @@ The following ``put-scaling-policy`` example applies a target tracking scaling p
     aws application-autoscaling put-scaling-policy --service-namespace ecs \
     --scalable-dimension ecs:service:DesiredCount \
     --resource-id service/default/web-app \
-    --policy-name cms75-target-tracking-scaling-policy
+    --policy-name cms75-target-tracking-scaling-policy \
     --policy-type TargetTrackingScaling \
     --target-tracking-scaling-policy-configuration file://config.json
 

--- a/awscli/examples/codecommit/create-pull-request-approval-rule.rst
+++ b/awscli/examples/codecommit/create-pull-request-approval-rule.rst
@@ -3,6 +3,7 @@
 The following ``create-pull-request-approval-rule`` example creates an approval rule named  ``Require two approved approvers`` for the specified pull request. The rule specifies that two approvals are required from an approval pool. The pool includes all users who access CodeCommit by assuming the role of  ``CodeCommitReview`` in the ``123456789012`` AWS account. It also includes either an IAM user or federated user named ``Nikhil_Jayashankar`` from the same AWS account. ::
 
     aws codecommit create-pull-request-approval-rule  \
+        --pull-request-id 42
         --approval-rule-name "Require two approved approvers"  \
         --approval-rule-content "{\"Version\": \"2018-11-08\",\"Statements\": [{\"Type\": \"Approvers\",\"NumberOfApprovalsNeeded\": 2,\"ApprovalPoolMembers\": [\"CodeCommitApprovers:123456789012:Nikhil_Jayashankar\", \"arn:aws:sts::123456789012:assumed-role/CodeCommitReview/*\"]}]}"
 

--- a/awscli/examples/codecommit/get-comments-for-pull-request.rst
+++ b/awscli/examples/codecommit/get-comments-for-pull-request.rst
@@ -4,6 +4,7 @@ This example demonstrates how to view comments for a pull request in a repositor
 
     aws codecommit get-comments-for-pull-request \
         --repository-name MyDemoRepo \
+        --pull-request-id 42 \
         --before-commit-ID 317f8570EXAMPLE \
         --after-commit-id 5d036259EXAMPLE
 

--- a/awscli/examples/codecommit/put-repository-triggers.rst
+++ b/awscli/examples/codecommit/put-repository-triggers.rst
@@ -3,7 +3,8 @@
 This example demonstrates how to update triggers named 'MyFirstTrigger' and 'MySecondTrigger' using an already-created JSON file (here named MyTriggers.json) that contains the structure of all the triggers for a repository named MyDemoRepo. To learn how to get the JSON for existing triggers, see the get-repository-triggers command. ::
 
     aws codecommit put-repository-triggers \
-        --repository-name MyDemoRepo file://MyTriggers.json
+        --repository-name MyDemoRepo \
+        --triggers file://MyTriggers.json
 
 Contents of ``MyTriggers.json``::
 

--- a/awscli/examples/codecommit/update-pull-request-approval-rule-content.rst
+++ b/awscli/examples/codecommit/update-pull-request-approval-rule-content.rst
@@ -5,7 +5,7 @@ The following ``update-pull-request-approval-rule-content`` example updates she 
     aws codecommit update-pull-request-approval-rule-content \
         --pull-request-id 27  \
         --approval-rule-name "Require two approved approvers" \
-        --approval-rule-content "{Version: 2018-11-08, Statements: [{Type: \"Approvers\", NumberOfApprovalsNeeded: 1, ApprovalPoolMembers:[\"CodeCommitApprovers:123456789012:user/*\"]}]}}" 
+        --new-rule-content "{Version: 2018-11-08, Statements: [{Type: \"Approvers\", NumberOfApprovalsNeeded: 1, ApprovalPoolMembers:[\"CodeCommitApprovers:123456789012:user/*\"]}]}}" 
 
 Output::
 

--- a/awscli/examples/codepipeline/disable-stage-transition.rst
+++ b/awscli/examples/codepipeline/disable-stage-transition.rst
@@ -4,7 +4,11 @@ This example disables transitions into the Beta stage of the MyFirstPipeline pip
 
 Command::
 
-  aws codepipeline disable-stage-transition --pipeline-name MyFirstPipeline --stage-name Beta  --transition-type Inbound
+  aws codepipeline disable-stage-transition \
+  --pipeline-name MyFirstPipeline \
+  --stage-name Beta  \
+  --transition-type Inbound \
+  --reason "An example reason"
 
 
 Output::

--- a/awscli/examples/cognito-identity/delete-identities.rst
+++ b/awscli/examples/cognito-identity/delete-identities.rst
@@ -4,7 +4,7 @@ This example deletes an identity pool.
 
 Command::
 
-  aws cognito-identity delete-identity-pool --identity-ids-to-delete "us-west-2:11111111-1111-1111-1111-111111111111"
+  aws cognito-identity delete-identities --identity-ids-to-delete "us-west-2:11111111-1111-1111-1111-111111111111"
 
 Output::
 

--- a/awscli/examples/comprehend/create-document-classifier.rst
+++ b/awscli/examples/comprehend/create-document-classifier.rst
@@ -4,7 +4,7 @@ The following ``create-document-classifier`` example begins the training process
 
     aws comprehend create-document-classifier \
         --document-classifier-name example-classifier \
-        --data-access-arn arn:aws:comprehend:us-west-2:111122223333:pii-entities-detection-job/123456abcdeb0e11022f22a11EXAMPLE \
+        --data-access-role-arn arn:aws:iam::111122223333:role/service-role/AmazonComprehendServiceRole-example-role \
         --input-data-config "S3Uri=s3://amzn-s3-demo-bucket/" \
         --language-code en
     

--- a/awscli/examples/comprehend/describe-entity-recognizer.rst
+++ b/awscli/examples/comprehend/describe-entity-recognizer.rst
@@ -3,7 +3,7 @@
 The following ``describe-entity-recognizer`` example gets the properties of a custom entity recognizer model. ::
 
     aws comprehend describe-entity-recognizer \
-        entity-recognizer-arn arn:aws:comprehend:us-west-2:111122223333:entity-recognizer/business-recongizer-1/version/1
+        --entity-recognizer-arn arn:aws:comprehend:us-west-2:111122223333:entity-recognizer/business-recongizer-1/version/1
 
 Output:: 
 

--- a/awscli/examples/connect/describe-user-hierarchy-structure.rst
+++ b/awscli/examples/connect/describe-user-hierarchy-structure.rst
@@ -2,7 +2,7 @@
 
 The following ``describe-user-hierarchy-structure`` example displays the details for the hierarchy structure for the specified Amazon Connect instance. ::
 
-    aws connect describe-user-hierarchy-group \
+    aws connect describe-user-hierarchy-structure \
         --instance-id a1b2c3d4-5678-90ab-cdef-EXAMPLE11111
 
 Output::

--- a/awscli/examples/directconnect/allocate-hosted-connection.rst
+++ b/awscli/examples/directconnect/allocate-hosted-connection.rst
@@ -5,9 +5,9 @@ The following ``allocate-hosted-connection`` example creates a hosted connection
     aws directconnect allocate-hosted-connection \
         --bandwidth 500Mbps \
         --connection-name mydcinterconnect \
-        --owner-account 123456789012 
-        -connection-id dxcon-fgktov66 
-        -vlan 101
+        --owner-account 123456789012 \
+        --connection-id dxcon-fgktov66 \
+        --vlan 101
 
 Output::
 

--- a/awscli/examples/ds-data/search-users.rst
+++ b/awscli/examples/ds-data/search-users.rst
@@ -5,7 +5,7 @@ The following ``search-users`` example searches for the specified user in the sp
     aws ds-data search-users \
         --directory-id d-1234567890 \
         --search-attributes 'SamAccountName' \
-        --Search-string 'john.doe'
+        --search-string 'john.doe'
 
 Output::
 

--- a/awscli/examples/dynamodb/restore-table-from-backup.rst
+++ b/awscli/examples/dynamodb/restore-table-from-backup.rst
@@ -4,7 +4,7 @@ The following ``restore-table-from-backup`` example restores the specified table
 
     aws dynamodb restore-table-from-backup \
         --target-table-name MusicCollection \
-        --backup-arnarn:aws:dynamodb:us-west-2:123456789012:table/MusicCollection/backup/01576616366715-b4e58d3a
+        --backup-arn arn:aws:dynamodb:us-west-2:123456789012:table/MusicCollection/backup/01576616366715-b4e58d3a
 
 Output::
 

--- a/awscli/examples/ec2/describe-byoip-cidrs.rst
+++ b/awscli/examples/ec2/describe-byoip-cidrs.rst
@@ -2,7 +2,8 @@
 
 The following ``describe-byoip-cidrs`` example displays details about the public IPv4 address ranges that you provisioned for use by AWS. ::
 
-    aws ec2 describe-byoip-cidrs
+    aws ec2 describe-byoip-cidrs \
+        --max-results 5
 
 Output::
 

--- a/awscli/examples/ec2/modify-fleet.rst
+++ b/awscli/examples/ec2/modify-fleet.rst
@@ -3,7 +3,7 @@
 The following ``modify-fleet`` example modifies the target capacity of the specified EC2 Fleet. If the specified value is greater than the current capacity, the EC2 Fleet launches additional instances. If the specified value is less than the current capacity, the EC2 Fleet cancels any open requests and if the termination policy is ``terminate``, the EC2 fleet terminates any instances that exceed the new target capacity. ::
 
     aws ec2 modify-fleet \
-        --fleet-ids fleet-12a34b55-67cd-8ef9-ba9b-9208dEXAMPLE \
+        --fleet-id fleet-12a34b55-67cd-8ef9-ba9b-9208dEXAMPLE \
         --target-capacity-specification TotalTargetCapacity=5
 
 Output::

--- a/awscli/examples/ec2/modify-spot-fleet-request.rst
+++ b/awscli/examples/ec2/modify-spot-fleet-request.rst
@@ -16,7 +16,7 @@ This example command decreases the target capacity of the specified Spot fleet r
 
 Command::
 
-  aws ec2 modify-spot-fleet-request --target-capacity 10 --excess-capacity-termination-policy NoTermination --spot-fleet-request-ids sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE
+  aws ec2 modify-spot-fleet-request --target-capacity 10 --excess-capacity-termination-policy NoTermination --spot-fleet-request-id sfr-73fbd2ce-aa30-494c-8788-1cee4EXAMPLE
 
 Output::
 

--- a/awscli/examples/ec2/reset-network-interface-attribute.rst
+++ b/awscli/examples/ec2/reset-network-interface-attribute.rst
@@ -4,6 +4,6 @@ The following ``reset-network-interface-attribute`` example resets the value of 
 
     aws ec2 reset-network-interface-attribute \
         --network-interface-id eni-686ea200 \
-        --source-dest-check
+        --source-dest-check sourceDestCheck
 
 This command produces no output.

--- a/awscli/examples/globalaccelerator/list-tags-for-resource.rst
+++ b/awscli/examples/globalaccelerator/list-tags-for-resource.rst
@@ -3,7 +3,7 @@
 The following ``list-tags-for-resource`` example lists the tags for a specific accelerator. ::
 
     aws globalaccelerator list-tags-for-resource \
-        --accelerator-arn arn:aws:globalaccelerator::012345678901:accelerator/1234abcd-abcd-1234-abcd-1234abcdefgh
+        --resource-arn arn:aws:globalaccelerator::012345678901:accelerator/1234abcd-abcd-1234-abcd-1234abcdefgh
 
 Output::
 

--- a/awscli/examples/iot/cancel-job.rst
+++ b/awscli/examples/iot/cancel-job.rst
@@ -3,7 +3,7 @@
 The following ``cancel-job`` example cancels the specified job. ::
 
     aws iot cancel-job \
-        --job-job "example-job-03"
+        --job-id "example-job-03"
         
 Output::
 

--- a/awscli/examples/iotevents/untag-resource.rst
+++ b/awscli/examples/iotevents/untag-resource.rst
@@ -4,7 +4,7 @@ The following ``untag-resource`` example removes the tag with the specified key 
 
     aws iotevents untag-resource \
         --resource-arn arn:aws:iotevents:us-west-2:123456789012:input/PressureInput \
-        --tagkeys deviceType
+        --tag-keys deviceType
 
 This command produces no output.
 

--- a/awscli/examples/iotsitewise/list-project-assets.rst
+++ b/awscli/examples/iotsitewise/list-project-assets.rst
@@ -2,7 +2,7 @@
 
 The following ``list-project-assets`` example lists all assets that are associated to a wind farm project. ::
 
-    aws iotsitewise list-projects \
+    aws iotsitewise list-project-assets \
         --project-id a1b2c3d4-5678-90ab-cdef-eeeeeEXAMPLE
 
 Output::

--- a/awscli/examples/iotsitewise/update-dashboard.rst
+++ b/awscli/examples/iotsitewise/update-dashboard.rst
@@ -3,7 +3,7 @@
 The following ``update-dashboard`` example changes the title of a dashboard's line chart that displays total generated power for a wind farm. ::
 
     aws iotsitewise update-dashboard \
-        --project-id a1b2c3d4-5678-90ab-cdef-fffffEXAMPLE \
+        --dashboard-id a1b2c3d4-5678-90ab-cdef-dddddEXAMPLE \
         --dashboard-name "Wind Farm" \
         --dashboard-definition file://update-wind-farm-dashboard.json
 

--- a/awscli/examples/iotthingsgraph/create-system-instance.rst
+++ b/awscli/examples/iotthingsgraph/create-system-instance.rst
@@ -2,8 +2,8 @@
 
 The following ``create-system-instance`` example creates a system instance. The value of ``MySystemInstanceDefinition`` is the GraphQL that models the system instance. ::
 
-    aws iotthingsgraph create-system-instance -\
-        -definition language=GRAPHQL,text="MySystemInstanceDefinition" \
+    aws iotthingsgraph create-system-instance \
+        --definition language=GRAPHQL,text="MySystemInstanceDefinition" \
         --target CLOUD \
         --flow-actions-role-arn myRoleARN
 

--- a/awscli/examples/ivs-realtime/get-storage-configuration.rst
+++ b/awscli/examples/ivs-realtime/get-storage-configuration.rst
@@ -3,7 +3,7 @@
 The following ``get-storage-configuration`` example gets the composition storage configuration specified by the given ARN (Amazon Resource Name). ::
 
     aws ivs-realtime get-storage-configuration \
-        --name arn "arn:aws:ivs:ap-northeast-1:123456789012:storage-configuration/abcdABCDefgh"
+        --arn "arn:aws:ivs:ap-northeast-1:123456789012:storage-configuration/abcdABCDefgh"
 
 Output::
 

--- a/awscli/examples/ivs/start-viewer-session-revocation.rst
+++ b/awscli/examples/ivs/start-viewer-session-revocation.rst
@@ -2,7 +2,7 @@
 
 The following ``start-viewer-session-revocation`` example starts the process of revoking the viewer session associated with a specified channel ARN and viewer ID, up to and including the specified session version number. If the version is not provided, it defaults to 0. ::
 
-    aws ivs batch-start-viewer-session-revocation \
+    aws ivs start-viewer-session-revocation \
         --channel-arn arn:aws:ivs:us-west-2:123456789012:channel/abcdABCDefgh \
         --viewer-id abcdefg \
         --viewer-session-versions-less-than-or-equal-to 1234567890

--- a/awscli/examples/ivschat/create-chat-token.rst
+++ b/awscli/examples/ivschat/create-chat-token.rst
@@ -3,10 +3,10 @@
 The following ``create-chat-token`` example creates an encrypted chat token that is used to establish an individual WebSocket connection to a room. The token is valid for one minute, and a connection (session) established with the token is valid for the specified duration. ::
 
     aws ivschat create-chat-token \
-        --roomIdentifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6", \
-        --userId" "11231234" \
-        --capabilities "SEND_MESSAGE", \
-        --sessionDurationInMinutes" 30
+        --room-identifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
+        --user-id "11231234" \
+        --capabilities "SEND_MESSAGE" \
+        --session-duration-in-minutes 30
 
 Output::
 

--- a/awscli/examples/ivschat/delete-message.rst
+++ b/awscli/examples/ivschat/delete-message.rst
@@ -3,7 +3,7 @@
 The following ``delete-message`` example sends an even to the specified room, which directs clients to delete the specified message: that is, unrender it from view and delete it from the client's chat history. ::
 
     aws ivschat delete-message \
-        --roomIdentifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
+        --room-identifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
         --id "ABC123def456" \
         --reason "Message contains profanity"
 

--- a/awscli/examples/ivschat/disconnect-user.rst
+++ b/awscli/examples/ivschat/disconnect-user.rst
@@ -3,8 +3,8 @@
 The following ``disconnect-user`` example disconnects all connections for the specified user from the specified room. On success it returns HTTP 200 with an empty response body. ::
 
     aws ivschat disconnect-user \
-        --roomIdentifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
-        --userId "ABC123def456" \
+        --room-identifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
+        --user-id "ABC123def456" \
         --reason "Violated terms of service"
 
 This command produces no output.

--- a/awscli/examples/ivschat/send-event.rst
+++ b/awscli/examples/ivschat/send-event.rst
@@ -3,8 +3,8 @@
 The following ``send-event`` example sends the given event to the specified room. ::
 
     aws ivschat send-event \
-        --roomIdentifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
-        --eventName "SystemMessage" \
+        --room-identifier "arn:aws:ivschat:us-west-2:12345689012:room/g1H2I3j4k5L6" \
+        --event-name "SystemMessage" \
         --attributes \
             "msgType"="user-notification", \
             "msgText"="This chat room will close in 15 minutes."

--- a/awscli/examples/memorydb/describe-parameters.rst
+++ b/awscli/examples/memorydb/describe-parameters.rst
@@ -1,8 +1,9 @@
 **To return a list of parameters**
 
-The following `describe-parameters`` returns a list of parameters. ::
+The following ``describe-parameters`` returns a list of parameters. ::
 
-    aws memorydb describe-parameters
+    aws memorydb describe-parameters \
+        --parameter-group-name default.memorydb-redis6
 
 Output::
 

--- a/awscli/examples/memorydb/list-allowed-node-type-updates.rst
+++ b/awscli/examples/memorydb/list-allowed-node-type-updates.rst
@@ -1,8 +1,9 @@
 **To return a list of allowed node type updates**
 
-The following `list-allowed-node-type-updates` returns a list of available node type updates. ::
+The following ``list-allowed-node-type-updates`` returns a list of available node type updates. ::
 
-    aws memorydb list-allowed-node-type-updates
+    aws memorydb list-allowed-node-type-updates \
+        --cluster-name my-cluster
 
 Output::
 

--- a/awscli/examples/omics/accept-share.rst
+++ b/awscli/examples/omics/accept-share.rst
@@ -3,7 +3,7 @@
 The following ``accept-share`` example accepts a share of HealthOmics analytics store data. ::
 
     aws omics accept-share \
-        ----share-id "495c21bedc889d07d0ab69d710a6841e-dd75ab7a1a9c384fa848b5bd8e5a7e0a"
+        --share-id "495c21bedc889d07d0ab69d710a6841e-dd75ab7a1a9c384fa848b5bd8e5a7e0a"
 
 Output::
 

--- a/awscli/examples/pipes/untag-resource.rst
+++ b/awscli/examples/pipes/untag-resource.rst
@@ -4,6 +4,6 @@ The following ``untag-resource`` example removes a tag with the key ``stack`` fr
 
     aws pipes untag-resource \
         --resource-arn arn:aws:pipes:us-east-1:123456789012:pipe/Demo_Pipe \
-        --tags stack
+        --tag-keys stack
 
 For more information, see `Amazon EventBridge Pipes concepts <https://docs.aws.amazon.com/eventbridge/latest/userguide/pipes-concepts.html>`__ in the *Amazon EventBridge User Guide*.

--- a/awscli/examples/ram/list-principals.rst
+++ b/awscli/examples/ram/list-principals.rst
@@ -3,6 +3,7 @@
 The following ``list-principals`` example displays a list of the principals that can access resources of the specified type through any resource shares. ::
 
     aws ram list-principals \
+        --resource-owner SELF \
         --resource-type ec2:Subnet
 
 Output::

--- a/awscli/examples/rds/describe-db-log-files.rst
+++ b/awscli/examples/rds/describe-db-log-files.rst
@@ -2,8 +2,8 @@
 
 The following ``describe-db-log-files`` example retrieves details about the log files for the specified DB instance. ::
 
-    aws rds describe-db-log-files -\
-        -db-instance-identifier test-instance
+    aws rds describe-db-log-files \
+        --db-instance-identifier test-instance
 
 Output::
 

--- a/awscli/examples/resource-explorer-2/search.rst
+++ b/awscli/examples/resource-explorer-2/search.rst
@@ -1,6 +1,6 @@
 **Example 1: To search using the default view**
 
-The following ``search`` example displays all resources in the specified  that are associated with the  service. The search uses the default view for the Region. The example response includes a ``NextToken`` value, which indicates that there is more output available to retrieve with additional calls. ::
+The following ``search`` example displays all resources in the specified Region that are associated with the IAM service. The search uses the default view for the Region. The example response includes a ``NextToken`` value, which indicates that there is more output available to retrieve with additional calls. ::
 
     aws resource-explorer-2 search \
         --query-string "service:iam"
@@ -40,8 +40,8 @@ Output::
 The following ``search`` example search displays all resources ("*") in the specified AWS Region that are visible through the specified view. The results include only resources associated with Amazon EC2 because of the filters attached to the view. ::
 
     aws resource-explorer-2 search \
-        -- query-string "*" \
-        -- view-arn arn:aws:resource-explorer-2:us-east-1:123456789012:view/My-EC2-view/EXAMPLE8-90ab-cdef-fedc-EXAMPLE22222
+        --query-string "*" \
+        --view-arn arn:aws:resource-explorer-2:us-east-1:123456789012:view/My-EC2-view/EXAMPLE8-90ab-cdef-fedc-EXAMPLE22222
 
 Output::
 

--- a/awscli/examples/route53resolver/put-firewall-rule-group-policy.rst
+++ b/awscli/examples/route53resolver/put-firewall-rule-group-policy.rst
@@ -3,6 +3,7 @@
 The following ``put-firewall-rule-group-policy`` example attaches an AWS Identity and Access Management (AWS IAM) policy for sharing the rule group. ::
 
     aws route53resolver put-firewall-rule-group-policy \
+        --arn arn:aws:route53resolver:us-east-1:AWS_ACCOUNT_ID:firewall-rule-group/rslvr-frg-47f93271fexample \
         --firewall-rule-group-policy "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"test\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::AWS_ACCOUNT_ID:root\"},\"Action\":[\"route53resolver:GetFirewallRuleGroup\",\"route53resolver:ListFirewallRuleGroups\"],\"Resource\":\"arn:aws:route53resolver:us-east-1:AWS_ACCOUNT_ID:firewall-rule-group/rslvr-frg-47f93271fexample\"}]}"
 
 Output::

--- a/awscli/examples/securityhub/accept-administrator-invitation.rst
+++ b/awscli/examples/securityhub/accept-administrator-invitation.rst
@@ -2,7 +2,7 @@
 
 The following ``accept-administrator-invitation`` example accepts the specified invitation from the specified administrator account. ::
 
-    aws securityhub accept-invitation \
+    aws securityhub accept-administrator-invitation \
         --administrator-id 123456789012 \
         --invitation-id 7ab938c5d52d7904ad09f9e7c20cc4eb
 

--- a/awscli/examples/securityhub/batch-get-configuration-policy-associations.rst
+++ b/awscli/examples/securityhub/batch-get-configuration-policy-associations.rst
@@ -3,7 +3,7 @@
 The following ``batch-get-configuration-policy-associations`` example retrieves association details for the specified targets. You can provide account IDs, organizational unit IDs, or the root ID for the target. ::
 
     aws securityhub batch-get-configuration-policy-associations \
-        --target '{"OrganizationalUnitId": "ou-6hi7-8j91kl2m"}'
+        --configuration-policy-association-identifiers '{"OrganizationalUnitId": "ou-6hi7-8j91kl2m"}'
 
 Output::
 

--- a/awscli/examples/securitylake/untag-resource.rst
+++ b/awscli/examples/securitylake/untag-resource.rst
@@ -4,7 +4,7 @@ The following ``untag-resource`` example removes the specified tags from an exis
 
     aws securitylake untag-resource \
         --resource-arn "arn:aws:securitylake:us-east-1:123456789012:subscriber/1234abcd-12ab-34cd-56ef-1234567890ab" \
-        --tags Environment Owner
+        --tag-keys Environment Owner
 
 This command produces no output.
 

--- a/awscli/examples/servicediscovery/untag-resource.rst
+++ b/awscli/examples/servicediscovery/untag-resource.rst
@@ -4,7 +4,7 @@ The following ``untag-resource`` example removes a ``Department`` tag from the s
 
     aws servicediscovery untag-resource \
         --resource-arn arn:aws:servicediscovery:us-west-2:123456789012:namespace/ns-e4anhexample0004 \
-        --tags Key=Department, Value=Engineering
+        --tag-keys Department
 
 This command produces no output.
 

--- a/awscli/examples/ssm/unlabel-parameter-version.rst
+++ b/awscli/examples/ssm/unlabel-parameter-version.rst
@@ -4,7 +4,7 @@ The following ``unlabel-parameter-version`` example deletes the specified labels
 
     aws ssm unlabel-parameter-version \
         --name "parameterName" \
-        --parameter-version "version" \
+        --parameter-version 2 \
         --labels "label_1" "label_2" "label_3"
 
 Output::

--- a/awscli/examples/verifiedpermissions/delete-policy-template.rst
+++ b/awscli/examples/verifiedpermissions/delete-policy-template.rst
@@ -2,7 +2,7 @@
 
 The following ``delete-policy-template`` example deletes the policy template that has the specified Id. ::
 
-    aws verifiedpermissions delete-policy \
+    aws verifiedpermissions delete-policy-template \
         --policy-template-id PTEXAMPLEabcdefg111111 \
         --policy-store-id PSEXAMPLEabcdefg111111
 

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -302,6 +302,9 @@ class CommandValidator:
 
             # Create the service parser
             cmd_table = service_cmd.create_help_command().command_table
+            if not cmd_table:
+                # Top-level commands without sub-operations (e.g. login)
+                return
             service_parser = ServiceArgParser(
                 operations_table=cmd_table, service_name=service_name
             )

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -261,53 +261,93 @@ class CommandValidator:
         )
 
     def validate_cli_command(self, command, filename):
-        # The plan is to expand this to use the proper CLI parser and
-        # parse arguments and verify them with the service model, but
-        # as a first pass, we're going to verify that the service name
-        # and operation match what we expect.  We can do this without
-        # having to use a parser.
-        self._parse_service_operation(command, filename)
-
-    def _parse_service_operation(self, command, filename):
+        """
+        Validates the syntax of a CLI command by actually parsing it, which catches:
+        - Invalid service names
+        - Invalid operation names
+        - Missing required arguments
+        - Invalid argument names
+        - Malformed argument syntax
+        """
         try:
             command_parts = shlex.split(command)[1:]
+            # Strip newlines from arguments that may have been included due to
+            # backslash line continuations in the RST examples
+            command_parts = [part.lstrip('\n') for part in command_parts]
         except Exception as e:
             raise AssertionError(
                 "Failed to parse this example as shell command: %s\n\n"
                 "Error:\n%s\n" % (command, e)
             )
-        # Strip off the 'aws ' part and break it out into a list.
-        parsed_args, remaining = self._parse_next_command(
-            filename, command, command_parts, self._main_parser
-        )
-        # We know the service is good.  Parse the operation.
-        cmd = self._service_command_table[parsed_args.command]
-        cmd_table = cmd.create_help_command().command_table
-        if (
-            not cmd_table
-        ):  # skip top-level commands without subcommands like 'aws login'
-            return
-        service_parser = ServiceArgParser(
-            operations_table=cmd_table, service_name=parsed_args.command
-        )
-        self._parse_next_command(filename, command, remaining, service_parser)
 
-    def _parse_next_command(self, filename, original_cmd, args_list, parser):
-        # Strip off the 'aws ' part and break it out into a list.
-        errors = []
-        parser._print_message = lambda message, file: errors.append(message)
+        # TODO - for now skip validation if command uses
+        # --cli-input-json, --cli-input-yaml, or --generate-cli-skeleton
+        if any(
+            arg.startswith('--cli-input-json')
+            or arg.startswith('--cli-input-yaml')
+            or arg == '--generate-cli-skeleton'
+            for arg in command_parts
+        ):
+            return
+
         try:
-            parsed_args, remaining = parser.parse_known_args(args_list)
-            return parsed_args, remaining
-        except SystemExit:
-            # Yes...we have to catch SystemExit. argparse raises this
-            # when you have an invalid command.
-            error_msg = [
-                'Invalid CLI command: %s\n\n' % original_cmd,
-            ]
-            if errors:
-                error_msg.extend(errors)
-            raise AssertionError(''.join(error_msg))
+            # Parse global args
+            parsed_args, remaining = self._main_parser.parse_known_args(
+                command_parts
+            )
+            service_name = parsed_args.command
+
+            # Get the service command
+            service_cmd = self._service_command_table[service_name]
+
+            # Create the service parser
+            cmd_table = service_cmd.create_help_command().command_table
+            service_parser = ServiceArgParser(
+                operations_table=cmd_table, service_name=service_name
+            )
+
+            # Parse the operation
+            parsed_operation, remaining_args = service_parser.parse_known_args(
+                remaining
+            )
+
+            if not hasattr(parsed_operation, 'operation'):
+                # Not a standard operation (might be help, wait, etc.)
+                return
+
+            operation_name = parsed_operation.operation
+            operation_cmd = cmd_table[operation_name]
+
+            # Validate all arguments using the operation's argument parser
+            from awscli.argparser import ArgTableArgParser
+
+            arg_table = operation_cmd.arg_table
+            operation_parser = ArgTableArgParser(arg_table)
+
+            errors = []
+            operation_parser._print_message = (
+                lambda message, file: errors.append(message)
+            )
+
+            try:
+                operation_parser.parse_known_args(remaining_args)
+            except (SystemExit, Exception) as e:
+                error_msg = [
+                    f'Invalid CLI command: {command}\n\n',
+                    f'File: {filename}\n\n',
+                ]
+                if errors:
+                    error_msg.extend(errors)
+                else:
+                    error_msg.append(f'Error: {e}\n')
+                raise AssertionError(''.join(error_msg))
+
+        except Exception as e:
+            raise AssertionError(
+                f"Failed to validate command: {command}\n"
+                f"File: {filename}\n"
+                f"Error: {e}"
+            )
 
 
 class CollectCLICommands(docutils.nodes.GenericNodeVisitor):

--- a/tests/functional/docs/test_examples.py
+++ b/tests/functional/docs/test_examples.py
@@ -31,7 +31,7 @@ import docutils.parsers.rst
 import docutils.utils
 import pytest
 
-from awscli.argparser import MainArgParser, ServiceArgParser
+from awscli.argparser import ArgTableArgParser, MainArgParser, ServiceArgParser
 from awscli.testutils import BaseAWSHelpOutputTest, create_clidriver
 
 # Mapping of command names to subcommands that have examples in their help
@@ -319,8 +319,6 @@ class CommandValidator:
             operation_cmd = cmd_table[operation_name]
 
             # Validate all arguments using the operation's argument parser
-            from awscli.argparser import ArgTableArgParser
-
             arg_table = operation_cmd.arg_table
             operation_parser = ArgTableArgParser(arg_table)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

This improves the validation we do in the existing `tests/functional/docs/test_examples.py`. Previously we were only testing the service and operation name. 

Now, it runs the example commands through the appropriate parser for each. This will catch more issues: invalid syntax, invalid argument names, missing required parameters.

This also fixes the examples that fail for the updated test.

**Note:** I did not address examples that specify `--cli-input-json`/etc., it'll require more work to parse and validate those.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
