### PR TITLE
[v2] Double-quote Windows alias command args if metacharacters present

### DIFF
--- a/awscli/alias.py
+++ b/awscli/alias.py
@@ -415,7 +415,9 @@ class ExternalAliasCommand(BaseAliasCommand):
 
     def __call__(self, args, parsed_globals):
         command_components = [self._alias_value[1:]]
-        command_components.extend(compat_shell_quote(a) for a in args)
+        command_components.extend(
+            compat_shell_quote(a, shell=True) for a in args
+        )
         command = ' '.join(command_components)
         LOG.debug(
             'Using external alias %r with value: %r to run: %r',

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -261,13 +261,14 @@ def compat_input(prompt):
         # This is unused directly when the user pastes the cross-device
         # verification code, which may be longer than some terminal's buffers
         import readline  # noqa: F401
+
         return raw_input()
     except ImportError:
         LOG.debug('readline module not available')
         return raw_input()
 
 
-def compat_shell_quote(s, platform=None):
+def compat_shell_quote(s, platform=None, shell=False):
     """Return a shell-escaped version of the string *s*
 
     Unfortunately `shlex.quote` doesn't support Windows, so this method
@@ -277,13 +278,15 @@ def compat_shell_quote(s, platform=None):
         platform = sys.platform
 
     if platform == "win32":
-        return _windows_shell_quote(s)
+        if shell:
+            return _windows_cmd_shell_quote(s)
+        return _windows_argv_quote(s)
     else:
         return shlex.quote(s)
 
 
-def _windows_shell_quote(s):
-    """Return a Windows shell-escaped version of the string *s*
+def _windows_argv_quote(s):
+    """Return a Windows argv-escaped version of the string *s*
 
     Windows has potentially bizarre rules depending on where you look. When
     spawning a process via the Windows C runtime the rules are as follows:
@@ -343,6 +346,52 @@ def _windows_shell_quote(s):
         # quoted.
         return '"%s"' % new_s
     return new_s
+
+
+def _windows_cmd_shell_quote(s):
+    """Return a Windows shell-escaped version of the string *s* that is
+    safe to pass through cmd.exe
+
+    Handles two interpretation layers:
+      1. cmd.exe metacharacters - neutralized by always double-quoting,
+         which prevents interpretation of &, |, >, <, ^, (, and ).
+      2. MSVC C runtime argv parsing - backslash/double-quote escaping
+         so the target process receives the correct argument.
+
+    Note: cmd.exe %VAR% expansion and !VAR! delayed expansion
+    cannot be reliably escaped inside double quotes on the
+    command line and are not handled here.
+
+    :param s: A string to escape
+    :return: An escaped string
+    """
+    if not s:
+        return '""'
+
+    buff = []
+    num_backspaces = 0
+    for character in s:
+        if character == '\\':
+            num_backspaces += 1
+        elif character == '"':
+            if num_backspaces > 0:
+                buff.append('\\' * (num_backspaces * 2))
+                num_backspaces = 0
+            buff.append('\\"')
+        else:
+            if num_backspaces > 0:
+                buff.append('\\' * num_backspaces)
+                num_backspaces = 0
+            buff.append(character)
+
+    # Trailing backslashes must be doubled because we always append
+    # a closing double quote. Without doubling, a trailing backslash
+    # would escape the closing quote.
+    if num_backspaces > 0:
+        buff.append('\\' * (num_backspaces * 2))
+
+    inner = ''.join(buff)
+    return f'"{inner}"'
 
 
 def get_popen_kwargs_for_pager_cmd(pager_cmd=None):

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -312,37 +312,37 @@ def _windows_argv_quote(s):
         return '""'
 
     buff = []
-    num_backspaces = 0
+    num_backslashes = 0
     for character in s:
         if character == '\\':
             # We can't simply append backslashes because we don't know if
             # they will need to be escaped. Instead we separately keep track
             # of how many we've seen.
-            num_backspaces += 1
+            num_backslashes += 1
         elif character == '"':
-            if num_backspaces > 0:
+            if num_backslashes > 0:
                 # The backslashes are part of a chain that lead up to a
                 # double quote, so they need to be escaped.
-                buff.append('\\' * (num_backspaces * 2))
-                num_backspaces = 0
+                buff.append('\\' * (num_backslashes * 2))
+                num_backslashes = 0
 
             # The double quote also needs to be escaped. The fact that we're
             # seeing it at all means that it must have been escaped in the
             # original source.
             buff.append('\\"')
         else:
-            if num_backspaces > 0:
+            if num_backslashes > 0:
                 # The backslashes aren't part of a chain leading up to a
                 # double quote, so they can be inserted directly without
                 # being escaped.
-                buff.append('\\' * num_backspaces)
-                num_backspaces = 0
+                buff.append('\\' * num_backslashes)
+                num_backslashes = 0
             buff.append(character)
 
-    # There may be some leftover backspaces if they were on the trailing
+    # There may be some leftover backslashes if they were on the trailing
     # end, so they're added back in here.
-    if num_backspaces > 0:
-        buff.append('\\' * num_backspaces)
+    if num_backslashes > 0:
+        buff.append('\\' * num_backslashes)
 
     new_s = ''.join(buff)
     if ' ' in new_s or '\t' in new_s:
@@ -373,21 +373,21 @@ def _windows_cmd_shell_quote(s):
         return '""'
 
     buff = []
-    num_backspaces = 0
+    num_backslashes = 0
     needs_quoting = False
     for character in s:
         if character == '\\':
-            num_backspaces += 1
+            num_backslashes += 1
         elif character == '"':
-            if num_backspaces > 0:
-                buff.append('\\' * (num_backspaces * 2))
-                num_backspaces = 0
+            if num_backslashes > 0:
+                buff.append('\\' * (num_backslashes * 2))
+                num_backslashes = 0
             buff.append('\\"')
             needs_quoting = True
         else:
-            if num_backspaces > 0:
-                buff.append('\\' * num_backspaces)
-                num_backspaces = 0
+            if num_backslashes > 0:
+                buff.append('\\' * num_backslashes)
+                num_backslashes = 0
             if character in _WIN_CMD_UNSAFE_CHARS:
                 needs_quoting = True
             buff.append(character)
@@ -396,13 +396,13 @@ def _windows_cmd_shell_quote(s):
         # Trailing backslashes must be doubled when we append a closing
         # double quote — without doubling, a trailing backslash would
         # escape the closing quote.
-        if num_backspaces > 0:
-            buff.append('\\' * (num_backspaces * 2))
+        if num_backslashes > 0:
+            buff.append('\\' * (num_backslashes * 2))
         inner = ''.join(buff)
         return f'"{inner}"'
 
-    if num_backspaces > 0:
-        buff.append('\\' * num_backspaces)
+    if num_backslashes > 0:
+        buff.append('\\' * num_backslashes)
     return ''.join(buff)
 
 

--- a/awscli/compat.py
+++ b/awscli/compat.py
@@ -75,6 +75,10 @@ raw_input = input
 OUTPUT_ENCODING_ENV_VAR = 'AWS_CLI_OUTPUT_ENCODING'
 PYTHONUTF8_ENV_VAR = 'PYTHONUTF8'
 
+# cmd.exe characters that require double-quoting to be treated as literals.
+# https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd
+_WIN_CMD_UNSAFE_CHARS = set('&<>[]|{}^=;!\'()+,`~ \t')
+
 LOG = logging.getLogger(__name__)
 
 
@@ -353,8 +357,8 @@ def _windows_cmd_shell_quote(s):
     safe to pass through cmd.exe
 
     Handles two interpretation layers:
-      1. cmd.exe metacharacters - neutralized by always double-quoting,
-         which prevents interpretation of &, |, >, <, ^, (, and ).
+      1. cmd.exe metacharacters - neutralized by double-quoting when
+         the string contains any cmd.exe special characters.
       2. MSVC C runtime argv parsing - backslash/double-quote escaping
          so the target process receives the correct argument.
 
@@ -370,6 +374,7 @@ def _windows_cmd_shell_quote(s):
 
     buff = []
     num_backspaces = 0
+    needs_quoting = False
     for character in s:
         if character == '\\':
             num_backspaces += 1
@@ -378,20 +383,27 @@ def _windows_cmd_shell_quote(s):
                 buff.append('\\' * (num_backspaces * 2))
                 num_backspaces = 0
             buff.append('\\"')
+            needs_quoting = True
         else:
             if num_backspaces > 0:
                 buff.append('\\' * num_backspaces)
                 num_backspaces = 0
+            if character in _WIN_CMD_UNSAFE_CHARS:
+                needs_quoting = True
             buff.append(character)
 
-    # Trailing backslashes must be doubled because we always append
-    # a closing double quote. Without doubling, a trailing backslash
-    # would escape the closing quote.
-    if num_backspaces > 0:
-        buff.append('\\' * (num_backspaces * 2))
+    if needs_quoting:
+        # Trailing backslashes must be doubled when we append a closing
+        # double quote — without doubling, a trailing backslash would
+        # escape the closing quote.
+        if num_backspaces > 0:
+            buff.append('\\' * (num_backspaces * 2))
+        inner = ''.join(buff)
+        return f'"{inner}"'
 
-    inner = ''.join(buff)
-    return f'"{inner}"'
+    if num_backspaces > 0:
+        buff.append('\\' * num_backspaces)
+    return ''.join(buff)
 
 
 def get_popen_kwargs_for_pager_cmd(pager_cmd=None):

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -83,13 +83,13 @@ def test_compat_shell_quote_windows(input_string, expected_output):
     "input_string, expected_output",
     (
         ('', '""'),
-        ('foo', '"foo"'),
+        ('foo', 'foo'),
         ('foo bar', '"foo bar"'),
         ('foo\tbar', '"foo\tbar"'),
         ('"', '"\\""'),
-        ('\\', '"\\\\"'),
-        ('\\a', '"\\a"'),
-        ('\\\\', '"\\\\\\\\"'),
+        ('\\', '\\'),
+        ('\\a', '\\a'),
+        ('\\\\', '\\\\'),
         ('\\"', '"\\\\\\""'),
         ('foo&bar', '"foo&bar"'),
         ('foo|bar', '"foo|bar"'),
@@ -97,12 +97,20 @@ def test_compat_shell_quote_windows(input_string, expected_output):
         ('foo<bar', '"foo<bar"'),
         ('foo^bar', '"foo^bar"'),
         ('foo(bar)', '"foo(bar)"'),
-        ('foo%PATH%bar', '"foo%PATH%bar"'),
-        ('foo!PATH!bar', '"foo!PATH!bar"'),
+        ('foo,bar', '"foo,bar"'),
+        ('foo;bar', '"foo;bar"'),
+        ('foo=bar', '"foo=bar"'),
+        ('foo!bar', '"foo!bar"'),
+        ('foo%PATH%bar', 'foo%PATH%bar'),
+        ('foo\\', 'foo\\'),
+        ('foo bar\\', '"foo bar\\\\"'),
     ),
 )
 def test_compat_shell_quote_windows_for_cmd_exe(input_string, expected_output):
-    assert compat_shell_quote(input_string, "win32", shell=True) == expected_output
+    assert (
+        compat_shell_quote(input_string, "win32", shell=True)
+        == expected_output
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_compat.py
+++ b/tests/unit/test_compat.py
@@ -82,6 +82,32 @@ def test_compat_shell_quote_windows(input_string, expected_output):
 @pytest.mark.parametrize(
     "input_string, expected_output",
     (
+        ('', '""'),
+        ('foo', '"foo"'),
+        ('foo bar', '"foo bar"'),
+        ('foo\tbar', '"foo\tbar"'),
+        ('"', '"\\""'),
+        ('\\', '"\\\\"'),
+        ('\\a', '"\\a"'),
+        ('\\\\', '"\\\\\\\\"'),
+        ('\\"', '"\\\\\\""'),
+        ('foo&bar', '"foo&bar"'),
+        ('foo|bar', '"foo|bar"'),
+        ('foo>bar', '"foo>bar"'),
+        ('foo<bar', '"foo<bar"'),
+        ('foo^bar', '"foo^bar"'),
+        ('foo(bar)', '"foo(bar)"'),
+        ('foo%PATH%bar', '"foo%PATH%bar"'),
+        ('foo!PATH!bar', '"foo!PATH!bar"'),
+    ),
+)
+def test_compat_shell_quote_windows_for_cmd_exe(input_string, expected_output):
+    assert compat_shell_quote(input_string, "win32", shell=True) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_string, expected_output",
+    (
         ('', "''"),
         ('*', "'*'"),
         ('foo', 'foo'),


### PR DESCRIPTION
`_windows_shell_quote()` only escapes for the MSVC C runtime argv parser (backslashes and double quotes) but
does not account for `cmd.exe` metacharacters. When `ExternalAliasCommand` passes user-supplied arguments through `subprocess.call(command, shell=True)`, the string is interpreted by `cmd.exe` before reaching the target process, meaning metacharacters aren't properly escaped.

This PR fixes the issue by double-quoting the alias value string when `shell=True` and cmd.exe metacharacters are present, automatically treating metacharacters as literals.

Ideally we could collapse `_windows_argv_quote` and `_windows_cmd_shell_quote` into a single function, but I'm hesitant to change the code path for other CLI features that use `compat_shell_quote`, especially features that don't spawn a subprocess with `shell=True` like `ec2-instance-connect ssh`. 

**NOTE:** `%VAR%` expansion and `!VAR!` delayed expansion cannot be reliably escaped inside double quotes in `cmd.exe /c`. `%%` doubling only works in batch file mode. There is no known reliable escape for `%` or `!` inside double quotes on the command line.