### PR TITLE
Auto-detect account regional namespace buckets in s3 mb

### DIFF
--- a/.changes/next-release/enhancement-s3-41977.json
+++ b/.changes/next-release/enhancement-s3-41977.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "s3",
+  "description": "Add support for creating S3 account regional namespace buckets with aws s3 mb. The command now automatically detects bucket names matching the account-regional naming pattern and sets the required x-amz-bucket-namespace header."
+}

--- a/.changes/next-release/enhancement-s3-41977.json
+++ b/.changes/next-release/enhancement-s3-41977.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
-  "category": "s3",
-  "description": "Add support for creating S3 account regional namespace buckets with aws s3 mb. The command now automatically detects bucket names matching the account-regional naming pattern and sets the required x-amz-bucket-namespace header."
+  "category": "``S3``",
+  "description": "Add support for creating S3 account regional namespace buckets with ``aws s3 mb``. The command now automatically detects bucket names matching the account-regional naming pattern and sets the required ``x-amz-bucket-namespace`` header."
 }

--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -31,7 +31,7 @@ from awscli.customizations.s3.s3handler import S3TransferHandlerFactory
 from awscli.customizations.s3.utils import find_bucket_key, AppendFilter, \
     find_dest_path_comp_key, human_readable_size, \
     RequestParamsMapper, split_s3_bucket_key, block_unsupported_resources, \
-    S3PathResolver
+    S3PathResolver, is_account_regional_namespace_bucket
 from awscli.customizations.utils import uni_print
 from awscli.customizations.s3.syncstrategy.base import MissingFileSync, \
     SizeAndLastModifiedSync, NeverSync, AlwaysSync
@@ -909,6 +909,9 @@ class MbCommand(S3Command):
         params = {'Bucket': bucket}
         bucket_config = {}
         bucket_tags = self._create_bucket_tags(parsed_args)
+
+        if is_account_regional_namespace_bucket(bucket):
+            params['BucketNamespace'] = 'account-regional'
 
         # Only set LocationConstraint when the region name is not us-east-1.
         # Sending LocationConstraint with value us-east-1 results in an error.

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -58,10 +58,6 @@ _S3_OUTPOST_BUCKET_ARN_TO_BUCKET_KEY_REGEX = re.compile(
     r'[a-zA-Z0-9\-]{1,63})[/:]?(?P<key>.*)$'
 )
 
