### PR TITLE
Add --revoke-sso-token flag to export-credentials

### DIFF
--- a/.changes/next-release/enhancement-configure-41258.json
+++ b/.changes/next-release/enhancement-configure-41258.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "configure",
+  "description": "Add ``--revoke-sso-token`` flag to ``aws configure export-credentials`` that, after exporting credentials, server-side revokes the IAM Identity Center access token used to mint them and removes its on-disk cache file."
+}

--- a/.changes/next-release/enhancement-configure-41258.json
+++ b/.changes/next-release/enhancement-configure-41258.json
@@ -1,5 +1,5 @@
 {
   "type": "enhancement",
   "category": "configure",
-  "description": "Add ``--revoke-sso-token`` flag to ``aws configure export-credentials`` that, after exporting credentials, server-side revokes the IAM Identity Center access token used to mint them and removes its on-disk cache file."
+  "description": "Add ``--revoke-sso-token`` flag to ``aws configure export-credentials`` that, after exporting credentials, server-side revokes the IAM Identity Center access token used to mint them and removes its on-disk cache file. The token is resolved through ``source_profile`` for assume-role profiles, and because tokens are cached per SSO session, revoking it affects all profiles bound to the same session."
 }

--- a/awscli/customizations/configure/exportcreds.py
+++ b/awscli/customizations/configure/exportcreds.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import csv
+import hashlib
 import io
 import json
 import os
@@ -20,6 +21,8 @@ from datetime import datetime
 
 from awscli.customizations.commands import BasicCommand
 from awscli.customizations.exceptions import ConfigurationError
+from awscli.customizations.sso.logout import revoke_sso_token
+from awscli.customizations.sso.utils import SSO_TOKEN_DIR
 
 # Takes botocore's ReadOnlyCredentials and exposes an expiry_time.
 Credentials = namedtuple(
@@ -199,6 +202,21 @@ class ConfigureExportCredentialsCommand(BasicCommand):
             'choices': list(SUPPORTED_FORMATS),
             'default': CredentialProcessFormatter.FORMAT,
         },
+        {
+            'name': 'revoke-sso-token',
+            'action': 'store_true',
+            'default': False,
+            'help_text': (
+                'After exporting credentials, server-side revoke the AWS '
+                'IAM Identity Center access token used to mint them and '
+                'remove its on-disk cache file. This is a no-op for '
+                'profiles that do not resolve credentials through IAM '
+                'Identity Center. Use this to minimize the on-disk '
+                'lifetime of the SSO access token. Note: when used in a '
+                '``credential_process`` configuration, every credential '
+                'refresh will require a new ``aws sso login`` flow.'
+            ),
+        },
     ]
     _RECURSION_VAR = '_AWS_CLI_PROFILE_CHAIN'
     # Two levels is reasonable because you might explicitly run
@@ -280,3 +298,55 @@ class ConfigureExportCredentialsCommand(BasicCommand):
         creds_with_expiry = convert_botocore_credentials(creds)
         formatter = SUPPORTED_FORMATS[parsed_args.format](self._out_stream)
         formatter.display_credentials(creds_with_expiry)
