### PR TITLE
Fix configure set profile-prefixed dotted varnames

### DIFF
--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -50,6 +50,13 @@ class ConfigureSetCommand(BasicCommand):
         config_path = self._session.get_config_variable(path)
         return os.path.expanduser(config_path)
 
+    def _is_known_profile_name(self, name):
+        """Return whether name is a configured profile (mirrors configure get)."""
+        full_config = getattr(self._session, 'full_config', None)
+        if full_config is None:
+            return False
+        return name in full_config.get('profiles', {})
+
     def _run_main(self, args, parsed_globals):
         varname = args.varname
         value = args.value
@@ -77,6 +84,14 @@ class ConfigureSetCommand(BasicCommand):
                     # [profile, profile_name, ...]
                     profile = parts[1]
                     remaining = parts[2:]
+                varname = remaining[0]
+                if len(remaining) == 2:
+                    value = {remaining[1]: value}
+            elif self._is_known_profile_name(parts[0]):
+                # Same syntax as configure get, e.g.
+                # emr-dev.emr.instance_profile
+                profile = parts[0]
+                remaining = parts[1:]
                 varname = remaining[0]
                 if len(remaining) == 2:
                     value = {remaining[1]: value}

--- a/tests/functional/configure/test_configure.py
+++ b/tests/functional/configure/test_configure.py
@@ -358,6 +358,28 @@ class TestConfigureCommand(BaseAWSCommandParamsTest):
         )
         self.assertEqual(stdout, "")
 
+    def test_set_get_roundtrip_with_profile_name_prefix(self):
+        self.set_config_file_contents(
+            "[profile emr-dev]\n"
+            "region = us-west-1\n"
+        )
+        self.run_cmd(
+            "configure set emr-dev.emr.instance_profile my_ip_emr",
+        )
+        self.assertEqual(
+            "[profile emr-dev]\n"
+            "region = us-west-1\n"
+            "emr =\n"
+            "    instance_profile = my_ip_emr\n",
+            self.get_config_file_contents(),
+        )
+        # Reload the driver so configure get sees the updated config file.
+        self.driver = create_clidriver()
+        stdout, _, _ = self.run_cmd(
+            "configure get emr-dev.emr.instance_profile"
+        )
+        self.assertEqual(stdout.strip(), "my_ip_emr")
+
     def test_can_handle_empty_section(self):
         self.set_config_file_contents("[default]\n")
         self.run_cmd(

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -70,6 +70,30 @@ class TestConfigureSetCommand(unittest.TestCase):
             {'__section__': 'profile emr-dev', 'emr':
                 {'instance_profile': 'my_ip_emr'}}, 'myconfigfile')
 
+    def test_configure_set_dotted_with_profile_name_prefix(self):
+        # Mirrors configure get syntax (test_dotted_get_with_profile).
+        self.session.full_config = {'profiles': {'emr-dev': {
+            'emr': {'instance_profile': 'old_ip'}}}}
+        set_command = ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(
+            args=['emr-dev.emr.instance_profile', 'my_ip_emr'],
+            parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'profile emr-dev', 'emr':
+                {'instance_profile': 'my_ip_emr'}}, 'myconfigfile')
+
+    def test_configure_set_dotted_profile_name_two_part_varname(self):
+        self.session.full_config = {'profiles': {'emr-dev': {
+            'region': 'us-west-1'}}}
+        set_command = ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(
+            args=['emr-dev.region', 'us-west-2'], parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'profile emr-dev', 'region': 'us-west-2'},
+            'myconfigfile')
+
     def test_configure_set_with_profile(self):
         self.session.profile = 'testing'
         set_command = ConfigureSetCommand(


### PR DESCRIPTION
Fixes bug : 10313

aws configure get supports varnames that start with a known profile name, for example emr-dev.emr.instance_profile. aws configure set did not use the same parsing. For the same varname, it could write to the wrong place, for example under [default] with a flat emr-dev key instead of under [profile emr-dev] with nested emr.instance_profile.

This change aligns configure set with configure get by detecting when the first segment of a dotted varname is a profile in full_config['profiles'], then writing the correct section and nested value.

What changed
Added _is_known_profile_name() in awscli/customizations/configure/set.py
Added parsing for profileName.section.key using the same nesting rules as configure get
Added unit tests in tests/unit/customizations/configure/test_set.py
Added a functional set/get round-trip test in tests/functional/configure/test_configure.py
Example
Before (incorrect):

aws configure set emr-dev.emr.instance_profile my_ip
# Could write under [default]: emr-dev = my_ip
After (correct):

aws configure set emr-dev.emr.instance_profile my_ip
# Writes under [profile emr-dev]:
# emr =
#     instance_profile = my_ip
Existing forms are unchanged: default.*, profile.*, preview.*, plugins.*, and section.key with --profile.

Test plan

 pytest tests/unit/customizations/configure/test_set.py -v
 pytest tests/unit/customizations/configure/ -v
 pytest tests/functional/configure/test_configure.py -v
 Manual round-trip: configure set emr-dev.emr.instance_profile then configure get emr-dev.emr.instance_profile