### PR TITLE
Preserve long Fn::Sub YAML strings

### DIFF
--- a/awscli/customizations/cloudformation/yamlhelper.py
+++ b/awscli/customizations/cloudformation/yamlhelper.py
@@ -69,6 +69,9 @@ def yaml_dump(dict_to_dump):
         dict_to_dump,
         default_flow_style=False,
         Dumper=FlattenAliasDumper,
+        # Prevent PyYAML from inserting physical line breaks into long
+        # double-quoted scalars (which can fold to spaces and corrupt content).
+        width=4096,
     )
 
 

--- a/tests/unit/customizations/cloudformation/test_yamlhelper.py
+++ b/tests/unit/customizations/cloudformation/test_yamlhelper.py
@@ -15,6 +15,8 @@ import tempfile
 from botocore.compat import json
 from botocore.compat import OrderedDict
 
+import yaml
+
 from awscli.testutils import mock, unittest
 from awscli.customizations.cloudformation.deployer import Deployer
 from awscli.customizations.cloudformation.yamlhelper import yaml_parse, yaml_dump
@@ -182,3 +184,38 @@ class TestYaml(unittest.TestCase):
         )
         actual = yaml_dump(template)
         self.assertEqual(actual, expected)
+
+    def test_yaml_dump_preserves_long_sub_string(self):
+        # Regression test: long strings in YAML double quotes must not be
+        # corrupted by emitter line wrapping (newline folding to spaces).
+        long_message = (
+            'template: |\\n'
+            '{{ define "test.message" }}\\n'
+            '{{- $queryExprClean := "" }}\\n'
+            '{{- $queryExprTemplated := reReplaceAll "\\\\]" "%5D" ('
+            'reReplaceAll "\\\\[" "%5B" (reReplaceAll "=" "%3D" ('
+            'reReplaceAll "\\\\}" "%7D" (reReplaceAll "\\\\{" "%7B" ('
+            'reReplaceAll ">" "%3E" (reReplaceAll "<" "%3C" ('
+            'reReplaceAll " " "%20" (reReplaceAll "\\"" "%22" ('
+            "reReplaceAll \"'\" \"%27\" ($queryExprClean)))))))))) }}\\n"
+            '{{ end }}\\n'
+        )
+        template = {
+            "Resources": {
+                "TestResource": {
+                    "Type": "AWS::SSM::Parameter",
+                    "Properties": {
+                        "Value": {
+                            "Fn::Sub": [
+                                long_message,
+                                {},
+                            ]
+                        }
+                    },
+                }
+            }
+        }
+
+        dumped = yaml_dump(template)
+        loaded = yaml.safe_load(dumped)
+        self.assertEqual(loaded, template)


### PR DESCRIPTION
Prevent PyYAML from wrapping long double-quoted scalars during\ncloudformation package output serialization, which can fold newlines to\nspaces and corrupt embedded templates.\n\nAdd a regression test that round-trips a long Fn::Sub string through\nyaml_dump() and YAML load.