+        if parsed_args.revoke_sso_token:
+            self._revoke_sso_token_for_profile(parsed_globals)
+
+    def _revoke_sso_token_for_profile(self, parsed_globals):
+        # Best-effort: credentials have already been emitted at this point,
+        # so any failure here must not change the exit status. We catch
+        # broadly to cover transport-level errors from the sso.Logout call
+        # (BotoCoreError, EndpointResolutionError, etc.) in addition to
+        # the ``ClientError`` path that ``revoke_sso_token`` already logs.
+        try:
+            self._do_revoke_sso_token_for_profile(parsed_globals)
+        except Exception:
+            pass
+
+    def _do_revoke_sso_token_for_profile(self, parsed_globals):
+        cache_key = self._sso_cache_key_for_current_profile()
+        if cache_key is None:
+            return
+        cache_path = os.path.join(SSO_TOKEN_DIR, cache_key + '.json')
+        try:
+            with open(cache_path) as f:
+                contents = json.load(f)
+        except (OSError, ValueError):
+            return
+        access_token = contents.get('accessToken')
+        sso_region = contents.get('region')
+        if not access_token or not sso_region:
+            return
+        revoke_sso_token(
+            self._session, sso_region, access_token, parsed_globals
+        )
+        try:
+            os.remove(cache_path)
+        except OSError:
+            pass
+
+    def _sso_cache_key_for_current_profile(self):
+        # Returns the SSO token cache key (sha1 digest) for the active
+        # profile, or None if the profile has no IAM Identity Center
+        # configuration. The cache key is computed identically to
+        # ``botocore.utils.SSOTokenLoader``: sha1 of the sso_session name
+        # when present, otherwise sha1 of the legacy sso_start_url.
+        scoped_config = self._session.get_scoped_config()
+        sso_session = scoped_config.get('sso_session')
+        if sso_session:
+            cache_input = sso_session
+        else:
+            sso_start_url = scoped_config.get('sso_start_url')
+            if not sso_start_url:
+                return None
+            cache_input = sso_start_url
+        return hashlib.sha1(cache_input.encode('utf-8')).hexdigest()

--- a/awscli/customizations/configure/exportcreds.py
+++ b/awscli/customizations/configure/exportcreds.py
@@ -209,10 +209,16 @@ class ConfigureExportCredentialsCommand(BasicCommand):
             'help_text': (
                 'After exporting credentials, server-side revoke the AWS '
                 'IAM Identity Center access token used to mint them and '
-                'remove its on-disk cache file. This is a no-op for '
+                'remove its on-disk cache file. The token is cached per SSO '
+                'session, so this revokes the shared session token: any '
+                'other profile bound to the same ``sso_session`` (or legacy '
+                '``sso_start_url``), including in other shells, will need to '
+                'run ``aws sso login`` again. For assume-role profiles the '
+                'token is resolved by following ``source_profile`` to the '
+                'IAM Identity Center-backed profile. This is a no-op for '
                 'profiles that do not resolve credentials through IAM '
-                'Identity Center. Use this to minimize the on-disk '
-                'lifetime of the SSO access token. Note: when used in a '
+                'Identity Center. Use this to minimize the on-disk lifetime '
+                'of the SSO access token. Note: when used in a '
                 '``credential_process`` configuration, every credential '
                 'refresh will require a new ``aws sso login`` flow.'
             ),
@@ -335,18 +341,38 @@ class ConfigureExportCredentialsCommand(BasicCommand):
             pass
 
     def _sso_cache_key_for_current_profile(self):
-        # Returns the SSO token cache key (sha1 digest) for the active
-        # profile, or None if the profile has no IAM Identity Center
-        # configuration. The cache key is computed identically to
+        # Walks the credential-resolution chain to the profile that carries
+        # the IAM Identity Center configuration and returns its SSO token
+        # cache key (sha1 digest), or None if no profile in the chain
+        # resolves through IAM Identity Center.
+        #
+        # The active profile may not hold the SSO config itself: an
+        # assume-role profile (``role_arn`` + ``source_profile``) inherits
+        # its SSO token from the source profile, possibly through several
+        # hops. We follow ``source_profile`` until we find the profile with
+        # ``sso_session`` (or the legacy ``sso_start_url``), guarding against
+        # cycles in malformed configs.
+        #
+        # The cache key is computed identically to
         # ``botocore.utils.SSOTokenLoader``: sha1 of the sso_session name
         # when present, otherwise sha1 of the legacy sso_start_url.
