### PR TITLE
[v2] Validate CloudTrail log files don't have appended data

### DIFF
--- a/.changes/next-release/enhancement-cloudtrailvalidatelogs-71283.json
+++ b/.changes/next-release/enhancement-cloudtrailvalidatelogs-71283.json
@@ -1,0 +1,5 @@
+{
+  "type": "enhancement",
+  "category": "``cloudtrail validate-logs``",
+  "description": "Invalidate log files with data appended to the end of the gzip stream."
+}

--- a/awscli/customizations/cloudtrail/validation.py
+++ b/awscli/customizations/cloudtrail/validation.py
@@ -1142,6 +1142,9 @@ class CloudTrailValidateLogs(BasicCommand):
             remaining_data = gzip_inflater.flush()
             if remaining_data:
                 rolling_hash.update(remaining_data)
+            if gzip_inflater.unused_data:
+                self._on_log_trailing_data(log)
+                return
             computed_hash = rolling_hash.hexdigest()
             if computed_hash != log['hashValue']:
                 self._on_log_invalid(log)
@@ -1246,6 +1249,14 @@ class CloudTrailValidateLogs(BasicCommand):
         self._invalid_logs += 1
         self._write_status(
             f'Log file\ts3://{log_data["s3Bucket"]}/{log_data["s3Object"]}\tINVALID: invalid format',
+            True,
+        )
+
+    def _on_log_trailing_data(self, log_data):
+        self._invalid_logs += 1
+        self._write_status(
+            f'Log file\ts3://{log_data["s3Bucket"]}/{log_data["s3Object"]}\t'
+            f'INVALID: unexpected data after end of compressed stream',
             True,
         )
 

--- a/tests/functional/cloudtrail/test_validation.py
+++ b/tests/functional/cloudtrail/test_validation.py
@@ -380,6 +380,33 @@ class TestCloudTrailCommand(BaseCloudTrailCommandTest):
         self.assertIn('1/1 backfill digest files valid', stdout)
         self.assertIn('0/2 log files valid, 2/2 log files INVALID', stdout)
 
+    def test_rejects_multi_member_gzip_log_file(self):
+        body = _gz_compress(self._logs[0]['_raw_value']) + _gz_compress(
+            '{"extra":"member"}'
+        )
+        key_provider, digest_provider, validator = create_scenario(
+            ['gap'], [[self._logs[0]]]
+        )
+        self.parsed_responses = [
+            {'LocationConstraint': ''},
+            {'Body': BytesIO(body)},
+            {'Body': BytesIO(body)},
+        ]
+        _setup_mock_traverser(
+            self._mock_traverser, key_provider, digest_provider, validator
+        )
+        stdout, stderr, rc = self.run_cmd(
+            f"cloudtrail validate-logs --trail-arn {TEST_TRAIL_ARN} "
+            f"--start-time {START_TIME_ARG} --region us-east-1",
+            1,
+        )
+        self.assertIn(
+            'Log file\ts3://1/key1\t'
+            'INVALID: unexpected data after end of compressed stream',
+            stderr,
+        )
+        self.assertIn('0/2 log files valid, 2/2 log files INVALID', stdout)
+
     def test_validates_valid_log_files(self):
         key_provider, digest_provider, validator = create_scenario(
             ['gap', 'link', 'link'],


### PR DESCRIPTION
Internal: D454429470

When validating CloudTrail logs, assert that there's no unused/appended data after the first gzip member is fully consumed and decompressed.