### PR TITLE
docs(readme): remove redundant "and greater" from per-minor Python version list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,11 +37,11 @@ Requirements
 
 The aws-cli package works on Python versions:
 
--  3.10.x and greater
--  3.11.x and greater
--  3.12.x and greater
--  3.13.x and greater
--  3.14.x and greater
+-  3.10.x
+-  3.11.x
+-  3.12.x
+-  3.13.x
+-  3.14.x
 
 Notices
 ~~~~~~~


### PR DESCRIPTION
## Summary

`README.rst` lists supported Python versions like this:

```
The aws-cli package works on Python versions:

-  3.10.x and greater
-  3.11.x and greater
-  3.12.x and greater
-  3.13.x and greater
-  3.14.x and greater
```

Each line says "X.Y.x and greater", which makes every subsequent line redundant — if 3.10.x and greater is supported, then 3.11.x / 3.12.x / 3.13.x / 3.14.x are already implied. As written, the list reads as either contradictory or accidentally copy-pasted.

The `v2` branch of this repo lists the same supported-versions block without "and greater":

```
The aws-cli package works on Python versions:

* 3.9.x
* 3.10.x
* 3.11.x
* 3.12.x
* 3.13.x
* 3.14.x
```

This PR aligns the v1 README with that pattern.

## Diff

```diff
 The aws-cli package works on Python versions:

--  3.10.x and greater
--  3.11.x and greater
--  3.12.x and greater
--  3.13.x and greater
--  3.14.x and greater
+-  3.10.x
+-  3.11.x
+-  3.12.x
+-  3.13.x
+-  3.14.x
```

## Test plan

- [x] Docs-only change; no code or test impact.