### PR TITLE
Fix CallerReference collision in unique_string() using uuid4

### DIFF
--- a/awscli/customizations/cloudfront.py
+++ b/awscli/customizations/cloudfront.py
@@ -11,8 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import sys
-import time
-import random
+import uuid
 
 import rsa
 from botocore.utils import parse_to_aware_datetime
@@ -63,7 +62,7 @@ def register(event_handler):
 
 
 def unique_string(prefix='cli'):
-    return '%s-%s-%s' % (prefix, int(time.time()), random.randint(1, 1000000))
+    return '%s-%s' % (prefix, uuid.uuid4())
 
 
 def _add_paths(argument_table, **kwargs):

--- a/tests/unit/customizations/test_cloudfront.py
+++ b/tests/unit/customizations/test_cloudfront.py
@@ -1,0 +1,40 @@
+# Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import re
+
+from awscli.testutils import unittest
+from awscli.customizations.cloudfront import unique_string
+
+
+class TestUniqueString(unittest.TestCase):
+
+    UUID_RE = re.compile(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+    )
+
+    def test_default_prefix(self):
+        result = unique_string()
+        self.assertTrue(result.startswith('cli-'), result)
+
+    def test_custom_prefix(self):
+        result = unique_string(prefix='myprefix')
+        self.assertTrue(result.startswith('myprefix-'), result)
+
+    def test_suffix_is_uuid4(self):
+        result = unique_string()
+        suffix = result[len('cli-'):]
+        self.assertRegex(suffix, self.UUID_RE)
+
+    def test_values_are_unique(self):
+        results = {unique_string() for _ in range(1000)}
+        self.assertEqual(len(results), 1000)


### PR DESCRIPTION
## Problem

`unique_string()` in `awscli/customizations/cloudfront.py` generates the
`CallerReference` for `create-invalidation` and `create-distribution` using
`random.randint(1, 1000000)` combined with a Unix timestamp at 1-second
precision:

```python
def unique_string(prefix='cli'):
    return '%s-%s-%s' % (prefix, int(time.time()), random.randint(1, 1000000))
```

Two invocations within the same second share the same timestamp and have a
**1-in-1,000,000** chance of producing an identical `CallerReference`. When
this occurs CloudFront silently treats the second request as a duplicate and
does not create a new invalidation or distribution.

Additionally, Python's `random` module uses the Mersenne Twister algorithm and
is not cryptographically secure, which is inappropriate for values that are
expected to be unique and unpredictable.

Closes #10281.

## Solution

Replace the implementation with `uuid.uuid4()`, which provides 122 bits of
cryptographically random entropy. This eliminates both the timestamp dependency
and the collision risk entirely. `uuid` is part of the Python standard library
and requires no new dependencies.

```python
def unique_string(prefix='cli'):
    return '%s-%s' % (prefix, uuid.uuid4())
```

## Changes

- `awscli/customizations/cloudfront.py` — replace `import time`/`import random`
  with `import uuid`; rewrite `unique_string()` to use `uuid.uuid4()`
- `tests/unit/customizations/test_cloudfront.py` — new unit tests verifying
  the UUID4 format, custom prefix support, and uniqueness across 1 000 calls

## Testing

```
# unit tests
pytest tests/unit/customizations/test_cloudfront.py -v

# existing functional tests still pass
pytest tests/functional/cloudfront/ -v
```

---
Generated by AI tools, and reviewed by shreyaskommuri