### PR TITLE
[v2] Add generic support for client context params to vendored botocore

### DIFF
--- a/awscli/botocore/args.py
+++ b/awscli/botocore/args.py
@@ -266,6 +266,7 @@ class ClientArgsCreator:
                 disable_request_compression=(
                     client_config.disable_request_compression
                 ),
+                client_context_params=client_config.client_context_params,
                 user_agent_extra=client_config.user_agent_extra,
                 user_agent_appid=client_config.user_agent_appid,
                 sigv4a_signing_region_set=(
@@ -577,14 +578,16 @@ class ClientArgsCreator:
             credentials=credentials,
             account_id_endpoint_mode=account_id_endpoint_mode,
         )
-        # botocore does not support client context parameters generically
-        # for every service. Instead, the s3 config section entries are
-        # available as client context parameters. In the future, endpoint
-        # rulesets of services other than s3/s3control may require client
-        # context parameters.
-        client_context = (
-            s3_config_raw if self._is_s3_service(service_name_raw) else {}
-        )
+        # Client context params for s3 conflict with the available settings
+        # in the `s3` parameter on the `Config` object. If the same parameter
+        # is set in both places, the value in the `s3` parameter takes priority.
+        if client_config is not None:
+            client_context = client_config.client_context_params or {}
+        else:
+            client_context = {}
+        if self._is_s3_service(service_name_raw):
+            client_context.update(s3_config_raw)
+
         sig_version = (
             client_config.signature_version
             if client_config is not None

--- a/awscli/botocore/config.py
+++ b/awscli/botocore/config.py
@@ -193,6 +193,15 @@ class Config:
 
         Defaults to None.
 
+    :type client_context_params: dict
+    :param client_context_params: A dictionary of parameters specific to
+        individual services. If available, valid parameters can be found in
+        the ``Client Context Parameters`` section of the service client's
+        documentation. Invalid parameters or ones that are not used by the
+        specified service will be ignored.
+
+        Defaults to None.
+
     :type sigv4a_signing_region_set: string
     :param sigv4a_signing_region_set: A set of AWS regions to apply the signature for
         when using SigV4a for signing. Set to ``*`` to represent all regions.
@@ -272,6 +281,7 @@ class Config:
             ('ignore_configured_endpoint_urls', None),
             ('request_min_compression_size_bytes', None),
             ('disable_request_compression', None),
+            ('client_context_params', None),
             ('sigv4a_signing_region_set', None),
             ('request_checksum_calculation', None),
             ('response_checksum_validation', None),

--- a/awscli/botocore/docs/client.py
+++ b/awscli/botocore/docs/client.py
@@ -13,6 +13,7 @@
 import inspect
 import os
 
+from botocore import xform_name
 from botocore.compat import OrderedDict
 from botocore.docs.bcdoc.restdoc import DocumentStructure
 from botocore.docs.example import ResponseExampleDocumenter
@@ -376,3 +377,56 @@ class ClientExceptionsDocumenter:
             shape,
             include=[self._GENERIC_ERROR_SHAPE],
         )
+
+
+class ClientContextParamsDocumenter:
+    _CONFIG_GUIDE_LINK = (
+        'https://boto3.amazonaws.com/'
+        'v1/documentation/api/latest/guide/configuration.html'
+    )
+
+    OMITTED_CONTEXT_PARAMS = {
+        's3': (
+            'Accelerate',
+            'DisableMultiRegionAccessPoints',
+            'ForcePathStyle',
+            'UseArnRegion',
+        ),
+        's3control': ('UseArnRegion',),
+    }
+
+    def __init__(self, service_name, context_params):
+        self._service_name = service_name
+        self._context_params = context_params
+
+    def document_context_params(self, section):
+        self._add_title(section)
+        self._add_overview(section)
+        self._add_context_params_list(section)
+
+    def _add_title(self, section):
+        section.style.h2('Client Context Parameters')
+
+    def _add_overview(self, section):
+        section.style.new_line()
+        section.write(
+            'Client context parameters are configurable on a client '
+            'instance via the ``client_context_params`` parameter in the '
+            '``Config`` object. For more detailed instructions and examples '
+            'on the exact usage of context params see the '
+        )
+        section.style.external_link(
+            title='configuration guide',
+            link=self._CONFIG_GUIDE_LINK,
+        )
+        section.write('.')
+        section.style.new_line()
+
+    def _add_context_params_list(self, section):
+        section.style.new_line()
+        sn = f'``{self._service_name}``'
+        section.writeln(f'The available {sn} client context params are:')
+        for param in self._context_params:
+            section.style.new_line()
+            name = f'``{xform_name(param.name)}``'
+            section.write(f'* {name} ({param.type}) - {param.documentation}')

