### PR TITLE
[V2] Add State and Paths fields to organizations example outputs

### DIFF
--- a/awscli/examples/organizations/describe-account.rst
+++ b/awscli/examples/organizations/describe-account.rst
@@ -14,6 +14,10 @@ The output shows an account object with the details about the account: ::
 			"Email": "anika@example.com",
 			"JoinedMethod": "INVITED",
 			"JoinedTimeStamp": 1481756563.134,
+			"Paths": [
+				"o-exampleorgid/r-examplerootid111/555555555555/"
+			],
+			"State": "ACTIVE",
 			"Status": "ACTIVE"
 		}
 	}

--- a/awscli/examples/organizations/list-accounts-for-parent.rst
+++ b/awscli/examples/organizations/list-accounts-for-parent.rst
@@ -15,6 +15,10 @@ The output includes a list of account summary objects. ::
 				"Id": "333333333333",
 				"Name": "Development Account",
 				"Email": "juan@example.com",
+				"Paths": [
+					"o-exampleorgid/r-examplerootid111/111111111111/"
+				],
+				"State": "ACTIVE",
 				"Status": "ACTIVE"
 			},
 			{
@@ -24,6 +28,10 @@ The output includes a list of account summary objects. ::
 				"Id": "444444444444",
 				"Name": "Test Account",
 				"Email": "anika@example.com",
+				"Paths": [
+					"o-exampleorgid/r-examplerootid111/111111111111/"
+				],
+				"State": "ACTIVE",
 				"Status": "ACTIVE"
 			}
 		]

--- a/awscli/examples/organizations/list-accounts.rst
+++ b/awscli/examples/organizations/list-accounts.rst
@@ -15,6 +15,10 @@ The output includes a list of account summary objects. ::
 				"Id": "111111111111",
 				"Name": "Master Account",
 				"Email": "bill@example.com",
+				"Paths": [
+					"o-exampleorgid/r-examplerootid111/111111111111/"
+				],
+				"State": "ACTIVE",
 				"Status": "ACTIVE"
 			},
 			{
@@ -24,6 +28,10 @@ The output includes a list of account summary objects. ::
 				"Id": "222222222222",
 				"Name": "Production Account",
 				"Email": "alice@example.com",
+				"Paths": [
+					"o-exampleorgid/r-examplerootid111/111111111111/"
+				],
+				"State": "ACTIVE",
 				"Status": "ACTIVE"
 			},
 			{
@@ -33,6 +41,10 @@ The output includes a list of account summary objects. ::
 				"Id": "333333333333",
 				"Name": "Development Account",
 				"Email": "juan@example.com",
+				"Paths": [
+					"o-exampleorgid/r-examplerootid111/111111111111/"
+				],
+				"State": "ACTIVE",
 				"Status": "ACTIVE"
 			},
 			{
@@ -42,6 +54,10 @@ The output includes a list of account summary objects. ::
 				"Id": "444444444444",
 				"Name": "Test Account",
 				"Email": "anika@example.com",
+				"Paths": [
+					"o-exampleorgid/r-examplerootid111/111111111111/"
+				],
+				"State": "ACTIVE",
 				"Status": "ACTIVE"
 			}
 		]


### PR DESCRIPTION
Port of PRs #10276, #10278, #10279, and #10289 from develop to v2. Adds the State and Paths fields to list-accounts, list-accounts-for-parent, and describe-account examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
