### PR TITLE
Allow SSEC bucket decryption in s3 integ tests v2

### DIFF
--- a/awscli/testutils.py
+++ b/awscli/testutils.py
@@ -198,6 +198,21 @@ def create_bucket(session, name=None, region=None):
             pass
         else:
             raise
+    client.put_bucket_encryption(
+        Bucket=bucket_name,
+        ServerSideEncryptionConfiguration={
+            'Rules': [
+                {
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'AES256',
+                    },
+                    'BlockedEncryptionTypes': {
+                        'EncryptionType': ['NONE'],
+                    },
+                }
+            ],
+        },
+    )
     client.delete_public_access_block(Bucket=bucket_name)
     return bucket_name
 

--- a/tests/integration/botocore/test_s3.py
+++ b/tests/integration/botocore/test_s3.py
@@ -91,6 +91,21 @@ def setup_module():
         # final call as to whether or not the bucket exists.
         LOG.debug("create_bucket() raised an exception: %s", e, exc_info=True)
     waiter.wait(Bucket=_SHARED_BUCKET)
+    s3.put_bucket_encryption(
+        Bucket=_SHARED_BUCKET,
+        ServerSideEncryptionConfiguration={
+            'Rules': [
+                {
+                    'ApplyServerSideEncryptionByDefault': {
+                        'SSEAlgorithm': 'AES256',
+                    },
+                    'BlockedEncryptionTypes': {
+                        'EncryptionType': ['NONE'],
+                    },
+                }
+            ],
+        },
+    )
     s3.delete_public_access_block(Bucket=_SHARED_BUCKET)
 
 

--- a/tests/unit/test_testutils.py
+++ b/tests/unit/test_testutils.py
@@ -33,5 +33,6 @@ class TestCreateBucket(BaseCLIDriverTest):
                         </Error>''',
                 ),
                 mock.Mock(status_code=200, headers={}, content=b''),
+                mock.Mock(status_code=200, headers={}, content=b''),
             ]
             self.assertEqual(create_bucket(self.session, 'bucket'), 'bucket')


### PR DESCRIPTION
Explicitly re-enable SSE-C on S3 integration test buckets after creation so SSE-C tests continue to pass after the April 2026 default bucket-setting rollout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
