### PR TITLE
Fix codeartifact login --namespace to accept uppercase characters

### DIFF
--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -469,7 +469,7 @@ class NpmLogin(BaseLogin):
     @classmethod
     def get_scope(cls, namespace):
         # Regex for valid scope name
-        valid_scope_name = re.compile('^(@[a-z0-9-~][a-z0-9-._~]*)')
+        valid_scope_name = re.compile('^(@[a-zA-Z0-9-~][a-zA-Z0-9-._~]*)')
 
         if namespace is None:
             return namespace

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -1083,6 +1083,11 @@ class TestNpmLogin(unittest.TestCase):
         scope = self.test_subject.get_scope(f'@{self.namespace}')
         self.assertEqual(scope, expected_value)
 
+    def test_get_scope_with_uppercase(self):
+        expected_value = '@Transform9'
+        scope = self.test_subject.get_scope('Transform9')
+        self.assertEqual(scope, expected_value)
+
     def test_get_commands(self):
         commands = self.test_subject.get_commands(
             self.endpoint, self.auth_token


### PR DESCRIPTION
## Summary
- The npm scope name regex in `NpmLogin.get_scope()` only allowed lowercase letters (`a-z`), causing valid `--namespace` values containing uppercase characters to be rejected with a misleading error about URL-safe characters.
- npm scopes are case-insensitive, so uppercase letters should be permitted. This adds `A-Z` to both character classes in the validation regex.
- Adds a unit test for uppercase namespace values.

Fixes #10207