### PR TITLE
Fix directory not found when it contain spaces

### DIFF
--- a/exe/assets/install
+++ b/exe/assets/install
@@ -75,7 +75,7 @@ set_global_vars() {
   INSTALLER_DIR="$( cd "$( dirname "$0" )" >/dev/null 2>&1 && pwd )"
   INSTALLER_DIST_DIR="$INSTALLER_DIR/dist"
   INSTALLER_EXE="$INSTALLER_DIST_DIR/$EXE_NAME"
-  AWS_EXE_VERSION=$($INSTALLER_EXE --version | cut -d ' ' -f 1 | cut -d '/' -f 2)
+  AWS_EXE_VERSION=$("$INSTALLER_EXE" --version | cut -d ' ' -f 1 | cut -d '/' -f 2)
 
   INSTALL_DIR="$ROOT_INSTALL_DIR/v2/$AWS_EXE_VERSION"
   INSTALL_DIR="$INSTALL_DIR"


### PR DESCRIPTION
*Issue #, if available:* #6939 

*Description of changes:* As the linked issue suggests, quoting $INSTALLER_EXE in line 78 fixes the problem.
From: [aws-cli/exe/assets/install](https://github.com/aws/aws-cli/blob/v2/exe/assets/install#L78)
To: [aws-cli/exe/assets/install](https://github.com/waknaudt/aws-cli/blob/v2/exe/assets/install#L78)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
