### PR TITLE
[v2] Add more granular metrics to benchmarking framework: plugin-load time, static imports time, client creation time.

### DIFF
--- a/awscli/botocore/session.py
+++ b/awscli/botocore/session.py
@@ -866,6 +866,7 @@ class Session:
         :return: A botocore client instance
 
         """
+        self.emit('before-create-client')
         default_client_config = self.get_default_client_config()
         # If a config is provided and a default config is set, then
         # use the config resulting from merging the two.
@@ -960,6 +961,7 @@ class Session:
         monitor = self._get_internal_component('monitor')
         if monitor is not None:
             monitor.register(client.meta.events)
+        self.emit('after-create-client')
         return client
 
     def _resolve_region_name(self, region_name, config):

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -119,8 +119,6 @@ def create_clidriver(args=None, event_hooks=None):
         debug = args.debug
     session = botocore.session.Session(event_hooks=event_hooks)
     _set_user_agent_for_session(session)
-    # if event_hooks is not None:
-    #     session.register_component('event_emitter', event_hooks)
     load_plugins(
         session.full_config.get('plugins', {}),
         event_hooks=session.get_component('event_emitter'),

--- a/awscli/clidriver.py
+++ b/awscli/clidriver.py
@@ -111,14 +111,16 @@ def main():
         return AWSCLIEntryPoint().main(sys.argv[1:])
 
 
-def create_clidriver(args=None):
+def create_clidriver(args=None, event_hooks=None):
     debug = None
     if args is not None:
         parser = FirstPassGlobalArgParser()
         args, _ = parser.parse_known_args(args)
         debug = args.debug
-    session = botocore.session.Session()
+    session = botocore.session.Session(event_hooks=event_hooks)
     _set_user_agent_for_session(session)
+    # if event_hooks is not None:
+    #     session.register_component('event_emitter', event_hooks)
     load_plugins(
         session.full_config.get('plugins', {}),
         event_hooks=session.get_component('event_emitter'),

--- a/awscli/plugin.py
+++ b/awscli/plugin.py
@@ -45,7 +45,9 @@ def load_plugins(plugin_mapping, event_hooks=None, include_builtins=True):
     if event_hooks is None:
         event_hooks = HierarchicalEmitter()
     if include_builtins:
+        event_hooks.emit('before-import-plugins')
         _load_plugins(BUILTIN_PLUGINS, event_hooks)
+        event_hooks.emit('after-import-plugins')
     plugin_path = plugin_mapping.pop(CLI_LEGACY_PLUGIN_PATH, None)
     if plugin_path is not None:
         _add_plugin_path_to_sys_path(plugin_path)

--- a/awscli/plugin.py
+++ b/awscli/plugin.py
@@ -45,9 +45,9 @@ def load_plugins(plugin_mapping, event_hooks=None, include_builtins=True):
     if event_hooks is None:
         event_hooks = HierarchicalEmitter()
     if include_builtins:
-        event_hooks.emit('before-import-plugins')
+        event_hooks.emit('before-load-plugins')
         _load_plugins(BUILTIN_PLUGINS, event_hooks)
-        event_hooks.emit('after-import-plugins')
+        event_hooks.emit('after-load-plugins')
     plugin_path = plugin_mapping.pop(CLI_LEGACY_PLUGIN_PATH, None)
     if plugin_path is not None:
         _add_plugin_path_to_sys_path(plugin_path)

--- a/scripts/performance/benchmark_utils.py
+++ b/scripts/performance/benchmark_utils.py
@@ -178,6 +178,11 @@ class Summarizer:
                 'Seconds',
                 worker_results['static_imports_time'],
             ),
+            'client.creation.time': Metric(
+                'Total time spent creating a botocore client.',
+                'Seconds',
+                worker_results['create-client-time'],
+            ),
         }
         # reset data state
         self._samples.clear()
@@ -273,6 +278,8 @@ class BenchmarkHarness:
         Runs a CLI command and logs CLI-specific metrics to a file.
         """
         first_client_invocation_time = None
+        create_client_start_time = None
+        create_client_end_time = None
         plugin_import_start_time = None
         plugin_import_end_time = None
         start_time = time.time()
@@ -289,6 +296,16 @@ class BenchmarkHarness:
             if first_client_invocation_time is None:
                 first_client_invocation_time = time.time()
 
+        def _log_create_client_start(**kwargs):
+            nonlocal create_client_start_time
+            if create_client_start_time is None:
+                create_client_start_time = time.time()
+
+        def _log_create_client_end(**kwargs):
+            nonlocal create_client_end_time
+            if create_client_end_time is None:
+                create_client_end_time = time.time()
+
         def _log_import_plugins_start(**kwargs):
             nonlocal plugin_import_start_time
             if plugin_import_start_time is None:
@@ -304,6 +321,16 @@ class BenchmarkHarness:
             'before-call',
             _log_invocation_time,
             'benchmarks.log-invocation-time',
+        )
+        event_hooks.register_last(
+            'before-create-client',
+            _log_create_client_start,
+            'benchmarks.log-before-create-client',
+        )
+        event_hooks.register_last(
+            'after-create-client',
+            _log_create_client_end,
+            'benchmarks.log-after-create-client',
         )
         event_hooks.register_last(
             'before-load-plugins',
@@ -335,6 +362,9 @@ class BenchmarkHarness:
                         'static_imports_time': (
                             after_imports - before_imports
                         ),
+                        'create-client-time': (
+                            create_client_end_time - create_client_start_time
+                        )
                     }
                 )
             )

--- a/scripts/performance/benchmark_utils.py
+++ b/scripts/performance/benchmark_utils.py
@@ -7,9 +7,6 @@ import time
 
 import psutil
 
