### PR TITLE
Add retries to test fail mb rb

### DIFF
--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1377,7 +1377,7 @@ class TestMbRb(BaseS3IntegrationTest):
         for i in range(4):
             # Choose a bucket name that already exists.
             p = aws('s3 mb s3://mybucket')
-            if "BucketAlreadyExists" in p.stderr:
+            if "OperationAborted" not in p.stderr:
                 break
             time.sleep(2**i)
         assert "BucketAlreadyExists" in p.stderr

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1372,8 +1372,8 @@ class TestMbRb(BaseS3IntegrationTest):
         self.assert_no_errors(p)
 
     def test_fail_mb_rb(self):
-        #S3 can intermittenly return an `OperationAborted` exception instead of
-        # `BucketAlreadyExists`, so we give this test three attempts
+        # S3 can intermittently return an `OperationAborted` exception instead of
+        # `BucketAlreadyExists`, so we give this test four attempts
         for i in range(4):
             # Choose a bucket name that already exists.
             p = aws('s3 mb s3://mybucket')

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1374,12 +1374,12 @@ class TestMbRb(BaseS3IntegrationTest):
     def test_fail_mb_rb(self):
         #S3 can intermittenly return an `OperationAborted` exception instead of
         # `BucketAlreadyExists`, so we give this test three attempts
-        for _ in range(3):
+        for i in range(4):
             # Choose a bucket name that already exists.
             p = aws('s3 mb s3://mybucket')
             if "BucketAlreadyExists" in p.stderr:
                 break
-            time.sleep(1)
+            time.sleep(2**i)
         assert "BucketAlreadyExists" in p.stderr
         assert p.rc == 1
 

--- a/tests/integration/customizations/s3/test_plugin.py
+++ b/tests/integration/customizations/s3/test_plugin.py
@@ -1372,8 +1372,14 @@ class TestMbRb(BaseS3IntegrationTest):
         self.assert_no_errors(p)
 
     def test_fail_mb_rb(self):
-        # Choose a bucket name that already exists.
-        p = aws('s3 mb s3://mybucket')
+        #S3 can intermittenly return an `OperationAborted` exception instead of
+        # `BucketAlreadyExists`, so we give this test three attempts
+        for _ in range(3):
+            # Choose a bucket name that already exists.
+            p = aws('s3 mb s3://mybucket')
+            if "BucketAlreadyExists" in p.stderr:
+                break
+            time.sleep(1)
         assert "BucketAlreadyExists" in p.stderr
         assert p.rc == 1
 


### PR DESCRIPTION
*Description of changes:*
During a test where we attempt to make a bucket that already exists, S3 will occasionally raise `OperationAborted` exceptions instead of the expected `BucketAlreadyExists`.  

This does not get retried as it is a 409 on an unmodeled exception.  This PR adds up to four attempts to get the expected error before failing, using an exponential backoff

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
