### PR TITLE
Warn on credentials file permissions

### DIFF
--- a/awscli/customizations/configure/__init__.py
+++ b/awscli/customizations/configure/__init__.py
@@ -10,8 +10,11 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
-import string
-from awscli.compat import shlex
+import os
+import sys
+
+from awscli.compat import is_windows, shlex
+from awscli.customizations.utils import uni_print
 
 NOT_SET = '<not set>'
 PREDEFINED_SECTION_NAMES = ('preview', 'plugins')
@@ -47,3 +50,35 @@ def profile_to_section(profile_name):
     if any(c in _WHITESPACE for c in profile_name):
         profile_name = shlex.quote(profile_name)
     return 'profile %s' % profile_name
+
+
+PERMISSIONS_WARNING_TEMPLATE = (
+    "\naws: [WARNING]: The file '{path}' is accessible by other users. "
+    "Consider running 'chmod 600 {path}' to restrict access to only your "
+    "user.\n"
+)
+
+
+def warn_if_permissive(file_path, err_stream=None):
+    if is_windows:
+        return
+
+    if not os.path.isfile(file_path):
+        return
+
+    if err_stream is None:
+        err_stream = sys.stderr
+
+    try:
+        file_mode = os.stat(file_path).st_mode
+        if is_overly_permissive(file_mode, 0o700):
+            uni_print(
+                PERMISSIONS_WARNING_TEMPLATE.format(path=file_path),
+                out_file=err_stream,
+            )
+    except OSError:
+        return
+
+
+def is_overly_permissive(file_mode, allowed_bits=0o700):
+    return bool((file_mode & 0o777) & ~allowed_bits)

--- a/awscli/customizations/configure/configure.py
+++ b/awscli/customizations/configure/configure.py
@@ -138,4 +138,6 @@ class ConfigureCommand(BasicCommand):
                 self._session.get_config_variable('credentials_file'))
             self._config_writer.update_config(
                 credential_file_values,
-                shared_credentials_filename)
+                shared_credentials_filename,
+                check_permissions=True,
+            )

--- a/awscli/customizations/configure/set.py
+++ b/awscli/customizations/configure/set.py
@@ -95,14 +95,20 @@ class ConfigureSetCommand(BasicCommand):
                 # of something in the [plugin] section.
                 profile, varname = parts
         config_filename = self._get_config_file('config_file')
+        check_permissions = False
         if varname in self._WRITE_TO_CREDS_FILE:
             # When writing to the creds file, the section is just the profile
             section = profile
             config_filename = self._get_config_file('credentials_file')
+            check_permissions = True
         elif profile in PREDEFINED_SECTION_NAMES or profile == 'default':
             section = profile
         else:
             section = profile_to_section(profile)
         updated_config = {'__section__': section, varname: value}
-        self._config_writer.update_config(updated_config, config_filename)
+        self._config_writer.update_config(
+            updated_config,
+            config_filename,
+            check_permissions=check_permissions,
+        )
         return 0

--- a/awscli/customizations/configure/writer.py
+++ b/awscli/customizations/configure/writer.py
@@ -13,7 +13,7 @@
 import os
 import re
 
-from . import SectionNotFoundError
+from . import SectionNotFoundError, warn_if_permissive
 
 
 class ConfigFileWriter(object):
@@ -24,7 +24,9 @@ class ConfigFileWriter(object):
         r'(?P<value>.*)$'
     )
 
-    def update_config(self, new_values, config_filename):
+    def update_config(
+        self, new_values, config_filename, check_permissions=False
+    ):
         """Update config file with new values.
 
         This method will update a section in a config file with
@@ -50,6 +52,10 @@ class ConfigFileWriter(object):
         :param config_filename: The config filename where values will be
             written.
 
+        :type check_permissions: bool
+        :param check_permissions: If True, warn if the file has
+            permissions more permissive than 0o600.
+
         """
         section_name = new_values.pop('__section__', 'default')
         if not os.path.isfile(config_filename):