-_S3_ACCOUNT_REGIONAL_NAMESPACE_REGEX = re.compile(
-    r'^.+-\d{12}-[a-z]{2}(-[a-z]+-\d+)?-an$'
-)
-
 _S3_OBJECT_LAMBDA_TO_BUCKET_KEY_REGEX = re.compile(
     r'^(?P<bucket>arn:(aws).*:s3-object-lambda:[a-z\-0-9]+:[0-9]{12}:'
     r'accesspoint[/:][a-zA-Z0-9\-]{1,63})[/:]?(?P<key>.*)$'
@@ -69,7 +65,7 @@ _S3_OBJECT_LAMBDA_TO_BUCKET_KEY_REGEX = re.compile(
 
 
 def is_account_regional_namespace_bucket(bucket):
-    return bool(_S3_ACCOUNT_REGIONAL_NAMESPACE_REGEX.match(bucket))
+    return bucket.endswith('-an')
 
 
 def human_readable_size(value):

--- a/awscli/customizations/s3/utils.py
+++ b/awscli/customizations/s3/utils.py
@@ -58,10 +58,18 @@ _S3_OUTPOST_BUCKET_ARN_TO_BUCKET_KEY_REGEX = re.compile(
     r'[a-zA-Z0-9\-]{1,63})[/:]?(?P<key>.*)$'
 )
 
+_S3_ACCOUNT_REGIONAL_NAMESPACE_REGEX = re.compile(
+    r'^.+-\d{12}-[a-z]{2}(-[a-z]+-\d+)?-an$'
+)
+
 _S3_OBJECT_LAMBDA_TO_BUCKET_KEY_REGEX = re.compile(
     r'^(?P<bucket>arn:(aws).*:s3-object-lambda:[a-z\-0-9]+:[0-9]{12}:'
     r'accesspoint[/:][a-zA-Z0-9\-]{1,63})[/:]?(?P<key>.*)$'
 )
+
+
+def is_account_regional_namespace_bucket(bucket):
+    return bool(_S3_ACCOUNT_REGIONAL_NAMESPACE_REGEX.match(bucket))
 
 
 def human_readable_size(value):

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -92,7 +92,7 @@ class TestMBCommand(BaseAWSCommandParamsTest):
 
     def test_account_regional_namespace_bucket(self):
         bucket = 'amzn-s3-demo-bucket-111122223333-us-west-2-an'
-        command = self.prefix + 's3://%s --region us-west-2' % bucket
+        command = self.prefix + f's3://{bucket} --region us-west-2'
         self.parsed_responses = [{'Location': 'us-west-2'}]
         expected_params = {
             'Bucket': bucket,
@@ -103,7 +103,16 @@ class TestMBCommand(BaseAWSCommandParamsTest):
 
     def test_account_regional_namespace_bucket_us_east_1(self):
         bucket = 'my-bucket-111122223333-us-east-1-an'
-        command = self.prefix + 's3://%s --region us-east-1' % bucket
+        command = self.prefix + f's3://{bucket} --region us-east-1'
+        expected_params = {
+            'Bucket': bucket,
+            'BucketNamespace': 'account-regional',
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_account_regional_namespace_short_bucket_name(self):
+        bucket = 'xyz-an'
+        command = self.prefix + f's3://{bucket} --region us-east-1'
         expected_params = {
             'Bucket': bucket,
             'BucketNamespace': 'account-regional',

--- a/tests/functional/s3/test_mb_command.py
+++ b/tests/functional/s3/test_mb_command.py
@@ -90,6 +90,31 @@ class TestMBCommand(BaseAWSCommandParamsTest):
         }
         self.assert_params_for_cmd(command, expected_params)
 
+    def test_account_regional_namespace_bucket(self):
+        bucket = 'amzn-s3-demo-bucket-111122223333-us-west-2-an'
+        command = self.prefix + 's3://%s --region us-west-2' % bucket
+        self.parsed_responses = [{'Location': 'us-west-2'}]
+        expected_params = {
+            'Bucket': bucket,
+            'BucketNamespace': 'account-regional',
+            'CreateBucketConfiguration': {'LocationConstraint': 'us-west-2'},
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_account_regional_namespace_bucket_us_east_1(self):
+        bucket = 'my-bucket-111122223333-us-east-1-an'
+        command = self.prefix + 's3://%s --region us-east-1' % bucket
+        expected_params = {
+            'Bucket': bucket,
+            'BucketNamespace': 'account-regional',
+        }
+        self.assert_params_for_cmd(command, expected_params)
+
+    def test_regular_bucket_no_namespace(self):
+        command = self.prefix + 's3://my-regular-bucket --region us-east-1'
+        expected_params = {'Bucket': 'my-regular-bucket'}
+        self.assert_params_for_cmd(command, expected_params)
+
     def test_tags_with_three_arguments_fails(self):
         command = self.prefix + 's3://bucket --tags Key1 Value1 ExtraArg'
         self.assert_params_for_cmd(

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -190,6 +190,13 @@ class BaseS3IntegrationTest(BaseS3CLICommand):
         super(BaseS3IntegrationTest, self).setUp()
 
 
+class TestMakeBucketAccountRegionalNamespace(BaseS3IntegrationTest):
+    def test_short_an_suffix_sends_namespace_header(self):
+        p = aws('s3 mb s3://xyz-an')
+        assert p.rc != 0
+        assert 'InvalidBucketNamespace' in p.stderr
+
+
 class TestMoveCommand(BaseS3IntegrationTest):
     def assert_mv_local_to_s3(self, bucket_name):
         full_path = self.files.create_file('foo.txt', 'this is foo.txt')

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -40,7 +40,8 @@ from awscli.customizations.s3.utils import (
     ProvideLastModifiedTimeSubscriber, DirectoryCreatorSubscriber,
     DeleteSourceObjectSubscriber, DeleteSourceFileSubscriber,
     DeleteCopySourceObjectSubscriber, NonSeekableStream, CreateDirectoryError,
-    S3PathResolver, CaseConflictCleanupSubscriber)
+    S3PathResolver, CaseConflictCleanupSubscriber,
+    is_account_regional_namespace_bucket)
 from awscli.customizations.s3.results import WarningResult
 from tests.unit.customizations.s3 import FakeTransferFuture
 from tests.unit.customizations.s3 import FakeTransferFutureMeta
@@ -358,6 +359,46 @@ class TestBlockUnsupportedResources(unittest.TestCase):
                  'arn:aws:s3-outposts:us-west-2:123456789012:'
                  'outpost/op-0a12345678abcdefg/bucket/bucket-foo'
             )
+
+
+class TestIsAccountRegionalNamespaceBucket(unittest.TestCase):
+    def test_matches_standard_pattern(self):
+        self.assertTrue(
+            is_account_regional_namespace_bucket(
+                'amzn-s3-demo-bucket-111122223333-us-west-2-an'
+            )
+        )
+
+    def test_matches_different_region(self):
+        self.assertTrue(
+            is_account_regional_namespace_bucket(
+                'my-bucket-123456789012-eu-central-1-an'
+            )
+        )
+
+    def test_no_match_regular_bucket(self):
+        self.assertFalse(
+            is_account_regional_namespace_bucket('my-regular-bucket')
+        )
+
+    def test_no_match_missing_an_suffix(self):
+        self.assertFalse(
+            is_account_regional_namespace_bucket(
+                'bucket-111122223333-us-west-2'
+            )
+        )
+
+    def test_no_match_wrong_account_id_length(self):
+        self.assertFalse(
+            is_account_regional_namespace_bucket(
+                'bucket-12345-us-west-2-an'
+            )
+        )
+
+    def test_no_match_express_directory_bucket(self):
+        self.assertFalse(
+            is_account_regional_namespace_bucket('bucket--usw2-az1--x-s3')
+        )
 
 
 class TestCreateWarning(unittest.TestCase):

--- a/tests/unit/customizations/s3/test_utils.py
+++ b/tests/unit/customizations/s3/test_utils.py
@@ -388,11 +388,9 @@ class TestIsAccountRegionalNamespaceBucket(unittest.TestCase):
             )
         )
 
-    def test_no_match_wrong_account_id_length(self):
-        self.assertFalse(
-            is_account_regional_namespace_bucket(
-                'bucket-12345-us-west-2-an'
-            )
+    def test_matches_short_bucket_name(self):
+        self.assertTrue(
+            is_account_regional_namespace_bucket('xyz-an')
         )
 
     def test_no_match_express_directory_bucket(self):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The s3 mb command now automatically detects account regional namespace bucket names (matching *-<accountId>-<region>-an) and sets the x-amz-bucket-namespace: account-regional header on the CreateBucket request. Previously, users had to fall back to s3api create-bucket --bucket-namespace for 
this workflow.

v2: https://github.com/aws/aws-cli/pull/10212


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
