### PR TITLE
Fix WSL browser opening for SSO login

### DIFF
--- a/awscli/customizations/sso/utils.py
+++ b/awscli/customizations/sso/utils.py
@@ -14,7 +14,11 @@ import datetime
 import json
 import logging
 import os
+import platform
+import shutil
 import socket
+import subprocess
+import sys
 import time
 import webbrowser
 from functools import partial
@@ -130,8 +134,31 @@ def parse_sso_registration_scopes(raw_scopes):
 
 
 def open_browser_with_original_ld_path(url):
+    if _is_wsl():
+        try:
+            return _open_browser_with_wslinterop(url)
+        except (OSError, subprocess.SubprocessError):
+            LOG.debug('Failed to open browser with WSL interop', exc_info=True)
+
     with original_ld_library_path():
         webbrowser.open_new_tab(url)
+
+
+def _is_wsl():
+    if sys.platform != 'linux':
+        return False
+    if os.environ.get('WSL_DISTRO_NAME') or os.environ.get('WSL_INTEROP'):
+        return True
+    return 'microsoft' in platform.release().lower()
+
+
+def _open_browser_with_wslinterop(url):
+    wslview = shutil.which('wslview')
+    if wslview:
+        subprocess.run([wslview, url], check=True)
+        return True
+    subprocess.run(['cmd.exe', '/C', 'start', '', url], check=True)
+    return True
 
 
 class BaseAuthorizationhandler:

--- a/tests/unit/customizations/sso/test_utils.py
+++ b/tests/unit/customizations/sso/test_utils.py
@@ -210,13 +210,70 @@ class TestOpenBrowserWithPatchedEnv(unittest.TestCase):
         # correctly.
         env = {'LD_LIBRARY_PATH': '/foo'}
         with mock.patch('os.environ', env):
-            with mock.patch('webbrowser.open_new_tab') as open_new_tab:
-                captured_env = {}
-                open_new_tab.side_effect = lambda x: captured_env.update(
-                    os.environ
-                )
-                open_browser_with_original_ld_path('http://example.com')
+            with mock.patch(
+                'awscli.customizations.sso.utils._is_wsl', return_value=False
+            ):
+                with mock.patch('webbrowser.open_new_tab') as open_new_tab:
+                    captured_env = {}
+                    open_new_tab.side_effect = lambda x: captured_env.update(
+                        os.environ
+                    )
+                    open_browser_with_original_ld_path('http://example.com')
         self.assertIsNone(captured_env.get('LD_LIBRARY_PATH'))
+
+    def test_open_browser_uses_wslview_in_wsl(self):
+        with mock.patch(
+            'awscli.customizations.sso.utils._is_wsl', return_value=True
+        ):
+            with mock.patch(
+                'awscli.customizations.sso.utils.shutil.which',
+                return_value='/usr/bin/wslview',
+            ):
+                with mock.patch(
+                    'awscli.customizations.sso.utils.subprocess.run'
+                ) as subprocess_run:
+                    with mock.patch('webbrowser.open_new_tab') as open_new_tab:
+                        open_browser_with_original_ld_path(
+                            'http://example.com'
+                        )
+        subprocess_run.assert_called_once_with(
+            ['/usr/bin/wslview', 'http://example.com'],
+            check=True,
+        )
+        open_new_tab.assert_not_called()
+
+    def test_open_browser_uses_cmd_exe_without_wslview(self):
+        with mock.patch(
+            'awscli.customizations.sso.utils._is_wsl', return_value=True
+        ):
+            with mock.patch(
+                'awscli.customizations.sso.utils.shutil.which',
+                return_value=None,
+            ):
+                with mock.patch(
+                    'awscli.customizations.sso.utils.subprocess.run'
+                ) as subprocess_run:
+                    with mock.patch('webbrowser.open_new_tab') as open_new_tab:
+                        open_browser_with_original_ld_path(
+                            'http://example.com'
+                        )
+        subprocess_run.assert_called_once_with(
+            ['cmd.exe', '/C', 'start', '', 'http://example.com'],
+            check=True,
+        )
+        open_new_tab.assert_not_called()
+
+    def test_open_browser_falls_back_when_wsl_open_fails(self):
+        with mock.patch(
+            'awscli.customizations.sso.utils._is_wsl', return_value=True
+        ):
+            with mock.patch(
+                'awscli.customizations.sso.utils._open_browser_with_wslinterop',
+                side_effect=OSError(),
+            ):
+                with mock.patch('webbrowser.open_new_tab') as open_new_tab:
+                    open_browser_with_original_ld_path('http://example.com')
+        open_new_tab.assert_called_once_with('http://example.com')
 
 
 class MockRequest:


### PR DESCRIPTION
*Issue #, if available:*

Closes #10242

*Description of changes:*

- Fix WSL browser launch behavior for `aws sso login` and `aws login` shared SSO flow.
- Detect WSL explicitly, then open the auth URL via WSL interop (`wslview` when available, otherwise `cmd.exe /C start`).
- Keep existing Linux behavior as fallback if WSL interop launch fails.
- Add unit tests covering WSL launch paths and fallback behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