-        scoped_config = self._session.get_scoped_config()
-        sso_session = scoped_config.get('sso_session')
-        if sso_session:
-            cache_input = sso_session
-        else:
-            sso_start_url = scoped_config.get('sso_start_url')
-            if not sso_start_url:
+        profiles = self._session.full_config.get('profiles', {})
+        config = self._session.get_scoped_config()
+        seen_profiles = set()
+        while True:
+            sso_session = config.get('sso_session')
+            if sso_session:
+                cache_input = sso_session
+                break
+            sso_start_url = config.get('sso_start_url')
+            if sso_start_url:
+                cache_input = sso_start_url
+                break
+            source_profile = config.get('source_profile')
+            if source_profile is None or source_profile in seen_profiles:
                 return None
-            cache_input = sso_start_url
+            seen_profiles.add(source_profile)
+            config = profiles.get(source_profile)
+            if config is None:
+                return None
         return hashlib.sha1(cache_input.encode('utf-8')).hexdigest()

--- a/awscli/customizations/sso/logout.py
+++ b/awscli/customizations/sso/logout.py
@@ -22,6 +22,24 @@ from awscli.customizations.sso.utils import AWS_CREDS_CACHE_DIR, SSO_TOKEN_DIR
 LOG = logging.getLogger(__name__)
 
 
