### PR TITLE
Allow SSEC bucket decryption in s3 integ tests

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -87,6 +87,21 @@ def setup_module():
     s3.delete_public_access_block(
         Bucket=_SHARED_BUCKET
     )
+    s3.put_bucket_encryption(
+        Bucket=_SHARED_BUCKET,
+        ServerSideEncryptionConfiguration={
+            'Rules': [
+                {
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'AES256',
+                    },
+                    'BlockedEncryptionTypes': {
+                        'EncryptionType': ['NONE'],
+                    },
+                }
+            ],
+        },
+    )
 
     # Validate that "_NON_EXISTENT_BUCKET" doesn't exist.
     waiter = s3.get_waiter('bucket_not_exists')


### PR DESCRIPTION
Explicitly re-enable SSE-C on S3 integration test buckets after creation so SSE-C tests continue to pass after the April 2026 default bucket-setting rollout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
