### PR TITLE
Fix InstanceMetadataRegionFetcher for local zones

### DIFF
--- a/awscli/utils.py
+++ b/awscli/utils.py
@@ -163,7 +163,7 @@ class IMDSRegionProvider(BaseProvider):
 
 
 class InstanceMetadataRegionFetcher(IMDSFetcher):
-    _URL_PATH = 'latest/meta-data/placement/availability-zone/'
+    _URL_PATH = 'latest/meta-data/placement/region'
 
     def retrieve_region(self):
         """Get the current region from the instance metadata service.
@@ -204,9 +204,7 @@ class InstanceMetadataRegionFetcher(IMDSFetcher):
             retry_func=self._default_retry,
             token=token,
         )
-        availability_zone = response.text
-        region = availability_zone[:-1]
-        return region
+        return response.text
 
 
 def split_on_commas(value):

--- a/tests/functional/test_clidriver.py
+++ b/tests/functional/test_clidriver.py
@@ -66,9 +66,8 @@ class TestSession(BaseCLIDriverTest):
         # First response should be from the IMDS server for security token
         # if server supports IMDSv1 only there will be no response for token
         self.add_response(None)
-        # Then another response from the IMDS server for an availability
-        # zone.
-        self.add_response(b'us-mars-2a')
+        # Then another response from the IMDS server for the region.
+        self.add_response(b'us-mars-2')
         # Once a region is fetched form the IMDS server we need to mock an
         # XML response from ec2 so that the CLI driver doesn't throw an error
         # during parsing.
@@ -84,9 +83,8 @@ class TestSession(BaseCLIDriverTest):
         # First response should be from the IMDS server for security token
         # if server supports IMDSv2 it'll return token
         self.add_response(b'token')
-        # Then another response from the IMDS server for an availability
-        # zone.
-        self.add_response(b'us-mars-2a')
+        # Then another response from the IMDS server for the region.
+        self.add_response(b'us-mars-2')
         # Once a region is fetched form the IMDS server we need to mock an
         # XML response from ec2 so that the CLI driver doesn't throw an error
         # during parsing.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -399,7 +399,7 @@ class BaseIMDSRegionTest(unittest.TestCase):
         self._send = self._urllib3_patch.start()
         self._imds_responses = []
         self._send.side_effect = self.get_imds_response
-        self._region = 'us-mars-1a'
+        self._region = 'us-mars-1'
         self.environ = {}
         self.environ_patch = mock.patch('os.environ', self.environ)
         self.environ_patch.start()
@@ -554,6 +554,28 @@ class TestInstanceMetadataRegionFetcher(BaseIMDSRegionTest):
             num_attempts=2
         ).retrieve_region()
         self.assertEqual(result, None)
+
+    def test_retrieve_region_local_zone_instance(self):
+        _imds_responses = {
+            'api/token': b'my-token',
+            'placement/region': b'us-east-1',
+            'placement/availability-zone': b'us-east-1-atl-2a',
+        }
+
+        def get_response(request):
+            for path, body in _imds_responses.items():
+                if path in request.url:
+                    return botocore.awsrequest.AWSResponse(
+                        url=request.url,
+                        status_code=200,
+                        headers={},
+                        raw=RawResponse(body),
+                    )
+            raise ValueError(f'Unexpected IMDS request: {request.url}')
+
+        self._send.side_effect = get_response
+        result = InstanceMetadataRegionFetcher().retrieve_region()
+        self.assertEqual(result, 'us-east-1')
 
 
 class TestIMDSRegionProvider(BaseIMDSRegionTest):


### PR DESCRIPTION
InstanceMetadataRegionFetcher queries latest/meta-data/placement/availability-zone/ and strips the trailing character to derive the region. This works for standard AZs (us-east-1a becomes us-east-1) but breaks for local zones (us-east-1-atl-2a becomes us-east-1-atl-2).

Switch to latest/meta-data/placement/region, which returns the parent region directly. This has been around since[0] 2020 so it _should_ be ok to use.

[0]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-data-categories

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