+def revoke_sso_token(session, sso_region, access_token, parsed_globals):
+    """Server-side revoke an SSO access token via the sso.Logout API.
+
+    Errors from the Logout call are caught and logged; this is best-effort.
+    """
+    sso = session.create_client(
+        'sso',
+        region_name=sso_region,
+        verify=parsed_globals.verify_ssl,
+    )
+    try:
+        sso.logout(accessToken=access_token)
+    except ClientError:
+        # The token may already be expired or otherwise invalid. If we
+        # get a client error on logout just log and continue on.
+        LOG.debug('Failed to call logout API:', exc_info=True)
+
+
 class LogoutCommand(BasicCommand):
     NAME = 'logout'
     DESCRIPTION = (
@@ -85,17 +103,12 @@ class SSOTokenSweeper(BaseCredentialSweeper):
         # and invoke the logout api to invalidate the token before deleting it.
         sso_region = contents.get('region')
         if sso_region:
-            sso = self._session.create_client(
-                'sso',
-                region_name=sso_region,
-                verify=self._parsed_globals.verify_ssl,
+            revoke_sso_token(
+                self._session,
+                sso_region,
+                contents['accessToken'],
+                self._parsed_globals,
             )
-            try:
-                sso.logout(accessToken=contents['accessToken'])
-            except ClientError:
-                # The token may already be expired or otherwise invalid. If we
-                # get a client error on logout just log and continue on
-                LOG.debug('Failed to call logout API:', exc_info=True)
 
 
 class SSOCredentialSweeper(BaseCredentialSweeper):

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -12,14 +12,18 @@
 # language governing permissions and limitations under the License.
 import io
 import json
+import os
 from datetime import datetime, timedelta
 
 import pytest
 from botocore.credentials import Credentials as StaticCredentials
 from botocore.credentials import ReadOnlyCredentials, RefreshableCredentials
+from botocore.exceptions import ClientError
 from botocore.session import Session
+from botocore.utils import SSOTokenLoader
 from dateutil.tz import tzutc
 
+from awscli.customizations.configure import exportcreds as exportcreds_mod
 from awscli.customizations.configure.exportcreds import (
     BashEnvVarFormatter,
     BashNoExportEnvFormatter,
@@ -350,3 +354,210 @@ class TestConfigureExportCredentialsCommand(unittest.TestCase):
             'Maximum recursive credential process resolution reached',
             str(excinfo),
         )
+
+
+class TestRevokeSSOTokenFlag(unittest.TestCase):
+    def setUp(self):
+        self.session = mock.Mock(spec=Session)
+        self.session.emit_first_non_none_response.return_value = None
+        self.session.get_config_variable.return_value = 'default'
+        self.session.get_credentials.return_value = StaticCredentials(
+            'access_key', 'secret_key', 'token'
+        )
+        self.out_stream = io.StringIO()
+        self.err_stream = io.StringIO()
+        self.os_env = {}
+        self.global_args = mock.Mock()
+        self.tmpdir = mock.MagicMock()
+
+        # Patch SSO_TOKEN_DIR to a temp dir for the duration of the test.
+        self._tmp_token_dir = os.path.join(
+            os.path.dirname(__file__), '_tmp_sso_cache_test'
+        )
+        os.makedirs(self._tmp_token_dir, exist_ok=True)
+        self._token_dir_patcher = mock.patch.object(
+            exportcreds_mod, 'SSO_TOKEN_DIR', self._tmp_token_dir
+        )
+        self._token_dir_patcher.start()
+
+        self.export_creds_cmd = ConfigureExportCredentialsCommand(
+            self.session, self.out_stream, self.err_stream, env=self.os_env
+        )
+
+    def tearDown(self):
+        self._token_dir_patcher.stop()
+        for name in os.listdir(self._tmp_token_dir):
+            os.remove(os.path.join(self._tmp_token_dir, name))
+        os.rmdir(self._tmp_token_dir)
+
+    def _write_token_cache(self, start_url, session_name, contents):
+        # Compute the cache filename via botocore's SSOTokenLoader, the
+        # authority for where SSO tokens are written by ``aws sso login``.
+        # Pinning the test to that contract — rather than to the command's
+        # own cache-key helper — ensures we catch drift between this
+        # command's lookup logic and botocore's storage logic.
+        cache_key = SSOTokenLoader()._generate_cache_key(
+            start_url, session_name
+        )
+        path = os.path.join(self._tmp_token_dir, cache_key + '.json')
+        with open(path, 'w') as f:
+            json.dump(contents, f)
+        return path
+
+    def _sso_session_profile_config(self):
+        return {
+            'scoped': {'sso_session': 'my-session'},
+            'full': {
+                'sso_sessions': {
+                    'my-session': {
+                        'sso_region': 'us-east-1',
+                        'sso_start_url': 'https://example.awsapps.com/start',
+                    }
+                }
+            },
+        }
+
+    def _legacy_profile_config(self):
+        return {
+            'scoped': {
+                'sso_region': 'us-east-1',
+                'sso_start_url': 'https://example.awsapps.com/start',
+            },
+            'full': {},
+        }
+
+    def _wire_profile(self, profile_config):
+        self.session.get_scoped_config.return_value = profile_config['scoped']
+        self.session.full_config = profile_config['full']
+
+    def test_revokes_token_for_sso_session_profile(self):
+        self._wire_profile(self._sso_session_profile_config())
+        cache_path = self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name='my-session',
+            contents={'accessToken': 'abc123', 'region': 'us-east-1'},
+        )
+        sso_client = mock.Mock()
+        self.session.create_client.return_value = sso_client
+
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+
+        self.assertEqual(rc, 0)
+        self.session.create_client.assert_called_once_with(
+            'sso',
+            region_name='us-east-1',
+            verify=self.global_args.verify_ssl,
+        )
+        sso_client.logout.assert_called_once_with(accessToken='abc123')
+        self.assertFalse(os.path.exists(cache_path))
+
+    def test_revokes_token_for_legacy_sso_profile(self):
+        self._wire_profile(self._legacy_profile_config())
+        cache_path = self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name=None,
+            contents={'accessToken': 'legacy-token', 'region': 'us-east-1'},
+        )
+        sso_client = mock.Mock()
+        self.session.create_client.return_value = sso_client
+
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+
+        self.assertEqual(rc, 0)
+        sso_client.logout.assert_called_once_with(accessToken='legacy-token')
+        self.assertFalse(os.path.exists(cache_path))
+
+    def test_no_op_for_non_sso_profile(self):
+        self._wire_profile({'scoped': {}, 'full': {}})
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+        self.assertEqual(rc, 0)
+        self.session.create_client.assert_not_called()
+
+    def test_no_op_when_cache_file_missing(self):
+        self._wire_profile(self._sso_session_profile_config())
+        # No cache file written.
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+        self.assertEqual(rc, 0)
+        self.session.create_client.assert_not_called()
+
+    def test_swallows_non_client_error_from_revoke_call(self):
+        # ``revoke_sso_token`` only catches ClientError. Non-ClientError
+        # transport-level exceptions (BotoCoreError, EndpointResolutionError,
+        # network failures, etc.) must not crash the export command, since
+        # credentials have already been emitted.
+        self._wire_profile(self._sso_session_profile_config())
+        self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name='my-session',
+            contents={'accessToken': 'abc123', 'region': 'us-east-1'},
+        )
+        self.session.create_client.side_effect = RuntimeError(
+            'simulated transport failure'
+        )
+
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+
+        self.assertEqual(rc, 0)
+        # Credentials must still have been emitted to stdout.
+        emitted = json.loads(self.out_stream.getvalue())
+        self.assertEqual(emitted['AccessKeyId'], 'access_key')
+
+    def test_swallows_logout_api_error_and_still_removes_cache(self):
+        self._wire_profile(self._sso_session_profile_config())
+        cache_path = self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name='my-session',
+            contents={'accessToken': 'abc123', 'region': 'us-east-1'},
+        )
+        sso_client = mock.Mock()
+        sso_client.logout.side_effect = ClientError(
+            {'Error': {'Code': 'UnauthorizedException', 'Message': 'expired'}},
+            'Logout',
+        )
+        self.session.create_client.return_value = sso_client
+
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+
+        self.assertEqual(rc, 0)
+        sso_client.logout.assert_called_once()
+        self.assertFalse(os.path.exists(cache_path))
+
+    def test_credentials_still_emitted_when_revoke_fails(self):
+        self._wire_profile(self._sso_session_profile_config())
+        # Cache contents missing required keys -> revoke is a no-op, but
+        # output must still be produced.
+        self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name='my-session',
+            contents={'accessToken': ''},
+        )
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+        self.assertEqual(rc, 0)
+        emitted = json.loads(self.out_stream.getvalue())
+        self.assertEqual(emitted['AccessKeyId'], 'access_key')
+        self.assertEqual(emitted['SecretAccessKey'], 'secret_key')
+
+    def test_flag_off_does_not_revoke(self):
+        self._wire_profile(self._sso_session_profile_config())
+        self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name='my-session',
+            contents={'accessToken': 'abc123', 'region': 'us-east-1'},
+        )
+        rc = self.export_creds_cmd(args=[], parsed_globals=self.global_args)
+        self.assertEqual(rc, 0)
+        self.session.create_client.assert_not_called()