--- a/awscli/botocore/docs/service.py
+++ b/awscli/botocore/docs/service.py
@@ -11,7 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from botocore.docs.bcdoc.restdoc import DocumentStructure
-from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
+from botocore.docs.client import (
+    ClientContextParamsDocumenter,
+    ClientDocumenter,
+    ClientExceptionsDocumenter,
+)
 from botocore.docs.paginator import PaginatorDocumenter
 from botocore.docs.utils import get_official_service_name
 from botocore.docs.waiter import WaiterDocumenter
@@ -39,6 +43,7 @@ class ServiceDocumenter:
             'client-exceptions',
             'paginator-api',
             'waiter-api',
+            'client-context-params',
         ]
 
     def document_service(self):
@@ -55,6 +60,10 @@ class ServiceDocumenter:
         self.client_exceptions(doc_structure.get_section('client-exceptions'))
         self.paginator_api(doc_structure.get_section('paginator-api'))
         self.waiter_api(doc_structure.get_section('waiter-api'))
+        context_params_section = doc_structure.get_section(
+            'client-context-params'
+        )
+        self.client_context_params(context_params_section)
         return doc_structure.flush_structure()
 
     def title(self, section):
@@ -110,3 +119,17 @@ class ServiceDocumenter:
         loader = self._session.get_component('data_loader')
         examples = loader.load_service_model(service_name, 'examples-1')
         return examples['examples']
+
+    def client_context_params(self, section):
+        omitted_params = ClientContextParamsDocumenter.OMITTED_CONTEXT_PARAMS
+        params_to_omit = omitted_params.get(self._service_name, [])
+        service_model = self._client.meta.service_model
+        raw_context_params = service_model.client_context_parameters
+        context_params = [
+            p for p in raw_context_params if p.name not in params_to_omit
+        ]
+        if context_params:
+            context_param_documenter = ClientContextParamsDocumenter(
+                self._service_name, context_params
+            )
+            context_param_documenter.document_context_params(section)

--- a/tests/functional/botocore/docs/test_s3.py
+++ b/tests/functional/botocore/docs/test_s3.py
@@ -10,6 +10,8 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+from botocore import xform_name
+from botocore.docs.client import ClientContextParamsDocumenter
 from botocore.docs.service import ServiceDocumenter
 
 from tests.functional.botocore.docs import BaseDocsFunctionalTest
@@ -79,3 +81,23 @@ class TestS3Docs(BaseDocsFunctionalTest):
         self.assert_contains_line(
             "You can also provide this value as a dictionary", param_docs
         )
+
+    def test_s3_context_params_omitted(self):
+        omitted_params = ClientContextParamsDocumenter.OMITTED_CONTEXT_PARAMS
+        s3_omitted_params = omitted_params['s3']
+        content = ServiceDocumenter(
+            's3', self._session, self.root_services_path
+        ).document_service()
+        for param in s3_omitted_params:
+            param_name = f'``{xform_name(param)}``'
+            self.assert_not_contains_line(param_name, content)
+
+    def test_s3control_context_params_omitted(self):
+        omitted_params = ClientContextParamsDocumenter.OMITTED_CONTEXT_PARAMS
+        s3control_omitted_params = omitted_params['s3control']
+        content = ServiceDocumenter(
+            's3control', self._session, self.root_services_path
+        ).document_service()
+        for param in s3control_omitted_params:
+            param_name = f'``{xform_name(param)}``'
+            self.assert_not_contains_line(param_name, content)

