### PR TITLE
Analyze bugs and errors of aws cli repo 

### DIFF
--- a/.changes/next-release/bugfix-argumentparsing-13262.json
+++ b/.changes/next-release/bugfix-argumentparsing-13262.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``argument parsing``",
+  "description": "Fix ``IndexError`` raised when a structure, map, or list parameter value contained only whitespace. The user-facing ``ParamError`` is now raised instead."
+}

--- a/.changes/next-release/bugfix-argumentparsing-36037.json
+++ b/.changes/next-release/bugfix-argumentparsing-36037.json
@@ -1,0 +1,5 @@
+{
+  "type": "bugfix",
+  "category": "``argument parsing``",
+  "description": "Fix ``NameError`` when raising ``ParamUnknownKeyError`` due to a reference to an undefined variable in the formatted message."
+}

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -55,7 +55,7 @@ class ParamUnknownKeyError(Exception):
     def __init__(self, key, valid_keys):
         valid_keys = ', '.join(valid_keys)
         full_message = (
-            f"Unknown key '{key}', valid choices are: {valid_key}"
+            f"Unknown key '{key}', valid choices are: {valid_keys}"
         )
         super().__init__(full_message)
 

--- a/awscli/argprocess.py
+++ b/awscli/argprocess.py
@@ -188,12 +188,12 @@ def _unpack_json_cli_arg(argument_model, value, cli_name):
 def _unpack_complex_cli_arg(argument_model, value, cli_name):
     type_name = argument_model.type_name
     if type_name == 'structure' or type_name == 'map':
-        if value.lstrip()[0] == '{':
+        if value.lstrip().startswith('{'):
             return _unpack_json_cli_arg(argument_model, value, cli_name)
         raise ParamError(cli_name, f"Invalid JSON:\n{value}")
     elif type_name == 'list':
         if isinstance(value, str):
-            if value.lstrip()[0] == '[':
+            if value.lstrip().startswith('['):
                 return _unpack_json_cli_arg(argument_model, value, cli_name)
         elif isinstance(value, list) and len(value) == 1:
             single_value = value[0].strip()

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -896,6 +896,13 @@ class TestJSONValueHeaderParams(BaseArgProcessTest):
             unpack_cli_arg(self.p, value)
 
 
+class TestParamUnknownKeyError(unittest.TestCase):
+    def test_message_includes_valid_keys(self):
+        error = ParamUnknownKeyError('bogus', ['Name', 'Value'])
+        self.assertIn("'bogus'", str(error))
+        self.assertIn('Name, Value', str(error))
+
+
 class TestArgumentPercentEscaping(BaseArgProcessTest):
     def _test_percent_escaping(self, arg_type, arg_class, doc_string):
         argument = self.create_argument(

--- a/tests/unit/test_argprocess.py
+++ b/tests/unit/test_argprocess.py
@@ -903,6 +903,18 @@ class TestParamUnknownKeyError(unittest.TestCase):
         self.assertIn('Name, Value', str(error))
 
 
+class TestUnpackComplexCliArgWhitespace(BaseArgProcessTest):
+    def test_whitespace_only_structure_raises_param_error(self):
+        p = self.get_param_model('ec2.RunInstances.Placement')
+        with self.assertRaises(ParamError):
+            unpack_cli_arg(p, '   ')
+
+    def test_whitespace_only_list_string_raises_param_error(self):
+        p = self.get_param_model('ec2.RunInstances.BlockDeviceMappings')
+        with self.assertRaises(ParamError):
+            unpack_cli_arg(p, '   ')
+
+
 class TestArgumentPercentEscaping(BaseArgProcessTest):
     def _test_percent_escaping(self, arg_type, arg_class, doc_string):
         argument = self.create_argument(


### PR DESCRIPTION
Hi, my contribution to the AWS CLI project aimed to fix some bugs and errors. Some index and syntax problems were found in one of the files by my AI agent, Claude Code Opus 4.7, so I suggested this PR in light of this small problem. The text below was written by the agent; don't worry about any generated garbage, as I have skills and hooks to prevent it from happening.

Two independent error-path bugs in `awscli/argprocess.py`, each addressed in its own commit with a regression test. Both are small, isolated fixes — no behavior change on the success path.

### 1. `NameError` in `ParamUnknownKeyError` (commit f485d79)

The f-string referenced an undefined name `valid_key`; the parameter is `valid_keys`, and the local variable is rebound to the joined string on the preceding line. Any attempt to raise this exception failed with `NameError` instead of producing the intended message.

Fixed line: https://github.com/andrey1bacelar-bit/aws-cli/blob/f485d79/awscli/argprocess.py#L58

```diff
-            f"Unknown key '{key}', valid choices are: {valid_key}"
+            f"Unknown key '{key}', valid choices are: {valid_keys}"
```

The exception is reachable — it is caught at `awscli/argprocess.py:368` — so the message formatting failure was a real user-visible regression on that error path.

### 2. `IndexError` on whitespace-only complex arg values (commit 1688b97)

`_unpack_complex_cli_arg` used `value.lstrip()[0]` to peek at the first non-whitespace character. With a whitespace-only string (for example `--filters "   "`), `lstrip()` returns `''` and the index access crashed with `IndexError` instead of the user-facing `ParamError`.

Fixed lines: https://github.com/andrey1bacelar-bit/aws-cli/blob/1688b97/awscli/argprocess.py#L188-L197

```diff
     if type_name == 'structure' or type_name == 'map':
-        if value.lstrip()[0] == '{':
+        if value.lstrip().startswith('{'):
             return _unpack_json_cli_arg(argument_model, value, cli_name)
         raise ParamError(cli_name, f"Invalid JSON:\n{value}")
     elif type_name == 'list':
         if isinstance(value, str):
-            if value.lstrip()[0] == '[':
+            if value.lstrip().startswith('['):
                 return _unpack_json_cli_arg(argument_model, value, cli_name)
```

`startswith` is safe on empty input. A nearby branch for single-element lists already used a guarded check (`if single_value and single_value[0] == '['`), so this aligns the three cases.

## Test plan

- [x] Added regression tests in `tests/unit/test_argprocess.py`:
  - `TestParamUnknownKeyError.test_message_includes_valid_keys`
  - `TestUnpackComplexCliArgWhitespace.test_whitespace_only_structure_raises_param_error`
  - `TestUnpackComplexCliArgWhitespace.test_whitespace_only_list_string_raises_param_error`
- [x] `python -m pytest tests/unit/test_argprocess.py` — **68 passed**
- [x] Verified both bugs reproduce on `develop` before the fix (`NameError` / `IndexError` as described above)
- [ ] Full unit suite green in CI

**Stats:** +22 / −3 across 2 files.
owner: andrey1bacelar-bit
pullNumber: 1
repo: aws-cli
title: Fix NameError and IndexError in argprocess error paths

{"id":"3694752974","url":"https://github.com/andrey1bacelar-bit/aws-cli/pull/1"}