### PR TITLE
sort files in cloudformation package when creating zip for consistency 

### DIFF
--- a/awscli/customizations/cloudformation/artifact_exporter.py
+++ b/awscli/customizations/cloudformation/artifact_exporter.py
@@ -186,7 +186,8 @@ def make_zip(filename, source_root):
         zip_file = zipfile.ZipFile(f, 'w', zipfile.ZIP_DEFLATED)
         with contextlib.closing(zip_file) as zf:
             for root, dirs, files in os.walk(source_root, followlinks=True):
-                for filename in files:
+                dirs.sort()
+                for filename in sorted(files):
                     full_path = os.path.join(root, filename)
                     relative_path = os.path.relpath(
                         full_path, source_root)


### PR DESCRIPTION
Sort files when zipping in cloudformation package

This change updates the `make_zip` function in `artifact_exporter.py` to sort
directories and files before adding them to the ZIP archive.
`make_zip` relies on `os.walk()` for file collection, and its iteration order
depends on the underlying filesystem. Since the package's S3 key is derived
from the hash of the final ZIP file, sorting the inputs increases determinism
when the source content is identical and helps avoid unnecessary deployments.

Note: This change affects only file ordering. Other ZIP metadata like mtime and
file permissions is also influencing the resulting hash code, but can be
controlled externally by the user before invoking the package command. This
keeps the change minimal and non-intrusive while still giving users additional
control over determinism when needed.

Partially addresses #3131.