@@ -66,6 +72,8 @@ class ConfigFileWriter(object):
                 f.write(''.join(contents))
         except SectionNotFoundError:
             self._write_new_section(section_name, new_values, config_filename)
+        if check_permissions:
+            warn_if_permissive(config_filename)
 
     def _create_file(self, config_filename):
         # Create the file as well as the parent dir if needed.

--- a/tests/unit/customizations/configure/test_configure.py
+++ b/tests/unit/customizations/configure/test_configure.py
@@ -37,7 +37,8 @@ class TestConfigureCommand(unittest.TestCase):
         credentials_file_call = called_args[0]
         expected_creds_file = os.path.expanduser('~/fake_credentials_filename')
         self.assertEqual(credentials_file_call,
-                         mock.call(new_values, expected_creds_file))
+                         mock.call(new_values, expected_creds_file,
+                                   check_permissions=True))
 
     def test_configure_command_sends_values_to_writer(self):
         self.configure(args=[], parsed_globals=self.global_args)
@@ -128,6 +129,22 @@ class TestConfigureCommand(unittest.TestCase):
             {'__section__': 'profile profile-does-not-exist',
              'region': 'new_value',
              'output': 'new_value'}, 'myconfigfile')
+
+    def test_check_permissions_when_credential_values_provided(self):
+        self.configure(args=[], parsed_globals=self.global_args)
+        expected_creds_file = os.path.expanduser('~/fake_credentials_filename')
+        self.writer.update_config.assert_any_call(
+            mock.ANY, expected_creds_file, check_permissions=True
+        )
+
+    def test_no_check_permissions_when_no_credential_values_changed(self):
+        user_presses_enter = None
+        precanned = PrecannedPrompter(value=user_presses_enter)
+        self.configure = configure.ConfigureCommand(
+            self.session, prompter=precanned, config_writer=self.writer
+        )
+        self.configure(args=[], parsed_globals=self.global_args)
+        self.writer.update_config.assert_not_called()
 
 
 class TestInteractivePrompter(unittest.TestCase):

--- a/tests/unit/customizations/configure/test_permissions.py
+++ b/tests/unit/customizations/configure/test_permissions.py
@@ -1,0 +1,81 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+import os
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from awscli.customizations.configure import (
+    is_overly_permissive,
+    warn_if_permissive,
+)
+
+
+@pytest.mark.parametrize("mode", [0o700, 0o600, 0o400, 0o200, 0o000])
+def test_acceptable_modes_are_not_overly_permissive(mode):
+    assert is_overly_permissive(mode) is False
+
+
+@pytest.mark.parametrize("mode", [0o644, 0o666, 0o777, 0o610, 0o601])
+def test_overly_permissive_modes_are_detected(mode):
+    assert is_overly_permissive(mode) is True
+
+
+def _create_creds_file(tmp_path, mode):
+    path = tmp_path / "credentials"
+    path.write_text("[default]\naws_access_key_id=testing\n")
+    os.chmod(path, mode)
+    return str(path)
+
+
+@patch("awscli.customizations.configure.is_windows", False)
+def test_prints_warning_for_permissive_file(tmp_path):
+    path = _create_creds_file(tmp_path, 0o644)
+    err = StringIO()
+    warn_if_permissive(path, err_stream=err)
+    output = err.getvalue()
+    assert "aws: [WARNING]" in output
+    assert path in output
+    assert "accessible by other users" in output
+
+
+@patch("awscli.customizations.configure.is_windows", False)
+def test_no_warning_for_0o600_file(tmp_path):
+    path = _create_creds_file(tmp_path, 0o600)
+    err = StringIO()
+    warn_if_permissive(path, err_stream=err)
+    assert err.getvalue() == ""
+
+
+@patch("awscli.customizations.configure.is_windows", False)
+def test_no_warning_for_0o700_file(tmp_path):
+    path = _create_creds_file(tmp_path, 0o700)
+    err = StringIO()
+    warn_if_permissive(path, err_stream=err)
+    assert err.getvalue() == ""
+
+
+@patch("awscli.customizations.configure.is_windows", False)
+def test_skips_when_file_does_not_exist(tmp_path):
+    err = StringIO()
+    warn_if_permissive(str(tmp_path / "nonexistent"), err_stream=err)
+    assert err.getvalue() == ""
+
+
+@patch("awscli.customizations.configure.is_windows", True)
+def test_skips_on_windows(tmp_path):
+    path = _create_creds_file(tmp_path, 0o777)
+    err = StringIO()
+    warn_if_permissive(path, err_stream=err)
+    assert err.getvalue() == ""

