### PR TITLE
Add list-studios subcommand docs for awscli v1

### DIFF
--- a/awscli/examples/emr/list-studios.rst
+++ b/awscli/examples/emr/list-studios.rst
@@ -1,0 +1,21 @@
+**To list available EMR Studios**
+ 
+The following ``list-studios`` example lists the EMR Studios in the AWS account.::
+ 
+    aws emr list-studios
+
+Output::
+
+    {
+        "Studios": [
+            {
+                "StudioId": "es-XXXXXXX132E0X7R0W7GAS1MVB",
+                "Name": "My_EMR_Studio",
+                "Url": "https://es-XXXXXXX132E0X7R0W7GAS1MVB.emrstudio-prod.us-east-1.amazonaws.com",
+                "AuthMode": "IAM",
+                "CreationTime": 1761664173.624
+            }
+        ]
+    }
+
+For more information, see `Monitor, update and delete Amazon EMR Studio resources <https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-studio-manage-studio.html>`__ in the *Amazon EMR Management Guide*.


### PR DESCRIPTION
*Issue #, if available:* Started with changes as part of #9827

*Description of changes:* Adds documentation for the `emr list-studios` page written as part of https://github.com/aws/aws-cli/pull/9820. That PR adds it for v2, this adds it for v1.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
