### PR TITLE
[v2] Raise TypeError on bare test decorator usage, fix bare @requires_crt usages, and add regression tests

### DIFF
--- a/tests/functional/s3/test_mv_command.py
+++ b/tests/functional/s3/test_mv_command.py
@@ -835,7 +835,7 @@ class TestMvCommandWithValidateSameS3Paths(BaseS3TransferCommandTest):
         self.assertEqual(self.operations_called[2][0].name, 'CopyObject')
         self.assertEqual(self.operations_called[3][0].name, 'DeleteObject')
 
-    @requires_crt
+    @requires_crt()
     def test_mv_works_if_mrap_arn_resolves_to_different_bucket(self):
         cmdline = (
             f"{self.prefix} s3://bucket/key "
@@ -911,7 +911,7 @@ class TestMvCommandWithValidateSameS3Paths(BaseS3TransferCommandTest):
         )
         self.assert_runs_mv_without_validation(cmdline)
 
-    @requires_crt
+    @requires_crt()
     def test_skips_validation_if_keys_are_different_mrap_arn(self):
         cmdline = (
             f"{self.prefix} s3://bucket/key "

--- a/tests/functional/s3transfer/test_crt.py
+++ b/tests/functional/s3transfer/test_crt.py
@@ -62,7 +62,7 @@ class RecordingSubscriber(BaseSubscriber):
         self.on_done_future = future
 
 
-@requires_crt
+@requires_crt()
 class TestCRTTransferManager(unittest.TestCase):
     def setUp(self):
         self.region = 'us-west-2'

--- a/tests/integration/s3transfer/test_crt.py
+++ b/tests/integration/s3transfer/test_crt.py
@@ -49,7 +49,7 @@ class RecordingSubscriber(BaseSubscriber):
         self.on_done_called = True
 
 
-@requires_crt
+@requires_crt()
 class TestCRTS3Transfers(BaseTransferManagerIntegTest):
     """Tests for the high level s3transfer based on CRT implementation."""
 

--- a/tests/unit/s3transfer/test_crt.py
+++ b/tests/unit/s3transfer/test_crt.py
@@ -89,7 +89,7 @@ class TestCRTProcessLock:
         mock_crt_process_lock.return_value.acquire.assert_called_once_with()
 
 
-@requires_crt
+@requires_crt()
 class TestBotocoreCRTRequestSerializer(unittest.TestCase):
     def setUp(self):
         self.region = 'us-west-2'
@@ -291,7 +291,7 @@ class TestBotocoreCRTCredentialsWrapper:
         self.assert_crt_credentials(crt_credentials)
 
 
-@requires_crt
+@requires_crt()
 class TestCRTTransferFuture(unittest.TestCase):
     def setUp(self):
         self.mock_s3_request = mock.Mock(awscrt.s3.S3RequestType)
@@ -320,7 +320,7 @@ class TestCRTTransferFuture(unittest.TestCase):
             self.future.result()
 
 
-@requires_crt
+@requires_crt()
 class TestOnBodyFileObjWriter(unittest.TestCase):
     def test_call(self):
         fileobj = io.BytesIO()

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -1,0 +1,115 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+
+import pytest
+
+from tests.utils.s3transfer import (
+    requires_crt,
+    skip_if_using_serial_implementation,
+    skip_if_windows,
+)
+
+
+class TestSkipIfWindows:
+    def test_bare_skip_if_windows_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @skip_if_windows
+            def my_test():
+                pass
+
+    def test_skip_if_windows_skips_on_windows(self):
+        with mock.patch('tests.utils.s3transfer.platform') as mock_platform:
+            mock_platform.system.return_value = 'Windows'
+
+            @skip_if_windows('Not supported on Windows')
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_skip_if_windows_runs_on_non_windows(self):
+        with mock.patch('tests.utils.s3transfer.platform') as mock_platform:
+            mock_platform.system.return_value = 'Linux'
+
+            @skip_if_windows('Not supported on Windows')
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False
+
+
+class TestSkipIfUsingSerialImplementation:
+    def test_bare_skip_if_using_serial_implementation_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @skip_if_using_serial_implementation
+            def my_test():
+                pass
+
+    def test_skip_if_using_serial_implementation_skips_when_serial(self):
+        with mock.patch(
+            'tests.utils.s3transfer.is_serial_implementation',
+            return_value=True,
+        ):
+
+            @skip_if_using_serial_implementation(
+                'Not supported in serial mode'
+            )
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_skip_if_using_serial_implementation_runs_when_not_serial(self):
+        with mock.patch(
+            'tests.utils.s3transfer.is_serial_implementation',
+            return_value=False,
+        ):
+
+            @skip_if_using_serial_implementation(
+                'Not supported in serial mode'
+            )
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False
+
+
+class TestRequiresCrt:
+    def test_bare_requires_crt_fails_immediately(self):
+        with pytest.raises(TypeError):
+
+            @requires_crt
+            def my_test():
+                pass
+
+    def test_requires_crt_skips_when_no_crt(self):
+        with mock.patch('tests.utils.s3transfer.HAS_CRT', False):
+
+            @requires_crt()
+            def my_test():
+                assert False
+
+            assert getattr(my_test, '__unittest_skip__', False) is True
+
+    def test_requires_crt_runs_when_crt_available(self):
+        with mock.patch('tests.utils.s3transfer.HAS_CRT', True):
+
+            @requires_crt()
+            def my_test():
+                pass
+
+            assert getattr(my_test, '__unittest_skip__', False) is False

--- a/tests/utils/s3transfer/__init__.py
+++ b/tests/utils/s3transfer/__init__.py
@@ -99,6 +99,11 @@ def skip_if_windows(reason):
             self.assertEqual(...)
 
     """
+    if callable(reason):
+        raise TypeError(
+            "Use @skip_if_windows('reason') with parentheses, "
+            "not bare @skip_if_windows"
+        )
 
     def decorator(func):
         return unittest.skipIf(
@@ -110,6 +115,11 @@ def skip_if_windows(reason):
 
 def skip_if_using_serial_implementation(reason):
     """Decorator to skip tests when running as the serial implementation"""
+    if callable(reason):
+        raise TypeError(
+            "Use @skip_if_using_serial_implementation('reason') with parentheses, "
+            "not bare @skip_if_using_serial_implementation"
+        )
 
     def decorator(func):
         return unittest.skipIf(is_serial_implementation(), reason)(func)
@@ -117,10 +127,18 @@ def skip_if_using_serial_implementation(reason):
     return decorator
 
 
-def requires_crt(cls, reason=None):
+def requires_crt(reason=None):
+    if callable(reason):
+        raise TypeError(
+            "Use @requires_crt() with parentheses, not bare @requires_crt"
+        )
     if reason is None:
         reason = "Test requires awscrt to be installed."
-    return unittest.skipIf(not HAS_CRT, reason)(cls)
+
+    def decorator(func):
+        return unittest.skipIf(not HAS_CRT, reason)(func)
+
+    return decorator
 
 
 class StreamWithError:


### PR DESCRIPTION
**Background:**
`@skip_if_windows`, `@skip_if_using_serial_implementation`, and `@requires_crt` are decorator factories in `tests/utils/s3transfer/__init__.py` for cli v2.

`@skip_if_windows` and `@skip_if_using_serial_implementation` are decorator factories that require parentheses. If they are used without parentheses (e.g., bare `@skip_if_using_serial_implementation`), this is unsafe because Python passes the test function as the first argument, causing the real test body to never run. Assertions are never evaluated, but the test may still appear to pass or skip silently. However, these two did not raise an error on bare usage.

On the other hand, `@requires_crt` in cli v2 only worked correctly with bare usage, while cli v1, botocore, boto3, and s3transfer already required the parenthesized form `@requires_crt()`. This cross-repo inconsistency creates a maintainer footgun because contributors move between repos and assume the decorator behaves the same way everywhere. It needs to be standardized to only accept the parenthesized form and all existing bare usages need to be updated.

Note: `requires_crt_pytest` in `tests/unit/s3transfer/test_crt.py` is a `pytest.mark.skipif` object, not a decorator factory. Bare usage is the correct form for it and is not affected by this change. Similarly, there is another `skip_if_windows` defined in `tests/markers.py` which is also a `pytest.mark.skipif` object and is not affected.

**Description of changes:**
All three decorator factories in `tests/utils/s3transfer/__init__.py` now raise a `TypeError` on bare usage. `@requires_crt` is updated to only accept the parenthesized form for consistency with the other two decorators in this repo as well as cli v1 and other repos. All existing bare `@requires_crt` usages across test files are updated to `@requires_crt()`.

**Testing:**
Regression tests are added in `tests/unit/test_decorators.py` to verify correct behavior for all three decorators. All tests including the new tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
