### PR TITLE
Add MD5 to checksum-algorithm choices for s3 commands

### DIFF
--- a/awscli/customizations/s3/subcommands.py
+++ b/awscli/customizations/s3/subcommands.py
@@ -459,7 +459,7 @@ CHECKSUM_MODE = {
 }
 
 CHECKSUM_ALGORITHM = {
-        'name': 'checksum-algorithm', 'choices': ['CRC64NVME', 'CRC32', 'SHA256', 'SHA1', 'CRC32C', 'SHA512', 'XXHASH64', 'XXHASH3', 'XXHASH128'],
+        'name': 'checksum-algorithm', 'choices': ['CRC64NVME', 'CRC32', 'SHA256', 'SHA1', 'CRC32C', 'SHA512', 'XXHASH64', 'XXHASH3', 'XXHASH128', 'MD5'],
         'help_text': 'Indicates the algorithm used to create the checksum for the object.'
 }
 

--- a/tests/unit/customizations/s3/test_subcommands.py
+++ b/tests/unit/customizations/s3/test_subcommands.py
@@ -753,6 +753,14 @@ class CommandParametersTest(unittest.TestCase):
             cmd_params.add_paths(paths)
             self.assertIn('Expected checksum-algorithm parameter to be used with one of following path formats', cm.msg)
 
+    def test_validate_checksum_algorithm_md5_upload(self):
+        paths = [self.file_creator.rootdir, 's3://bucket/key']
+        parameters = {'checksum_algorithm': 'MD5'}
+        cmd_params = CommandParameters('cp', parameters, '')
+        cmd_params.add_paths(paths)
+        self.assertEqual(cmd_params.parameters['checksum_algorithm'], 'MD5')
+
+
     def test_validate_checksum_algorithm_sync_download_error(self):
         paths = ['s3://bucket/key', self.file_creator.rootdir]
         parameters = {'checksum_algorithm': 'CRC32C'}


### PR DESCRIPTION
## Summary

Fixes aws/aws-cli#10295. MD5 was missing from the `--checksum-algorithm` choices list for high-level `s3` commands (`cp`, `sync`, `mv`), causing the CLI to reject it with an invalid choice error before the request was even made.

**Changes:**
- Add `MD5` to the `CHECKSUM_ALGORITHM` choices in `awscli/customizations/s3/subcommands.py`
- Add unit test verifying MD5 is accepted as a valid upload checksum algorithm

## Related

A companion fix in botocore registers the `Md5Checksum` implementation so the checksum is computed correctly at the request layer: https://github.com/boto/botocore/pull/3703

Without that botocore fix, `s3api` commands would still fail for MD5 — both PRs are needed for a complete fix.

## Test plan

- [x] `test_validate_checksum_algorithm_md5_upload` passes
- [x] All existing checksum parameter tests continue to pass

Developed with AI assistance, reviewed and tested by shreyaskommuri