### PR TITLE
[v2] Apply sigv4a_signing_region_set when SigV4A is resolved via auth scheme preference

### DIFF
--- a/.changes/next-release/bugfix-auth-28411.json
+++ b/.changes/next-release/bugfix-auth-28411.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "auth",
+  "description": "Fix ``sigv4a_signing_region_set`` config being ignored when SigV4a is selected via ``auth_scheme_preference``. The configured region set is now correctly applied to the signing context regardless of how SigV4a is resolved."
+}

--- a/awscli/botocore/handlers.py
+++ b/awscli/botocore/handlers.py
@@ -167,14 +167,7 @@ def set_operation_specific_signer(context, signing_name, **kwargs):
             return auth_type
 
         if auth_type == 'v4a':
-            # If sigv4a is chosen, we must add additional signing config for
-            # global signature.
-            region = _resolve_sigv4a_region(context)
-            signing = {'region': region, 'signing_name': signing_name}
-            if 'signing' in context:
-                context['signing'].update(signing)
-            else:
-                context['signing'] = signing
+            _set_sigv4a_signing_context(context, signing_name)
             signature_version = 'v4a'
         else:
             signature_version = 'v4'
@@ -199,6 +192,17 @@ def _resolve_sigv4a_region(context):
     if not region and context.get('signing', {}).get('region'):
         region = context['signing']['region']
     return region or '*'
+
+
+def _set_sigv4a_signing_context(context, signing_name):
+    # SigV4A signs for a region set rather than a single credential scope
+    # region, so ensure the request context reflects the configured region set.
+    region = _resolve_sigv4a_region(context)
+    signing = {'region': region, 'signing_name': signing_name}
+    if 'signing' in context:
+        context['signing'].update(signing)
+    else:
+        context['signing'] = signing
 
 
 def decode_console_output(parsed, **kwargs):
@@ -996,7 +1000,9 @@ def remove_bedrock_runtime_invoke_model_with_bidirectional_stream(
         del class_attributes['invoke_model_with_bidirectional_stream']
 
 
-def remove_connecthealth_start_medical_scribe_listening_session(class_attributes, **kwargs):
+def remove_connecthealth_start_medical_scribe_listening_session(
+    class_attributes, **kwargs
+):
     """Operation requires h2 which is currently unsupported in Python"""
     if 'start_medical_scribe_listening_session' in class_attributes:
         del class_attributes['start_medical_scribe_listening_session']
@@ -1271,6 +1277,9 @@ def _set_auth_scheme_preference_signer(context, signing_name, **kwargs):
     ):
         register_feature_id('BEARER_SERVICE_ENV_VARS')
         resolved_signature_version = 'bearer'
+
+    if resolved_signature_version == 'v4a':
+        _set_sigv4a_signing_context(context, signing_name)
 
     if resolved_signature_version == signature_version:
         return None

--- a/tests/unit/botocore/test_handlers.py
+++ b/tests/unit/botocore/test_handlers.py
@@ -48,7 +48,7 @@ from botocore.session import Session
 from botocore.signers import RequestSigner
 from botocore.utils import conditionally_calculate_md5
 
-from tests import BaseSessionTest, mock, unittest
+from tests import BaseSessionTest, mock, requires_crt, unittest
 
 
 class TestHandlers(BaseSessionTest):
@@ -1928,6 +1928,49 @@ def test_set_auth_scheme_preference_signer(
     assert (
         signature_version == expected_signature_version
     ), f"Expected '{expected_signature_version}' but got '{signature_version}'"
+
+
+@requires_crt()
+def test_set_auth_scheme_preference_signer_v4a_sets_signing_context():
+    config = Config(
+        signature_version="v4",
+        auth_scheme_preference=ClientConfigString("sigv4a"),
+        sigv4a_signing_region_set="region_1,region_2",
+    )
+    context = {
+        "client_config": config,
+        "auth_options": ["aws.auth#sigv4", "aws.auth#sigv4a"],
+        "signing": {"foo": "bar"},
+    }
+
+    signature_version = handlers._set_auth_scheme_preference_signer(
+        context, "my-service"
+    )
+
+    assert signature_version == "v4a"
+    assert context["signing"] == {
+        "foo": "bar",
+        "region": "region_1,region_2",
+        "signing_name": "my-service",
+    }
+
+
+def test_set_auth_scheme_preference_signer_explicit_v4a_sets_context():
+    config = Config(
+        signature_version=ClientConfigString("v4a"),
+        sigv4a_signing_region_set="*",
+    )
+    context = {"client_config": config}
+
+    signature_version = handlers._set_auth_scheme_preference_signer(
+        context, "my-service"
+    )
+
+    assert signature_version is None
+    assert context["signing"] == {
+        "region": "*",
+        "signing_name": "my-service",
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
*This is a port of https://github.com/boto/botocore/pull/3663 for AWS CLI v2*

## Overview
Fix `sigv4a_signing_region_set` being ignored when SigV4A is selected via `auth_scheme_preference` or explicit `signature_version='v4a'`, causing `X-Amz-Region-Set` to fall back to the endpoint-derived region (e.g., `us-west-2` instead of `*`).

## Problem
SigV4A signing-context setup only ran inside `set_operation_specific_signer()` when `auth_type == 'v4a'`. This path isn't reached when SigV4A is resolved later by `_set_auth_scheme_preference_signer()` or configured directly on the client, so the region set was never applied.

## Solution
Extract the SigV4A signing-context update into a shared helper and call it whenever the resolved signer is `v4a`, preserving existing region-set precedence.

## Testing

Added unit coverage for:
- `auth_scheme_preference='sigv4a'` applying the configured SigV4A region set
- `explicit signature_version='v4a'` applying the configured SigV4A region set


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
