### PR TITLE
Add @validates_models to test_verify_generated_completions_are_valid

### DIFF
--- a/tests/functional/autocomplete/test_completion_files.py
+++ b/tests/functional/autocomplete/test_completion_files.py
@@ -135,6 +135,7 @@ def test_completions_operations_exist_in_model(
         f"update references to this operation."
     )
 
+
 @pytest.mark.validates_models
 @pytest.mark.parametrize(
     "test_data",

--- a/tests/functional/autocomplete/test_completion_files.py
+++ b/tests/functional/autocomplete/test_completion_files.py
@@ -135,7 +135,7 @@ def test_completions_operations_exist_in_model(
         f"update references to this operation."
     )
 
-
+@pytest.mark.validates_models
 @pytest.mark.parametrize(
     "test_data",
     get_models_with_completions(),

--- a/tests/functional/autocomplete/test_completion_files.py
+++ b/tests/functional/autocomplete/test_completion_files.py
@@ -114,6 +114,10 @@ def _get_invalid_completion_operations():
         for op_name in test_data.completions['operations']:
             if op_name not in known_ops:
                 cases.append((test_data.service_name, op_name))
+        for resource in test_data.completions.get('resources', {}).values():
+            op_name = resource.get('operation')
+            if op_name and op_name not in known_ops:
+                cases.append((test_data.service_name, op_name))
     return cases
 
 


### PR DESCRIPTION
*Description of changes:*
This PR adds `@validates_models` annotation to a test which validates the completion models.

I've also edited another test which already has the annotation to catch cases that could otherwise be missed in the completions test.  Any operations that don't exist in the service model but are referenced in the completion file's `resources` section would have been missed by the existing `test_completions_operations_exist_in_model` test prior to this PR.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
