### PR TITLE
[v2] Add tagging support for the s3 mb command

### DIFF
--- a/.changes/next-release/enhancement-s3-62595.json
+++ b/.changes/next-release/enhancement-s3-62595.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``s3``",
+  "description": "Add support for specifying tags on buckets during bucket creation using the ``aws s3 mb`` command via a new ``--tags`` flag."
+}

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1240,16 +1240,17 @@ class MbCommand(S3Command):
                 "Cannot use mb command with a directory bucket."
             )
 
-        bucket_config = {
-            'LocationConstraint': self.client.meta.region_name
-        }
-
         params = {'Bucket': bucket}
+        bucket_config = {}
         bucket_tags = self._create_bucket_tags(parsed_args)
 
+        # Only set LocationConstraint when  the region name is not us-east-1.
+        # Sending LocationConstraint with value us-east-1 results in an error.
+        if self.client.meta.region_name != 'us-east-1':
+            bucket_config['LocationConstraint'] = self.client.meta.region_name
         if bucket_tags:
             bucket_config['Tags'] = bucket_tags
-        if self.client.meta.region_name != 'us-east-1':
+        if bucket_config:
             params['CreateBucketConfiguration'] = bucket_config
 
         # TODO: Consolidate how we handle return codes and errors

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -673,6 +673,15 @@ NO_OVERWRITE = {
     ),
 }
 
+TAGS = {
+    'name': 'tags',
+    'action': 'append',
+    'nargs': 2,
+    'help_text': (
+        "This flag specifies tags to be added to the bucket."
+    ),
+}
+
 
 CASE_CONFLICT = {
     'name': 'case-conflict',
@@ -1206,7 +1215,16 @@ class MbCommand(S3Command):
     NAME = 'mb'
     DESCRIPTION = "Creates an S3 bucket."
     USAGE = "<S3Uri>"
-    ARG_TABLE = [{'name': 'path', 'positional_arg': True, 'synopsis': USAGE}]
+    ARG_TABLE = (
+        [
+            {
+                'name': 'path',
+                'positional_arg': True,
+                'synopsis': USAGE,
+            }
+        ]
+        + [TAGS]
+    )
 
     def _run_main(self, parsed_args, parsed_globals):
         super(MbCommand, self)._run_main(parsed_args, parsed_globals)
@@ -1222,7 +1240,10 @@ class MbCommand(S3Command):
                 "Cannot use mb command with a directory bucket."
             )
 
-        bucket_config = {'LocationConstraint': self.client.meta.region_name}
+        bucket_config = {
+            'LocationConstraint': self.client.meta.region_name,
+            'Tags': self._create_bucket_tags(parsed_args),
+        }
         params = {'Bucket': bucket}
         if self.client.meta.region_name != 'us-east-1':
             params['CreateBucketConfiguration'] = bucket_config
@@ -1238,6 +1259,11 @@ class MbCommand(S3Command):
                 sys.stderr,
             )
             return 1
+
+    def _create_bucket_tags(self, parsed_args):
+        if parsed_args.tags is not None:
+            return [{'Key': tag[0], 'Value': tag[1]} for tag in parsed_args.tags]
+        return []
 
 
 class RbCommand(S3Command):

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1241,10 +1241,14 @@ class MbCommand(S3Command):
             )
 
         bucket_config = {
-            'LocationConstraint': self.client.meta.region_name,
-            'Tags': self._create_bucket_tags(parsed_args),
+            'LocationConstraint': self.client.meta.region_name
         }
+
         params = {'Bucket': bucket}