--- a/tests/unit/customizations/configure/test_set.py
+++ b/tests/unit/customizations/configure/test_set.py
@@ -31,14 +31,16 @@ class TestConfigureSetCommand(unittest.TestCase):
             self.session, self.config_writer)
         set_command(args=['region', 'us-west-2'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
-            {'__section__': 'default', 'region': 'us-west-2'}, 'myconfigfile')
+            {'__section__': 'default', 'region': 'us-west-2'}, 'myconfigfile',
+            check_permissions=False)
 
     def test_configure_set_command_dotted(self):
         set_command = ConfigureSetCommand(
             self.session, self.config_writer)
         set_command(args=['preview.emr', 'true'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
-            {'__section__': 'preview', 'emr': 'true'}, 'myconfigfile')
+            {'__section__': 'preview', 'emr': 'true'}, 'myconfigfile',
+            check_permissions=False)
 
     def test_configure_set_command_dotted_with_default_profile(self):
         self.session.variables['profile'] = 'default'
@@ -48,7 +50,8 @@ class TestConfigureSetCommand(unittest.TestCase):
             args=['emr.instance_profile', 'my_ip_emr'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'default',
-             'emr': {'instance_profile': 'my_ip_emr'}}, 'myconfigfile')
+             'emr': {'instance_profile': 'my_ip_emr'}}, 'myconfigfile',
+            check_permissions=False)
 
     def test_configure_set_handles_predefined_plugins_section(self):
         self.session.variables['profile'] = 'default'
@@ -58,7 +61,8 @@ class TestConfigureSetCommand(unittest.TestCase):
             args=['plugins.foo', 'mypackage'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'plugins',
-             'foo': 'mypackage'}, 'myconfigfile')
+             'foo': 'mypackage'}, 'myconfigfile',
+            check_permissions=False)
 
     def test_configure_set_command_dotted_with_profile(self):
         self.session.profile = 'emr-dev'
@@ -68,7 +72,8 @@ class TestConfigureSetCommand(unittest.TestCase):
             args=['emr.instance_profile', 'my_ip_emr'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'profile emr-dev', 'emr':
-                {'instance_profile': 'my_ip_emr'}}, 'myconfigfile')
+                {'instance_profile': 'my_ip_emr'}}, 'myconfigfile',
+            check_permissions=False)
 
     def test_configure_set_with_profile(self):
         self.session.profile = 'testing'
@@ -77,7 +82,7 @@ class TestConfigureSetCommand(unittest.TestCase):
         set_command(args=['region', 'us-west-2'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'profile testing', 'region': 'us-west-2'},
-            'myconfigfile')
+            'myconfigfile', check_permissions=False)
 
     def test_configure_set_triple_dotted(self):
         # aws configure set default.s3.signature_version s3v4
@@ -87,7 +92,7 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'default', 's3': {'signature_version': 's3v4'}},
-            'myconfigfile')
+            'myconfigfile', check_permissions=False)
 
     def test_configure_set_with_profile_nested(self):
         # aws configure set default.s3.signature_version s3v4
