### PR TITLE
[v2] Exclude completion models from PyInstaller distribution

### DIFF
--- a/.changes/next-release/bugfix-autocomplete-48067.json
+++ b/.changes/next-release/bugfix-autocomplete-48067.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "autocomplete",
+  "description": "Exclude completion models from final PyInstaller distribution since they're not needed at runtime."
+}

--- a/exe/pyinstaller/hook-awscli.py
+++ b/exe/pyinstaller/hook-awscli.py
@@ -1,3 +1,5 @@
+import os
+
 from PyInstaller.utils import hooks
 
 hiddenimports = [
@@ -26,7 +28,23 @@ alias_packages_plugins = hooks.collect_submodules(
 ) + hooks.collect_submodules('awscli.s3transfer')
 hiddenimports += alias_packages_plugins
 
-datas = hooks.collect_data_files('awscli')
+
+# Completion model files are only used at build time to generate the
+# ac.index SQLite database. They are not needed at runtime and can be
+# excluded to reduce the size of the PyInstaller distribution.
+EXCLUDED_DATA_FILE_BASENAMES = {
+    'completions-1.json',
+    'completions-1.sdk-extras.json',
+}
+
+
+datas = [
+    (src, dest)
+    for src, dest in hooks.collect_data_files('awscli')
+    if os.path.basename(src) not in EXCLUDED_DATA_FILE_BASENAMES
+]
+
+
 # prompt_toolkit uses its own metadata to determine
 # its version. So we need to bundle the package
 # metadata to avoid runtime errors.


### PR DESCRIPTION
Completion models are only used at build time to generate the autocomplete index, `ac.index`. They're not used at runtime by the completer binary so we can save some disk space by excluding completion models from the final PyInstaller distribution.