### PR TITLE
[v2] Fix flaky download test

### DIFF
--- a/awscli/s3transfer/download.py
+++ b/awscli/s3transfer/download.py
@@ -551,8 +551,7 @@ class DownloadSubmissionTask(SubmissionTask):
                 callback()
             except Exception as e:
                 self._transfer_coordinator.set_exception(e)
-                self._transfer_coordinator.announce_done()
-                return
+                break
         finalize_callback()
 
     def _get_final_io_task_submission_callback(


### PR DESCRIPTION
Fixes a Windows race condition introduced in https://github.com/aws/aws-cli/commit/d49acc3a67278c411e8ead7a02982dad5366fb62 that caused a flaky test:
```
================================== FAILURES ===================================
_ TestRangedDownload.test_ranged_download_full_object_checksum_mismatch_raises _
[gw2] win32 -- Python 3.13.13 C:\hostedtoolcache\windows\Python\3.13.13\x64\python.exe

self = <tests.functional.s3transfer.test_download.TestRangedDownload testMethod=test_ranged_download_full_object_checksum_mismatch_raises>

    def tearDown(self):
        super().tearDown()
>       shutil.rmtree(self.tempdir)

functional\s3transfer\test_download.py:69: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
C:\hostedtoolcache\windows\Python\3.13.13\x64\Lib\shutil.py:790: in rmtree
    return _rmtree_unsafe(path, onexc)
C:\hostedtoolcache\windows\Python\3.13.13\x64\Lib\shutil.py:629: in _rmtree_unsafe
    onexc(os.unlink, fullname, err)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpl2hbz3lw'
onexc = <function rmtree.<locals>.onexc at 0x000001AFB553B1A0>

    def _rmtree_unsafe(path, onexc):
        def onerror(err):
            if not isinstance(err, FileNotFoundError):
                onexc(os.scandir, err.filename, err)
        results = os.walk(path, topdown=False, onerror=onerror, followlinks=os._walk_symlinks_as_files)
        for dirpath, dirnames, filenames in results:
            for name in dirnames:
                fullname = os.path.join(dirpath, name)
                try:
                    os.rmdir(fullname)
                except FileNotFoundError:
                    continue
                except OSError as err:
                    onexc(os.rmdir, fullname, err)
            for name in filenames:
                fullname = os.path.join(dirpath, name)
                try:
>                   os.unlink(fullname)
E                   PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\tmpl2hbz3lw\\myfile.169bbCC9'

C:\hostedtoolcache\windows\Python\3.13.13\x64\Lib\shutil.py:625: PermissionError
```

Before full object checksum validation, when a download failed, `announce_done` would be called once the single-threaded `IOWriteTasks` queue was drained. Since the transfer failed, `announce_done` fires failure cleanup tasks, which include deleting the file. Because there are no queued write tasks at this point, it's always safe to delete the file.

The commit introduced a change where `announce_done` is directly invoked from the submission thread when a pre-finalize callback fails. This direct `announce_done` call fires cleanup tasks. But because it's in a separate thread, it races against any pending write tasks. This isn't an issue in Linux/macOS, but Windows will throw an error when attempting to delete a file that's opened by another thread.

This PR fixes the issue by removing the direct `announce_done` call. Instead, it indirectly calls it by always running the final callback (same as previous behavior).