### PR TITLE
Add aws_security_token to credentials file keys

### DIFF
--- a/.changes/next-release/enhancement-configure-59283.json
+++ b/.changes/next-release/enhancement-configure-59283.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "configure",
+  "description": "Added aws_security_token to the list of keys that are written to the shared credentials file when using aws configure set."
+}

--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -38,7 +38,7 @@ class ConfigureSetCommand(BasicCommand):
     # Any variables specified in this list will be written to
     # the ~/.aws/credentials file instead of ~/.aws/config.
     _WRITE_TO_CREDS_FILE = ['aws_access_key_id', 'aws_secret_access_key',
-                            'aws_session_token']
+                            'aws_session_token', 'aws_security_token']
 
     def __init__(self, session, config_writer=None):
         super(ConfigureSetCommand, self).__init__(session)

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -126,6 +126,15 @@ class TestConfigureSetCommand(unittest.TestCase):
             {'__section__': 'default',
              'aws_session_token': 'foo'}, self.fake_credentials_filename)
 
+    def test_security_token_written_to_shared_credentials_file(self):
+        set_command = ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(args=['aws_security_token', 'foo'],
+                    parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'default',
+             'aws_security_token': 'foo'}, self.fake_credentials_filename)
+
     def test_access_key_written_to_shared_credentials_file_profile(self):
         set_command = ConfigureSetCommand(
             self.session, self.config_writer)


### PR DESCRIPTION
*Description of changes:*
Backport of #10152 to CLIv1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
