### PR TITLE
fix: avoid mutating summarize_args list in summarize()

### DIFF
--- a/scripts/performance/benchmark_utils.py
+++ b/scripts/performance/benchmark_utils.py
@@ -23,8 +23,8 @@ def summarize(script, result_dir, summary_dir):
     with open(os.path.join(summary_dir, 'summary.txt'), 'wb') as f:
         subprocess.check_call(summarize_args, stdout=f)
     with open(os.path.join(summary_dir, 'summary.json'), 'wb') as f:
-        summarize_args.extend(['--output-format', 'json'])
-        subprocess.check_call(summarize_args, stdout=f)
+        json_args = summarize_args + ['--output-format', 'json']
+        subprocess.check_call(json_args, stdout=f)
 
 
 def _get_s3transfer_performance_script(script_name):


### PR DESCRIPTION
## Summary

Fix a list mutation bug in `scripts/performance/benchmark_utils.py`.

Closes #10121

## Problem

`summarize()` called `.extend()` on the shared `summarize_args` list before the second `subprocess.check_call()`. This mutates the list in-place, making the function non-idempotent: any repeated call accumulates duplicate `--output-format json` flags.

```python
# Before (buggy)
with open(os.path.join(summary_dir, 'summary.json'), 'wb') as f:
    summarize_args.extend(['--output-format', 'json'])  # mutates original
    subprocess.check_call(summarize_args, stdout=f)
```

## Fix

Construct a new list for the JSON invocation, leaving the original untouched.

```python
# After
with open(os.path.join(summary_dir, 'summary.json'), 'wb') as f:
    json_args = summarize_args + ['--output-format', 'json']
    subprocess.check_call(json_args, stdout=f)
```

## Testing

Verified locally that `summarize_args` is not mutated after the call, and the JSON summary subprocess receives exactly the expected arguments.