### PR TITLE
Add aws_security_token to credentials file keys

### DIFF
--- a/.changes/next-release/enhancement-configure-59283.json
+++ b/.changes/next-release/enhancement-configure-59283.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "configure",
+  "description": "Added aws_security_token to the list of keys that are written to the shared credentials file when using aws configure set."
+}

--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -48,6 +48,7 @@ class ConfigureSetCommand(BasicCommand):
         'aws_access_key_id',
         'aws_secret_access_key',
         'aws_session_token',
+        'aws_security_token',
     ]
 
     def __init__(self, session, config_writer=None):

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -136,6 +136,14 @@ class TestConfigureSetCommand(unittest.TestCase):
             self.fake_credentials_filename,
         )
 
+    def test_security_token_written_to_shared_credentials_file(self):
+        set_command = ConfigureSetCommand(self.session, self.config_writer)
+        set_command(args=['aws_security_token', 'foo'], parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'default', 'aws_security_token': 'foo'},
+            self.fake_credentials_filename,
+        )
+
     def test_access_key_written_to_shared_credentials_file_profile(self):
         set_command = ConfigureSetCommand(self.session, self.config_writer)
         set_command(


### PR DESCRIPTION
*Issue #5084*

*Description of changes:*
  Add `aws_security_token` to `WRITE_TO_CREDS_FILE_KEYS` so that `aws configure set aws_security_token` writes the value to `~/.aws/credentials` instead of `~/.aws/config`.

  Legacy boto expects `aws_security_token` in the credentials file, and this change makes the behavior consistent with how `aws_session_token` is already handled.

  Includes unit test as requested in the original PR #5085.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.