-from awscli.botocore.hooks import HierarchicalEmitter
-
-from awscli.clidriver import AWSCLIEntryPoint, create_clidriver
 from scripts.performance import BaseBenchmarkSuite
 from scripts.performance.simple_stubbed_tests import (
     JSONStubbedBenchmarkSuite,
@@ -171,11 +168,16 @@ class Summarizer:
                 worker_results['first_client_invocation_time']
                 - worker_results['start_time'],
             ),
-            'plugins.import.time': Metric(
+            'plugins.load.time': Metric(
                 'Total time spent loading all built-in plugins.',
                 'Seconds',
-                worker_results['plugin_imports'],
-            )
+                worker_results['load_plugins_time'],
+            ),
+            'imports.static.time': Metric(
+                'Total time spent on static Python imports.',
+                'Seconds',
+                worker_results['static_imports_time'],
+            ),
         }
         # reset data state
         self._samples.clear()
@@ -275,6 +277,13 @@ class BenchmarkHarness:
         plugin_import_end_time = None
         start_time = time.time()
 
+        before_imports = start_time
+        # We import from awscli lazily to ensure import time is measured in
+        # total runtime.
+        from awscli.botocore.hooks import HierarchicalEmitter
+        from awscli.clidriver import AWSCLIEntryPoint, create_clidriver
+        after_imports = time.time()
+
         def _log_invocation_time(params, request_signer, model, **kwargs):
             nonlocal first_client_invocation_time
             if first_client_invocation_time is None:
@@ -297,14 +306,14 @@ class BenchmarkHarness:
             'benchmarks.log-invocation-time',
         )
         event_hooks.register_last(
-            'before-import-plugins',
+            'before-load-plugins',
             _log_import_plugins_start,
-            'benchmarks.log-before-import-plugins',
+            'benchmarks.log-before-load-plugins',
         )
         event_hooks.register_last(
-            'after-import-plugins',
+            'after-load-plugins',
             _log_import_plugins_end,
-            'benchmarks.log-after-import-plugins',
+            'benchmarks.log-after-load-plugins',
         )
 
         driver = create_clidriver(event_hooks=event_hooks)
@@ -320,8 +329,11 @@ class BenchmarkHarness:
                         'start_time': start_time,
                         'end_time': end_time,
                         'first_client_invocation_time': first_client_invocation_time,
-                        'plugin_imports': (
+                        'load_plugins_time': (
                             plugin_import_end_time - plugin_import_start_time
+                        ),
+                        'static_imports_time': (
+                            after_imports - before_imports
                         ),
                     }
                 )
@@ -351,7 +363,6 @@ class BenchmarkHarness:
         os.chdir(result_dir)
 
         # fork a child process to run the command on.
-        print('0')
         pid = os.fork()
 
         try:
@@ -382,7 +393,6 @@ class BenchmarkHarness:
                                 os.dup2(f.fileno(), sys.stdout.fileno())
                                 os.dup2(f_err.fileno(), sys.stderr.fileno())
                     # execute command on child process
-                    print('1')
                     self._run_command_with_metric_hooks(
                         benchmark['command'], metrics_path
                     )
@@ -448,7 +458,6 @@ class BenchmarkHarness:
             for suite, case in cases:
                 for idx in range(args.num_iterations):
                     for cmd in case:
-                        print(cmd)
                         samples, execution_results = (
                             self._run_isolated_benchmark(
                                 result_dir,

--- a/scripts/performance/benchmark_utils.py
+++ b/scripts/performance/benchmark_utils.py
@@ -169,6 +169,14 @@ class Summarizer:
                 worker_results['first_client_invocation_time']
                 - worker_results['start_time'],
             ),
+            'plugins.import.time': Metric(
+                'Total time spent loading all built-in plugins.',
+                'Seconds',
+                (
+                    worker_results['plugin_import_end']
+                    - worker_results['plugin_import_start']
+                ),
+            )
         }
         # reset data state
         self._samples.clear()
