### PR TITLE
Raise TypeError on bare @requires_crt, fix existing bare @requires_crt usages, and add regression tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -327,6 +327,10 @@ class CaseInsensitiveDict(collections_abc.MutableMapping):
 
 
 def requires_crt(reason=None):
+    if callable(reason):
+        raise TypeError(
+            "Use @requires_crt() with parentheses, not bare @requires_crt"
+        )
     if reason is None:
         reason = "Test requires awscrt to be installed"
 

--- a/tests/functional/s3/test_cp_command.py
+++ b/tests/functional/s3/test_cp_command.py
@@ -735,7 +735,7 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertEqual(self.operations_called[0][1]['ChecksumAlgorithm'], 'CRC32')
 
-    @requires_crt
+    @requires_crt()
     def test_upload_with_checksum_algorithm_crc32c(self):
         full_path = self.files.create_file('foo.txt', 'contents')
         cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --checksum-algorithm CRC32C'
@@ -743,7 +743,7 @@ class TestCPCommand(BaseCPCommandTest):
         self.assertEqual(self.operations_called[0][0].name, 'PutObject')
         self.assertEqual(self.operations_called[0][1]['ChecksumAlgorithm'], 'CRC32C')
 
-    @requires_crt
+    @requires_crt()
     def test_upload_with_checksum_algorithm_crc64nvme(self):
         full_path = self.files.create_file('foo.txt', 'contents')
         cmdline = f'{self.prefix} {full_path} s3://bucket/key.txt --checksum-algorithm CRC64NVME'

--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -370,7 +370,7 @@ class TestMvCommandWithValidateSameS3Paths(BaseS3TransferCommandTest):
         self.assertEqual(self.operations_called[2][0].name, 'CopyObject')
         self.assertEqual(self.operations_called[3][0].name, 'DeleteObject')
 
-    @requires_crt
+    @requires_crt()
     def test_mv_works_if_mrap_arn_resolves_to_different_bucket(self):
         cmdline = (f"{self.prefix} s3://bucket/key "
                    "s3://arn:aws:s3::123456789012:accesspoint/foobar.mrap/key "
@@ -429,7 +429,7 @@ class TestMvCommandWithValidateSameS3Paths(BaseS3TransferCommandTest):
                    "--validate-same-s3-paths")
         self.assert_runs_mv_without_validation(cmdline)
 
-    @requires_crt
+    @requires_crt()
     def test_skips_validation_if_keys_are_different_mrap_arn(self):
         cmdline = (f"{self.prefix} s3://bucket/key "
                    "s3://arn:aws:s3::123456789012:accesspoint/foobar.mrap/key2 "

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,0 +1,45 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import pytest
+
+from tests import requires_crt
+
+
+class TestRequiresCrt:
+    def test_bare_requires_crt_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @requires_crt
+            def my_test():
+                pass
+
+    def test_requires_crt_skips_when_no_crt(self):
+        with mock.patch('tests.HAS_CRT', False):
+
+            @requires_crt()
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_requires_crt_runs_when_crt_available(self):
+        with mock.patch('tests.HAS_CRT', True):
+
+            @requires_crt()
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False


### PR DESCRIPTION
*Background:*
`requires_crt` is used to skip tests when the optional CRT dependency is not installed. The only supported form should be `@requires_crt()`. However, the current codebase mixes both `@requires_crt` and `@requires_crt()` forms. Using bare `@requires_crt` is unsafe because `requires_crt` is implemented as a decorator factory. Python passes the test function as the `reason` argument, causing the real test body to never run. Assertions are never evaluated, but the test may still appear to pass or skip silently. 

*Description of changes:*
This PR makes bare `@requires_crt` fail immediately with a `TypeError`. Four existing bare `@requires_crt` usages across test files are updated to `@requires_crt()`.

*Testing:*
Regression tests are added to verify correct behavior. All tests including the new tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
