### PR TITLE
Update CloudWatch otel alias strategy for botocore compatibility

### DIFF
--- a/.changes/next-release/bugfix-cloudwatch-5230.json
+++ b/.changes/next-release/bugfix-cloudwatch-5230.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``cloudwatch``",
+  "description": "Rename ``get-o-tel-enrichment``, ``start-o-tel-enrichment``, and ``stop-o-tel-enrichment`` commands to ``get-otel-enrichment``, ``start-otel-enrichment``, and ``stop-otel-enrichment``. The old names are kept as hidden aliases for backward compatibility."
+}

--- a/.changes/next-release/cloudwatch-otel-rename.json
+++ b/.changes/next-release/cloudwatch-otel-rename.json
@@ -1,7 +1,0 @@
-[
-    {
-        "category": "``cloudwatch``",
-        "description": "Rename ``get-o-tel-enrichment``, ``start-o-tel-enrichment``, and ``stop-o-tel-enrichment`` commands to ``get-otel-enrichment``, ``start-otel-enrichment``, and ``stop-otel-enrichment``. The old names are kept as hidden aliases for backward compatibility.",
-        "type": "bugfix"
-    }
-]

--- a/awscli/customizations/cloudwatch.py
+++ b/awscli/customizations/cloudwatch.py
@@ -11,26 +11,23 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 from awscli.customizations.utils import make_hidden_command_alias
-from awscli.customizations.utils import rename_command
 
 
 def register_rename_otel_commands(event_emitter):
-    event_emitter.register(
-        'building-command-table.cloudwatch',
-        rename_otel_commands
-    )
+  event_emitter.register(
+      'building-command-table.cloudwatch',
+      alias_otel_commands
+  )
 
 
-def rename_otel_commands(command_table, **kwargs):
-    """Rename o-tel commands to otel, keeping o-tel as hidden aliases."""
-    renames = {
-        'get-o-tel-enrichment': 'get-otel-enrichment',
-        'start-o-tel-enrichment': 'start-otel-enrichment',
-        'stop-o-tel-enrichment': 'stop-otel-enrichment',
-    }
-    for old_name, new_name in renames.items():
-        if old_name in command_table:
-            rename_command(command_table, old_name, new_name)
-            make_hidden_command_alias(
-                command_table, new_name, old_name
-            )
+def alias_otel_commands(command_table, **kwargs):
+  aliases = {
+      'get-otel-enrichment': 'get-o-tel-enrichment',
+      'start-otel-enrichment': 'start-o-tel-enrichment',
+      'stop-otel-enrichment': 'stop-o-tel-enrichment',
+  }
+  for existing_name, alias_name in aliases.items():
+      if existing_name in command_table:
+          make_hidden_command_alias(
+              command_table, existing_name, alias_name
+          )

--- a/awscli/customizations/cloudwatch.py
+++ b/awscli/customizations/cloudwatch.py
@@ -14,20 +14,17 @@ from awscli.customizations.utils import make_hidden_command_alias
 
 
 def register_rename_otel_commands(event_emitter):
-  event_emitter.register(
-      'building-command-table.cloudwatch',
-      alias_otel_commands
-  )
+    event_emitter.register(
+        'building-command-table.cloudwatch', alias_otel_commands
+    )
 
 
 def alias_otel_commands(command_table, **kwargs):
-  aliases = {
-      'get-otel-enrichment': 'get-o-tel-enrichment',
-      'start-otel-enrichment': 'start-o-tel-enrichment',
-      'stop-otel-enrichment': 'stop-o-tel-enrichment',
-  }
-  for existing_name, alias_name in aliases.items():
-      if existing_name in command_table:
-          make_hidden_command_alias(
-              command_table, existing_name, alias_name
-          )
+    aliases = {
+        'get-otel-enrichment': 'get-o-tel-enrichment',
+        'start-otel-enrichment': 'start-o-tel-enrichment',
+        'stop-otel-enrichment': 'stop-o-tel-enrichment',
+    }
+    for existing_name, alias_name in aliases.items():
+        if existing_name in command_table:
+            make_hidden_command_alias(command_table, existing_name, alias_name)


### PR DESCRIPTION
*Description of changes:*
We merged an update to the cloudwatch commands to make a hidden alias for commands with otel in the name; the merged alias is incompatible with the botocore PR to ensure the rename works for boto3 as well.  This PR updates the strategy to function with [the botocore PR](https://github.com/boto/botocore/pull/3676/changes), and must be merged after that PR.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
