### PR TITLE
fix: replace 1 bare except clause with except Exception

### DIFF
--- a/awscli/customizations/ec2/addcount.py
+++ b/awscli/customizations/ec2/addcount.py
@@ -90,7 +90,7 @@ class CountArgument(BaseCLIArgument):
                 minstr, maxstr = (value, value)
             parameters['MinCount'] = int(minstr)
             parameters['MaxCount'] = int(maxstr)
-        except:
+        except Exception:
             msg = ('count parameter should be of '
                    'form min[:max] (e.g. 1 or 1:10)')
             raise ValueError(msg)


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.