--- a/tests/unit/customizations/configure/test_exportcreds.py
+++ b/tests/unit/customizations/configure/test_exportcreds.py
@@ -426,6 +426,28 @@ class TestRevokeSSOTokenFlag(unittest.TestCase):
             'full': {},
         }
 
+    def _assume_role_chain_profile_config(self):
+        # Active profile assumes a role and sources its SSO token from
+        # another profile via ``source_profile``; that source profile is
+        # the one holding the IAM Identity Center config.
+        return {
+            'scoped': {
+                'role_arn': 'arn:aws:iam::123456789012:role/target',
+                'source_profile': 'sso-base',
+            },
+            'full': {
+                'profiles': {
+                    'sso-base': {'sso_session': 'my-session'},
+                },
+                'sso_sessions': {
+                    'my-session': {
+                        'sso_region': 'us-east-1',
+                        'sso_start_url': 'https://example.awsapps.com/start',
+                    }
+                },
+            },
+        }
+
     def _wire_profile(self, profile_config):
         self.session.get_scoped_config.return_value = profile_config['scoped']
         self.session.full_config = profile_config['full']
@@ -482,6 +504,69 @@ class TestRevokeSSOTokenFlag(unittest.TestCase):
     def test_no_op_when_cache_file_missing(self):
         self._wire_profile(self._sso_session_profile_config())
         # No cache file written.
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+        self.assertEqual(rc, 0)
+        self.session.create_client.assert_not_called()
+
+    def test_revokes_token_via_source_profile_chain(self):
+        # An assume-role profile resolves its SSO token through
+        # ``source_profile``; the token under that source profile's session
+        # must be the one revoked.
+        self._wire_profile(self._assume_role_chain_profile_config())
+        cache_path = self._write_token_cache(
+            start_url='https://example.awsapps.com/start',
+            session_name='my-session',
+            contents={'accessToken': 'chained-token', 'region': 'us-east-1'},
+        )
+        sso_client = mock.Mock()
+        self.session.create_client.return_value = sso_client
+
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+
+        self.assertEqual(rc, 0)
+        sso_client.logout.assert_called_once_with(accessToken='chained-token')
+        self.assertFalse(os.path.exists(cache_path))
+
+    def test_no_op_when_source_profile_chain_has_no_sso(self):
+        # Assume-role chain that bottoms out at a non-SSO profile must not
+        # revoke anything.
+        self._wire_profile(
+            {
+                'scoped': {
+                    'role_arn': 'arn:aws:iam::123456789012:role/target',
+                    'source_profile': 'static-base',
+                },
+                'full': {
+                    'profiles': {
+                        'static-base': {'aws_access_key_id': 'AKID'},
+                    },
+                },
+            }
+        )
+        rc = self.export_creds_cmd(
+            args=['--revoke-sso-token'], parsed_globals=self.global_args
+        )
+        self.assertEqual(rc, 0)
+        self.session.create_client.assert_not_called()
+
+    def test_no_op_on_source_profile_cycle(self):
+        # A malformed config where source_profile forms a cycle must
+        # terminate and revoke nothing rather than loop forever.
+        self._wire_profile(
+            {
+                'scoped': {'source_profile': 'a'},
+                'full': {
+                    'profiles': {
+                        'a': {'source_profile': 'b'},
+                        'b': {'source_profile': 'a'},
+                    },
+                },
+            }
+        )
         rc = self.export_creds_cmd(
             args=['--revoke-sso-token'], parsed_globals=self.global_args
         )


