### PR TITLE
Rename CloudWatch o-tel commands to otel with hidden backward-compatibility

### DIFF
--- a/.changes/next-release/cloudwatch-otel-rename.json
+++ b/.changes/next-release/cloudwatch-otel-rename.json
@@ -1,0 +1,7 @@
+[
+    {
+        "category": "``cloudwatch``",
+        "description": "Rename ``get-o-tel-enrichment``, ``start-o-tel-enrichment``, and ``stop-o-tel-enrichment`` commands to ``get-otel-enrichment``, ``start-otel-enrichment``, and ``stop-otel-enrichment``. The old names are kept as hidden aliases for backward compatibility.",
+        "type": "bugfix"
+    }
+]

--- a/awscli/customizations/cloudwatch.py
+++ b/awscli/customizations/cloudwatch.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.customizations.utils import alias_command
+
+
+def register_rename_otel_commands(event_emitter):
+    event_emitter.register(
+        'building-command-table.cloudwatch',
+        rename_otel_commands
+    )
+
+
+def rename_otel_commands(command_table, **kwargs):
+    """Rename o-tel commands to otel, keeping o-tel as hidden aliases."""
+    renames = {
+        'get-o-tel-enrichment': 'get-otel-enrichment',
+        'start-o-tel-enrichment': 'start-otel-enrichment',
+        'stop-o-tel-enrichment': 'stop-otel-enrichment',
+    }
+    for old_name, new_name in renames.items():
+        if old_name in command_table:
+            alias_command(command_table, old_name, new_name)

--- a/awscli/handlers.py
+++ b/awscli/handlers.py
@@ -34,6 +34,7 @@ from awscli.customizations.cloudfront import register as register_cloudfront
 from awscli.customizations.cloudsearch import initialize as cloudsearch_init
 from awscli.customizations.cloudsearchdomain import register_cloudsearchdomain
 from awscli.customizations.cloudtrail import initialize as cloudtrail_init
+from awscli.customizations.cloudwatch import register_rename_otel_commands
 from awscli.customizations.codeartifact import register_codeartifact_commands
 from awscli.customizations.codecommit import initialize as codecommit_init
 from awscli.customizations.codedeploy.codedeploy import (
@@ -223,6 +224,7 @@ def awscli_initialize(event_handlers):
     cloudformation_init(event_handlers)
     register_servicecatalog_commands(event_handlers)
     register_translate_import_terminology(event_handlers)
+    register_rename_otel_commands(event_handlers)
     register_history_mode(event_handlers)
     register_history_commands(event_handlers)
     register_event_stream_arg(event_handlers)

--- a/tests/functional/cloudwatch/test_otel_alias.py
+++ b/tests/functional/cloudwatch/test_otel_alias.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+from awscli.testutils import BaseAWSCommandParamsTest
+
+
+class TestOTelAlias(BaseAWSCommandParamsTest):
+    def test_get_otel_enrichment_alias(self):
+        self.run_cmd('cloudwatch get-otel-enrichment', expected_rc=0)
+        self.run_cmd('cloudwatch get-o-tel-enrichment', expected_rc=0)
+
+    def test_start_otel_enrichment_alias(self):
+        self.run_cmd('cloudwatch start-otel-enrichment', expected_rc=0)
+        self.run_cmd('cloudwatch start-o-tel-enrichment', expected_rc=0)
+
+    def test_stop_otel_enrichment_alias(self):
+        self.run_cmd('cloudwatch stop-otel-enrichment', expected_rc=0)
+        self.run_cmd('cloudwatch stop-o-tel-enrichment', expected_rc=0)


### PR DESCRIPTION
Rename the 3 CloudWatch OTel enrichment CLI commands from o-tel to otel naming, consistent with the OpenTelemetry (https://opentelemetry.io/) community convention:

  - get-o-tel-enrichment → get-otel-enrichment
  - start-o-tel-enrichment → start-otel-enrichment
  - stop-o-tel-enrichment → stop-otel-enrichment

  The old o-tel names are kept as hidden aliases for backward compatibility using the v2 alias_command utility.

  Changes:

  - Added awscli/customizations/cloudwatch.py with a building-command-table.cloudwatch event handler that renames the commands via alias_command.
  - Registered the handler in awscli/handlers.py.
  - Added functional tests verifying both old and new command names work.
  - Added a changelog entry.

  By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.