@@ -97,7 +102,8 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'profile foo',
-             's3': {'signature_version': 's3v4'}}, 'myconfigfile')
+             's3': {'signature_version': 's3v4'}}, 'myconfigfile',
+            check_permissions=False)
 
     def test_access_key_written_to_shared_credentials_file(self):
         set_command = ConfigureSetCommand(
@@ -106,7 +112,8 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'default',
-             'aws_access_key_id': 'foo'}, self.fake_credentials_filename)
+             'aws_access_key_id': 'foo'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_secret_key_written_to_shared_credentials_file(self):
         set_command = ConfigureSetCommand(
@@ -115,7 +122,8 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'default',
-             'aws_secret_access_key': 'foo'}, self.fake_credentials_filename)
+             'aws_secret_access_key': 'foo'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_session_token_written_to_shared_credentials_file(self):
         set_command = ConfigureSetCommand(
@@ -124,7 +132,8 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'default',
-             'aws_session_token': 'foo'}, self.fake_credentials_filename)
+             'aws_session_token': 'foo'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_access_key_written_to_shared_credentials_file_profile(self):
         set_command = ConfigureSetCommand(
@@ -133,7 +142,8 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'foo',
-             'aws_access_key_id': 'bar'}, self.fake_credentials_filename)
+             'aws_access_key_id': 'bar'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_credential_set_profile_with_space(self):
         self.session.profile = 'some profile'
@@ -141,7 +151,8 @@ class TestConfigureSetCommand(unittest.TestCase):
         set_command(args=['aws_session_token', 'foo'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'some profile',
-             'aws_session_token': 'foo'}, self.fake_credentials_filename)
+             'aws_session_token': 'foo'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_credential_set_profile_with_space_dotted(self):
         set_command = ConfigureSetCommand(self.session, self.config_writer)
@@ -149,7 +160,8 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'some profile',
-             'aws_session_token': 'foo'}, self.fake_credentials_filename)
+             'aws_session_token': 'foo'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_configure_set_with_profile_with_space(self):
         self.session.profile = 'some profile'
@@ -157,7 +169,7 @@ class TestConfigureSetCommand(unittest.TestCase):
         set_command(args=['region', 'us-west-2'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': "profile 'some profile'", 'region': 'us-west-2'},
-            'myconfigfile')
+            'myconfigfile', check_permissions=False)
 
     def test_configure_set_with_profile_with_space_dotted(self):
         set_command = ConfigureSetCommand(self.session, self.config_writer)
@@ -165,7 +177,7 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': "profile 'some profile'", 'region': 'us-west-2'},
-            'myconfigfile')
+            'myconfigfile', check_permissions=False)
 
     def test_credential_set_profile_with_tab(self):
         self.session.profile = 'some\tprofile'
@@ -173,7 +185,8 @@ class TestConfigureSetCommand(unittest.TestCase):
         set_command(args=['aws_session_token', 'foo'], parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': 'some\tprofile',
-             'aws_session_token': 'foo'}, self.fake_credentials_filename)
+             'aws_session_token': 'foo'}, self.fake_credentials_filename,
+            check_permissions=True)
 
     def test_configure_set_with_profile_with_tab_dotted(self):
         set_command = ConfigureSetCommand(self.session, self.config_writer)
@@ -181,4 +194,4 @@ class TestConfigureSetCommand(unittest.TestCase):
                     parsed_globals=None)
         self.config_writer.update_config.assert_called_with(
             {'__section__': "profile 'some\tprofile'", 'region': 'us-west-2'},
-            'myconfigfile')
+            'myconfigfile', check_permissions=False)


### PR DESCRIPTION
*Issue #, if available:*

#10019

*Description of changes:*

Users running the following commands now see a warning if the credentials file has permissions beyond the default of `0o600`.

- `aws configure set` (if setting access key,secret key, or token)
- `aws configure` (if setting access key,secret key, or token)

Developers can now specify a credential check in the `ConfigFileWriter.update_config` method.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