--- a/tests/functional/botocore/test_context_params.py
+++ b/tests/functional/botocore/test_context_params.py
@@ -59,6 +59,11 @@ FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM = {
             "documentation": "",
             "type": "String",
         },
+        "BarClientContextParamName": {
+            "required": False,
+            "documentation": "",
+            "type": "String",
+        },
     },
 }
 
@@ -134,7 +139,11 @@ FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM = {
         "FooClientContextParamName": {
             "documentation": "My mock client context parameter",
             "type": "string",
-        }
+        },
+        "BarClientContextParamName": {
+            "documentation": "My mock client context parameter",
+            "type": "string",
+        },
     },
 }
 
@@ -224,86 +233,178 @@ FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM = {
     **FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM,
     "metadata": S3CONTROL_METADATA,
 }
+CLIENT_CONTEXT_PARAM_INPUT = {
+    "foo_client_context_param_name": "foo_context_param_value"
+}
+OTHER_CLIENT_CONTEXT_PARAM_INPUT = {
+    "bar_client_context_param_name": "bar_value"
+}
+
+CONFIG_WITH_S3 = Config(s3=CLIENT_CONTEXT_PARAM_INPUT)
+CONFIG_WITH_CLIENT_CONTEXT_PARAMS = Config(
+    client_context_params=CLIENT_CONTEXT_PARAM_INPUT
+)
+CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS = Config(
+    s3=CLIENT_CONTEXT_PARAM_INPUT,
+    client_context_params=OTHER_CLIENT_CONTEXT_PARAM_INPUT,
+)
+CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS = Config(
+    s3=CLIENT_CONTEXT_PARAM_INPUT,
+    client_context_params={"foo_client_context_param_name": "bar_value"},
+)
+NO_CTX_PARAM_EXPECTED_CALL_KWARGS = {"Region": "us-east-1"}
+CTX_PARAM_EXPECTED_CALL_KWARGS = {
+    **NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
+    "FooClientContextParamName": "foo_context_param_value",
+}
+MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS = {
+    **CTX_PARAM_EXPECTED_CALL_KWARGS,
+    "BarClientContextParamName": "bar_value",
+}
 
 
 @pytest.mark.parametrize(
-    'service_name,service_model,ruleset,call_should_include_ctx_param',
+    'service_name,service_model,ruleset,config,expected_call_kwargs',
     [
         # s3
         (
             's3',
             FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-            True,
+            CONFIG_WITH_S3,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             's3',
             FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITHOUT_ANY_CONTEXT_PARAMS,
-            False,
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             's3',
             FAKE_S3_MODEL_WITHOUT_ANY_CONTEXT_PARAMS,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-            False,
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             's3',
             FAKE_S3_MODEL_WITHOUT_ANY_CONTEXT_PARAMS,
             FAKE_RULESET_WITHOUT_ANY_CONTEXT_PARAMS,
-            False,
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
+        (
+            's3',
+            FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
+        # use both s3 and client_context_params when they don't overlap
+        (
+            's3',
+            FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS,
+            MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS,
+        ),
+        # use s3 over client_context_params when they overlap
+        (
+            's3',
+            FAKE_S3_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         # s3control
         (
             's3control',
             FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-            True,
+            CONFIG_WITH_S3,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             's3control',
             FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITHOUT_ANY_CONTEXT_PARAMS,
-            False,
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             's3control',
             FAKE_S3CONTROL_MODEL_WITHOUT_ANY_CONTEXT_PARAMS,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-            False,
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             's3control',
             FAKE_S3CONTROL_MODEL_WITHOUT_ANY_CONTEXT_PARAMS,
             FAKE_RULESET_WITHOUT_ANY_CONTEXT_PARAMS,
-            False,
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
-        # botocore does not currently support client context params for
-        # services other than s3 and s3-control.
+        (
+                's3control',
+                FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+                FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+                CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
+                CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
+        # use both s3 and client_context_params when they don't overlap
+        (
+                's3control',
+                FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+                FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+                CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS,
+                MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS,
+        ),
+        # use s3 over client_context_params when they overlap
+        (
+                's3control',
+                FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+                FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+                CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS,
+                CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
+        # otherservice
         (
             'otherservice',
             FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-            False,  # would be True for s3 and s3control
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             'otherservice',
             FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM,
             FAKE_RULESET_WITHOUT_ANY_CONTEXT_PARAMS,
-            False,  # same as for s3 and s3control
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             'otherservice',
             FAKE_MODEL_WITHOUT_ANY_CONTEXT_PARAMS,
             FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-            False,  # same as for s3 and s3control
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
             'otherservice',
             FAKE_MODEL_WITHOUT_ANY_CONTEXT_PARAMS,
             FAKE_RULESET_WITHOUT_ANY_CONTEXT_PARAMS,
-            False,  # same as for s3 and s3control
+            CONFIG_WITH_S3,
+            NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
+        ),
+        (
+            'otherservice',
+            FAKE_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
     ],
 )
@@ -313,7 +414,8 @@ def test_client_context_param_sent_to_endpoint_resolver(
     service_name,
     service_model,
     ruleset,
-    call_should_include_ctx_param,
+    config,
+    expected_call_kwargs,
 ):
     # patch loader to return fake service model and fake endpoint ruleset
     patch_load_service_model(
@@ -321,13 +423,11 @@ def test_client_context_param_sent_to_endpoint_resolver(
     )
 
     # construct client using patched loader and a config object with an s3
-    # section that sets the foo_context_param to a value
+    # or client_context_param section that sets the foo_context_param to a value
     client = patched_session.create_client(
         service_name,
         region_name='us-east-1',
-        config=Config(
-            s3={'foo_client_context_param_name': 'foo_context_param_value'}
-        ),
+        config=config,
     )
 
     # Stub client to prevent a request from getting sent and ascertain that
@@ -342,13 +442,7 @@ def test_client_context_param_sent_to_endpoint_resolver(
         ) as mock_resolve_endpoint:
             client.mock_operation(MockOpParam='mock-op-param-value')
 
-    if call_should_include_ctx_param:
-        mock_resolve_endpoint.assert_called_once_with(
-            Region='us-east-1',
-            FooClientContextParamName='foo_context_param_value',
-        )
-    else:
-        mock_resolve_endpoint.assert_called_once_with(Region='us-east-1')
+    mock_resolve_endpoint.assert_called_once_with(**expected_call_kwargs)
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/botocore/test_context_params.py
+++ b/tests/functional/botocore/test_context_params.py
@@ -348,27 +348,27 @@ MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS = {
             NO_CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         (
-                's3control',
-                FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
-                FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-                CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
-                CTX_PARAM_EXPECTED_CALL_KWARGS,
+            's3control',
+            FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         # use both s3 and client_context_params when they don't overlap
         (
-                's3control',
-                FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
-                FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-                CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS,
-                MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS,
+            's3control',
+            FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_S3_AND_CLIENT_CONTEXT_PARAMS,
+            MULTIPLE_CONTEXT_PARAMS_EXPECTED_CALL_KWARGS,
         ),
         # use s3 over client_context_params when they overlap
         (
-                's3control',
-                FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
-                FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
-                CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS,
-                CTX_PARAM_EXPECTED_CALL_KWARGS,
+            's3control',
+            FAKE_S3CONTROL_MODEL_WITH_CLIENT_CONTEXT_PARAM,
+            FAKE_RULESET_WITH_CLIENT_CONTEXT_PARAM,
+            CONFIG_WITH_CONFLICTING_S3_AND_CLIENT_CONTEXT_PARAMS,
+            CTX_PARAM_EXPECTED_CALL_KWARGS,
         ),
         # otherservice
         (

--- a/tests/unit/botocore/docs/test_client.py
+++ b/tests/unit/botocore/docs/test_client.py
@@ -10,7 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-from botocore.docs.client import ClientDocumenter, ClientExceptionsDocumenter
+from botocore.docs.client import (
+    ClientContextParamsDocumenter,
+    ClientDocumenter,
+    ClientExceptionsDocumenter,
+)
 
 from tests.unit.botocore.docs import BaseDocsTest
 
@@ -166,4 +170,40 @@ class TestClientExceptionsDocumenter(BaseDocsTest):
             self.get_nested_service_contents(
                 'myservice', 'client/exceptions', 'SomeException'
             ),
+        )
+
+
+class TestClientContextParamsDocumenter(BaseDocsTest):
+    def setUp(self):
+        super().setUp()
+        self.json_model['clientContextParams'] = {
+            'ClientContextParam1': {
+                'type': 'string',
+                'documentation': 'A client context param',
+            },
+            'ClientContextParam2': {
+                'type': 'boolean',
+                'documentation': 'A second client context param',
+            },
+        }
+        self.setup_client()
+        service_model = self.client.meta.service_model
+        self.context_params_documenter = ClientContextParamsDocumenter(
+            service_model.service_name, service_model.client_context_parameters
+        )
+
+    def test_client_context_params(self):
+        self.context_params_documenter.document_context_params(
+            self.doc_structure
+        )
+        self.assert_contains_lines_in_order(
+            [
+                '========================',
+                'Client Context Parameters',
+                '========================',
+                'Client context parameters are configurable',
+                'The available ``myservice`` client context params are:',
+                '* ``client_context_param1`` (string) - A client context param',
+                '* ``client_context_param2`` (boolean) - A second client context param',
+            ]
         )

--- a/tests/unit/botocore/docs/test_service.py
+++ b/tests/unit/botocore/docs/test_service.py
@@ -22,6 +22,9 @@ from tests.unit.botocore.docs import BaseDocsTest
 class TestServiceDocumenter(BaseDocsTest):
     def setUp(self):
         super().setUp()
+        self.setup_documenter()
+
+    def setup_documenter(self):
         self.add_shape_to_params('Biz', 'String')
         self.setup_client()
         with mock.patch(
@@ -100,3 +103,22 @@ class TestServiceDocumenter(BaseDocsTest):
         os.remove(self.waiter_model_file)
         contents = self.service_documenter.document_service().decode('utf-8')
         self.assertNotIn('Waiters', contents)
+
+    def test_document_service_no_context_params(self):
+        contents = self.service_documenter.document_service().decode('utf-8')
+        self.assertNotIn('Client Context Parameters', contents)
+
+    def test_document_service_context_params(self):
+        self.json_model['clientContextParams'] = {
+            'ClientContextParam1': {
+                'type': 'string',
+                'documentation': 'A client context param',
+            },
+            'ClientContextParam2': {
+                'type': 'boolean',
+                'documentation': 'A second client context param',
+            },
+        }
+        self.setup_documenter()
+        contents = self.service_documenter.document_service().decode('utf-8')
+        self.assertIn('Client Context Parameters', contents)


### PR DESCRIPTION
*Description of changes:*

* Ports https://github.com/boto/botocore/pull/3037 to vendored botocore. This PR is expected to have **no customer-facing** impact.
* "Adds `client_context_params` config option. If the service is s3 or s3control, still use the s3 config param over client context params if it is set. Params are modeled as capital case but are expected in snake case by the endpoint resolver. This commit also includes some code cleanup for the existing client context params test."

*Description of tests:*

* Successfully ran the build-and-validate workflow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
