### PR TITLE
Add support for reading --cli-input-json and --cli-input-yaml from stdin

### DIFF
--- a/.changes/next-release/cli-input-stdin.json
+++ b/.changes/next-release/cli-input-stdin.json
@@ -1,0 +1,7 @@
+[
+  {
+    "category": "``cli``",
+    "description": "Add support for reading ``--cli-input-json`` and ``--cli-input-yaml`` from standard input by passing ``-`` as the value (e.g. ``aws s3api head-object --cli-input-json -``). This is consistent with the existing ``aws s3 cp -`` convention.",
+    "type": "feature"
+  }
+]

--- a/awscli/customizations/cliinput.py
+++ b/awscli/customizations/cliinput.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import json
+import sys
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
@@ -85,6 +86,11 @@ class CliInputArgument(OverrideRequiredArgsArgument):
                 'Only one --cli-input- parameter may be specified.'
             )
 
+        # Read from stdin when '-' is passed, consistent with
+        # 'aws s3 cp - s3://bucket/key'.
+        if arg_value == '-':
+            return sys.stdin.read()
+
         # If the value starts with file:// or fileb://, return the contents
         # from the file.
         paramfile_data = get_paramfile(arg_value, LOCAL_PREFIX_MAP)
@@ -122,7 +128,8 @@ class CliInputJSONArgument(CliInputArgument):
             'will override the JSON-provided values. It is not possible to '
             'pass arbitrary binary values using a JSON-provided value as the '
             'string will be taken literally. This may not be specified along '
-            'with ``--cli-input-yaml``.'
+            'with ``--cli-input-yaml``. If the value is ``-``, the JSON '
+            'string will be read from standard input.'
         ),
     }
 
@@ -143,7 +150,8 @@ class CliInputYAMLArgument(CliInputArgument):
             '``--generate-cli-skeleton yaml-input``. '
             'If other arguments are provided on the command line, those '
             'values will override the YAML-provided values. This may not be '
-            'specified along with ``--cli-input-json``.'
+            'specified along with ``--cli-input-json``. If the value is '
+            '``-``, the YAML string will be read from standard input.'
         ),
     }
 

--- a/tests/functional/test_cliinput.py
+++ b/tests/functional/test_cliinput.py
@@ -10,9 +10,10 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 import os
 
-from awscli.testutils import BaseAWSCommandParamsTest, FileCreator
+from awscli.testutils import BaseAWSCommandParamsTest, FileCreator, mock
 from awscli.utils import dump_yaml_to_str
 
 
@@ -76,6 +77,26 @@ class TestCLIInputJSON(BaseCLIInputArgumentTest):
         self.assert_params_for_cmd(
             cmdline, expected_rc=252, stderr_contains='Unknown'
         )
+
+    def test_cli_input_json_from_stdin(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO(self.input_json),
+        ):
+            cmdline = 's3api head-object --cli-input-json -'
+            self.assert_params_for_cmd(
+                cmdline, params={'Bucket': 'bucket', 'Key': 'key'}
+            )
+
+    def test_cli_input_json_stdin_can_override(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO(self.input_json),
+        ):
+            cmdline = 's3api head-object --key bar --cli-input-json -'
+            self.assert_params_for_cmd(
+                cmdline, params={'Bucket': 'bucket', 'Key': 'bar'}
+            )
 
 
 class TestCLIInputYAML(BaseCLIInputArgumentTest):
@@ -147,6 +168,21 @@ class TestCLIInputYAML(BaseCLIInputArgumentTest):
         self.assert_params_for_cmd(
             command, {'Bucket': 'test-bucket', 'EncodingType': 'url'}
         )
+
+    def test_input_yaml_from_stdin(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO('Bucket: test-bucket\nEncodingType: url'),
+        ):
+            command = [
+                's3api',
+                'list-objects-v2',
+                '--cli-input-yaml',
+                '-',
+            ]
+            self.assert_params_for_cmd(
+                command, {'Bucket': 'test-bucket', 'EncodingType': 'url'}
+            )
 
     def test_errors_when_both_yaml_and_json_provided(self):
         command = [

--- a/tests/unit/customizations/test_cliinput.py
+++ b/tests/unit/customizations/test_cliinput.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+import io
 import os
 import shutil
 import tempfile
@@ -122,6 +123,64 @@ class TestCliInputJSONArgument(unittest.TestCase):
                     parsed_globals=None,
                 )
 
