### PR TITLE
Fix 'Cherry-Pick PR to v2' Workflow

### DIFF
--- a/.github/workflows/doc-pr-cherry-pick.yml
+++ b/.github/workflows/doc-pr-cherry-pick.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # 4.2.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* We recently tightened some GitHub actions via zizmor via https://github.com/aws/aws-cli/pull/10202, but that broke the workflow for copying PRs from CLIv1 to CLIv2. We still need to persist Git credentials to allow it to create the PR later in the worfklow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