+        bucket_tags = self._create_bucket_tags(parsed_args)
+
+        if bucket_tags:
+            bucket_config['Tags'] = bucket_tags
         if self.client.meta.region_name != 'us-east-1':
             params['CreateBucketConfiguration'] = bucket_config
 

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -675,10 +675,13 @@ NO_OVERWRITE = {
 
 TAGS = {
     'name': 'tags',
+    'synopsis': '--tags <key> <value>',
     'action': 'append',
     'nargs': 2,
     'help_text': (
-        "This flag specifies tags to be added to the bucket."
+        'This flag specifies tags to be added to the bucket in the format of '
+        '``--tags key value``. You can specify this flag multiple times, '
+        'once for each tag.'
     ),
 }
 

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -1247,7 +1247,7 @@ class MbCommand(S3Command):
         bucket_config = {}
         bucket_tags = self._create_bucket_tags(parsed_args)
 
-        # Only set LocationConstraint when  the region name is not us-east-1.
+        # Only set LocationConstraint when the region name is not us-east-1.
         # Sending LocationConstraint with value us-east-1 results in an error.
         if self.client.meta.region_name != 'us-east-1':
             bucket_config['LocationConstraint'] = self.client.meta.region_name

--- a/awscli/examples/s3/mb.rst
+++ b/awscli/examples/s3/mb.rst
@@ -20,3 +20,17 @@ user makes the bucket ``amzn-s3-demo-bucket`` in the region ``us-west-1``::
 Output::
 
     make_bucket: s3://amzn-s3-demo-bucket
+
+
+**Example 3: Create a bucket with specified tags**
+
+The following ``mb`` command creates a bucket with specified tags using the ``--tags`` parameter. In this example, the
+user makes the bucket ``amzn-s3-demo-bucket`` with two tags with keys ``Key1`` and ``Key2``, respectively. ::
+
+    aws s3 mb s3://amzn-s3-demo-bucket \
+        --tags Key1 Value1 \
+        --tags Key2 Value2
+
+Output::
+
+    make_bucket: s3://amzn-s3-demo-bucket

--- a/awscli/examples/s3/mb.rst
+++ b/awscli/examples/s3/mb.rst
@@ -21,7 +21,6 @@ Output::
 
     make_bucket: s3://amzn-s3-demo-bucket
 
-
 **Example 3: Create a bucket with specified tags**
 
 The following ``mb`` command creates a bucket with specified tags using the ``--tags`` parameter. In this example, the

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -59,6 +59,18 @@ class TestMBCommand(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(command, expected_params)
 
+    def test_make_bucket_with_single_tag_us_east_1(self):
+        command = self.prefix + 's3://bucket --tags Key1 Value1 --region us-east-1'
+        expected_params = {
+            'Bucket': 'bucket',
+            'CreateBucketConfiguration': {
+                'Tags': [
+                    {'Key': 'Key1', 'Value': 'Value1'}
+                ]
+            }
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
     def test_make_bucket_with_multiple_tags(self):
         command = self.prefix + 's3://bucket --tags Key1 Value1 --tags Key2 Value2 --region us-west-2'
         expected_params = {

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -52,7 +52,7 @@ class TestMBCommand(BaseAWSCommandParamsTest):
             'Bucket': 'bucket',
             'CreateBucketConfiguration': {
                 'LocationConstraint': 'us-west-2',
-                'TagSet': [
+                'Tags': [
                     {'Key': 'Key1', 'Value': 'Value1'}
                 ]
             }
@@ -65,7 +65,7 @@ class TestMBCommand(BaseAWSCommandParamsTest):
             'Bucket': 'bucket',
             'CreateBucketConfiguration': {
                 'LocationConstraint': 'us-west-2',
-                'TagSet': [
+                'Tags': [
                     {'Key': 'Key1', 'Value': 'Value1'},
                     {'Key': 'Key2', 'Value': 'Value2'}
                 ]

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -45,3 +45,38 @@ class TestMBCommand(BaseAWSCommandParamsTest):
         command = self.prefix + 's3://bucket--usw2-az1--x-s3/'
         stderr = self.run_cmd(command, expected_rc=252)[1]
         self.assertIn('Cannot use mb command with a directory bucket.', stderr)
+
+    def test_make_bucket_with_single_tag(self):
+        command = self.prefix + 's3://bucket --tags Key1 Value1 --region us-west-2'
+        expected_params = {
+            'Bucket': 'bucket',
+            'CreateBucketConfiguration': {
+                'LocationConstraint': 'us-west-2',
+                'TagSet': [
+                    {'Key': 'Key1', 'Value': 'Value1'}
+                ]
+            }
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_make_bucket_with_multiple_tags(self):
+        command = self.prefix + 's3://bucket --tags Key1 Value1 --tags Key2 Value2 --region us-west-2'
+        expected_params = {
+            'Bucket': 'bucket',
+            'CreateBucketConfiguration': {
+                'LocationConstraint': 'us-west-2',
+                'TagSet': [
+                    {'Key': 'Key1', 'Value': 'Value1'},
+                    {'Key': 'Key2', 'Value': 'Value2'}
+                ]
+            }
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_tags_with_three_arguments_fails(self):
+        command = self.prefix + 's3://bucket --tags Key1 Value1 ExtraArg'
+        self.assert_params_for_cmd(
+            command, 
+            expected_rc=252, 
+            stderr_contains='ParamValidation'
+        )


### PR DESCRIPTION
v2 version of https://github.com/aws/aws-cli/pull/10119

*Issues:*

* Contributes to https://github.com/aws/aws-cli/issues/2458

*Description of changes:*

* Added support for specifying tags on bucket creation for the `aws s3 mb` command.
* Added functional tests for testing the new feature.
* Added a new `aws s3 mb` command example using the new flag.

*Description of test:*

* Ran a successful build-and-validate workflow. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
