### PR TITLE
Use UUIDs for deploy ChangeSet names

### DIFF
--- a/awscli/customizations/cloudformation/deployer.py
+++ b/awscli/customizations/cloudformation/deployer.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import sys
-import time
+import uuid
 import logging
 import botocore
 import collections
@@ -26,6 +26,10 @@ LOG = logging.getLogger(__name__)
 
 ChangeSetResult = collections.namedtuple(
                 "ChangeSetResult", ["changeset_id", "changeset_type"])
+
+
+def _make_changeset_name(prefix):
+    return prefix + str(uuid.uuid4())
 
 
 class Deployer(object):
@@ -88,8 +92,7 @@ class Deployer(object):
         now = get_current_datetime().isoformat()
         description = "Created by AWS CLI at {0} UTC".format(now)
 
-        # Each changeset will get a unique name based on time
-        changeset_name = self.changeset_prefix + str(int(time.time()))
+        changeset_name = _make_changeset_name(self.changeset_prefix)
 
         if not self.has_stack(stack_name):
             changeset_type = "CREATE"

--- a/tests/unit/customizations/cloudformation/test_deployer.py
+++ b/tests/unit/customizations/cloudformation/test_deployer.py
@@ -2,7 +2,9 @@ import botocore.session
 
 from botocore.stub import Stubber
 from awscli.testutils import mock, unittest
-from awscli.customizations.cloudformation.deployer import Deployer, ChangeSetResult
+from awscli.customizations.cloudformation.deployer import (
+    ChangeSetResult, Deployer, _make_changeset_name
+)
 from awscli.customizations.cloudformation import exceptions
 
 
@@ -15,6 +17,14 @@ class TestDeployer(unittest.TestCase):
 
         self.changeset_prefix = "some-changeset-prefix"
         self.deployer = Deployer(client, self.changeset_prefix)
+
+    def test_make_changeset_name_uses_uuid(self):
+        uuid = "123e4567-e89b-12d3-a456-426614174000"
+        with mock.patch('awscli.customizations.cloudformation.deployer.uuid.uuid4',
+                        return_value=uuid):
+            self.assertEqual(
+                self.changeset_prefix + uuid,
+                _make_changeset_name(self.changeset_prefix))
 
     def test_has_stack_success(self):
         stack_name = "stack_name"


### PR DESCRIPTION
## Summary

Fixes #10315.

`aws cloudformation deploy` was generating ChangeSet names from a one-second timestamp. If two deploy commands started in the same second for the same stack, both could try to create the same ChangeSet name and one would fail with `AlreadyExistsException`.

This changes the generated ChangeSet name to use `uuid.uuid4()` while keeping the existing AWS CLI prefix. That keeps the name format valid and avoids collisions between concurrent deploys.

## Testing

- `/tmp/awscli-10315-venv/bin/python -m pytest tests/unit/customizations/cloudformation/test_deployer.py`
- `/tmp/awscli-10315-venv/bin/python -m py_compile awscli/customizations/cloudformation/deployer.py tests/unit/customizations/cloudformation/test_deployer.py`