### PR DESCRIPTION
Fixes #10258.

## Description of changes

* Add a new `--revoke-sso-token` flag to `aws configure export-credentials`. When set, after credentials are emitted, the SSO access token used to resolve them is server-side revoked via `sso.Logout` and its `~/.aws/sso/cache/<digest>.json` file is removed.
* Surgical: only the cache file for the active profile's `sso_session` (or legacy `sso_start_url`) is touched. Other profiles and concurrent SSO sessions are untouched.
* Best-effort: revoke failures are logged at DEBUG and do not change the exit status, since the credentials have already been written to the caller.
* No default behavior changes; flag is opt-in.
* Refactored the existing `sso.Logout` call site in `awscli/customizations/sso/logout.py` into a small reusable helper `revoke_sso_token(...)` so both `aws sso logout` and the new flag share one revocation path. `aws sso logout`'s behavior is unchanged.

## Description of tests

* New `TestRevokeSSOTokenFlag` class in `tests/unit/customizations/configure/test_exportcreds.py` covers: sso-session profile, legacy SSO profile, non-SSO profile (no-op), missing cache file, `Logout` API client error, output unaffected on revoke failure, and flag-off baseline.
* Existing `tests/unit/customizations/sso/test_logout.py` continues to pass (24 tests) — the refactor preserves `aws sso logout` behavior.
* Existing `tests/unit/customizations/configure/test_exportcreds.py` continues to pass (20 baseline tests).

By submitting this PR, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.