### PR TITLE
Accept npm scopes with capital letters in CodeArtifact login

### DIFF
--- a/.changes/next-release/enhancement-CodeArtifact-63909.json
+++ b/.changes/next-release/enhancement-CodeArtifact-63909.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "CodeArtifact",
+  "description": "CodeArtifact login now accepts npm scopes containing capital letters with a warning, matching npm's own behavior."
+}

--- a/awscli/customizations/codeartifact/login.py
+++ b/awscli/customizations/codeartifact/login.py
@@ -469,7 +469,7 @@ class NpmLogin(BaseLogin):
     @classmethod
     def get_scope(cls, namespace):
         # Regex for valid scope name
-        valid_scope_name = re.compile('^(@[a-z0-9-~][a-z0-9-._~]*)')
+        valid_scope_name = re.compile('^(@[a-zA-Z0-9-~][a-zA-Z0-9-._~]*)')
 
         if namespace is None:
             return namespace
@@ -484,6 +484,12 @@ class NpmLogin(BaseLogin):
             raise ValueError(
                 'Invalid scope name, scope must contain URL-safe '
                 'characters, no leading dots or underscores'
+            )
+        
+        if not scope.islower():
+            sys.stderr.write(
+                'Warning: scope name "%s" can no longer contain '
+                'capital letters.\n' % scope
             )
 
         return scope

--- a/tests/unit/customizations/codeartifact/test_adapter_login.py
+++ b/tests/unit/customizations/codeartifact/test_adapter_login.py
@@ -1069,6 +1069,11 @@ class TestNpmLogin(unittest.TestCase):
         scope = self.test_subject.get_scope(self.namespace)
         self.assertEqual(scope, expected_value)
 
+    def test_get_scope_lowercase_no_warning(self):
+        with mock.patch('sys.stderr') as mock_stderr:
+            self.test_subject.get_scope(self.namespace)
+        mock_stderr.write.assert_not_called()
+
     def test_get_scope_none_namespace(self):
         expected_value = None
         scope = self.test_subject.get_scope(None)
@@ -1082,6 +1087,22 @@ class TestNpmLogin(unittest.TestCase):
         expected_value = f'@{self.namespace}'
         scope = self.test_subject.get_scope(f'@{self.namespace}')
         self.assertEqual(scope, expected_value)
+
+    def test_get_scope_uppercase_warns(self):
+        with mock.patch('sys.stderr') as mock_stderr:
+            scope = self.test_subject.get_scope('MyNamespace')
+        self.assertEqual(scope, '@MyNamespace')
+        mock_stderr.write.assert_called_once()
+        warning = mock_stderr.write.call_args[0][0]
+        self.assertIn('capital letters', warning)
+
+    def test_get_scope_uppercase_with_prefix_warns(self):
+        with mock.patch('sys.stderr') as mock_stderr:
+            scope = self.test_subject.get_scope('@MyNamespace')
+        self.assertEqual(scope, '@MyNamespace')
+        mock_stderr.write.assert_called_once()
+        warning = mock_stderr.write.call_args[0][0]
+        self.assertIn('capital letters', warning)
 
     def test_get_commands(self):
         commands = self.test_subject.get_commands(


### PR DESCRIPTION
*Issue #, if available:*
[#10207](https://github.com/aws/aws-cli/issues/10207)

*Note:*

Npm warns against using uppercase characters in scope names but doesn't block users from doing so. Although newer packages should only have lowercase scope names for several reasons (e.g., case sensitivity across different filesystems), we still want to support older packages and match npm's behavior.

*Description of changes:*
- Similarly to [#10208](https://github.com/aws/aws-cli/pull/10208), this adjusts the regex to accept uppercase characters (A-Z) and adds a conditional that checks case sensitivity and throws a warning. 
- Adds three tests for warnings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