@@ -264,6 +272,8 @@ class BenchmarkHarness:
         Runs a CLI command and logs CLI-specific metrics to a file.
         """
         first_client_invocation_time = None
+        plugin_import_start_time = None
+        plugin_import_end_time = None
         start_time = time.time()
         driver = create_clidriver()
         event_emitter = driver.session.get_component('event_emitter')
@@ -273,10 +283,30 @@ class BenchmarkHarness:
             if first_client_invocation_time is None:
                 first_client_invocation_time = time.time()
 
+        def _log_import_plugins_start(**kwargs):
+            nonlocal plugin_import_start_time
+            if plugin_import_start_time is None:
+                plugin_import_start_time = time.time()
+
+        def _log_import_plugins_end(**kwargs):
+            nonlocal plugin_import_end_time
+            if plugin_import_end_time is None:
+                plugin_import_end_time = time.time()
+
         event_emitter.register_last(
             'before-call',
             _log_invocation_time,
             'benchmarks.log-invocation-time',
+        )
+        event_emitter.register_last(
+            'before-import-plugins',
+            _log_import_plugins_start,
+            'benchmarks.log-before-import-plugins',
+        )
+        event_emitter.register_last(
+            'after-import-plugins',
+            _log_import_plugins_end,
+            'benchmarks.log-after-import-plugins',
         )
 
         rc = AWSCLIEntryPoint(driver).main(cmd)
@@ -291,6 +321,9 @@ class BenchmarkHarness:
                         'start_time': start_time,
                         'end_time': end_time,
                         'first_client_invocation_time': first_client_invocation_time,
+                        'plugin_imports': (
+                            plugin_import_end_time - plugin_import_start_time
+                        ),
                     }
                 )
             )

--- a/scripts/performance/benchmark_utils.py
+++ b/scripts/performance/benchmark_utils.py
@@ -7,6 +7,8 @@ import time
 
 import psutil
 
+from awscli.botocore.hooks import HierarchicalEmitter
+
 from awscli.clidriver import AWSCLIEntryPoint, create_clidriver
 from scripts.performance import BaseBenchmarkSuite
 from scripts.performance.simple_stubbed_tests import (
@@ -172,10 +174,7 @@ class Summarizer:
             'plugins.import.time': Metric(
                 'Total time spent loading all built-in plugins.',
                 'Seconds',
-                (
-                    worker_results['plugin_import_end']
-                    - worker_results['plugin_import_start']
-                ),
+                worker_results['plugin_imports'],
             )
         }
         # reset data state
@@ -275,8 +274,6 @@ class BenchmarkHarness:
         plugin_import_start_time = None
         plugin_import_end_time = None
         start_time = time.time()
-        driver = create_clidriver()
-        event_emitter = driver.session.get_component('event_emitter')
 
         def _log_invocation_time(params, request_signer, model, **kwargs):
             nonlocal first_client_invocation_time
@@ -293,22 +290,24 @@ class BenchmarkHarness:
             if plugin_import_end_time is None:
                 plugin_import_end_time = time.time()
 
-        event_emitter.register_last(
+        event_hooks = HierarchicalEmitter()
+        event_hooks.register_last(
             'before-call',
             _log_invocation_time,
             'benchmarks.log-invocation-time',
         )
-        event_emitter.register_last(
+        event_hooks.register_last(
             'before-import-plugins',
             _log_import_plugins_start,
             'benchmarks.log-before-import-plugins',
         )
-        event_emitter.register_last(
+        event_hooks.register_last(
             'after-import-plugins',
             _log_import_plugins_end,
             'benchmarks.log-after-import-plugins',
         )
 
+        driver = create_clidriver(event_hooks=event_hooks)
         rc = AWSCLIEntryPoint(driver).main(cmd)
         end_time = time.time()
 
@@ -352,6 +351,7 @@ class BenchmarkHarness:
         os.chdir(result_dir)
 
         # fork a child process to run the command on.
+        print('0')
         pid = os.fork()
 
         try:
@@ -386,6 +386,7 @@ class BenchmarkHarness:
                                 os.dup2(f.fileno(), sys.stdout.fileno())
                                 os.dup2(f_err.fileno(), sys.stderr.fileno())
                     # execute command on child process
+                    print('1')
                     self._run_command_with_metric_hooks(
                         benchmark['command'], metrics_path
                     )
@@ -451,6 +452,7 @@ class BenchmarkHarness:
             for suite, case in cases:
                 for idx in range(args.num_iterations):
                     for cmd in case:
+                        print(cmd)
                         samples, execution_results = (
                             self._run_isolated_benchmark(
                                 result_dir,

--- a/scripts/performance/benchmark_utils.py
+++ b/scripts/performance/benchmark_utils.py
@@ -366,20 +366,16 @@ class BenchmarkHarness:
                         os.dup2(err.fileno(), sys.stderr.fileno())
                     else:
                         with open(
-                            os.path.abspath(
-                                os.path.join(
-                                    args.debug_dir,
-                                    f'{benchmark["name"]}-{iteration}.txt',
-                                )
+                            os.path.join(
+                                args.debug_dir,
+                                f'{benchmark["name"]}-{iteration}.txt',
                             ),
                             'w',
                         ) as f:
                             with open(
-                                os.path.abspath(
-                                    os.path.join(
-                                        args.debug_dir,
-                                        f'{benchmark["name"]}-{iteration}-err.txt',
-                                    )
+                                os.path.join(
+                                    args.debug_dir,
+                                    f'{benchmark["name"]}-{iteration}-err.txt',
                                 ),
                                 'w',
                             ) as f_err:

--- a/scripts/performance/benchmarks.json
+++ b/scripts/performance/benchmarks.json
@@ -117,9 +117,9 @@
           "name": "key.json",
           "content": "{\n \"Group\": {\"S\": \"Group1\"},\n \"Item\": {\"S\": \"Item1\"} }"
         }
-      ]
+      ],
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
     },
-    "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc",
     "responses": [
       {
         "body": "{\"ConsumedCapacity\": {\"CapacityUnits\": 0.5, \"TableName\": \"MyTable\"}, \"Item\": {\"Group\": {\"S\": \"Group1\"}, {\"Item\": {\"S\": \"Item1\"} }"
@@ -135,9 +135,9 @@
           "name": "request-items.json",
           "content": "{\"MyTable\": { \"Keys\": [ {\"Group\": {\"S\": \"Group1\"}, \"Item\": {\"S\": \"Item1\"}}, { \"Group\": {\"S\": \"Group1\"}, \"Item\": {\"S\": \"Item1\"} }, { \"Group\": {\"S\": \"Group1\"}, \"Item\": {\"S\": \"Item1\"} }],\"ProjectionExpression\":\"Genre\"}}"
         }
-      ]
+      ],
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
     },
-    "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc",
     "responses": [
       {
         "body": "{\"Responses\": {\"MyTable\": [{\"Genre\": {\"S\": \"Genre1\"}}, {\"Genre\": {\"S\": \"Genre2\"}},{\"Genre\": {\"S\": \"Genre3\"}}]}, \"UnprocessedKeys\": {},\"ConsumedCapacity\": [{\"TableName\": \"MyTable\",\"CapacityUnits\": 1.5}]}"
@@ -153,9 +153,9 @@
           "name": "item.json",
           "content": "{\"Group\": {\"S\": \"Group1\"},\"Item\": {\"S\": \"Item1\"},\"Category\": {\"S\": \"Category1\"}}"
         }
-      ]
+      ],
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
     },
-    "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc",
     "responses": [
       {
         "body": "{\"ConsumedCapacity\": {\"TableName\": \"MyTable\",\"CapacityUnits\": 1.0}, \"ItemCollectionMetrics\": {\"ItemCollectionKey\": {\"Group\": {\"S\": \"Group1\"}}, \"SizeEstimateRangeGB\": [0.0, 1.0]}}"

--- a/scripts/performance/benchmarks.json
+++ b/scripts/performance/benchmarks.json
@@ -13,7 +13,7 @@
           "size": 3.2e7
         }
       ],
-      "config": "[default]\ns3 =\n preferred_transfer_client = classic"
+      "config": "[default]\nAWS_ACCESS_KEY_ID=key\nAWS_SECRET_ACCESS_KEY=key\nAWS_SESSION_TOKEN=key\ns3 =\n preferred_transfer_client = classic"
     },
     "responses": [
       {

--- a/scripts/performance/benchmarks.json
+++ b/scripts/performance/benchmarks.json
@@ -13,7 +13,7 @@
           "size": 3.2e7
         }
       ],
-      "config": "[default]\nAWS_ACCESS_KEY_ID=key\nAWS_SECRET_ACCESS_KEY=key\nAWS_SESSION_TOKEN=key\ns3 =\n preferred_transfer_client = classic"
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc\ns3 =\n preferred_transfer_client = classic"
     },
     "responses": [
       {
@@ -41,7 +41,8 @@
           "name": "test_file",
           "size": 3.2e7
         }
-      ]
+      ],
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc\ns3 =\n preferred_transfer_client = classic"
     },
     "responses": [
       {
@@ -66,7 +67,7 @@
       {"name": "S3TransferClient", "value": "Classic"}
     ],
     "environment": {
-      "config": "[default]\ns3 =\n preferred_transfer_client = classic"
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc\ns3 =\n preferred_transfer_client = classic"
     },
     "responses": [
       {
@@ -95,7 +96,7 @@
           "file_size": 4e3
         }
       ],
-      "config": "[default]\ns3 =\n preferred_transfer_client = classic"
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc\ns3 =\n preferred_transfer_client = classic"
     },
     "responses": [
       {
@@ -118,6 +119,7 @@
         }
       ]
     },
+    "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc",
     "responses": [
       {
         "body": "{\"ConsumedCapacity\": {\"CapacityUnits\": 0.5, \"TableName\": \"MyTable\"}, \"Item\": {\"Group\": {\"S\": \"Group1\"}, {\"Item\": {\"S\": \"Item1\"} }"
@@ -135,6 +137,7 @@
         }
       ]
     },
+    "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc",
     "responses": [
       {
         "body": "{\"Responses\": {\"MyTable\": [{\"Genre\": {\"S\": \"Genre1\"}}, {\"Genre\": {\"S\": \"Genre2\"}},{\"Genre\": {\"S\": \"Genre3\"}}]}, \"UnprocessedKeys\": {},\"ConsumedCapacity\": [{\"TableName\": \"MyTable\",\"CapacityUnits\": 1.5}]}"
@@ -152,6 +155,7 @@
         }
       ]
     },
+    "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc",
     "responses": [
       {
         "body": "{\"ConsumedCapacity\": {\"TableName\": \"MyTable\",\"CapacityUnits\": 1.0}, \"ItemCollectionMetrics\": {\"ItemCollectionKey\": {\"Group\": {\"S\": \"Group1\"}}, \"SizeEstimateRangeGB\": [0.0, 1.0]}}"
@@ -170,7 +174,8 @@
           "name": "items.json",
           "content": "[{\"Category\": \"Cat1\",\"Item\": \"Item1\",\"Group\": \"Group1\"}, {\"Category\": \"Cat1\",\"Item\": \"Item2\",\"Group\": \"Group2\"}, {\"Category\": \"Cat1\",\"Item\": \"Item3\",\"Group\": \"Group2\"}, {\"Category\": \"Cat2\",\"Item\": \"Item4\",\"Group\": \"Group3\"}, {\"Category\": \"Cat2\",\"Item\": \"Item5\",\"Group\": \"Group4\"}, {\"Category\": \"Cat3\",\"Item\": \"Item6\",\"Group\": \"Group5\"}, {\"Category\": \"Cat3\",\"Item\": \"Item7\",\"Group\": \"Group6\"}, {\"Category\": \"Cat3\",\"Item\": \"Item8\",\"Group\": \"Group6\"}, {\"Category\": \"Cat4\",\"Item\": \"Item9\",\"Group\": \"Group7\"}, {\"Category\": \"Cat4\",\"Item\": \"Item10\",\"Group\": \"Group4\"}]"
         }
-      ]
+      ],
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
     },
     "responses": [
       {
@@ -181,6 +186,9 @@
   {
     "name": "sts.assumerole",
     "command": ["sts", "assume-role", "--role-arn", "arn:aws:iam::123456789012:role/role123", "--role-session-name", "role-session123"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<AssumeRoleResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\"> <AssumeRoleResult> <AssumedRoleUser> <Arn>arn:aws:sts::123456789012:assumed-role/role123/role-session123</Arn> <AssumedRoleId>id1234:role-session123</AssumedRoleId></AssumedRoleUser> <Credentials> <SecretAccessKey>accesskey</SecretAccessKey><SessionToken>token123</SessionToken><Expiration>2016-03-15T00:05:07Z</Expiration><AccessKeyId>acesskeyid123</AccessKeyId> </Credentials></AssumeRoleResult></AssumeRoleResponse>"
@@ -190,6 +198,9 @@
   {
     "name": "sts.getcalleridentity",
     "command": ["sts", "get-caller-identity"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<GetCallerIdentityResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\"> <GetCallerIdentityResult> <Arn>arn:aws:iam::123456789012:user/user123</Arn> <UserId>userid123</UserId> <Account>123456789012</Account> </GetCallerIdentityResult></GetCallerIdentityResponse>"
@@ -199,6 +210,9 @@
   {
     "name": "sts.assumerolewithwebidentity",
     "command": ["sts", "assume-role-with-web-identity", "--duration-seconds", "3600", "--role-session-name", "session-name", "--provider-id", "www.amazon.com", "--policy-arns", "arn=arn:aws:iam::123456789012:policy/q=webidentitypolicy1", "arn=arn:aws:iam::123456789012:policy/webidentitypolicy2", "--role-arn", "arn:aws:iam::123456789012:role/FederatedRole1", "--web-identity-token", "token-123"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<AssumeRoleWithWebIdentityResponse xmlns=\"https://sts.amazonaws.com/doc/2011-06-15/\"> <AssumeRoleWithWebIdentityResult> <SubjectFromWebIdentityToken>amzn1.account.tokenvalue</SubjectFromWebIdentityToken> <Audience>client.12345.6789@email.address</Audience> <AssumedRoleUser> <Arn>arn:aws:sts::123456789012:assumed-role/FederatedRole1/session-name</Arn> <AssumedRoleId>roleid123:session-name</AssumedRoleId> </AssumedRoleUser> <Credentials> <SessionToken>session-token123</SessionToken> <SecretAccessKey>secret-access-key</SecretAccessKey> <Expiration>2014-10-24T23:00:23Z</Expiration> <AccessKeyId>access-key-id123</AccessKeyId></Credentials> <Provider>www.amazon.com</Provider></AssumeRoleWithWebIdentityResult></AssumeRoleWithWebIdentityResponse>"
@@ -208,6 +222,9 @@
   {
     "name": "ec2.describetags",
     "command": ["ec2", "describe-tags", "--filters", "Name=resource-id,Values=i-1234567890"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<DescribeTagsResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\"> <requestId>EXAMPLE</requestId><tagSet> <item> <resourceId>i-1234567890</resourceId> <resourceType>instance</resourceType> <key>webserver</key> <value/> </item> <item> <resourceId>i-1234567890</resourceId> <resourceType>instance</resourceType> <key>stack</key> <value>Production</value> </item> <item> <resourceId>i-1234567890</resourceId> <resourceType>instance</resourceType> <key>database_server</key> <value/> </item> <item> <resourceId>i-1234567890</resourceId> <resourceType>instance</resourceType> <key>stack</key> <value>Test</value> </item> </tagSet></DescribeTagsResponse>"
@@ -217,6 +234,9 @@
   {
     "name": "ec2.describeinstances",
     "command": ["ec2", "describe-instances", "--instance-ids", "i-1234567890abcdef0"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<DescribeInstancesResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\"> <requestId>8f7724cf-496f-496e-8fe3-example</requestId> <reservationSet> <item> <reservationId>r-1234567890abcdef0</reservationId> <ownerId>123456789012</ownerId> <groupSet/> <instancesSet> <item> <instanceId>i-1234567890abcdef0</instanceId> <imageId>ami-bff32ccc</imageId> <instanceState> <code>16</code> <name>running</name> </instanceState> <privateDnsName>ip-192-168-1-88.eu-west-1.compute.internal</privateDnsName> <dnsName>ec2-54-194-252-215.eu-west-1.compute.amazonaws.com</dnsName> <reason/> <keyName>my_keypair</keyName> <amiLaunchIndex>0</amiLaunchIndex> <productCodes/> <instanceType>t2.micro</instanceType> <launchTime>2018-05-08T16:46:19.000Z</launchTime> <placement> <availabilityZone>eu-west-1c</availabilityZone> <groupName/> <tenancy>default</tenancy> </placement> <monitoring> <state>disabled</state> </monitoring> <subnetId>subnet-56f5f633</subnetId> <vpcId>vpc-11112222</vpcId> <privateIpAddress>192.168.1.88</privateIpAddress> <ipAddress>54.194.252.215</ipAddress> <sourceDestCheck>true</sourceDestCheck> <groupSet> <item> <groupId>sg-e4076980</groupId> <groupName>SecurityGroup1</groupName> </item> </groupSet> <architecture>x86_64</architecture> <rootDeviceType>ebs</rootDeviceType> <rootDeviceName>/dev/xvda</rootDeviceName> <blockDeviceMapping> <item> <deviceName>/dev/xvda</deviceName> <ebs> <volumeId>vol-1234567890abcdef0</volumeId> <status>attached</status> <attachTime>2015-12-22T10:44:09.000Z</attachTime> <deleteOnTermination>true</deleteOnTermination> </ebs> </item> </blockDeviceMapping> <virtualizationType>hvm</virtualizationType> <clientToken>xMcwG14507example</clientToken> <tagSet> <item> <key>Name</key> <value>Server_1</value> </item> </tagSet> <hypervisor>xen</hypervisor> <networkInterfaceSet> <item> <networkInterfaceId>eni-551ba033</networkInterfaceId> <subnetId>subnet-56f5f633</subnetId> <vpcId>vpc-11112222</vpcId> <description>Primary network interface</description> <ownerId>123456789012</ownerId> <status>in-use</status> <macAddress>02:dd:2c:5e:01:69</macAddress> <privateIpAddress>192.168.1.88</privateIpAddress> <privateDnsName>ip-192-168-1-88.eu-west-1.compute.internal</privateDnsName> <sourceDestCheck>true</sourceDestCheck> <groupSet> <item> <groupId>sg-e4076980</groupId> <groupName>SecurityGroup1</groupName> </item> </groupSet> <attachment> <attachmentId>eni-attach-39697adc</attachmentId> <deviceIndex>0</deviceIndex> <status>attached</status> <attachTime>2018-05-08T16:46:19.000Z</attachTime> <deleteOnTermination>true</deleteOnTermination> </attachment> <association> <publicIp>54.194.252.215</publicIp> <publicDnsName>ec2-54-194-252-215.eu-west-1.compute.amazonaws.com</publicDnsName> <ipOwnerId>amazon</ipOwnerId> </association> <privateIpAddressesSet> <item> <privateIpAddress>192.168.1.88</privateIpAddress> <privateDnsName>ip-192-168-1-88.eu-west-1.compute.internal</privateDnsName> <primary>true</primary> <association> <publicIp>54.194.252.215</publicIp> <publicDnsName>ec2-54-194-252-215.eu-west-1.compute.amazonaws.com</publicDnsName> <ipOwnerId>amazon</ipOwnerId> </association> </item> </privateIpAddressesSet> <ipv6AddressesSet> <item> <ipv6Address>2001:db8:1234:1a2b::123</ipv6Address> </item> </ipv6AddressesSet> </item> </networkInterfaceSet> <iamInstanceProfile> <arn>arn:aws:iam::123456789012:instance-profile/AdminRole</arn> <id>ABCAJEDNCAA64SSD123AB</id> </iamInstanceProfile> <ebsOptimized>false</ebsOptimized> <cpuOptions> <coreCount>1</coreCount> <threadsPerCore>1</threadsPerCore> </cpuOptions> </item> </instancesSet> </item> </reservationSet> </DescribeInstancesResponse>"
@@ -226,6 +246,9 @@
   {
     "name": "ec2.describevolumesmodifications",
     "command": ["ec2", "describe-volumes-modifications", "--volume-ids", "vol-0123456789EXAMPLE"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<DescribeVolumesModificationsResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\"> <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId> <volumeModificationSet> <item> <targetIops>10000</targetIops> <originalIops>300</originalIops> <modificationState>optimizing</modificationState> <targetSize>200</targetSize> <targetVolumeType>io1</targetVolumeType> <volumeId>vol-0123456789EXAMPLE</volumeId> <progress>40</progress> <startTime>2017-01-19T23:58:04.922Z</startTime> <originalSize>100</originalSize> <originalVolumeType>gp2</originalVolumeType> <originalMultiAttachEnabled>false</originalMultiAttachEnabled> <targetMultiAttachEnabled>true</targetMultiAttachEnabled> </item> </volumeModificationSet> </DescribeVolumesModificationsResponse>"
@@ -235,6 +258,9 @@
   {
     "name": "ecs.describecontainerinstances",
     "command": ["ecs", "describe-container-instances", "--cluster", "update", "--container-instances", "a1b2c3d4-5678-90ab-cdef-11111EXAMPLE"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "{ \"containerInstances\": [ { \"agentConnected\": true, \"attributes\": [ { \"name\": \"com.amazonaws.ecs.capability.privileged-container\" }, { \"name\": \"com.amazonaws.ecs.capability.docker-remote-api.1.17\" }, { \"name\": \"com.amazonaws.ecs.capability.docker-remote-api.1.18\" }, { \"name\": \"com.amazonaws.ecs.capability.docker-remote-api.1.19\" }, { \"name\": \"com.amazonaws.ecs.capability.docker-remote-api.1.20\" }, { \"name\": \"com.amazonaws.ecs.capability.docker-remote-api.1.21\" }, { \"name\": \"com.amazonaws.ecs.capability.logging-driver.json-file\" }, { \"name\": \"com.amazonaws.ecs.capability.logging-driver.syslog\" }, { \"name\": \"com.amazonaws.ecs.capability.logging-driver.awslogs\" }, { \"name\": \"com.amazonaws.ecs.capability.ecr-auth\" } ], \"containerInstanceArn\": \"arn:aws:ecs:us-west-2:012345678910:container-instance/default/f9cc75bb-0c94-46b9-bf6d-49d320bc1551\", \"ec2InstanceId\": \"i-042f39dc\", \"pendingTasksCount\": 0, \"registeredResources\": [ { \"doubleValue\": 0, \"integerValue\": 1024, \"longValue\": 0, \"name\": \"CPU\", \"type\": \"INTEGER\" }, { \"doubleValue\": 0, \"integerValue\": 995, \"longValue\": 0, \"name\": \"MEMORY\", \"type\": \"INTEGER\" }, { \"doubleValue\": 0, \"integerValue\": 0, \"longValue\": 0, \"name\": \"PORTS\", \"stringSetValue\": [ \"22\", \"2376\", \"2375\", \"51678\" ], \"type\": \"STRINGSET\" }, { \"doubleValue\": 0, \"integerValue\": 0, \"longValue\": 0, \"name\": \"PORTS_UDP\", \"stringSetValue\": [], \"type\": \"STRINGSET\" } ], \"remainingResources\": [ { \"doubleValue\": 0, \"integerValue\": 1024, \"longValue\": 0, \"name\": \"CPU\", \"type\": \"INTEGER\" }, { \"doubleValue\": 0, \"integerValue\": 995, \"longValue\": 0, \"name\": \"MEMORY\", \"type\": \"INTEGER\" }, { \"doubleValue\": 0, \"integerValue\": 0, \"longValue\": 0, \"name\": \"PORTS\", \"stringSetValue\": [ \"22\", \"2376\", \"2375\", \"51678\" ], \"type\": \"STRINGSET\" }, { \"doubleValue\": 0, \"integerValue\": 0, \"longValue\": 0, \"name\": \"PORTS_UDP\", \"stringSetValue\": [], \"type\": \"STRINGSET\" } ], \"runningTasksCount\": 0, \"status\": \"ACTIVE\", \"version\": 850, \"versionInfo\": { \"agentHash\": \"0931217\", \"agentVersion\": \"1.9.0\", \"dockerVersion\": \"DockerVersion: 1.9.1\" } } ], \"failures\": [] }"
@@ -244,6 +270,9 @@
   {
     "name": "ecs.describetasks",
     "command": ["ecs", "describe-tasks", "--cluster", "default", "--tasks", "1dc5c17a-422b-4dc4-b493-371970c6c4d6"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "{ \"failures\": [], \"tasks\": [ { \"taskArn\": \"arn:aws:ecs:us-east-1:012345678910:task/1dc5c17a-422b-4dc4-b493-371970c6c4d6\", \"overrides\": { \"containerOverrides\": [ { \"name\": \"simple-app\" }, { \"name\": \"busybox\" } ] }, \"lastStatus\": \"RUNNING\", \"containerInstanceArn\": \"arn:aws:ecs:us-east-1:012345678910:container-instance/default/5991d8da-1d59-49d2-a31f-4230f9e73140\", \"createdAt\": 1476822811.295, \"version\": 0, \"clusterArn\": \"arn:aws:ecs:us-east-1:012345678910:cluster/default\", \"startedAt\": 1476822833.998, \"desiredStatus\": \"RUNNING\", \"taskDefinitionArn\": \"arn:aws:ecs:us-east-1:012345678910:task-definition/console-sample-app-dynamic-ports:1\", \"startedBy\": \"ecs-svc/9223370560032507596\", \"containers\": [ { \"containerArn\": \"arn:aws:ecs:us-east-1:012345678910:container/4df26bb4-f057-467b-a079-961675296e64\", \"taskArn\": \"arn:aws:ecs:us-east-1:012345678910:task/default/1dc5c17a-422b-4dc4-b493-371970c6c4d6\", \"lastStatus\": \"RUNNING\", \"name\": \"simple-app\", \"networkBindings\": [ { \"protocol\": \"tcp\", \"bindIP\": \"0.0.0.0\", \"containerPort\": 80, \"hostPort\": 32774 } ], \"runtimeId\": \"runtime-123\" }, { \"containerArn\": \"arn:aws:ecs:us-east-1:012345678910:container/e09064f7-7361-4c87-8ab9-8d073bbdbcb9\", \"taskArn\": \"arn:aws:ecs:us-east-1:012345678910:task/default/1dc5c17a-422b-4dc4-b493-371970c6c4d6\", \"lastStatus\": \"RUNNING\", \"name\": \"busybox\", \"networkBindings\": [] } ] } ] }"
@@ -253,6 +282,9 @@
   {
     "name": "ecs.listcontainerinstances",
     "command": ["ecs", "list-container-instances", "--cluster", "example"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "{ \"containerInstanceArns\": [ \"arn:aws:ecs:us-east-1:012345678910:container-instance/example/1eb22c8ab33149b397dc769f68cc1319\", \"arn:aws:ecs:us-east-1:012345678910:container-instance/example/5cf7e311a2b74d3882650353cf3b2214\" ] }"
@@ -262,6 +294,9 @@
   {
     "name": "logs.putlogevents",
     "command": ["logs", "put-log-events", "--log-group-name", "my-logs", "--log-stream-name", "20150601", "--log-events", "[\n  {\n    \"timestamp\": 1433190184356,\n    \"message\": \"Example Event 1\"\n  },\n  {\n    \"timestamp\": 1433190184358,\n    \"message\": \"Example Event 2\"\n  },\n  {\n    \"timestamp\": 1433190184360,\n    \"message\": \"Example Event 3\"\n  }\n]"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "{  \"nextSequenceToken\": \"token123\"}"
@@ -271,6 +306,9 @@
   {
     "name": "logs.createloggroup",
     "command": ["logs", "create-log-group", "--log-group-name", "my-logs"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": ""
@@ -280,6 +318,9 @@
   {
     "name": "cloudwatch.putmetricdata",
     "command": ["cloudwatch", "put-metric-data", "--namespace", "Usage Metrics", "--metric-data", "[\n  {\n    \"MetricName\": \"New Posts\",\n    \"Timestamp\": \"Wednesday, June 12, 2013 8:28:20 PM\",\n    \"Value\": 0.50,\n    \"Unit\": \"Count\"\n  }\n]\n"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<PutMetricDataOutput></PutMetricDataOutput>"
@@ -289,6 +330,9 @@
   {
     "name": "cloudwatch.getmetricstatistics",
     "command": ["cloudwatch", "get-metric-statistics", "--metric-name", "CPUUtilization", "--start-time", "2014-04-08T23:18:00Z", "--end-time", "2014-04-09T23:18:00Z", "--period", "3600", "--namespace", "AWS/EC2", "--statistics", "Maximum", "--dimensions", "Name=InstanceId,Value=i-abcdef"],
+    "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<GetMetricStatisticsOutput> <GetMetricStatisticsResult> <Datapoints> <Datapoint>\n         <Timestamp>2014-04-09T11:18:00Z</Timestamp>\n         <Maximum>44.79</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T20:18:00Z</Timestamp>\n         <Maximum>47.92</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T19:18:00Z</Timestamp>\n         <Maximum>50.85</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T09:18:00Z</Timestamp>\n         <Maximum>47.92</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T03:18:00Z</Timestamp>\n         <Maximum>76.84</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T21:18:00Z</Timestamp>\n         <Maximum>48.96</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T14:18:00Z</Timestamp>\n         <Maximum>47.92</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>\n     <Datapoint>\n         <Timestamp>2014-04-09T08:18:00Z</Timestamp>\n         <Maximum>47.92</Maximum>\n         <Unit>Percent</Unit>\n     </Datapoint>  </Datapoints> <Label>CPUUtilization</Label> </GetMetricStatisticsResult> </GetMetricStatisticsOutput> "
@@ -298,6 +342,9 @@
   {
     "name": "cloudwatch.getmetricdata",
     "command": ["cloudwatch", "get-metric-data", "--metric-data-queries", "[ { \"Id\": \"m3\", \"Expression\": \"(m1+m2)/300\", \"Label\": \"Avg Total IOPS\" }, { \"Id\": \"m1\", \"MetricStat\": { \"Metric\": { \"Namespace\": \"AWS/EC2\", \"MetricName\": \"EBSReadOps\", \"Dimensions\": [ { \"Name\": \"InstanceId\", \"Value\": \"i-abcdef\" } ] }, \"Period\": 300, \"Stat\": \"Sum\", \"Unit\": \"Count\" }, \"ReturnData\": false }, { \"Id\": \"m2\", \"MetricStat\": { \"Metric\": { \"Namespace\": \"AWS/EC2\", \"MetricName\": \"EBSWriteOps\", \"Dimensions\": [ { \"Name\": \"InstanceId\", \"Value\": \"i-abcdef\" } ] }, \"Period\": 300, \"Stat\": \"Sum\", \"Unit\": \"Count\" }, \"ReturnData\": false } ]", "--start-time", "2024-09-29T22:10:00Z", "--end-time", "2024-09-29T22:15:00Z"],
+   "environment": {
+      "config": "[default]\nAWS_ACCESS_KEY_ID=abc\nAWS_SECRET_ACCESS_KEY=abc\nAWS_SESSION_TOKEN=abc"
+    },
     "responses": [
       {
         "body": "<GetMetricDataOutput> <GetMetricDataResult> <Messages></Messages> <MetricDataResults> <MetricDataResult> <Id>m3</Id> <Label>Avg Total IOPS</Label> <Timestamps><Timestamp>2024-09-29T22:10:00+00:00</Timestamp></Timestamps> <Values> <DatapointValue>96.85</DatapointValue> </Values> <StatusCode>Complete</StatusCode> </MetricDataResult> </MetricDataResults> </GetMetricDataResult> </GetMetricDataOutput>"

--- a/scripts/performance/run-benchmarks
+++ b/scripts/performance/run-benchmarks
@@ -89,6 +89,9 @@ def main():
                 "--chunk-id must be an integer between 0 (inclusive) and num-chunks (exclusive)."
             )
 
+    if parsed_args.debug_dir is not None:
+        parsed_args.debug_dir = os.path.abspath(parsed_args.debug_dir)
+
     test_suites = harness.get_test_suites(parsed_args)
     test_cases = []
     for suite in test_suites:

--- a/scripts/performance/simple_stubbed_tests.py
+++ b/scripts/performance/simple_stubbed_tests.py
@@ -21,7 +21,6 @@ class RawResponse(BytesIO):
 
 class StubbedHTTPClient:
     def _get_response(self, request):
-        print(request)
         response = self._responses.pop(0)
         if isinstance(response, Exception):
             raise response

--- a/scripts/performance/simple_stubbed_tests.py
+++ b/scripts/performance/simple_stubbed_tests.py
@@ -21,6 +21,7 @@ class RawResponse(BytesIO):
 
 class StubbedHTTPClient:
     def _get_response(self, request):
+        print(request)
         response = self._responses.pop(0)
         if isinstance(response, Exception):
             raise response


### PR DESCRIPTION
*Description of changes:*

* The benchmarking framework (callable from `./scripts/performance/run-benchmarks`) now emits plugin-load time, static imports time, and client creation time.
* Fixed bug with performance framework on IMDS-compatible instances where the CLI would attempt to reach the IMDS endpoints to retrieve credentials but the stubbed responses did not support this. Now, we supply mock credentials in the stubbed config files in each of our stubbed JSON benchmarks.
* In vendored botocore, emit `before-create-ciient` and `after-create-client` before and after client creation, respectively.
* In `create_clidriver`, add a new optional `event_hooks` argument to allow callers to provide their own event emitter. This change was needed so the benchmark framework can register against the `load_plugins` event, which is emitted during `create_clidriver`. 
* Modified `--debug-dir` parameter in `run-benchmarks` script so that it supports relative paths (previously it only supported absolute paths).

*Description of tests:*

* Manually ran the benchmarking framework locally and on an IMDS-compatible EC2 instance, and verified the numbers are successfully being emitted, and are in an expected range aligned with previous benchmarking efforts.
* Manually tested the `--debug-dir` parameter with relative and absolute paths, and verified expected behavior in both cases.
* Successfully ran an internal pre-prod build workflow.

Example plugin-load time emission:

```json
{
      "name": "cloudwatch.getmetricdata.plugins.import.time",
      "description": "Total time spent loading all built-in plugins.",
      "unit": "Seconds",
      "dimensions": [],
      "measurements": [
        0.08212709426879883
      ]
}
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
