### PR TITLE
Update README zsh completion for bundled installer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,17 +87,8 @@ For tcsh::
 
 You should add this to your startup scripts to enable it for future sessions.
 
-For zsh (Package Manager, e.g. pip installs) please refer to 
-``bin/aws_zsh_completer.sh``.  Source that file, e.g. from your 
-``~/.zshrc``, and make sure you run ``compinit`` before::
-
-    $ source bin/aws_zsh_completer.sh
-
-For now the bash compatibility auto completion (``bashcompinit``) is used.
-For further details please refer to the top of ``bin/aws_zsh_completer.sh``.
-
-For zsh (bundled installer, e.g. zip/pkg), use ``aws_completer``
-directly with ``bashcompinit``::
+For zsh, run ``bashcompinit`` and ``compinit``, then use the built-in
+``complete`` command::
 
     $ autoload bashcompinit && bashcompinit
     $ autoload -Uz compinit && compinit

--- a/README.rst
+++ b/README.rst
@@ -87,13 +87,26 @@ For tcsh::
 
 You should add this to your startup scripts to enable it for future sessions.
 
-For zsh please refer to ``bin/aws_zsh_completer.sh``.  Source that file, e.g.
-from your ``~/.zshrc``, and make sure you run ``compinit`` before::
+For zsh (Package Manager, e.g. pip installs) please refer to 
+``bin/aws_zsh_completer.sh``.  Source that file, e.g. from your 
+``~/.zshrc``, and make sure you run ``compinit`` before::
 
     $ source bin/aws_zsh_completer.sh
 
 For now the bash compatibility auto completion (``bashcompinit``) is used.
 For further details please refer to the top of ``bin/aws_zsh_completer.sh``.
+
+For zsh (bundled installer, e.g. zip/pkg), use ``aws_completer``
+directly with ``bashcompinit``::
+
+    $ autoload bashcompinit && bashcompinit
+    $ autoload -Uz compinit && compinit
+    $ complete -C '/usr/local/bin/aws_completer' aws
+
+Replace ``/usr/local/bin/aws_completer`` with the path returned by
+``which aws_completer`` if different. Add these commands to your
+``~/.zshrc`` to enable completion in future sessions.
+
 
 ---------------
 Getting Started


### PR DESCRIPTION
Fixes #8957. The README's zsh instructions point to
`bin/aws_zsh_completer.sh`, which ships with Package Manager
installs (e.g. pip) but not with the bundled installer (zip/pkg).
Bundled-installer users hit "No such file or directory".

## Change

Scope the existing zsh block to Package Manager installs and add a
parallel block for the bundled installer using `bashcompinit` +
`complete -C aws_completer aws`.

## Reference

[Configuring command completion in the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-completion.html)
