### PR TITLE
Fix configure set handling of profile-prefixed dotted varnames

### DIFF
--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -68,15 +68,19 @@ class ConfigureSetCommand(BasicCommand):
         else:
             # First figure out if it's been scoped to a profile.
             parts = varname.split('.')
-            if parts[0] in ('default', 'profile'):
+            if parts[0] == 'profile':
                 # Then we know we're scoped to a profile.
-                if parts[0] == 'default':
-                    profile = 'default'
-                    remaining = parts[1:]
-                else:
-                    # [profile, profile_name, ...]
-                    profile = parts[1]
-                    remaining = parts[2:]
+                # [profile, profile_name, ...]
+                profile = parts[1]
+                remaining = parts[2:]
+                varname = remaining[0]
+                if len(remaining) == 2:
+                    value = {remaining[1]: value}
+            elif parts[0] == 'default' or \
+                    (self._session.full_config is not None and \
+                     parts[0] in self._session.full_config.get('profiles', {})):
+                profile = parts[0]
+                remaining = parts[1:]
                 varname = remaining[0]
                 if len(remaining) == 2:
                     value = {remaining[1]: value}

--- a/tests/unit/customizations/configure/__init__.py
+++ b/tests/unit/customizations/configure/__init__.py
@@ -21,6 +21,7 @@ class FakeSession(object):
         self.variables = all_variables
         self.profile_does_not_exist = profile_does_not_exist
         self.config = {}
+        self.full_config = {'profiles': {}}
         if config_file_vars is None:
             config_file_vars = {}
         self.config_file_vars = config_file_vars

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -191,3 +191,24 @@ class TestConfigureSetCommand(unittest.TestCase):
         self.config_writer.update_config.assert_called_with(
             {'__section__': "profile 'some\tprofile'", 'region': 'us-west-2'},
             'myconfigfile')
+
+    def test_configure_set_command_dotted_with_existing_profile(self):
+        self.session.full_config['profiles']['emr-dev'] = {}
+        set_command = ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(
+            args=['emr-dev.emr.instance_profile', 'my_ip_emr'],
+            parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'profile emr-dev',
+             'emr': {'instance_profile': 'my_ip_emr'}}, 'myconfigfile')
+
+    def test_configure_set_command_dotted_with_existing_profile_no_nesting(self):
+        self.session.full_config['profiles']['emr-dev'] = {}
+        set_command = ConfigureSetCommand(
+            self.session, self.config_writer)
+        set_command(
+            args=['emr-dev.region', 'us-west-2'], parsed_globals=None)
+        self.config_writer.update_config.assert_called_with(
+            {'__section__': 'profile emr-dev',
+             'region': 'us-west-2'}, 'myconfigfile')


### PR DESCRIPTION
### Description

This PR fixes a bug (Issue #10313) where `aws configure set` mishandles profile-prefixed dotted varnames.

When executing a command like `aws configure set emr-dev.emr.instance_profile my_ip` (where `emr-dev` is an existing profile), the command previously failed to recognize `emr-dev` as the target profile. Instead, it would write to the `[default]` profile, mapping the key `emr-dev` to `my_ip`.

**The Fix:**

I've updated `awscli/customizations/configure/set.py` to mirror the profile detection logic currently used by `configure get` (`get.py`). When parsing a dotted varname, it now explicitly checks if the first segment is `default` or exists within the session's loaded `profiles` configuration. If a match is found, it correctly assigns the value to that specific nested profile section.

This ensures the syntax for reading and writing profile-scoped multi-part variables is perfectly symmetrical.

### Testing

- Added tests to `test_set.py` mimicking the `FakeSession` setup from `test_get.py`.
- All 123 configure unit and functional tests execute successfully:
  `pytest tests/unit/customizations/configure/ tests/functional/configure/`

Resolves #10313.