+    def test_add_to_call_parameters_from_stdin(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO(self.input_json),
+        ):
+            parsed_args = self.create_args('-')
+            call_parameters = {}
+            self.argument.add_to_call_parameters(
+                service_operation=None,
+                call_parameters=call_parameters,
+                parsed_args=parsed_args,
+                parsed_globals=None,
+            )
+            self.assertEqual(call_parameters, {'A': 'foo', 'B': 'bar'})
+
+    def test_stdin_does_not_clobber(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO(self.input_json),
+        ):
+            parsed_args = self.create_args('-')
+            call_parameters = {'A': 'baz'}
+            self.argument.add_to_call_parameters(
+                service_operation=None,
+                call_parameters=call_parameters,
+                parsed_args=parsed_args,
+                parsed_globals=None,
+            )
+            self.assertEqual(call_parameters, {'A': 'baz', 'B': 'bar'})
+
+    def test_stdin_bad_json(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO('not valid json'),
+        ):
+            parsed_args = self.create_args('-')
+            with self.assertRaises(ParamError):
+                self.argument.add_to_call_parameters(
+                    service_operation=None,
+                    call_parameters={},
+                    parsed_args=parsed_args,
+                    parsed_globals=None,
+                )
+
+    def test_stdin_empty(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO(''),
+        ):
+            parsed_args = self.create_args('-')
+            with self.assertRaises(ParamError):
+                self.argument.add_to_call_parameters(
+                    service_operation=None,
+                    call_parameters={},
+                    parsed_args=parsed_args,
+                    parsed_globals=None,
+                )
+
 
 class TestCliInputYAMLArgument(TestCliInputJSONArgument):
     def setUp(self):
@@ -191,3 +250,18 @@ class TestCliInputYAMLArgument(TestCliInputJSONArgument):
             parsed_globals=None,
         )
         self.assertEqual(call_parameters, {'A': 'baz', 'B': 'bar'})
+
+    def test_input_yaml_from_stdin(self):
+        with mock.patch(
+            'awscli.customizations.cliinput.sys.stdin',
+            io.StringIO(self.input_yaml),
+        ):
+            parsed_args = self.create_args('-')
+            call_parameters = {}
+            self.argument.add_to_call_parameters(
+                service_operation=None,
+                call_parameters=call_parameters,
+                parsed_args=parsed_args,
+                parsed_globals=None,
+            )
+            self.assertEqual(call_parameters, {'A': 'foo', 'B': 'bar'})


### PR DESCRIPTION
## Description

Add support for passing `-` as the value of `--cli-input-json` and `--cli-input-yaml` to read input from standard input. This enables clean pipeline usage:

```bash
cat params.json | aws s3api head-object --cli-input-json -
generate_yaml | aws s3api list-objects-v2 --cli-input-yaml -
```

Fixes #5982
Fixes #7850

## Motivation and Context

This has been requested since 2018 (PR #3209, issue #3700, issue #5982, issue #7850). Users need stdin support for:

- **Pipeline/CI workflows** — generating JSON/YAML dynamically and piping it directly
- **Security** — avoiding exposure of sensitive values (e.g. secrets) in process tables via command-line arguments (raised by @Nanovox in #5982)

## Approach

Following the direction suggested by @stealthycoin in [PR #3209](https://github.com/aws/aws-cli/pull/3209#issuecomment-1098522868):

> "I think it makes more sense to make a special case for `--cli-input-json` where it accepts `-` as a value that means read stdin. Much like `aws s3 cp - s3://mybucket/stream.txt` will copy stdin to a bucket."

The implementation adds a `-` check in `CliInputArgument._get_arg_value()` before the existing `file://` resolution. This:

- **Follows the existing `s3 cp -` convention** already established in the CLI
- **Is scoped to `--cli-input-json` / `--cli-input-yaml` only** — avoids interactive mode conflicts raised in PR #3209
- **Reads stdin exactly once** — avoids the double-read problem that breaks `file:///dev/stdin` workarounds
- **Works cross-platform** — no `/dev/stdin` dependency (works on Windows)
- **Does NOT add a generic `pipe://` or `stdin://` scheme** — keeps the change minimal and focused

## Testing

- **4 new unit tests** for JSON stdin: basic read, no-clobber, bad JSON, empty stdin
- **1 new unit test** for YAML stdin
- **2 new functional tests** for JSON stdin: basic read, CLI arg override
- **1 new functional test** for YAML stdin

All existing tests continue to pass. The inherited test structure ensures YAML tests also get the JSON stdin tests via class inheritance.

## Changes

| File | Change |
|------|--------|
| `awscli/customizations/cliinput.py` | Add `sys` import; add `-` stdin check in `_get_arg_value()`; update help text for both JSON and YAML arguments |
| `tests/unit/customizations/test_cliinput.py` | Add 5 stdin test methods |
| `tests/functional/test_cliinput.py` | Add 3 stdin test methods |
| `.changes/next-release/cli-input-stdin.json` | Changelog entry |