### PR TITLE
Add OIDC discovery/JWKS dual-thumbprint note to examples

### DIFF
--- a/awscli/examples/iam/create-open-id-connect-provider.rst
+++ b/awscli/examples/iam/create-open-id-connect-provider.rst
@@ -19,6 +19,8 @@ The previous command creates a JSON file called create-open-id-connect-provider.
         ]
     }
 
+If your OIDC provider's discovery and JWKS endpoints use different certificates, include thumbprints for both endpoints in the ``ThumbprintList``.
+
 Next, to create the OpenID Connect (OIDC) provider, use the ``create-open-id-connect-provider`` command again, this time passing the ``--cli-input-json`` parameter to specify your JSON file. The following ``create-open-id-connect-provider`` command uses the ``--cli-input-json`` parameter with a JSON file called create-open-id-connect-provider.json. ::
 
     aws iam create-open-id-connect-provider \

--- a/awscli/examples/iam/update-open-id-connect-provider-thumbprint.rst
+++ b/awscli/examples/iam/update-open-id-connect-provider-thumbprint.rst
@@ -7,6 +7,8 @@ This example updates the certificate thumbprint list for the OIDC provider whose
         --open-id-connect-provider-arn arn:aws:iam::123456789012:oidc-provider/example.oidcprovider.com \
         --thumbprint-list 7359755EXAMPLEabc3060bce3EXAMPLEec4542a3
 
+If your OIDC provider's discovery and JWKS endpoints use different certificates, include thumbprints for both endpoints in the ``--thumbprint-list`` value.
+
 This command produces no output.
 
 For more information, see `Creating OpenID Connect (OIDC) identity providers <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html>`__ in the *AWS IAM User Guide*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add note to create-open-id-connect-provider example about including thumbprints for both discovery and JWKS endpoints when they use different certificates
- Add same note to update-open-id-connect-provider-thumbprint example

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
