### PR TITLE
Improve error message when test_models_contain_only_known_file_types fails

### DIFF
--- a/tests/functional/botocore/test_models_directory.py
+++ b/tests/functional/botocore/test_models_directory.py
@@ -37,7 +37,9 @@ def test_models_contain_only_known_file_types(service, loader):
     api_version = loader.determine_latest_version(service, "service-2")
     service_dir = os.path.join(loader.BUILTIN_DATA_PATH, service, api_version)
     for model_file in os.listdir(service_dir):
-        assert model_file.split(".")[0] in known_types
+        assert (
+            model_file.split(".")[0] in known_types
+        ), f'Found unexpected model file: \'{model_file}\' in \'{service_dir}\''
 
 
 @pytest.mark.parametrize("service", _available_services())


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* I had a `.DS_Store` locally that was causing this test to fail. Because it splits on the `.`, the error that `''` was not in `known_types` was confusing. This adds a more verbose error message to the assertion. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
