### PR TITLE
auth: exclude additional hop-by-hop headers from SigV4 signing

### DIFF
--- a/.changes/next-release/enhancement-auth-13800.json
+++ b/.changes/next-release/enhancement-auth-13800.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "auth",
+  "description": "Exclude additional hop-by-hop headers from SigV4 signing to prevent signature mismatches when intermediaries mutate transport headers (connection, keep-alive, proxy-authenticate, proxy-authorization, TE, trailer, upgrade)."
+}

--- a/awscli/botocore/auth.py
+++ b/awscli/botocore/auth.py
@@ -57,8 +57,15 @@ PAYLOAD_BUFFER = 1024 * 1024
 ISO8601 = '%Y-%m-%dT%H:%M:%SZ'
 SIGV4_TIMESTAMP = '%Y%m%dT%H%M%SZ'
 SIGNED_HEADERS_BLACKLIST = [
+    'connection',
     'expect',
+    'keep-alive',
+    'proxy-authenticate',
+    'proxy-authorization',
+    'te',
+    'trailer',
     'transfer-encoding',
+    'upgrade',
     'user-agent',
     'x-amzn-trace-id',
 ]

--- a/tests/unit/botocore/auth/test_signers.py
+++ b/tests/unit/botocore/auth/test_signers.py
@@ -239,7 +239,12 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
         )
         auth = self.AuthClass(credentials, 's3', 'us-east-1')
         auth.add_auth(request)
-        self.assertNotIn(header, request.headers['Authorization'])
+        signed_headers = (
+            request.headers['Authorization']
+            .split('SignedHeaders=', 1)[1]
+            .split(',', 1)[0]
+        )
+        self.assertNotIn(header.lower(), signed_headers.split(';'))
 
     def test_blocklist_expect_headers(self):
         self._test_blocklist_header('expect', '100-continue')
@@ -254,6 +259,31 @@ class TestS3SigV4Auth(BaseTestWithFixedDate):
 
     def test_blocklist_transfer_encoding_header(self):
         self._test_blocklist_header('transfer-encoding', 'chunked')
+
+    def test_blocklist_connection_header(self):
+        self._test_blocklist_header('connection', 'keep-alive')
+
+    def test_blocklist_keep_alive_header(self):
+        self._test_blocklist_header('keep-alive', 'timeout=5')
+
+    def test_blocklist_proxy_authenticate_header(self):
+        self._test_blocklist_header(
+            'proxy-authenticate', 'Basic realm="proxy.example.com"'
+        )
+
+    def test_blocklist_proxy_authorization_header(self):
+        self._test_blocklist_header(
+            'proxy-authorization', 'Basic YWxhZGRpbjpvcGVuc2VzYW1l'
+        )
+
+    def test_blocklist_te_header(self):
+        self._test_blocklist_header('te', 'trailers')
+
+    def test_blocklist_trailer_header(self):
+        self._test_blocklist_header('trailer', 'x-amz-checksum-sha256')
+
+    def test_blocklist_upgrade_header(self):
+        self._test_blocklist_header('upgrade', 'websocket')
 
     def test_uses_sha256_if_config_value_is_true(self):
         self.client_config.s3['payload_signing_enabled'] = True


### PR DESCRIPTION
Ports: https://github.com/boto/botocore/pull/3643

TLDR;

This PR aligns SigV4 header signing behavior with IAM guidance by excluding additional hop-by-hop headers from signature calculation. This prevents signature mismatch failures when intermediaries (for example, proxies or load balancers) mutate transport headers in transit.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
