### PR TITLE
fix(cloudfront): replace random.randint with uuid4 for CallerReference generation

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -11,8 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
-import time
-import random
+import uuid
 
 import rsa
 from botocore.utils import parse_to_aware_datetime
@@ -63,7 +62,7 @@ def register(event_handler):
 
 
 def unique_string(prefix='cli'):
-    return '%s-%s-%s' % (prefix, int(time.time()), random.randint(1, 1000000))
+    return '%s-%s' % (prefix, uuid.uuid4())
 
 
 def _add_paths(argument_table, **kwargs):


### PR DESCRIPTION
## Summary

- `unique_string()` in `awscli/customizations/cloudfront.py` was generating `CallerReference` values using `random.randint(1, 1000000)` combined with a Unix timestamp (1-second granularity)
- Two invocations within the same second had a 1-in-1,000,000 chance of producing an identical `CallerReference`, causing CloudFront to silently treat the second request as a duplicate
- Replace with `uuid.uuid4()` which provides 122 bits of cryptographic randomness, eliminating both the collision risk and the unnecessary timestamp dependency

Fixes #10281

## Test plan

- [ ] Verify `create-invalidation --paths` generates a unique `CallerReference` on each invocation
- [ ] Verify `create-distribution` generates a unique `CallerReference` on each invocation
- [ ] Run existing unit tests: `pytest tests/unit/customizations/test_cloudfront.py`